### PR TITLE
Enable `application/rdf+json` as rdf representation

### DIFF
--- a/jena-fuseki/src/main/java/org/apache/jena/fuseki/DEF.java
+++ b/jena-fuseki/src/main/java/org/apache/jena/fuseki/DEF.java
@@ -36,11 +36,12 @@ public class DEF
     public static final MediaType acceptNQuads        = MediaType.create(WebContent.contentTypeNQuads) ;
     public static final MediaType acceptNQuadsAlt1    = MediaType.create(WebContent.contentTypeNQuadsAlt1) ;
     public static final MediaType acceptNQuadsAlt2    = MediaType.create(WebContent.contentTypeNQuadsAlt2) ;
+    public static final MediaType acceptRDFJSON       = MediaType.create(WebContent.contentTypeRDFJSON) ;
     public static final MediaType charsetUTF8         = MediaType.create(WebContent.charsetUTF8) ;
     
     public static final MediaType acceptRSXML         = MediaType.create(WebContent.contentTypeResultsXML) ;
 
-    public static final AcceptList rdfOffer           = AcceptList.create(acceptRDFXML, acceptTurtle1, acceptTurtle2, acceptTurtle3, acceptNTriples, acceptNTriplesAlt) ;
+    public static final AcceptList rdfOffer           = AcceptList.create(acceptRDFXML, acceptTurtle1, acceptTurtle2, acceptTurtle3, acceptNTriples, acceptNTriplesAlt, acceptRDFJSON) ;
     public static final AcceptList quadsOffer         = AcceptList.create(acceptNQuads, acceptNQuadsAlt1, acceptNQuadsAlt2, acceptTriG, acceptTriGAlt1, acceptTriGAlt2) ;
     public static final AcceptList charsetOffer       = AcceptList.create(charsetUTF8) ;
     


### PR DESCRIPTION
I just added `application/rdf+json` as media type for rdf representations. The `WebContent` already had the `contentTypeRDFJSON` property, so only small changes in `DEF.java` were necessary.
