### PR TITLE
JENA-551 Inconsistency between assembler usage for tdb:location and text:directory

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextIndexLuceneAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextIndexLuceneAssembler.java
@@ -45,12 +45,12 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
     /*
     <#index> a :TextIndexLucene ;
         #text:directory "mem" ;
+        #text:directory "DIR" ;
         text:directory <file:DIR> ;
         text:entityMap <#endMap> ;
         .
     */
 
-    @SuppressWarnings("resource")
     @Override
     public TextIndex open(Assembler a, Resource root, Mode mode) {
         try {
@@ -61,10 +61,13 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
             
             RDFNode n = root.getProperty(pDirectory).getObject() ;
             if ( n.isLiteral() ) {
-                if ( !"mem".equals(n.asLiteral().getLexicalForm()) )
-                    throw new TextIndexException("No 'text:directory' property on " + root
-                                                 + " is a literal and not \"mem\"") ;
-                directory = new RAMDirectory() ;
+                String literalValue = n.toString() ; 
+                if (literalValue.equals("mem")) {
+                    directory = new RAMDirectory() ;
+                } else {
+                    File dir = new File(literalValue) ;
+                    directory = FSDirectory.open(dir) ;
+                }
             } else {
                 Resource x = n.asResource() ;
                 String path = IRILib.IRIToFilename(x.getURI()) ;

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/AbstractTestTextAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/AbstractTestTextAssembler.java
@@ -32,6 +32,8 @@ public abstract class AbstractTestTextAssembler {
 	protected static final Resource SIMPLE_DATASET_SPEC;
 	protected static final Resource SIMPLE_INDEX_SPEC;
 	protected static final Resource SIMPLE_ENTITY_MAP_SPEC;
+	protected static final Resource SIMPLE_INDEX_SPEC_LITERAL_DIR;
+	protected static final Resource SIMPLE_INDEX_SPEC_MEM_DIR;
 	
 	static {
 		SIMPLE_ENTITY_MAP_SPEC = 
@@ -56,6 +58,18 @@ public abstract class AbstractTestTextAssembler {
 				model.createResource(TESTBASE + "simpleIndexSpec")
 				     .addProperty(RDF.type, TextVocab.textIndexLucene)
 				     .addProperty(TextVocab.pDirectory, model.createResource("file:target/test/simpleLuceneIndex"))
+				     .addProperty(TextVocab.pEntityMap, SIMPLE_ENTITY_MAP_SPEC);
+
+		SIMPLE_INDEX_SPEC_LITERAL_DIR =
+				model.createResource(TESTBASE + "simpleIndexLiteralDirSpec")
+				     .addProperty(RDF.type, TextVocab.textIndexLucene)
+				     .addProperty(TextVocab.pDirectory, model.createLiteral("target/test/simpleLuceneIndex"))
+				     .addProperty(TextVocab.pEntityMap, SIMPLE_ENTITY_MAP_SPEC);
+
+		SIMPLE_INDEX_SPEC_MEM_DIR =
+				model.createResource(TESTBASE + "simpleIndexMemDirSpec")
+				     .addProperty(RDF.type, TextVocab.textIndexLucene)
+				     .addProperty(TextVocab.pDirectory, model.createLiteral("mem"))
 				     .addProperty(TextVocab.pEntityMap, SIMPLE_ENTITY_MAP_SPEC);
 	}
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextIndexLuceneAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextIndexLuceneAssembler.java
@@ -19,22 +19,61 @@
 package org.apache.jena.query.text.assembler;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import org.apache.jena.query.text.TextIndex;
 import org.apache.jena.query.text.TextIndexLucene;
+import org.apache.lucene.store.RAMDirectory;
 import org.junit.Test;
 
 import com.hp.hpl.jena.assembler.Assembler;
+import com.hp.hpl.jena.rdf.model.Resource;
 import com.hp.hpl.jena.vocabulary.RDFS;
 
 public class TestTextIndexLuceneAssembler extends AbstractTestTextAssembler {
-	
-	@Test public void testIndexHasEntityMap() {
-		TextIndexLucene indexLucene = (TextIndexLucene) Assembler.general.open(SIMPLE_INDEX_SPEC);
-		assertEquals(RDFS.label.asNode(), indexLucene.getDocDef().getPrimaryPredicate());		
-	}
-	
-	static {
-		TextAssembler.init();
-	}
+    
+    @Test public void testIndexHasEntityMap() {
+        TextIndexLucene indexLucene = (TextIndexLucene) Assembler.general.open(SIMPLE_INDEX_SPEC);
+        assertEquals(RDFS.label.asNode(), indexLucene.getDocDef().getPrimaryPredicate());        
+    }
+
+    @Test public void testLiteralDirectory() {
+        TextIndexLuceneAssembler assembler = new TextIndexLuceneAssembler();
+        
+        Resource root = SIMPLE_INDEX_SPEC_LITERAL_DIR;
+        Assembler a = Assembler.general;
+        // the open method is not supposed to throw exceptions when the directory is
+        // a literal
+        TextIndex index = assembler.open(a, root, /*mode*/ null);
+        assertNotNull(index);
+    }
+
+    @Test public void testResourceDirectory() {
+        TextIndexLuceneAssembler assembler = new TextIndexLuceneAssembler();
+
+        Resource root = SIMPLE_INDEX_SPEC;
+        Assembler a = Assembler.general;
+        // the open method is not supposed to throw exceptions when the directory is
+        // a resource
+        TextIndexLucene index = (TextIndexLucene) assembler.open(a, root, /*mode*/ null);
+        assertFalse(index.getDirectory() instanceof RAMDirectory);
+    }
+
+    @Test public void testMemDirectory() {
+        TextIndexLuceneAssembler assembler = new TextIndexLuceneAssembler();
+
+        Resource root = SIMPLE_INDEX_SPEC_MEM_DIR;
+        Assembler a = Assembler.general;
+        // the open method is not supposed to throw exceptions when the directory is
+        // a iri resource
+        TextIndexLucene index = (TextIndexLucene) assembler.open(a, root, /*mode*/ null);
+        assertTrue(index.getDirectory() instanceof RAMDirectory);
+    }
+
+    static {
+        TextAssembler.init();
+    }
 
 }


### PR DESCRIPTION
This pull request changes the logic in the TextIndexLuceneAssembler#open method, allowing literals for text:directory, mimicking the behaviour of tdb:location. 

The issue hasn't been discussed in the mailing list or in JIRA, so it is all right if this PR is not merged. 

While the fix allows directories to be created using literals, it also adds the "special case" when a literal is equals to "mem" (so it uses a RAMDirectory). What is not very elegant.

If this pull request looks good and gets merged, I can update the site to reflect the changes as well.
