### PR TITLE
Create iri from uri

### DIFF
--- a/jena-iri/src/main/java/org/apache/jena/iri/IRIFactoryI.java
+++ b/jena-iri/src/main/java/org/apache/jena/iri/IRIFactoryI.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.iri;
 
+import java.net.URI;
+
 /**
  * This interface is used for
  * making new {@link IRI} objects.
@@ -103,5 +105,19 @@ public interface IRIFactoryI {
      * 
      */
     IRI create(String s);
+    /**
+     * Make a new IRI object (possibly
+     * including IRI resolution),
+     * and check it for violations
+     * of the standards being enforced by the factory.
+     *  This method does not throw exceptions, but
+     *  records all errors and warnings found
+     *  to be queried later using {@link IRI#hasViolation(boolean)}
+     *  and {@link IRI#violations(boolean)}.
+     * @param uri The URI to use (relative or absolute).
+     * @return A new IRI object.
+     * 
+     */
+    IRI create(URI uri);
 
 }

--- a/jena-iri/src/main/java/org/apache/jena/iri/impl/AbsIRIFactoryImpl.java
+++ b/jena-iri/src/main/java/org/apache/jena/iri/impl/AbsIRIFactoryImpl.java
@@ -46,11 +46,6 @@ abstract public class AbsIRIFactoryImpl implements IRIFactoryI {
     
     @Override
     public IRI create(URI uri) {
-// TODO: Should a relative URI remain relative IRI?    	
-    	if (! uri.isAbsolute()) {
-    		IRI relative = create(uri.toASCIIString());
-    		return create(relative);
-    	}
 		return create(uri.toASCIIString());
     }
     

--- a/jena-iri/src/main/java/org/apache/jena/iri/impl/AbsIRIFactoryImpl.java
+++ b/jena-iri/src/main/java/org/apache/jena/iri/impl/AbsIRIFactoryImpl.java
@@ -19,6 +19,8 @@
 package org.apache.jena.iri.impl;
 
 
+import java.net.URI;
+
 import org.apache.jena.iri.IRI ;
 import org.apache.jena.iri.IRIException ;
 import org.apache.jena.iri.IRIFactoryI ;
@@ -41,6 +43,17 @@ abstract public class AbsIRIFactoryImpl implements IRIFactoryI {
 //                AbsIRIImpl.NO_EXCEPTIONS)
                 );
     }
+    
+    @Override
+    public IRI create(URI uri) {
+// TODO: Should a relative URI remain relative IRI?    	
+    	if (! uri.isAbsolute()) {
+    		IRI relative = create(uri.toASCIIString());
+    		return create(relative);
+    	}
+		return create(uri.toASCIIString());
+    }
+    
     
     //@Override
     @Override

--- a/jena-iri/src/test/java/org/apache/jena/iri/TS_IRI.java
+++ b/jena-iri/src/test/java/org/apache/jena/iri/TS_IRI.java
@@ -31,6 +31,8 @@ public class TS_IRI extends TestCase{
         rslt.addTest(TestMoreExamples.suite());
         rslt.addTest(MoreTests.suite());
         rslt.addTest(Additional.suite());
+        rslt.addTest(TestIRIFactory.suite());
+        
         return rslt;
     }
 }

--- a/jena-iri/src/test/java/org/apache/jena/iri/TestIRIFactory.java
+++ b/jena-iri/src/test/java/org/apache/jena/iri/TestIRIFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.iri;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+
+import junit.framework.JUnit4TestAdapter;
+
+import org.junit.Test;
+
+public class TestIRIFactory {
+	static public junit.framework.Test suite() {
+		return new JUnit4TestAdapter(TestIRIFactory.class);
+	}
+	
+	private static IRIFactory iriFactory = IRIFactory.jenaImplementation();
+	
+	@Test
+	public void createFromURI() throws Exception {
+		URI uri = URI.create("http://johndoe:secret@example.com:81/page?2#hash");
+		IRI iri = iriFactory.create(uri);		
+		assertEquals("http", iri.getScheme());
+		assertEquals("johndoe:secret", iri.getRawUserinfo());
+		assertEquals("example.com", iri.getRawHost());
+		assertEquals(81, iri.getPort());
+		assertEquals("/page", iri.getRawPath());
+		assertEquals("2", iri.getRawQuery());
+		assertEquals("hash", iri.getRawFragment());
+	}
+
+	@Test
+	public void createFromRelativeURI() throws Exception {
+		URI relative = URI.create("page/deeper.txt?q");
+		IRI relativeIri = iriFactory.create(relative);
+		assertEquals("page/deeper.txt", relativeIri.getRawPath());
+		
+		IRI base = iriFactory.create("http://example.com/relative/path?q=somethingelse");
+		IRI absolute = base.create(relative);
+		assertEquals("http://example.com/relative/page/deeper.txt?q", absolute.toString());
+		
+		URI other = URI.create("http://other.example.net/");
+		IRI otherIri = base.create(other);
+		assertEquals("http://other.example.net/", otherIri.toASCIIString());
+	}
+
+	
+}


### PR DESCRIPTION
Adds `IRIfactoryI.create(java.lang.URI)` to complement JENA-846 `IRI.toURI()`.

I believe I don't need the special case `if (! uri.isAbsolute())`  - see second commit 
d0c4669.