### PR TITLE
JENA-624: Correction to transaction begin for DatasetGraphInMemory

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
@@ -133,6 +133,7 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
 		commitLock().readLock().lock(); // if a commit is proceeding, wait so that we see a coherent index state
 		try {
 			quadsIndex().begin(readWrite);
+			defaultGraph().begin(readWrite);
 		} finally {
 			commitLock().readLock().unlock();
 		}


### PR DESCRIPTION
Correction to transaction begin for DatasetGraphInMemory to include default graph as well as quad table.