### PR TITLE
JENA-732 jena-maven-tools outputs to target/generated-sources/jena

### DIFF
--- a/jena-maven-tools/README
+++ b/jena-maven-tools/README
@@ -15,7 +15,7 @@ Changes
 
 Version 0.8
   * Output folder is now by default target/generated-sources/jena
-    Use <output> to override.
+    Use <outputDirectory> to override.
   * Generated Java source files are also compiled by Maven
 
 Version 0.4

--- a/jena-maven-tools/README
+++ b/jena-maven-tools/README
@@ -13,6 +13,11 @@ Available plugins:
 
 Changes
 
+Version 0.8
+  * Output folder is now by default target/generated-sources/jena
+    Use <output> to override.
+  * Generated Java source files are also compiled by Maven
+
 Version 0.4
 
   * Moved source code from org.openjena package tree to org.apache.jena

--- a/jena-maven-tools/src/it/schemagen-integration-0/verify.bsh
+++ b/jena-maven-tools/src/it/schemagen-integration-0/verify.bsh
@@ -25,6 +25,6 @@ if (!testDir.exists()) {
 
 Verifier verifier = new Verifier( testDir.getAbsolutePath() );
 
-String test1 = verifier.getBasedir() + "/target/generated-sources/Test1.java";
+String test1 = verifier.getBasedir() + "/target/generated-sources/jena/Test1.java";
 // note that ?s modifier makes . pattern match newlines
 verifier.assertFileMatches(  test1, "(?s).*public static final Resource Cls.*" );

--- a/jena-maven-tools/src/it/schemagen-integration-0/verify.bsh
+++ b/jena-maven-tools/src/it/schemagen-integration-0/verify.bsh
@@ -28,3 +28,7 @@ Verifier verifier = new Verifier( testDir.getAbsolutePath() );
 String test1 = verifier.getBasedir() + "/target/generated-sources/jena/Test1.java";
 // note that ?s modifier makes . pattern match newlines
 verifier.assertFileMatches(  test1, "(?s).*public static final Resource Cls.*" );
+
+// should also be compiled
+String test2 = verifier.getBasedir() + "/target/classes/Test1.class";
+verifier.assertFilePresent(test2);

--- a/jena-maven-tools/src/it/schemagen-integration-1/verify.bsh
+++ b/jena-maven-tools/src/it/schemagen-integration-1/verify.bsh
@@ -24,6 +24,6 @@ if (!testDir.exists()) {
 }
 Verifier verifier = new Verifier( testDir.getAbsolutePath() );
 
-String test1 = verifier.getBasedir() + "/target/generated-sources/org/example/test/Test1.java";
+String test1 = verifier.getBasedir() + "/target/generated-sources/jena/org/example/test/Test1.java";
 // no package specified, so output is just in generated-sources
 verifier.assertFileMatches( test1, "(?s).*package org.example.test.*public static final Resource Cls.*" );

--- a/jena-maven-tools/src/it/schemagen-integration-1/verify.bsh
+++ b/jena-maven-tools/src/it/schemagen-integration-1/verify.bsh
@@ -27,3 +27,6 @@ Verifier verifier = new Verifier( testDir.getAbsolutePath() );
 String test1 = verifier.getBasedir() + "/target/generated-sources/jena/org/example/test/Test1.java";
 // no package specified, so output is just in generated-sources
 verifier.assertFileMatches( test1, "(?s).*package org.example.test.*public static final Resource Cls.*" );
+
+String test2 = verifier.getBasedir() + "/target/classes/org/example/test/Test1.class";
+verifier.assertFilePresent(test2);

--- a/jena-maven-tools/src/it/schemagen-integration-2/verify.bsh
+++ b/jena-maven-tools/src/it/schemagen-integration-2/verify.bsh
@@ -27,3 +27,9 @@ Verifier verifier = new Verifier( testDir.getAbsolutePath() );
 String test1 = verifier.getBasedir() + "/target/alt-source-dir/org/example/test/Test1.java";
 // output directory specified, so check the output is there
 verifier.assertFileMatches( test1, "(?s).*package org.example.test.*public static final Resource Cls.*" );
+
+// NOT present as <source> was overriden
+// TODO: ... is this what is expected?
+String test2 = verifier.getBasedir() + "/target/classes/org/example/test/Test1.class";
+verifier.assertFileNotPresent(test2);
+

--- a/jena-maven-tools/src/it/schemagen-integration-3/verify.bsh
+++ b/jena-maven-tools/src/it/schemagen-integration-3/verify.bsh
@@ -30,3 +30,9 @@ verifier.assertFileMatches( test1, "(?s).*package org.example.test.*public stati
 
 String test2 = verifier.getBasedir() + "/target/generated-sources/jena/org/example/test/Test2.java";
 verifier.assertFileMatches( test2, "(?s).*package org.example.test.*public static final OntClass Cls2.*" );
+
+String test3 = verifier.getBasedir() + "/target/classes/org/example/test/Test1.class";
+verifier.assertFilePresent(test3);
+
+String test4 = verifier.getBasedir() + "/target/classes/org/example/test/Test2.class";
+verifier.assertFilePresent(test4);

--- a/jena-maven-tools/src/it/schemagen-integration-3/verify.bsh
+++ b/jena-maven-tools/src/it/schemagen-integration-3/verify.bsh
@@ -25,8 +25,8 @@ if (!testDir.exists()) {
 Verifier verifier = new Verifier( testDir.getAbsolutePath() );
 
 // Test2.java should use the Ont API, Test1.java should not
-String test1 = verifier.getBasedir() + "/target/generated-sources/org/example/test/Test1.java";
+String test1 = verifier.getBasedir() + "/target/generated-sources/jena/org/example/test/Test1.java";
 verifier.assertFileMatches( test1, "(?s).*package org.example.test.*public static final Resource Cls.*" );
 
-String test2 = verifier.getBasedir() + "/target/generated-sources/org/example/test/Test2.java";
+String test2 = verifier.getBasedir() + "/target/generated-sources/jena/org/example/test/Test2.java";
 verifier.assertFileMatches( test2, "(?s).*package org.example.test.*public static final OntClass Cls2.*" );

--- a/jena-maven-tools/src/it/schemagen-integration-4/pom.xml
+++ b/jena-maven-tools/src/it/schemagen-integration-4/pom.xml
@@ -1,0 +1,62 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.openjena.tools</groupId>
+  <artifactId>schemagen-test</artifactId>
+  <version>@project.version@</version>
+  <packaging>jar</packaging>
+  <name>schemagen-test</name>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-maven-tools</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <outputDirectory>${project.build.directory}/custom</outputDirectory>
+          <includes>
+            <include>src/main/vocabs/*.ttl</include>
+          </includes>
+          <fileOptions>
+            <source>
+              <input>default</input>
+              <package-name>org.example.test</package-name>
+            </source>
+          </fileOptions>
+        </configuration>
+        <executions>
+          <execution>
+            <id>schemagen</id>
+            <goals>
+              <goal>translate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-core</artifactId>
+      <version>@jenaCoreVersion@</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/jena-maven-tools/src/it/schemagen-integration-4/src/main/vocabs/test1.ttl
+++ b/jena-maven-tools/src/it/schemagen-integration-4/src/main/vocabs/test1.ttl
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+@prefix rdf:                <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:               <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:                <http://www.w3.org/2002/07/owl#> .
+@prefix skos:               <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd:                <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:                 <http://example.org/test#>.
+
+<http://example.org/test>
+  a owl:Ontology.
+
+ex:Cls a owl:Class.
+
+

--- a/jena-maven-tools/src/it/schemagen-integration-4/verify.bsh
+++ b/jena-maven-tools/src/it/schemagen-integration-4/verify.bsh
@@ -18,18 +18,14 @@
 
 import org.apache.maven.it.Verifier;
 
-File testDir = new File("target/it/schemagen-integration-2");
+File testDir = new File("target/it/schemagen-integration-4");
 if (!testDir.exists()) {
     testDir = new File( "jena-maven-tools/" + testDir.getPath() );
 }
 Verifier verifier = new Verifier( testDir.getAbsolutePath() );
 
-String test1 = verifier.getBasedir() + "/target/alt-source-dir/org/example/test/Test1.java";
-// output directory specified, so check the output is there
+String test1 = verifier.getBasedir() + "/target/custom/org/example/test/Test1.java";
 verifier.assertFileMatches( test1, "(?s).*package org.example.test.*public static final Resource Cls.*" );
 
-// NOT present as <source> was overriden for this particular file
-// and <outputDirectory> was not set
 String test2 = verifier.getBasedir() + "/target/classes/org/example/test/Test1.class";
-verifier.assertFileNotPresent(test2);
-
+verifier.assertFilePresent(test2);

--- a/jena-maven-tools/src/main/java/org/apache/jena/tools/schemagen/SchemagenMojo.java
+++ b/jena-maven-tools/src/main/java/org/apache/jena/tools/schemagen/SchemagenMojo.java
@@ -39,9 +39,11 @@ import jena.schemagen.SchemagenOptions.OPT;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.DirectoryScanner;
 
 import com.hp.hpl.jena.rdf.model.Resource;
@@ -61,9 +63,6 @@ public class SchemagenMojo
     /* Constants                       */
     /***********************************/
 
-    /** Default output location */
-    public static final String GENERATED_SOURCES = File.separator + "generated-sources";
-
     /** Default pattern for includes */
 
     /** Name of default options element */
@@ -77,13 +76,8 @@ public class SchemagenMojo
     /* Instance variables              */
     /***********************************/
 
-    /**
-     * @parameter property="project.build.directory"
-     */
-
-    @Parameter(property="project.build.directory")
-    private String projectBuildDir;
-
+    @Parameter(defaultValue = "${project.build.directory}/generated-sources/jena")
+    private String outputDirectory;
 
     /**
      * Array of file patterns to include in processing
@@ -109,11 +103,17 @@ public class SchemagenMojo
     @Parameter(property="basedir")
     private File baseDir;
 
+    @Component
+    private MavenProject project;
+
     /** The default options object, if any */
     private SchemagenOptions defaultOptions;
 
     /** Map of source options, indexed by name */
     private Map<String, SchemagenOptions> optIndex = new HashMap<>();
+
+    public SchemagenMojo() {
+    }
 
     /***********************************/
     /* Constructors                    */
@@ -150,6 +150,7 @@ public class SchemagenMojo
             for (String fileName: matchFileNames()) {
                 processFile( fileName );
             }
+            project.addCompileSourceRoot( new File( outputDirectory ).getAbsolutePath() );
         } catch (SchemagenOptionsConfigurationException e) {
             throw new MojoExecutionException(
                     "Error during default schemagen options creation", e);
@@ -191,12 +192,7 @@ public class SchemagenMojo
         return defaultOptions;
     }
 
-    /** Return the value of <code>${project.build.directory}</code> */
-    public String getProjectBuildDir() {
-        return projectBuildDir;
-    }
-
-    /**
+      /**
      * Handle the default options by creating a default options object and assigning
      * the options values from the given source object.
      * @param defOptionsSource The source object containing the default options
@@ -350,7 +346,7 @@ public class SchemagenMojo
     }
 
     protected String getDefaultOutputDir(){
-        return projectBuildDir + GENERATED_SOURCES;
+        return outputDirectory;
     }
 
     /***********************************/


### PR DESCRIPTION
fixes JENA-731 and JENA-732

This reverts the reverted commit by Benson Margulies so that generated sources are put in `target/generated-sources/jena` according to Maven plugin conventions, instead of straight into `target/generated-sources`.  (JENA-732)

This also solves JENA-731 so that the source files are also compiled by Maven. I've therefore added tests to `src/it` to test for presence of the `*.class` files 

.. except for where `<sources>` configuration has been overridden as in [schemagen-integration-2](https://github.com/stain/jena/blob/JENA-732-reborn/jena-maven-tools/src/it/schemagen-integration-2/verify.bsh#L31) - but should it perhaps also add those sources to the compile path? Other plugins like jaxb-maven-plugin usually do..
