### PR TITLE
JENA-1083: Using ColumnMap in transactional in-memory dataset implementation

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/Quad.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/Quad.java
@@ -181,17 +181,7 @@ public class Quad extends Tuple<Node>
     @Override
     public boolean equals(Object other) 
     { 
-        if ( this == other ) return true ;
-
-        if ( ! ( other instanceof Quad) )
-            return false ;
-        Quad quad = (Quad)other ;
-        
-        if ( ! Objects.equals(tuple[0], quad.tuple[0]) ) return false ;
-        if ( ! tuple[1].equals(quad.tuple[1]) ) return false ;
-        if ( ! tuple[2].equals(quad.tuple[2]) ) return false ;
-        if ( ! tuple[3].equals(quad.tuple[3]) ) return false ;
-        return true ;
+        { return other instanceof Quad && super.equals(other); }
     }
     
     public boolean matches(Node g, Node s, Node p, Node o)

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/Quad.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/Quad.java
@@ -20,11 +20,12 @@ package org.apache.jena.sparql.core;
 
 import java.util.Objects;
 
+import org.apache.jena.atlas.lib.Tuple;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.graph.Triple ;
 
-public class Quad
+public class Quad extends Tuple<Node>
 {
     // Create QuadNames? GraphNames?
     
@@ -48,8 +49,6 @@ public class Quad
      */
     public static final Node tripleInQuad           =  null ;
     
-    private final Node graph, subject, predicate, object ;
-    
     public Quad(Node graph, Triple triple)
     {
         this(graph, triple.getSubject(), triple.getPredicate(), triple.getObject()) ;
@@ -57,34 +56,31 @@ public class Quad
     
     public Quad(Node g, Node s, Node p, Node o)
     {
+        super(g, s, p, o);
         // Null means it's a triple really.
         //if ( g == null ) throw new UnsupportedOperationException("Quad: graph cannot be null");
         if ( s == null ) throw new UnsupportedOperationException("Quad: subject cannot be null");
         if ( p == null ) throw new UnsupportedOperationException("Quad: predicate cannot be null");
         if ( o == null ) throw new UnsupportedOperationException("Quad: object cannot be null");
-        this.graph = g ;
-        this.subject = s ;
-        this.predicate = p ;
-        this.object = o ;
     }
     
     public static Quad create(Node g, Node s, Node p, Node o)   { return new Quad(g,s,p,o) ; }
     public static Quad create(Node g, Triple t)                 { return new Quad(g,t) ; }
 
-    public final Node getGraph()      { return graph ; }
-    public final Node getSubject()    { return subject ; }
-    public final Node getPredicate()  { return predicate ; }
-    public final Node getObject()     { return object ; }
+    public final Node getGraph()      { return tuple[0] ; }
+    public final Node getSubject()    { return tuple[1] ; }
+    public final Node getPredicate()  { return tuple[2] ; }
+    public final Node getObject()     { return tuple[3] ; }
 
     /** Get as a triple - useful because quads often come in blocks for the same graph */  
     public Triple asTriple()
     { 
-        return new Triple(subject, predicate, object) ;
+        return new Triple(tuple[1], tuple[2], tuple[3]) ;
     }
     
     public boolean isConcrete()
     {
-        return subject.isConcrete() && predicate.isConcrete() && object.isConcrete() && graph.isConcrete() ;
+        return tuple[1].isConcrete() && tuple[2].isConcrete() && tuple[3].isConcrete() && tuple[0].isConcrete() ;
     }
     
     /** Test whether this is a quad for the default graph (not the default graphs by explicit name) */
@@ -136,10 +132,10 @@ public class Quad
 //        return node.equals(unionGraph) ;
 //    }
 //    
-    public boolean isUnionGraph()           { return isUnionGraph(graph) ; }
+    public boolean isUnionGraph()           { return isUnionGraph(tuple[0]) ; }
 
     /** Is it really a triple? */  
-    public boolean isTriple()               { return Objects.equals(graph, tripleInQuad) ; } 
+    public boolean isTriple()               { return Objects.equals(tuple[0], tripleInQuad) ; } 
 
     /** Is this quad a legal data quad (legal data triple, IRI for graph) */   
     public boolean isLegalAsData()
@@ -170,11 +166,11 @@ public class Quad
     public int hashCode() 
     { 
         int x = 
-               (subject.hashCode() >> 1) ^ 
-               predicate.hashCode() ^ 
-               (object.hashCode() << 1);
-        if ( graph != null )
-            x ^= (graph.hashCode()>>2) ;
+               (tuple[1].hashCode() >> 1) ^ 
+               tuple[2].hashCode() ^ 
+               (tuple[3].hashCode() << 1);
+        if ( tuple[0] != null )
+            x ^= (tuple[0].hashCode()>>2) ;
         else
             x++ ;
         return x ;
@@ -191,10 +187,10 @@ public class Quad
             return false ;
         Quad quad = (Quad)other ;
         
-        if ( ! Objects.equals(graph, quad.graph) ) return false ;
-        if ( ! subject.equals(quad.subject) ) return false ;
-        if ( ! predicate.equals(quad.predicate) ) return false ;
-        if ( ! object.equals(quad.object) ) return false ;
+        if ( ! Objects.equals(tuple[0], quad.tuple[0]) ) return false ;
+        if ( ! tuple[1].equals(quad.tuple[1]) ) return false ;
+        if ( ! tuple[2].equals(quad.tuple[2]) ) return false ;
+        if ( ! tuple[3].equals(quad.tuple[3]) ) return false ;
         return true ;
     }
     
@@ -213,7 +209,7 @@ public class Quad
     @Override
     public String toString()
     {
-        String str = (graph==null)?"_":graph.toString() ;
-        return "["+str+" "+subject.toString()+" "+predicate.toString()+" "+object.toString()+"]" ;
+        String str = (tuple[0]==null)?"_":tuple[0].toString() ;
+        return "["+str+" "+tuple[1].toString()+" "+tuple[2].toString()+" "+tuple[3].toString()+"]" ;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/TripleTableForm.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/TripleTableForm.java
@@ -27,8 +27,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.mem.PMapTripleTable.TripleOrder;
 
 /**
  * Forms for triple indexes.
@@ -40,33 +39,11 @@ public enum TripleTableForm implements Supplier<TripleTable>,Predicate<Set<Tuple
      * Subject-predicate-object.
      */
     SPO(of(SUBJECT, PREDICATE), SUBJECT) {
+        
         @Override
         public TripleTable get() {
-            return new PMapTripleTable(name()) {
-
-                @Override
-                protected Triple triple(final Node s, final Node p, final Node o) {
-                    return Triple.create(s, p, o);
-                }
-
-                @Override
-                public Stream<Triple> find(final Node s, final Node p, final Node o) {
-                    return _find(s, p, o);
-                }
-
-                @Override
-                public void add(final Triple t) {
-                    _add(t.getSubject(), t.getPredicate(), t.getObject());
-                }
-
-                @Override
-                public void delete(final Triple t) {
-                    _delete(t.getSubject(), t.getPredicate(), t.getObject());
-                }
-
-            };
+            return new PMapTripleTable(new TripleOrder("SPO"));
         }
-
     },
     /**
      * Predicate-object-subject.
@@ -75,29 +52,7 @@ public enum TripleTableForm implements Supplier<TripleTable>,Predicate<Set<Tuple
 
         @Override
         public TripleTable get() {
-            return new PMapTripleTable(name()) {
-
-                @Override
-                protected Triple triple(final Node p, final Node o, final Node s) {
-                    return Triple.create(s, p, o);
-                }
-
-                @Override
-                public Stream<Triple> find(final Node s, final Node p, final Node o) {
-                    return _find(p, o, s);
-                }
-
-                @Override
-                public void add(final Triple t) {
-                    _add(t.getPredicate(), t.getObject(), t.getSubject());
-                }
-
-                @Override
-                public void delete(final Triple t) {
-                    _delete(t.getPredicate(), t.getObject(), t.getSubject());
-                }
-
-            };
+            return new PMapTripleTable(new TripleOrder("POS"));
         }
     },
     /**
@@ -107,31 +62,10 @@ public enum TripleTableForm implements Supplier<TripleTable>,Predicate<Set<Tuple
 
         @Override
         public TripleTable get() {
-            return new PMapTripleTable(name()) {
-
-                @Override
-                protected Triple triple(final Node o, final Node s, final Node p) {
-                    return Triple.create(s, p, o);
-                }
-
-                @Override
-                public Stream<Triple> find(final Node s, final Node p, final Node o) {
-                    return _find(o, s, p);
-                }
-
-                @Override
-                public void add(final Triple t) {
-                    _add(t.getObject(), t.getSubject(), t.getPredicate());
-                }
-
-                @Override
-                public void delete(final Triple t) {
-                    _delete(t.getObject(), t.getSubject(), t.getPredicate());
-                }
-
-            };
+            return new PMapTripleTable(new TripleOrder("OSP"));
         }
     };
+    
     private TripleTableForm(final Set<TupleSlot> tp, final TupleSlot op) {
         this.twoPrefix = tp;
         this.onePrefix = of(op);

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/ColumnMap.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/ColumnMap.java
@@ -22,7 +22,6 @@ import static java.lang.String.format ;
 
 import java.util.Arrays ;
 import java.util.List ;
-
 import org.apache.jena.atlas.AtlasException ;
 
 
@@ -49,7 +48,13 @@ public class ColumnMap
     /** Construct a column mapping that maps the input (one col, one char) to the output */  
     public ColumnMap(String input, String output)
     {
-        this(input+"->"+output, compileMapping(input, output)) ;
+        this(input+"->"+output, input, output) ;
+    }
+    
+    /** Construct a column mapping that maps the input (one col, one char) to the output, with a label */  
+    public ColumnMap(String label, String input, String output)
+    {
+        this(label, compileMapping(input, output)) ;
     }
     
     public <T> ColumnMap(String label, List<T> input, List<T> output)
@@ -142,9 +147,21 @@ public class ColumnMap
     {
         return map(src, insertOrder) ;
     }
+    
+    /** Apply to an <em>unmapped</em> tuple to get a tuple with the column mapping applied */
+    public <T> T[] map(T... src)
+    {
+        return map(src, insertOrder) ;
+    }
 
     /** Apply to a <em>mapped</em> tuple to get a tuple with the column mapping reverse-applied */
     public <T> Tuple<T> unmap(Tuple<T> src)
+    {
+        return map(src, fetchOrder) ;
+    }
+    
+    /** Apply to a <em>mapped</em> tuple to get a tuple with the column mapping reverse-applied */
+    public <T> T[] unmap(T... src)
     {
         return map(src, fetchOrder) ;
     }
@@ -160,6 +177,17 @@ public class ColumnMap
             elts[j] = src.get(i) ;
         }
         return Tuple.create(elts) ;
+    }
+    
+    private <T> T[] map(T[] src, int[] map) {
+        // We use copy to effect the creation of a properly-typed array for a type parameter. This is more expensive
+        // than simply casting an Object[src.length], but allows us to safely pass the array out of this method.
+        T[] elts = ArrayUtils.copy(src);
+        for (int i = 0; i < src.length; i++) {
+            int j = map[i];
+            elts[j] = src[i];
+        }
+        return elts;
     }
     
     /** Compile a mapping encoded as single charcaters e.g. "SPO", "POS" */

--- a/jena-core/src/main/java/org/apache/jena/graph/Triple.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/Triple.java
@@ -20,6 +20,7 @@ package org.apache.jena.graph;
 
 import java.util.function.Predicate;
 
+import org.apache.jena.atlas.lib.Tuple;
 import org.apache.jena.shared.PrefixMapping ;
 import org.apache.jena.util.iterator.ExtendedIterator ;
 import org.apache.jena.util.iterator.NullIterator ;
@@ -29,18 +30,15 @@ import org.apache.jena.util.iterator.NullIterator ;
     object field (all nodes) and express the notion that the relationship named
     by the predicate holds between the subject and the object.
  */
-public class Triple 
+public class Triple extends Tuple<Node>
     {    
-	private final Node subj, pred, obj;
- 
+
 	public Triple( Node s, Node p, Node o ) 
         {
+        super(s, p, o);
         if (s == null) throw new UnsupportedOperationException( "subject cannot be null" );
         if (p == null) throw new UnsupportedOperationException( "predicate cannot be null" );
         if (o == null) throw new UnsupportedOperationException( "object cannot be null" );
-		subj = s;
-		pred = p;
-		obj = o;
         }
 	
 	/**
@@ -59,40 +57,40 @@ public class Triple
     
     public String toString( PrefixMapping pm )
        {
-	   return subj.toString( pm, true ) 
-            + " @" + pred.toString( pm, true ) 
-            + " " + obj.toString( pm, true );
+	   return tuple[0].toString( pm, true ) 
+            + " @" + tuple[1].toString( pm, true ) 
+            + " " + tuple[2].toString( pm, true );
 	   }
     
     /**
         @return the subject of the triple
     */
 	public final Node getSubject() 
-        { return subj; }
+        { return tuple[0]; }
     
     /**
         @return the predicate of the triple
     */
 	public final Node getPredicate() 
-        { return pred; }
+        { return tuple[1]; }
     
     /**
         @return the object of the triple
     */
 	public final Node getObject() 
-        { return obj; }
+        { return tuple[2]; }
 
 	/** Return subject or null, not Node.ANY */ 
     public Node getMatchSubject()
-        { return anyToNull( subj ); }
+        { return anyToNull( tuple[0] ); }
     
     /** Return predicate or null, not Node.ANY */ 
     public Node getMatchPredicate()
-        { return anyToNull( pred ); }
+        { return anyToNull( tuple[1] ); }
         
     /** Return object or null, not Node.ANY */ 
     public Node getMatchObject()
-        { return anyToNull( obj ); }
+        { return anyToNull( tuple[2] ); }
         
     private static Node anyToNull( Node n )
         { return Node.ANY.equals( n ) ? null : n; }
@@ -101,7 +99,7 @@ public class Triple
         { return n == null ? Node.ANY : n; }        
         
     public boolean isConcrete()
-        { return subj.isConcrete() && pred.isConcrete() && obj.isConcrete(); }
+        { return tuple[0].isConcrete() && tuple[1].isConcrete() && tuple[2].isConcrete(); }
         
     /** 
          Answer true if <code>o</code> is a Triple with the same subject, predicate,
@@ -109,32 +107,32 @@ public class Triple
     */
 	@Override
     public boolean equals(Object o) 
-        { return o instanceof Triple && ((Triple) o).sameAs( subj, pred, obj ); }
+        { return o instanceof Triple && ((Triple) o).sameAs( tuple[0], tuple[1], tuple[2] ); }
     
     /** 
         Answer true iff this triple has subject s, predicate p, and object o.
     */    
     public boolean sameAs( Node s, Node p, Node o )
-        { return subj.equals( s ) && pred.equals( p ) && obj.equals( o ); }
+        { return tuple[0].equals( s ) && tuple[1].equals( p ) && tuple[2].equals( o ); }
         
     /** Does this triple, used as a pattern match, the other triple (usually a ground triple) */ 
     public boolean matches( Triple other )
-        { return other.matchedBy( subj, pred, obj  ); }
+        { return other.matchedBy( tuple[0], tuple[1], tuple[2]  ); }
         
     public boolean matches( Node s, Node p, Node o )
-        { return subj.matches( s ) && pred.matches( p ) && obj.matches( o ); }
+        { return tuple[0].matches( s ) && tuple[1].matches( p ) && tuple[2].matches( o ); }
         
     private boolean matchedBy( Node s, Node p, Node o )
-        { return s.matches( subj ) && p.matches( pred ) && o.matches( obj ); }
+        { return s.matches( tuple[0] ) && p.matches( tuple[1] ) && o.matches( tuple[2] ); }
         
     public boolean subjectMatches( Node s )
-        { return subj.matches( s ); }
+        { return tuple[0].matches( s ); }
         
     public boolean predicateMatches( Node p )
-        { return pred.matches( p ); }
+        { return tuple[1].matches( p ); }
         
     public boolean objectMatches( Node o )
-        { return obj.matches( o ); }
+        { return tuple[2].matches( o ); }
         
     /**
         The hash-code of a triple is the hash-codes of its components munged
@@ -142,7 +140,7 @@ public class Triple
     */
     @Override
     public int hashCode() 
-        { return hashCode( subj, pred, obj ); }
+        { return hashCode( tuple[0], tuple[1], tuple[2] ); }
     
     /**
         Return the munged hashCodes of the specified nodes, an exclusive-or of 
@@ -184,12 +182,12 @@ public class Triple
         public static final Field fieldSubject = new Field() 
             { 
             @Override public Node getField( Triple t ) 
-                { return t.subj; }
+                { return t.tuple[0]; }
             
             @Override public Predicate<Triple> filterOn( final Node n )
                 { 
                 return n.isConcrete() 
-                    ? x -> n.equals( x.subj )
+                    ? x -> n.equals( x.tuple[0] )
                     : anyTriple
                     ;
                 }
@@ -198,11 +196,11 @@ public class Triple
         public static final Field fieldObject = new Field() 
             { 
             @Override public Node getField( Triple t ) 
-                { return t.obj; } 
+                { return t.tuple[2]; } 
             
             @Override public Predicate<Triple> filterOn( final Node n )
                 { return n.isConcrete() 
-                    ? x -> n.sameValueAs( x.obj )
+                    ? x -> n.sameValueAs( x.tuple[2] )
                     : anyTriple; 
                 }
             };
@@ -210,11 +208,11 @@ public class Triple
         public static final Field fieldPredicate = new Field() 
             { 
             @Override public Node getField( Triple t ) 
-                { return t.pred; } 
+                { return t.tuple[1]; } 
             
             @Override public Predicate<Triple> filterOn( final Node n )
                 { return n.isConcrete()
-                    ? x -> n.equals( x.pred )
+                    ? x -> n.equals( x.tuple[1] )
                     : anyTriple; 
                 }
             };

--- a/jena-core/src/main/java/org/apache/jena/graph/Triple.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/Triple.java
@@ -107,7 +107,7 @@ public class Triple extends Tuple<Node>
     */
 	@Override
     public boolean equals(Object o) 
-        { return o instanceof Triple && ((Triple) o).sameAs( tuple[0], tuple[1], tuple[2] ); }
+        { return o instanceof Triple && super.equals(o); }
     
     /** 
         Answer true iff this triple has subject s, predicate p, and object o.


### PR DESCRIPTION
Okay, @afs : Second try. This time I avoid unneeded object creation or packing and unpacking, and I don't do weird things to the semantics of `Quad` and `Triple` (I hope!).

I did add some convenience methods to `ColumnMap` and also let the two tuple types subtype `Tuple<Node>` in order to work more closely with `ColumnMap`. I don't think this should be any problem, since they truly are tuples, but I'm sure you will let me know if that is not the case :).

The gains here are much more clarity for the forms of `PMapTupleTable`-based in-memory indexes and it should also be possible much more easily to create other index orderings, if users find that useful for special purposes. (I.e. saving space under conditions where the possible queries are known and very restricted.)