### PR TITLE
JENA-909 - Docker image for Fuseki 2

### DIFF
--- a/jena-fuseki2/jena-fuseki-docker/Dockerfile
+++ b/jena-fuseki2/jena-fuseki-docker/Dockerfile
@@ -13,7 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM maven:3.3-jdk-7
+FROM maven:3.3-jdk-8
 
 # Config and data
 VOLUME /fuseki

--- a/jena-fuseki2/jena-fuseki-docker/Dockerfile
+++ b/jena-fuseki2/jena-fuseki-docker/Dockerfile
@@ -1,0 +1,62 @@
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM maven:3.3-jdk-7
+
+# Config and data
+VOLUME /fuseki
+ENV FUSEKI_BASE /fuseki
+
+# Installation folder
+ENV FUSEKI_HOME /jena-fuseki
+
+ENV DEPS pwgen
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get update && \
+    apt-get install -y $DEPS && \
+    apt-get autoremove -y && \
+    apt-get autoclean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+
+WORKDIR /tmp
+COPY . /tmp/
+# Use target/ from host as-is, or build inside if missing
+RUN if [ ! -d target/dist ] ; then mvn install ; fi && \
+    mv target/dist/* $FUSEKI_HOME && rm -rf /tmp/*
+
+
+# As "localhost" is often inaccessible within Docker container,
+# we'll enable basic-auth with a random admin password 
+# (which we'll generate on start-up)
+COPY shiro.ini /jena-fuseki/shiro.ini
+COPY docker-entrypoint.sh /
+RUN chmod 755 /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# Loader scripts
+COPY load.sh /jena-fuseki/
+COPY tdbloader /jena-fuseki/
+RUN chmod 755 /jena-fuseki/load.sh /jena-fuseki/tdbloader
+#VOLUME /staging
+
+
+# Where we start our server from
+WORKDIR /jena-fuseki
+EXPOSE 3030
+CMD ["/jena-fuseki/fuseki-server"]
+

--- a/jena-fuseki2/jena-fuseki-docker/Dockerfile
+++ b/jena-fuseki2/jena-fuseki-docker/Dockerfile
@@ -29,15 +29,14 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y $DEPS && \
     apt-get autoremove -y && \
     apt-get autoclean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* 
 
 
 WORKDIR /tmp
 COPY . /tmp/
 # Use target/ from host as-is, or build inside if missing
 RUN if [ ! -d target/dist ] ; then mvn install ; fi && \
-    mv target/dist/* $FUSEKI_HOME && rm -rf /tmp/*
+    mv target/dist/* $FUSEKI_HOME && rm -rf /tmp/* /root/.m2
 
 
 # As "localhost" is often inaccessible within Docker container,

--- a/jena-fuseki2/jena-fuseki-docker/README.md
+++ b/jena-fuseki2/jena-fuseki-docker/README.md
@@ -1,9 +1,11 @@
 # Apache Jena Fuseki 2 docker image
 
-**Docker image:** [stain/jena-fuseki](https://registry.hub.docker.com/u/stain/jena-fuseki/)
+**Docker image:** [stain/jena-fuseki](https://hub.docker.com/r/stain/jena-fuseki/)
 
-This is a [Docker](http://docker.io/) image for running 
-[Apache Jena Fuseki](http://jena.apache.org/documentation/serving_data/) 2,
+(*TODO*: Register as official image on Docker Hub)
+
+This is a [Docker](https://www.docker.com/) image for running 
+[Apache Jena Fuseki](http://jena.apache.org/documentation/fuseki2/) 2,
 which is a [SPARQL 1.1](http://www.w3.org/TR/sparql11-overview/) server with a
 web interface, backed by the 
 [Apache Jena TDB](http://jena.apache.org/documentation/tdb/) RDF triple store.

--- a/jena-fuseki2/jena-fuseki-docker/README.md
+++ b/jena-fuseki2/jena-fuseki-docker/README.md
@@ -1,0 +1,195 @@
+# Apache Jena Fuseki 2 docker image
+
+**Docker image:** [stain/jena-fuseki](https://registry.hub.docker.com/u/stain/jena-fuseki/)
+
+This is a [Docker](http://docker.io/) image for running 
+[Apache Jena Fuseki](http://jena.apache.org/documentation/serving_data/) 2,
+which is a [SPARQL 1.1](http://www.w3.org/TR/sparql11-overview/) server with a
+web interface, backed by the 
+[Apache Jena TDB](http://jena.apache.org/documentation/tdb/) RDF triple store.
+
+Feel free to contact the [jena users
+list](http://jena.apache.org/help_and_support/) for any questions on using
+Jena or Fuseki.
+
+
+## Use
+
+To try out this image, try:
+
+    docker run -p 3030:3030 -it stain/jena-fuseki
+
+The Apache Jena Fuseki should then be available at http://localhost:3030/
+
+To expose Fuseki on a different port, modify `-p` and run `./fuseki-server --port=PORT` (see [JENA-868](https://issues.apache.org/jira/browse/JENA-868)):
+
+    docker run -p 8080:8080 -it stain/jena-fuseki ./fuseki-server --port=8080
+
+
+To load RDF graphs, you will need to log in as the `admin` user. To see the 
+automatically generated admin password, see the output from above, or
+use `docker logs` with the name of your container.
+
+Note that the password is only generated on the first run, e.g. when the
+volume `/fuseki` is an empty directory.
+
+You can override the admin-password using the form 
+`-e ADMIN_PASSWORD=pw123`:
+
+    docker run -p 3030:3030 -e ADMIN_PASSWORD=pw123 -it stain/jena-fuseki
+
+To specify Java settings such as the amount of memory to allocate for the
+heap (default: 1200 MiB), set the `JVM_ARGS` environment with `-e`:
+
+    docker run -p 3030:3030 -e JVM_ARGS=-Xmx2g -it stain/jena-fuseki
+
+
+## Data persistence
+
+Fuseki's data is stored in the Docker volume `/fuseki` within the container.
+Note that unless you use `docker restart` or one of the mechanisms below, data
+is lost between each run of the jena-fuseki image.
+
+To store the data in a named Docker volume container `fuseki-data`
+(recommended), create it first as:
+
+    docker run --name fuseki-data -v /fuseki busybox
+
+Then start fuseki using `--volumes-from`. This allows you to later upgrade the
+jena-fuseki docker image without losing the data. The command below also uses
+`-d` to start the container in the background.
+
+    docker run -d --name fuseki -p 3030:3030 --volumes-from fuseki-data stain/jena-fuseki
+
+If you want to store fuseki data in a specified location on the host (e.g. for
+disk space or speed requirements), specify it using `-v`:
+
+    docker run -d --name fuseki -p 3030:3030 -v /ssd/data/fuseki:/fuseki -it stain/jena-fuseki
+
+Note that the `/fuseki` volume must only be accessed from a single Fuseki 
+container at a time.    
+
+To check the logs for the container you gave `--name fuseki`, use:
+
+    docker logs fuseki
+
+To stop the named container, use:    
+
+    docker stop fuseki
+
+.. or press Ctrl-C if you started the container with `-it`.    
+
+To restart a named container (it will remember the volume and port config)
+
+    docker restart fuseki
+
+## Upgrading Fuseki
+
+If you want to upgrade the Fuseki container named `fuseki` which use the data
+volume `fuseki-data` as recommended above, do:
+
+    docker pull stain/jena-fuseki
+    docker stop fuseki
+    docker rm fuseki
+    docker run -d --name fuseki -p 3030:3030 --volumes-from fuseki-data stain/jena-fuseki
+
+
+## Data loading
+
+Fuseki allows uploading of RDF datasets through the web interface and web
+services, but for large datasets it is more efficient to load them directly
+using the command line.
+
+This docker image includes a shell script `load.sh` that invokes the
+[tdbloader](https://jena.apache.org/documentation/tdb/commands.html)
+command line tool and load datasets from the docker volume `/staging`.
+
+
+For help, try:
+
+    docker run stain/jena-fuseki ./load.sh
+
+You will most likely want to load from a folder on the host computer by using
+`-v`, and into a data volume that you can then use with the regular fuseki.
+
+Before data loading, you must either stop the Fuseki container, or
+load the data into a brand new dataset that Fuseki doesn't know about yet. 
+To stop the docker container you named `fuseki`:
+
+    docker stop fuseki
+
+The example below assume you want to populate the Fuseki dataset 'chembl19'
+from the Docker data volume `fuseki-data` (see above) by loading the two files
+`cco.ttl.gz` and `void.ttl.gz` from `/home/stain/ops/chembl19` on the host
+computer:
+
+    docker run --volumes-from fuseki-data -v /home/stain/ops/chembl19:/staging \
+       stain/jena-fuseki ./load.sh chembl19 cco.ttl.gz void.ttl.gz
+
+**Tip:** You might find it benefitial to run data loading from the data staging
+directory in order to use tab-completion etc. without exposing the path on the
+host. The `./load.sh` will expand patterns like `*.ttl` - you might have to 
+use single quotes (e.g. `'*.ttl'`) on the host to avoid them being expanded
+locally.
+
+If you don't specify any filenames to `load.sh`, all filenames directly under
+`/staging` that match these GLOB patterns will be loaded:
+
+    *.rdf *.rdf.gz *.ttl *.ttl.gz *.owl *.owl.gz *.nt *.nt.gz *.nquads *.nquads.gz
+
+`load.sh` populates the default graph. To populate named
+graphs, see the `tdbloader` section below.
+
+**NOTE**: If you load data into a brand new `/fuseki` volume, a new random
+admin password will be set before you have started Fuseki. 
+You can either check the output of the data loading, or later override the
+password using `-e ADMIN_PASSWORD=pw123`.
+
+
+## Recognizing the dataset in Fuseki
+
+If you loaded into an existing dataset, Fuseki should find the data after
+(re)starting with the same data volume (see [Data
+persistence](#Data_persistence) above):
+
+    docker restart fuseki
+
+If you created a brand new dataset, then in Fuseki go to *Manage datasets*,
+click **Add new dataset**, tick **Persistent** and provide the database name
+exactly as provided to `load.sh`, e.g. `chembl19`. 
+
+Now go to *Dataset*, select from the dropdown menu, and try out *Info* and *Query*.
+
+**Tip**: It is possible to load a new dataset into the volume of a 
+running Fuseki server, as long as you don't "create" it in Fuseki before
+`load.sh` has finished.
+
+
+## Loading with tdbloader
+
+If you have more advanced requirements, like loading multiple datasets or named graphs, you can 
+use [tdbloader](https://jena.apache.org/documentation/tdb/commands.html) directly together with 
+a [TDB assembler file](https://jena.apache.org/documentation/tdb/assembler.html).
+
+Note that Fuseki TDB datasets are sub-folders in `/fuseki/databases/`.
+
+You will need to provide the assembler file on a mounted Docker volume together with the
+data:
+
+    docker run --volumes-from fuseki-data -v /home/stain/data:/staging stain/jena-fuseki \
+      ./tdbloader --desc=/staging/tdb.ttl
+
+Remember to use the Docker container's data volume paths within the assembler
+file, e.g. `/staging/dataset.ttl` instead of `/home/stain/data/dataset.ttl`.
+
+
+## Customizing Fuseki configuration
+
+If you need to modify Fuseki's configuration further, you can use the equivalent of:
+
+    docker run --volumes-from fuseki-data -it ubuntu bash
+
+and inspect `/fuseki` with the shell. Remember to restart fuseki afterwards:
+
+    docker restart fuseki
+

--- a/jena-fuseki2/jena-fuseki-docker/docker-entrypoint.sh
+++ b/jena-fuseki2/jena-fuseki-docker/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -e
+
+if [ ! -f "$FUSEKI_BASE/shiro.ini" ] ; then
+  # First time
+  echo "###################################" 
+  echo "Initializing Apache Jena Fuseki" 
+  echo ""
+  cp "$FUSEKI_HOME/shiro.ini" "$FUSEKI_BASE/shiro.ini"
+  if [ -z "$ADMIN_PASSWORD" ] ; then
+    ADMIN_PASSWORD=$(pwgen -s 15)
+    echo "Randomly generated admin password:"
+    echo ""
+    echo "admin=$ADMIN_PASSWORD"
+  fi
+  echo ""
+  echo "###################################"
+fi
+
+# $ADMIN_PASSWORD can always override
+if [ -n "$ADMIN_PASSWORD" ] ; then
+  sed -i "s/^admin=.*/admin=$ADMIN_PASSWORD/" "$FUSEKI_BASE/shiro.ini"
+fi
+
+exec "$@"

--- a/jena-fuseki2/jena-fuseki-docker/load.sh
+++ b/jena-fuseki2/jena-fuseki-docker/load.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+extensions="rdf ttl owl nt nquads"
+PATTERNS=""
+for e in $extensions ; do
+  PATTERNS="$PATTERNS *.$e *.$e.gz"
+done
+
+if [ $# -eq 0 ] ; then 
+  echo "$0 [DB] [PATTERN ...]" 
+  echo "Load one or more RDF files into Jena Fuseki TDB database DB."
+  echo ""
+  echo "Current directory is assumed to be /staging"
+  echo ""
+  echo 'PATTERNs can be a filename or a shell glob pattern like *ttl'
+  echo ""
+  echo "If no PATTERN are given, the default patterns are searched:"
+  echo "$PATTERNS"
+  exit 0
+fi
+
+cd /staging 2>/dev/null || echo "/staging not found" >&2
+echo "Current directory:" $(pwd)
+
+DB=$1
+shift
+
+if [ $# -eq 0 ] ; then 
+  patterns="$PATTERNS"
+else
+  patterns="$@"
+fi
+
+files=""
+for f in $patterns; do
+  if [ -f $f ] ; then
+    files="$files $f"
+  else 
+    if [ $# -gt 0 ] ; then 
+      # User-specified file/pattern missing
+      echo "WARNING: Not found: $f" >&2
+    fi
+  fi
+done
+
+if [ "$files" == "" ] ; then
+  echo "No files found for: " >&2
+  echo "$patterns" >&2
+  exit 1
+fi
+
+mkdir -p $FUSEKI_BASE/databases/
+
+echo "#########"
+echo "Loading to Fuseki TDB database $DB:"
+echo ""
+echo $files
+echo "#########"
+
+
+exec $FUSEKI_HOME/tdbloader --loc=$FUSEKI_BASE/databases/$DB $files

--- a/jena-fuseki2/jena-fuseki-docker/pom.xml
+++ b/jena-fuseki2/jena-fuseki-docker/pom.xml
@@ -26,13 +26,13 @@
   <parent>
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-fuseki</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.3.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent> 
 
   <description>Fuseki Docker image
   This pom file does not actually build the docker image, but
-  is used to unpack the the apache-jena-fuseki distribution.
+  is used to unpack the apache-jena-fuseki distribution.
   </description>
   <dependencies>
 

--- a/jena-fuseki2/jena-fuseki-docker/pom.xml
+++ b/jena-fuseki2/jena-fuseki-docker/pom.xml
@@ -18,24 +18,54 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <name>Apache Jena - Fuseki Binary Distribution</name>
+  <artifactId>jena-fuseki-docker</artifactId>
+  <packaging>pom</packaging>
+
   <parent>
     <groupId>org.apache.jena</groupId>
-    <artifactId>jena-parent</artifactId>
-    <version>15-SNAPSHOT</version>
-    <relativePath>../jena-parent</relativePath>
+    <artifactId>jena-fuseki</artifactId>
+    <version>2.0.1-SNAPSHOT</version>
+    <relativePath>../</relativePath>
   </parent> 
 
-  <name>Apache Jena - Fuseki - A SPARQL 1.1 Server</name>
-  <artifactId>jena-fuseki</artifactId>
-  <version>2.3.1-SNAPSHOT</version>
-
-  <description>Fuseki is a SPARQL 1.1 Server which provides the SPARQL query, 
-  SPARQL update and SPARQL graph store protocols.
+  <description>Fuseki Docker image
+  This pom file does not actually build the docker image, but
+  is used to unpack the the apache-jena-fuseki distribution.
   </description>
+  <dependencies>
 
-  <packaging>pom</packaging>
-  
-  <url>http://jena.apache.org/</url>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+             <id>unpack</id>
+             <phase>package</phase>
+             <goals>
+               <goal>unpack</goal>
+             </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.apache.jena</groupId>
+                  <artifactId>apache-jena-fuseki</artifactId>
+                  <version>${project.version}</version>
+                  <type>tar.gz</type>
+                  <outputDirectory>${project.build.directory}/dist</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      
+    </plugins>
+
+  </build>
 
   <repositories>
     <repository>
@@ -47,33 +77,5 @@
       </releases>
     </repository>
   </repositories>
-
-  <organization>
-    <name>Apache Jena</name>
-    <url>http://jena.apache.org/</url>
-  </organization>
-
-  <licenses>
-    <license>
-      <name>Apache 2.0 License</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-    </license>
-  </licenses>
-
-  <properties>
-    <!--<ver.jetty>9.1.1.v20140108</ver.jetty>-->
-    <ver.jetty>9.3.3.v20150827</ver.jetty>
-    <ver.shiro>1.2.2</ver.shiro>
-    <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
-    <build.time.xsd>${maven.build.timestamp}</build.time.xsd>  
-  </properties>
-
-  <modules>
-    <module>jena-fuseki-core</module>
-    <module>jena-fuseki-war</module>
-    <module>jena-fuseki-server</module>
-    <module>jena-fuseki-docker</module>
-    <module>apache-jena-fuseki</module>
-  </modules>
   
 </project>

--- a/jena-fuseki2/jena-fuseki-docker/shiro.ini
+++ b/jena-fuseki2/jena-fuseki-docker/shiro.ini
@@ -1,0 +1,52 @@
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+[main]
+# Development
+ssl.enabled = false 
+
+plainMatcher=org.apache.shiro.authc.credential.SimpleCredentialsMatcher
+#iniRealm=org.apache.shiro.realm.text.IniRealm 
+iniRealm.credentialsMatcher = $plainMatcher
+
+#localhost=org.apache.jena.fuseki.authz.LocalhostFilter
+
+[users]
+# Implicitly adds "iniRealm =  org.apache.shiro.realm.text.IniRealm"
+admin=pw
+
+[roles]
+
+[urls]
+## Control functions open to anyone
+/$/status = anon
+/$/ping   = anon
+
+## and the rest are restricted
+/$/** = authcBasic,user[admin]
+
+
+## If you want simple, basic authentication user/password
+## on the operations, 
+##    1 - set a password in [users]
+##    2 - change the line above to:
+## /$/** = authcBasic,user[admin]
+## and set a better 
+
+## or to allow any access.
+##/$/** = anon
+
+# Everything else
+/**=anon

--- a/jena-fuseki2/jena-fuseki-docker/tdbloader
+++ b/jena-fuseki2/jena-fuseki-docker/tdbloader
@@ -1,0 +1,17 @@
+#!/bin/bash
+#   Licensed to the Apache Software Foundation (ASF) under one or more
+#   contributor license agreements.  See the NOTICE file distributed with
+#   this work for additional information regarding copyright ownership.
+#   The ASF licenses this file to You under the Apache License, Version 2.0
+#   (the "License"); you may not use this file except in compliance with
+#   the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+JVM_ARGS=${JVM_ARGS:--Xmx1200M}
+exec java $JVM_ARGS -cp $FUSEKI_HOME/fuseki-server.jar tdb.tdbloader $@


### PR DESCRIPTION
JENA-909 - Docker image for Fuseki

This is based on Maven, which is run either inside the Docker image, or if target/dist already exist in the host, use that (thus it should also work for local snapshots, or download from Maven on demand).

The Maven build does not make the docker image - and the readme now refers to stain/jena-fuseki (this should be changed to jena/jena-fuseki probably - presumably someone in PMC should make the organization in http://registry.hub.docker.com/ ?)
