### PR TITLE
Introduce interface TransactionalComponent.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/TransactionalComponent.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/TransactionalComponent.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.core;
+
+import org.apache.jena.query.ReadWrite ;
+
+
+/** Interface that encapulsated the transaction lifecycle for a component in a transaction.
+ *  This is the system interface. {@link Transactional} is the application view of a set of 
+ *  collection of components that together provide transactions.
+ */
+public interface TransactionalComponent 
+{
+    // This interface may evolve in the future.
+    // Having it isolates such changes from the applications usage of Transactional.
+    // One example is the introduction of an explicit Transaction object.
+    
+    /** Start either a READ or WRITE transaction */ 
+    public void begin(ReadWrite readWrite) ;
+    
+    /** Commit a transaction - finish the transaction and make any changes permanent (if a "write" transaction) */  
+    public void commit() ;
+    
+    /** Abort a transaction - finish the transaction and undo any changes (if a "write" transaction) */  
+    public void abort() ;
+    
+    /** Finish the transaction - if a write transaction and commit() has not been called, then abort */  
+    public void end() ;
+
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/TransactionalOfOne.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/TransactionalOfOne.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.core;
+
+import org.apache.jena.query.ReadWrite ;
+import static java.lang.ThreadLocal.withInitial; 
+
+public class TransactionalOfOne implements Transactional
+{
+    private TransactionalComponent component;
+    private ThreadLocal<ReadWrite> state = withInitial(()->null) ;
+    
+    public TransactionalOfOne(TransactionalComponent component) { this.component = component ; }
+    
+    @Override
+    public void begin(ReadWrite readWrite) {
+        state.set(readWrite) ;
+        component.begin(readWrite);
+    }
+    
+    @Override
+    public void commit() {
+        component.commit();
+        end() ;
+    }
+    
+    @Override
+    public void abort() {
+        component.abort();
+        end() ;
+    }
+    
+    @Override
+    public boolean isInTransaction() {
+        return state.get() != null ;
+    }
+    
+    @Override
+    public void end() {
+        if ( isInTransaction() ) {
+            component.end();
+            state.set(null) ;
+        }
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapTupleTable.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapTupleTable.java
@@ -61,17 +61,6 @@ public abstract class PMapTupleTable<TupleMapType, TupleType> implements TupleTa
         return local;
     }
 
-    private final ThreadLocal<Boolean> isInTransaction = withInitial(() -> false);
-
-    @Override
-    public boolean isInTransaction() {
-        return isInTransaction.get();
-    }
-
-    protected void isInTransaction(final boolean b) {
-        isInTransaction.set(b);
-    }
-
     private final String tableName;
 
     /**
@@ -93,14 +82,13 @@ public abstract class PMapTupleTable<TupleMapType, TupleType> implements TupleTa
 
     @Override
     public void begin(final ReadWrite rw) {
-        isInTransaction(true);
+        // local is never used.
     }
 
     @Override
     public void end() {
         debug("Abandoning transactional reference.");
         local.remove();
-        isInTransaction.remove();
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/TriTable.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/TriTable.java
@@ -18,13 +18,14 @@
 
 package org.apache.jena.sparql.core.mem;
 
-import static java.lang.ThreadLocal.withInitial;
 import static java.util.EnumSet.noneOf;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.jena.sparql.core.mem.TripleTableForm.chooseFrom;
 import static org.apache.jena.sparql.core.mem.TripleTableForm.tableForms;
-import static org.apache.jena.sparql.core.mem.TupleSlot.*;
+import static org.apache.jena.sparql.core.mem.TupleSlot.OBJECT ;
+import static org.apache.jena.sparql.core.mem.TupleSlot.PREDICATE ;
+import static org.apache.jena.sparql.core.mem.TupleSlot.SUBJECT ;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -51,17 +52,6 @@ public class TriTable implements TripleTable {
         return indexBlock;
     }
 
-    private final ThreadLocal<Boolean> isInTransaction = withInitial(() -> false);
-
-    @Override
-    public boolean isInTransaction() {
-        return isInTransaction.get();
-    }
-
-    protected void isInTransaction(final boolean b) {
-        isInTransaction.set(b);
-    }
-
     @Override
     public void commit() {
         indexBlock().values().forEach(TripleTable::commit);
@@ -77,7 +67,6 @@ public class TriTable implements TripleTable {
     @Override
     public void end() {
         indexBlock().values().forEach(TripleTable::end);
-        isInTransaction.remove();
     }
 
     @Override
@@ -106,7 +95,6 @@ public class TriTable implements TripleTable {
 
     @Override
     public void begin(final ReadWrite rw) {
-        isInTransaction(true);
         indexBlock().values().forEach(table -> table.begin(rw));
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/TupleTable.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/TupleTable.java
@@ -18,14 +18,14 @@
 
 package org.apache.jena.sparql.core.mem;
 
-import org.apache.jena.sparql.core.Transactional;
+import org.apache.jena.sparql.core.TransactionalComponent ;
 
 /**
  * A mutable table of tuples. The expectation is that some kind of query functionality will be provided by subtypes.
  *
  * @param <TupleType> the type of tuple stored herein
  */
-public interface TupleTable<TupleType> extends Transactional {
+public interface TupleTable<TupleType> extends TransactionalComponent {
 
     /**
      * Add a tuple to the table

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/AbstractTestTupleTable.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/AbstractTestTupleTable.java
@@ -22,15 +22,16 @@ import static java.util.stream.Collectors.toSet;
 import static org.apache.jena.ext.com.google.common.collect.ImmutableSet.of;
 import static org.apache.jena.query.ReadWrite.READ;
 import static org.apache.jena.query.ReadWrite.WRITE;
+import static org.junit.Assert.assertEquals ;
+import static org.junit.Assert.assertTrue ;
 
 import java.util.Set;
 import java.util.stream.Stream;
 
 import org.apache.jena.ext.com.google.common.collect.ImmutableSet;
-import org.junit.Assert;
 import org.junit.Test;
 
-public abstract class AbstractTestTupleTable<TupleType, TupleTableType extends TupleTable<TupleType>> extends Assert {
+public abstract class AbstractTestTupleTable<TupleType, TupleTableType extends TupleTable<TupleType>> {
 
 	protected abstract TupleType testTuple();
 
@@ -42,71 +43,68 @@ public abstract class AbstractTestTupleTable<TupleType, TupleTableType extends T
 
 	protected static final Set<TupleSlot> allWildcardQuery = of();
 
+	protected long transactionalCount() {
+	    table().begin(READ);
+	    long x = rawCount() ;
+        table().end() ;
+        return x ;
+	}
+
+	protected long rawCount() {
+	    return tuples().count() ;
+	}
+	
 	@Test
 	public void addAndRemoveSomeTuples() {
-
+        assertEquals(0, transactionalCount()) ;
+        
 		// simple add-and-delete
-		table().begin(WRITE);
-		assertTrue(table().isInTransaction());
+	    table().begin(WRITE);
 		table().add(testTuple());
+		
+		assertEquals(1, rawCount()) ;
+		
 		Set<TupleType> contents = tuples().collect(toSet());
 		assertEquals(ImmutableSet.of(testTuple()), contents);
 		table().delete(testTuple());
-		contents = tuples().collect(toSet());
+		
+        assertEquals(0, rawCount()) ;
+        contents = tuples().collect(toSet());
 		assertTrue(contents.isEmpty());
 		table().end();
-		assertFalse(table().isInTransaction());
-
+		
+        assertEquals(0, transactionalCount()) ;
+		
 		// add, abort, then check to see that nothing was persisted
 		table().begin(WRITE);
-		assertTrue(table().isInTransaction());
 		table().add(testTuple());
+		
+		assertEquals(1, rawCount()) ;
 		contents = tuples().collect(toSet());
 		assertEquals(ImmutableSet.of(testTuple()), contents);
 		table().abort();
-		assertFalse(table().isInTransaction());
-		table().begin(READ);
-		assertTrue(table().isInTransaction());
-		try {
-			contents = tuples().collect(toSet());
-			assertTrue(contents.isEmpty());
-		} finally {
-			table().end();
-			assertFalse(table().isInTransaction());
-		}
+		
+        assertEquals(0, transactionalCount()) ;
 
 		// add, commit, and check to see that persistence occurred
 		table().begin(WRITE);
-		assertTrue(table().isInTransaction());
 		table().add(testTuple());
+        assertEquals(1, rawCount()) ;
 		contents = tuples().collect(toSet());
 		assertEquals(ImmutableSet.of(testTuple()), contents);
 		table().commit();
-		assertFalse(table().isInTransaction());
-		table().begin(READ);
-		assertTrue(table().isInTransaction());
-		try {
-			contents = tuples().collect(toSet());
-			assertEquals(ImmutableSet.of(testTuple()), contents);
-		} finally {
-			table().end();
-			assertFalse(table().isInTransaction());
-		}
+		
+		assertEquals(1, transactionalCount()) ;
+		
 		// remove the test tuple and check to see that it is gone
 		table().begin(WRITE);
-		assertTrue(table().isInTransaction());
+		assertEquals(1, rawCount()) ;
 		table().clear();
+		assertEquals(0, rawCount()) ;
 		contents = tuples().collect(toSet());
 		assertTrue(contents.isEmpty());
 		table().commit();
-		table().begin(READ);
-		assertTrue(table().isInTransaction());
-		try {
-			contents = tuples().collect(toSet());
-			assertTrue(contents.isEmpty());
-		} finally {
-			table().end();
-			assertFalse(table().isInTransaction());
-		}
+
+		assertEquals(0, transactionalCount()) ;
 	}
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestHexTable.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestHexTable.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.Quad;
 import org.junit.Test;
+import static org.junit.Assert.* ;
 
 public class TestHexTable extends AbstractTestQuadTable {
 


### PR DESCRIPTION
Mantis has a more general concept of transaction.  As part of that, it differentiates between `Transactional` (the view from users of a transaction system) and `TransactionalComponent` (units of code that participate in providing transactionality).

See [the code for TransactionalComponent](https://github.com/afs/mantis/blob/master/dboe-transaction/src/main/java/org/seaborne/dboe/transaction/txn/TransactionalComponent.java) -- for example, that has a explicit `Transaction` object and only the upper layers manage the `Transaction` by thread.

For the in-memory dataset, the difference is currently small but introducing this now prepares for more complex setups, without disturbing `Transactional`.  It also removes the need for components to know whether they are in a transaction or not; that is a concept of the coordinator function currently in `DatasetGraphInMemory`.  During times of state change, some components may be in different states to others, making the idea of a component being "in a transaction" imprecise. It also removes 11 ThreadLocals that were not used except in testing. The testing is adapted.

To use individual components on their own (if ever needed) then a simple wrapper that provides `Transactional` over a single component is a better design as it separates the roles of collection and component. Included is `TransactionalOfOne` but that is just illustrative and not for inclusion.
