### PR TITLE
Add triples only if they are not stoppped at

### DIFF
--- a/jena-core/src/main/java/com/hp/hpl/jena/graph/GraphExtract.java
+++ b/jena-core/src/main/java/com/hp/hpl/jena/graph/GraphExtract.java
@@ -89,6 +89,4 @@ public class GraphExtract
                 }
             }
         }
-    
-
     }

--- a/jena-core/src/main/java/com/hp/hpl/jena/graph/TripleBoundary.java
+++ b/jena-core/src/main/java/com/hp/hpl/jena/graph/TripleBoundary.java
@@ -21,7 +21,7 @@ package com.hp.hpl.jena.graph;
 /**
      An interface for expressing a stopping condition on triples, such as in 
      sub-graph extraction.
-  */
+*/
 public interface TripleBoundary
     {
     /**
@@ -43,5 +43,10 @@ public interface TripleBoundary
     public static final TripleBoundary stopAtAnonObject = new TripleBoundary()
         { @Override
         public boolean stopAt( Triple t ) { return t.getObject().isBlank(); } };
-
+	/**
+	 	A TripleBoundary that stops at triples with anonymous subjects.
+	 */
+    public static final TripleBoundary stopAtAnonSubject = new TripleBoundary()
+        { @Override
+        public boolean stopAt( Triple t ) { return t.getSubject().isBlank(); } };
     }

--- a/jena-core/src/test/java/com/hp/hpl/jena/graph/test/TestGraphExtract.java
+++ b/jena-core/src/test/java/com/hp/hpl/jena/graph/test/TestGraphExtract.java
@@ -79,6 +79,10 @@ public class TestGraphExtract extends GraphTestBase
         assertFalse( TripleBoundary.stopAtAnonObject.stopAt( triple( "a R b" ) ) );
         assertFalse( TripleBoundary.stopAtAnonObject.stopAt( triple( "a _R b" ) ) );
         assertFalse( TripleBoundary.stopAtAnonObject.stopAt( triple( "_a R b" ) ) );
+		assertFalse( TripleBoundary.stopAtAnonSubject.stopAt( triple( "a R _b" ) ) );
+		assertFalse( TripleBoundary.stopAtAnonSubject.stopAt( triple( "a R b" ) ) );
+		assertFalse( TripleBoundary.stopAtAnonSubject.stopAt( triple( "a _R b" ) ) );
+		assertTrue( TripleBoundary.stopAtAnonSubject.stopAt( triple( "_a R b" ) ) );
         }
     
     public void testExtractBoundary()

--- a/jena-core/src/test/java/com/hp/hpl/jena/rdf/model/test/TestModelExtract.java
+++ b/jena-core/src/test/java/com/hp/hpl/jena/rdf/model/test/TestModelExtract.java
@@ -159,12 +159,24 @@ public class TestModelExtract extends AbstractModelTestBase
 
 	public void testStatementTripleBoundaryAnon()
 	{
-		final TripleBoundary anon = TripleBoundary.stopAtAnonObject;
-		Assert.assertSame(anon,
-				new StatementTripleBoundary(anon).asTripleBoundary(null));
-		Assert.assertFalse(new StatementTripleBoundary(anon).stopAt(ModelHelper
+		final TripleBoundary anonObject = TripleBoundary.stopAtAnonObject;
+		Assert.assertSame(anonObject,
+				new StatementTripleBoundary(anonObject).asTripleBoundary(null));
+		Assert.assertFalse(new StatementTripleBoundary(anonObject).stopAt(ModelHelper
 				.statement("s P o")));
 		Assert.assertTrue(new StatementTripleBoundary(anon).stopAt(ModelHelper
+				Assert.assertFalse(new StatementTripleBoundary(anonObject).stopAt(ModelHelper
+						.statement("_s P o")));
+		Assert.assertTrue(new StatementTripleBoundary(anonObject).stopAt(ModelHelper
+				.statement("s P _o")));
+		final TripleBoundary anonSubject = TripleBoundary.stopAtAnonSubject;
+		Assert.assertSame(anonSubject,
+				new StatementTripleBoundary(anonSubject).asTripleBoundary(null));
+		Assert.assertFalse(new StatementTripleBoundary(anonSubject).stopAt(ModelHelper
+				.statement("s P o")));
+		Assert.assertTrue(new StatementTripleBoundary(anonSubject).stopAt(ModelHelper
+				.statement("_s P o")));
+		Assert.assertFalse(new StatementTripleBoundary(anonSubject).stopAt(ModelHelper
 				.statement("s P _o")));
 	}
 


### PR DESCRIPTION
- update tests

`GraphExtract` should updates its model _after_ it is checked if the triple should be taken into account or stopped at (ok, it's maybe not really a bug , depending on your your definition if "stop at" is meant inclusive or exclusive).

As reflected in the test, this prohibits the addition of a triple like `s p _o` using `TripleBoundary.stopAtAnonObject`. If you want to include this triple you would now use `TripleBoundary.stopAtAnonSubject`.

_I admit that this may break applications and thus is not a good idea._
It breaks down to my following question:
How could a `TripleBoundary` looks like if you only want triples with one given subject?
(with the changes reflected in this pull request #4, one can do something like this https://github.com/lobid/lodmill/blob/9a87ba36f7efd775dae1f61bb21f45031fa27468/lodmill-rd/src/main/java/org/lobid/lodmill/SubjectBoundary.java )
