### PR TITLE
Test that TextDocProducer with buffered state has opportunity to flush before dataset commits.

### DIFF
--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
@@ -44,124 +44,124 @@ import com.hp.hpl.jena.vocabulary.RDF ;
  */
 public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
 
-    private static final String TESTBASE = "http://example.org/testDatasetAssembler/";
+	private static final String TESTBASE = "http://example.org/testDatasetAssembler/";
 
-    private static final Resource spec1;
-    private static final Resource noDatasetPropertySpec;
-    private static final Resource noIndexPropertySpec;
-    private static final Resource customTextDocProducerSpec;
-    private static final Resource customDyadicTextDocProducerSpec;
+	private static final Resource spec1;
+	private static final Resource noDatasetPropertySpec;
+	private static final Resource noIndexPropertySpec;
+	private static final Resource customTextDocProducerSpec;
+	private static final Resource customDyadicTextDocProducerSpec;
 
-    @Test
-    public void testSimpleDatasetAssembler() {
-        Dataset dataset = (Dataset) Assembler.general.open(spec1);
-        assertTrue(dataset.getContext().get(TextQuery.textIndex) instanceof TextIndexLucene);
-    }
+	@Test
+	public void testSimpleDatasetAssembler() {
+		Dataset dataset = (Dataset) Assembler.general.open(spec1);
+		assertTrue(dataset.getContext().get(TextQuery.textIndex) instanceof TextIndexLucene);
+	}
 
-    @Test(expected = AssemblerException.class)
-    public void testErrorOnNoDataset() {
-        Assembler.general.open(noDatasetPropertySpec);
-    }
+	@Test(expected = AssemblerException.class)
+	public void testErrorOnNoDataset() {
+	    Assembler.general.open(noDatasetPropertySpec);
+	}
 
-    @Test(expected = AssemblerException.class)
-    public void testErrorOnNoIndex() {
-        Assembler.general.open(noIndexPropertySpec);
-    }
+	@Test(expected = AssemblerException.class)
+	public void testErrorOnNoIndex() {
+	    Assembler.general.open(noIndexPropertySpec);
+	}
 
-    @Test
-    public void testCustomTextDocProducer() {
-        Dataset dataset = (Dataset)Assembler.general.open(customTextDocProducerSpec) ;
-        DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
-    assertTrue(dsgText.getMonitor() instanceof CustomTextDocProducer) ;
-    dataset.close();
-    }
+	@Test
+	public void testCustomTextDocProducer() {
+	    Dataset dataset = (Dataset)Assembler.general.open(customTextDocProducerSpec) ;
+	    DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
+	assertTrue(dsgText.getMonitor() instanceof CustomTextDocProducer) ;
+	dataset.close();
+	}
 
-    @Test
-    public void testCustomTextDocProducerDyadicConstructor() {
-        Dataset dataset = (Dataset)Assembler.general.open(customDyadicTextDocProducerSpec) ;
-        DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
-    assertTrue(dsgText.getMonitor() instanceof CustomDyadicTextDocProducer) ;
-    
-    Node G= NodeFactory.createURI("http://example.com/G");
-    Node S = NodeFactory.createURI("http://example.com/S");
-    Node P = NodeFactory.createURI("http://example.com/P");
-    Node O = NodeFactory.createLiteral("http://example.com/O");
-    
-    dsgText.begin(ReadWrite.WRITE);
-    dsgText.add(G, S, P, O);
-    dsgText.commit();
-    dataset.close();
-    }
+	@Test
+	public void testCustomTextDocProducerDyadicConstructor() {
+	    Dataset dataset = (Dataset)Assembler.general.open(customDyadicTextDocProducerSpec) ;
+	    DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
+	assertTrue(dsgText.getMonitor() instanceof CustomDyadicTextDocProducer) ;
+	
+	Node G= NodeFactory.createURI("http://example.com/G");
+	Node S = NodeFactory.createURI("http://example.com/S");
+	Node P = NodeFactory.createURI("http://example.com/P");
+	Node O = NodeFactory.createLiteral("http://example.com/O");
+	
+	dsgText.begin(ReadWrite.WRITE);
+	dsgText.add(G, S, P, O);
+	dsgText.commit();
+	dataset.close();
+	}
 
-    static {
-        TextAssembler.init();
-        AssemblerTDB.init();
-        spec1 =
-                model.createResource(TESTBASE + "spec1")
-                     .addProperty(RDF.type, TextVocab.textDataset)
-                     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC3);
-        noDatasetPropertySpec =
-                model.createResource(TESTBASE + "noDatasetPropertySpec")
-                     .addProperty(RDF.type, TextVocab.textDataset)
-                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC4);
-        noIndexPropertySpec =
-                model.createResource(TESTBASE + "noIndexPropertySpec")
-                     .addProperty(RDF.type, TextVocab.textDataset)
-                     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC);
-        customTextDocProducerSpec =
-        model.createResource(TESTBASE + "customTextDocProducerSpec")
-             .addProperty(RDF.type, TextVocab.textDataset)
-             .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-             .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
-             .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomTextDocProducer"));
+	static {
+		TextAssembler.init();
+		AssemblerTDB.init();
+		spec1 =
+				model.createResource(TESTBASE + "spec1")
+				     .addProperty(RDF.type, TextVocab.textDataset)
+				     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+				     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC3);
+		noDatasetPropertySpec =
+				model.createResource(TESTBASE + "noDatasetPropertySpec")
+				     .addProperty(RDF.type, TextVocab.textDataset)
+				     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC4);
+		noIndexPropertySpec =
+				model.createResource(TESTBASE + "noIndexPropertySpec")
+				     .addProperty(RDF.type, TextVocab.textDataset)
+				     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC);
+		customTextDocProducerSpec =
+		model.createResource(TESTBASE + "customTextDocProducerSpec")
+		     .addProperty(RDF.type, TextVocab.textDataset)
+		     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+		     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
+		     .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomTextDocProducer"));
 
-        customDyadicTextDocProducerSpec =
-        model.createResource(TESTBASE + "customDyadicTextDocProducerSpec")
-             .addProperty(RDF.type, TextVocab.textDataset)
-             .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-             .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
-             .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomDyadicTextDocProducer"));
+		customDyadicTextDocProducerSpec =
+		model.createResource(TESTBASE + "customDyadicTextDocProducerSpec")
+		     .addProperty(RDF.type, TextVocab.textDataset)
+		     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+		     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
+		     .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomDyadicTextDocProducer"));
 
-    }
+	}
 
-    private static class CustomTextDocProducer implements TextDocProducer {
-        
-        public CustomTextDocProducer(TextIndex textIndex) { }
+	private static class CustomTextDocProducer implements TextDocProducer {
+	    
+	    public CustomTextDocProducer(TextIndex textIndex) { }
 
-    @Override
-    public void start() { }
+	@Override
+	public void start() { }
 
-    @Override
-    public void finish() { }
+	@Override
+	public void finish() { }
 
-    @Override
-    public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { }
-    }
+	@Override
+	public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { }
+	}
 
 
-    private static class CustomDyadicTextDocProducer implements TextDocProducer {
-        
-        final DatasetGraph dg;
-        Node lastSubject = null;
+	private static class CustomDyadicTextDocProducer implements TextDocProducer {
+	    
+		final DatasetGraph dg;
+		Node lastSubject = null;
 
-        public CustomDyadicTextDocProducer(DatasetGraph dg, TextIndex textIndex) { 
-            this.dg = dg;
-        }
+		public CustomDyadicTextDocProducer(DatasetGraph dg, TextIndex textIndex) { 
+			this.dg = dg;
+		}
 
-    @Override
-    public void start() { }
+	@Override
+	public void start() { }
 
-    @Override
-    public void finish() { 
-        Iterator<Quad> qi = dg.find(null, lastSubject, Node.ANY, Node.ANY);
-        while (qi.hasNext()) qi.next();
-    }
+	@Override
+	public void finish() { 
+		Iterator<Quad> qi = dg.find(null, lastSubject, Node.ANY, Node.ANY);
+		while (qi.hasNext()) qi.next();
+	}
 
-    @Override
-    public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { 
-        lastSubject = s;
-    }
-    }
+	@Override
+	public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { 
+		lastSubject = s;
+	}
+	}
 
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
@@ -19,99 +19,115 @@
 package org.apache.jena.query.text.assembler;
 
 import static org.junit.Assert.assertTrue ;
+
+import java.util.Iterator;
+
 import org.apache.jena.query.text.* ;
 import org.junit.Test ;
 
 import com.hp.hpl.jena.assembler.Assembler ;
 import com.hp.hpl.jena.assembler.exceptions.AssemblerException ;
 import com.hp.hpl.jena.graph.Node ;
+import com.hp.hpl.jena.graph.NodeFactory;
 import com.hp.hpl.jena.query.Dataset ;
+import com.hp.hpl.jena.query.ReadWrite;
 import com.hp.hpl.jena.rdf.model.Resource ;
 import com.hp.hpl.jena.sparql.core.DatasetGraph ;
+import com.hp.hpl.jena.sparql.core.Quad;
 import com.hp.hpl.jena.sparql.core.QuadAction ;
 import com.hp.hpl.jena.tdb.assembler.AssemblerTDB ;
 import com.hp.hpl.jena.vocabulary.RDF ;
+
 
 /**
  * Test the text dataset assembler.
  */
 public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
-	
-	private static final String TESTBASE = "http://example.org/testDatasetAssembler/";
-	
-	private static final Resource spec1;
-	private static final Resource noDatasetPropertySpec;
-	private static final Resource noIndexPropertySpec;
-	private static final Resource customTextDocProducerSpec;
-	private static final Resource customDyadicTextDocProducerSpec;
-	
-	@Test
-	public void testSimpleDatasetAssembler() {
-		Dataset dataset = (Dataset) Assembler.general.open(spec1);
-		assertTrue(dataset.getContext().get(TextQuery.textIndex) instanceof TextIndexLucene);
-	}
-	
-	@Test(expected = AssemblerException.class)
-	public void testErrorOnNoDataset() {
-	    Assembler.general.open(noDatasetPropertySpec);
-	}
-	
-	@Test(expected = AssemblerException.class)
-	public void testErrorOnNoIndex() {
-	    Assembler.general.open(noIndexPropertySpec);
-	}
-	
-	@Test
-	public void testCustomTextDocProducer() {
-	    Dataset dataset = (Dataset)Assembler.general.open(customTextDocProducerSpec) ;
-	    DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
+
+        private static final String TESTBASE = "http://example.org/testDatasetAssembler/";
+
+        private static final Resource spec1;
+        private static final Resource noDatasetPropertySpec;
+        private static final Resource noIndexPropertySpec;
+        private static final Resource customTextDocProducerSpec;
+        private static final Resource customDyadicTextDocProducerSpec;
+
+        @Test
+        public void testSimpleDatasetAssembler() {
+                Dataset dataset = (Dataset) Assembler.general.open(spec1);
+                assertTrue(dataset.getContext().get(TextQuery.textIndex) instanceof TextIndexLucene);
+        }
+
+        @Test(expected = AssemblerException.class)
+        public void testErrorOnNoDataset() {
+            Assembler.general.open(noDatasetPropertySpec);
+        }
+
+        @Test(expected = AssemblerException.class)
+        public void testErrorOnNoIndex() {
+            Assembler.general.open(noIndexPropertySpec);
+        }
+
+        @Test
+        public void testCustomTextDocProducer() {
+            Dataset dataset = (Dataset)Assembler.general.open(customTextDocProducerSpec) ;
+            DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
         assertTrue(dsgText.getMonitor() instanceof CustomTextDocProducer) ;
         dataset.close();
-	}
-	
-	@Test
-	public void testCustomTextDocProducerDyadicConstructor() {
-	    Dataset dataset = (Dataset)Assembler.general.open(customDyadicTextDocProducerSpec) ;
-	    DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
+        }
+
+        @Test
+        public void testCustomTextDocProducerDyadicConstructor() {
+            Dataset dataset = (Dataset)Assembler.general.open(customDyadicTextDocProducerSpec) ;
+            DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
         assertTrue(dsgText.getMonitor() instanceof CustomDyadicTextDocProducer) ;
+        
+        Node G= NodeFactory.createURI("http://example.com/G");
+        Node S = NodeFactory.createURI("http://example.com/S");
+        Node P = NodeFactory.createURI("http://example.com/P");
+        Node O = NodeFactory.createLiteral("http://example.com/O");
+        
+        dsgText.begin(ReadWrite.WRITE);
+        dsgText.add(G, S, P, O);
+        dsgText.commit();
         dataset.close();
-	}
-	
-	static {
-		TextAssembler.init();
-		AssemblerTDB.init();
-		spec1 =
-				model.createResource(TESTBASE + "spec1")
-				     .addProperty(RDF.type, TextVocab.textDataset)
-				     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-				     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC3);
-		noDatasetPropertySpec =
-				model.createResource(TESTBASE + "noDatasetPropertySpec")
-				     .addProperty(RDF.type, TextVocab.textDataset)
-				     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC4);
-		noIndexPropertySpec =
-				model.createResource(TESTBASE + "noIndexPropertySpec")
-				     .addProperty(RDF.type, TextVocab.textDataset)
-				     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC);
-		customTextDocProducerSpec =
+        }
+
+        static {
+                TextAssembler.init();
+                AssemblerTDB.init();
+                spec1 =
+                                model.createResource(TESTBASE + "spec1")
+                                     .addProperty(RDF.type, TextVocab.textDataset)
+                                     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+                                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC3);
+                noDatasetPropertySpec =
+                                model.createResource(TESTBASE + "noDatasetPropertySpec")
+                                     .addProperty(RDF.type, TextVocab.textDataset)
+                                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC4);
+                noIndexPropertySpec =
+                                model.createResource(TESTBASE + "noIndexPropertySpec")
+                                     .addProperty(RDF.type, TextVocab.textDataset)
+                                     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC);
+                customTextDocProducerSpec =
                 model.createResource(TESTBASE + "customTextDocProducerSpec")
                      .addProperty(RDF.type, TextVocab.textDataset)
                      .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
                      .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
                      .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomTextDocProducer"));
-		
-		customDyadicTextDocProducerSpec =
+
+                customDyadicTextDocProducerSpec =
                 model.createResource(TESTBASE + "customDyadicTextDocProducerSpec")
                      .addProperty(RDF.type, TextVocab.textDataset)
                      .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
                      .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
                      .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomDyadicTextDocProducer"));
-		
-	}
-	
-	private static class CustomTextDocProducer implements TextDocProducer {
-	    
-	    public CustomTextDocProducer(TextIndex textIndex) { }
+
+        }
+
+        private static class CustomTextDocProducer implements TextDocProducer {
+            
+            public CustomTextDocProducer(TextIndex textIndex) { }
 
         @Override
         public void start() { }
@@ -121,21 +137,31 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
 
         @Override
         public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { }
-	}
-	
-	
-	private static class CustomDyadicTextDocProducer implements TextDocProducer {
-	    
-	    public CustomDyadicTextDocProducer(DatasetGraph dg, TextIndex textIndex) { }
+        }
+
+
+        private static class CustomDyadicTextDocProducer implements TextDocProducer {
+            
+                final DatasetGraph dg;
+                Node lastSubject = null;
+
+                public CustomDyadicTextDocProducer(DatasetGraph dg, TextIndex textIndex) { 
+                        this.dg = dg;
+                }
 
         @Override
         public void start() { }
 
         @Override
-        public void finish() { }
+        public void finish() { 
+                Iterator<Quad> qi = dg.find(null, lastSubject, Node.ANY, Node.ANY);
+                while (qi.hasNext()) qi.next();
+        }
 
         @Override
-        public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { }
-	}
+        public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { 
+                lastSubject = s;
+        }
+        }
 
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
@@ -44,124 +44,124 @@ import com.hp.hpl.jena.vocabulary.RDF ;
  */
 public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
 
-        private static final String TESTBASE = "http://example.org/testDatasetAssembler/";
+    private static final String TESTBASE = "http://example.org/testDatasetAssembler/";
 
-        private static final Resource spec1;
-        private static final Resource noDatasetPropertySpec;
-        private static final Resource noIndexPropertySpec;
-        private static final Resource customTextDocProducerSpec;
-        private static final Resource customDyadicTextDocProducerSpec;
+    private static final Resource spec1;
+    private static final Resource noDatasetPropertySpec;
+    private static final Resource noIndexPropertySpec;
+    private static final Resource customTextDocProducerSpec;
+    private static final Resource customDyadicTextDocProducerSpec;
 
-        @Test
-        public void testSimpleDatasetAssembler() {
-                Dataset dataset = (Dataset) Assembler.general.open(spec1);
-                assertTrue(dataset.getContext().get(TextQuery.textIndex) instanceof TextIndexLucene);
-        }
+    @Test
+    public void testSimpleDatasetAssembler() {
+        Dataset dataset = (Dataset) Assembler.general.open(spec1);
+        assertTrue(dataset.getContext().get(TextQuery.textIndex) instanceof TextIndexLucene);
+    }
 
-        @Test(expected = AssemblerException.class)
-        public void testErrorOnNoDataset() {
-            Assembler.general.open(noDatasetPropertySpec);
-        }
+    @Test(expected = AssemblerException.class)
+    public void testErrorOnNoDataset() {
+        Assembler.general.open(noDatasetPropertySpec);
+    }
 
-        @Test(expected = AssemblerException.class)
-        public void testErrorOnNoIndex() {
-            Assembler.general.open(noIndexPropertySpec);
-        }
+    @Test(expected = AssemblerException.class)
+    public void testErrorOnNoIndex() {
+        Assembler.general.open(noIndexPropertySpec);
+    }
 
-        @Test
-        public void testCustomTextDocProducer() {
-            Dataset dataset = (Dataset)Assembler.general.open(customTextDocProducerSpec) ;
-            DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
-        assertTrue(dsgText.getMonitor() instanceof CustomTextDocProducer) ;
-        dataset.close();
-        }
+    @Test
+    public void testCustomTextDocProducer() {
+        Dataset dataset = (Dataset)Assembler.general.open(customTextDocProducerSpec) ;
+        DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
+    assertTrue(dsgText.getMonitor() instanceof CustomTextDocProducer) ;
+    dataset.close();
+    }
 
-        @Test
-        public void testCustomTextDocProducerDyadicConstructor() {
-            Dataset dataset = (Dataset)Assembler.general.open(customDyadicTextDocProducerSpec) ;
-            DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
-        assertTrue(dsgText.getMonitor() instanceof CustomDyadicTextDocProducer) ;
-        
-        Node G= NodeFactory.createURI("http://example.com/G");
-        Node S = NodeFactory.createURI("http://example.com/S");
-        Node P = NodeFactory.createURI("http://example.com/P");
-        Node O = NodeFactory.createLiteral("http://example.com/O");
-        
-        dsgText.begin(ReadWrite.WRITE);
-        dsgText.add(G, S, P, O);
-        dsgText.commit();
-        dataset.close();
-        }
+    @Test
+    public void testCustomTextDocProducerDyadicConstructor() {
+        Dataset dataset = (Dataset)Assembler.general.open(customDyadicTextDocProducerSpec) ;
+        DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
+    assertTrue(dsgText.getMonitor() instanceof CustomDyadicTextDocProducer) ;
+    
+    Node G= NodeFactory.createURI("http://example.com/G");
+    Node S = NodeFactory.createURI("http://example.com/S");
+    Node P = NodeFactory.createURI("http://example.com/P");
+    Node O = NodeFactory.createLiteral("http://example.com/O");
+    
+    dsgText.begin(ReadWrite.WRITE);
+    dsgText.add(G, S, P, O);
+    dsgText.commit();
+    dataset.close();
+    }
 
-        static {
-                TextAssembler.init();
-                AssemblerTDB.init();
-                spec1 =
-                                model.createResource(TESTBASE + "spec1")
-                                     .addProperty(RDF.type, TextVocab.textDataset)
-                                     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-                                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC3);
-                noDatasetPropertySpec =
-                                model.createResource(TESTBASE + "noDatasetPropertySpec")
-                                     .addProperty(RDF.type, TextVocab.textDataset)
-                                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC4);
-                noIndexPropertySpec =
-                                model.createResource(TESTBASE + "noIndexPropertySpec")
-                                     .addProperty(RDF.type, TextVocab.textDataset)
-                                     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC);
-                customTextDocProducerSpec =
-                model.createResource(TESTBASE + "customTextDocProducerSpec")
+    static {
+        TextAssembler.init();
+        AssemblerTDB.init();
+        spec1 =
+                model.createResource(TESTBASE + "spec1")
                      .addProperty(RDF.type, TextVocab.textDataset)
                      .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
-                     .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomTextDocProducer"));
-
-                customDyadicTextDocProducerSpec =
-                model.createResource(TESTBASE + "customDyadicTextDocProducerSpec")
+                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC3);
+        noDatasetPropertySpec =
+                model.createResource(TESTBASE + "noDatasetPropertySpec")
                      .addProperty(RDF.type, TextVocab.textDataset)
-                     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
-                     .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomDyadicTextDocProducer"));
+                     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC4);
+        noIndexPropertySpec =
+                model.createResource(TESTBASE + "noIndexPropertySpec")
+                     .addProperty(RDF.type, TextVocab.textDataset)
+                     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC);
+        customTextDocProducerSpec =
+        model.createResource(TESTBASE + "customTextDocProducerSpec")
+             .addProperty(RDF.type, TextVocab.textDataset)
+             .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+             .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
+             .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomTextDocProducer"));
 
+        customDyadicTextDocProducerSpec =
+        model.createResource(TESTBASE + "customDyadicTextDocProducerSpec")
+             .addProperty(RDF.type, TextVocab.textDataset)
+             .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+             .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
+             .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomDyadicTextDocProducer"));
+
+    }
+
+    private static class CustomTextDocProducer implements TextDocProducer {
+        
+        public CustomTextDocProducer(TextIndex textIndex) { }
+
+    @Override
+    public void start() { }
+
+    @Override
+    public void finish() { }
+
+    @Override
+    public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { }
+    }
+
+
+    private static class CustomDyadicTextDocProducer implements TextDocProducer {
+        
+        final DatasetGraph dg;
+        Node lastSubject = null;
+
+        public CustomDyadicTextDocProducer(DatasetGraph dg, TextIndex textIndex) { 
+            this.dg = dg;
         }
 
-        private static class CustomTextDocProducer implements TextDocProducer {
-            
-            public CustomTextDocProducer(TextIndex textIndex) { }
+    @Override
+    public void start() { }
 
-        @Override
-        public void start() { }
+    @Override
+    public void finish() { 
+        Iterator<Quad> qi = dg.find(null, lastSubject, Node.ANY, Node.ANY);
+        while (qi.hasNext()) qi.next();
+    }
 
-        @Override
-        public void finish() { }
-
-        @Override
-        public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { }
-        }
-
-
-        private static class CustomDyadicTextDocProducer implements TextDocProducer {
-            
-                final DatasetGraph dg;
-                Node lastSubject = null;
-
-                public CustomDyadicTextDocProducer(DatasetGraph dg, TextIndex textIndex) { 
-                        this.dg = dg;
-                }
-
-        @Override
-        public void start() { }
-
-        @Override
-        public void finish() { 
-                Iterator<Quad> qi = dg.find(null, lastSubject, Node.ANY, Node.ANY);
-                while (qi.hasNext()) qi.next();
-        }
-
-        @Override
-        public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { 
-                lastSubject = s;
-        }
-        }
+    @Override
+    public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { 
+        lastSubject = s;
+    }
+    }
 
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
@@ -60,83 +60,82 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
 
 	@Test(expected = AssemblerException.class)
 	public void testErrorOnNoDataset() {
-	    Assembler.general.open(noDatasetPropertySpec);
+		Assembler.general.open(noDatasetPropertySpec);
 	}
 
 	@Test(expected = AssemblerException.class)
 	public void testErrorOnNoIndex() {
-	    Assembler.general.open(noIndexPropertySpec);
+		Assembler.general.open(noIndexPropertySpec);
 	}
 
 	@Test
 	public void testCustomTextDocProducer() {
-	    Dataset dataset = (Dataset)Assembler.general.open(customTextDocProducerSpec) ;
-	    DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
-	assertTrue(dsgText.getMonitor() instanceof CustomTextDocProducer) ;
-	dataset.close();
+		Dataset dataset = (Dataset)Assembler.general.open(customTextDocProducerSpec) ;
+		DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
+		assertTrue(dsgText.getMonitor() instanceof CustomTextDocProducer) ;
+		dataset.close();
 	}
 
 	@Test
 	public void testCustomTextDocProducerDyadicConstructor() {
-	    Dataset dataset = (Dataset)Assembler.general.open(customDyadicTextDocProducerSpec) ;
-	    DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
-	assertTrue(dsgText.getMonitor() instanceof CustomDyadicTextDocProducer) ;
+		Dataset dataset = (Dataset)Assembler.general.open(customDyadicTextDocProducerSpec) ;
+		DatasetGraphText dsgText = (DatasetGraphText)dataset.asDatasetGraph() ;
+		assertTrue(dsgText.getMonitor() instanceof CustomDyadicTextDocProducer) ;
 	
-	Node G= NodeFactory.createURI("http://example.com/G");
-	Node S = NodeFactory.createURI("http://example.com/S");
-	Node P = NodeFactory.createURI("http://example.com/P");
-	Node O = NodeFactory.createLiteral("http://example.com/O");
+		Node G= NodeFactory.createURI("http://example.com/G");
+		Node S = NodeFactory.createURI("http://example.com/S");
+		Node P = NodeFactory.createURI("http://example.com/P");
+		Node O = NodeFactory.createLiteral("http://example.com/O");
 	
-	dsgText.begin(ReadWrite.WRITE);
-	dsgText.add(G, S, P, O);
-	dsgText.commit();
-	dataset.close();
+		dsgText.begin(ReadWrite.WRITE);
+		dsgText.add(G, S, P, O);
+		dsgText.commit();
+		dataset.close();
 	}
 
 	static {
 		TextAssembler.init();
 		AssemblerTDB.init();
 		spec1 =
-				model.createResource(TESTBASE + "spec1")
-				     .addProperty(RDF.type, TextVocab.textDataset)
-				     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-				     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC3);
+			model.createResource(TESTBASE + "spec1")
+			     .addProperty(RDF.type, TextVocab.textDataset)
+			     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+			     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC3);
 		noDatasetPropertySpec =
-				model.createResource(TESTBASE + "noDatasetPropertySpec")
-				     .addProperty(RDF.type, TextVocab.textDataset)
-				     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC4);
+			model.createResource(TESTBASE + "noDatasetPropertySpec")
+			     .addProperty(RDF.type, TextVocab.textDataset)
+			     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC4);
 		noIndexPropertySpec =
-				model.createResource(TESTBASE + "noIndexPropertySpec")
-				     .addProperty(RDF.type, TextVocab.textDataset)
-				     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC);
+			model.createResource(TESTBASE + "noIndexPropertySpec")
+			     .addProperty(RDF.type, TextVocab.textDataset)
+			     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC);
 		customTextDocProducerSpec =
-		model.createResource(TESTBASE + "customTextDocProducerSpec")
-		     .addProperty(RDF.type, TextVocab.textDataset)
-		     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-		     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
-		     .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomTextDocProducer"));
+			model.createResource(TESTBASE + "customTextDocProducerSpec")
+		    	.addProperty(RDF.type, TextVocab.textDataset)
+		    	.addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+		    	.addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
+		    	.addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomTextDocProducer"));
 
 		customDyadicTextDocProducerSpec =
-		model.createResource(TESTBASE + "customDyadicTextDocProducerSpec")
-		     .addProperty(RDF.type, TextVocab.textDataset)
-		     .addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
-		     .addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
-		     .addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomDyadicTextDocProducer"));
-
+			model.createResource(TESTBASE + "customDyadicTextDocProducerSpec")
+				.addProperty(RDF.type, TextVocab.textDataset)
+				.addProperty(TextVocab.pDataset, SIMPLE_DATASET_SPEC)
+				.addProperty(TextVocab.pIndex, SIMPLE_INDEX_SPEC5)
+				.addProperty(TextVocab.pTextDocProducer, model.createResource("java:org.apache.jena.query.text.assembler.TestTextDatasetAssembler$CustomDyadicTextDocProducer"));
 	}
 
 	private static class CustomTextDocProducer implements TextDocProducer {
 	    
-	    public CustomTextDocProducer(TextIndex textIndex) { }
+		public CustomTextDocProducer(TextIndex textIndex) { }
 
-	@Override
-	public void start() { }
+		@Override
+		public void start() { }
 
-	@Override
-	public void finish() { }
+		@Override
+		public void finish() { }
 
-	@Override
-	public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { }
+		@Override
+		public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { }
 	}
 
 
@@ -149,19 +148,19 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
 			this.dg = dg;
 		}
 
-	@Override
-	public void start() { }
+		@Override
+		public void start() { }
 
-	@Override
-	public void finish() { 
-		Iterator<Quad> qi = dg.find(null, lastSubject, Node.ANY, Node.ANY);
-		while (qi.hasNext()) qi.next();
-	}
+		@Override
+		public void finish() { 
+			Iterator<Quad> qi = dg.find(null, lastSubject, Node.ANY, Node.ANY);
+			while (qi.hasNext()) qi.next();
+		}
 
-	@Override
-	public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { 
-		lastSubject = s;
-	}
+		@Override
+		public void change(QuadAction qaction, Node g, Node s, Node p, Node o) { 
+			lastSubject = s;
+		}
 	}
 
 }


### PR DESCRIPTION
When a TextDatasetGraph commits, it finish()es the attached TextDocProducer. If that producer
has buffered state whose flushing may read/write the quads of the dataset, this must happen
before the two-phase commit protocol runs. Pull Request #42 arranged that this was true.
This Pull Request adds a test to TestTextDatasetAssembler which opens, writes, and commits
to a dataset with a TextDocProducer which does a quad add to the dataset, without the commit
failing.

(To see the failure this protects against, edit TextDatasetGraph's commit method to call the
monitor's finish() method at the end of the commit() rather than the beginning.) 

[Sorry, there's a bunch of tab/space layout noise in the diffs; it's much easier to track with ?w=1]