### PR TITLE
JENA-938: Nonfunctional cleanup in jena-jdbc

### DIFF
--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/JenaDriver.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/JenaDriver.java
@@ -266,7 +266,7 @@ public abstract class JenaDriver implements Driver {
     }
 
     @Override
-    public boolean acceptsURL(String url) throws SQLException {
+    public boolean acceptsURL(String url) {
         if (url.startsWith(DRIVER_PREFIX + this.implPrefix)) {
             return true;
         } else {
@@ -812,7 +812,7 @@ public abstract class JenaDriver implements Driver {
      * @param props
      *            Properties
      */
-    protected void modifyProperties(Properties props) throws SQLException {
+    protected void modifyProperties(Properties props) {
         // Default implementation does nothing
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/connections/DatasetConnection.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/connections/DatasetConnection.java
@@ -111,17 +111,17 @@ public abstract class DatasetConnection extends JenaConnection {
     }
 
     @Override
-    public boolean isClosed() throws SQLException {
+    public boolean isClosed() {
         return this.ds == null;
     }
 
     @Override
-    public boolean isReadOnly() throws SQLException {
+    public boolean isReadOnly() {
         return this.readonly;
     }
 
     @Override
-    public boolean isValid(int timeout) throws SQLException {
+    public boolean isValid(int timeout) {
         return !this.isClosed();
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/connections/JenaConnection.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/connections/JenaConnection.java
@@ -27,7 +27,6 @@ import java.sql.DatabaseMetaData;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLRecoverableException;
@@ -448,7 +447,7 @@ public abstract class JenaConnection implements Connection {
     }
 
     @Override
-    public void clearWarnings() throws SQLException {
+    public void clearWarnings() {
         this.warnings = null;
     }
 
@@ -568,27 +567,27 @@ public abstract class JenaConnection implements Connection {
     }
 
     @Override
-    public boolean getAutoCommit() throws SQLException {
+    public boolean getAutoCommit() {
         return this.autoCommit;
     }
 
     @Override
-    public String getCatalog() throws SQLException {
+    public String getCatalog() {
         return JenaMetadata.DEFAULT_CATALOG;
     }
 
     @Override
-    public Properties getClientInfo() throws SQLException {
+    public Properties getClientInfo() {
         return this.clientInfo;
     }
 
     @Override
-    public String getClientInfo(String name) throws SQLException {
+    public String getClientInfo(String name) {
         return this.clientInfo.getProperty(name);
     }
 
     @Override
-    public int getHoldability() throws SQLException {
+    public int getHoldability() {
         return this.holdability;
     }
 
@@ -596,7 +595,7 @@ public abstract class JenaConnection implements Connection {
     public abstract DatabaseMetaData getMetaData() throws SQLException;
 
     @Override
-    public int getTransactionIsolation() throws SQLException {
+    public int getTransactionIsolation() {
         return this.isolationLevel;
     }
 
@@ -606,7 +605,7 @@ public abstract class JenaConnection implements Connection {
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException {
+    public SQLWarning getWarnings() {
         return this.warnings;
     }
 
@@ -739,7 +738,7 @@ public abstract class JenaConnection implements Connection {
     }
 
     @Override
-    public void setAutoCommit(boolean autoCommit) throws SQLException {
+    public void setAutoCommit(boolean autoCommit) {
         this.autoCommit = autoCommit;
     }
 
@@ -749,12 +748,12 @@ public abstract class JenaConnection implements Connection {
     }
 
     @Override
-    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+    public void setClientInfo(Properties properties) {
         this.clientInfo = properties;
     }
 
     @Override
-    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+    public void setClientInfo(String name, String value) {
         this.clientInfo.put(name, value);
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/metadata/DatasetMetadata.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/metadata/DatasetMetadata.java
@@ -39,7 +39,7 @@ public abstract class DatasetMetadata extends JenaMetadata {
     }
 
     @Override
-    public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
+    public boolean supportsTransactionIsolationLevel(int level) {
         // Dataset connections can support None or Serializable transactions
         switch (level) {
         case Connection.TRANSACTION_NONE:
@@ -52,7 +52,7 @@ public abstract class DatasetMetadata extends JenaMetadata {
     }
 
     @Override
-    public boolean supportsTransactions() throws SQLException {
+    public boolean supportsTransactions() {
         // Transactions are only supported if the underlying dataset supports them
         return ((DatasetConnection)this.getConnection()).getJenaDataset().supportsTransactions();
     }

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/metadata/JenaMetadata.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/metadata/JenaMetadata.java
@@ -116,55 +116,55 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public boolean isWrapperFor(Class<?> arg0) throws SQLException {
+    public boolean isWrapperFor(Class<?> arg0) throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException();
     }
 
     @Override
-    public <T> T unwrap(Class<T> arg0) throws SQLException {
+    public <T> T unwrap(Class<T> arg0) throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException();
     }
 
     @Override
-    public boolean allProceduresAreCallable() throws SQLException {
+    public boolean allProceduresAreCallable() {
         // Callable procedures not supported in SPARQL
         return false;
     }
 
     @Override
-    public boolean allTablesAreSelectable() throws SQLException {
+    public boolean allTablesAreSelectable() {
         // There is a single table in RDF (the quads table) and it is selectable
         return true;
     }
 
     @Override
-    public boolean autoCommitFailureClosesAllResultSets() throws SQLException {
+    public boolean autoCommitFailureClosesAllResultSets() {
         // Auto-commit failure does not close all result sets
         return false;
     }
 
     @Override
-    public boolean dataDefinitionCausesTransactionCommit() throws SQLException {
+    public boolean dataDefinitionCausesTransactionCommit() {
         // SPARQL Update causes a commit by default for non-transactional
         // connections
         return true;
     }
 
     @Override
-    public boolean dataDefinitionIgnoredInTransactions() throws SQLException {
+    public boolean dataDefinitionIgnoredInTransactions() {
         // SPARQL Update is not ignored for non-transactional connections
         return false;
     }
 
     @Override
-    public boolean deletesAreDetected(int arg0) throws SQLException {
+    public boolean deletesAreDetected(int arg0) {
         // Since modification of result sets is not supported we can report
         // true for the ability to detect row deletes
         return true;
     }
 
     @Override
-    public boolean doesMaxRowSizeIncludeBlobs() throws SQLException {
+    public boolean doesMaxRowSizeIncludeBlobs() {
         // There is no max row size in RDF/SPARQL
         return true;
     }
@@ -180,13 +180,13 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public String getCatalogSeparator() throws SQLException {
+    public String getCatalogSeparator() {
         // Use an empty string to indicate not applicable
         return "";
     }
 
     @Override
-    public String getCatalogTerm() throws SQLException {
+    public String getCatalogTerm() {
         return CATALOG_TERM;
     }
 
@@ -211,7 +211,7 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public final Connection getConnection() throws SQLException {
+    public final Connection getConnection() {
         return this.connection;
     }
 
@@ -222,19 +222,19 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public abstract int getDatabaseMajorVersion() throws SQLException;
+    public abstract int getDatabaseMajorVersion();
 
     @Override
-    public abstract int getDatabaseMinorVersion() throws SQLException;
+    public abstract int getDatabaseMinorVersion();
 
     @Override
-    public abstract String getDatabaseProductName() throws SQLException;
+    public abstract String getDatabaseProductName();
 
     @Override
-    public abstract String getDatabaseProductVersion() throws SQLException;
+    public abstract String getDatabaseProductVersion();
 
     @Override
-    public int getDefaultTransactionIsolation() throws SQLException {
+    public int getDefaultTransactionIsolation() {
         return Connection.TRANSACTION_NONE;
     }
 
@@ -245,10 +245,10 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     public abstract int getDriverMinorVersion();
 
     @Override
-    public abstract String getDriverName() throws SQLException;
+    public abstract String getDriverName();
 
     @Override
-    public abstract String getDriverVersion() throws SQLException;
+    public abstract String getDriverVersion();
 
     @Override
     public ResultSet getExportedKeys(String arg0, String arg1, String arg2) throws SQLException {
@@ -256,7 +256,7 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public String getExtraNameCharacters() throws SQLException {
+    public String getExtraNameCharacters() {
         // Since SPARQL doesn't really have a notion of identifiers like SQL
         // does we return that there are no extra name characters
         return "";
@@ -273,7 +273,7 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public String getIdentifierQuoteString() throws SQLException {
+    public String getIdentifierQuoteString() {
         // Not supported in SPARQL so return space per the JDBC javadoc
         return " ";
     }
@@ -289,140 +289,140 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public final int getJDBCMajorVersion() throws SQLException {
+    public final int getJDBCMajorVersion() {
         return 4;
     }
 
     @Override
-    public final int getJDBCMinorVersion() throws SQLException {
+    public final int getJDBCMinorVersion() {
         return 0;
     }
 
     @Override
-    public int getMaxBinaryLiteralLength() throws SQLException {
+    public int getMaxBinaryLiteralLength() {
         // No limit on RDF term sizes
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxCatalogNameLength() throws SQLException {
+    public int getMaxCatalogNameLength() {
         // No limit on catalog name lengths because we don't
         // really support catalogs
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxCharLiteralLength() throws SQLException {
+    public int getMaxCharLiteralLength() {
         // No limit on RDF term sizes
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxColumnNameLength() throws SQLException {
+    public int getMaxColumnNameLength() {
         // No limit on column name lengths
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxColumnsInGroupBy() throws SQLException {
+    public int getMaxColumnsInGroupBy() {
         // SPARQL allows arbitrarily many columns in a GROUP BY
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxColumnsInIndex() throws SQLException {
+    public int getMaxColumnsInIndex() {
         // RDF stores typically index on up to 4 columns since that is all we
         // have
         return 4;
     }
 
     @Override
-    public int getMaxColumnsInOrderBy() throws SQLException {
+    public int getMaxColumnsInOrderBy() {
         // SPARQL allows arbitrarily many columns in ORDER BY
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxColumnsInSelect() throws SQLException {
+    public int getMaxColumnsInSelect() {
         // SPARQL allows arbitrarily many columns in SELECT clause
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxColumnsInTable() throws SQLException {
+    public int getMaxColumnsInTable() {
         // RDF stores have up to 4 columns
         return 4;
     }
 
     @Override
-    public int getMaxConnections() throws SQLException {
+    public int getMaxConnections() {
         // Max connections will typically be unlimited
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxCursorNameLength() throws SQLException {
+    public int getMaxCursorNameLength() {
         // Named cursors aren't supported so there is no limit
         return UNKNOWN_LIMIT;
     }
 
     @Override
-    public int getMaxIndexLength() throws SQLException {
+    public int getMaxIndexLength() {
         // RDF stores typically have no limit on index size, they are as big as
         // they need to be
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxProcedureNameLength() throws SQLException {
+    public int getMaxProcedureNameLength() {
         // Procedures aren't supported so unknown
         return UNKNOWN_LIMIT;
     }
 
     @Override
-    public int getMaxRowSize() throws SQLException {
+    public int getMaxRowSize() {
         // No limit on triple size
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxSchemaNameLength() throws SQLException {
+    public int getMaxSchemaNameLength() {
         // We don't really support schemas so there is no limit
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxStatementLength() throws SQLException {
+    public int getMaxStatementLength() {
         // SPARQL Queries/Updates may be arbitrarily large
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxStatements() throws SQLException {
+    public int getMaxStatements() {
         // We don't impose any limit on this
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxTableNameLength() throws SQLException {
+    public int getMaxTableNameLength() {
         // We don't support tables so there is no limit
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxTablesInSelect() throws SQLException {
+    public int getMaxTablesInSelect() {
         // No limit
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxUserNameLength() throws SQLException {
+    public int getMaxUserNameLength() {
         // Authentication is an implementation specific detail so unknown
         return UNKNOWN_LIMIT;
     }
 
     @Override
-    public String getNumericFunctions() throws SQLException {
+    public String getNumericFunctions() {
         return StrUtils.strjoin(",", SPARQL_NUMERIC_FUNCTIONS);
     }
 
@@ -437,7 +437,7 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public String getProcedureTerm() throws SQLException {
+    public String getProcedureTerm() {
         // Not supported
         return null;
     }
@@ -448,30 +448,30 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public int getResultSetHoldability() throws SQLException {
+    public int getResultSetHoldability() {
         return JenaConnection.DEFAULT_HOLDABILITY;
     }
 
     @Override
-    public RowIdLifetime getRowIdLifetime() throws SQLException {
+    public RowIdLifetime getRowIdLifetime() {
         // Not supported
         return RowIdLifetime.ROWID_UNSUPPORTED;
     }
 
     @Override
-    public String getSQLKeywords() throws SQLException {
+    public String getSQLKeywords() {
         // TODO Use http://developer.mimer.com/validator/sql-reserved-words.tml
         // as a reference to remove those that also count as SQL Keywords
         return StrUtils.strjoin(",", SPARQL_KEYWORDS);
     }
 
     @Override
-    public int getSQLStateType() throws SQLException {
+    public int getSQLStateType() {
         return sqlStateXOpen;
     }
 
     @Override
-    public String getSchemaTerm() throws SQLException {
+    public String getSchemaTerm() {
         return SCHEMA_TERM;
     }
 
@@ -494,13 +494,13 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public String getSearchStringEscape() throws SQLException {
+    public String getSearchStringEscape() {
         // Does not apply to SPARQL
         return "";
     }
 
     @Override
-    public String getStringFunctions() throws SQLException {
+    public String getStringFunctions() {
         return StrUtils.strjoin(",", SPARQL_STR_FUNCTIONS);
     }
 
@@ -515,7 +515,7 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public String getSystemFunctions() throws SQLException {
+    public String getSystemFunctions() {
         // No system functions supported
         return "";
     }
@@ -536,7 +536,7 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public String getTimeDateFunctions() throws SQLException {
+    public String getTimeDateFunctions() {
         return StrUtils.strjoin(",", SPARQL_DATETIME_FUNCTIONS);
     }
 
@@ -635,10 +635,10 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public abstract String getURL() throws SQLException;
+    public abstract String getURL();
 
     @Override
-    public String getUserName() throws SQLException {
+    public String getUserName() {
         // No authentication used by default
         return null;
     }
@@ -649,13 +649,13 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public boolean insertsAreDetected(int arg0) throws SQLException {
+    public boolean insertsAreDetected(int arg0) {
         // We can't detect inserts that happen while streaming results
         return false;
     }
 
     @Override
-    public boolean isCatalogAtStart() throws SQLException {
+    public boolean isCatalogAtStart() {
         // We don't really support catalogs so we'll say yes
         return true;
     }
@@ -666,402 +666,402 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public boolean locatorsUpdateCopy() throws SQLException {
+    public boolean locatorsUpdateCopy() {
         // SPARQL doesn't support the LOB types so return false
         return false;
     }
 
     @Override
-    public boolean nullPlusNonNullIsNull() throws SQLException {
+    public boolean nullPlusNonNullIsNull() {
         // Concatenating nulls (i.e. unbound/type error) in SPARQL results
         // leads to nulls
         return true;
     }
 
     @Override
-    public boolean nullsAreSortedAtEnd() throws SQLException {
+    public boolean nullsAreSortedAtEnd() {
         // SPARQL sort order puts nulls (i.e. unbound) first
         return false;
     }
 
     @Override
-    public boolean nullsAreSortedAtStart() throws SQLException {
+    public boolean nullsAreSortedAtStart() {
         // SPARQL sort order puts nulls (i.e. unbound) first
         return true;
     }
 
     @Override
-    public boolean nullsAreSortedHigh() throws SQLException {
+    public boolean nullsAreSortedHigh() {
         // SPARQL sort order puts nulls (i.e. unbound) first
         return false;
     }
 
     @Override
-    public boolean nullsAreSortedLow() throws SQLException {
+    public boolean nullsAreSortedLow() {
         // SPARQL sort order puts nulls (i.e. unbound) first
         return true;
     }
 
     @Override
-    public boolean othersDeletesAreVisible(int arg0) throws SQLException {
+    public boolean othersDeletesAreVisible(int arg0) {
         // Since results are streamed it may be possible to see deletes from
         // others depending on the underlying implementation
         return true;
     }
 
     @Override
-    public boolean othersInsertsAreVisible(int arg0) throws SQLException {
+    public boolean othersInsertsAreVisible(int arg0) {
         // Since results are streamed it may be possible to see inserts from
         // others depending on the underlying implementation
         return true;
     }
 
     @Override
-    public boolean othersUpdatesAreVisible(int arg0) throws SQLException {
+    public boolean othersUpdatesAreVisible(int arg0) {
         // Since results are streamed it may be possible to see updates from
         // others depending on the underlying implementation
         return true;
     }
 
     @Override
-    public boolean ownDeletesAreVisible(int arg0) throws SQLException {
+    public boolean ownDeletesAreVisible(int arg0) {
         // Since results are streamed it may be possible to see deletes from
         // ourselves depending on the underlying implementation
         return true;
     }
 
     @Override
-    public boolean ownInsertsAreVisible(int arg0) throws SQLException {
+    public boolean ownInsertsAreVisible(int arg0) {
         // Since results are streamed it may be possible to see inserts from
         // ourselves depending on the underlying implementation
         return true;
     }
 
     @Override
-    public boolean ownUpdatesAreVisible(int arg0) throws SQLException {
+    public boolean ownUpdatesAreVisible(int arg0) {
         // Since results are streamed it may be possible to see deletes from
         // others depending on the underlying implementation
         return true;
     }
 
     @Override
-    public boolean storesLowerCaseIdentifiers() throws SQLException {
+    public boolean storesLowerCaseIdentifiers() {
         // We don't support identifiers in the way that JDBC means so we say
         // false
         return false;
     }
 
     @Override
-    public boolean storesLowerCaseQuotedIdentifiers() throws SQLException {
+    public boolean storesLowerCaseQuotedIdentifiers() {
         // We don't support identifiers in the way that JDBC means so we say
         // false
         return false;
     }
 
     @Override
-    public boolean storesMixedCaseIdentifiers() throws SQLException {
+    public boolean storesMixedCaseIdentifiers() {
         // We don't support identifiers in the way that JDBC means so we say
         // false
         return false;
     }
 
     @Override
-    public boolean storesMixedCaseQuotedIdentifiers() throws SQLException {
+    public boolean storesMixedCaseQuotedIdentifiers() {
         // We don't support identifiers in the way that JDBC means so we say
         // false
         return false;
     }
 
     @Override
-    public boolean storesUpperCaseIdentifiers() throws SQLException {
+    public boolean storesUpperCaseIdentifiers() {
         // We don't support identifiers in the way that JDBC means so we say
         // false
         return false;
     }
 
     @Override
-    public boolean storesUpperCaseQuotedIdentifiers() throws SQLException {
+    public boolean storesUpperCaseQuotedIdentifiers() {
         // We don't support identifiers in the way that JDBC means so we say
         // false
         return false;
     }
 
     @Override
-    public boolean supportsANSI92EntryLevelSQL() throws SQLException {
+    public boolean supportsANSI92EntryLevelSQL() {
         // We don't support SQL
         return false;
     }
 
     @Override
-    public boolean supportsANSI92FullSQL() throws SQLException {
+    public boolean supportsANSI92FullSQL() {
         // We don't support SQL
         return false;
     }
 
     @Override
-    public boolean supportsANSI92IntermediateSQL() throws SQLException {
+    public boolean supportsANSI92IntermediateSQL() {
         // We don't support SQL
         return false;
     }
 
     @Override
-    public boolean supportsAlterTableWithAddColumn() throws SQLException {
+    public boolean supportsAlterTableWithAddColumn() {
         // Schema alteration is not supported
         return false;
     }
 
     @Override
-    public boolean supportsAlterTableWithDropColumn() throws SQLException {
+    public boolean supportsAlterTableWithDropColumn() {
         // Schema alteration is not supported
         return false;
     }
 
     @Override
-    public boolean supportsBatchUpdates() throws SQLException {
+    public boolean supportsBatchUpdates() {
         // Batch updates are implemented
         return true;
     }
 
     @Override
-    public boolean supportsCatalogsInDataManipulation() throws SQLException {
+    public boolean supportsCatalogsInDataManipulation() {
         // We don't really support catalogs so using them in SPARQL Update is
         // not permitted
         return false;
     }
 
     @Override
-    public boolean supportsCatalogsInIndexDefinitions() throws SQLException {
+    public boolean supportsCatalogsInIndexDefinitions() {
         // Custom indexes are not supported
         return false;
     }
 
     @Override
-    public boolean supportsCatalogsInPrivilegeDefinitions() throws SQLException {
+    public boolean supportsCatalogsInPrivilegeDefinitions() {
         // SPARQL has no privilege definition statements
         return false;
     }
 
     @Override
-    public boolean supportsCatalogsInProcedureCalls() throws SQLException {
+    public boolean supportsCatalogsInProcedureCalls() {
         // SPARQL has no procedure calls
         return false;
     }
 
     @Override
-    public boolean supportsCatalogsInTableDefinitions() throws SQLException {
+    public boolean supportsCatalogsInTableDefinitions() {
         // SPARQL has no table definition statements
         return false;
     }
 
     @Override
-    public boolean supportsColumnAliasing() throws SQLException {
+    public boolean supportsColumnAliasing() {
         // SPARQL requires aliasing for computed columns
         return true;
     }
 
     @Override
-    public boolean supportsConvert() throws SQLException {
+    public boolean supportsConvert() {
         // JDBC convert is not supported
         return false;
     }
 
     @Override
-    public boolean supportsConvert(int arg0, int arg1) throws SQLException {
+    public boolean supportsConvert(int arg0, int arg1) {
         // JDBC convert is not supported
         return false;
     }
 
     @Override
-    public boolean supportsCoreSQLGrammar() throws SQLException {
+    public boolean supportsCoreSQLGrammar() {
         // We don't support SQL
         return false;
     }
 
     @Override
-    public boolean supportsCorrelatedSubqueries() throws SQLException {
+    public boolean supportsCorrelatedSubqueries() {
         // SPARQL supports sub-queries
         return true;
     }
 
     @Override
-    public boolean supportsDataDefinitionAndDataManipulationTransactions() throws SQLException {
+    public boolean supportsDataDefinitionAndDataManipulationTransactions() {
         // SPARQL update may be used within a transaction
         return true;
     }
 
     @Override
-    public boolean supportsDataManipulationTransactionsOnly() throws SQLException {
+    public boolean supportsDataManipulationTransactionsOnly() {
         // Transactions may consist only of SPARQL updates
         return true;
     }
 
     @Override
-    public boolean supportsDifferentTableCorrelationNames() throws SQLException {
+    public boolean supportsDifferentTableCorrelationNames() {
         // We don't support tables as such so no
         return false;
     }
 
     @Override
-    public boolean supportsExpressionsInOrderBy() throws SQLException {
+    public boolean supportsExpressionsInOrderBy() {
         // SPARQL allows expressions in ORDER BY
         return true;
     }
 
     @Override
-    public boolean supportsExtendedSQLGrammar() throws SQLException {
+    public boolean supportsExtendedSQLGrammar() {
         // We don't support SQL
         return false;
     }
 
     @Override
-    public boolean supportsFullOuterJoins() throws SQLException {
+    public boolean supportsFullOuterJoins() {
         // SPARQL supports all sorts of joins
         return true;
     }
 
     @Override
-    public boolean supportsGetGeneratedKeys() throws SQLException {
+    public boolean supportsGetGeneratedKeys() {
         // SPARQL has no notion of auto-generated keys (you can argue that
         // UUID() counts) but we certainly can't return them
         return false;
     }
 
     @Override
-    public boolean supportsGroupBy() throws SQLException {
+    public boolean supportsGroupBy() {
         // SPARQL supports GROUP BY
         return true;
     }
 
     @Override
-    public boolean supportsGroupByBeyondSelect() throws SQLException {
+    public boolean supportsGroupByBeyondSelect() {
         // You can GROUP BY a column that you don't select in SPARQL
         return true;
     }
 
     @Override
-    public boolean supportsGroupByUnrelated() throws SQLException {
+    public boolean supportsGroupByUnrelated() {
         // You can GROUP BY a column that you don't select in SPARQL
         return true;
     }
 
     @Override
-    public boolean supportsIntegrityEnhancementFacility() throws SQLException {
+    public boolean supportsIntegrityEnhancementFacility() {
         // Integrity Enhancement SQL is not supported
         return false;
     }
 
     @Override
-    public boolean supportsLikeEscapeClause() throws SQLException {
+    public boolean supportsLikeEscapeClause() {
         // No LIKE in SPARQL
         return false;
     }
 
     @Override
-    public boolean supportsLimitedOuterJoins() throws SQLException {
+    public boolean supportsLimitedOuterJoins() {
         // SPARQL supports all kinds of joins
         return true;
     }
 
     @Override
-    public boolean supportsMinimumSQLGrammar() throws SQLException {
+    public boolean supportsMinimumSQLGrammar() {
         // We don't support SQL
         return false;
     }
 
     @Override
-    public boolean supportsMixedCaseIdentifiers() throws SQLException {
+    public boolean supportsMixedCaseIdentifiers() {
         // We have no direct equivalent to SQL identifiers
         return false;
     }
 
     @Override
-    public boolean supportsMixedCaseQuotedIdentifiers() throws SQLException {
+    public boolean supportsMixedCaseQuotedIdentifiers() {
         // We have no direct equivalent to SQL identifiers
         return false;
     }
 
     @Override
-    public boolean supportsMultipleOpenResults() throws SQLException {
+    public boolean supportsMultipleOpenResults() {
         // We support multiple open results
         return true;
     }
 
     @Override
-    public boolean supportsMultipleResultSets() throws SQLException {
+    public boolean supportsMultipleResultSets() {
         // We don't support multiple result sets from a single execute() call,
         // we do support this from executeBatch()
         return false;
     }
 
     @Override
-    public boolean supportsMultipleTransactions() throws SQLException {
+    public boolean supportsMultipleTransactions() {
         // In principle yes this is possible though exact behaviour may vary by
         // underlying implementation
         return true;
     }
 
     @Override
-    public boolean supportsNamedParameters() throws SQLException {
+    public boolean supportsNamedParameters() {
         // We don't support callable statements
         return false;
     }
 
     @Override
-    public boolean supportsNonNullableColumns() throws SQLException {
+    public boolean supportsNonNullableColumns() {
         // All columns in a RDF store are non-nullable
         return true;
     }
 
     @Override
-    public boolean supportsOpenCursorsAcrossCommit() throws SQLException {
+    public boolean supportsOpenCursorsAcrossCommit() {
         // Cursors may be closed depending on the type of commit
         return false;
     }
 
     @Override
-    public boolean supportsOpenCursorsAcrossRollback() throws SQLException {
+    public boolean supportsOpenCursorsAcrossRollback() {
         // Cursors may be closed depending on the type of commit
         return false;
     }
 
     @Override
-    public boolean supportsOpenStatementsAcrossCommit() throws SQLException {
+    public boolean supportsOpenStatementsAcrossCommit() {
         // Statements remain open across commits
         return true;
     }
 
     @Override
-    public boolean supportsOpenStatementsAcrossRollback() throws SQLException {
+    public boolean supportsOpenStatementsAcrossRollback() {
         // Statements remain open across rollbacks
         return true;
     }
 
     @Override
-    public boolean supportsOrderByUnrelated() throws SQLException {
+    public boolean supportsOrderByUnrelated() {
         // SPARQL allows ORDER BY on a column that you don't SELECT
         return true;
     }
 
     @Override
-    public boolean supportsOuterJoins() throws SQLException {
+    public boolean supportsOuterJoins() {
         // SPARQL supports all kinds of joins
         return true;
     }
 
     @Override
-    public boolean supportsPositionedDelete() throws SQLException {
+    public boolean supportsPositionedDelete() {
         // We don't support deleting from result set
         return false;
     }
 
     @Override
-    public boolean supportsPositionedUpdate() throws SQLException {
+    public boolean supportsPositionedUpdate() {
         // We don't support updating from result set
         return false;
     }
 
     @Override
-    public boolean supportsResultSetConcurrency(int type, int concurrency) throws SQLException {
+    public boolean supportsResultSetConcurrency(int type, int concurrency) {
         // We only support read-only result sets
         if (concurrency != ResultSet.CONCUR_READ_ONLY)
             return false;
@@ -1069,13 +1069,13 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public boolean supportsResultSetHoldability(int holdability) throws SQLException {
+    public boolean supportsResultSetHoldability(int holdability) {
         // Both kinds of holdability are supported
         return true;
     }
 
     @Override
-    public boolean supportsResultSetType(int type) throws SQLException {
+    public boolean supportsResultSetType(int type) {
         // FORWARD_ONLY and SCROLL_INSENSITIVE are supported
         switch (type) {
         case ResultSet.TYPE_FORWARD_ONLY:
@@ -1087,99 +1087,99 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public boolean supportsSavepoints() throws SQLException {
+    public boolean supportsSavepoints() {
         // No notion of savepoints
         return false;
     }
 
     @Override
-    public boolean supportsSchemasInDataManipulation() throws SQLException {
+    public boolean supportsSchemasInDataManipulation() {
         // We don't really support schemas
         return false;
     }
 
     @Override
-    public boolean supportsSchemasInIndexDefinitions() throws SQLException {
+    public boolean supportsSchemasInIndexDefinitions() {
         // RDF stores don't allow custom indices
         return false;
     }
 
     @Override
-    public boolean supportsSchemasInPrivilegeDefinitions() throws SQLException {
+    public boolean supportsSchemasInPrivilegeDefinitions() {
         // SPARQL has no privilege definition statements
         return false;
     }
 
     @Override
-    public boolean supportsSchemasInProcedureCalls() throws SQLException {
+    public boolean supportsSchemasInProcedureCalls() {
         // SPARQL has no procedure calls
         return false;
     }
 
     @Override
-    public boolean supportsSchemasInTableDefinitions() throws SQLException {
+    public boolean supportsSchemasInTableDefinitions() {
         // We don't really support schemas
         return false;
     }
 
     @Override
-    public boolean supportsSelectForUpdate() throws SQLException {
+    public boolean supportsSelectForUpdate() {
         // No SPARQL equivalent
         return false;
     }
 
     @Override
-    public boolean supportsStatementPooling() throws SQLException {
+    public boolean supportsStatementPooling() {
         // We don't do pooling
         return false;
     }
 
     @Override
-    public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException {
+    public boolean supportsStoredFunctionsUsingCallSyntax() {
         // Stored procedures are not supported in SPARQL
         return false;
     }
 
     @Override
-    public boolean supportsStoredProcedures() throws SQLException {
+    public boolean supportsStoredProcedures() {
         // Stored procedures are not supported in SPARQL
         return false;
     }
 
     @Override
-    public boolean supportsSubqueriesInComparisons() throws SQLException {
+    public boolean supportsSubqueriesInComparisons() {
         // Can't use subqueries in this way in SPARQL
         return false;
     }
 
     @Override
-    public boolean supportsSubqueriesInExists() throws SQLException {
+    public boolean supportsSubqueriesInExists() {
         // SPARQL does allow sub-queries in EXISTS though strictly speaking our
         // EXISTS has no relation to the SQL equivalent
         return true;
     }
 
     @Override
-    public boolean supportsSubqueriesInIns() throws SQLException {
+    public boolean supportsSubqueriesInIns() {
         // Can't use subqueries in this way in SPARQL
         return false;
     }
 
     @Override
-    public boolean supportsSubqueriesInQuantifieds() throws SQLException {
+    public boolean supportsSubqueriesInQuantifieds() {
         // I have no idea what this mean so assume we can't use sub-queries this
         // way in SPARQL
         return false;
     }
 
     @Override
-    public boolean supportsTableCorrelationNames() throws SQLException {
+    public boolean supportsTableCorrelationNames() {
         // We don't really support tables
         return false;
     }
 
     @Override
-    public boolean supportsTransactionIsolationLevel(int arg0) throws SQLException {
+    public boolean supportsTransactionIsolationLevel(int arg0) {
         // Currently only None or Serializable is supported
         switch (arg0) {
         case Connection.TRANSACTION_NONE:
@@ -1191,34 +1191,34 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     }
 
     @Override
-    public boolean supportsTransactions() throws SQLException {
+    public boolean supportsTransactions() {
         // Currently transactions are not supported
         return false;
     }
 
     @Override
-    public boolean supportsUnion() throws SQLException {
+    public boolean supportsUnion() {
         // SPARQL supports UNION
         return true;
     }
 
     @Override
-    public boolean supportsUnionAll() throws SQLException {
+    public boolean supportsUnionAll() {
         // No SPARQL equivalent of UNION ALL
         return false;
     }
 
     @Override
-    public boolean updatesAreDetected(int arg0) throws SQLException {
+    public boolean updatesAreDetected(int arg0) {
         // Updates are never detectable
         return false;
     }
 
     @Override
-    public abstract boolean usesLocalFilePerTable() throws SQLException;
+    public abstract boolean usesLocalFilePerTable();
 
     @Override
-    public abstract boolean usesLocalFiles() throws SQLException;
+    public abstract boolean usesLocalFiles();
 
     @SuppressWarnings("javadoc")
     public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
@@ -1228,7 +1228,7 @@ public abstract class JenaMetadata implements DatabaseMetaData {
 
     // Java 6/7 compatibility
     @SuppressWarnings("javadoc")
-    public boolean generatedKeyAlwaysReturned() throws SQLException {
+    public boolean generatedKeyAlwaysReturned() {
         // We don't support returning keys
         return false;
     }

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/metadata/results/MetaResultSet.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/metadata/results/MetaResultSet.java
@@ -164,12 +164,12 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public void clearWarnings() throws SQLException {
+    public void clearWarnings() {
         // No-op
     }
 
     @Override
-    public void close() throws SQLException {
+    public void close() {
         this.closed = true;
     }
 
@@ -350,7 +350,7 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public int getConcurrency() throws SQLException {
+    public int getConcurrency() {
         return ResultSet.CONCUR_READ_ONLY;
     }
 
@@ -390,12 +390,12 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public int getFetchDirection() throws SQLException {
+    public int getFetchDirection() {
         return ResultSet.FETCH_FORWARD;
     }
 
     @Override
-    public int getFetchSize() throws SQLException {
+    public int getFetchSize() {
         // Not supported
         return 0;
     }
@@ -411,7 +411,7 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public int getHoldability() throws SQLException {
+    public int getHoldability() {
         return ResultSet.HOLD_CURSORS_OVER_COMMIT;
     }
 
@@ -436,7 +436,7 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getMetaData() {
         return this.metadata;
     }
 
@@ -471,7 +471,7 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public Object getObject(int columnIndex) throws SQLException {
+    public Object getObject(int columnIndex) {
         // TODO Auto-generated method stub
         return null;
     }
@@ -502,7 +502,7 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public int getRow() throws SQLException {
+    public int getRow() {
         // Remember JDBC used a 1 based index
         if (this.currRow >= 0 && this.currRow < this.rows.length) {
             return this.currRow + 1;
@@ -542,7 +542,7 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public Statement getStatement() throws SQLException {
+    public Statement getStatement() {
         return null;
     }
 
@@ -597,7 +597,7 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public int getType() throws SQLException {
+    public int getType() {
         return ResultSet.TYPE_SCROLL_INSENSITIVE;
     }
 
@@ -633,13 +633,13 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException {
+    public SQLWarning getWarnings() {
         // TODO Auto-generated method stub
         return null;
     }
 
     @Override
-    public void insertRow() throws SQLException {
+    public void insertRow() {
         // TODO Auto-generated method stub
 
     }
@@ -659,7 +659,7 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public boolean isClosed() throws SQLException {
+    public boolean isClosed() {
         return this.closed;
     }
 
@@ -762,30 +762,30 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public boolean rowDeleted() throws SQLException {
+    public boolean rowDeleted() {
         // Results are read-only
         return false;
     }
 
     @Override
-    public boolean rowInserted() throws SQLException {
+    public boolean rowInserted() {
         // Results are read-only
         return false;
     }
 
     @Override
-    public boolean rowUpdated() throws SQLException {
+    public boolean rowUpdated() {
         // Results are read-only
         return false;
     }
 
     @Override
-    public void setFetchDirection(int direction) throws SQLException {
+    public void setFetchDirection(int direction) {
         // Not supported
     }
 
     @Override
-    public void setFetchSize(int rows) throws SQLException {
+    public void setFetchSize(int rows) {
         // Not supported
     }
 
@@ -1205,7 +1205,7 @@ public class MetaResultSet implements ResultSet {
     }
 
     @Override
-    public boolean wasNull() throws SQLException {
+    public boolean wasNull() {
         return this.wasNull;
     }
 }

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/AskResults.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/AskResults.java
@@ -75,11 +75,11 @@ public class AskResults extends JenaResultSet {
         }
     }
 
-    public void afterLast() throws SQLException {
+    public void afterLast() {
         this.currRow = 2;
     }
 
-    public void beforeFirst() throws SQLException {
+    public void beforeFirst() {
         this.currRow = 0;
     }
 
@@ -103,19 +103,19 @@ public class AskResults extends JenaResultSet {
         return true;
     }
 
-    public int getFetchDirection() throws SQLException {
+    public int getFetchDirection() {
         return ResultSet.FETCH_FORWARD;
     }
 
-    public int getFetchSize() throws SQLException {
+    public int getFetchSize() {
         return 1;
     }
 
-    public int getRow() throws SQLException {
+    public int getRow() {
         return this.currRow;
     }
 
-    public int getType() throws SQLException {
+    public int getType() {
         return ResultSet.TYPE_SCROLL_INSENSITIVE;
     }
 
@@ -129,7 +129,7 @@ public class AskResults extends JenaResultSet {
         return this.currRow == 0;
     }
 
-    public boolean isClosed() throws SQLException {
+    public boolean isClosed() {
         return this.closed;
     }
 
@@ -183,7 +183,7 @@ public class AskResults extends JenaResultSet {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getMetaData() {
         return this.metadata;
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/JenaResultSet.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/JenaResultSet.java
@@ -116,7 +116,7 @@ public abstract class JenaResultSet implements ResultSet {
     }
 
     @Override
-    public final void clearWarnings() throws SQLException {
+    public final void clearWarnings() {
         this.warnings = null;
     }
 
@@ -126,12 +126,12 @@ public abstract class JenaResultSet implements ResultSet {
     }
 
     @Override
-    public final int getHoldability() throws SQLException {
+    public final int getHoldability() {
         return this.holdability;
     }
 
     @Override
-    public final int getConcurrency() throws SQLException {
+    public final int getConcurrency() {
         return ResultSet.CONCUR_READ_ONLY;
     }
 
@@ -674,7 +674,7 @@ public abstract class JenaResultSet implements ResultSet {
     }
 
     @Override
-    public Statement getStatement() throws SQLException {
+    public Statement getStatement() {
         return this.statement;
     }
 
@@ -711,7 +711,7 @@ public abstract class JenaResultSet implements ResultSet {
     }
 	
     @Override
-    public final SQLWarning getWarnings() throws SQLException {
+    public final SQLWarning getWarnings() {
         return this.warnings;
     }
 
@@ -774,22 +774,22 @@ public abstract class JenaResultSet implements ResultSet {
     }
 
     @Override
-    public void refreshRow() throws SQLException {
+    public void refreshRow() {
         // No-op
     }
 
     @Override
-    public boolean rowDeleted() throws SQLException {
+    public boolean rowDeleted() {
         return false;
     }
 
     @Override
-    public boolean rowInserted() throws SQLException {
+    public boolean rowInserted() {
         return false;
     }
 
     @Override
-    public boolean rowUpdated() throws SQLException {
+    public boolean rowUpdated() {
         return false;
     }
 
@@ -1209,7 +1209,7 @@ public abstract class JenaResultSet implements ResultSet {
     }
 
     @Override
-    public boolean wasNull() throws SQLException {
+    public boolean wasNull() {
         return this.wasNull;
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/MaterializedResults.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/MaterializedResults.java
@@ -245,24 +245,24 @@ public abstract class MaterializedResults<T> extends QueryExecutionResults {
     }
 
     @Override
-    public final int getFetchDirection() throws SQLException {
+    public final int getFetchDirection() {
         return ResultSet.FETCH_FORWARD;
     }
 
     @Override
-    public final int getFetchSize() throws SQLException {
+    public final int getFetchSize() {
         // TODO Need a buffering wrapper around ResultSet to make this
         // configurable
         return 0;
     }
 
     @Override
-    public final int getRow() throws SQLException {
+    public final int getRow() {
         return this.currRow;
     }
 
     @Override
-    public final int getType() throws SQLException {
+    public final int getType() {
         return ResultSet.TYPE_SCROLL_INSENSITIVE;
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/MaterializedSelectResults.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/MaterializedSelectResults.java
@@ -71,7 +71,7 @@ public class MaterializedSelectResults extends MaterializedResults<Binding> {
     }
 
     @Override
-    public void closeStreamInternal() throws SQLException {
+    public void closeStreamInternal() {
         if (this.innerResults != null) {
             if (this.innerResults instanceof Closeable) {
                 ((Closeable) this.innerResults).close();
@@ -116,7 +116,7 @@ public class MaterializedSelectResults extends MaterializedResults<Binding> {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getMetaData() {
         return this.metadata;
     }
 
@@ -124,7 +124,7 @@ public class MaterializedSelectResults extends MaterializedResults<Binding> {
      * Gets whether there are further rows in the underlying SELECT results
      */
     @Override
-    protected boolean hasNext() throws SQLException {
+    protected boolean hasNext() {
         // No null check here because superclass will not call us after we are
         // closed and set to null
         return !this.nextResults.isEmpty() || this.innerResults.hasNext();
@@ -134,7 +134,7 @@ public class MaterializedSelectResults extends MaterializedResults<Binding> {
      * Gets the next row from the underlying SELECT results
      */
     @Override
-    protected Binding moveNext() throws SQLException {
+    protected Binding moveNext() {
         // No null check here because superclass will not call us after we are
         // closed and set to null
 
@@ -149,12 +149,12 @@ public class MaterializedSelectResults extends MaterializedResults<Binding> {
     }
 
     @Override
-    protected boolean hasPrevious() throws SQLException {
+    protected boolean hasPrevious() {
         return this.previousResults.size() > 0;
     }
 
     @Override
-    protected Binding movePrevious() throws SQLException {
+    protected Binding movePrevious() {
         this.nextResults.push(this.previousResults.pop());
         return this.nextResults.peek();
     }

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/QueryExecutionResults.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/QueryExecutionResults.java
@@ -82,7 +82,7 @@ public abstract class QueryExecutionResults extends JenaResultSet {
     protected abstract void closeInternal() throws SQLException;
 
     @Override
-    public final boolean isClosed() throws SQLException {
+    public final boolean isClosed() {
         return this.qe == null;
     }
     

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/SelectResults.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/SelectResults.java
@@ -88,7 +88,7 @@ public class SelectResults extends StreamedResults<Binding> {
     }
 
     @Override
-    public void closeStreamInternal() throws SQLException {
+    public void closeStreamInternal() {
         if (this.innerResults != null) {
             if (this.innerResults instanceof Closeable) {
                 ((Closeable) this.innerResults).close();
@@ -133,7 +133,7 @@ public class SelectResults extends StreamedResults<Binding> {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getMetaData() {
         return this.metadata;
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/StreamedResults.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/StreamedResults.java
@@ -172,24 +172,24 @@ public abstract class StreamedResults<T> extends QueryExecutionResults {
     }
 
     @Override
-    public final int getFetchDirection() throws SQLException {
+    public final int getFetchDirection() {
         return ResultSet.FETCH_FORWARD;
     }
 
     @Override
-    public final int getFetchSize() throws SQLException {
+    public final int getFetchSize() {
         // TODO Need a buffering wrapper around ResultSet to make this
         // configurable
         return 0;
     }
 
     @Override
-    public final int getRow() throws SQLException {
+    public final int getRow() {
         return this.currRow;
     }
 
     @Override
-    public final int getType() throws SQLException {
+    public final int getType() {
         return ResultSet.TYPE_FORWARD_ONLY;
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/TripleIteratorResults.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/TripleIteratorResults.java
@@ -115,7 +115,7 @@ public class TripleIteratorResults extends StreamedResults<Triple> {
     }
 
     @Override
-    protected void closeStreamInternal() throws SQLException {
+    protected void closeStreamInternal() {
         if (this.triples != null) {
             if (this.triples instanceof Closeable) {
                 ((Closeable) this.triples).close();
@@ -125,7 +125,7 @@ public class TripleIteratorResults extends StreamedResults<Triple> {
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getMetaData() {
         return metadata;
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/TripleListResults.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/TripleListResults.java
@@ -85,24 +85,24 @@ public class TripleListResults extends MaterializedResults<Triple> {
     }
 
     @Override
-    protected boolean hasNext() throws SQLException {
+    protected boolean hasNext() {
         // No null check here because superclass will not call us after we are
         // closed and set to null
         return this.getRow() < this.triples.size();
     }
 
     @Override
-    protected Triple moveNext() throws SQLException {
+    protected Triple moveNext() {
         return this.triples.get(this.getRow());
     }
 
     @Override
-    protected boolean hasPrevious() throws SQLException {
+    protected boolean hasPrevious() {
         return this.getRow() > 1;
     }
 
     @Override
-    protected Triple movePrevious() throws SQLException {
+    protected Triple movePrevious() {
         return this.triples.get(this.getRow() - 1);
     }
 
@@ -112,14 +112,14 @@ public class TripleListResults extends MaterializedResults<Triple> {
     }
 
     @Override
-    protected void closeStreamInternal() throws SQLException {
+    protected void closeStreamInternal() {
         if (this.triples != null) {
             this.triples = null;
         }
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getMetaData() {
         return metadata;
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/metadata/AbstractResultsMetadata.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/metadata/AbstractResultsMetadata.java
@@ -89,7 +89,7 @@ public class AbstractResultsMetadata implements ResultSetMetaData {
     }
 
     @Override
-    public int getColumnCount() throws SQLException {
+    public int getColumnCount() {
         return this.columns.size();
     }
 
@@ -138,13 +138,13 @@ public class AbstractResultsMetadata implements ResultSetMetaData {
     }
 
     @Override
-    public String getSchemaName(int column) throws SQLException {
+    public String getSchemaName(int column) {
         // Not applicable so return empty string
         return "";
     }
 
     @Override
-    public String getTableName(int column) throws SQLException {
+    public String getTableName(int column) {
         // Not applicable so return empty string
         return "";
     }
@@ -198,9 +198,8 @@ public class AbstractResultsMetadata implements ResultSetMetaData {
      * Gets a copy of the raw underlying column information
      * 
      * @return Column Information
-     * @throws SQLException
      */
-    public List<ColumnInfo> getJenaColumnInfo() throws SQLException {
+    public List<ColumnInfo> getJenaColumnInfo() {
         return new ArrayList<ColumnInfo>(this.columns);
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/DatasetPreparedStatement.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/DatasetPreparedStatement.java
@@ -138,7 +138,7 @@ public class DatasetPreparedStatement extends JenaPreparedStatement {
     }
 
     @Override
-    protected boolean hasActiveTransaction() throws SQLException {
+    protected boolean hasActiveTransaction() {
         return this.dsConn.getJenaDataset().isInTransaction();
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/DatasetStatement.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/DatasetStatement.java
@@ -135,7 +135,7 @@ public class DatasetStatement extends JenaStatement {
     }
 
     @Override
-    protected boolean hasActiveTransaction() throws SQLException {
+    protected boolean hasActiveTransaction() {
         return this.dsConn.getJenaDataset().isInTransaction();
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/JenaPreparedStatement.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/JenaPreparedStatement.java
@@ -93,12 +93,12 @@ public abstract class JenaPreparedStatement extends JenaStatement implements Pre
     }
 
     @Override
-    public void addBatch() throws SQLException {
+    public void addBatch() {
         this.addBatch(this.sparqlStr.toString());
     }
 
     @Override
-    public void clearParameters() throws SQLException {
+    public void clearParameters() {
         this.sparqlStr.clearParams();
     }
 
@@ -118,13 +118,13 @@ public abstract class JenaPreparedStatement extends JenaStatement implements Pre
     }
 
     @Override
-    public ResultSetMetaData getMetaData() throws SQLException {
+    public ResultSetMetaData getMetaData() {
         // Return null because we don't know in advance the column types
         return null;
     }
 
     @Override
-    public ParameterMetaData getParameterMetaData() throws SQLException {
+    public ParameterMetaData getParameterMetaData() {
         return this.paramMetadata;
     }
 
@@ -451,7 +451,7 @@ public abstract class JenaPreparedStatement extends JenaStatement implements Pre
                 if (value instanceof Double) {
                     this.setParameter(parameterIndex, NodeFactoryExtra.doubleToNode((Double)value));
                 } else if (value instanceof Float) {
-                    this.setParameter(parameterIndex, NodeFactoryExtra.doubleToNode((double)(Float)value));
+                    this.setParameter(parameterIndex, NodeFactoryExtra.doubleToNode((Float)value));
                 } else if (value instanceof Node) {
                     Double d = JdbcNodeUtils.toDouble((Node)value);
                     this.setParameter(parameterIndex, NodeFactoryExtra.doubleToNode(d));
@@ -473,9 +473,9 @@ public abstract class JenaPreparedStatement extends JenaStatement implements Pre
                 if (value instanceof Integer) {
                     this.setParameter(parameterIndex, NodeFactoryExtra.intToNode((Integer)value));
                 } else if (value instanceof Short) {
-                    this.setParameter(parameterIndex, NodeFactoryExtra.intToNode((int)(Short)value));
+                    this.setParameter(parameterIndex, NodeFactoryExtra.intToNode((Short)value));
                 } else if (value instanceof Byte) {
-                    this.setParameter(parameterIndex, NodeFactoryExtra.intToNode((int)(Byte)value));
+                    this.setParameter(parameterIndex, NodeFactoryExtra.intToNode((Byte)value));
                 } else if (value instanceof Node) {
                     Integer i = JdbcNodeUtils.toInt((Node)value);
                     this.setParameter(parameterIndex, NodeFactoryExtra.intToNode(i));
@@ -536,7 +536,7 @@ public abstract class JenaPreparedStatement extends JenaStatement implements Pre
                     Short s = (Short)value;
                     this.setParameter(parameterIndex, NodeFactory.createLiteral(Short.toString(s), XSDDatatype.XSDshort));
                 } else if (value instanceof Byte) {
-                    this.setParameter(parameterIndex, NodeFactory.createLiteral(Short.toString((short)(Byte)value), XSDDatatype.XSDshort));
+                    this.setParameter(parameterIndex, NodeFactory.createLiteral(Short.toString((Byte)value), XSDDatatype.XSDshort));
                 } else if (value instanceof Node) {
                     Short s = JdbcNodeUtils.toShort((Node)value);
                     this.setParameter(parameterIndex, NodeFactory.createLiteral(Short.toString(s), XSDDatatype.XSDshort));

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/JenaStatement.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/JenaStatement.java
@@ -197,7 +197,7 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public void addBatch(String sql) throws SQLException {
+    public void addBatch(String sql) {
         this.commands.add(sql);
     }
 
@@ -207,12 +207,12 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public void clearBatch() throws SQLException {
+    public void clearBatch() {
         this.commands.clear();
     }
 
     @Override
-    public void clearWarnings() throws SQLException {
+    public void clearWarnings() {
         this.warnings = null;
     }
 
@@ -615,17 +615,17 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public final Connection getConnection() throws SQLException {
+    public final Connection getConnection() {
         return this.connection;
     }
 
     @Override
-    public int getFetchDirection() throws SQLException {
+    public int getFetchDirection() {
         return this.fetchDirection;
     }
 
     @Override
-    public int getFetchSize() throws SQLException {
+    public int getFetchSize() {
         return this.fetchSize;
     }
 
@@ -635,12 +635,12 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public int getMaxFieldSize() throws SQLException {
+    public int getMaxFieldSize() {
         return NO_LIMIT;
     }
 
     @Override
-    public int getMaxRows() throws SQLException {
+    public int getMaxRows() {
         return maxRows;
     }
 
@@ -688,7 +688,7 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public int getQueryTimeout() throws SQLException {
+    public int getQueryTimeout() {
         return this.timeout;
     }
 
@@ -719,12 +719,12 @@ public abstract class JenaStatement implements Statement {
      * Gets that result sets are read-only
      */
     @Override
-    public final int getResultSetConcurrency() throws SQLException {
+    public final int getResultSetConcurrency() {
         return ResultSet.CONCUR_READ_ONLY;
     }
 
     @Override
-    public int getResultSetHoldability() throws SQLException {
+    public int getResultSetHoldability() {
         return this.holdability;
     }
 
@@ -739,12 +739,12 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public final int getResultSetType() throws SQLException {
+    public final int getResultSetType() {
         return this.type;
     }
 
     @Override
-    public int getUpdateCount() throws SQLException {
+    public int getUpdateCount() {
         return this.updateCount;
     }
 
@@ -759,7 +759,7 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public SQLWarning getWarnings() throws SQLException {
+    public SQLWarning getWarnings() {
         return this.warnings;
     }
 
@@ -803,12 +803,12 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public final boolean isClosed() throws SQLException {
+    public final boolean isClosed() {
         return this.closed;
     }
 
     @Override
-    public final boolean isPoolable() throws SQLException {
+    public final boolean isPoolable() {
         return true;
     }
 
@@ -818,7 +818,7 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public void setEscapeProcessing(boolean enable) throws SQLException {
+    public void setEscapeProcessing(boolean enable) {
         this.escapeProcessing = enable;
     }
 
@@ -847,18 +847,18 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public void setFetchSize(int rows) throws SQLException {
+    public void setFetchSize(int rows) {
         this.fetchSize = rows;
     }
 
     @Override
-    public void setMaxFieldSize(int max) throws SQLException {
+    public void setMaxFieldSize(int max) {
         // Ignored
         this.setWarning("setMaxFieldSize() was called but there is no field size limit for Jena JDBC connections");
     }
 
     @Override
-    public void setMaxRows(int max) throws SQLException {
+    public void setMaxRows(int max) {
         if (max <= NO_LIMIT) {
             this.maxRows = NO_LIMIT;
         } else {
@@ -867,13 +867,13 @@ public abstract class JenaStatement implements Statement {
     }
 
     @Override
-    public void setPoolable(boolean poolable) throws SQLException {
+    public void setPoolable(boolean poolable) {
         // Ignored
         this.setWarning("setPoolable() was called but Jena JDBC statements are always considered poolable");
     }
 
     @Override
-    public void setQueryTimeout(int seconds) throws SQLException {
+    public void setQueryTimeout(int seconds) {
         if (seconds <= NO_LIMIT) {
             this.timeout = NO_LIMIT;
         } else {
@@ -883,7 +883,7 @@ public abstract class JenaStatement implements Statement {
 
     // Java 6/7 compatibility
     @SuppressWarnings("javadoc")
-    public boolean isCloseOnCompletion() throws SQLException {
+    public boolean isCloseOnCompletion() {
         // Statements do not automatically close
         return false;
     }

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/metadata/JenaParameterMetadata.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/metadata/JenaParameterMetadata.java
@@ -67,7 +67,7 @@ public class JenaParameterMetadata implements ParameterMetaData {
     }
 
     @Override
-    public int getParameterCount() throws SQLException {
+    public int getParameterCount() {
         return this.paramCount;
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/connections/AbstractJenaConnectionTests.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/connections/AbstractJenaConnectionTests.java
@@ -405,10 +405,9 @@ public abstract class AbstractJenaConnectionTests {
      * Tests use of prepared statements
      * 
      * @throws SQLException
-     * @throws MalformedURLException
      */
     @Test
-    public void connection_prepared_statement_select_02() throws SQLException, MalformedURLException {
+    public void connection_prepared_statement_select_02() throws SQLException {
         // Prepare a dataset
         Dataset ds = DatasetFactory.createMem();
         ds.asDatasetGraph().add(
@@ -454,10 +453,9 @@ public abstract class AbstractJenaConnectionTests {
      * Tests use of prepared statements
      * 
      * @throws SQLException
-     * @throws MalformedURLException
      */
     @Test
-    public void connection_prepared_statement_select_03() throws SQLException, MalformedURLException {
+    public void connection_prepared_statement_select_03() throws SQLException {
         // Prepare a dataset
         Dataset ds = DatasetFactory.createMem();
         ds.asDatasetGraph().add(

--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/postprocessing/ResultsEcho.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/postprocessing/ResultsEcho.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.jdbc.postprocessing;
 
-import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.Properties;
 
@@ -36,7 +35,7 @@ import org.apache.jena.query.ResultSet ;
 public class ResultsEcho implements ResultsPostProcessor {
 
     @Override
-    public void initialize(Properties props) throws SQLException {
+    public void initialize(Properties props) {
         // No op
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/preprocessing/Echo.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/preprocessing/Echo.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.jdbc.preprocessing;
 
-import java.sql.SQLException;
 import java.util.Properties;
 
 import org.apache.jena.query.Query ;
@@ -49,17 +48,17 @@ public class Echo implements CommandPreProcessor {
     }
 
     @Override
-    public String preProcessCommandText(String text) throws SQLException {
+    public String preProcessCommandText(String text) {
         return text;
     }
 
     @Override
-    public Query preProcessQuery(Query q) throws SQLException {
+    public Query preProcessQuery(Query q) {
         return q;
     }
 
     @Override
-    public UpdateRequest preProcessUpdate(UpdateRequest u) throws SQLException {
+    public UpdateRequest preProcessUpdate(UpdateRequest u) {
         return u;
     }
 

--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/statements/AbstractJenaStatementTests.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/statements/AbstractJenaStatementTests.java
@@ -2151,11 +2151,10 @@ public abstract class AbstractJenaStatementTests {
      * function correctly
      * 
      * @throws SQLException
-     * @throws MalformedURLException
      * @throws URISyntaxException
      */
     @Test
-    public void prepared_statement_setters_13() throws SQLException, MalformedURLException, URISyntaxException {
+    public void prepared_statement_setters_13() throws SQLException, URISyntaxException {
         JenaConnection conn = this.getConnection();
         JenaPreparedStatement stmt = (JenaPreparedStatement) conn.prepareStatement("SELECT * WHERE { ?s ?p ? }");
 
@@ -3421,11 +3420,10 @@ public abstract class AbstractJenaStatementTests {
      * function correctly
      * 
      * @throws SQLException
-     * @throws MalformedURLException
      * @throws URISyntaxException
      */
     @Test
-    public void prepared_statement_setters_78() throws SQLException, MalformedURLException, URISyntaxException {
+    public void prepared_statement_setters_78() throws SQLException, URISyntaxException {
         JenaConnection conn = this.getConnection();
         JenaPreparedStatement stmt = (JenaPreparedStatement) conn.prepareStatement("SELECT * WHERE { ?s ?p ? }");
 
@@ -3442,10 +3440,9 @@ public abstract class AbstractJenaStatementTests {
      * function correctly
      * 
      * @throws SQLException
-     * @throws MalformedURLException
      */
     @Test
-    public void prepared_statement_setters_79() throws SQLException, MalformedURLException {
+    public void prepared_statement_setters_79() throws SQLException {
         JenaConnection conn = this.getConnection();
         JenaPreparedStatement stmt = (JenaPreparedStatement) conn.prepareStatement("SELECT * WHERE { ?s ?p ? }");
 
@@ -3464,10 +3461,9 @@ public abstract class AbstractJenaStatementTests {
      * function correctly
      * 
      * @throws SQLException
-     * @throws MalformedURLException
      */
     @Test
-    public void prepared_statement_setters_80() throws SQLException, MalformedURLException {
+    public void prepared_statement_setters_80() throws SQLException {
         JenaConnection conn = this.getConnection();
         JenaPreparedStatement stmt = (JenaPreparedStatement) conn.prepareStatement("SELECT * WHERE { ?s ?p ? }");
 
@@ -3487,10 +3483,9 @@ public abstract class AbstractJenaStatementTests {
      * function correctly
      * 
      * @throws SQLException
-     * @throws MalformedURLException
      */
     @Test
-    public void prepared_statement_setters_81() throws SQLException, MalformedURLException {
+    public void prepared_statement_setters_81() throws SQLException {
         JenaConnection conn = this.getConnection();
         JenaPreparedStatement stmt = (JenaPreparedStatement) conn.prepareStatement("SELECT * WHERE { ?s ?p ? }");
 

--- a/jena-jdbc/jena-jdbc-driver-mem/src/main/java/org/apache/jena/jdbc/mem/connections/MemConnection.java
+++ b/jena-jdbc/jena-jdbc-driver-mem/src/main/java/org/apache/jena/jdbc/mem/connections/MemConnection.java
@@ -57,7 +57,7 @@ public class MemConnection extends DatasetConnection {
     }
 
     @Override
-    public DatabaseMetaData getMetaData() throws SQLException {
+    public DatabaseMetaData getMetaData() {
         return this.metadata;
     }
 }

--- a/jena-jdbc/jena-jdbc-driver-mem/src/main/java/org/apache/jena/jdbc/mem/metadata/MemDatasetMetadata.java
+++ b/jena-jdbc/jena-jdbc-driver-mem/src/main/java/org/apache/jena/jdbc/mem/metadata/MemDatasetMetadata.java
@@ -49,22 +49,22 @@ public class MemDatasetMetadata extends DatasetMetadata {
     }
 
     @Override
-    public int getDatabaseMajorVersion() throws SQLException {
+    public int getDatabaseMajorVersion() {
         return 2;
     }
 
     @Override
-    public int getDatabaseMinorVersion() throws SQLException {
+    public int getDatabaseMinorVersion() {
         return 10;
     }
 
     @Override
-    public String getDatabaseProductName() throws SQLException {
+    public String getDatabaseProductName() {
         return "Apache Jena - ARQ - In-Memory";
     }
 
     @Override
-    public String getDatabaseProductVersion() throws SQLException {
+    public String getDatabaseProductVersion() {
         return arq.toString();
     }
 
@@ -79,28 +79,28 @@ public class MemDatasetMetadata extends DatasetMetadata {
     }
 
     @Override
-    public String getDriverName() throws SQLException {
+    public String getDriverName() {
         return "Apache Jena - JDBC - In-Memory Driver";
     }
 
     @Override
-    public String getDriverVersion() throws SQLException {
+    public String getDriverVersion() {
         return jdbc.toString();
     }
 
     @Override
-    public String getURL() throws SQLException {
+    public String getURL() {
         return "http://jena.apache.org";
     }
 
     @Override
-    public boolean usesLocalFilePerTable() throws SQLException {
+    public boolean usesLocalFilePerTable() {
         // In-Memory database doesn't use files
         return false;
     }
 
     @Override
-    public boolean usesLocalFiles() throws SQLException {
+    public boolean usesLocalFiles() {
         // In-Memory database doesn't use files
         return false;
     }

--- a/jena-jdbc/jena-jdbc-driver-mem/src/test/java/org/apache/jena/jdbc/mem/results/TestResultSets.java
+++ b/jena-jdbc/jena-jdbc-driver-mem/src/test/java/org/apache/jena/jdbc/mem/results/TestResultSets.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.jdbc.mem.results;
 
-import java.sql.SQLException;
-
 import org.apache.jena.jdbc.mem.connections.DebugMemConnection;
 import org.apache.jena.query.Dataset ;
 
@@ -30,7 +28,7 @@ import org.apache.jena.query.Dataset ;
 public class TestResultSets extends AbstractMemResultSetTests {
 
     @Override
-    protected Dataset prepareDataset(Dataset ds) throws SQLException {
+    protected Dataset prepareDataset(Dataset ds) {
         // No preparation necessary
         return ds;
     }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/connections/RemoteEndpointConnection.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/connections/RemoteEndpointConnection.java
@@ -197,7 +197,7 @@ public class RemoteEndpointConnection extends JenaConnection {
     }
 
     @Override
-    protected void closeInternal() throws SQLException {
+    protected void closeInternal() {
         this.closed = true;
     }
 
@@ -230,17 +230,17 @@ public class RemoteEndpointConnection extends JenaConnection {
     }
 
     @Override
-    public boolean isClosed() throws SQLException {
+    public boolean isClosed() {
         return this.closed;
     }
 
     @Override
-    public boolean isReadOnly() throws SQLException {
+    public boolean isReadOnly() {
         return this.readonly;
     }
 
     @Override
-    public boolean isValid(int timeout) throws SQLException {
+    public boolean isValid(int timeout) {
         return !this.isClosed();
     }
 
@@ -258,17 +258,17 @@ public class RemoteEndpointConnection extends JenaConnection {
     }
 
     @Override
-    public DatabaseMetaData getMetaData() throws SQLException {
+    public DatabaseMetaData getMetaData() {
         return this.metadata;
     }
 
     @Override
-    protected void commitInternal() throws SQLException {
+    protected void commitInternal() {
         // No-op
     }
 
     @Override
-    protected void rollbackInternal() throws SQLException {
+    protected void rollbackInternal() {
         // No-op
     }
 

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/metadata/RemoteEndpointMetadata.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/metadata/RemoteEndpointMetadata.java
@@ -51,7 +51,7 @@ public class RemoteEndpointMetadata extends JenaMetadata {
     }
 
     @Override
-    public boolean supportsTransactionIsolationLevel(int isolationLevel) throws SQLException {
+    public boolean supportsTransactionIsolationLevel(int isolationLevel) {
         // No transactions supported for remote endpoints
         switch (isolationLevel) {
         case Connection.TRANSACTION_NONE:
@@ -62,24 +62,24 @@ public class RemoteEndpointMetadata extends JenaMetadata {
     }
 
     @Override
-    public int getDatabaseMajorVersion() throws SQLException {
+    public int getDatabaseMajorVersion() {
         // Underlying database is unknown
         return 0;
     }
 
     @Override
-    public int getDatabaseMinorVersion() throws SQLException {
+    public int getDatabaseMinorVersion() {
         // Underlying database is unknown
         return 0;
     }
 
     @Override
-    public String getDatabaseProductName() throws SQLException {
+    public String getDatabaseProductName() {
         return "";
     }
 
     @Override
-    public String getDatabaseProductVersion() throws SQLException {
+    public String getDatabaseProductVersion() {
         // Underlying database is unknown
         return "";
     }
@@ -95,23 +95,23 @@ public class RemoteEndpointMetadata extends JenaMetadata {
     }
 
     @Override
-    public String getDriverName() throws SQLException {
+    public String getDriverName() {
         return "Apache Jena - JDBC - Remote Endpoint Driver";
     }
 
     @Override
-    public String getDriverVersion() throws SQLException {
+    public String getDriverVersion() {
         return jdbc.toString();
     }
 
     @Override
-    public String getURL() throws SQLException {
+    public String getURL() {
         // Underlying database is unknown
         return null;
     }
 
     @Override
-    public String getUserName() throws SQLException {
+    public String getUserName() {
         // Even though we may be using a HTTP authenticator that may not be
         // using a user name based login method and regardless for security
         // reasons the authenticator APIs don't expose the underlying
@@ -120,13 +120,13 @@ public class RemoteEndpointMetadata extends JenaMetadata {
     }
 
     @Override
-    public boolean usesLocalFilePerTable() throws SQLException {
+    public boolean usesLocalFilePerTable() {
         // Remote endpoints don't use local files
         return false;
     }
 
     @Override
-    public boolean usesLocalFiles() throws SQLException {
+    public boolean usesLocalFiles() {
         // Remote endpoints don't use local files
         return false;
     }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/statements/RemoteEndpointPreparedStatement.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/statements/RemoteEndpointPreparedStatement.java
@@ -156,7 +156,7 @@ public class RemoteEndpointPreparedStatement extends JenaPreparedStatement {
     }
 
     @Override
-    protected boolean hasActiveTransaction() throws SQLException {
+    protected boolean hasActiveTransaction() {
         // Remote endpoints don't support transactions so can't ever have an
         // active transaction
         return false;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/statements/RemoteEndpointStatement.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/statements/RemoteEndpointStatement.java
@@ -151,7 +151,7 @@ public class RemoteEndpointStatement extends JenaStatement {
     }
 
     @Override
-    protected boolean hasActiveTransaction() throws SQLException {
+    protected boolean hasActiveTransaction() {
         // Remote endpoints don't support transactions so can't ever have an
         // active transaction
         return false;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithGraphUris.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithGraphUris.java
@@ -113,7 +113,7 @@ public class TestRemoteEndpointConnectionWithGraphUris extends AbstractRemoteEnd
     }
 
     @Override
-    protected String getDefaultGraphName() throws SQLException {
+    protected String getDefaultGraphName() {
         return DEFAULT_GRAPH_URI;
     }
 

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResults.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResults.java
@@ -54,19 +54,17 @@ public class TestRemoteEndpointResults extends AbstractRemoteEndpointResultSetTe
     
     /**
      * Clean up after each test by resetting the Fuseki instance
-     * @throws InterruptedException 
      */
     @After
-    public void cleanupTest() throws InterruptedException {
+    public void cleanupTest() {
         ServerTest.resetServer();
     }
     /**
      * Clean up after tests by de-allocating the Fuseki instance
      * @throws SQLException 
-     * @throws InterruptedException 
      */
     @AfterClass
-    public static void cleanup() throws SQLException, InterruptedException {
+    public static void cleanup() throws SQLException {
         connection.close();
         ServerTest.freeServer();
     }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithAuth.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithAuth.java
@@ -96,10 +96,9 @@ public class TestRemoteEndpointResultsWithAuth extends AbstractRemoteEndpointRes
 
     /**
      * Clean up after each test by resetting the Fuseki instance
-     * @throws InterruptedException 
      */
     @After
-    public void cleanupTest() throws InterruptedException {
+    public void cleanupTest() {
         Update clearRequest = new UpdateDrop(Target.ALL) ;
         UpdateProcessor proc = UpdateExecutionFactory.createRemote(clearRequest, ServerTest.serviceUpdate, authenticator) ;
         proc.execute() ;
@@ -109,10 +108,9 @@ public class TestRemoteEndpointResultsWithAuth extends AbstractRemoteEndpointRes
      * Clean up after tests by de-allocating the Fuseki instance
      * 
      * @throws SQLException
-     * @throws InterruptedException 
      */
     @AfterClass
-    public static void cleanup() throws SQLException, InterruptedException {
+    public static void cleanup() throws SQLException {
         
         // Sleep attempts to avoid a intermittent timing issue on the build server that can result in hung builds
         

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithGraphUris.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithGraphUris.java
@@ -63,20 +63,18 @@ public class TestRemoteEndpointResultsWithGraphUris extends AbstractRemoteEndpoi
     
     /**
      * Clean up after each test by resetting the Fuseki instance
-     * @throws InterruptedException 
      */
     @After
-    public void cleanupTest() throws InterruptedException {
+    public void cleanupTest() {
         ServerTest.resetServer();
     }
     
     /**
      * Clean up after tests by de-allocating the Fuseki instance
      * @throws SQLException 
-     * @throws InterruptedException 
      */
     @AfterClass
-    public static void cleanup() throws SQLException, InterruptedException {
+    public static void cleanup() throws SQLException {
         connection.close();
         ServerTest.freeServer();
     }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithResultSetTypes.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithResultSetTypes.java
@@ -55,20 +55,18 @@ public class TestRemoteEndpointResultsWithResultSetTypes extends AbstractRemoteE
     
     /**
      * Clean up after each test by resetting the Fuseki instance
-     * @throws InterruptedException 
      */
     @After
-    public void cleanupTest() throws InterruptedException {
+    public void cleanupTest() {
         ServerTest.resetServer();
     }
     
     /**
      * Clean up after tests by de-allocating the Fuseki instance
      * @throws SQLException 
-     * @throws InterruptedException 
      */
     @AfterClass
-    public static void cleanup() throws SQLException, InterruptedException {
+    public static void cleanup() throws SQLException {
         
         // Sleep attempts to avoid a intermittent timing issue on the build server that can result in hung builds
         

--- a/jena-jdbc/jena-jdbc-driver-tdb/src/main/java/org/apache/jena/jdbc/tdb/connections/TDBConnection.java
+++ b/jena-jdbc/jena-jdbc-driver-tdb/src/main/java/org/apache/jena/jdbc/tdb/connections/TDBConnection.java
@@ -49,7 +49,7 @@ public class TDBConnection extends DatasetConnection {
     }
 
     @Override
-    public DatabaseMetaData getMetaData() throws SQLException {
+    public DatabaseMetaData getMetaData() {
         return this.metadata;
     }
 

--- a/jena-jdbc/jena-jdbc-driver-tdb/src/main/java/org/apache/jena/jdbc/tdb/metadata/TDBDatasetMetadata.java
+++ b/jena-jdbc/jena-jdbc-driver-tdb/src/main/java/org/apache/jena/jdbc/tdb/metadata/TDBDatasetMetadata.java
@@ -50,27 +50,27 @@ public class TDBDatasetMetadata extends DatasetMetadata {
     }
 
     @Override
-    public int getDatabaseMajorVersion() throws SQLException {
+    public int getDatabaseMajorVersion() {
         return 0;
     }
 
     @Override
-    public int getDatabaseMinorVersion() throws SQLException {
+    public int getDatabaseMinorVersion() {
         return 10;
     }
 
     @Override
-    public String getDatabaseProductName() throws SQLException {
+    public String getDatabaseProductName() {
         return "Apache Jena - TDB";
     }
 
     @Override
-    public String getDatabaseProductVersion() throws SQLException {
+    public String getDatabaseProductVersion() {
         return tdb.toString(true);
     }
     
     @Override
-    public int getDefaultTransactionIsolation() throws SQLException {
+    public int getDefaultTransactionIsolation() {
         return Connection.TRANSACTION_SERIALIZABLE;
     }
 
@@ -85,34 +85,34 @@ public class TDBDatasetMetadata extends DatasetMetadata {
     }
 
     @Override
-    public String getDriverName() throws SQLException {
+    public String getDriverName() {
         return "Apache Jena - JDBC - TDB Driver";
     }
 
     @Override
-    public String getDriverVersion() throws SQLException {
+    public String getDriverVersion() {
         return jdbc.toString(true);
     }
 
     @Override
-    public String getURL() throws SQLException {
+    public String getURL() {
         return "http://jena.apache.org";
     }
 
     @Override
-    public boolean usesLocalFilePerTable() throws SQLException {
+    public boolean usesLocalFilePerTable() {
         // TDB database doesn't use files per table
         return false;
     }
 
     @Override
-    public boolean usesLocalFiles() throws SQLException {
+    public boolean usesLocalFiles() {
         // TDB database does use files
         return true;
     }
 
     @Override
-    public boolean supportsTransactionIsolationLevel(int level) throws SQLException {
+    public boolean supportsTransactionIsolationLevel(int level) {
         // TDB supports Serializable transactions
         switch (level) {
         case Connection.TRANSACTION_SERIALIZABLE:
@@ -123,7 +123,7 @@ public class TDBDatasetMetadata extends DatasetMetadata {
     }
 
     @Override
-    public boolean supportsTransactions() throws SQLException {
+    public boolean supportsTransactions() {
         // TDB supports transactions
         return true;
     }

--- a/jena-jdbc/jena-jdbc-driver-tdb/src/test/java/org/apache/jena/jdbc/tdb/results/TestTdbDiskResultSets.java
+++ b/jena-jdbc/jena-jdbc-driver-tdb/src/test/java/org/apache/jena/jdbc/tdb/results/TestTdbDiskResultSets.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.jdbc.tdb.results;
 
-import java.sql.SQLException;
-
 import org.apache.jena.jdbc.utils.TestUtils;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.tdb.StoreConnection ;
@@ -56,7 +54,7 @@ public class TestTdbDiskResultSets extends AbstractTdbResultSetTests {
     }
 
     @Override
-    protected Dataset prepareDataset(Dataset ds) throws SQLException {
+    protected Dataset prepareDataset(Dataset ds) {
         if (this.currDataset != null) {
             this.currDataset.close();
         }

--- a/jena-jdbc/jena-jdbc-driver-tdb/src/test/java/org/apache/jena/jdbc/tdb/results/TestTdbMemResultSets.java
+++ b/jena-jdbc/jena-jdbc-driver-tdb/src/test/java/org/apache/jena/jdbc/tdb/results/TestTdbMemResultSets.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.jdbc.tdb.results;
 
-import java.sql.SQLException;
-
 import org.apache.jena.jdbc.utils.TestUtils;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.tdb.StoreConnection ;
@@ -47,7 +45,7 @@ public class TestTdbMemResultSets extends AbstractTdbResultSetTests {
     }
     
     @Override
-    protected Dataset prepareDataset(Dataset ds) throws SQLException {
+    protected Dataset prepareDataset(Dataset ds) {
         if (currDataset != null) {
             currDataset.close();
         }


### PR DESCRIPTION
Remove some forms of dead code from jena-jdbc, including:

Unthrown checked exceptions
Unnecessary superinterface declarations
Needless typecasts
Unused imports