### PR TITLE
Javadoc rdf lang links

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
@@ -61,7 +61,7 @@ public class RDFLanguages
      * ".owx" is the OWL direct XML syntax.
      */
 
-    /** <a href="http://www.w3.org/TR/REC-rdf-syntax/">RDF/XML</a> */
+    /** <a href="http://www.w3.org/TR/rdf-syntax-grammar/">RDF/XML</a> */
     public static final Lang RDFXML   = LangBuilder.create(strLangRDFXML, contentTypeRDFXML)
                                                 .addAltNames("RDFXML", "RDF/XML-ABBREV", "RDFXML-ABBREV")
                                                 .addFileExtensions("rdf", "owl", "xml")

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangNQuads.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangNQuads.java
@@ -30,7 +30,8 @@ import com.hp.hpl.jena.sparql.core.Quad ;
 
 /**
  * N-Quads.
- * http://sw.deri.org/2008/07/n-quads/
+ *
+ * @see <a href="http://www.w3.org/TR/n-quads/">http://www.w3.org/TR/n-quads/</a>
  */
 public class LangNQuads extends LangNTuple<Quad>
 {

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangNTriples.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangNTriples.java
@@ -31,6 +31,11 @@ import org.slf4j.LoggerFactory ;
 import com.hp.hpl.jena.graph.Node ;
 import com.hp.hpl.jena.graph.Triple ;
 
+/**
+ * NTriples
+ * 
+ * @see <a href="http://www.w3.org/TR/n-triples/">http://www.w3.org/TR/n-triples/</a>
+ */
 public final class LangNTriples extends LangNTuple<Triple>
 {
     private static Logger messageLog = LoggerFactory.getLogger("N-Triples") ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangRDFJSON.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangRDFJSON.java
@@ -32,7 +32,9 @@ import com.hp.hpl.jena.graph.Node ;
 import com.hp.hpl.jena.graph.Triple ;
 
 /**
- * See http://docs.api.talis.com/platform-api/output-types/rdf-json
+ * RDF-JSON
+ *
+ * @see <a href="http://www.w3.org/TR/rdf-json/">http://www.w3.org/TR/rdf-json/</a>
  */
 public class LangRDFJSON extends LangBase
 {

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangRDFXML.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangRDFXML.java
@@ -43,6 +43,10 @@ import com.hp.hpl.jena.rdf.model.RDFErrorHandler ;
 import com.hp.hpl.jena.rdfxml.xmlinput.* ;
 import com.hp.hpl.jena.rdfxml.xmlinput.impl.ARPSaxErrorHandler ;
 
+/** RDF/XML
+ *
+ * @see <a href="http://www.w3.org/TR/rdf-syntax-grammar/">http://www.w3.org/TR/rdf-syntax-grammar/</a>
+ */
 public class LangRDFXML implements LangRIOT
 {
     // This is not a full member of the RIOT suite because it needs to work

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangTriG.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangTriG.java
@@ -29,7 +29,10 @@ import org.apache.jena.riot.tokens.Tokenizer ;
 import com.hp.hpl.jena.graph.Node ;
 import com.hp.hpl.jena.sparql.core.Quad ;
 
-/** TriG language: http://www.w3.org/TR/trig/ */
+/** TriG language
+ *
+ * @see <a href="http://www.w3.org/TR/trig/">http://www.w3.org/TR/trig/</a> 
+ */
 public class LangTriG extends LangTurtleBase {
 
     public LangTriG(Tokenizer tokens, ParserProfile profile, StreamRDF dest) {

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangTurtle.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangTurtle.java
@@ -27,7 +27,10 @@ import org.apache.jena.riot.tokens.Tokenizer ;
 import com.hp.hpl.jena.graph.Node ;
 import com.hp.hpl.jena.graph.Triple ;
 
-/** Turtle language */
+/** Turtle 
+ *
+ * @see <a href="http://www.w3.org/TR/turtle/">http://www.w3.org/TR/turtle/</a>
+ **/
 public class LangTurtle extends LangTurtleBase {
     public LangTurtle(Tokenizer tokens, ParserProfile profile, StreamRDF dest) {
         super(tokens, profile, dest) ;


### PR DESCRIPTION
Some of the javadocs linked to the wrong specifications of RDF languages. Updated to a common style.

RDFLanguages javadoc was mostly correct.