### PR TITLE
Quieter jena-osgi-test logging

### DIFF
--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -39,8 +39,8 @@ limitations under the License.
     <pax.logging.version>1.8.1</pax.logging.version>
   </properties>
 
-  <dependencies>
 
+  <dependencies>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-osgi</artifactId>
@@ -62,7 +62,19 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
 
-    <!-- needed to get a org.slf4j bundle for PAX -->
+    <!-- needed to get a org.slf4j bundle for PAX 
+    NOTE: As we also inherit slf4j-log4j from jena-parent, we will get this
+    warning at startup:
+
+SLF4J: Class path contains multiple SLF4J bindings.
+SLF4J: Found binding in [jar:file:/home/stain/.m2/repository/org/ops4j/pax/logging/pax-logging-api/1.8.1/pax-logging-api-1.8.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+SLF4J: Found binding in [jar:file:/home/stain/.m2/repository/org/slf4j/slf4j-log4j12/1.7.6/slf4j-log4j12-1.7.6.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
+SLF4J: Actual binding is of type [org.ops4j.pax.logging.slf4j.Slf4jLoggerFactory]
+
+    As long as the actual binding is the org.ops4j binding, this can be ignored.
+
+    -->
     <dependency>
       <groupId>org.ops4j.pax.logging</groupId>
       <artifactId>pax-logging-log4j2</artifactId>
@@ -74,6 +86,7 @@ limitations under the License.
       <groupId>org.ops4j.pax.logging</groupId>
       <artifactId>pax-logging-api</artifactId>
       <version>${pax.logging.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -130,7 +143,7 @@ limitations under the License.
           <systemPropertyVariables>
             <!-- So the test can find the current version of jena-osgi -->
             <jena-osgi.version>${project.version}</jena-osgi.version>
-            <!-- not so noisy logging -->
+            <!-- not so noisy OSGi logging -->
             <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
           </systemPropertyVariables>
         </configuration>

--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -17,7 +17,7 @@ limitations under the License.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.jena</groupId>
@@ -123,29 +123,29 @@ limitations under the License.
   <build>
     <plugins>
       <plugin>
-	<groupId>org.apache.felix</groupId>
-	<artifactId>maven-bundle-plugin</artifactId>
-	<extensions>true</extensions>
-	<configuration>
-	  <instructions>
-	    <!-- <Import-Package>com.hp.hpl.jena</Import-Package> -->
-	    <!-- <Embed-Dependency>artifactId=jena-core;inline=true</Embed-Dependency> -->
-	  </instructions>
-	</configuration>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <!-- <Import-Package>com.hp.hpl.jena</Import-Package> -->
+            <!-- <Embed-Dependency>artifactId=jena-core;inline=true</Embed-Dependency> -->
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
-	<groupId>org.ops4j.pax.exam</groupId>
-	<artifactId>exam-maven-plugin</artifactId>
-	<version>${pax.exam.version}</version>
-	<executions>
-	  <execution>
-	    <id>generate-link-files</id>
-	    <goals>
-	      <goal>generate-link-files</goal>
-	    </goals>
-	    <phase>generate-test-resources</phase>
-	  </execution>
-	</executions>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>exam-maven-plugin</artifactId>
+        <version>${pax.exam.version}</version>
+        <executions>
+          <execution>
+            <id>generate-link-files</id>
+            <goals>
+              <goal>generate-link-files</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -63,25 +63,14 @@ limitations under the License.
     </dependency>
 
     <!-- needed to get a org.slf4j bundle for PAX 
-    NOTE: As we also inherit slf4j-log4j from jena-parent, we will get this
-    warning at startup:
-
-SLF4J: Class path contains multiple SLF4J bindings.
-SLF4J: Found binding in [jar:file:/home/stain/.m2/repository/org/ops4j/pax/logging/pax-logging-api/1.8.1/pax-logging-api-1.8.1.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-SLF4J: Found binding in [jar:file:/home/stain/.m2/repository/org/slf4j/slf4j-log4j12/1.7.6/slf4j-log4j12-1.7.6.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
-SLF4J: Actual binding is of type [org.ops4j.pax.logging.slf4j.Slf4jLoggerFactory]
-
-    As long as the actual binding is the org.ops4j binding, this can be ignored.
-
-    -->
+         as we exclude slf4j-log4j due to 
+         "Fragment bundle" warning -->
     <dependency>
       <groupId>org.ops4j.pax.logging</groupId>
       <artifactId>pax-logging-log4j2</artifactId>
       <version>${pax.logging.version}</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.ops4j.pax.logging</groupId>
       <artifactId>pax-logging-api</artifactId>
@@ -140,6 +129,9 @@ SLF4J: Actual binding is of type [org.ops4j.pax.logging.slf4j.Slf4jLoggerFactory
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>org.slf4j:slf4j-log4j12</classpathDependencyExclude>
+          </classpathDependencyExcludes>
           <systemPropertyVariables>
             <!-- So the test can find the current version of jena-osgi -->
             <jena-osgi.version>${project.version}</jena-osgi.version>

--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -62,6 +62,7 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
 
+    <!-- needed to get a org.slf4j bundle for PAX -->
     <dependency>
       <groupId>org.ops4j.pax.logging</groupId>
       <artifactId>pax-logging-log4j2</artifactId>
@@ -123,17 +124,24 @@ limitations under the License.
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <instructions>
-            <!-- <Import-Package>com.hp.hpl.jena</Import-Package> -->
-            <!-- <Embed-Dependency>artifactId=jena-core;inline=true</Embed-Dependency> -->
-          </instructions>
+          <systemPropertyVariables>
+            <!-- So the test can find the current version of jena-osgi -->
+            <jena-osgi.version>${project.version}</jena-osgi.version>
+            <!-- not so noisy logging -->
+            <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <!-- generate target/pax-exam-links -->
         <groupId>org.ops4j.pax.exam</groupId>
         <artifactId>exam-maven-plugin</artifactId>
         <version>${pax.exam.version}</version>

--- a/apache-jena-osgi/jena-osgi-test/src/test/java/org/apache/jena/osgi/test/JenaOSGITest.java
+++ b/apache-jena-osgi/jena-osgi-test/src/test/java/org/apache/jena/osgi/test/JenaOSGITest.java
@@ -80,25 +80,15 @@ public class JenaOSGITest {
 	@Configuration
 	public Option[] config() {
 		return options(
-//				bootDelegationPackages("sun.*", 
-//						"com.sun.*",
-//						"java.*",
-//						"javax.*",
-//						"javax.net.ssl"),
-						// In PAX we have to list transitive dependencies
-						// manually. See ../jena-osgi/pom.xml 
-						// for dependencies that are NOT in <scope>provided</scope>
-						// (luckily the version numbers are picked up!)
-				//  Error starting bundle slf4j.log4j12. Fragment bundles can not be started.
-				//linkBundle("slf4j.log4j12"),
-				//linkBundle("slf4j.api"),
-				// Not sure if this is a Felix problem or what..
-				// Instead we'll use:
+        // bundle with org.slf4j implementation
 				linkBundle("org.ops4j.pax.logging.pax-logging-log4j2"),
 				linkBundle("org.ops4j.pax.logging.pax-logging-api"),
 
-				
-				mavenBundle("org.apache.jena", "jena-osgi"),
+        // jena-osgi
+				mavenBundle("org.apache.jena", "jena-osgi", 
+          System.getProperty("jena-osgi.version", "LATEST")),
+
+        // dependencies of jena-osgi
 				linkBundle("org.apache.httpcomponents.httpclient"),
 				linkBundle("org.apache.httpcomponents.httpcore"),
 				linkBundle("com.github.jsonld-java"),


### PR DESCRIPTION
.. by setting system property
now the only noise is because of duplicate slf4j binding, as slf4j-log4j is inherited from Jena parent.

Also fixes the missing `LATEST` version for jena-osgi