### PR TITLE
rat: exlude anything under target/*

### DIFF
--- a/jena-parent/pom.xml
+++ b/jena-parent/pom.xml
@@ -453,7 +453,7 @@
 	       <exclude>**/*.classpath</exclude>
 
 	       <!-- Exclude anything created during the build (plugin generated files) ->-->
-	       <exclude>**/target/.plxarc</exclude>
+         <exclude>**/target/**/*</exclude>
 
             </excludes>
         </configuration>


### PR DESCRIPTION
.. as it only excluded `target/.plxarc`