### PR TITLE
Bump versions of JUnit, Guava for Elephas

### DIFF
--- a/jena-elephas/pom.xml
+++ b/jena-elephas/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <plugin.compiler.version>2.6.0</plugin.compiler.version>
     <arq.version>3.0.0-SNAPSHOT</arq.version>
-    <junit.version>4.11</junit.version>
+    <junit.version>4.12</junit.version>
     <mrunit.version>1.0.0</mrunit.version>
     <airline.version>0.9.2</airline.version>
   </properties>
@@ -70,7 +70,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>11.0.2</version>
+        <version>16.0.1</version>
       </dependency>
 
       <!-- Jena Dependencies -->


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JENA-994

Possibly off-target or too late for this ticket, but bumping Hadoop to latest release enables bringing Guava to latest release as well, a nice bonus.