### PR TITLE
JENA-1139 workaround

### DIFF
--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -123,6 +123,12 @@
       <version>3.1.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
+    <!--
+    NOTE: Also update 
+    src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
+    to the concatenation of the different Jena modules' JenaSubsystemLifecycle
+    (order does not matter). See JENA-1139 for details.
+    -->
 
     <dependency>
       <groupId>org.apache.jena</groupId>

--- a/apache-jena-osgi/jena-osgi/src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
+++ b/apache-jena-osgi/jena-osgi/src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
@@ -1,0 +1,4 @@
+org.apache.jena.system.InitJenaCore
+org.apache.jena.riot.system.InitRIOT
+org.apache.jena.sparql.system.InitARQ
+org.apache.jena.tdb.sys.InitTDB


### PR DESCRIPTION
This workaround for JENA-1139 concatenates
the content of the other Jena modules
`src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle`
from jena-osgi's inlined modules `jena-core`, `jena-arq` and `jena-tdb`