### PR TITLE
JENA-901 Use Guava for cache, shadowed in jena-core

### DIFF
--- a/jena-core/pom.xml
+++ b/jena-core/pom.xml
@@ -61,6 +61,22 @@
       <artifactId>xercesImpl</artifactId>
     </dependency>
 
+    <dependency>
+
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <!-- Version number specified explicitly and not in jena-parent, 
+           as it should only be used here, and further shadowing/bundle/NOTICE
+           consideration might be needed on upgrade. -->
+      <version>18.0</version>
+      <!--
+        As Guava does not contain a NOTICE and is also 
+        licensed under Apache License, no additional
+        NOTICE is required by us. In a way we should probably
+        NOT include our own NOTICE file in this JAR..
+      -->
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -145,7 +161,7 @@
           <windowtitle>Apache Jena</windowtitle>
           <doctitle>Apache Jena Core ${project.version}</doctitle>
           <bottom>Licenced under the Apache License, Version 2.0</bottom>
-          <excludePackageNames>com.hp.hpl.jena.shared.*:*.impl:com.hp.hpl.jena.assembler.assemblers:*.exceptions:*.regexptrees:com.hp.hpl.jena.mem:com.hp.hpl.jena.mem.*:com.hp.hpl.jena.n3:com.hp.hpl.jena.n3.*:com.hp.hpl.jena.rdf.arp.*:com.hp.hpl.jena.util.*:jena.cmdline:jena.util</excludePackageNames>
+          <excludePackageNames>com.hp.hpl.jena.shared.*:*.impl:com.hp.hpl.jena.assembler.assemblers:*.exceptions:*.regexptrees:com.hp.hpl.jena.mem:com.hp.hpl.jena.mem.*:com.hp.hpl.jena.n3:com.hp.hpl.jena.n3.*:com.hp.hpl.jena.rdf.arp.*:com.hp.hpl.jena.util.*:jena.cmdline:jena.util:org.apache.jena.impl.ext.*</excludePackageNames>
           <groups>
             <group>
               <title>API - Application Programming Interface</title>
@@ -197,7 +213,47 @@
         </executions>
       </plugin>
       -->
+
+      <plugin>
+
+        <!--
+    This module shadows some external libraries like Guava, 
+    which we don't want to be depending on in their regular
+    package names, as they are likely to change/upgrade
+    externally and also be used in other libraries 
+    in potentially conflicting versions.
+
+    This module uses the Shade plugin to re-package them
+    under the package name
+    org.apache.jena.ext, which should 
+    only be used by used by other Jena modules.
+    -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <artifactSet>
+            <includes>
+              <artifact>com.google.guava:guava</artifact>
+            </includes>
+          </artifactSet>
+          <relocations>
+            <relocation>
+              <pattern>com.google</pattern>
+              <shadedPattern>org.apache.jena.ext.impl.com.google</shadedPattern>
+            </relocation>
+          </relocations>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
+
 
 </project>

--- a/jena-core/src/test/java/com/hp/hpl/jena/reasoner/rulesys/impl/TestLPBRuleEngine.java
+++ b/jena-core/src/test/java/com/hp/hpl/jena/reasoner/rulesys/impl/TestLPBRuleEngine.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package com.hp.hpl.jena.reasoner.rulesys.impl;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+import org.junit.Test;
+
+import com.hp.hpl.jena.graph.Factory;
+import com.hp.hpl.jena.graph.Graph;
+import com.hp.hpl.jena.graph.Node;
+import com.hp.hpl.jena.graph.NodeFactory;
+import com.hp.hpl.jena.graph.Triple;
+import com.hp.hpl.jena.reasoner.rulesys.FBRuleInfGraph;
+import com.hp.hpl.jena.reasoner.rulesys.FBRuleReasoner;
+import com.hp.hpl.jena.reasoner.rulesys.Rule;
+import com.hp.hpl.jena.util.iterator.ExtendedIterator;
+import com.hp.hpl.jena.vocabulary.RDF;
+import com.hp.hpl.jena.vocabulary.RDFS;
+
+public class TestLPBRuleEngine extends TestCase {
+	public static TestSuite suite() {
+		return new TestSuite(TestLPBRuleEngine.class, "TestLPBRuleEngine");
+	}
+
+	protected Node a = NodeFactory.createURI("a");
+	protected Node p = NodeFactory.createURI("p");
+	protected Node C1 = NodeFactory.createURI("C1");
+	protected Node C2 = NodeFactory.createURI("C2");
+	protected Node ty = RDF.Nodes.type;
+
+	public FBRuleReasoner createReasoner(List<Rule> rules) {
+		FBRuleReasoner reasoner = new FBRuleReasoner(rules);
+		reasoner.tablePredicate(RDFS.Nodes.subClassOf);
+		reasoner.tablePredicate(RDF.Nodes.type);
+		reasoner.tablePredicate(p);
+		return reasoner;
+	}
+
+	@Test
+	public void testTabledGoalsCacheHits() throws Exception {
+		Graph data = Factory.createGraphMem();
+		data.add(new Triple(a, ty, C1));
+		List<Rule> rules = Rule
+				.parseRules("[r1:  (?x p ?t) <- (?x rdf:type C1), makeInstance(?x, p, C2, ?t)]"
+						+ "[r2:  (?t rdf:type C2) <- (?x rdf:type C1), makeInstance(?x, p, C2, ?t)]");
+
+		FBRuleInfGraph infgraph = (FBRuleInfGraph) createReasoner(rules).bind(
+				data);
+
+		LPBRuleEngine engine = getEngineForGraph(infgraph);
+		assertEquals(0, engine.activeInterpreters.size());
+		assertEquals(0, engine.tabledGoals.size());
+
+		ExtendedIterator<Triple> it = infgraph.find(a, ty, C1);
+		while (it.hasNext()) {
+			it.next();
+			// FIXME: Why do I need to consume all from the iterator
+			// to avoid leaking activeInterpreters? Calling .close()
+			// below should have been enough.
+		}
+		it.close();
+		// how many were cached
+		assertEquals(1, engine.tabledGoals.size());
+		// and no leaks of activeInterpreters
+		assertEquals(0, engine.activeInterpreters.size());
+
+		// Now ask again:
+		it = infgraph.find(a, ty, C1);
+		while (it.hasNext()) {
+			it.next();
+		}
+		it.close();
+		// if it was a cache hit, no change here:
+		assertEquals(1, engine.tabledGoals.size());
+		assertEquals(0, engine.activeInterpreters.size());
+	}
+
+	@Test
+	public void testSaturateTabledGoals() throws Exception {
+		final int MAX = 1024;
+		// Set the cache size very small just for this test
+		System.setProperty("jena.rulesys.lp.max_cached_tabled_goals", "" + MAX);
+		try {
+			Graph data = Factory.createGraphMem();
+			data.add(new Triple(a, ty, C1));
+			List<Rule> rules = Rule
+					.parseRules("[r1:  (?x p ?t) <- (?x rdf:type C1), makeInstance(?x, p, C2, ?t)]"
+							+ "[r2:  (?t rdf:type C2) <- (?x rdf:type C1), makeInstance(?x, p, C2, ?t)]");
+
+			FBRuleInfGraph infgraph = (FBRuleInfGraph) createReasoner(rules)
+					.bind(data);
+
+			LPBRuleEngine engine = getEngineForGraph(infgraph);
+			assertEquals(0, engine.activeInterpreters.size());
+			assertEquals(0, engine.tabledGoals.size());
+
+			// JENA-901
+			// Let's ask about lots of unknown subjects
+			for (int i = 0; i < MAX * 128; i++) {
+				Node test = NodeFactory.createURI("test" + i);
+				ExtendedIterator<Triple> it = infgraph.find(test, ty, C2);
+				assertFalse(it.hasNext());
+				it.close();
+			}
+
+			// Let's see how many were cached
+			assertEquals(MAX, engine.tabledGoals.size());
+			// and no leaks of activeInterpreters (this will happen if we forget
+			// to call hasNext above)
+			assertEquals(0, engine.activeInterpreters.size());
+		} finally {
+			System.clearProperty("jena.rulesys.lp.max_cached_tabled_goals");
+
+		}
+	}
+
+	/**
+	 * Use introspection to get to the LPBRuleEngine.
+	 * <p>
+	 * We are crossing package boundaries and therefore this test would always
+	 * be in the wrong package for either FBRuleInfGraph or LPBRuleEngine.
+	 * <p>
+	 * <strong>This method should only be used for test purposes.</strong>
+	 * 
+	 * @param infgraph
+	 * @return
+	 * @throws SecurityException
+	 * @throws NoSuchFieldException
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 */
+	private LPBRuleEngine getEngineForGraph(FBRuleInfGraph infgraph)
+			throws NoSuchFieldException, SecurityException,
+			IllegalArgumentException, IllegalAccessException {
+		Field bEngine = FBRuleInfGraph.class.getDeclaredField("bEngine");
+		bEngine.setAccessible(true);
+		LPBRuleEngine engine = (LPBRuleEngine) bEngine.get(infgraph);
+		return engine;
+	}
+
+}

--- a/jena-core/src/test/java/com/hp/hpl/jena/reasoner/rulesys/test/TestPackage.java
+++ b/jena-core/src/test/java/com/hp/hpl/jena/reasoner/rulesys/test/TestPackage.java
@@ -20,8 +20,11 @@ package com.hp.hpl.jena.reasoner.rulesys.test;
 
 
 import junit.framework.TestSuite ;
+
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
+
+import com.hp.hpl.jena.reasoner.rulesys.impl.TestLPBRuleEngine;
 
 /**
  * Aggregate tester that runs all the test associated with the rulesys package.
@@ -45,6 +48,7 @@ public class TestPackage extends TestSuite {
         addTest( "TestBackchainer", TestBackchainer.suite() );
         addTest( "TestLPBasics", TestBasicLP.suite() );
         addTest( "TestLPDerivation", TestLPDerivation.suite() );
+        addTest( TestLPBRuleEngine.suite() );
         addTest( "TestFBRules", TestFBRules.suite() );
         addTest( "TestGenericRules", TestGenericRules.suite() );
         addTest( "TestRETE", TestRETE.suite() );

--- a/jena-parent/pom.xml
+++ b/jena-parent/pom.xml
@@ -665,6 +665,11 @@
           <version>2.5.3</version>
           <extensions>true</extensions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>2.3</version>
+        </plugin>
 
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
In comparison with #47, this shadows Guava directly in `jena-core` without introducing `jena-shadowed-ext`. 

This is thus acceptable as a patch-version update - but at the downside that `jena-core` have to do

    import com.google.common.cache.Cache

directly - while all other Jena modules would have to use 

    import org.apache.jena.impl.ext.com.google.common.cache.Cache

as it is shadowed with the JAR. This will cause problems in the other modules in an Eclipse-like environment, as the IDE will re-expose com.google version if `jena-core` is open - and they would then seemingly not be able to find the `oaj.impl.ext.*` version as that only exist in the Maven-built JAR.

In this scenario, it would probably be cleaner for the other modules to also shadow guava - in addition to the space-wastage, this probably becomes a bit awkward - it also means you can't pass any Guava structures between Jena modules. 

One advantage however is that if they all shadow individually, then they can shadow with the [minimizeJar](https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#minimizeJar) option to only get the few Guava classes used (e.g. in jena-core only the Cache).