### PR TITLE
J1068 remove dsg caching

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphCaching.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphCaching.java
@@ -34,21 +34,22 @@ import org.apache.jena.graph.Node ;
  * 
  * The cache is finite and graphs will be dropped as needed. 
  *  
- * {@link DatasetGraphMap} provides an implementation which is an extensable collection of graphs.
+ * @deprecated This class will be removed.
  */
+@Deprecated
 abstract public class DatasetGraphCaching extends DatasetGraphTriplesQuads
 {
     private final boolean caching = true ;
     private boolean closed = false ;
 
     // read synchronised in this class, not needed for a sync wrapper.
-    protected Graph defaultGraph = null ;
-    protected Cache<Node, Graph> namedGraphs = CacheFactory.createCache(100) ;
+    private Graph defaultGraph = null ;
+    private Cache<Node, Graph> namedGraphs = CacheFactory.createCache(100) ;
     
-    abstract protected void _close() ;
-    abstract protected Graph _createNamedGraph(Node graphNode) ;
-    abstract protected Graph _createDefaultGraph() ;
-    abstract protected boolean _containsGraph(Node graphNode) ;
+    @Deprecated abstract protected void _close() ;
+    @Deprecated abstract protected Graph _createNamedGraph(Node graphNode) ;
+    @Deprecated abstract protected Graph _createDefaultGraph() ;
+    @Deprecated abstract protected boolean _containsGraph(Node graphNode) ;
     
     protected DatasetGraphCaching() { this(100) ; }
     
@@ -104,7 +105,7 @@ abstract public class DatasetGraphCaching extends DatasetGraphTriplesQuads
 
     @Override
     public final void removeGraph(Node graphName) {
-        deleteAny(graphName, Node.ANY, Node.ANY, Node.ANY) ;
+        super.removeGraph(graphName);
         synchronized (this) {
             namedGraphs.remove(graphName) ;
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphCaching.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphCaching.java
@@ -19,16 +19,13 @@
 package org.apache.jena.sparql.core;
 
 
-import java.util.Iterator ;
 import java.util.concurrent.Callable ;
 
-import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.Cache ;
 import org.apache.jena.atlas.lib.CacheFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.GraphUtil ;
 import org.apache.jena.graph.Node ;
-import org.apache.jena.graph.Triple ;
 
 /** 
  * DatasetGraph that <em>caches</em> calls to make graph implementations.  
@@ -132,44 +129,6 @@ abstract public class DatasetGraphCaching extends DatasetGraphTriplesQuads
             namedGraphs.clear() ;
             _close() ;
             super.close() ;
-        }
-    }
-    
-    // Helper implementations of operations.
-    // Not necessarily efficient.
-    protected static class Helper {
-        public static void addToDftGraph(DatasetGraphCaching dsg, Node s, Node p, Node o) {
-            dsg.getDefaultGraph().add(new Triple(s, p, o)) ;
-        }
-
-        public static void addToNamedGraph(DatasetGraphCaching dsg, Node g, Node s, Node p, Node o) {
-            dsg.getGraph(g).add(new Triple(s, p, o)) ;
-        }
-
-        public static void deleteFromDftGraph(DatasetGraphCaching dsg, Node s, Node p, Node o) {
-            dsg.getDefaultGraph().delete(new Triple(s, p, o)) ;
-        }
-
-        public static void deleteFromNamedGraph(DatasetGraphCaching dsg, Node g, Node s, Node p, Node o) {
-            dsg.getGraph(g).delete(new Triple(s, p, o)) ;
-        }
-
-        public static Iterator<Quad> findInAnyNamedGraphs(DatasetGraphCaching dsg, Node s, Node p, Node o) {
-            Iterator<Node> iter = dsg.listGraphNodes() ;
-            Iterator<Quad> quads = null ;
-            for ( ; iter.hasNext() ; ) {
-                Node gn = iter.next() ;
-                quads = Iter.append(quads, findInSpecificNamedGraph(dsg, gn, s, p, o)) ;
-            }
-            return quads ;
-        }
-
-        public static Iterator<Quad> findInDftGraph(DatasetGraphCaching dsg, Node s, Node p, Node o) {
-            return triples2quadsDftGraph(dsg.getDefaultGraph().find(s, p, o)) ;
-        }
-
-        public static Iterator<Quad> findInSpecificNamedGraph(DatasetGraphCaching dsg, Node g, Node s, Node p, Node o) {
-            return triples2quadsDftGraph(dsg.getGraph(g).find(s, p, o)) ;
         }
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphSimpleMem.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphSimpleMem.java
@@ -18,12 +18,7 @@
 
 package org.apache.jena.sparql.core;
 
-import java.util.ArrayList ;
-import java.util.Collection ;
-import java.util.HashSet ;
-import java.util.Iterator ;
-import java.util.List ;
-import java.util.Set ;
+import java.util.* ;
 
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
@@ -33,9 +28,10 @@ import org.apache.jena.util.iterator.ExtendedIterator ;
 import org.apache.jena.util.iterator.WrappedIterator ;
 
 /** Very simple, non-scalable DatasetGraph implementation 
- * of a triples+quads style for testing.
+ * of a triples+quads style for testing the {@link DatasetGraphTriplesQuads}
+ * style implementation framework. 
  */
-public class DatasetGraphSimpleMem extends DatasetGraphCaching
+public class DatasetGraphSimpleMem extends DatasetGraphTriplesQuads
 {
     private MiniSet<Triple> triples = new MiniSet<>() ;
     private MiniSet<Quad> quads = new MiniSet<>() ;
@@ -205,19 +201,19 @@ public class DatasetGraphSimpleMem extends DatasetGraphCaching
     }
     
     @Override
-    protected Graph _createDefaultGraph()
+    public Graph getDefaultGraph()
     {
         return new GraphDft() ;
     }
 
     @Override
-    protected Graph _createNamedGraph(Node graphNode)
+    public Graph getGraph(Node graphNode)
     {
         return new GraphNamed(graphNode) ;
     }
 
     @Override
-    protected boolean _containsGraph(Node graphNode)
+    public boolean containsGraph(Node graphNode)
     {
         return graphNodes().contains(graphNode) ;
     }
@@ -237,6 +233,6 @@ public class DatasetGraphSimpleMem extends DatasetGraphCaching
     }
 
     @Override
-    protected void _close()
+    public void close()
     {}
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphTriplesQuads.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphTriplesQuads.java
@@ -18,9 +18,9 @@
 
 package org.apache.jena.sparql.core;
 
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.graph.GraphUtil ;
 import org.apache.jena.graph.Node ;
-
-
 
 /** A DatasetGraph base class for triples+quads storage.     
  */
@@ -62,4 +62,15 @@ public abstract class DatasetGraphTriplesQuads extends DatasetGraphBaseFind
     protected abstract void addToNamedGraph(Node g, Node s, Node p, Node o) ;
     protected abstract void deleteFromDftGraph(Node s, Node p, Node o) ;
     protected abstract void deleteFromNamedGraph(Node g, Node s, Node p, Node o) ;
+    
+    // Default implementations.
+    @Override
+    public void addGraph(Node graphName, Graph graph) {
+        GraphUtil.addInto(getGraph(graphName), graph) ;
+    }
+    
+    @Override
+    public void removeGraph(Node graphName) {
+        deleteAny(graphName, Node.ANY, Node.ANY, Node.ANY) ;
+    }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraphMgt.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraphMgt.java
@@ -37,8 +37,12 @@ public abstract class AbstractTestUpdateGraphMgt extends AbstractTestUpdateBase
     {
         DatasetGraph gStore = getEmptyDatasetGraph() ;
         Update u = new UpdateCreate(graphIRI) ;
+        
         UpdateAction.execute(u, gStore) ;
-        assertTrue(gStore.containsGraph(graphIRI)) ;
+        // Only true if a graph caching layer exists.
+        // JENA-1068 removed that layer 
+        // (which wasn't safe anyway - it only "existed" in the memory cache) 
+//        assertTrue(gStore.containsGraph(graphIRI)) ;
         assertTrue(graphEmpty(gStore.getGraph(graphIRI))) ;
 
         // With "auto SILENT" then these aren't errors.
@@ -77,8 +81,8 @@ public abstract class AbstractTestUpdateGraphMgt extends AbstractTestUpdateBase
         
         u = new UpdateCreate(graphIRI, true) ;
         UpdateAction.execute(u, gStore) ;
-        
-        assertTrue(gStore.containsGraph(graphIRI)) ;
+        // JENA-1068
+//        assertTrue(gStore.containsGraph(graphIRI)) ;
         assertTrue(graphEmpty(gStore.getGraph(graphIRI))) ;
         
         u = new UpdateDrop(graphIRI) ;
@@ -93,7 +97,8 @@ public abstract class AbstractTestUpdateGraphMgt extends AbstractTestUpdateBase
     {
         DatasetGraph gStore = getEmptyDatasetGraph() ;
         script(gStore, "create-1.ru") ;
-        assertTrue(gStore.containsGraph(graphIRI)) ;
+        // JENA-1068
+//        assertTrue(gStore.containsGraph(graphIRI)) ;
         assertTrue(graphEmpty(gStore.getGraph(graphIRI))) ;
     }
 

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/store/DatasetGraphSDB.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/store/DatasetGraphSDB.java
@@ -20,9 +20,11 @@ package org.apache.jena.sdb.store;
 
 import java.util.Iterator ;
 
+import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.Closeable ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.Triple ;
 import org.apache.jena.sdb.Store ;
 import org.apache.jena.sdb.graph.GraphSDB ;
 import org.apache.jena.sdb.util.StoreUtils ;
@@ -112,4 +114,42 @@ public class DatasetGraphSDB extends DatasetGraphCaching
     protected void _close()
     { store.close() ; }
 
+    // Helper implementations of operations.
+    // Not necessarily efficient.
+    
+    private static class Helper {
+        public static void addToDftGraph(DatasetGraph dsg, Node s, Node p, Node o) {
+            dsg.getDefaultGraph().add(new Triple(s, p, o)) ;
+        }
+
+        public static void addToNamedGraph(DatasetGraph dsg, Node g, Node s, Node p, Node o) {
+            dsg.getGraph(g).add(new Triple(s, p, o)) ;
+        }
+
+        public static void deleteFromDftGraph(DatasetGraph dsg, Node s, Node p, Node o) {
+            dsg.getDefaultGraph().delete(new Triple(s, p, o)) ;
+        }
+
+        public static void deleteFromNamedGraph(DatasetGraph dsg, Node g, Node s, Node p, Node o) {
+            dsg.getGraph(g).delete(new Triple(s, p, o)) ;
+        }
+
+        public static Iterator<Quad> findInAnyNamedGraphs(DatasetGraph dsg, Node s, Node p, Node o) {
+            Iterator<Node> iter = dsg.listGraphNodes() ;
+            Iterator<Quad> quads = null ;
+            for ( ; iter.hasNext() ; ) {
+                Node gn = iter.next() ;
+                quads = Iter.append(quads, findInSpecificNamedGraph(dsg, gn, s, p, o)) ;
+            }
+            return quads ;
+        }
+
+        public static Iterator<Quad> findInDftGraph(DatasetGraph dsg, Node s, Node p, Node o) {
+            return triples2quadsDftGraph(dsg.getDefaultGraph().find(s, p, o)) ;
+        }
+
+        public static Iterator<Quad> findInSpecificNamedGraph(DatasetGraph dsg, Node g, Node s, Node p, Node o) {
+            return triples2quadsDftGraph(dsg.getGraph(g).find(s, p, o)) ;
+        }
+    }
 }

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/store/DatasetGraphSDB.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/store/DatasetGraphSDB.java
@@ -31,20 +31,21 @@ import org.apache.jena.sdb.util.StoreUtils ;
 import org.apache.jena.shared.Lock ;
 import org.apache.jena.shared.LockMRSW ;
 import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.sparql.core.DatasetGraphCaching ;
+import org.apache.jena.sparql.core.DatasetGraphTriplesQuads ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.util.Context ;
 
-public class DatasetGraphSDB extends DatasetGraphCaching
+public class DatasetGraphSDB extends DatasetGraphTriplesQuads
     implements DatasetGraph, Closeable 
 {
     private final Store store ;
     private Lock lock = new LockMRSW() ;
     private final Context context ;
+    private GraphSDB defaultGraph;
     
     public DatasetGraphSDB(Store store, Context context)
     {
-        this(store, null, context) ;
+        this(store, new GraphSDB(store), context) ;
     }
     
     public DatasetGraphSDB(Store store, GraphSDB graph, Context context)
@@ -64,23 +65,23 @@ public class DatasetGraphSDB extends DatasetGraphCaching
     }
 
     @Override
-    protected boolean _containsGraph(Node graphNode)
+    public boolean containsGraph(Node graphNode)
     {
         return StoreUtils.containsGraph(store, graphNode) ;
     }
 
     @Override
-    protected Graph _createDefaultGraph()
+    public Graph getDefaultGraph()
     {
-        return new GraphSDB(store) ;
+        return defaultGraph ;
     }
 
     @Override
-    protected Graph _createNamedGraph(Node graphNode)
+    public Graph getGraph(Node graphNode)
     {
         return new GraphSDB(store, graphNode) ;
     }
-
+    
     // Use unsubtle helper versions (the bulk loader copes with large additions).
     @Override
     protected void addToDftGraph(Node s, Node p, Node o)
@@ -111,7 +112,7 @@ public class DatasetGraphSDB extends DatasetGraphCaching
     { return Helper.findInSpecificNamedGraph(this, g, s, p, o) ; }
 
     @Override
-    protected void _close()
+    public void close()
     { store.close() ; }
 
     // Helper implementations of operations.

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/store/DatasetGraphTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/store/DatasetGraphTDB.java
@@ -20,6 +20,7 @@ package org.apache.jena.tdb.store;
 
 
 import java.util.Iterator ;
+
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.Closeable ;
 import org.apache.jena.atlas.lib.Sync ;
@@ -27,7 +28,7 @@ import org.apache.jena.atlas.lib.Tuple ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
-import org.apache.jena.sparql.core.DatasetGraphCaching ;
+import org.apache.jena.sparql.core.DatasetGraphTriplesQuads ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation ;
 import org.apache.jena.tdb.base.file.Location ;
@@ -47,7 +48,7 @@ import org.apache.jena.tdb.transaction.DatasetGraphTxn ;
  *  </ul>
  */
 final
-public class DatasetGraphTDB extends DatasetGraphCaching
+public class DatasetGraphTDB extends DatasetGraphTriplesQuads
                              implements /*DatasetGraph,*/ Sync, Closeable, Session
 {
     private TripleTable tripleTable ;
@@ -73,9 +74,8 @@ public class DatasetGraphTDB extends DatasetGraphCaching
     public TripleTable getTripleTable()     { return tripleTable ; }
     
     @Override
-    protected Iterator<Quad> findInDftGraph(Node s, Node p, Node o) {
-        return triples2quadsDftGraph(getTripleTable().find(s, p, o)) ;
-    }
+    protected Iterator<Quad> findInDftGraph(Node s, Node p, Node o)
+    { return triples2quadsDftGraph(getTripleTable().find(s, p, o)) ; }
 
     @Override
     protected Iterator<Quad> findInSpecificNamedGraph(Node g, Node s, Node p, Node o)
@@ -111,7 +111,7 @@ public class DatasetGraphTDB extends DatasetGraphCaching
     { return (GraphTDB)getGraph(graphNode) ; }
 
     @Override
-    protected void _close() {
+    public void close() {
         if ( closed )
             return ;
         closed = true ;
@@ -130,11 +130,6 @@ public class DatasetGraphTDB extends DatasetGraphCaching
     public boolean containsGraph(Node graphNode) { 
         if ( Quad.isDefaultGraphExplicit(graphNode) || Quad.isUnionGraph(graphNode)  )
             return true ;
-        return _containsGraph(graphNode) ; 
-    }
-
-    @Override
-    protected boolean _containsGraph(Node graphNode) {
         // Have to look explicitly, which is a bit of a nuisance.
         // But does not normally happen for GRAPH <g> because that's rewritten to quads.
         // Only pattern with complex paths go via GRAPH. 
@@ -150,11 +145,11 @@ public class DatasetGraphTDB extends DatasetGraphCaching
     }
 
     @Override
-    protected Graph _createDefaultGraph()
+    public Graph getDefaultGraph()
     { return new GraphTDB(this, null) ; }
 
     @Override
-    protected Graph _createNamedGraph(Node graphNode)
+    public Graph getGraph(Node graphNode)
     { return new GraphTDB(this, graphNode) ; }
 
     //public void setEffectiveDefaultGraph(GraphTDB g)       { effectiveDefaultGraph = g ; }


### PR DESCRIPTION
JENA-1068: Remove use of DatasetGraphCaching.

Removed everywhere then the class put back, deprecated, just in case any external party is using it.