### PR TITLE
Fix for ordering problem in JENA-624

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapQuadTable.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapQuadTable.java
@@ -20,7 +20,6 @@ package org.apache.jena.sparql.core.mem;
 
 import static java.util.stream.Stream.empty;
 import static java.util.stream.Stream.of;
-import static org.apache.jena.sparql.core.Quad.create;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.stream.Stream;
@@ -59,6 +58,8 @@ public abstract class PMapQuadTable extends PMapTupleTable<FourTupleMap, Quad>im
 		return new FourTupleMap();
 	}
 
+	protected abstract Quad quad(final Node first, final Node second, final Node third, final Node fourth);
+
 	/**
 	 * We descend through the nested {@link PMap}s building up {@link Stream}s of partial tuples from which we develop a
 	 * {@link Stream} of full tuples which is our result. Use {@link Node#ANY} or <code>null</code> for a wildcard.
@@ -85,26 +86,26 @@ public abstract class PMapQuadTable extends PMapTupleTable<FourTupleMap, Quad>im
 								if (isConcrete(fourth)) {
 									debug("Using a specific fourth slot value.");
 									return oneTuples
-											.contains(fourth) ? of(create(first, second, third, fourth)) : empty();
+											.contains(fourth) ? of(quad(first, second, third, fourth)) : empty();
 								}
 								debug("Using a wildcard fourth slot value.");
-								return oneTuples.stream().map(slot4 -> create(first, second, third, slot4));
+								return oneTuples.stream().map(slot4 -> quad(first, second, third, slot4));
 							}).orElse(empty());
 
 						}
 						debug("Using wildcard third and fourth slot values.");
 						return twoTuples.flatten((slot3, oneTuples) -> oneTuples.stream()
-								.map(slot4 -> create(first, second, slot3, slot4)));
+								.map(slot4 -> quad(first, second, slot3, slot4)));
 					}).orElse(empty());
 				}
 				debug("Using wildcard second, third and fourth slot values.");
 				return threeTuples.flatten((slot2, twoTuples) -> twoTuples.flatten(
-						(slot3, oneTuples) -> oneTuples.stream().map(slot4 -> create(first, slot2, slot3, slot4))));
+						(slot3, oneTuples) -> oneTuples.stream().map(slot4 -> quad(first, slot2, slot3, slot4))));
 			}).orElse(empty());
 		}
 		debug("Using a wildcard for all slot values.");
 		return fourTuples.flatten((slot1, threeTuples) -> threeTuples.flatten((slot2, twoTuples) -> twoTuples
-				.flatten((slot3, oneTuples) -> oneTuples.stream().map(slot4 -> create(slot1, slot2, slot3, slot4)))));
+				.flatten((slot3, oneTuples) -> oneTuples.stream().map(slot4 -> quad(slot1, slot2, slot3, slot4)))));
 	}
 
 	protected void _add(final Node first, final Node second, final Node third, final Node fourth) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapQuadTable.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapQuadTable.java
@@ -58,6 +58,16 @@ public abstract class PMapQuadTable extends PMapTupleTable<FourTupleMap, Quad>im
 		return new FourTupleMap();
 	}
 
+	/**
+	 * Constructs a {@link Quad} from the nodes given, using the appropriate order for this table. E.g. a OPSG table
+	 * should return a {@code Quad} using ({@code fourth}, {@code third}, {@code second}, {@code first}).
+	 *
+	 * @param first
+	 * @param second
+	 * @param third
+	 * @param fourth
+	 * @return a {@code Quad}
+	 */
 	protected abstract Quad quad(final Node first, final Node second, final Node third, final Node fourth);
 
 	/**

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapTripleTable.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapTripleTable.java
@@ -19,7 +19,6 @@
 package org.apache.jena.sparql.core.mem;
 
 import static java.util.stream.Stream.empty;
-import static org.apache.jena.graph.Triple.create;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.stream.Stream;
@@ -78,21 +77,23 @@ public abstract class PMapTripleTable extends PMapTupleTable<ThreeTupleMap, Trip
 					return twoTuples.get(second).map(oneTuples -> {
 						if (isConcrete(third)) {
 							debug("Using a specific third slot value.");
-							return oneTuples.contains(third) ? Stream.of(create(first, second, third)) : empty();
+							return oneTuples.contains(third) ? Stream.of(triple(first, second, third)) : empty();
 						}
 						debug("Using a wildcard third slot value.");
-						return oneTuples.stream().map(slot3 -> create(first, second, slot3));
+						return oneTuples.stream().map(slot3 -> triple(first, second, slot3));
 					}).orElse(empty());
 				}
 				debug("Using wildcard second and third slot values.");
 				return twoTuples
-						.flatten((slot2, oneTuples) -> oneTuples.stream().map(slot3 -> create(first, slot2, slot3)));
+						.flatten((slot2, oneTuples) -> oneTuples.stream().map(slot3 -> triple(first, slot2, slot3)));
 			}).orElse(empty());
 		}
 		debug("Using a wildcard for all slot values.");
 		return threeTuples.flatten((slot1, twoTuples) -> twoTuples
-				.flatten((slot2, oneTuples) -> oneTuples.stream().map(slot3 -> create(slot1, slot2, slot3))));
+				.flatten((slot2, oneTuples) -> oneTuples.stream().map(slot3 -> triple(slot1, slot2, slot3))));
 	}
+
+	protected abstract Triple triple(final Node first, final Node second, final Node third);
 
 	protected void _add(final Node first, final Node second, final Node third) {
 		debug("Adding three-tuple {} {} {}", first, second, third);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapTripleTable.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapTripleTable.java
@@ -93,6 +93,15 @@ public abstract class PMapTripleTable extends PMapTupleTable<ThreeTupleMap, Trip
 				.flatten((slot2, oneTuples) -> oneTuples.stream().map(slot3 -> triple(slot1, slot2, slot3))));
 	}
 
+	/**
+	 * Constructs a {@link Triple} from the nodes given, using the appropriate order for this table. E.g. a POS table
+	 * should return a {@code Triple} using ({@code second}, {@code third}, {@code first}).
+	 *
+	 * @param first
+	 * @param second
+	 * @param third
+	 * @return a {@code Triple}
+	 */
 	protected abstract Triple triple(final Node first, final Node second, final Node third);
 
 	protected void _add(final Node first, final Node second, final Node third) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/QuadTableForm.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/QuadTableForm.java
@@ -54,6 +54,12 @@ public enum QuadTableForm implements Supplier<QuadTable>,Predicate<Set<TupleSlot
 		@Override
 		public PMapQuadTable get() {
 			return new PMapQuadTable(name()) {
+
+				@Override
+				protected Quad quad(final Node g, final Node s, final Node p, final Node o) {
+					return Quad.create(g, s, p, o);
+				}
+
 				@Override
 				public Stream<Quad> find(final Node g, final Node s, final Node p, final Node o) {
 					return _find(g, s, p, o);
@@ -86,6 +92,11 @@ public enum QuadTableForm implements Supplier<QuadTable>,Predicate<Set<TupleSlot
 			return new PMapQuadTable(name()) {
 
 				@Override
+				protected Quad quad(final Node g, final Node o, final Node p, final Node s) {
+					return Quad.create(g, s, p, o);
+				}
+
+				@Override
 				public Stream<Quad> find(final Node g, final Node s, final Node p, final Node o) {
 					return _find(g, o, p, s);
 				}
@@ -111,6 +122,11 @@ public enum QuadTableForm implements Supplier<QuadTable>,Predicate<Set<TupleSlot
 		@Override
 		public PMapQuadTable get() {
 			return new PMapQuadTable(name()) {
+
+				@Override
+				protected Quad quad(final Node s, final Node p, final Node o, final Node g) {
+					return Quad.create(g, s, p, o);
+				}
 
 				@Override
 				public Stream<Quad> find(final Node g, final Node s, final Node p, final Node o) {
@@ -148,6 +164,11 @@ public enum QuadTableForm implements Supplier<QuadTable>,Predicate<Set<TupleSlot
 			return new PMapQuadTable(name()) {
 
 				@Override
+				protected Quad quad(final Node o, final Node s, final Node p, final Node g) {
+					return Quad.create(g, s, p, o);
+				}
+
+				@Override
 				public Stream<Quad> find(final Node g, final Node s, final Node p, final Node o) {
 					return _find(o, s, g, p);
 				}
@@ -174,6 +195,11 @@ public enum QuadTableForm implements Supplier<QuadTable>,Predicate<Set<TupleSlot
 			return new PMapQuadTable(name()) {
 
 				@Override
+				protected Quad quad(final Node p, final Node g, final Node s, final Node o) {
+					return Quad.create(g, s, p, o);
+				}
+
+				@Override
 				public Stream<Quad> find(final Node g, final Node s, final Node p, final Node o) {
 					return _find(p, g, s, o);
 				}
@@ -198,6 +224,11 @@ public enum QuadTableForm implements Supplier<QuadTable>,Predicate<Set<TupleSlot
 		@Override
 		public PMapQuadTable get() {
 			return new PMapQuadTable(name()) {
+
+				@Override
+				protected Quad quad(final Node o, final Node p, final Node s, final Node g) {
+					return Quad.create(g, s, p, o);
+				}
 
 				@Override
 				public Stream<Quad> find(final Node g, final Node s, final Node p, final Node o) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/TripleTableForm.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/TripleTableForm.java
@@ -45,6 +45,11 @@ public enum TripleTableForm implements Supplier<TripleTable>,Predicate<Set<Tuple
 			return new PMapTripleTable(name()) {
 
 				@Override
+				protected Triple triple(final Node s, final Node p, final Node o) {
+					return Triple.create(s, p, o);
+				}
+
+				@Override
 				public Stream<Triple> find(final Node s, final Node p, final Node o) {
 					return _find(s, p, o);
 				}
@@ -73,6 +78,11 @@ public enum TripleTableForm implements Supplier<TripleTable>,Predicate<Set<Tuple
 			return new PMapTripleTable(name()) {
 
 				@Override
+				protected Triple triple(final Node p, final Node o, final Node s) {
+					return Triple.create(s, p, o);
+				}
+
+				@Override
 				public Stream<Triple> find(final Node s, final Node p, final Node o) {
 					return _find(p, o, s);
 				}
@@ -98,6 +108,11 @@ public enum TripleTableForm implements Supplier<TripleTable>,Predicate<Set<Tuple
 		@Override
 		public TripleTable get() {
 			return new PMapTripleTable(name()) {
+
+				@Override
+				protected Triple triple(final Node o, final Node s, final Node p) {
+					return Triple.create(s, p, o);
+				}
 
 				@Override
 				public Stream<Triple> find(final Node s, final Node p, final Node o) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemory.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemory.java
@@ -19,7 +19,9 @@
 package org.apache.jena.sparql.core.mem;
 
 import static com.jayway.awaitility.Awaitility.await;
+import static java.lang.System.err;
 import static org.apache.jena.atlas.iterator.Iter.iter;
+import static org.apache.jena.atlas.iterator.Iter.some;
 import static org.apache.jena.graph.Node.ANY;
 import static org.apache.jena.graph.NodeFactory.createBlankNode;
 import static org.apache.jena.graph.NodeFactory.createURI;
@@ -27,11 +29,14 @@ import static org.apache.jena.query.ReadWrite.READ;
 import static org.apache.jena.query.ReadWrite.WRITE;
 import static org.apache.jena.sparql.core.Quad.unionGraph;
 import static org.apache.jena.sparql.graph.GraphFactory.createGraphMem;
+import static org.apache.jena.sparql.sse.SSE.*;
 import static org.junit.Assert.*;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Dataset;
@@ -192,6 +197,27 @@ public class TestDatasetGraphInMemory {
 	}
 
 	public static class TestDatasetGraphInMemoryBasic extends AbstractDatasetGraphTests {
+
+		@Test
+		public void orderingOfNodesFromFindIsCorrect() {
+			final DatasetGraph dsg = DatasetGraphFactory.createTxnMem() ;
+
+	        final Node p = parseNode(":p") ;
+	        final Triple triple = parseTriple("(:s :p :o)");
+			dsg.getDefaultGraph().add(triple);
+	        final Iterator<Triple> iter = dsg.getDefaultGraph().find(null, p, null) ;
+	        assertTrue(some(iter, triple::equals));
+
+
+	        final Node p1 = parseNode(":p1") ;
+	        final Quad quad = parseQuad("(:g1 :s1 :p1 :o1)");
+			dsg.add(quad) ;
+
+	        final Iterator<Quad> iter2 = dsg.find(null, null, p1, null) ;
+
+	        assertTrue(some(iter2, quad::equals));
+	        Iter.print(err,iter2);
+		}
 
 		@Test
 		public void prefixesAreManaged() {


### PR DESCRIPTION
Introduces new ordering methods `PMapTripleTable::triple` and `PMapQuadTable::quad` to provide correct ordering in the construction of tuples for query results.