### PR TITLE
Jena osgi integration test

### DIFF
--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -160,6 +160,48 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <!-- delay test compilation until pre-integration-test phase -->
+            <id>default-testCompile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <phase>pre-integration-test</phase>
+          </execution>
+        </executions>
+        <configuration>
+        </configuration>
+
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>org.slf4j:slf4j-log4j12</classpathDependencyExclude>
+          </classpathDependencyExcludes>
+          <systemPropertyVariables>
+            <!-- So the test can find the current version of jena-osgi -->
+            <jena-osgi.version>${project.version}</jena-osgi.version>
+            <!-- not so noisy OSGi logging -->
+            <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <!-- delay until integration-test phase -->
+            <phase>integration-test</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
 
   <artifactId>jena-osgi-test</artifactId>
   <version>2.13.0-SNAPSHOT</version>
-  <name>Apache Jena - OSGi bundle tests</name>
+  <name>Apache Jena - OSGi integration tests</name>
   <description>Tests for jena-osgi as a bundle</description>
   <packaging>bundle</packaging>
 


### PR DESCRIPTION
Only compile+run jena-osgi-test in `mvn install` - ignore in `mvn test`.

Note that with #28 this will also work with `mvn verify`.