### PR TITLE
JENA-865: Include prefixes in example query

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/src/main/webapp/js/app/qonsole-config.js
+++ b/jena-fuseki2/jena-fuseki-core/src/main/webapp/js/app/qonsole-config.js
@@ -10,16 +10,17 @@ define( [], function() {
     },
     queries: [
       { "name": "Selection of triples",
-        "query": "SELECT ?subject ?predicate ?object\nwhere {\n" +
+        "query": "SELECT ?subject ?predicate ?object\nWHERE {\n" +
                  "  ?subject ?predicate ?object\n}\n" +
                  "LIMIT 25"
       },
       { "name": "Selection of classes",
-        "query": "SELECT distinct ?class ?label ?description\nwhere {\n" +
+        "query": "SELECT DISTINCT ?class ?label ?description\nWHERE {\n" +
                  "  ?class a owl:Class.\n" +
                  "  OPTIONAL { ?class rdfs:label ?label}\n" +
                  "  OPTIONAL { ?class rdfs:comment ?description}\n}\n" +
-                 "LIMIT 25"
+                 "LIMIT 25",
+        "prefixes": ["owl", "rdfs"]
       }
     ]
   };


### PR DESCRIPTION
Fixes JENA-865 by explicitly requiring `owl` and `rdfs` prefixes.

Also SPARQL keywords now in consistent CAPS style.