### PR TITLE
JENA-1085: Common pattern for transaction lifecycle. Always call down to index operations.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
@@ -26,7 +26,7 @@ import static org.apache.jena.sparql.core.Quad.isUnionGraph;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.Iterator;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock ;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -37,11 +37,7 @@ import org.apache.jena.query.ReadWrite;
 import org.apache.jena.shared.Lock;
 import org.apache.jena.shared.LockMRPlusSW;
 import org.apache.jena.sparql.JenaTransactionException;
-import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphTriplesQuads;
-import org.apache.jena.sparql.core.DatasetPrefixStorage;
-import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.sparql.core.Transactional;
+import org.apache.jena.sparql.core.* ;
 import org.slf4j.Logger;
 
 /**
@@ -55,21 +51,15 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
 
     private final DatasetPrefixStorage prefixes = new DatasetPrefixStorageInMemory();
 
+    /** This lock imposes the multiple-reader and single-writer policy of transactions */
     private final Lock writeLock = new LockMRPlusSW();
 
-    private Lock writeLock() {
-        return writeLock;
-    }
-
-    private final ReentrantReadWriteLock commitLock = new ReentrantReadWriteLock(true);
-
     /**
-     * Commits must be atomic, and because a thread that is committing alters the various indexes one after another, we
-     * lock out {@link #begin(ReadWrite)} while {@link #commit()} is executing.
+     * Transaction lifecycle operations must be atomi, especially begin and commit where
+     * the global state of the indexes is read or written one after another.
+     *  and because a thread that is committing alters the various indexes.
      */
-    private ReentrantReadWriteLock commitLock() {
-        return commitLock;
-    }
+    private final ReentrantLock systemLock = new ReentrantLock(true);
 
     private final ThreadLocal<Boolean> isInTransaction = withInitial(() -> false);
 
@@ -125,57 +115,104 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
 
     @Override
     public void begin(final ReadWrite readWrite) {
-        if (isInTransaction()) throw new JenaTransactionException("Transactions cannot be nested!");
-        transactionType(readWrite);
-        isInTransaction(true);
-        writeLock().enterCriticalSection(readWrite.equals(READ)); // get the dataset write lock, if needed.
-        commitLock().readLock().lock(); // if a commit is proceeding, wait so that we see a coherent index state
-        try {
+        if (isInTransaction()) 
+            throw new JenaTransactionException("Transactions cannot be nested!");
+        startTransaction(readWrite) ;
+        _begin(readWrite) ;
+    }
+
+    private void _begin(ReadWrite readWrite) {
+        withLock(systemLock, () ->{
             quadsIndex().begin(readWrite);
             defaultGraph().begin(readWrite);
-        } finally {
-            commitLock().readLock().unlock();
-        }
+        }) ;
+    }
+    
+    /** Called transaction start code at most once per transaction. */ 
+    private void startTransaction(ReadWrite mode) {
+        writeLock.enterCriticalSection(mode.equals(READ)); // get the dataset write lock, if needed.
+        transactionType(mode);
+        isInTransaction(true);
     }
 
+    /** Called transaction ending code at most once per transaction. */ 
+    private void finishTransaction() {
+        isInTransaction.remove();
+        transactionType.remove();
+        writeLock.leaveCriticalSection();
+    }
+     
     @Override
     public void commit() {
-        if (!isInTransaction()) throw new JenaTransactionException("Tried to commit outside a transaction!");
-        commitLock().writeLock().lock();
-        try {
+        if (!isInTransaction())
+            throw new JenaTransactionException("Tried to commit outside a transaction!");
+        if (transactionType().equals(WRITE))
+            _commit();
+        finishTransaction();
+    }
+
+    private void _commit() {
+        withLock(systemLock, () -> {
             quadsIndex().commit();
             defaultGraph().commit();
-        } finally {
-            commitLock().writeLock().unlock();
-        }
-        isInTransaction.remove();
-        writeLock().leaveCriticalSection();
+            quadsIndex().end();
+            defaultGraph().end();
+        } ) ;
     }
-
+    
     @Override
     public void abort() {
-        if (!isInTransaction()) throw new JenaTransactionException("Tried to abort outside a transaction!");
-        end();
+        if (!isInTransaction()) 
+            throw new JenaTransactionException("Tried to abort outside a transaction!");
+        if (transactionType().equals(WRITE))
+            _abort();
+        finishTransaction();
     }
 
+    private void _abort() {
+        withLock(systemLock, () -> {
+            quadsIndex().abort();
+            defaultGraph().abort();
+            quadsIndex().end();
+            defaultGraph().end();
+        } ) ;
+    }
+    
     @Override
     public void close() {
-        if (isInTransaction()) abort();
+        if (isInTransaction())
+            abort();
     }
 
     @Override
     public void end() {
         if (isInTransaction()) {
-            if (transactionType().equals(WRITE))
-                log.warn("end() called for WRITE transaction without commit or abort having been called");
-            quadsIndex().end();
-            defaultGraph().end();
-            isInTransaction.remove();
-            transactionType.remove();
-            writeLock().leaveCriticalSection();
+            if (transactionType().equals(WRITE)) {
+                log.warn("end() called for WRITE transaction without commit or abort having been called causing a forced abort");
+                // _abort does _end actions inside the lock. 
+                _abort() ;
+            } else {
+                _end() ;
+            }
+            finishTransaction();
         }
     }
-
+    
+    private void _end() {
+        withLock(systemLock, () -> {
+            quadsIndex().end();
+            defaultGraph().end();
+        } ) ;
+    }
+    
+    private static void withLock(java.util.concurrent.locks.Lock lock, Runnable action) {
+        lock.lock();
+        try { action.run(); }
+        finally {
+            lock.unlock();
+        }
+    }
+    
     private <T> Iterator<T> access(final Supplier<Iterator<T>> source) {
         if (!isInTransaction()) {
             begin(READ);

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryThreading.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryThreading.java
@@ -154,6 +154,7 @@ public class TestDatasetGraphInMemoryThreading extends Assert {
 		await().untilTrue(readLockCaptured);
 		if (writeLockCaptured.get()) fail("Write lock captured by two threads at once!");
 
+		dsg.abort();
 		dsg.end(); // release the write lock to competitor
 		await().untilTrue(writeLockCaptured);
 		assertTrue("Lock was not handed over to waiting thread!", writeLockCaptured.get());

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryTransactions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryTransactions.java
@@ -18,12 +18,18 @@
 
 package org.apache.jena.sparql.core.mem;
 
+import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.DatasetFactory ;
 import org.apache.jena.sparql.transaction.AbstractTestTransaction ;
+import org.junit.AfterClass ;
+import org.junit.BeforeClass ;
 
 public class TestDatasetGraphInMemoryTransactions extends AbstractTestTransaction {
-
+    static Class<?> targetClassLogger = DatasetGraphInMemory.class ;
+    @BeforeClass public static void beforeClassLoggingOff() { LogCtl.disable(targetClassLogger) ; } 
+    @AfterClass public static void afterClassLoggingOn()    { LogCtl.setInfo(targetClassLogger) ; }
+    
 	@Override
 	protected Dataset create() {
 		return DatasetFactory.createTxnMem();


### PR DESCRIPTION
(Cleaned version of PR #107)

This revision

* Puts the transaction finalization code inside the commit/abort code that takes the system lock. This mean the lock is taken once at the finishing of a transaction.
* Reorganises the code to a rigid pattern for operations.
* Renames commitLock as systemLock
* Uses ReentrantLock, not ReentrantReadWriteLock (only the write lock was used; the implement of a ReentrantReadWriteLock.WriteLock and ReentrantLock is much the same for our usage, just calls to the sync object).

As well as code review, design review would be appreciated. 

Compared to the original design, this makes abort take a lock and call abort on indexes whereas previously it simply did nothing, knowing the index implementations would cope. Because abort is a not a performance critical operation (usually!), the symmetric and explicit calls to index operations makes things clearer in my view.