### PR TITLE
jena-text updates for constructing documents suitable for conjunctive queries

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
@@ -142,6 +142,7 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
      */
     @Override
     public void commit() {
+    	super.getMonitor().finish() ;
         // Phase 1
         if (readWriteMode.get() == ReadWrite.WRITE) {
             try {
@@ -167,7 +168,6 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
             throw new TextIndexException(t);
         }
         readWriteMode.set(null);
-        super.getMonitor().finish() ;
     }
 
     @Override

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndex.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndex.java
@@ -36,6 +36,7 @@ public interface TextIndex extends Closeable //, Transactional
     
     // Update operations
     void addEntity(Entity entity) ;
+    void updateEntity(Entity entity) ;
     
     
     // read operations

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
@@ -38,6 +38,7 @@ import org.apache.lucene.index.DirectoryReader ;
 import org.apache.lucene.index.IndexReader ;
 import org.apache.lucene.index.IndexWriter ;
 import org.apache.lucene.index.IndexWriterConfig ;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.ParseException ;
 import org.apache.lucene.queryparser.classic.QueryParser ;
 import org.apache.lucene.queryparser.classic.QueryParserBase ;
@@ -186,6 +187,18 @@ public class TextIndexLucene implements TextIndex {
         }
         catch (IOException ex) {
             throw new TextIndexException(ex) ;
+        }
+    }
+    
+    @Override public void updateEntity(Entity entity) {
+        if ( log.isDebugEnabled() )
+            log.debug("Update entity: " + entity) ;
+        try {
+        	Document doc = doc(entity);
+        	Term term = new Term(docDef.getEntityField(), entity.getId());
+        	indexWriter.updateDocument(	term, doc);
+        } catch (IOException e) {
+            throw new TextIndexException(e) ;
         }
     }
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexSolr.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexSolr.java
@@ -53,6 +53,11 @@ public class TextIndexSolr implements TextIndex
         this.solrServer = server ;
         this.docDef = def ;
     }
+
+	@Override
+	public void updateEntity(Entity entity) {
+		throw new RuntimeException("TextIndexSolr.updateEntity not implemented.");
+	}
     
     @Override
     public void prepareCommit() { }

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
@@ -23,6 +23,7 @@ import org.apache.jena.query.text.TextDocProducer ;
 import org.apache.jena.query.text.TextIndex ;
 import org.apache.jena.query.text.TextIndexLucene ;
 import org.apache.jena.query.text.TextQuery ;
+import org.junit.Ignore;
 import org.junit.Test ;
 
 import com.hp.hpl.jena.assembler.Assembler ;
@@ -30,6 +31,7 @@ import com.hp.hpl.jena.assembler.exceptions.AssemblerException ;
 import com.hp.hpl.jena.graph.Node ;
 import com.hp.hpl.jena.query.Dataset ;
 import com.hp.hpl.jena.rdf.model.Resource ;
+import com.hp.hpl.jena.sparql.core.DatasetGraph;
 import com.hp.hpl.jena.sparql.core.QuadAction ;
 import com.hp.hpl.jena.tdb.assembler.AssemblerTDB ;
 import com.hp.hpl.jena.vocabulary.RDF ;
@@ -47,6 +49,7 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
 	private static final Resource noDatasetPropertySpec;
 	private static final Resource noIndexPropertySpec;
 	private static final Resource customTextDocProducerSpec;
+	private static final Resource customDyadicTextDocProducerSpec;
 	
 	@Test
 	public void testSimpleDatasetAssembler() {
@@ -69,6 +72,15 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
 	    Dataset dataset = (Dataset)Assembler.general.open(customTextDocProducerSpec) ;
 	    DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
         assertTrue(dsgText.getMonitor() instanceof CustomTextDocProducer) ;
+        dataset.close();
+	}
+	
+	@Test
+	public void testCustomTextDocProducerDyadicConstructor() {
+	    Dataset dataset = (Dataset)Assembler.general.open(customDyadicTextDocProducerSpec) ;
+	    DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
+        assertTrue(dsgText.getMonitor() instanceof CustomDyadicTextDocProducer) ;
+        dataset.close();
 	}
 	
 	static {
@@ -94,11 +106,33 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
                      .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
                      .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomTextDocProducer"));
 		
+		customDyadicTextDocProducerSpec =
+                model.createResource(TESTBASE + "customDyadicTextDocProducerSpec")
+                     .addProperty(RDF.type, TextVocab.textDataset)
+                     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
+                     .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomDyadicTextDocProducer"));
+		
 	}
 	
 	private static class CustomTextDocProducer implements TextDocProducer {
 	    
 	    public CustomTextDocProducer(TextIndex textIndex) { }
+
+        @Override
+        public void start() { }
+
+        @Override
+        public void finish() { }
+
+        @Override
+        public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { }
+	}
+	
+	
+	private static class CustomDyadicTextDocProducer implements TextDocProducer {
+	    
+	    public CustomDyadicTextDocProducer(DatasetGraph dg, TextIndex textIndex) { }
 
         @Override
         public void start() { }


### PR DESCRIPTION
This change to jena-text allows TextDocumentProducers
to access the dataset they are monitoring, and to
create indexes where there is a single (Lucene) document
for a given subject and all its defined properties
rather than a separate document per triple that the
subject appears in.

This allows indexes to be used for conjunctive query
eg a request such as

	city: Plymouth AND street: Station

See https://github.com/epimorphics/ppd-text-index for an
an example project that uses conjunctive queries and 
provides a bulk index creation utility.

The changes to jena-text are spread over six files as follows:

# jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java 

The two-phase commit protocol is modified to ensure that a
DatasetChanges monitor finishes() before the commit protocol
starts. It is possible for a DatasetChanges to have buffered-up
changes which have not yet been applied; applying these
changes mid-commit can cause errors.

[This problem was detected in https://github.com/epimorphics/ppd-text-index
where TextDocProducerBatch does have buffered state and closing
the DatasetGraphText threw an exception when the state was flushed.]

A test for this behaviour is not currently available.

# jena-text/src/main/java/org/apache/jena/query/text/TextIndex.java 

Added the abstract method updateEntity, contracted with addEntity().
Updating an index with updateEntity is intended to discard any
existing Document with the entity key and create a new one with
all and only the fields specified by the given Entity, as opposed
to addEntity which creates a new Document from the Entity even if
one with that key already exists.

This allows Documents suitable for conjunctive query to
be created. The project 

# jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java 

Implement updateEntity for a TextIndexLucene.

# jena-text/src/main/java/org/apache/jena/query/text/TextIndexSolr.java 

Placeholder for implementation of TextIndexLucene.updateEntity; at the
moment we do not support it.

# jena-text/src/main/java/org/apache/jena/query/text/assembler/TextDatasetAssembler.java 

The DatasetAssembler may construct a non-default TextDocProducer to
feed to the TextDatasetFactory, passing in to the constructor the
TextIndex that the TextDocProducer uses. This change additionally
allows for a two-argument constructor taking the DatasetGraph as
well as the TextIndex as arguments.

The TextDocProducer can use this to query the dataset for triples.
(EG other triples with the same subject as one it has received, so
as to build all the properties into a single Document.)

#  jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java 

Changes to have a test that the two-argument constructor is called
when appropriate.

