### PR TITLE
Removing out-of-date comment and empty @Overrides from Dataset

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/Dataset.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/Dataset.java
@@ -32,7 +32,6 @@ import org.apache.jena.sparql.util.Context ;
 
 public interface Dataset extends Transactional
 {
-    // Rather than pull in the internal "Tranactional" interface, we duplicate it here. 
     /** Get the default graph as a Jena Model */
     public Model getDefaultModel() ;
     
@@ -69,27 +68,7 @@ public interface Dataset extends Transactional
      *  which otherwise may throw {@link UnsupportedOperationException}
      */
     public boolean supportsTransactions() ;
-    
-    /** Start either a READ or WRITE transaction */ 
-    @Override
-    public void begin(ReadWrite readWrite) ;
-    
-    /** Commit a transaction - finish the transaction and make any changes permanent (if a "write" transaction) */  
-    @Override
-    public void commit() ;
-    
-    /** Abort a transaction - finish the transaction and undo any changes (if a "write" transaction) */  
-    @Override
-    public void abort() ;
 
-    /** Say whether a transaction is active */ 
-    @Override
-    public boolean isInTransaction() ;
-    
-    /** Finish the transaction - if a write transaction and commit() has not been called, then abort */  
-    @Override
-    public void end() ;
-    
     /** Get the dataset in graph form */
     public DatasetGraph asDatasetGraph() ; 
     


### PR DESCRIPTION
A comment in `Dataset` indicated that it did not implement `Transactional` when in fact it now does. I removed that comment and the now-unnecessary overriden methods.