### PR TITLE
JENA-938: Nonfunctional cleanup in various modules

### DIFF
--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/QuadsInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/QuadsInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -38,8 +36,7 @@ import org.apache.jena.hadoop.rdf.types.QuadWritable;
 public class QuadsInputFormat extends AbstractWholeFileInputFormat<LongWritable, QuadWritable> {
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new QuadsReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/TriplesInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/TriplesInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -34,8 +32,7 @@ import org.apache.jena.hadoop.rdf.types.TripleWritable;
 public class TriplesInputFormat extends AbstractWholeFileInputFormat<LongWritable, TripleWritable> {
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new TriplesReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/TriplesOrQuadsInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/TriplesOrQuadsInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -39,8 +37,7 @@ import org.apache.jena.hadoop.rdf.types.QuadWritable;
 public class TriplesOrQuadsInputFormat extends AbstractWholeFileInputFormat<LongWritable, QuadWritable> {
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new TriplesOrQuadsReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/jsonld/JsonLDQuadInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/jsonld/JsonLDQuadInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.jsonld;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -31,8 +29,7 @@ import org.apache.jena.hadoop.rdf.types.QuadWritable;
 public class JsonLDQuadInputFormat extends AbstractWholeFileInputFormat<LongWritable, QuadWritable> {
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new JsonLDQuadReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/jsonld/JsonLDTripleInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/jsonld/JsonLDTripleInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.jsonld;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -31,8 +29,7 @@ import org.apache.jena.hadoop.rdf.types.TripleWritable;
 public class JsonLDTripleInputFormat extends AbstractWholeFileInputFormat<LongWritable, TripleWritable> {
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new JsonLDTripleReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/nquads/BlockedNQuadsInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/nquads/BlockedNQuadsInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.nquads;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -45,8 +43,7 @@ import org.apache.jena.hadoop.rdf.types.QuadWritable;
 public class BlockedNQuadsInputFormat extends AbstractNLineFileInputFormat<LongWritable, QuadWritable> {
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new BlockedNQuadsReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/nquads/NQuadsInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/nquads/NQuadsInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.nquads;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -38,8 +36,7 @@ import org.apache.jena.hadoop.rdf.types.QuadWritable;
 public class NQuadsInputFormat extends AbstractNLineFileInputFormat<LongWritable, QuadWritable> {
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit arg0, TaskAttemptContext arg1)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit arg0, TaskAttemptContext arg1) {
         return new NQuadsReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/nquads/WholeFileNQuadsInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/nquads/WholeFileNQuadsInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.nquads;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -43,8 +41,7 @@ import org.apache.jena.hadoop.rdf.types.QuadWritable;
 public class WholeFileNQuadsInputFormat extends AbstractWholeFileInputFormat<LongWritable, QuadWritable> {
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new WholeFileNQuadsReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/ntriples/BlockedNTriplesInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/ntriples/BlockedNTriplesInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.ntriples;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -45,8 +43,7 @@ import org.apache.jena.hadoop.rdf.types.TripleWritable;
 public class BlockedNTriplesInputFormat extends AbstractNLineFileInputFormat<LongWritable, TripleWritable> {
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new BlockedNTriplesReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/ntriples/NTriplesInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/ntriples/NTriplesInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.ntriples;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -38,8 +36,7 @@ import org.apache.jena.hadoop.rdf.types.TripleWritable;
 public class NTriplesInputFormat extends AbstractNLineFileInputFormat<LongWritable, TripleWritable> {
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit inputSplit, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit inputSplit, TaskAttemptContext context) {
         return new NTriplesReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/ntriples/WholeFileNTriplesInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/ntriples/WholeFileNTriplesInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.ntriples;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -43,8 +41,7 @@ import org.apache.jena.hadoop.rdf.types.TripleWritable;
 public class WholeFileNTriplesInputFormat extends AbstractWholeFileInputFormat<LongWritable, TripleWritable> {
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new WholeFileNTriplesReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/rdfjson/RdfJsonInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/rdfjson/RdfJsonInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.rdfjson;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -38,8 +36,7 @@ import org.apache.jena.hadoop.rdf.types.TripleWritable;
 public class RdfJsonInputFormat extends AbstractWholeFileInputFormat<LongWritable, TripleWritable> {
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new RdfJsonReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/rdfxml/RdfXmlInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/rdfxml/RdfXmlInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.rdfxml;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -38,8 +36,7 @@ import org.apache.jena.hadoop.rdf.types.TripleWritable;
 public class RdfXmlInputFormat extends AbstractWholeFileInputFormat<LongWritable, TripleWritable> {
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new RdfXmlReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractBlockBasedNodeTupleReader.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractBlockBasedNodeTupleReader.java
@@ -86,7 +86,7 @@ public abstract class AbstractBlockBasedNodeTupleReader<TValue, T extends Abstra
     private Throwable parserError = null;
 
     @Override
-    public void initialize(InputSplit genericSplit, TaskAttemptContext context) throws IOException, InterruptedException {
+    public void initialize(InputSplit genericSplit, TaskAttemptContext context) throws IOException {
         LOG.debug("initialize({}, {})", genericSplit, context);
 
         // Assuming file split
@@ -242,7 +242,7 @@ public abstract class AbstractBlockBasedNodeTupleReader<TValue, T extends Abstra
     protected abstract T createInstance(TValue tuple);
 
     @Override
-    public boolean nextKeyValue() throws IOException, InterruptedException {
+    public boolean nextKeyValue() throws IOException {
         // Reuse key for efficiency
         if (key == null) {
             key = new LongWritable();
@@ -308,17 +308,17 @@ public abstract class AbstractBlockBasedNodeTupleReader<TValue, T extends Abstra
     }
 
     @Override
-    public LongWritable getCurrentKey() throws IOException, InterruptedException {
+    public LongWritable getCurrentKey() {
         return this.key;
     }
 
     @Override
-    public T getCurrentValue() throws IOException, InterruptedException {
+    public T getCurrentValue() {
         return this.tuple;
     }
 
     @Override
-    public float getProgress() throws IOException, InterruptedException {
+    public float getProgress() {
         float progress = 0.0f;
         if (this.key == null) {
             // We've either not started or we've finished

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractLineBasedNodeTupleReader.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractLineBasedNodeTupleReader.java
@@ -69,7 +69,7 @@ public abstract class AbstractLineBasedNodeTupleReader<TValue, T extends Abstrac
     private boolean ignoreBadTuples = true;
 
     @Override
-    public final void initialize(InputSplit genericSplit, TaskAttemptContext context) throws IOException, InterruptedException {
+    public final void initialize(InputSplit genericSplit, TaskAttemptContext context) throws IOException {
         LOG.debug("initialize({}, {})", genericSplit, context);
 
         // Assuming file split
@@ -124,7 +124,7 @@ public abstract class AbstractLineBasedNodeTupleReader<TValue, T extends Abstrac
         // This is to do with how line reader reads lines and how
         // NLineInputFormat will provide the split information to use
         if (skipFirstLine) {
-            start += in.readLine(new Text(), 0, (int) Math.min((long) Integer.MAX_VALUE, end - start));
+            start += in.readLine(new Text(), 0, (int) Math.min(Integer.MAX_VALUE, end - start));
         }
         this.pos = start;
     }
@@ -150,7 +150,7 @@ public abstract class AbstractLineBasedNodeTupleReader<TValue, T extends Abstrac
     protected abstract T createInstance(TValue tuple);
 
     @Override
-    public final boolean nextKeyValue() throws IOException, InterruptedException {
+    public final boolean nextKeyValue() throws IOException {
         // Reuse key for efficiency
         if (key == null) {
             key = new LongWritable();
@@ -225,19 +225,19 @@ public abstract class AbstractLineBasedNodeTupleReader<TValue, T extends Abstrac
     }
 
     @Override
-    public LongWritable getCurrentKey() throws IOException, InterruptedException {
+    public LongWritable getCurrentKey() {
         LOG.debug("getCurrentKey() --> {}", key);
         return key;
     }
 
     @Override
-    public T getCurrentValue() throws IOException, InterruptedException {
+    public T getCurrentValue() {
         LOG.debug("getCurrentValue() --> {}", tuple);
         return tuple;
     }
 
     @Override
-    public float getProgress() throws IOException, InterruptedException {
+    public float getProgress() {
         float progress = 0.0f;
         if (start != end) {
             if (end == Long.MAX_VALUE) {

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractWholeFileNodeTupleReader.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractWholeFileNodeTupleReader.java
@@ -88,7 +88,7 @@ public abstract class AbstractWholeFileNodeTupleReader<TValue, T extends Abstrac
     private Throwable parserError = null;
 
     @Override
-    public void initialize(InputSplit genericSplit, TaskAttemptContext context) throws IOException, InterruptedException {
+    public void initialize(InputSplit genericSplit, TaskAttemptContext context) throws IOException {
         LOG.debug("initialize({}, {})", genericSplit, context);
 
         // Assuming file split
@@ -229,7 +229,7 @@ public abstract class AbstractWholeFileNodeTupleReader<TValue, T extends Abstrac
     protected abstract T createInstance(TValue tuple);
 
     @Override
-    public boolean nextKeyValue() throws IOException, InterruptedException {
+    public boolean nextKeyValue() throws IOException {
         // Reuse key for efficiency
         if (key == null) {
             key = new LongWritable();
@@ -292,17 +292,17 @@ public abstract class AbstractWholeFileNodeTupleReader<TValue, T extends Abstrac
     }
 
     @Override
-    public LongWritable getCurrentKey() throws IOException, InterruptedException {
+    public LongWritable getCurrentKey() {
         return this.key;
     }
 
     @Override
-    public T getCurrentValue() throws IOException, InterruptedException {
+    public T getCurrentValue() {
         return this.tuple;
     }
 
     @Override
-    public float getProgress() throws IOException, InterruptedException {
+    public float getProgress() {
         float progress = 0.0f;
         if (this.key == null) {
             // We've either not started or we've finished

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/thrift/ThriftQuadInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/thrift/ThriftQuadInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.thrift;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -31,8 +29,7 @@ import org.apache.jena.hadoop.rdf.types.QuadWritable;
 public class ThriftQuadInputFormat extends AbstractWholeFileInputFormat<LongWritable, QuadWritable> {
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new ThriftQuadReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/thrift/ThriftTripleInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/thrift/ThriftTripleInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.thrift;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -31,8 +29,7 @@ import org.apache.jena.hadoop.rdf.types.TripleWritable;
 public class ThriftTripleInputFormat extends AbstractWholeFileInputFormat<LongWritable, TripleWritable> {
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new ThriftTripleReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/trig/TriGInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/trig/TriGInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.trig;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -38,8 +36,7 @@ import org.apache.jena.hadoop.rdf.types.QuadWritable;
 public class TriGInputFormat extends AbstractWholeFileInputFormat<LongWritable, QuadWritable> {
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new TriGReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/trix/TriXInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/trix/TriXInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.trix;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -34,8 +32,7 @@ import org.apache.jena.hadoop.rdf.types.QuadWritable;
 public class TriXInputFormat extends AbstractWholeFileInputFormat<LongWritable, QuadWritable> {
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, QuadWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new TriXReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/turtle/TurtleInputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/turtle/TurtleInputFormat.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.input.turtle;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -38,8 +36,7 @@ import org.apache.jena.hadoop.rdf.types.TripleWritable;
 public class TurtleInputFormat extends AbstractWholeFileInputFormat<LongWritable, TripleWritable> {
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
-            throws IOException, InterruptedException {
+    public RecordReader<LongWritable, TripleWritable> createRecordReader(InputSplit split, TaskAttemptContext context) {
         return new TurtleReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/AbstractNodeOutputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/AbstractNodeOutputFormat.java
@@ -50,14 +50,14 @@ public abstract class AbstractNodeOutputFormat<TValue> extends FileOutputFormat<
     private static final Logger LOG = LoggerFactory.getLogger(AbstractNodeOutputFormat.class);
 
     @Override
-    public RecordWriter<NodeWritable, TValue> getRecordWriter(TaskAttemptContext context) throws IOException, InterruptedException {
+    public RecordWriter<NodeWritable, TValue> getRecordWriter(TaskAttemptContext context) throws IOException {
         Configuration config = context.getConfiguration();
         boolean isCompressed = getCompressOutput(context);
         CompressionCodec codec = null;
         String extension = this.getFileExtension();
         if (isCompressed) {
             Class<? extends CompressionCodec> codecClass = getOutputCompressorClass(context, GzipCodec.class);
-            codec = (CompressionCodec) ReflectionUtils.newInstance(codecClass, config);
+            codec = ReflectionUtils.newInstance(codecClass, config);
             extension += codec.getDefaultExtension();
         }
         Path file = getDefaultWorkFile(context, extension);

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/AbstractNodeTupleOutputFormat.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/AbstractNodeTupleOutputFormat.java
@@ -55,7 +55,7 @@ public abstract class AbstractNodeTupleOutputFormat<TKey, TValue, T extends Abst
     private static final Logger LOG = LoggerFactory.getLogger(AbstractNodeTupleOutputFormat.class);
 
     @Override
-    public RecordWriter<TKey, T> getRecordWriter(TaskAttemptContext context) throws IOException, InterruptedException {
+    public RecordWriter<TKey, T> getRecordWriter(TaskAttemptContext context) throws IOException {
         Configuration config = context.getConfiguration();
         boolean isCompressed = getCompressOutput(context);
         CompressionCodec codec = null;
@@ -65,7 +65,7 @@ public abstract class AbstractNodeTupleOutputFormat<TKey, TValue, T extends Abst
         if (isCompressed) {
             // Add compression extension if applicable
             Class<? extends CompressionCodec> codecClass = getOutputCompressorClass(context, GzipCodec.class);
-            codec = (CompressionCodec) ReflectionUtils.newInstance(codecClass, config);
+            codec = ReflectionUtils.newInstance(codecClass, config);
             extension += codec.getDefaultExtension();
         }
         Path file = getDefaultWorkFile(context, extension);

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractBatchedNodeTupleWriter.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractBatchedNodeTupleWriter.java
@@ -66,7 +66,7 @@ public abstract class AbstractBatchedNodeTupleWriter<TKey, TValue, T extends Abs
     }
 
     @Override
-    public final void write(TKey key, T value) throws IOException, InterruptedException {
+    public final void write(TKey key, T value) throws IOException {
         LOG.debug("write({}={})", key, value);
         if (this.add(value) >= this.batchSize) {
             long size = this.writeOutput(writer);
@@ -87,7 +87,7 @@ public abstract class AbstractBatchedNodeTupleWriter<TKey, TValue, T extends Abs
     protected abstract long add(T value);
 
     @Override
-    public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+    public void close(TaskAttemptContext context) throws IOException {
         if (this.writer != null) {
             long size = this.writeOutput(writer);
             if (size > 0)

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractLineBasedNodeTupleWriter.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractLineBasedNodeTupleWriter.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.output.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import org.apache.hadoop.mapreduce.RecordWriter;
@@ -93,7 +92,7 @@ public abstract class AbstractLineBasedNodeTupleWriter<TKey, TValue, T extends A
     }
 
     @Override
-    public void write(TKey key, T value) throws IOException, InterruptedException {
+    public void write(TKey key, T value) {
         log.debug("write({}={})", key, value);
 
         Node[] ns = this.getNodes(value);
@@ -144,7 +143,7 @@ public abstract class AbstractLineBasedNodeTupleWriter<TKey, TValue, T extends A
     }
 
     @Override
-    public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+    public void close(TaskAttemptContext context) {
         log.debug("close({})", context);
         writer.close();
     }

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractNodeWriter.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractNodeWriter.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.output.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import org.apache.hadoop.io.NullWritable;
@@ -87,7 +86,7 @@ public abstract class AbstractNodeWriter<TValue> extends RecordWriter<NodeWritab
     }
 
     @Override
-    public final void write(NodeWritable key, TValue value) throws IOException, InterruptedException {
+    public final void write(NodeWritable key, TValue value) {
         this.writeKey(key);
         this.writer.write(this.getSeparator());
         this.writeValue(value);
@@ -166,7 +165,7 @@ public abstract class AbstractNodeWriter<TValue> extends RecordWriter<NodeWritab
     }
 
     @Override
-    public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+    public void close(TaskAttemptContext context) {
         log.debug("close({})", context);
         writer.close();
     }

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractStreamRdfNodeTupleWriter.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractStreamRdfNodeTupleWriter.java
@@ -43,15 +43,13 @@ public abstract class AbstractStreamRdfNodeTupleWriter<TKey, TTuple, TValue exte
 	}
 
 	@Override
-	public void close(TaskAttemptContext context) throws IOException,
-			InterruptedException {
+	public void close(TaskAttemptContext context) throws IOException {
 		this.stream.finish();
 		this.writer.close();
 	}
 
 	@Override
-	public void write(TKey key, TValue value) throws IOException,
-			InterruptedException {
+	public void write(TKey key, TValue value) {
 		this.sendOutput(key, value, this.stream);
 	}
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractWholeFileNodeTupleWriter.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/output/writers/AbstractWholeFileNodeTupleWriter.java
@@ -62,7 +62,7 @@ public abstract class AbstractWholeFileNodeTupleWriter<TKey, TValue, T extends A
     }
 
     @Override
-    public final void write(TKey key, T value) throws IOException, InterruptedException {
+    public final void write(TKey key, T value) {
         LOG.debug("write({}={})", key, value);
         this.add(value);
     }
@@ -76,7 +76,7 @@ public abstract class AbstractWholeFileNodeTupleWriter<TKey, TValue, T extends A
     protected abstract void add(T value);
 
     @Override
-    public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+    public void close(TaskAttemptContext context) throws IOException {
         if (this.writer != null) {
             this.writeOutput(writer);
             this.writer.close();

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/JsonLDReaderFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/JsonLDReaderFactory.java
@@ -17,8 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.readers;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.jena.hadoop.rdf.io.input.readers.jsonld.JsonLDQuadReader;
@@ -37,12 +35,12 @@ public class JsonLDReaderFactory extends AbstractReaderFactory {
     }
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createQuadReader() throws IOException {
+    public RecordReader<LongWritable, QuadWritable> createQuadReader() {
         return new JsonLDQuadReader();
     }
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createTripleReader() throws IOException {
+    public RecordReader<LongWritable, TripleWritable> createTripleReader() {
         return new JsonLDTripleReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/NQuadsReaderFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/NQuadsReaderFactory.java
@@ -17,8 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.readers;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.jena.hadoop.rdf.io.input.readers.nquads.WholeFileNQuadsReader;
@@ -35,7 +33,7 @@ public class NQuadsReaderFactory extends AbstractQuadsOnlyReaderFactory {
     }
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createQuadReader() throws IOException {
+    public RecordReader<LongWritable, QuadWritable> createQuadReader() {
         return new WholeFileNQuadsReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/NTriplesReaderFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/NTriplesReaderFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.registry.readers;
 
-import java.io.IOException;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.jena.hadoop.rdf.io.input.readers.ntriples.WholeFileNTriplesReader;
@@ -32,7 +31,7 @@ public class NTriplesReaderFactory extends AbstractTriplesOnlyReaderFactory {
     }
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createTripleReader() throws IOException {
+    public RecordReader<LongWritable, TripleWritable> createTripleReader() {
         return new WholeFileNTriplesReader();
     }
 }

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/RdfJsonReaderFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/RdfJsonReaderFactory.java
@@ -17,8 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.readers;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.jena.hadoop.rdf.io.input.readers.rdfjson.RdfJsonReader;
@@ -35,7 +33,7 @@ public class RdfJsonReaderFactory extends AbstractTriplesOnlyReaderFactory {
     }
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createTripleReader() throws IOException {
+    public RecordReader<LongWritable, TripleWritable> createTripleReader() {
         return new RdfJsonReader();
     }
 }

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/RdfXmlReaderFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/RdfXmlReaderFactory.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.registry.readers;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.jena.hadoop.rdf.io.input.readers.rdfxml.RdfXmlReader;
@@ -33,7 +31,7 @@ public class RdfXmlReaderFactory extends AbstractTriplesOnlyReaderFactory {
     }
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createTripleReader() throws IOException {
+    public RecordReader<LongWritable, TripleWritable> createTripleReader() {
         return new RdfXmlReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/ThriftReaderFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/ThriftReaderFactory.java
@@ -17,8 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.readers;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.jena.hadoop.rdf.io.input.readers.thrift.ThriftQuadReader;
@@ -37,12 +35,12 @@ public class ThriftReaderFactory extends AbstractReaderFactory {
     }
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createQuadReader() throws IOException {
+    public RecordReader<LongWritable, QuadWritable> createQuadReader() {
         return new ThriftQuadReader();
     }
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createTripleReader() throws IOException {
+    public RecordReader<LongWritable, TripleWritable> createTripleReader() {
         return new ThriftTripleReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/TriGReaderFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/TriGReaderFactory.java
@@ -17,8 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.readers;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.jena.hadoop.rdf.io.input.readers.trig.TriGReader;
@@ -35,7 +33,7 @@ public class TriGReaderFactory extends AbstractQuadsOnlyReaderFactory {
     }
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createQuadReader() throws IOException {
+    public RecordReader<LongWritable, QuadWritable> createQuadReader() {
         return new TriGReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/TriXReaderFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/TriXReaderFactory.java
@@ -17,8 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.readers;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.jena.hadoop.rdf.io.input.readers.trix.TriXReader;
@@ -35,7 +33,7 @@ public class TriXReaderFactory extends AbstractQuadsOnlyReaderFactory {
     }
 
     @Override
-    public RecordReader<LongWritable, QuadWritable> createQuadReader() throws IOException {
+    public RecordReader<LongWritable, QuadWritable> createQuadReader() {
         return new TriXReader();
     }
 }

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/TurtleReaderFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/readers/TurtleReaderFactory.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.hadoop.rdf.io.registry.readers;
 
-import java.io.IOException;
-
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.jena.hadoop.rdf.io.input.readers.turtle.TurtleReader;
@@ -33,7 +31,7 @@ public class TurtleReaderFactory extends AbstractTriplesOnlyReaderFactory {
     }
 
     @Override
-    public RecordReader<LongWritable, TripleWritable> createTripleReader() throws IOException {
+    public RecordReader<LongWritable, TripleWritable> createTripleReader() {
         return new TurtleReader();
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/JsonLDWriterFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/JsonLDWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -38,14 +37,12 @@ public class JsonLDWriterFactory extends AbstractWriterFactory {
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config) {
         return new JsonLDQuadWriter<>(writer);
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config) {
         return new JsonLDTripleWriter<>(writer);
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/NQuadsWriterFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/NQuadsWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,8 +35,7 @@ public class NQuadsWriterFactory extends AbstractQuadsOnlyWriterFactory {
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config) {
         return new NQuadsWriter<TKey>(writer);
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/NTriplesWriterFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/NTriplesWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,8 +35,7 @@ public class NTriplesWriterFactory extends AbstractTriplesOnlyWriterFactory {
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config) {
         return new NTriplesWriter<TKey>(writer);
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/RdfJsonWriterFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/RdfJsonWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,8 +35,7 @@ public class RdfJsonWriterFactory extends AbstractTriplesOnlyWriterFactory {
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config) {
         return new RdfJsonWriter<TKey>(writer);
     }
 }

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/RdfXmlWriterFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/RdfXmlWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,8 +35,7 @@ public class RdfXmlWriterFactory extends AbstractTriplesOnlyWriterFactory {
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config) {
         return new RdfXmlWriter<TKey>(writer);
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/ThriftWriterFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/ThriftWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 
@@ -41,15 +40,13 @@ public class ThriftWriterFactory extends AbstractWriterFactory {
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config) {
         return new StreamRdfQuadWriter<TKey>(new StreamRDF2Thrift(new WriterOutputStream(writer, Charset.forName("utf-8")),
                 false), writer);
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config) {
         return new StreamRdfTripleWriter<TKey>(new StreamRDF2Thrift(new WriterOutputStream(writer, Charset.forName("utf-8")),
                 false), writer);
     }

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/TriGWriterFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/TriGWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -37,8 +36,7 @@ public class TriGWriterFactory extends AbstractQuadsOnlyWriterFactory {
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config) {
         return new StreamRdfQuadWriter<TKey>(new WriterStreamRDFBlocks(writer), writer);
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/TriXWriterFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/TriXWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
 
@@ -39,8 +38,7 @@ public class TriXWriterFactory extends AbstractQuadsOnlyWriterFactory {
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, QuadWritable> createQuadWriter(Writer writer, Configuration config) {
         return new StreamRdfQuadWriter<>(new StreamWriterTriX(new WriterOutputStream(writer, Charset.forName("utf-8"))), writer);
     }
 

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/TurtleWriterFactory.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/registry/writers/TurtleWriterFactory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.hadoop.rdf.io.registry.writers;
 
-import java.io.IOException;
 import java.io.Writer;
 
 import org.apache.hadoop.conf.Configuration;
@@ -37,8 +36,7 @@ public class TurtleWriterFactory extends AbstractTriplesOnlyWriterFactory {
     }
 
     @Override
-    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config)
-            throws IOException {
+    public <TKey> RecordWriter<TKey, TripleWritable> createTripleWriter(Writer writer, Configuration config) {
         return new StreamRdfTripleWriter<>(new WriterStreamRDFBlocks(writer), writer);
     }
 

--- a/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/AbstractNodeTupleInputFormatTests.java
+++ b/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/AbstractNodeTupleInputFormatTests.java
@@ -352,11 +352,10 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * Basic tuples input test
      * 
      * @throws IOException
-     * @throws ClassNotFoundException
      * @throws InterruptedException
      */
     @Test
-    public final void single_input_01() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void single_input_01() throws IOException, InterruptedException {
         testSingleInput(empty, this.canSplitInputs() ? 0 : 1, EMPTY_SIZE);
     }
 
@@ -368,7 +367,7 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * @throws InterruptedException
      */
     @Test
-    public final void single_input_02() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void single_input_02() throws IOException, InterruptedException {
         testSingleInput(small, 1, SMALL_SIZE);
     }
 
@@ -380,7 +379,7 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * @throws InterruptedException
      */
     @Test
-    public final void single_input_03() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void single_input_03() throws IOException, InterruptedException {
         testSingleInput(large, 1, LARGE_SIZE);
     }
 
@@ -392,7 +391,7 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * @throws InterruptedException
      */
     @Test
-    public final void single_input_04() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void single_input_04() throws IOException, InterruptedException {
         testSingleInput(bad, 1, 0);
     }
 
@@ -404,7 +403,7 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * @throws InterruptedException
      */
     @Test
-    public final void single_input_05() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void single_input_05() throws IOException, InterruptedException {
         testSingleInput(mixed, 1, MIXED_SIZE / 2);
     }
 
@@ -483,11 +482,10 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * tuples test with multiple inputs
      * 
      * @throws IOException
-     * @throws ClassNotFoundException
      * @throws InterruptedException
      */
     @Test
-    public final void multiple_inputs_01() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void multiple_inputs_01() throws IOException, InterruptedException {
         testMultipleInputs(new File[] { empty, small, large }, this.canSplitInputs() ? 2 : 3, EMPTY_SIZE + SMALL_SIZE
                 + LARGE_SIZE);
     }
@@ -500,7 +498,7 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * @throws InterruptedException
      */
     @Test
-    public final void multiple_inputs_02() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void multiple_inputs_02() throws IOException, InterruptedException {
         testMultipleInputs(new File[] { folder.getRoot() }, this.canSplitInputs() ? 4 : 5, EMPTY_SIZE + SMALL_SIZE
                 + LARGE_SIZE + (MIXED_SIZE / 2));
     }
@@ -542,9 +540,8 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * @param split
      *            Input split
      * @return True if a valid split, false otherwise
-     * @throws IOException
      */
-    protected boolean isValidSplit(InputSplit split, Configuration config) throws IOException {
+    protected boolean isValidSplit(InputSplit split, Configuration config) {
         return split instanceof FileSplit;
     }
 
@@ -565,7 +562,7 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * @throws ClassNotFoundException
      */
     @Test
-    public final void split_input_01() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void split_input_01() throws IOException, InterruptedException {
         Assume.assumeTrue(this.canSplitInputs());
 
         Configuration config = this.prepareConfiguration();
@@ -582,7 +579,7 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * @throws ClassNotFoundException
      */
     @Test
-    public final void split_input_02() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void split_input_02() throws IOException, InterruptedException {
         Assume.assumeTrue(this.canSplitInputs());
 
         Configuration config = this.prepareConfiguration();
@@ -600,7 +597,7 @@ public abstract class AbstractNodeTupleInputFormatTests<TValue, T extends Abstra
      * @throws ClassNotFoundException
      */
     @Test
-    public final void split_input_03() throws IOException, InterruptedException, ClassNotFoundException {
+    public final void split_input_03() throws IOException, InterruptedException {
         Assume.assumeTrue(this.canSplitInputs());
 
         Configuration config = this.prepareConfiguration();

--- a/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/AbstractWholeFileQuadInputFormatTests.java
+++ b/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/AbstractWholeFileQuadInputFormatTests.java
@@ -60,7 +60,7 @@ public abstract class AbstractWholeFileQuadInputFormatTests extends AbstractNode
      */
     protected abstract Lang getRdfLanguage();
 
-    private void writeGoodTuples(OutputStream output, int num) throws IOException {
+    private void writeGoodTuples(OutputStream output, int num) {
         Dataset ds = DatasetFactory.createMem();
         Model m = ModelFactory.createDefaultModel();
         Resource currSubj = m.createResource("http://example.org/subjects/0");

--- a/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/bnodes/AbstractBlankNodeTests.java
+++ b/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/bnodes/AbstractBlankNodeTests.java
@@ -52,7 +52,6 @@ import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.hadoop.rdf.io.RdfIOConstants;
 import org.apache.jena.hadoop.rdf.types.AbstractNodeTupleWritable;
 import org.apache.jena.riot.system.ParserProfile;
-import org.apache.log4j.BasicConfigurator;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -63,7 +62,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Test case that embodies the scenario described in JENA-820
  */
-@SuppressWarnings("unused")
 public abstract class AbstractBlankNodeTests<T, TValue extends AbstractNodeTupleWritable<T>> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractBlankNodeTests.class);

--- a/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/compressed/AbstractCompressedWholeFileQuadInputFormatTests.java
+++ b/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/compressed/AbstractCompressedWholeFileQuadInputFormatTests.java
@@ -95,7 +95,7 @@ public abstract class AbstractCompressedWholeFileQuadInputFormatTests extends
      */
     protected abstract Lang getRdfLanguage();
 
-    private void writeGoodTuples(OutputStream output, int num) throws IOException {
+    private void writeGoodTuples(OutputStream output, int num) {
         Dataset ds = DatasetFactory.createMem();
         Model m = ModelFactory.createDefaultModel();
         Resource currSubj = m.createResource("http://example.org/subjects/0");

--- a/jena-elephas/jena-elephas-stats/src/main/java/org/apache/jena/hadoop/rdf/stats/RdfStats.java
+++ b/jena-elephas/jena-elephas-stats/src/main/java/org/apache/jena/hadoop/rdf/stats/RdfStats.java
@@ -127,9 +127,8 @@ public class RdfStats implements Tool {
      * 
      * @param args
      *            Arguments
-     * @throws Exception
      */
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         try {
             // Run and exit with result code if no errors bubble up
             // Note that the exit code may still be a error code
@@ -163,7 +162,7 @@ public class RdfStats implements Tool {
     }
 
     @Override
-    public int run(String[] args) throws Exception {
+    public int run(String[] args) {
         try {
             if (args.length == 0) {
                 showUsage();

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/WhereHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/WhereHandler.java
@@ -24,9 +24,6 @@ import java.util.Map;
 
 import org.apache.jena.arq.querybuilder.SelectBuilder;
 import org.apache.jena.arq.querybuilder.clauses.ConstructClause;
-import org.apache.jena.arq.querybuilder.clauses.DatasetClause;
-import org.apache.jena.arq.querybuilder.clauses.SolutionModifierClause;
-import org.apache.jena.arq.querybuilder.clauses.WhereClause;
 import org.apache.jena.arq.querybuilder.rewriters.ElementRewriter;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -221,8 +218,7 @@ public class WhereHandler implements Handler {
 	 * @param subQuery The sub query to convert
 	 * @return THe converted element.
 	 */
-	@SuppressWarnings("cast")
-    private ElementSubQuery makeSubQuery(SelectBuilder subQuery) {
+	private ElementSubQuery makeSubQuery(SelectBuilder subQuery) {
 		Query q = new Query();
 		PrologHandler ph = new PrologHandler(query);
 		ph.addAll(subQuery.getPrologHandler());
@@ -237,22 +233,12 @@ public class WhereHandler implements Handler {
 			ch.addAll(((ConstructClause<?>) subQuery).getConstructHandler());
 
 		}
-		if (subQuery instanceof DatasetClause) {
-			DatasetHandler dh = new DatasetHandler(q);
-			dh.addAll(((DatasetClause<?>) subQuery).getDatasetHandler());
-
-		}
-		if (subQuery instanceof SolutionModifierClause) {
-			SolutionModifierHandler smh = new SolutionModifierHandler(q);
-			smh.addAll(((SolutionModifierClause<?>) subQuery)
-					.getSolutionModifierHandler());
-
-		}
-		if (subQuery instanceof WhereClause) {
-			WhereHandler wh = new WhereHandler(q);
-			wh.addAll(((WhereClause<?>) subQuery).getWhereHandler());
-
-		}
+		DatasetHandler dh = new DatasetHandler(q);
+		dh.addAll( subQuery.getDatasetHandler() );
+		SolutionModifierHandler smh = new SolutionModifierHandler(q);
+		smh.addAll( subQuery.getSolutionModifierHandler() );
+		WhereHandler wh = new WhereHandler(q);
+		wh.addAll( subQuery.getWhereHandler() );
 		return new ElementSubQuery(q);
 
 	}

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/mgt/ActionBackup.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/mgt/ActionBackup.java
@@ -96,7 +96,7 @@ public class ActionBackup extends ServletBase
         try {
             final Callable<Boolean> task = new Callable<Boolean>() {
                 @Override
-                public Boolean call() throws Exception
+                public Boolean call()
                 {
                     log.info(format("[%d] Start backup %s to '%s'", action.id, ds, filename)) ;
                     action.beginRead() ;

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_REST.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_REST.java
@@ -20,12 +20,10 @@ package org.apache.jena.fuseki.servlets;
 
 import static org.apache.jena.fuseki.HttpNames.* ;
 
-import java.io.IOException ;
 import java.io.InputStream ;
 import java.util.Enumeration ;
 import java.util.Locale ;
 
-import javax.servlet.ServletException ;
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
 
@@ -160,7 +158,7 @@ public abstract class SPARQL_REST extends SPARQL_ServletBase
     { super() ; }
 
     @Override
-    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    protected void service(HttpServletRequest request, HttpServletResponse response) {
         // Direct all verbs to our common framework.
         doCommon(request, response) ;
     }

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_ServletBase.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_ServletBase.java
@@ -28,7 +28,6 @@ import java.util.Enumeration ;
 import java.util.Map ;
 import java.util.concurrent.atomic.AtomicLong ;
 
-import javax.servlet.ServletException ;
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
 
@@ -274,11 +273,10 @@ public abstract class SPARQL_ServletBase extends ServletBase
      * <p>Throws ServletException or IOException as per overloaded method signature.</p>
      * @param request HTTP request
      * @param response HTTP response
-     * @throws ServletException from overloaded method signature
      * @throws IOException from overloaded method signature
      */
     protected void doPatch(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException
+    throws IOException
     {
         response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "HTTP PATCH not supported");
     }

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
@@ -34,7 +34,6 @@ import java.util.Collection ;
 import java.util.Enumeration ;
 import java.util.List ;
 
-import javax.servlet.ServletException ;
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
 
@@ -68,14 +67,13 @@ public class SPARQL_Update extends SPARQL_Protocol
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException
+    throws IOException
     {
         response.sendError(HttpSC.BAD_REQUEST_400, "Attempt to perform SPARQL update by GET.  Use POST") ;
     }
     
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException
     {
         doCommon(request, response) ;
     }

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
@@ -20,12 +20,10 @@ package org.apache.jena.fuseki.servlets;
 
 import static java.lang.String.format ;
 
-import java.io.IOException ;
 import java.io.InputStream ;
 import java.io.PrintWriter ;
 import java.util.zip.GZIPInputStream ;
 
-import javax.servlet.ServletException ;
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
 
@@ -60,7 +58,6 @@ public class SPARQL_Upload extends SPARQL_ServletBase
     // Methods to respond to.
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException
     {
         doCommon(request, response) ;
     }

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SimpleVelocityServlet.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SimpleVelocityServlet.java
@@ -127,7 +127,7 @@ public class SimpleVelocityServlet extends HttpServlet
         }
         
         @Override
-        public void init(RuntimeServices rs) throws Exception
+        public void init(RuntimeServices rs)
         { }
 
         @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/authz/LocalhostFilter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/authz/LocalhostFilter.java
@@ -51,7 +51,7 @@ public class LocalhostFilter extends AuthorizationFilter403 {
     private static String LOCALHOST_IpV4 =  "127.0.0.1" ;   // Strictly, 127.*.*.*
     
     @Override
-    protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) throws Exception {
+    protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) {
         String remoteAddr = request.getRemoteAddr() ;
         if ( LOCALHOST_IpV6.equals(remoteAddr) || LOCALHOST_IpV4.equals(remoteAddr) )
             return true ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
@@ -210,7 +210,7 @@ public class FusekiConfig {
         // Files that are not hidden.
         DirectoryStream.Filter<Path> filter = new DirectoryStream.Filter<Path>() {
             @Override
-            public boolean accept(Path entry) throws IOException {
+            public boolean accept(Path entry) {
                 File f = entry.toFile() ;
                 return ! f.isHidden() && f.isFile() ;
             }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
@@ -25,7 +25,6 @@ import java.util.HashMap ;
 import java.util.Iterator ;
 import java.util.Map ;
 
-import javax.servlet.ServletException ;
 import javax.servlet.ServletOutputStream ;
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
@@ -90,7 +89,7 @@ public class ActionDatasets extends ActionContainerItem {
     }
     
     @Override
-    protected void doDelete(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    protected void doDelete(HttpServletRequest request, HttpServletResponse response) {
         doCommon(request, response);
     }
     

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionBase.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionBase.java
@@ -24,7 +24,6 @@ import java.io.IOException ;
 import java.util.Enumeration ;
 import java.util.Map ;
 
-import javax.servlet.ServletException ;
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
 
@@ -187,8 +186,7 @@ public abstract class ActionBase extends ServletBase
       return name ; 
   }
 
-    @SuppressWarnings("unused") // ServletException
-    protected void doPatch(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    protected void doPatch(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, "HTTP PATCH not supported");
     }
     

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionREST.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionREST.java
@@ -18,10 +18,8 @@
 
 package org.apache.jena.fuseki.servlets;
 
-import java.io.IOException ;
 import java.util.Locale ;
 
-import javax.servlet.ServletException ;
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
 
@@ -34,7 +32,7 @@ public abstract class ActionREST extends ActionSPARQL
     { super() ; }
 
     @Override
-    protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    protected void service(HttpServletRequest request, HttpServletResponse response) {
         // Direct all verbs to our common framework.
         doCommon(request, response) ;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
@@ -37,7 +37,7 @@ public class FusekiFilter implements Filter {
     private static SPARQL_UberServlet überServlet = new SPARQL_UberServlet.AccessByConfig() ;
     
     @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
+    public void init(FilterConfig filterConfig) {
 //        log.info("Filter: ["+Utils.className(this)+"] ServletContextName = "+filterConfig.getServletContext().getServletContextName()) ;
 //        log.info("Filter: ["+Utils.className(this)+"] ContextPath        = "+filterConfig.getServletContext().getContextPath()) ;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
@@ -39,7 +39,6 @@ import java.util.Collection ;
 import java.util.Enumeration ;
 import java.util.List ;
 
-import javax.servlet.ServletException ;
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
 
@@ -73,13 +72,12 @@ public class SPARQL_Update extends SPARQL_Protocol
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response) 
-            throws ServletException, IOException {
+            throws IOException {
         response.sendError(HttpSC.BAD_REQUEST_400, "Attempt to perform SPARQL update by GET.  Use POST") ;
     }
 
     @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response) 
-            throws ServletException, IOException {
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) {
         doCommon(request, response) ;
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
@@ -20,12 +20,10 @@ package org.apache.jena.fuseki.servlets;
 
 import static java.lang.String.format ;
 
-import java.io.IOException ;
 import java.io.InputStream ;
 import java.io.PrintWriter ;
 import java.util.zip.GZIPInputStream ;
 
-import javax.servlet.ServletException ;
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
 
@@ -60,7 +58,6 @@ public class SPARQL_Upload extends ActionSPARQL
     // Methods to respond to.
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
-    throws ServletException, IOException
     {
         doCommon(request, response) ;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestDatasetOps.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestDatasetOps.java
@@ -22,7 +22,6 @@ import static org.apache.jena.fuseki.ServerTest.serviceQuery ;
 import static org.apache.jena.fuseki.ServerTest.serviceREST ;
 import static org.apache.jena.fuseki.ServerTest.urlDataset ;
 
-import java.io.IOException ;
 import java.io.OutputStream ;
 
 import org.apache.http.HttpEntity ;
@@ -62,7 +61,7 @@ public class TestDatasetOps extends AbstractFusekiTest
         final RDFFormat syntax = RDFFormat.NQUADS ;
         ContentProducer producer = new ContentProducer() {
             @Override
-            public void writeTo(OutputStream out) throws IOException {
+            public void writeTo(OutputStream out) {
                 RDFDataMgr.write(out, dsg, syntax) ;
             }
         } ;


### PR DESCRIPTION
Remove some forms of dead code from jena-elephas and its submodules, jena-querybuilder, and jena-fuseki1 and jena-fuseki2, including:

Unthrown checked exceptions
Unnecessary superinterface declarations
Needless typecasts
Unused imports