### PR TITLE
Re-enable jena-osgi-tests

### DIFF
--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -137,6 +137,8 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <!-- re-enable extensions here for older Mavens -->
+        <extensions>true</extensions>
       </plugin>
       <plugin>
         <!-- generate target/pax-exam-links -->
@@ -184,6 +186,8 @@ limitations under the License.
             <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
           </systemPropertyVariables>
         </configuration>
+        <!-- Explicit execution to run in a phase after the OSGi bundle
+             has been created -->
         <executions>
           <execution>
             <id>default-test</id>

--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -134,23 +134,6 @@ limitations under the License.
 
   <build>
     <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <classpathDependencyExcludes>
-            <classpathDependencyExclude>org.slf4j:slf4j-log4j12</classpathDependencyExclude>
-          </classpathDependencyExcludes>
-          <systemPropertyVariables>
-            <!-- So the test can find the current version of jena-osgi -->
-            <jena-osgi.version>${project.version}</jena-osgi.version>
-            <!-- not so noisy OSGi logging -->
-            <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -185,8 +168,33 @@ limitations under the License.
         </executions>
         <configuration>
         </configuration>
-      </plugin>
 
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <classpathDependencyExcludes>
+            <classpathDependencyExclude>org.slf4j:slf4j-log4j12</classpathDependencyExclude>
+          </classpathDependencyExcludes>
+          <systemPropertyVariables>
+            <!-- So the test can find the current version of jena-osgi -->
+            <jena-osgi.version>${project.version}</jena-osgi.version>
+            <!-- not so noisy OSGi logging -->
+            <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <!-- delay until integration-test phase -->
+            <phase>integration-test</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -219,6 +219,8 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
+        <!-- re-enable extensions here for older Mavens -->
+        <extensions>true</extensions>
         <configuration>
           <instructions>
             <Export-Package>com.hp.hpl.jena.*,org.apache.jena.*</Export-Package>

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -224,7 +224,7 @@
             <Export-Package>com.hp.hpl.jena.*,org.apache.jena.*</Export-Package>
             <Embed-Dependency>artifactId=jena*;inline=true,artifactId=xercesImpl;inline=true,artifactId=xml-apis;inline=true</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
-            <Import-Package>!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,!org.apache.jena.ext.*,*</Import-Package>
+            <Import-Package>!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
             <Private-Package>org.apache.jena.ext.*</Private-Package>
           </instructions>
         </configuration>

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -223,7 +223,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>com.hp.hpl.jena.*,org.apache.jena.*</Export-Package>
+            <Export-Package>com.hp.hpl.jena.*,!org.apache.taverna.ext.*,org.apache.jena.*</Export-Package>
             <Embed-Dependency>artifactId=jena*;inline=true,artifactId=xercesImpl;inline=true,artifactId=xml-apis;inline=true</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Import-Package>!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>


### PR DESCRIPTION
Re-enable the surefire-plugin for jena-osgi-tests - as the tests didn't actually run on the master.

It needs an explicit <execution> so that it runs in a later phase. I've added comments about this to the pom.

Now that the OSGi tests were running correctly, this highlighted a problem from #45 in that Guava has an optional import on `sun.misc` which prevented starting, so I added that as optional in our shading (as it is in the upstream Guava `META-INF/MANIFEST.MF`).

I also re-added the explicit `<extensions>true</extensions>` as those were added as a workaround for  Maven 3.0.2 (see #32).