### PR TITLE
JENA-878: Explicit imports of org.apache.xerces.impl.dv

### DIFF
--- a/jena-core/src/main/java/com/hp/hpl/jena/datatypes/xsd/XSDDatatype.java
+++ b/jena-core/src/main/java/com/hp/hpl/jena/datatypes/xsd/XSDDatatype.java
@@ -18,34 +18,53 @@
 
 package com.hp.hpl.jena.datatypes.xsd;
 
-import java.io.Reader ;
-import java.math.BigDecimal ;
-import java.math.BigInteger ;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.URI;
-import java.util.ArrayList ;
-import java.util.List ;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.apache.xerces.impl.dv.* ;
-import org.apache.xerces.impl.dv.util.Base64 ;
-import org.apache.xerces.impl.dv.util.HexBin ;
-import org.apache.xerces.impl.dv.xs.DecimalDV ;
-import org.apache.xerces.impl.dv.xs.XSSimpleTypeDecl ;
-import org.apache.xerces.impl.validation.ValidationState ;
-import org.apache.xerces.parsers.XMLGrammarPreparser ;
-import org.apache.xerces.util.SymbolHash ;
-import org.apache.xerces.xni.grammars.XMLGrammarDescription ;
-import org.apache.xerces.xni.grammars.XSGrammar ;
-import org.apache.xerces.xni.parser.XMLInputSource ;
-import org.apache.xerces.xs.XSConstants ;
-import org.apache.xerces.xs.XSNamedMap ;
-import org.apache.xerces.xs.XSTypeDefinition ;
+import org.apache.xerces.impl.dv.InvalidDatatypeValueException;
+import org.apache.xerces.impl.dv.SchemaDVFactory;
+import org.apache.xerces.impl.dv.ValidatedInfo;
+import org.apache.xerces.impl.dv.ValidationContext;
+import org.apache.xerces.impl.dv.XSSimpleType;
+import org.apache.xerces.impl.dv.util.Base64;
+import org.apache.xerces.impl.dv.util.HexBin;
+import org.apache.xerces.impl.dv.xs.DecimalDV;
+import org.apache.xerces.impl.dv.xs.XSSimpleTypeDecl;
+import org.apache.xerces.impl.validation.ValidationState;
+import org.apache.xerces.parsers.XMLGrammarPreparser;
+import org.apache.xerces.util.SymbolHash;
+import org.apache.xerces.xni.grammars.XMLGrammarDescription;
+import org.apache.xerces.xni.grammars.XSGrammar;
+import org.apache.xerces.xni.parser.XMLInputSource;
+import org.apache.xerces.xs.XSConstants;
+import org.apache.xerces.xs.XSNamedMap;
+import org.apache.xerces.xs.XSTypeDefinition;
 
-import com.hp.hpl.jena.datatypes.BaseDatatype ;
-import com.hp.hpl.jena.datatypes.DatatypeFormatException ;
-import com.hp.hpl.jena.datatypes.RDFDatatype ;
-import com.hp.hpl.jena.datatypes.TypeMapper ;
-import com.hp.hpl.jena.datatypes.xsd.impl.* ;
-import com.hp.hpl.jena.graph.impl.LiteralLabel ;
+import com.hp.hpl.jena.datatypes.BaseDatatype;
+import com.hp.hpl.jena.datatypes.DatatypeFormatException;
+import com.hp.hpl.jena.datatypes.RDFDatatype;
+import com.hp.hpl.jena.datatypes.TypeMapper;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDBaseNumericType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDBaseStringType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDByteType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDDateTimeType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDDateType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDDayType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDDouble;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDDurationType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDFloat;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDGenericType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDMonthDayType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDMonthType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDPlainType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDTimeType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDYearMonthType;
+import com.hp.hpl.jena.datatypes.xsd.impl.XSDYearType;
+import com.hp.hpl.jena.graph.impl.LiteralLabel;
 
 /**
  * Representation of an XSD datatype based on the Xerces-2


### PR DESCRIPTION
.. by doing Organize Imports in Eclipse.

not that it solves JENA-878, but at least we would know
more explicitly which org.apache.xerces.impl classes
we depend on.