### PR TITLE
JENA-612 log output of Fuseki service init to file

### DIFF
--- a/jena-fuseki/fuseki
+++ b/jena-fuseki/fuseki
@@ -269,7 +269,7 @@ start() {
     then
       CH_USER="--chuid $FUSEKI_USER"
     fi
-    if start-stop-daemon --start $CH_USER --chdir "$FUSEKI_HOME" --background --make-pidfile --pidfile "$FUSEKI_PID" --startas "$JAVA" -- "${RUN_ARGS[@]}"
+    if start-stop-daemon --start $CH_USER --chdir "$FUSEKI_HOME" --background --make-pidfile --pidfile "$FUSEKI_PID" --startas /bin/bash -- -c "exec $JAVA ${RUN_ARGS[*]} > $FUSEKI_LOGS_STDERROUT 2>&1"
     then
       sleep 1
       if running "$FUSEKI_PID"

--- a/jena-fuseki2/fuseki
+++ b/jena-fuseki2/fuseki
@@ -333,7 +333,7 @@ start() {
     then
       CH_USER="--chuid $FUSEKI_USER"
     fi
-    if start-stop-daemon --start $CH_USER --chdir "$FUSEKI_HOME" --background --make-pidfile --pidfile "$FUSEKI_PID" --startas "$JAVA" -- "${RUN_ARGS[@]}"
+    if start-stop-daemon --start $CH_USER --chdir "$FUSEKI_HOME" --background --make-pidfile --pidfile "$FUSEKI_PID" --startas /bin/bash -- -c "exec $JAVA ${RUN_ARGS[*]} > $FUSEKI_LOGS_STDERROUT 2>&1"
     then
       sleep 2
       if running "$FUSEKI_PID"


### PR DESCRIPTION
This pull request is related to [JENA-612](https://issues.apache.org/jira/browse/JENA-612). This is a patch to log the Fuseki service init output and err to the stderrout.log, so that errors such as mentioned in the issue won't happen silently. 

Applied to Fusekiv1 and Fusekiv2.

Hope that helps,
Thank you.
