### PR TITLE
Workaround Maven 3.0.2 bug for jena-osgi

### DIFF
--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -155,7 +155,6 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
       </plugin>
       <plugin>
         <!-- generate target/pax-exam-links -->

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -223,7 +223,6 @@
             <Import-Package>!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,*</Import-Package>
           </instructions>
         </configuration>
-        <extensions>true</extensions>
       </plugin>
     </plugins>
   </build>

--- a/jena-parent/pom.xml
+++ b/jena-parent/pom.xml
@@ -458,6 +458,11 @@
             </excludes>
         </configuration>
       </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <extensions>true</extensions>
+        </plugin>
     </plugins>
 
     <!-- Plugin version list: http://maven.apache.org/plugins/index.html -->


### PR DESCRIPTION
If using Maven 3.0.2, gets rid of error

    org.apache.maven.plugins.enforcer.RequirePluginVersions
    >> failed with message:
    >> [ERROR] Cannot find lifecycle mapping for packaging: 'bundle'.

This was caused by multi-module build where the `<extensions>` from `maven-bundle-plugin` got loaded too late. Note that this bug was not present in newer and older Mavens  - probably bug [MNG-4973](https://jira.codehaus.org/browse/MNG-4973)


See email thread 
http://mail-archives.apache.org/mod_mbox/jena-dev/201502.mbox/%3CD1124C6A.45FC3%25rvesse%40dotnetrdf.org%3E