### PR TITLE
JENA-1085 : Common pattern for passing down transaction lifecycle operations.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpVars.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpVars.java
@@ -260,17 +260,8 @@ public class OpVars
 
         @Override
         public void visit(OpPropFunc opPropFunc) {
-            addvars(opPropFunc.getSubjectArgs()) ;
-            addvars(opPropFunc.getObjectArgs()) ;
-        }
-
-        private void addvars(PropFuncArg pfArg) {
-            if (pfArg.isNode()) {
-                addVar(acc, pfArg.getArg()) ;
-                return ;
-            }
-            for (Node n : pfArg.getArgList())
-                addVar(acc, n) ;
+            PropFuncArg.addVars(acc, opPropFunc.getSubjectArgs()) ;
+            PropFuncArg.addVars(acc, opPropFunc.getObjectArgs()) ;
         }
 
         @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpProcedure.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpProcedure.java
@@ -91,7 +91,7 @@ public class OpProcedure extends Op1
     @Override
     public Op1 copy(Op subOp)
     {
-        return new OpProcedure(procId, args, getSubOp()) ;
+        return new OpProcedure(procId, args, subOp) ;
     }
 
     public Node getProcId()

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpPropFunc.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpPropFunc.java
@@ -47,19 +47,16 @@ public class OpPropFunc extends Op1
         this.objectArgs = args2 ;
     }
     
-    public PropFuncArg getSubjectArgs()
-    {
+    public PropFuncArg getSubjectArgs() {
         return subjectArgs ;
     } 
     
-    public PropFuncArg getObjectArgs()
-    {
+    public PropFuncArg getObjectArgs() {
         return objectArgs ;
     } 
     
     @Override
-    public Op apply(Transform transform, Op subOp)
-    {
+    public Op apply(Transform transform, Op subOp) {
         return transform.transform(this, subOp) ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpPropFunc.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpPropFunc.java
@@ -70,22 +70,32 @@ public class OpPropFunc extends Op1
     public Node getProperty() { return uri ; }
     
     @Override
-    public Op1 copy(Op op)
-    {
+    public String getName() {
+        return Tags.tagPropFunc ;
+    }
+
+    @Override
+    public Op1 copy(Op op) {
         return new OpPropFunc(uri, subjectArgs, objectArgs, op) ;
     }
 
     @Override
-    public int hashCode()
-    {
+    public int hashCode() {
         return uri.hashCode() ^ getSubOp().hashCode() ;
     }
 
     @Override
-    public boolean equalTo(Op other, NodeIsomorphismMap labelMap)
-    {
-        if ( ! ( other instanceof OpPropFunc ) ) return false ;
+    public boolean equalTo(Op other, NodeIsomorphismMap labelMap) {
+        if ( ! ( other instanceof OpPropFunc ) ) 
+            return false ;
         OpPropFunc procFunc = (OpPropFunc)other ;
+        if ( ! this.getProperty().equals(procFunc.getProperty()) )
+            return false ;
+        
+        PropFuncArg s1 = getSubjectArgs() ;
+        PropFuncArg s2 = procFunc.getSubjectArgs() ;
+        s1.equals(s2) ;
+        
         if ( ! isomorphic(getSubjectArgs(), procFunc.getSubjectArgs(), labelMap) )
             return false ;
         if ( ! isomorphic(getObjectArgs(), procFunc.getObjectArgs(), labelMap) )
@@ -99,15 +109,13 @@ public class OpPropFunc extends Op1
         if ( pfa1 == null ) return false ;
         if ( pfa2 == null ) return false ;
         
-        List<Node> list1 = pfa1.getArgList() ;
-        List<Node> list2 = pfa2.getArgList() ;
-                
-        return Iso.isomorphicNodes(list1, list2, labelMap) ;
-    }
-    
-    @Override
-    public String getName()
-    {
-        return Tags.tagPropFunc ;
+        if ( pfa1.isList() && pfa2.isList() ) {
+            List<Node> list1 = pfa1.getArgList() ;
+            List<Node> list2 = pfa2.getArgList() ;
+            return Iso.isomorphicNodes(list1, list2, labelMap) ;
+        }
+        if ( pfa1.isNode() && pfa2.isNode() )
+            return Iso.nodeIso(pfa1.getArg(), pfa2.getArg(), labelMap) ;
+        return false ;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
@@ -26,7 +26,7 @@ import static org.apache.jena.sparql.core.Quad.isUnionGraph;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.Iterator;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock ;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -37,11 +37,7 @@ import org.apache.jena.query.ReadWrite;
 import org.apache.jena.shared.Lock;
 import org.apache.jena.shared.LockMRPlusSW;
 import org.apache.jena.sparql.JenaTransactionException;
-import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphTriplesQuads;
-import org.apache.jena.sparql.core.DatasetPrefixStorage;
-import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.sparql.core.Transactional;
+import org.apache.jena.sparql.core.* ;
 import org.slf4j.Logger;
 
 /**
@@ -58,19 +54,12 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
     /** This lock imposes the multiple-reader and single-writer policy of transactions */
     private final Lock writeLock = new LockMRPlusSW();
 
-    private Lock writeLock() {
-        return writeLock;
-    }
-
-    private final ReentrantReadWriteLock commitLock = new ReentrantReadWriteLock(true);
-
     /**
-     * Commits must be atomic, and because a thread that is committing alters the various indexes one after another, we
-     * lock out {@link #begin(ReadWrite)} while {@link #commit()} is executing.
+     * Transaction lifecycle operations must be atomi, especially begin and commit where
+     * the global state of the indexes is read or written one after another.
+     *  and because a thread that is committing alters the various indexes.
      */
-    private ReentrantReadWriteLock commitLock() {
-        return commitLock;
-    }
+    private final ReentrantLock systemLock = new ReentrantLock(true);
 
     private final ThreadLocal<Boolean> isInTransaction = withInitial(() -> false);
 
@@ -126,54 +115,73 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
 
     @Override
     public void begin(final ReadWrite readWrite) {
-        if (isInTransaction()) throw new JenaTransactionException("Transactions cannot be nested!");
-        transactionType(readWrite);
-        isInTransaction(true);
-        writeLock().enterCriticalSection(readWrite.equals(READ)); // get the dataset write lock, if needed.
-        commitLock().readLock().lock(); // if a commit is proceeding, wait so that we see a coherent index state
-        try {
-            quadsIndex().begin(readWrite);
-            defaultGraph().begin(readWrite);
-        } finally {
-            commitLock().readLock().unlock();
-        }
+        if (isInTransaction()) 
+            throw new JenaTransactionException("Transactions cannot be nested!");
+        startTransaction(readWrite) ;
+        _begin(readWrite) ;
     }
 
+    private void _begin(ReadWrite readWrite) {
+        withLock(systemLock, () ->{
+            quadsIndex().begin(readWrite);
+            defaultGraph().begin(readWrite);
+        }) ;
+    }
+    
+    /** Called transaction start code at most once per transaction. */ 
+    private void startTransaction(ReadWrite mode) {
+        writeLock.enterCriticalSection(mode.equals(READ)); // get the dataset write lock, if needed.
+        transactionType(mode);
+        isInTransaction(true);
+    }
+
+    /** Called transaction ending code at most once per transaction. */ 
+    private void finishTransaction() {
+        isInTransaction.remove();
+        transactionType.remove();
+        writeLock.leaveCriticalSection();
+    }
+     
     @Override
     public void commit() {
-        if (!isInTransaction()) throw new JenaTransactionException("Tried to commit outside a transaction!");
+        if (!isInTransaction())
+            throw new JenaTransactionException("Tried to commit outside a transaction!");
         if (transactionType().equals(WRITE))
             _commit();
         finishTransaction();
     }
 
     private void _commit() {
-        commitLock().writeLock().lock();
-        try {
+        withLock(systemLock, () -> {
             quadsIndex().commit();
             defaultGraph().commit();
-        } finally { commitLock().writeLock().unlock(); }
+            quadsIndex().end();
+            defaultGraph().end();
+        } ) ;
     }
     
     @Override
     public void abort() {
-        if (!isInTransaction()) throw new JenaTransactionException("Tried to abort outside a transaction!");
+        if (!isInTransaction()) 
+            throw new JenaTransactionException("Tried to abort outside a transaction!");
         if (transactionType().equals(WRITE))
             _abort();
         finishTransaction();
     }
 
     private void _abort() {
-        commitLock().writeLock().lock();
-        try {
+        withLock(systemLock, () -> {
             quadsIndex().abort();
             defaultGraph().abort();
-        } finally { commitLock().writeLock().unlock(); }
+            quadsIndex().end();
+            defaultGraph().end();
+        } ) ;
     }
     
     @Override
     public void close() {
-        if (isInTransaction()) abort();
+        if (isInTransaction())
+            abort();
     }
 
     @Override
@@ -181,29 +189,30 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
         if (isInTransaction()) {
             if (transactionType().equals(WRITE)) {
                 log.warn("end() called for WRITE transaction without commit or abort having been called causing a forced abort");
+                // _abort does _end actions inside the lock. 
                 _abort() ;
+            } else {
+                _end() ;
             }
             finishTransaction();
-            return ;
         }
     }
     
-    /** Called transaction ending code at most once per transaction. */ 
-    private void finishTransaction() {
-//        if ( ! isInTransaction() ) {
-//            log.error("finishTransaction() called multiple times.");
-//            return ;
-//        }
-        commitLock().writeLock().lock();
-        try {
+    private void _end() {
+        withLock(systemLock, () -> {
             quadsIndex().end();
             defaultGraph().end();
-        } finally { commitLock().writeLock().unlock(); }
-        isInTransaction.remove();
-        transactionType.remove();
-        writeLock().leaveCriticalSection();
+        } ) ;
     }
-     
+    
+    private static void withLock(java.util.concurrent.locks.Lock lock, Runnable action) {
+        lock.lock();
+        try { action.run(); }
+        finally {
+            lock.unlock();
+        }
+    }
+    
     private <T> Iterator<T> access(final Supplier<Iterator<T>> source) {
         if (!isInTransaction()) {
             begin(READ);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/aggregate/AggGroupConcat.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/aggregate/AggGroupConcat.java
@@ -68,10 +68,9 @@ public class AggGroupConcat extends AggregatorBase
     
     protected static String asSparqlExpr(boolean isDistinct, String separator, ExprList exprs, SerializationContext sCxt) {
         IndentedLineBuffer x = new IndentedLineBuffer() ;
-        x.append("GROUP_CONCAT") ;
+        x.append("GROUP_CONCAT(") ;
         if ( isDistinct )
-            x.append(" DISTINCT") ;
-        x.append(" (") ;
+            x.append("DISTINCT ") ;
         ExprUtils.fmtSPARQL(x, exprs, sCxt) ;
         if ( separator != null ) {
             x.append(" ; separator=") ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/aggregate/AggMinDistinct.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/aggregate/AggMinDistinct.java
@@ -18,15 +18,13 @@
 
 package org.apache.jena.sparql.expr.aggregate;
 
-import java.util.Objects;
-
 import org.apache.jena.sparql.expr.Expr ;
 import org.apache.jena.sparql.expr.ExprList ;
 
 public class AggMinDistinct extends AggMinBase
 {
     // ---- MIN(DISTINCT expr)
-    public AggMinDistinct(Expr expr) { super(expr, false) ; } 
+    public AggMinDistinct(Expr expr) { super(expr, true) ; } 
     @Override
     public Aggregator copy(ExprList exprs) { return new AggMinDistinct(exprs.get(0)) ; }
     @Override
@@ -39,6 +37,6 @@ public class AggMinDistinct extends AggMinBase
         if ( ! ( other instanceof AggMinDistinct ) )
             return false ;
         AggMinDistinct agg = (AggMinDistinct)other ;
-        return Objects.equals(exprList, agg.exprList) ;
+        return exprList.equals(agg.exprList, bySyntax) ;
     } 
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/pfunction/PropFuncArg.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/pfunction/PropFuncArg.java
@@ -18,10 +18,14 @@
 
 package org.apache.jena.sparql.pfunction;
 
+import static org.apache.jena.sparql.core.Vars.addVar ;
+
+import java.util.Collection ;
 import java.util.List ;
 
 import org.apache.jena.atlas.io.IndentedWriter ;
 import org.apache.jena.graph.Node ;
+import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.expr.Expr ;
 import org.apache.jena.sparql.expr.ExprList ;
 import org.apache.jena.sparql.graph.NodeConst ;
@@ -130,5 +134,14 @@ public class PropFuncArg extends PrintSerializableBase
         }
         if ( arg != null )
             out.print(FmtUtils.stringForNode(arg)) ;
+    }
+
+    public static void addVars(Collection<Var> acc, PropFuncArg pfArg) {
+        if (pfArg.isNode()) {
+            addVar(acc, pfArg.getArg()) ;
+            return ;
+        }
+        for (Node n : pfArg.getArgList())
+            addVar(acc, n) ;
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryThreading.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryThreading.java
@@ -154,6 +154,7 @@ public class TestDatasetGraphInMemoryThreading extends Assert {
 		await().untilTrue(readLockCaptured);
 		if (writeLockCaptured.get()) fail("Write lock captured by two threads at once!");
 
+		dsg.abort() ;
 		dsg.end(); // release the write lock to competitor
 		await().untilTrue(writeLockCaptured);
 		assertTrue("Lock was not handed over to waiting thread!", writeLockCaptured.get());

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryTransactions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryTransactions.java
@@ -18,12 +18,19 @@
 
 package org.apache.jena.sparql.core.mem;
 
+import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.DatasetFactory ;
 import org.apache.jena.sparql.transaction.AbstractTestTransaction ;
+import org.junit.AfterClass ;
+import org.junit.BeforeClass ;
 
 public class TestDatasetGraphInMemoryTransactions extends AbstractTestTransaction {
-
+    static Class<?> targetClassLogger = DatasetGraphInMemory.class ;
+    
+    @BeforeClass public static void beforeClassLoggingOff() { LogCtl.disable(targetClassLogger) ; } 
+    @AfterClass public static void afterClassLoggingOn()    { LogCtl.setInfo(targetClassLogger) ; }
+    
 	@Override
 	protected Dataset create() {
 		return DatasetFactory.createTxnMem();

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/SetUtils.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/SetUtils.java
@@ -56,5 +56,9 @@ public class SetUtils
         s3.removeAll(s2) ;
         return s3 ;
     }
+
+    public static <T> boolean disjoint(Set<T> set1, Set<T> set2) {
+        return CollectionUtils.disjoint(set1, set2) ;   
+    }
 }
 

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestSetUtils.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestSetUtils.java
@@ -126,6 +126,16 @@ public class TestSetUtils extends BaseTest
         test(x3,4,5,6) ;
     }
     
+    @Test public void set11() 
+    {
+        Set<Integer> x1 = set(1,2,3) ;
+        Set<Integer> x2 = set(5,6) ;
+        Set<Integer> x3 = set(1,6) ;
+        assertTrue(SetUtils.disjoint(x1, x2)) ;
+        assertFalse(SetUtils.disjoint(x1, x3)) ;
+        assertFalse(SetUtils.disjoint(x1, x1)) ;
+    }
+
     // --------
     
     private static Set<Integer> set(int... values)

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/ParserSupport.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/ParserSupport.java
@@ -29,6 +29,7 @@ import java.util.Map ;
 
 import org.apache.jena.iri.IRI ;
 import org.apache.jena.rdfxml.xmlinput.ARPErrorNumbers ;
+import org.apache.xerces.util.XML11Char ;
 import org.apache.xerces.util.XMLChar ;
 import org.xml.sax.SAXParseException ;
 
@@ -80,26 +81,38 @@ public class ParserSupport implements ARPErrorNumbers, Names {
 			}
 		}
 
-
-		checkXMLName(taintMe,str);
+		checkID_XMLName(taintMe,str);
 		checkEncoding(taintMe,str);
 	}
-	protected void checkXMLName( Taint taintMe, String str) throws SAXParseException {
-		if (!XMLChar.isValidNCName(str)) {
-			//   	System.err.println("not name (id): " + str);
+	
+	protected void checkNodeID_XMLName( Taint taintMe, String str) throws SAXParseException {
+	    if ( ! XMLChar.isValidNCName(str) ) { 
+            warning(taintMe,
+                WARN_BAD_NAME,
+                "Not an XML Name: '" + str + "'");
+        }
+	}
+	
+	protected void checkID_XMLName( Taint taintMe, String str) throws SAXParseException {
+	    // Was called "checkXMLName" and same code as checkNodeID_XMLName until Jena 3.1.0.
+	    // See JENA-1071
+	    
+	    // Java and xerces are XML 1.0 4th edition.
+	    // XML 1.0 5th edition and XML 1.1 allow a wider range of characters in an NCName.
+	    
+	    // rdf:about="..." is any string but rdf:ID="..." is an XML NCName.
+	    
+	    // This operation here should allow the wider range to make
+	    // it compatible with rdf:about="...full URI..."
+
+	    //if (!XMLChar.isValidNCName(str)) {
+		if ( ! XML11Char.isXML11ValidNCName(str) ) { 
 			warning(taintMe,
 				WARN_BAD_NAME,
 				"Not an XML Name: '" + str + "'");
 		}
-
 	}
-//	protected void checkNodeID(Taint taintMe, String str) throws SAXParseException {
-//		if (!XMLChar.isValidNCName(str)) {
-//			warning(taintMe,
-//				WARN_BAD_NAME,
-//				"Not an XML Name: '" + str + "'");
-//		}
-//	}
+
 	public void checkString(Taint taintMe,String t) throws SAXParseException {
 		if (!CharacterModel.isNormalFormC(t))
 			warning(taintMe,

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/states/WantDescription.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/states/WantDescription.java
@@ -71,7 +71,7 @@ abstract public class WantDescription extends Frame implements HasSubjectFrameI 
                     warning(ERR_SYNTAX_ERROR,"Both ID and nodeID");
             }
             subject = new ARPResource(arp,ap.nodeID);
-            checkXMLName(subject,ap.nodeID);
+            checkNodeID_XMLName(subject,ap.nodeID);
             subjectIsBlank = true;
         }
         if (subject==null) {

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/states/WantPropertyElement.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/states/WantPropertyElement.java
@@ -101,7 +101,7 @@ public class WantPropertyElement extends Frame implements WantsObjectFrameI,
             if (ap.nodeID != null) {
 
                 object = new ARPResource(arp, ap.nodeID);
-                checkXMLName(object, ap.nodeID);
+                checkNodeID_XMLName(object, ap.nodeID);
                 objectIsBlank = true;
             }
             if (ap.resource != null) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiConfigException.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiConfigException.java
@@ -21,6 +21,8 @@ package org.apache.jena.fuseki;
 
 public class FusekiConfigException extends FusekiException
 {
+    private static final long serialVersionUID = 8076422665235298924L;
+
     public FusekiConfigException(String msg, Throwable cause)    { super(msg, cause) ; }
     public FusekiConfigException(String msg)                     { super(msg) ; }
     public FusekiConfigException(Throwable cause)                { super(cause) ; }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiException.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiException.java
@@ -22,6 +22,8 @@ import org.apache.jena.sparql.ARQException ;
 
 public class FusekiException extends ARQException
 {
+    private static final long serialVersionUID = -3213544429295511644L;
+
     public FusekiException(String msg, Throwable cause)    { super(msg, cause) ; }
     public FusekiException(String msg)                     { super(msg) ; }
     public FusekiException(Throwable cause)                { super(cause) ; }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiNotFoundException.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiNotFoundException.java
@@ -22,5 +22,7 @@ import org.apache.jena.web.HttpSC ;
 
 public class FusekiNotFoundException extends FusekiRequestException
 {
+    private static final long serialVersionUID = -5322471109173269457L;
+
     public FusekiNotFoundException(String msg)    { super(HttpSC.NOT_FOUND_404, msg) ; }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiRequestException.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiRequestException.java
@@ -23,6 +23,8 @@ import org.apache.jena.web.HttpSC ;
 
 public class FusekiRequestException extends FusekiException
 {
+    private static final long serialVersionUID = 5851755307160508151L;
+
     public static FusekiRequestException create(int code, String msg)
     {
         if ( code == HttpSC.NOT_FOUND_404 )

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/cmd/FusekiCmd.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/cmd/FusekiCmd.java
@@ -45,6 +45,9 @@ import jena.cmd.CmdException ;
 import arq.cmdline.CmdARQ ;
 import arq.cmdline.ModDatasetAssembler ;
 
+/**
+ * Handles the fuseki command, used to start a Fuseki server.
+ */
 public class FusekiCmd {
     // This allows us to set logging before calling FusekiCmdInner
     // FusekiCmdInner inherits from CmdMain which statically sets logging.
@@ -232,7 +235,7 @@ public class FusekiCmd {
 
                 // Directly populate the dataset.
                 cmdLineConfig.reset();
-                cmdLineConfig.dsg = DatasetGraphFactory.createMem() ;
+                cmdLineConfig.dsg = DatasetGraphFactory.createGeneral() ;
 
                 // INITIAL DATA.
                 Lang language = RDFLanguages.filenameToLang(filename) ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionAsyncTask.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionAsyncTask.java
@@ -28,6 +28,8 @@ import org.apache.jena.fuseki.servlets.ServletOps ;
 /** Base helper class for creating async tasks on "items", based on POST  */ 
 public abstract class ActionAsyncTask extends ActionItem
 {
+    private static final long serialVersionUID = 4522916022736091383L;
+
     // ?? Better as a library (mixin) so can be used outside ActionItem
     private static AsyncPool asyncPool = AsyncPool.get() ;
     

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionBackup.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionBackup.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory ;
 
 public class ActionBackup extends ActionAsyncTask
 {
+    private static final long serialVersionUID = -8749893367585603207L;
+
     public ActionBackup() { super() ; }
 
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionBackupList.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionBackupList.java
@@ -43,6 +43,8 @@ import org.apache.jena.fuseki.servlets.ServletOps ;
  */
 public class ActionBackupList extends ActionCtl {
 
+    private static final long serialVersionUID = -802856229813346198L;
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
         doCommon(req, resp);

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionContainerItem.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionContainerItem.java
@@ -29,6 +29,8 @@ import org.apache.jena.web.HttpSC ;
 /** Base for actions that are container and also have action on items */ 
 public abstract class ActionContainerItem extends ActionCtl {
     
+    private static final long serialVersionUID = 2824158659375951964L;
+
     public ActionContainerItem() { super() ; }
 
     // Redirect operations so they dispatch to perform(HttpAction)

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionCtl.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionCtl.java
@@ -29,6 +29,8 @@ import org.apache.jena.fuseki.servlets.ServletOps ;
 /** Control/admin request lifecycle */
 public abstract class ActionCtl extends ActionBase
 {
+    private static final long serialVersionUID = 3129123436565022299L;
+
     protected ActionCtl() { super(Fuseki.adminLog) ; }
     
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
@@ -66,6 +66,8 @@ import org.apache.jena.web.HttpSC ;
 
 public class ActionDatasets extends ActionContainerItem {
     
+    private static final long serialVersionUID = 5171975468398320835L;
+
     private static Dataset system = SystemState.getDataset() ;
     private static DatasetGraphTransaction systemDSG = SystemState.getDatasetGraph() ; 
     

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionItem.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionItem.java
@@ -26,6 +26,8 @@ import org.apache.jena.web.HttpSC ;
 /** Action on items in a container, but not the container itself */ 
 public abstract class ActionItem extends ActionContainerItem
 {
+    private static final long serialVersionUID = 2383436292454272466L;
+
     public ActionItem() { super() ; }
     
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionLogs.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionLogs.java
@@ -32,6 +32,8 @@ import org.apache.jena.fuseki.servlets.ServletOps ;
 
 public class ActionLogs extends ActionCtl
 {
+    private static final long serialVersionUID = 7574964005106399076L;
+
     public ActionLogs() { super() ; } 
     
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionPing.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionPing.java
@@ -39,6 +39,8 @@ import org.apache.jena.web.HttpSC ;
  */
 public class ActionPing extends HttpServlet
 {
+    private static final long serialVersionUID = -7784830233939700895L;
+
     // Ping is special.
     // To avoid excessive logging and id allocation for a "noise" operation,
     // this is a raw servlet.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionServerStatus.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionServerStatus.java
@@ -38,6 +38,8 @@ import org.apache.jena.fuseki.servlets.ServletOps ;
 /** Description of datasets for a server */ 
 public class ActionServerStatus extends ActionCtl
 {
+    private static final long serialVersionUID = 2080524239699772724L;
+
     public ActionServerStatus() { super() ; }
     
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionSleep.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionSleep.java
@@ -34,6 +34,8 @@ import org.slf4j.Logger ;
 /** A task that kicks off a asynchornous operation that simply waits and exits.  For testing. */
 public class ActionSleep extends ActionCtl /* Not ActionAsyncTask - that is a container-item based.c */
 {
+    private static final long serialVersionUID = 1925107412069359647L;
+
     public ActionSleep() { super() ; }
     
     // And only POST

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionStats.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionStats.java
@@ -36,6 +36,8 @@ import org.apache.jena.fuseki.servlets.HttpAction ;
 
 public class ActionStats extends ActionContainerItem
 {
+    private static final long serialVersionUID = 7077403170416268730L;
+
     public ActionStats() { super() ; } 
     
     // This does not consult the system database for dormant etc.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionTasks.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionTasks.java
@@ -34,6 +34,8 @@ import org.apache.jena.web.HttpSC ;
 
 public class ActionTasks extends ActionBase //ActionContainerItem
 {
+    private static final long serialVersionUID = 21567238976872928L;
+
     private static AsyncPool[] pools = { AsyncPool.get() } ; 
     
     public ActionTasks() { super(Fuseki.serverLog) ; }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionBase.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionBase.java
@@ -39,6 +39,8 @@ import org.slf4j.Logger ;
 /** General request lifecycle */
 public abstract class ActionBase extends ServletBase
 {
+    private static final long serialVersionUID = -8235479824229554685L;
+
     protected final Logger log ;
 
     protected ActionBase(Logger log) {
@@ -157,9 +159,11 @@ public abstract class ActionBase extends ServletBase
      */
     protected abstract void execCommonWorker(HttpAction action) ;
     
-    /** Extract the name after the container name (serverlet name).
-     * Returns "/name" or null 
-     */  
+    /**
+     * Extract the name after the container name (servlet name).
+     * @param action an HTTP action
+     * @return item name as "/name" or {@code null}
+     */
     protected static String extractItemName(HttpAction action) {
 //      action.log.info("context path  = "+action.request.getContextPath()) ;
 //      action.log.info("pathinfo      = "+action.request.getPathInfo()) ;
@@ -246,7 +250,7 @@ public abstract class ActionBase extends ServletBase
      * <p>Given a time point, return the time as a milli second string if it is less than 1000,
      * otherwise return a seconds string.</p>
      * <p>It appends a 'ms' suffix when using milli seconds,
-     *  and <i>s</i> for seconds.</p>
+     *  and 's' for seconds.</p>
      * <p>For instance: </p>
      * <ul>
      * <li>10 emits 10 ms</li>

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionErrorException.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionErrorException.java
@@ -20,6 +20,8 @@ package org.apache.jena.fuseki.servlets;
 
 public class ActionErrorException extends RuntimeException
 {
+    private static final long serialVersionUID = -5606469595255433671L;
+
     public final Throwable exception ;
     public final String message ;
     public final int rc ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionREST.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionREST.java
@@ -28,6 +28,8 @@ import org.apache.jena.fuseki.server.CounterName ;
 /** Common point for operations that are "REST"ish (use GET/PUT etc as operations). */ 
 public abstract class ActionREST extends ActionSPARQL
 {
+    private static final long serialVersionUID = 7202577783034128479L;
+
     public ActionREST()
     { super() ; }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionSPARQL.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionSPARQL.java
@@ -39,6 +39,8 @@ import org.apache.jena.riot.system.StreamRDF ;
 /** SPARQL request lifecycle */
 public abstract class ActionSPARQL extends ActionBase
 {
+    private static final long serialVersionUID = 8655400764034493574L;
+
     protected ActionSPARQL() { super(Fuseki.actionLog) ; }
     
     protected abstract void validate(HttpAction action) ;
@@ -145,7 +147,7 @@ public abstract class ActionSPARQL extends ActionBase
     
     /**
      * Map request {@link HttpAction} to uri in the registry.
-     * A return of ull means no mapping done (passthrough).
+     * A return of {@code null} means no mapping done (passthrough).
      * @param uri the URI
      * @return the dataset
      */
@@ -154,7 +156,7 @@ public abstract class ActionSPARQL extends ActionBase
     }
 
     /**
-     * Map request to uri in the registry. null means no mapping done
+     * Map request to uri in the registry. {@code null} means no mapping done
      * (passthrough).
      */
     protected String mapRequestToOperation(HttpAction action, DataAccessPoint dataAccessPoint) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads.java
@@ -26,6 +26,8 @@ package org.apache.jena.fuseki.servlets ;
 
 public abstract class REST_Quads extends SPARQL_GSP
 {
+    private static final long serialVersionUID = 5366276922758465169L;
+
     public REST_Quads() {
         super() ;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads_R.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads_R.java
@@ -36,6 +36,9 @@ import org.apache.jena.sparql.core.DatasetGraph ;
  */
 
 public class REST_Quads_R extends REST_Quads {
+
+    private static final long serialVersionUID = 1309929984893333563L;
+
     public REST_Quads_R() {
         super() ;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads_RW.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads_RW.java
@@ -33,6 +33,8 @@ import org.apache.jena.sparql.core.DatasetGraphFactory ;
 
 public class REST_Quads_RW extends REST_Quads_R {
 
+    private static final long serialVersionUID = 4752486333862676195L;
+
     public REST_Quads_RW() {
         super() ;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads_RW.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads_RW.java
@@ -112,7 +112,7 @@ public class REST_Quads_RW extends REST_Quads_R {
     }
     
     private void doPutPostNonTxn(HttpAction action, boolean clearFirst) {
-        DatasetGraph dsgTmp = DatasetGraphFactory.createMem() ;
+        DatasetGraph dsgTmp = DatasetGraphFactory.create() ;
         StreamRDF dest = StreamRDFLib.dataset(dsgTmp) ;
 
         UploadDetails details ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_GSP.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_GSP.java
@@ -32,6 +32,8 @@ import org.apache.jena.sparql.core.DatasetGraph ;
 
 public abstract class SPARQL_GSP extends ActionREST
 {
+    private static final long serialVersionUID = 5807509103047946413L;
+
     protected final static Target determineTarget(HttpAction action) {
         // Delayed until inside a transaction.
         if ( action.getActiveDSG() == null )

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_GSP_R.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_GSP_R.java
@@ -33,6 +33,8 @@ import org.apache.jena.riot.* ;
 /** Only the READ operations */
 public class SPARQL_GSP_R extends SPARQL_GSP
 {
+    private static final long serialVersionUID = 4247885351334928271L;
+
     public SPARQL_GSP_R()
     { super() ; }
     

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_GSP_RW.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_GSP_RW.java
@@ -41,6 +41,8 @@ import org.apache.jena.web.HttpSC ;
 /** The WRITE operations added to the READ operations */
 public class SPARQL_GSP_RW extends SPARQL_GSP_R
 {
+    private static final long serialVersionUID = 6406692451479514797L;
+
     public SPARQL_GSP_RW()
     { super() ; }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Protocol.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Protocol.java
@@ -38,6 +38,9 @@ import org.apache.jena.sparql.core.DatasetDescription ;
  * Support for the SPARQL protocol (SPARQL Query, SPARQL Update)
  */
 public abstract class SPARQL_Protocol extends ActionSPARQL {
+
+    private static final long serialVersionUID = -5083114105751562449L;
+
     protected SPARQL_Protocol() {
         super() ;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Query.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Query.java
@@ -64,6 +64,8 @@ import org.apache.jena.web.HttpSC ;
  */ 
 public abstract class SPARQL_Query extends SPARQL_Protocol
 {
+    private static final long serialVersionUID = 6670547318463759949L;
+
     private static final String QueryParseBase = Fuseki.BaseParserSPARQL ;
     
     public SPARQL_Query() {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryDataset.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryDataset.java
@@ -27,6 +27,8 @@ import org.apache.jena.sparql.core.DynamicDatasets ;
 
 public class SPARQL_QueryDataset extends SPARQL_Query
 {
+    private static final long serialVersionUID = 7831017147865247480L;
+
     public SPARQL_QueryDataset(boolean verbose)     { super() ; }
 
     public SPARQL_QueryDataset()
@@ -40,7 +42,7 @@ public class SPARQL_QueryDataset extends SPARQL_Query
     protected void validateQuery(HttpAction action, Query query) 
     { }
    
-    /** Decide the datset - this modifies the query 
+    /** Decide the dataset - this modifies the query 
      *  If the query has a dataset description.   
      */
     @Override
@@ -55,6 +57,6 @@ public class SPARQL_QueryDataset extends SPARQL_Query
             }
         }
         
-        return DatasetFactory.create(dsg) ;
+        return DatasetFactory.wrap(dsg) ;
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryGeneral.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryGeneral.java
@@ -78,7 +78,7 @@ public class SPARQL_QueryGeneral extends SPARQL_Query {
             if ( graphURLs.size() == 0 && namedGraphs.size() == 0 )
                 return null ;
 
-            Dataset dataset = DatasetFactory.createGeneral() ;
+            Dataset dataset = DatasetFactory.create() ;
             // Look in cache for loaded graphs!!
 
             // ---- Default graph

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryGeneral.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryGeneral.java
@@ -33,6 +33,8 @@ import org.apache.jena.riot.RiotException ;
 import org.apache.jena.sparql.core.DatasetDescription ;
 
 public class SPARQL_QueryGeneral extends SPARQL_Query {
+    private static final long serialVersionUID = -3322268853028371757L;
+
     final static int MaxTriples = 100 * 1000 ;
 
     public SPARQL_QueryGeneral() {
@@ -76,7 +78,7 @@ public class SPARQL_QueryGeneral extends SPARQL_Query {
             if ( graphURLs.size() == 0 && namedGraphs.size() == 0 )
                 return null ;
 
-            Dataset dataset = DatasetFactory.createMem() ;
+            Dataset dataset = DatasetFactory.createGeneral() ;
             // Look in cache for loaded graphs!!
 
             // ---- Default graph

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_UberServlet.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_UberServlet.java
@@ -48,6 +48,8 @@ import org.apache.jena.riot.web.HttpNames ;
  */
 public abstract class SPARQL_UberServlet extends ActionSPARQL
 {
+    private static final long serialVersionUID = -491895535163680509L;
+
     protected abstract boolean allowQuery(HttpAction action) ;
     protected abstract boolean allowUpdate(HttpAction action) ;
     protected abstract boolean allowREST_R(HttpAction action) ;
@@ -57,6 +59,8 @@ public abstract class SPARQL_UberServlet extends ActionSPARQL
     
     public static class ReadOnly extends SPARQL_UberServlet
     {
+        private static final long serialVersionUID = -3486969173228213955L;
+
         public ReadOnly()    { super() ; }
         @Override protected boolean allowQuery(HttpAction action)    { return true ; }
         @Override protected boolean allowUpdate(HttpAction action)   { return false ; }
@@ -68,6 +72,8 @@ public abstract class SPARQL_UberServlet extends ActionSPARQL
 
     public static class ReadWrite extends SPARQL_UberServlet
     {
+        private static final long serialVersionUID = 1383389566691599382L;
+
         public ReadWrite()    { super() ; }
         @Override protected boolean allowQuery(HttpAction action)    { return true ; }
         @Override protected boolean allowUpdate(HttpAction action)   { return true ; }
@@ -79,6 +85,8 @@ public abstract class SPARQL_UberServlet extends ActionSPARQL
 
     public static class AccessByConfig extends SPARQL_UberServlet
     {
+        private static final long serialVersionUID = 5078964040391977778L;
+
         public AccessByConfig()    { super() ; }
         @Override protected boolean allowQuery(HttpAction action)    { return isEnabled(action, OperationName.Query) ; }
         @Override protected boolean allowUpdate(HttpAction action)   { return isEnabled(action, OperationName.Update) ; }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
@@ -65,6 +65,7 @@ import org.apache.jena.web.HttpSC ;
 
 public class SPARQL_Update extends SPARQL_Protocol 
 {
+    private static final long serialVersionUID = 6136544994836781248L;
     // Base URI used to isolate parsing from the current directory of the server. 
     private static final String UpdateParseBase = Fuseki.BaseParserSPARQL ;
     private static final IRIResolver resolver = IRIResolver.create(UpdateParseBase) ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
@@ -184,7 +184,7 @@ public class SPARQL_Upload extends ActionSPARQL
     // ?? Combine with Upload.fileUploadWorker
     // Difference is the handling of names for graphs.  
     static private UploadDetails uploadWorker(HttpAction action, String base) {
-        DatasetGraph dsgTmp = DatasetGraphFactory.createGeneral() ;
+        DatasetGraph dsgTmp = DatasetGraphFactory.create() ;
         ServletFileUpload upload = new ServletFileUpload() ;
         String graphName = null ;
         boolean isQuads = false ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
@@ -51,6 +51,8 @@ import org.apache.jena.web.HttpSC ;
 
 public class SPARQL_Upload extends ActionSPARQL 
 {
+    private static final long serialVersionUID = -8762461819710807201L;
+
     public SPARQL_Upload() {
         super() ;
     }
@@ -182,7 +184,7 @@ public class SPARQL_Upload extends ActionSPARQL
     // ?? Combine with Upload.fileUploadWorker
     // Difference is the handling of names for graphs.  
     static private UploadDetails uploadWorker(HttpAction action, String base) {
-        DatasetGraph dsgTmp = DatasetGraphFactory.createMem() ;
+        DatasetGraph dsgTmp = DatasetGraphFactory.createGeneral() ;
         ServletFileUpload upload = new ServletFileUpload() ;
         String graphName = null ;
         boolean isQuads = false ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServletBase.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServletBase.java
@@ -32,6 +32,9 @@ import org.apache.jena.riot.web.HttpNames ;
  * Addition HTTP Servlet operations. 
  */
 public abstract class ServletBase extends HttpServlet {
+
+    private static final long serialVersionUID = -4391231243228221820L;
+
     public static final String METHOD_DELETE    = "DELETE" ;
     public static final String METHOD_HEAD      = "HEAD" ;
     public static final String METHOD_GET       = "GET" ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/DataValidator.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/DataValidator.java
@@ -33,6 +33,8 @@ import org.apache.jena.riot.system.StreamRDF ;
 import org.apache.jena.riot.system.StreamRDFLib ;
 
 public class DataValidator extends ValidatorBaseJson {
+    private static final long serialVersionUID = -7052864052858485344L;
+
     public DataValidator() { }
   
     static final String jInput           = "input" ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/IRIValidator.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/IRIValidator.java
@@ -31,6 +31,9 @@ import org.apache.jena.iri.Violation ;
 import org.apache.jena.riot.system.IRIResolver ;
 
 public class IRIValidator extends ValidatorBaseJson {
+
+    private static final long serialVersionUID = -2137772518194890583L;
+
     public IRIValidator() { }
     
     static IRIFactory iriFactory = IRIResolver.iriFactory ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/QueryValidator.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/QueryValidator.java
@@ -31,6 +31,9 @@ import org.apache.jena.sparql.algebra.Op ;
 import org.apache.jena.sparql.serializer.SerializationContext ;
 
 public class QueryValidator extends ValidatorBaseJson {
+
+    private static final long serialVersionUID = 5113754839333382031L;
+
     public QueryValidator() {}
 
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/UpdateValidator.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/UpdateValidator.java
@@ -28,6 +28,9 @@ import org.apache.jena.update.UpdateFactory ;
 import org.apache.jena.update.UpdateRequest ;
 
 public class UpdateValidator extends ValidatorBaseJson {
+
+    private static final long serialVersionUID = 8656799942497464291L;
+
     public UpdateValidator() {}
     
     static final String paramUpdate           = "update" ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/ValidatorBaseJson.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/ValidatorBaseJson.java
@@ -43,6 +43,9 @@ import org.slf4j.Logger ;
 /** ValidationBase for JSON out */ 
 public abstract class ValidatorBaseJson extends ServletBase
 {
+
+    private static final long serialVersionUID = 6539771233008186266L;
+
     private static Logger vLog = Fuseki.validationLog ;
     public static final String jErrors          = "errors" ;
     public static final String jWarnings        = "warning" ;

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/ServerTest.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/ServerTest.java
@@ -116,7 +116,7 @@ public class ServerTest {
         SystemState.init$() ;
         
         ServerInitialConfig params = new ServerInitialConfig() ;
-        DatasetGraph dsg = DatasetGraphFactory.createMem() ;
+        DatasetGraph dsg = DatasetGraphFactory.create() ;
         params.dsg = dsg ;
         params.datasetPath = datasetPath ;
         params.allowUpdate = updateable ;

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestDatasetOps.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestDatasetOps.java
@@ -79,7 +79,7 @@ public class TestDatasetOps extends AbstractFusekiTest
     private void gsp_x(String outward, String inward) {
         HttpEntity e = datasetToHttpEntity(data) ;
         HttpOp.execHttpPut(outward, e);
-        DatasetGraph dsg = DatasetGraphFactory.createMem() ;
+        DatasetGraph dsg = DatasetGraphFactory.create() ;
         RDFDataMgr.read(dsg, inward) ;
 //        String x = HttpOp.execHttpGetString(inward, "application/n-quads") ;
 //        RDFDataMgr.read(dsg, new StringReader(x), null, Lang.NQUADS) ;
@@ -123,7 +123,7 @@ public class TestDatasetOps extends AbstractFusekiTest
         HttpOp.execHttpPut(urlDataset, e);
         TypedInputStream in = HttpOp.execHttpGet(urlDataset, acceptheader) ;
         assertEqualsIgnoreCase(contentTypeResponse, in.getContentType()) ;
-        DatasetGraph dsg = DatasetGraphFactory.createMem() ;
+        DatasetGraph dsg = DatasetGraphFactory.create() ;
         StreamRDF dest = StreamRDFLib.dataset(dsg) ;
         RDFDataMgr.parse(dest, in) ;
     }


### PR DESCRIPTION
* Abort called `end` directly causing the warning to be emitted
* Abort did not call quadIndex.abort/defaultGraph.abort
* Pair up quadIndex.end/defaultGraph.end for read transactions
* Add locks around all pairs of quadIndex, defaultGraph operation calls

Discussion points:

* `writeLock` is used even for read transactions (it's a no-op but it's called). Should we rename it as e.g. `readerWriterLock`?
* `TupleTable.abort` defaults to end.  Given the importance of the transaction cycle, might it be better to require each implementation to do that. It puts all the begin/commit/abort/end code for one component in one place for the next person to look at the code.