### PR TITLE
JENA-897 Override java.io.tmpdir to write to target/

### DIFF
--- a/jena-jdbc/jena-jdbc-driver-tdb/pom.xml
+++ b/jena-jdbc/jena-jdbc-driver-tdb/pom.xml
@@ -77,6 +77,9 @@
 				<version>2.14</version>
 				<configuration>
 					<argLine>-Xmx2G</argLine>
+					<systemProperties>
+						<java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+					</systemProperties>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
.. instead of /tmp or %TEMP%

Fixes JENA-897 (although it still needs > 35 GB of disk space on Windows)