### PR TITLE
Updates to jena-osgi according to email thread

### DIFF
--- a/jena-osgi-test/pom.xml
+++ b/jena-osgi-test/pom.xml
@@ -98,12 +98,19 @@
             <environment>
               <id>felix</id>
               <framework>felix</framework>
-              <timeout>150000</timeout><!-- 15000ms = 15s -->
+              <timeout>15000</timeout><!-- = 15s -->
+              <systemProperties>
+                <!-- We don't care if there are any JNAs -->
+                <jna.nosys>true</jna.nosys>
+              </systemProperties>
             </environment>
             <environment>
               <id>equinox</id>
               <framework>equinox</framework>
-              <timeout>150000</timeout> <!-- 15000ms = 15s -->
+              <timeout>15000</timeout> <!-- = 15s -->
+              <systemProperties>
+                <jna.nosys>true</jna.nosys>
+              </systemProperties>
             </environment>
           </environments>
         </configuration>

--- a/jena-osgi/pom.xml
+++ b/jena-osgi/pom.xml
@@ -123,36 +123,21 @@
       <artifactId>httpcore-osgi</artifactId>
       <version>${ver.httpcore}</version> 
       <exclusions>
-	<exclusion>
-	  <groupId>org.apache.httpcomponents</groupId>
-	  <artifactId>httpcore</artifactId>
-	</exclusion>
-	<exclusion>
-	  <groupId>org.apache.httpcomponents</groupId>
-	  <artifactId>httpcore-nio</artifactId>
-	</exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore-nio</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
+
     <dependency>
       <groupId>com.github.jsonld-java</groupId>
       <artifactId>jsonld-java</artifactId>
     </dependency>
-    <!--
-      but until jsonld-java 0.5.1, we'll need to depend on jackson-databind
-      and jackson-core ourselves as bundles:
-    
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>${ver.jackson}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${ver.jackson}</version>
-    </dependency>
-    -->
-
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>


### PR DESCRIPTION
From email thread [Jena OSGi pull request](http://mail-archives.apache.org/mod_mbox/jena-dev/201502.mbox/%3C54CE2655.20006%40apache.org%3E)

jsonld comments in pom, submodules under apache-jena-osgi, millioseconds, and only build jena-osgi-test on -Papache-release.

In addition a rat-plugin configuratoin in parent was modified as it didn't exclude all in target/