### PR TITLE
JENA-1147 : Introduce FactoryRDF

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangEngine.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangEngine.java
@@ -20,9 +20,9 @@ package org.apache.jena.riot.lang;
 
 import static org.apache.jena.riot.tokens.TokenType.EOF ;
 import static org.apache.jena.riot.tokens.TokenType.NODE ;
+
 import org.apache.jena.atlas.AtlasException ;
 import org.apache.jena.atlas.iterator.PeekIterator ;
-import org.apache.jena.graph.Node ;
 import org.apache.jena.riot.RiotParseException ;
 import org.apache.jena.riot.system.ErrorHandler ;
 import org.apache.jena.riot.system.ParserProfile ;
@@ -117,11 +117,11 @@ public class LangEngine
         }
     }
 
-    protected final Node scopedBNode(Node scopeNode, String label)
-    {
-        return profile.getLabelToNode().get(scopeNode, label) ;
-    }
-    
+//    protected final Node scopedBNode(Node scopeNode, String label)
+//    {
+//        return profile.getLabelToNode().get(scopeNode, label) ;
+//    }
+//    
     protected final void expectOrEOF(String msg, TokenType tokenType)
     {
         // DOT or EOF

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDF.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.datatypes.RDFDatatype ;
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.Quad ;
+
+/**
+ * Create core RDF objects: {@link Node}s, {@link Triple}s, {@link Quad}s,
+ * {@link Graph}, {@link DatasetGraph}s.
+ * <p>
+ */
+public interface FactoryRDF {
+    // ?? Are these too varied?
+    public Graph createGraph() ;
+    // ?? Are these too varied?
+    public DatasetGraph createDatasetGraph() ;
+    public Triple createTriple(Node subject, Node predicate, Node object) ;
+    public Quad createQuad(Node graph, Node subject, Node predicate, Node object) ;
+    public Node createURI(String uriStr) ;
+    public Node createTypedLiteral(String lexical, RDFDatatype datatype) ;
+    public Node createLangLiteral(String lexical, String langTag) ;
+    public Node createStringLiteral(String lexical) ;
+    /** Create a blank node */
+    public Node createBlankNode() ;
+    /** Create a blank node with the given string as internal system id */ 
+    public Node createBlankNode(String label) ;
+    /** Create a blank with the internal system id taken from 128 bit number provided.
+     */
+    public Node createBlankNode(long mostSigBits, long leastSigBits) ;
+
+//    // Object for scope better?
+//    public Node createBlankNode(Node scope, String label) ;
+//    // Object for scope better?
+//    public Node createBlankNode(Node scope) ;
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFCaching.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFCaching.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.atlas.lib.Cache ;
+import org.apache.jena.atlas.lib.CacheFactory ;
+import org.apache.jena.atlas.lib.cache.CacheGuava ;
+import org.apache.jena.atlas.lib.cache.CacheInfo ;
+import org.apache.jena.datatypes.RDFDatatype ;
+import org.apache.jena.datatypes.xsd.XSDDatatype ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.NodeFactory ;
+import org.apache.jena.riot.lang.LabelToNode ;
+import org.apache.jena.sparql.graph.NodeConst ;
+
+/** Adds some caching of created nodes - the caching is tuned to RIOT parser usage */ 
+public class FactoryRDFCaching extends FactoryRDFStd {
+
+    // Double caching
+    public final int NodeCacheSize = 10000 ; 
+    public final int PredicateCacheSize = 1000 ;
+    
+    public FactoryRDFCaching() {
+        super() ;
+    }
+    
+    public FactoryRDFCaching(LabelToNode labelMapping) {
+        super(labelMapping) ; 
+    }
+
+    // Better by S,P,O?
+    // Better by Node->Node in triple?
+    
+    // By role?
+    // By policy key?
+    
+    Cache<String, Node> cache = CacheFactory.createCache(NodeCacheSize) ;
+    
+    @Override
+    public Node createURI(String uriStr) {
+        Node n = cache.getOrFill(uriStr, ()->RiotLib.createIRIorBNode(uriStr)) ;
+        return n ;
+    }
+
+    // Constants
+    
+    @Override
+    public Node createTypedLiteral(String lexical, RDFDatatype datatype) {
+        if ( XSDDatatype.XSDinteger.equals(datatype) ) {
+            switch(lexical) {
+                case "0" : return NodeConst.nodeZero ; 
+                case "1" : return NodeConst.nodeOne ;
+                case "2" : return NodeConst.nodeTwo ;
+                case "-1" : return NodeConst.nodeMinusOne ;
+            }
+            // fallthrough.
+        } else if ( XSDDatatype.XSDboolean.equals(datatype) ) {
+            switch(lexical) {
+                case "true" : return NodeConst.nodeTrue ; 
+                case "false" : return NodeConst.nodeFalse ;
+            }
+            // fallthrough.
+        }
+        return NodeFactory.createLiteral(lexical, datatype) ;
+    }
+
+    @Override
+    public Node createStringLiteral(String lexical) {
+        if ( lexical.isEmpty() )
+            return NodeConst.emptyString ;
+        return NodeFactory.createLiteral(lexical) ;
+    }
+    
+//    // A predicate cache.  No significant addional effect.
+//    Cache<Node, Node> cachePredicate = CacheFactory.createCache(PredicateCacheSize) ;
+//    
+//    @Override
+//    public Triple createTriple(Node subject, Node predicate, Node object) {
+//        Node p = cachePredicate.getOrFill(predicate, ()->predicate) ; 
+//        return super.createTriple(subject, p, object) ;
+//    }
+//
+//    // A graph name cache.
+//    Cache<Node, Node> cacheGraphName = CacheFactory.createCache(100) ;
+//
+//    @Override
+//    public Quad createQuad(Node graph, Node subject, Node predicate, Node object) {
+//        Node g = 
+//            graph != null ? cacheGraphName.getOrFill(graph, ()->graph) : null ;
+//        Node p = cachePredicate.getOrFill(predicate, ()->predicate) ;
+//        return super.createQuad(g, subject, p, object) ;
+//    }
+    
+    public CacheInfo stats() {
+        return new CacheInfo(NodeCacheSize, ((CacheGuava<?, ?>)cache).stats()) ;
+    }
+    
+//    public void details() {
+//        details("Node cache", (CacheGuava<?, ?>)cache, NodeCacheSize) ;
+////        details("Predicate Cache", (CacheGuava<?, ?>)cachePredicate, PredicateCacheSize) ;
+//    }
+//        
+//    private void details(String label, CacheGuava<?, ?> cache, int cacheSize) {
+//        System.out.printf("%s [%,d]\n", label, cacheSize) ;
+//        CacheStats stats = ((CacheGuava<?, ?>)cache).stats() ;
+////        System.out.printf("  Cache usage:      %,d\n", cache.size()) ;
+//        System.out.printf("  Requests:         %,d\n", stats.requestCount()) ;
+//        System.out.printf("  Hit rate:         %.1f%%\n", 100*stats.hitRate()) ; 
+////        System.out.printf("  Hits:             %,d\n", stats.hitCount()) ;
+////        System.out.printf("  Misses:           %,d\n", stats.missCount()) ;
+////        if ( stats.loadSuccessCount() != stats.missCount() ) {
+////            System.out.printf("  Load success:     %,d\n", stats.loadSuccessCount()) ;
+////            System.out.printf("  Load ex:          %,d\n", stats.loadExceptionCount()) ;
+////        }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFStd.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFStd.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.datatypes.RDFDatatype ;
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.NodeFactory ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.riot.lang.LabelToNode ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.DatasetGraphFactory ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.sparql.graph.GraphFactory ;
+
+public class FactoryRDFStd implements FactoryRDF {
+    // Needs reset?
+    private final LabelToNode labelMapping ;
+    
+    public FactoryRDFStd() {
+        this(SyntaxLabels.createLabelToNode()) ;
+    }
+    
+    public FactoryRDFStd(LabelToNode labelMapping) {
+        this.labelMapping = labelMapping ; 
+    }
+    
+    @Override
+    public Graph createGraph() {
+        return GraphFactory.createDefaultGraph() ;
+    }
+
+    @Override
+    public DatasetGraph createDatasetGraph() {
+        return DatasetGraphFactory.create(); // createTxnMem() ;
+    }
+
+    @Override
+    public Triple createTriple(Node subject, Node predicate, Node object) {
+        return Triple.create(subject, predicate, object);
+    }
+
+    @Override
+    public Quad createQuad(Node graph, Node subject, Node predicate, Node object) {
+        return Quad.create(graph, subject, predicate, object) ;
+    }
+
+    @Override
+    public Node createURI(String uriStr) {
+        return RiotLib.createIRIorBNode(uriStr) ;
+        //return NodeFactory.createURI(uriStr) ;
+    }
+
+    @Override
+    public Node createTypedLiteral(String lexical, RDFDatatype datatype) {
+        return NodeFactory.createLiteral(lexical, datatype) ;
+    }
+
+    @Override
+    public Node createLangLiteral(String lexical, String langTag) {
+        return NodeFactory.createLiteral(lexical, langTag) ;
+    }
+
+    @Override
+    public Node createStringLiteral(String lexical) {
+        return NodeFactory.createLiteral(lexical) ;
+    }
+
+    @Override
+    public Node createBlankNode(long mostSigBits, long leastSigBits) {
+        // XXX Style: Do this fast.  Guava? Apache commons? Special case for char[32]
+        // (Eventually, blank node Nodes will have two longs normally.)  
+        return createBlankNode(String.format("%08X%08X", mostSigBits, leastSigBits)) ;
+    }
+
+    // Fixed scope.
+    private static Node scope = NodeFactory.createURI("urn:jena:global_scope") ;
+    // Scope
+    @Override
+    public Node createBlankNode(String label) {
+        //return NodeFactory.createBlankNode(label) ;
+        return labelMapping.get(scope, label) ;
+    }
+
+    // Scope
+    @Override
+    public Node createBlankNode() {
+        //return NodeFactory.createBlankNode() ;
+        return labelMapping.create() ;
+    }
+    
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
@@ -18,12 +18,10 @@
 
 package org.apache.jena.riot.system;
 
-
 import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.iri.IRI ;
-import org.apache.jena.riot.lang.LabelToNode ;
 import org.apache.jena.riot.tokens.Token ;
 import org.apache.jena.sparql.core.Quad ;
 
@@ -55,20 +53,22 @@ public interface ParserProfile
     /** Create a fresh blank node */ 
     public Node createBlankNode(Node scope, long line, long col) ;
     
-    /** Make a node from a token - called after all else has been tried - return null for no such node */
+    /** Make a node from a token - called after all else has been tried to handle special cases 
+     *  Return null for "no special node recoginzed"
+     */
     public Node createNodeFromToken(Node scope, Token token, long line, long col) ;
     
     /** Make any node from a token as appropriate */
     public Node create(Node currentGraph, Token token) ;
-    
-    public LabelToNode getLabelToNode() ;
-    public void setLabelToNode(LabelToNode labelToNode) ;
-    
+
     public ErrorHandler getHandler() ;
     public void setHandler(ErrorHandler handler) ;
     
     public Prologue getPrologue() ;
     public void setPrologue(Prologue prologue) ;
+    
+    public FactoryRDF getFactoryRDF() ;
+    public void setFactoryRDF(FactoryRDF factory) ;
     
     public boolean isStrictMode() ;
     public void setStrictMode(boolean mode) ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileBase.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.riot.system ;
 
+import java.util.Objects ;
+
 import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
@@ -26,7 +28,6 @@ import org.apache.jena.graph.Triple ;
 import org.apache.jena.iri.IRI ;
 import org.apache.jena.riot.RiotException ;
 import org.apache.jena.riot.SysRIOT ;
-import org.apache.jena.riot.lang.LabelToNode ;
 import org.apache.jena.riot.tokens.Token ;
 import org.apache.jena.riot.tokens.TokenType ;
 import org.apache.jena.sparql.core.Quad ;
@@ -38,17 +39,20 @@ import org.apache.jena.sparql.core.Quad ;
 public class ParserProfileBase implements ParserProfile {
     protected ErrorHandler errorHandler ;
     protected Prologue     prologue ;
-    protected LabelToNode  labelMapping ;
     protected boolean      strictMode = SysRIOT.isStrictMode() ;
+    protected FactoryRDF   factory ;
 
     public ParserProfileBase(Prologue prologue, ErrorHandler errorHandler) {
-        this(prologue, errorHandler, SyntaxLabels.createLabelToNode()) ;
+        this(prologue, errorHandler, RiotLib.factoryRDF()) ;
     }
 
-    public ParserProfileBase(Prologue prologue, ErrorHandler errorHandler, LabelToNode labelMapping) {
+    public ParserProfileBase(Prologue prologue, ErrorHandler errorHandler, FactoryRDF factory) {
+        Objects.requireNonNull(prologue) ;
+        Objects.requireNonNull(errorHandler) ;
+        Objects.requireNonNull(factory) ;
         this.prologue = prologue ;
         this.errorHandler = errorHandler ;
-        this.labelMapping = labelMapping ;
+        this.factory = factory ;
     }
 
     @Override
@@ -72,15 +76,15 @@ public class ParserProfileBase implements ParserProfile {
     }
 
     @Override
-    public LabelToNode getLabelToNode() {
-        return labelMapping ;
+    public FactoryRDF getFactoryRDF() {
+        return factory;
     }
 
     @Override
-    public void setLabelToNode(LabelToNode mapper) {
-        labelMapping = mapper ;
+    public void setFactoryRDF(FactoryRDF factory) {
+        this.factory = factory;
     }
-
+   
     @Override
     public String resolveIRI(String uriStr, long line, long col) {
         return prologue.getResolver().resolveToString(uriStr) ;
@@ -93,44 +97,44 @@ public class ParserProfileBase implements ParserProfile {
 
     @Override
     public Quad createQuad(Node g, Node s, Node p, Node o, long line, long col) {
-        return new Quad(g, s, p, o) ;
+        return factory.createQuad(g, s, p, o);
     }
 
     @Override
     public Triple createTriple(Node s, Node p, Node o, long line, long col) {
-        return new Triple(s, p, o) ;
+        return factory.createTriple(s, p, o);
     }
 
     @Override
     public Node createURI(String uriStr, long line, long col) {
-        return RiotLib.createIRIorBNode(uriStr) ;
+        return factory.createURI(uriStr);
     }
 
     @Override
     public Node createBlankNode(Node scope, String label, long line, long col) {
-        return labelMapping.get(scope, label) ;
+        return factory.createBlankNode(label);
     }
 
     @Override
     public Node createBlankNode(Node scope, long line, long col) {
-        return labelMapping.create() ;
+        return factory.createBlankNode();
     }
 
     @Override
     public Node createTypedLiteral(String lexical, RDFDatatype dt, long line, long col) {
-        return NodeFactory.createLiteral(lexical, dt) ;
+        return factory.createTypedLiteral(lexical, dt);
     }
 
     @Override
     public Node createLangLiteral(String lexical, String langTag, long line, long col) {
-        return NodeFactory.createLiteral(lexical, langTag) ;
+        return factory.createLangLiteral(lexical, langTag);
     }
 
     @Override
     public Node createStringLiteral(String lexical, long line, long col) {
-        return NodeFactory.createLiteral(lexical) ;
+        return factory.createStringLiteral(lexical);
     }
-
+  
     /** Special token forms */
     @Override
     public Node createNodeFromToken(Node scope, Token token, long line, long col) {
@@ -144,27 +148,31 @@ public class ParserProfileBase implements ParserProfile {
 
     @Override
     public Node create(Node currentGraph, Token token) {
-        // Dispatches to the underlying operation
+        return create(this, currentGraph, token) ;
+    }
+        
+    private static Node create(ParserProfile pp, Node currentGraph, Token token) {
+        // Dispatches to the underlying ParserProfile operation
         long line = token.getLine() ;
         long col = token.getColumn() ;
         String str = token.getImage() ;
         switch (token.getType()) {
             case BNODE :
-                return createBlankNode(currentGraph, str, line, col) ;
+                return pp.createBlankNode(currentGraph, str, line, col) ;
             case IRI :
-                return createURI(str, line, col) ;
+                return pp.createURI(str, line, col) ;
             case PREFIXED_NAME : {
                 String prefix = str ;
                 String suffix = token.getImage2() ;
-                String expansion = expandPrefixedName(prefix, suffix, token) ;
-                return createURI(expansion, line, col) ;
+                String expansion = expandPrefixedName(pp, prefix, suffix, token) ;
+                return pp.createURI(expansion, line, col) ;
             }
             case DECIMAL :
-                return createTypedLiteral(str, XSDDatatype.XSDdecimal, line, col) ;
+                return pp.createTypedLiteral(str, XSDDatatype.XSDdecimal, line, col) ;
             case DOUBLE :
-                return createTypedLiteral(str, XSDDatatype.XSDdouble, line, col) ;
+                return pp.createTypedLiteral(str, XSDDatatype.XSDdouble, line, col) ;
             case INTEGER :
-                return createTypedLiteral(str, XSDDatatype.XSDinteger, line, col) ;
+                return pp.createTypedLiteral(str, XSDDatatype.XSDinteger, line, col) ;
             case LITERAL_DT : {
                 Token tokenDT = token.getSubToken2() ;
                 String uriStr ;
@@ -176,41 +184,41 @@ public class ParserProfileBase implements ParserProfile {
                     case PREFIXED_NAME : {
                         String prefix = tokenDT.getImage() ;
                         String suffix = tokenDT.getImage2() ;
-                        uriStr = expandPrefixedName(prefix, suffix, tokenDT) ;
+                        uriStr = expandPrefixedName(pp, prefix, suffix, tokenDT) ;
                         break ;
                     }
                     default :
                         throw new RiotException("Expected IRI for datatype: " + token) ;
                 }
 
-                uriStr = resolveIRI(uriStr, tokenDT.getLine(), tokenDT.getColumn()) ;
+                uriStr = pp.resolveIRI(uriStr, tokenDT.getLine(), tokenDT.getColumn()) ;
                 RDFDatatype dt = NodeFactory.getType(uriStr) ;
-                return createTypedLiteral(str, dt, line, col) ;
+                return pp.createTypedLiteral(str, dt, line, col) ;
             }
 
             case LITERAL_LANG :
-                return createLangLiteral(str, token.getImage2(), line, col) ;
+                return pp.createLangLiteral(str, token.getImage2(), line, col) ;
 
             case STRING :
             case STRING1 :
             case STRING2 :
             case LONG_STRING1 :
             case LONG_STRING2 :
-                return createStringLiteral(str, line, col) ;
+                return pp.createStringLiteral(str, line, col) ;
             default : {
-                Node x = createNodeFromToken(currentGraph, token, line, col) ;
+                Node x = pp.createNodeFromToken(currentGraph, token, line, col) ;
                 if (x != null)
                     return x ;
-                errorHandler.fatal("Not a valid token for an RDF term: " + token, line, col) ;
+                pp.getHandler().fatal("Not a valid token for an RDF term: " + token, line, col) ;
                 return null ;
             }
         }
     }
 
-    private String expandPrefixedName(String prefix, String localPart, Token token) {
-        String expansion = prologue.getPrefixMap().expand(prefix, localPart) ;
+    private static String expandPrefixedName(ParserProfile pp, String prefix, String localPart, Token token) {
+        String expansion = pp.getPrologue().getPrefixMap().expand(prefix, localPart) ;
         if (expansion == null)
-            errorHandler.fatal("Undefined prefix: " + prefix, token.getLine(), token.getColumn()) ;
+            pp.getHandler().fatal("Undefined prefix: " + prefix, token.getLine(), token.getColumn()) ;
         return expansion ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileChecker.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileChecker.java
@@ -26,7 +26,6 @@ import org.apache.jena.iri.IRI ;
 import org.apache.jena.riot.RiotException ;
 import org.apache.jena.riot.checker.CheckerIRI ;
 import org.apache.jena.riot.checker.CheckerLiterals ;
-import org.apache.jena.riot.lang.LabelToNode ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.util.FmtUtils ;
 
@@ -40,8 +39,7 @@ import org.apache.jena.sparql.util.FmtUtils ;
  * </ul>
  */
 
-public class ParserProfileChecker extends ParserProfileBase // implements
-                                                            // ParserProfile
+public class ParserProfileChecker extends ParserProfileBase // implements ParserProfile
 {
     private boolean checkLiterals = true ;
 
@@ -49,8 +47,8 @@ public class ParserProfileChecker extends ParserProfileBase // implements
         super(prologue, errorHandler) ;
     }
 
-    public ParserProfileChecker(Prologue prologue, ErrorHandler errorHandler, LabelToNode labelMapping) {
-        super(prologue, errorHandler, labelMapping) ;
+    public ParserProfileChecker(Prologue prologue, ErrorHandler errorHandler, FactoryRDF factory) {
+        super(prologue, errorHandler, factory) ;
     }
 
     @Override
@@ -105,19 +103,9 @@ public class ParserProfileChecker extends ParserProfileBase // implements
 
     @Override
     public Node createURI(String x, long line, long col) {
-        try {
-            if ( RiotLib.isBNodeIRI(x) )
-                return RiotLib.createIRIorBNode(x) ;
-            else {
-                String resolvedIRI = resolveIRI(x, line, col) ;
-                return NodeFactory.createURI(resolvedIRI) ;
-            }
-        }
-        catch (RiotException ex) {
-            // Error was handled.
-            // errorHandler.error(ex.getMessage(), line, col) ;
-            throw ex ;
-        }
+        if ( ! RiotLib.isBNodeIRI(x) )
+            x = resolveIRI(x, line, col) ;
+        return super.createURI(x, line, col) ;
     }
 
     @Override
@@ -134,14 +122,14 @@ public class ParserProfileChecker extends ParserProfileBase // implements
         return n ;
     }
 
-    @Override
-    public Node createStringLiteral(String lexical, long line, long col) {
-        return NodeFactory.createLiteral(lexical) ;
-    }
-
-    @Override
-    public Node createBlankNode(Node scope, String label, long line, long col) {
-        return labelMapping.get(scope, label) ;
-    }
-
+    // No checks
+//    @Override
+//    public Node createStringLiteral(String lexical, long line, long col) {
+//        return super.createStringLiteral(lexical, line, col) ;
+//    }
+//
+//    @Override
+//    public Node createBlankNode(Node scope, String label, long line, long col) {
+//        return super.createBlankNode(scope, label, line, col) ;
+//    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ProgressStreamRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ProgressStreamRDF.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.atlas.lib.ProgressMonitor ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.sparql.core.Quad ;
+
+/** Send ticks to a {@link ProgressMonitor} as triples and quads
+ * are sent along the {@link StreamRDF}.
+ */
+ 
+public class ProgressStreamRDF extends StreamRDFWrapper {
+
+    private final ProgressMonitor monitor ;
+    
+    public ProgressStreamRDF(StreamRDF other, ProgressMonitor monitor) {
+        super(other);
+        this.monitor = monitor ;
+    }
+
+    // Better that the app call start/finish on the monitor so that a number of
+    // inputs on the stream can call start/finish. i.e the monitor can be used
+    // for a batch of oeprations.
+    
+//    @Override
+//    public void start() {
+//        monitor.start();
+//        super.start();
+//    }
+//
+//    @Override
+//    public void finish() {
+//        super.finish();
+//        monitor.finish();
+//    }
+
+    @Override
+    public void triple(Triple triple) {
+        super.triple(triple);
+        monitor.tick();
+    }
+
+    @Override
+    public void quad(Quad quad) {
+        super.quad(quad);
+        monitor.tick();
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
@@ -38,10 +38,7 @@ import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.query.ARQ ;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.riot.SysRIOT ;
-import org.apache.jena.riot.WriterDatasetRIOT ;
+import org.apache.jena.riot.* ;
 import org.apache.jena.riot.lang.LabelToNode ;
 import org.apache.jena.riot.tokens.Token ;
 import org.apache.jena.riot.tokens.Tokenizer ;
@@ -82,7 +79,7 @@ public class RiotLib
         return skolomizedBNodes && iri.startsWith(bNodeLabelStart) ;
     }
     
-    private static ParserProfile profile = profile(RDFLanguages.TURTLE, null, null) ;
+    private static ParserProfile profile = profile(RDFLanguages.TURTLE, null, ErrorHandlerFactory.errorHandlerStd) ;
     static {
         PrefixMap pmap = profile.getPrologue().getPrefixMap() ;
         pmap.add("rdf",  ARQConstants.rdfPrefix) ;
@@ -147,9 +144,23 @@ public class RiotLib
             prologue = new Prologue(PrefixMapFactory.createForInput(), IRIResolver.createNoResolve()) ;
     
         if ( checking )
-            return new ParserProfileChecker(prologue, handler, labelToNode) ;
+            return new ParserProfileChecker(prologue, handler, factoryRDF(labelToNode)) ;
         else
-            return new ParserProfileBase(prologue, handler, labelToNode) ;
+            return new ParserProfileBase(prologue, handler, factoryRDF(labelToNode)) ;
+    }
+
+    /** Create a new (notinfluenced by anything else) FactoryRDF
+     * using the label to blank node scheme provided. 
+     */
+    public static FactoryRDF factoryRDF(LabelToNode labelMapping) {
+        return new FactoryRDFStd(labelMapping);
+    }
+
+    /** Create a new (not influenced by anything else) FactoryRDF
+     * using the label to blank node scheme scope by this FactoryRDF. 
+     */  
+    public static FactoryRDF factoryRDF() {
+        return factoryRDF(SyntaxLabels.createLabelToNode());
     }
 
     /** Get triples with the same subject */

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/SerializationFactoryFinder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/SerializationFactoryFinder.java
@@ -81,9 +81,11 @@ public class SerializationFactoryFinder
             @Override
             public Iterator<Triple> createDeserializer(InputStream in)
             {
-                Tokenizer tokenizer = TokenizerFactory.makeTokenizerASCII(in) ;
-                ParserProfileBase profile = new ParserProfileBase(new Prologue(null, IRIResolver.createNoResolve()), null, LabelToNode.createUseLabelEncoded()) ;
-                LangNTriples parser = new LangNTriples(tokenizer, profile, null) ;
+                Tokenizer tokenizer = TokenizerFactory.makeTokenizerASCII(in);
+                ParserProfileBase profile = new ParserProfileBase(new Prologue(null, IRIResolver.createNoResolve()), 
+                                                                  ErrorHandlerFactory.errorHandlerNoWarnings,
+                                                                  RiotLib.factoryRDF(LabelToNode.createUseLabelEncoded()));
+                LangNTriples parser = new LangNTriples(tokenizer, profile, null);
                 return parser ;
             }
             
@@ -110,7 +112,9 @@ public class SerializationFactoryFinder
             public Iterator<Quad> createDeserializer(InputStream in)
             {
                 Tokenizer tokenizer = TokenizerFactory.makeTokenizerASCII(in) ;
-                ParserProfileBase profile = new ParserProfileBase(new Prologue(null, IRIResolver.createNoResolve()), null, LabelToNode.createUseLabelEncoded()) ;
+                ParserProfileBase profile = new ParserProfileBase(new Prologue(null, IRIResolver.createNoResolve()), 
+                                                                  ErrorHandlerFactory.errorHandlerNoWarnings,
+                                                                  RiotLib.factoryRDF(LabelToNode.createUseLabelEncoded())) ;
                 LangNQuads parser = new LangNQuads(tokenizer, profile, null) ;
                 return parser ;
             }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingInputStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingInputStream.java
@@ -82,8 +82,8 @@ public class BindingInputStream extends LangEngine implements Iterator<Binding>,
         // Don't do anything with IRIs.
         Prologue prologue = new Prologue(PrefixMapFactory.createForInput(), IRIResolver.createNoResolve()) ;
         ErrorHandler handler = ErrorHandlerFactory.getDefaultErrorHandler() ;
-        ParserProfile profile = new ParserProfileBase(prologue, handler) ;
-        profile.setLabelToNode(LabelToNode.createUseLabelAsGiven()) ;
+        FactoryRDF factory = RiotLib.factoryRDF(LabelToNode.createUseLabelAsGiven()) ;
+        ParserProfile profile = new ParserProfileBase(prologue, handler, factory) ;
         // Include safe bNode labels.
         return profile ;
     }

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TS_RiotSystem.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TS_RiotSystem.java
@@ -30,6 +30,9 @@ import org.junit.runners.Suite.SuiteClasses ;
 @SuiteClasses({ 
     TestChecker.class
     , TestStreamRDF.class
+    , TestFactoryRDF.class
+    , TestFactoryRDFCaching.class
+
     // Prefix Map implementations
     , TestPrefixMap.class
     , TestPrefixMapWrapper.class
@@ -37,11 +40,13 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestFastAbbreviatingPrefixMap.class
     , TestPrefixMapExtended1.class
     , TestPrefixMapExtended2.class
+    
     , TestIO_JenaReaders.class
     , TestIO_JenaWriters.class
     , TestLangRegistration.class
     , TestFormatRegistration.class
     , TestJsonLDReadWrite.class         // Some simple testing of the jsonld-java engine. 
+    
     // May be subject to performance vagaries, with the improvements made
     // to the fast implementation this should be fairly safe
     //, TestAbbreviationPerformance.class

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDF.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDF.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import static org.junit.Assert.assertEquals ;
+import static org.junit.Assert.assertNotEquals ;
+import static org.junit.Assert.assertNotNull ;
+import static org.junit.Assert.assertTrue ;
+
+import org.apache.jena.datatypes.xsd.XSDDatatype ;
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.riot.lang.LabelToNode ;
+import org.apache.jena.riot.system.FactoryRDF ;
+import org.apache.jena.riot.system.FactoryRDFStd ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.vocabulary.RDF ;
+import org.junit.Test ;
+
+public class TestFactoryRDF {
+    protected FactoryRDF factory = new FactoryRDFStd(LabelToNode.createUseLabelAsGiven()) ;
+    
+    @Test public void factoryRDF_blanknode_01() {
+        Node n1 = factory.createBlankNode() ;
+        assertTrue(n1.isBlank()) ;
+        Node n2 = factory.createBlankNode() ;
+        assertNotEquals(n1, n2);
+    }
+    
+    @Test public void factoryRDF_blanknode_02() {
+        Node n1 = factory.createBlankNode("ABCDE") ;
+        assertTrue(n1.isBlank()) ;
+        Node n2 = factory.createBlankNode("ABCDE") ;
+        assertEquals(n1, n2);
+        assertEquals("ABCDE", n1.getBlankNodeLabel()) ;
+    }
+
+    @Test public void factoryRDF_blanknode_03() {
+        Node n1 = factory.createBlankNode(0x1234L, 0x5678L) ;
+        assertTrue(n1.isBlank()) ;
+        Node n2 = factory.createBlankNode(0x1234L, 0x5678L) ;
+        assertEquals(n1, n2);
+        assertEquals("0000123400005678", n1.getBlankNodeLabel()) ;
+    }
+
+    @Test public void factoryRDF_uri_02() {
+        Node n = factory.createURI("http://example/") ;
+        assertTrue(n.isURI()) ;
+        assertEquals("http://example/", n.getURI()) ; 
+    }
+
+    @Test public void factoryRDF_uri_03() {
+        Node n = factory.createURI("_:abc") ;   // Blank node!
+        assertTrue(n.isBlank()) ;
+        assertEquals("abc", n.getBlankNodeLabel()) ; 
+    }
+
+    @Test public void factoryRDF_literal_01() {
+        Node n = factory.createStringLiteral("hello") ;
+        assertTrue(n.isLiteral()) ;
+        assertEquals("hello", n.getLiteralLexicalForm()) ; 
+        assertEquals(XSDDatatype.XSDstring, n.getLiteralDatatype()) ;
+        assertEquals("", n.getLiteralLanguage()) ;
+    }
+
+    @Test public void factoryRDF_literal_02() {
+        Node n = factory.createLangLiteral("xyz", "en") ;
+        assertTrue(n.isLiteral()) ;
+        assertEquals("xyz", n.getLiteralLexicalForm()) ; 
+        assertEquals(RDF.dtLangString, n.getLiteralDatatype()) ;
+        assertEquals("en", n.getLiteralLanguage()) ;
+    }
+
+    @Test public void factoryRDF_literal_03() {
+        Node n = factory.createTypedLiteral("1", XSDDatatype.XSDinteger) ;
+        assertTrue(n.isLiteral()) ;
+        assertEquals("1", n.getLiteralLexicalForm()) ; 
+        assertEquals(XSDDatatype.XSDinteger, n.getLiteralDatatype()) ;
+        assertEquals("", n.getLiteralLanguage()) ;
+    }
+    
+    @Test public void factoryRDF_triple_01() {
+        Node s = factory.createURI("http://test/s") ;
+        Node p = factory.createURI("http://test/p") ;
+        Node o = factory.createURI("http://test/o") ;
+        Triple triple = factory.createTriple(s, p, o) ;
+        assertEquals(s, triple.getSubject()) ;
+        assertEquals(p, triple.getPredicate()) ;
+        assertEquals(o, triple.getObject()) ;
+    }
+
+    @Test public void factoryRDF_quad_01() {
+        Node g = factory.createURI("http://test/g") ;
+        Node s = factory.createURI("http://test/s") ;
+        Node p = factory.createURI("http://test/p") ;
+        Node o = factory.createURI("http://test/o") ;
+        Quad quad = factory.createQuad(g, s, p, o) ;
+        assertEquals(g, quad.getGraph()) ;
+        assertEquals(s, quad.getSubject()) ;
+        assertEquals(p, quad.getPredicate()) ;
+        assertEquals(o, quad.getObject()) ;
+    }
+    
+    @Test public void factoryRDF_graph_01() {
+        Graph graph = factory.createGraph() ;
+        assertNotNull(graph) ;
+    }
+
+    @Test public void factoryRDF_dataset_01() {
+        DatasetGraph dsg = factory.createDatasetGraph() ;
+        assertNotNull(dsg) ;
+    }
+}
+

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDFCaching.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDFCaching.java
@@ -27,7 +27,7 @@ import org.junit.Test ;
 public class TestFactoryRDFCaching extends TestFactoryRDF {
  
     public TestFactoryRDFCaching() {
-        super.factory = new FactoryRDFCaching(LabelToNode.createUseLabelAsGiven()) ;
+        super.factory = new FactoryRDFCaching(100, LabelToNode.createUseLabelAsGiven()) ;
     }
     
     @Test public void factory_cache_01() {

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDFCaching.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDFCaching.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import static org.junit.Assert. * ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.riot.lang.LabelToNode ;
+import org.apache.jena.riot.system.FactoryRDFCaching ;
+import org.junit.Test ;
+
+public class TestFactoryRDFCaching extends TestFactoryRDF {
+ 
+    public TestFactoryRDFCaching() {
+        super.factory = new FactoryRDFCaching(LabelToNode.createUseLabelAsGiven()) ;
+    }
+    
+    @Test public void factory_cache_01() {
+        Node n1 = factory.createStringLiteral("") ;
+        Node n2 = factory.createStringLiteral("") ;
+        assertSame(n1, n2); 
+    }
+    
+    @Test public void factory_cache_02() {
+        Node n1 = factory.createURI("http://test/n1") ;
+        Node n2 = factory.createURI("http://test/n2") ;
+        Node n3 = factory.createURI("http://test/n1") ;
+        assertSame(n1, n3); 
+    }
+}
+
+

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheInfo.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheInfo.java
@@ -21,42 +21,28 @@ package org.apache.jena.atlas.lib.cache;
 import org.apache.jena.ext.com.google.common.cache.CacheStats ;
 
 /** Simplified version of Guava's CacheStats (and abstractign away from Guava cache implementation) */
-    public class CacheInfo {
-        public final long requests;
-        public final long hits;
-        public final long misses;
-        public final double hitRate;
-        public final int cacheSize;
+public class CacheInfo {
+    public final long requests;
+    public final long hits;
+    public final long misses;
+    public final double hitRate;
+    public final int cacheSize;
 
-        public CacheInfo(int cacheSize, CacheStats stats) {
-            this(cacheSize, stats.requestCount(), stats.hitCount(), stats.missCount(), stats.hitRate() ) ;
-        }
-        
-        public CacheInfo(int cacheSize, long requests, long hits, long misses, double hitRate) {
-            this.cacheSize = cacheSize ;
-            this.requests = requests ;
-            this.hits = hits ;
-            this.misses = misses ;
-            this.hitRate = hitRate ;
-        }
-
-        @Override
-        public String toString() {
-            return String.format("size=%,d  count=%,d  hits=%,d  misses=%,d  rate=%.1f",
-                                 cacheSize, requests, hits, misses, hitRate) ;
-        }
-        
-//      private void details(String label, CacheGuava<?, ?> cache, int cacheSize) {
-//      System.out.printf("%s [%,d]\n", label, cacheSize) ;
-//      CacheStats stats = ((CacheGuava<?, ?>)cache).stats() ;
-////      System.out.printf("  Cache usage:      %,d\n", cache.size()) ;
-//      System.out.printf("  Requests:         %,d\n", stats.requestCount()) ;
-//      System.out.printf("  Hit rate:         %.1f%%\n", 100*stats.hitRate()) ; 
-////      System.out.printf("  Hits:             %,d\n", stats.hitCount()) ;
-////      System.out.printf("  Misses:           %,d\n", stats.missCount()) ;
-////      if ( stats.loadSuccessCount() != stats.missCount() ) {
-////          System.out.printf("  Load success:     %,d\n", stats.loadSuccessCount()) ;
-////          System.out.printf("  Load ex:          %,d\n", stats.loadExceptionCount()) ;
-////      }
-
+    public CacheInfo(int cacheSize, CacheStats stats) {
+        this(cacheSize, stats.requestCount(), stats.hitCount(), stats.missCount(), stats.hitRate() ) ;
     }
+
+    public CacheInfo(int cacheSize, long requests, long hits, long misses, double hitRate) {
+        this.cacheSize = cacheSize ;
+        this.requests = requests ;
+        this.hits = hits ;
+        this.misses = misses ;
+        this.hitRate = hitRate ;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("size=%,d  count=%,d  hits=%,d  misses=%,d  rate=%.1f",
+                             cacheSize, requests, hits, misses, hitRate) ;
+    }
+}

--- a/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
+++ b/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
@@ -276,8 +276,11 @@ public abstract class CmdLangParse extends CmdGeneral
             } else
                 reader.setParserProfile(RiotLib.profile(baseURI, false, false, errHandler)) ;
 
-            if ( labelsAsGiven )
-                reader.getParserProfile().setLabelToNode(LabelToNode.createUseLabelAsGiven()) ;
+            if ( labelsAsGiven ) {
+                FactoryRDF f = RiotLib.factoryRDF(LabelToNode.createUseLabelAsGiven()) ;
+                reader.getParserProfile().setFactoryRDF(f);
+            }
+
             modTime.startTimer() ;
             sink.start() ;
             reader.read(in, baseURI, ct, sink, null) ;

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilder.java
@@ -164,8 +164,11 @@ public abstract class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>>
 		values = new HashMap<Var, Node>();
 	}
 	
+	/**
+	 * Get the HandlerBlock for this query builder.
+	 * @return The associated handler block.
+	 */
 	public abstract HandlerBlock getHandlerBlock();
-	
 	
 	@Override
 	public final PrologHandler getPrologHandler() {
@@ -274,6 +277,8 @@ public abstract class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>>
 	 */
 	public final Query build() {
 		Query q = new Query();
+		
+		// set the query type
 		switch (query.getQueryType())
 		{
 		case Query.QueryTypeAsk:
@@ -292,8 +297,11 @@ public abstract class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>>
 			throw new IllegalStateException( "Internal query is not a known type: "+q.getQueryType());			
 		}
 		
+		// use the HandlerBlock implementation to copy the data.
 		HandlerBlock handlerBlock = new HandlerBlock(q);
 		handlerBlock.addAll( getHandlerBlock() );
+		
+		// set the vars
 		handlerBlock.setVars(values);
 		
 		//  make sure we have a query pattern before we start building.
@@ -320,6 +328,7 @@ public abstract class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>>
 	public static Query clone(Query q2) {
 		Query retval = new Query();
 		
+		// set the query type
 	    if (q2.isSelectType())
 	    {
 	    	retval.setQuerySelectType();
@@ -333,6 +342,7 @@ public abstract class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>>
 	    	retval.setQueryConstructType();
 	    }
 	    
+	    // use the handler block to clone the data
 	    HandlerBlock hb = new HandlerBlock( retval );
 	    HandlerBlock hb2 = new HandlerBlock( q2 );
 	    hb.addAll(hb2);

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilder.java
@@ -19,23 +19,9 @@ package org.apache.jena.arq.querybuilder;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Stack;
-
-import org.apache.jena.arq.querybuilder.clauses.ConstructClause;
-import org.apache.jena.arq.querybuilder.clauses.DatasetClause;
 import org.apache.jena.arq.querybuilder.clauses.PrologClause;
-import org.apache.jena.arq.querybuilder.clauses.SelectClause;
-import org.apache.jena.arq.querybuilder.clauses.SolutionModifierClause;
-import org.apache.jena.arq.querybuilder.clauses.WhereClause;
-import org.apache.jena.arq.querybuilder.handlers.AggregationHandler;
-import org.apache.jena.arq.querybuilder.handlers.ConstructHandler;
-import org.apache.jena.arq.querybuilder.handlers.DatasetHandler;
-import org.apache.jena.arq.querybuilder.handlers.Handler;
 import org.apache.jena.arq.querybuilder.handlers.HandlerBlock;
 import org.apache.jena.arq.querybuilder.handlers.PrologHandler;
-import org.apache.jena.arq.querybuilder.handlers.SelectHandler;
-import org.apache.jena.arq.querybuilder.handlers.SolutionModifierHandler;
-import org.apache.jena.arq.querybuilder.handlers.WhereHandler;
 import org.apache.jena.graph.FrontsNode ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
@@ -181,6 +167,7 @@ public abstract class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>>
 	public abstract HandlerBlock getHandlerBlock();
 	
 	
+	@Override
 	public final PrologHandler getPrologHandler() {
 		return getHandlerBlock().getPrologHandler();
 	}

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AskBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AskBuilder.java
@@ -24,7 +24,6 @@ import org.apache.jena.arq.querybuilder.clauses.SolutionModifierClause;
 import org.apache.jena.arq.querybuilder.clauses.WhereClause;
 import org.apache.jena.arq.querybuilder.handlers.DatasetHandler;
 import org.apache.jena.arq.querybuilder.handlers.HandlerBlock;
-import org.apache.jena.arq.querybuilder.handlers.PrologHandler;
 import org.apache.jena.arq.querybuilder.handlers.SolutionModifierHandler;
 import org.apache.jena.arq.querybuilder.handlers.WhereHandler;
 import org.apache.jena.graph.FrontsTriple ;

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
@@ -26,7 +26,6 @@ import org.apache.jena.arq.querybuilder.clauses.WhereClause;
 import org.apache.jena.arq.querybuilder.handlers.ConstructHandler;
 import org.apache.jena.arq.querybuilder.handlers.DatasetHandler;
 import org.apache.jena.arq.querybuilder.handlers.HandlerBlock;
-import org.apache.jena.arq.querybuilder.handlers.PrologHandler;
 import org.apache.jena.arq.querybuilder.handlers.SolutionModifierHandler;
 import org.apache.jena.arq.querybuilder.handlers.WhereHandler;
 import org.apache.jena.graph.FrontsTriple ;
@@ -46,6 +45,7 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder>
 		ConstructClause<ConstructBuilder> {
 
 	private final HandlerBlock handlerBlock;
+	
 	/**
 	 * Constructor
 	 */

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
@@ -25,6 +25,8 @@ import org.apache.jena.arq.querybuilder.clauses.SolutionModifierClause;
 import org.apache.jena.arq.querybuilder.clauses.WhereClause;
 import org.apache.jena.arq.querybuilder.handlers.ConstructHandler;
 import org.apache.jena.arq.querybuilder.handlers.DatasetHandler;
+import org.apache.jena.arq.querybuilder.handlers.HandlerBlock;
+import org.apache.jena.arq.querybuilder.handlers.PrologHandler;
 import org.apache.jena.arq.querybuilder.handlers.SolutionModifierHandler;
 import org.apache.jena.arq.querybuilder.handlers.WhereHandler;
 import org.apache.jena.graph.FrontsTriple ;
@@ -43,118 +45,112 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder>
 		SolutionModifierClause<ConstructBuilder>,
 		ConstructClause<ConstructBuilder> {
 
-	// the handlers used by this builder
-	private final DatasetHandler datasetHandler;
-	private final WhereHandler whereHandler;
-	private final SolutionModifierHandler solutionModifier;
-	private final ConstructHandler constructHandler;
-
+	private final HandlerBlock handlerBlock;
 	/**
 	 * Constructor
 	 */
 	public ConstructBuilder() {
 		super();
 		query.setQueryConstructType();
-		datasetHandler = new DatasetHandler(query);
-		whereHandler = new WhereHandler(query);
-		solutionModifier = new SolutionModifierHandler(query);
-		constructHandler = new ConstructHandler(query);
+		handlerBlock = new HandlerBlock(query);
 	}
 
 	@Override
 	public DatasetHandler getDatasetHandler() {
-		return datasetHandler;
+		return handlerBlock.getDatasetHandler();
 	}
 
 	@Override
 	public WhereHandler getWhereHandler() {
-		return whereHandler;
+		return handlerBlock.getWhereHandler();
 	}
 
 	@Override
 	public ConstructHandler getConstructHandler() {
-		return constructHandler;
+		return handlerBlock.getConstructHandler();
 	}
 
 	@Override
 	public SolutionModifierHandler getSolutionModifierHandler() {
-		return solutionModifier;
+		return handlerBlock.getModifierHandler();
 	}
 
 	@Override
+	public HandlerBlock getHandlerBlock()
+	{
+		return handlerBlock;
+	}
+	
+	@Override
 	public ConstructBuilder clone() {
 		ConstructBuilder qb = new ConstructBuilder();
-		qb.prologHandler.addAll(prologHandler);
-		qb.datasetHandler.addAll(datasetHandler);
-		qb.whereHandler.addAll(whereHandler);
-		qb.solutionModifier.addAll(solutionModifier);
-		qb.constructHandler.addAll(constructHandler);
+		qb.handlerBlock.addAll( handlerBlock );
 		return qb;
 	}
 
 	@Override
 	public ConstructBuilder fromNamed(String graphName) {
-		datasetHandler.fromNamed(graphName);
+		getDatasetHandler().fromNamed(graphName);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder fromNamed(Collection<String> graphNames) {
-		datasetHandler.fromNamed(graphNames);
+		getDatasetHandler().fromNamed(graphNames);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder from(String graphName) {
-		datasetHandler.from(graphName);
+		getDatasetHandler().from(graphName);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder from(Collection<String> graphName) {
-		datasetHandler.from(graphName);
+		getDatasetHandler().from(graphName);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addOrderBy(String orderBy) {
-		solutionModifier.addOrderBy(orderBy);
+		getSolutionModifierHandler().addOrderBy(orderBy);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addGroupBy(String groupBy) {
-		solutionModifier.addGroupBy(groupBy);
+		getSolutionModifierHandler().addGroupBy(groupBy);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addHaving(String having) throws ParseException {
-		solutionModifier.addHaving(having);
+		getSolutionModifierHandler().addHaving(having);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder setLimit(int limit) {
-		solutionModifier.setLimit(limit);
+		getSolutionModifierHandler().setLimit(limit);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder setOffset(int offset) {
-		solutionModifier.setOffset(offset);
+		getSolutionModifierHandler().setOffset(offset);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addWhere(Triple t) {
-		whereHandler.addWhere(t);
+		getWhereHandler().addWhere(t);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addWhere(FrontsTriple t) {
-		whereHandler.addWhere(t.asTriple());
+		getWhereHandler().addWhere(t.asTriple());
 		return this;
 	}
 
@@ -166,20 +162,20 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder>
 
 	@Override
 	public ConstructBuilder addOptional(Triple t) {
-		whereHandler.addOptional(t);
+		getWhereHandler().addOptional(t);
 		return this;
 	}
 	
 	@Override
 	public ConstructBuilder addOptional(SelectBuilder t)
 	{
-		whereHandler.addOptional(t.getWhereHandler());
+		getWhereHandler().addOptional(t.getWhereHandler());
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addOptional(FrontsTriple t) {
-		whereHandler.addOptional(t.asTriple());
+		getWhereHandler().addOptional(t.asTriple());
 		return this;
 	}
 
@@ -191,45 +187,44 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder>
 
 	@Override
 	public ConstructBuilder addFilter(String s) throws ParseException {
-		whereHandler.addFilter(s);
+		getWhereHandler().addFilter(s);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addSubQuery(SelectBuilder subQuery) {
-		prologHandler.addAll(subQuery.prologHandler);
-		whereHandler.addSubQuery(subQuery);
+		getWhereHandler().addSubQuery(subQuery);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addUnion(SelectBuilder subQuery) {
-		whereHandler.addUnion(subQuery);
+		getWhereHandler().addUnion(subQuery);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addGraph(Object graph, SelectBuilder subQuery) {
-		prologHandler.addAll(subQuery.prologHandler);
-		whereHandler.addGraph(makeNode(graph), subQuery.getWhereHandler());
+		getPrologHandler().addAll(subQuery.getPrologHandler());
+		getWhereHandler().addGraph(makeNode(graph), subQuery.getWhereHandler());
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addBind(Expr expression, Object var) {
-		whereHandler.addBind( expression, makeVar(var) );
+		getWhereHandler().addBind( expression, makeVar(var) );
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addBind(String expression, Object var) throws ParseException {
-		whereHandler.addBind( expression, makeVar(var) );
+		getWhereHandler().addBind( expression, makeVar(var) );
 		return this;
 	}
 	
 	@Override
 	public ConstructBuilder addConstruct(Triple t) {
-		constructHandler.addConstruct(t);
+		getConstructHandler().addConstruct(t);
 		return this;
 	}
 
@@ -245,6 +240,6 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder>
 	
 	@Override
 	public Node list(Object... objs) {
-		return whereHandler.list(objs);
+		return getWhereHandler().list(objs);
 	}
 }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
@@ -25,6 +25,8 @@ import org.apache.jena.arq.querybuilder.clauses.SelectClause;
 import org.apache.jena.arq.querybuilder.clauses.SolutionModifierClause;
 import org.apache.jena.arq.querybuilder.clauses.WhereClause;
 import org.apache.jena.arq.querybuilder.handlers.DatasetHandler;
+import org.apache.jena.arq.querybuilder.handlers.HandlerBlock;
+import org.apache.jena.arq.querybuilder.handlers.PrologHandler;
 import org.apache.jena.arq.querybuilder.handlers.SelectHandler;
 import org.apache.jena.arq.querybuilder.handlers.SolutionModifierHandler;
 import org.apache.jena.arq.querybuilder.handlers.WhereHandler;
@@ -45,60 +47,54 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder>
 		SolutionModifierClause<SelectBuilder>, SelectClause<SelectBuilder> {
 
 	// the handlers.
-	private DatasetHandler datasetHandler;
-	private WhereHandler whereHandler;
-	private SolutionModifierHandler solutionModifier;
-	private SelectHandler selectHandler;
-
+	private final HandlerBlock handlerBlock;
 	/**
 	 * Constructor.
 	 */
 	public SelectBuilder() {
 		super();
 		query.setQuerySelectType();
-		datasetHandler = new DatasetHandler(query);
-		whereHandler = new WhereHandler(query);
-		solutionModifier = new SolutionModifierHandler(query);
-		selectHandler = new SelectHandler(query);
+		handlerBlock = new HandlerBlock( query );
 	}
 
 	@Override
 	public DatasetHandler getDatasetHandler() {
-		return datasetHandler;
+		return handlerBlock.getDatasetHandler();
 	}
 
 	@Override
+	public HandlerBlock getHandlerBlock()
+	{
+		return handlerBlock;
+	}
+	
+	@Override
 	public WhereHandler getWhereHandler() {
-		return whereHandler;
+		return handlerBlock.getWhereHandler();
 	}
 
 	@Override
 	public SelectBuilder clone() {
 		SelectBuilder qb = new SelectBuilder();
-		qb.prologHandler.addAll(prologHandler);
-		qb.datasetHandler.addAll(datasetHandler);
-		qb.whereHandler.addAll(whereHandler);
-		qb.solutionModifier.addAll(solutionModifier);
-		qb.selectHandler.addAll(selectHandler);
-
+		qb.handlerBlock.addAll(handlerBlock);
 		return qb;
 	}
 
 	@Override
 	public SelectBuilder setDistinct(boolean state) {
-		selectHandler.setDistinct(state);
+		getSelectHandler().setDistinct(state);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder setReduced(boolean state) {
-		selectHandler.setReduced(state);
+		getSelectHandler().setReduced(state);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addVar(Object var) {
-		selectHandler.addVar(makeVar(var));
+		getSelectHandler().addVar(makeVar(var));
 		return this;
 	}
 
@@ -109,77 +105,77 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder>
 	 */
 	@Override
 	public SelectBuilder addVar(String expression, Object var) throws ParseException {
-		selectHandler.addVar( expression, makeVar(var) );
+		getSelectHandler().addVar( expression, makeVar(var) );
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addVar(Expr expr, Object var) {
-		selectHandler.addVar(expr, makeVar(var));
+		getSelectHandler().addVar(expr, makeVar(var));
 		return this;
 	}
 	
 	@Override
 	public List<Var> getVars() {
-		return selectHandler.getVars();
+		return getSelectHandler().getVars();
 	}
 
 	@Override
 	public SelectBuilder fromNamed(String graphName) {
-		datasetHandler.fromNamed(graphName);
+		getDatasetHandler().fromNamed(graphName);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder fromNamed(Collection<String> graphNames) {
-		datasetHandler.fromNamed(graphNames);
+		getDatasetHandler().fromNamed(graphNames);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder from(String graphName) {
-		datasetHandler.from(graphName);
+		getDatasetHandler().from(graphName);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder from(Collection<String> graphName) {
-		datasetHandler.from(graphName);
+		getDatasetHandler().from(graphName);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addOrderBy(String orderBy) {
-		solutionModifier.addOrderBy(orderBy);
+		getSolutionModifierHandler().addOrderBy(orderBy);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addGroupBy(String groupBy) {
-		solutionModifier.addGroupBy(groupBy);
+		getSolutionModifierHandler().addGroupBy(groupBy);
 		return this;
 	}
 
 	@Override
 	public SolutionModifierHandler getSolutionModifierHandler() {
-		return solutionModifier;
+		return handlerBlock.getModifierHandler();
 	}
 
 	@Override
 	public SelectBuilder addHaving(String having) throws ParseException {
-		solutionModifier.addHaving(having);
+		getSolutionModifierHandler().addHaving(having);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder setLimit(int limit) {
-		solutionModifier.setLimit(limit);
+		getSolutionModifierHandler().setLimit(limit);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder setOffset(int offset) {
-		solutionModifier.setOffset(offset);
+		getSolutionModifierHandler().setOffset(offset);
 		return this;
 	}
 
@@ -231,13 +227,13 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder>
 
 	@Override
 	public SelectBuilder addWhere(Triple t) {
-		whereHandler.addWhere(t);
+		getWhereHandler().addWhere(t);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addWhere(FrontsTriple t) {
-		whereHandler.addWhere(t.asTriple());
+		getWhereHandler().addWhere(t.asTriple());
 		return this;
 	}
 
@@ -249,13 +245,13 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder>
 
 	@Override
 	public SelectBuilder addOptional(Triple t) {
-		whereHandler.addOptional(t);
+		getWhereHandler().addOptional(t);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addOptional(FrontsTriple t) {
-		whereHandler.addOptional(t.asTriple());
+		getWhereHandler().addOptional(t.asTriple());
 		return this;
 	}
 
@@ -268,55 +264,54 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder>
 	@Override
 	public SelectBuilder addOptional(SelectBuilder t)
 	{
-		whereHandler.addOptional(t.getWhereHandler());
+		getWhereHandler().addOptional(t.getWhereHandler());
 		return this;
 	}
 	
 	@Override
 	public SelectBuilder addFilter(String s) throws ParseException {
-		whereHandler.addFilter(s);
+		getWhereHandler().addFilter(s);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addSubQuery(SelectBuilder subQuery) {
-		prologHandler.addAll(subQuery.prologHandler);
-		whereHandler.addSubQuery(subQuery);
+		getWhereHandler().addSubQuery(subQuery);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addUnion(SelectBuilder subQuery) {
-		whereHandler.addUnion(subQuery);
+		getWhereHandler().addUnion(subQuery);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addGraph(Object graph, SelectBuilder subQuery) {
-		prologHandler.addAll(subQuery.prologHandler);
-		whereHandler.addGraph(makeNode(graph), subQuery.whereHandler);
+		getPrologHandler().addAll(subQuery.getPrologHandler());
+		getWhereHandler().addGraph(makeNode(graph), subQuery.getWhereHandler());
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addBind(Expr expression, Object var) {
-		whereHandler.addBind( expression, makeVar(var) );
+		getWhereHandler().addBind( expression, makeVar(var) );
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addBind(String expression, Object var) throws ParseException {
-		whereHandler.addBind( expression, makeVar(var) );
+		getWhereHandler().addBind( expression, makeVar(var) );
 		return this;
 	}
 
 	@Override
 	public SelectHandler getSelectHandler() {
-		return selectHandler;
+		return handlerBlock.getSelectHandler();
 	}
 
 	@Override
 	public Node list(Object... objs) {
-		return whereHandler.list(objs);
+		return getWhereHandler().list(objs);
 	}
 }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
@@ -26,7 +26,6 @@ import org.apache.jena.arq.querybuilder.clauses.SolutionModifierClause;
 import org.apache.jena.arq.querybuilder.clauses.WhereClause;
 import org.apache.jena.arq.querybuilder.handlers.DatasetHandler;
 import org.apache.jena.arq.querybuilder.handlers.HandlerBlock;
-import org.apache.jena.arq.querybuilder.handlers.PrologHandler;
 import org.apache.jena.arq.querybuilder.handlers.SelectHandler;
 import org.apache.jena.arq.querybuilder.handlers.SolutionModifierHandler;
 import org.apache.jena.arq.querybuilder.handlers.WhereHandler;
@@ -46,8 +45,8 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder>
 		implements DatasetClause<SelectBuilder>, WhereClause<SelectBuilder>,
 		SolutionModifierClause<SelectBuilder>, SelectClause<SelectBuilder> {
 
-	// the handlers.
 	private final HandlerBlock handlerBlock;
+	
 	/**
 	 * Constructor.
 	 */

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/SelectClause.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/SelectClause.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
 import org.apache.jena.arq.querybuilder.handlers.SelectHandler;
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.lang.sparql_11.ParseException;
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/AggregationHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/AggregationHandler.java
@@ -1,0 +1,78 @@
+package org.apache.jena.arq.querybuilder.handlers;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.query.Query;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.core.VarExprList;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprAggregator;
+import org.apache.jena.sparql.expr.aggregate.Aggregator;
+
+public class AggregationHandler implements Handler {
+	private final Query query;
+	private final Map<Var,ExprAggregator> aggMap;
+
+	public AggregationHandler( Query query )
+	{
+		this.query = query;
+		aggMap = new HashMap<Var,ExprAggregator>();
+	}
+	
+	public AggregationHandler addAll(AggregationHandler handler)
+	{
+		for (ExprAggregator agg : handler.query.getAggregators())
+		{
+			query.allocAggregate(agg.getAggregator());
+		}
+		for (Map.Entry<Var, ExprAggregator> entry : handler.aggMap.entrySet())
+		{
+			aggMap.put( entry.getKey(), entry.getValue());
+		}
+		return this;
+	}
+		
+	public Query getQuery()
+	{
+		return query;
+	}
+	
+	public Map<Var, ExprAggregator> getVarMap() {
+		Map<Var,ExprAggregator> retval = new HashMap<Var,ExprAggregator>();
+		for (ExprAggregator agg : query.getAggregators())
+		{
+			retval.put( agg.getVar(), agg);
+		}
+		return retval;
+	}
+	
+	@Override
+	public void setVars(Map<Var, Node> values) {
+		// nothing to do
+
+	}
+
+	@Override
+	public void build() {
+		for (Map.Entry<Var,Expr> entry : query.getProject().getExprs().entrySet())
+		{
+			if (aggMap.containsKey(entry.getKey()))
+			{
+				entry.setValue( aggMap.get(entry.getKey()));
+			}
+		}
+	}
+	
+	public void add(Expr expr, Var var) {
+		if (expr instanceof ExprAggregator)
+		{
+			ExprAggregator eAgg = (ExprAggregator)expr;
+			Expr expr2 = query.allocAggregate( eAgg.getAggregator() );	
+			aggMap.put(var, (ExprAggregator)expr2);
+		}
+	}
+
+}

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/AggregationHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/AggregationHandler.java
@@ -1,5 +1,21 @@
 package org.apache.jena.arq.querybuilder.handlers;
-
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/AggregationHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/AggregationHandler.java
@@ -17,27 +17,40 @@ package org.apache.jena.arq.querybuilder.handlers;
  * limitations under the License.
  */
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Query;
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprAggregator;
-import org.apache.jena.sparql.expr.aggregate.Aggregator;
 
+/**
+ * Class to handle manipulation the aggregation variables in the query.
+ *
+ */
 public class AggregationHandler implements Handler {
+	// the query
 	private final Query query;
+	
+	// a map of variables to aggregators
 	private final Map<Var,ExprAggregator> aggMap;
 
+	/**
+	 * Constructor.
+	 * @param query the query to handle.
+	 */
 	public AggregationHandler( Query query )
 	{
 		this.query = query;
 		aggMap = new HashMap<Var,ExprAggregator>();
 	}
 	
+	/**
+	 * Add all the aggregations from the other handler.
+	 * @param handler The other handler.
+	 * @return This handler for chaining.
+	 */
 	public AggregationHandler addAll(AggregationHandler handler)
 	{
 		for (ExprAggregator agg : handler.query.getAggregators())
@@ -51,18 +64,13 @@ public class AggregationHandler implements Handler {
 		return this;
 	}
 		
+	/**
+	 * Get the query we are executing against.
+	 * @return the query.
+	 */
 	public Query getQuery()
 	{
 		return query;
-	}
-	
-	public Map<Var, ExprAggregator> getVarMap() {
-		Map<Var,ExprAggregator> retval = new HashMap<Var,ExprAggregator>();
-		for (ExprAggregator agg : query.getAggregators())
-		{
-			retval.put( agg.getVar(), agg);
-		}
-		return retval;
 	}
 	
 	@Override
@@ -82,6 +90,14 @@ public class AggregationHandler implements Handler {
 		}
 	}
 	
+	/**
+	 * Add and expression aggregator and variable to the mapping.
+	 * 
+	 * if the expr parameter is not an instance of ExprAggregator then no action is taken.
+	 * 
+	 * @param expr The expression to add.
+	 * @param var The variable that it is bound to.
+	 */
 	public void add(Expr expr, Var var) {
 		if (expr instanceof ExprAggregator)
 		{

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/HandlerBlock.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/HandlerBlock.java
@@ -1,0 +1,158 @@
+package org.apache.jena.arq.querybuilder.handlers;
+
+import java.util.Map;
+import java.util.Stack;
+
+import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
+import org.apache.jena.arq.querybuilder.clauses.ConstructClause;
+import org.apache.jena.arq.querybuilder.clauses.DatasetClause;
+import org.apache.jena.arq.querybuilder.clauses.SelectClause;
+import org.apache.jena.arq.querybuilder.clauses.SolutionModifierClause;
+import org.apache.jena.arq.querybuilder.clauses.WhereClause;
+import org.apache.jena.graph.Node;
+import org.apache.jena.query.Query;
+import org.apache.jena.sparql.core.Var;
+
+public class HandlerBlock {
+	private final AggregationHandler aggHandler;
+	private final ConstructHandler constructHandler;
+	private final DatasetHandler datasetHandler;
+	private final PrologHandler prologHandler;
+	private final SelectHandler selectHandler;
+	private final SolutionModifierHandler modifierHandler;
+	private final WhereHandler whereHandler;
+
+	public HandlerBlock(Query query) {
+		prologHandler = new PrologHandler(query);
+		aggHandler = new AggregationHandler(query);
+		whereHandler = new WhereHandler(query);
+		datasetHandler = new DatasetHandler(query);
+		modifierHandler = new SolutionModifierHandler(query);
+		SelectHandler sTemp = null;
+		ConstructHandler cTemp = null;
+		if (query.isSelectType()) {
+			sTemp = new SelectHandler(aggHandler);
+
+		} else if (query.isAskType()) {
+			// nochange
+		} else if (query.isDescribeType()) {
+			// no change
+		} else if (query.isConstructType()) {
+			cTemp = new ConstructHandler(query);
+		}
+		selectHandler = sTemp;
+		constructHandler = cTemp;
+	}
+
+	public AggregationHandler getAggregationHandler() {
+		return aggHandler;
+	}
+
+	public ConstructHandler getConstructHandler() {
+		return constructHandler;
+	}
+
+	public DatasetHandler getDatasetHandler() {
+		return datasetHandler;
+	}
+
+	public PrologHandler getPrologHandler() {
+		return prologHandler;
+	}
+
+	public SelectHandler getSelectHandler() {
+		return selectHandler;
+	}
+
+	public SolutionModifierHandler getModifierHandler() {
+		return modifierHandler;
+	}
+
+	public WhereHandler getWhereHandler() {
+		return whereHandler;
+	}
+
+	public void addAll(PrologHandler handler) {
+		prologHandler.addAll(handler);
+	}
+
+	public void addAll(AggregationHandler handler) {
+		aggHandler.addAll(handler);
+	}
+
+	public void addAll(ConstructHandler handler) {
+		if (constructHandler != null) {
+			constructHandler.addAll(handler);
+		}
+	}
+
+	public void addAll(DatasetHandler handler) {
+		datasetHandler.addAll(handler);
+	}
+
+	public void addAll(SolutionModifierHandler handler) {
+		modifierHandler.addAll(handler);
+	}
+
+	public void addAll(SelectHandler handler) {
+		if (selectHandler != null) {
+			selectHandler.addAll(handler);
+		}
+	}
+
+	public void addAll(WhereHandler handler) {
+		whereHandler.addAll(handler);
+	}
+	
+	public void addAll(HandlerBlock handler)
+	{
+		addAll(handler.aggHandler);
+		if (handler.constructHandler != null)
+		{
+			addAll(handler.constructHandler);
+		}
+		if (handler.selectHandler != null)
+		{
+			addAll(handler.selectHandler);
+		}
+		addAll( handler.datasetHandler);
+		addAll( handler.modifierHandler);
+		addAll( handler.prologHandler);
+		addAll( handler.whereHandler);
+	}
+
+	public void setVars(Map<Var, Node> values) {
+		aggHandler.setVars(values);
+
+		if (constructHandler != null) {
+			constructHandler.setVars(values);
+		}
+
+		datasetHandler.setVars(values);
+
+		prologHandler.setVars(values);
+
+		if (selectHandler != null) {
+			selectHandler.setVars(values);
+		}
+
+		modifierHandler.setVars(values);
+		whereHandler.setVars(values);
+
+	}
+	
+	public void build() {
+		prologHandler.build();
+		
+		if (selectHandler != null) {
+			selectHandler.build();
+		}
+		if (constructHandler != null) {
+			constructHandler.build();
+		}
+		datasetHandler.build();
+		modifierHandler.build();
+		whereHandler.build();
+		aggHandler.build();
+	}
+}

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/HandlerBlock.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/HandlerBlock.java
@@ -17,18 +17,14 @@ package org.apache.jena.arq.querybuilder.handlers;
  * limitations under the License.
  */
 import java.util.Map;
-import java.util.Stack;
-
-import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
-import org.apache.jena.arq.querybuilder.clauses.ConstructClause;
-import org.apache.jena.arq.querybuilder.clauses.DatasetClause;
-import org.apache.jena.arq.querybuilder.clauses.SelectClause;
-import org.apache.jena.arq.querybuilder.clauses.SolutionModifierClause;
-import org.apache.jena.arq.querybuilder.clauses.WhereClause;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Query;
 import org.apache.jena.sparql.core.Var;
 
+/**
+ * A class to handle all the handlers of a query builder and keep them in sync as needed.
+ *
+ */
 public class HandlerBlock {
 	private final AggregationHandler aggHandler;
 	private final ConstructHandler constructHandler;
@@ -38,17 +34,21 @@ public class HandlerBlock {
 	private final SolutionModifierHandler modifierHandler;
 	private final WhereHandler whereHandler;
 
+	/**
+	 * Constructor.
+	 * @param query The query we are working with.
+	 */
 	public HandlerBlock(Query query) {
 		prologHandler = new PrologHandler(query);
 		aggHandler = new AggregationHandler(query);
 		whereHandler = new WhereHandler(query);
 		datasetHandler = new DatasetHandler(query);
 		modifierHandler = new SolutionModifierHandler(query);
+		/* selecthandler and constructhandler may be null so processthem accordingly */
 		SelectHandler sTemp = null;
 		ConstructHandler cTemp = null;
 		if (query.isSelectType()) {
 			sTemp = new SelectHandler(aggHandler);
-
 		} else if (query.isAskType()) {
 			// nochange
 		} else if (query.isDescribeType()) {
@@ -60,92 +60,152 @@ public class HandlerBlock {
 		constructHandler = cTemp;
 	}
 
+	/**
+	 * Get the aggregation handler.
+	 * @return the aggregation handler.
+	 */
 	public AggregationHandler getAggregationHandler() {
 		return aggHandler;
 	}
 
+	/**
+	 * Get the construct handler.
+	 * @return the construct handler or null.
+	 */
 	public ConstructHandler getConstructHandler() {
 		return constructHandler;
 	}
 
+	/**
+	 * Get the dataset handler.
+	 * @return the dataset handler.
+	 */
 	public DatasetHandler getDatasetHandler() {
 		return datasetHandler;
 	}
 
+	/**
+	 * Get the prolog handler.
+	 * @return the prolog handler.
+	 */
 	public PrologHandler getPrologHandler() {
 		return prologHandler;
 	}
 
+	/**
+	 * Get the select handler.
+	 * @return the select handler or null.
+	 */
 	public SelectHandler getSelectHandler() {
 		return selectHandler;
 	}
 
+	/**
+	 * Get the solution modifier handler.
+	 * @return the solution modifier handler.
+	 */
 	public SolutionModifierHandler getModifierHandler() {
 		return modifierHandler;
 	}
 
+	/**
+	 * Get the where handler.
+	 * @return the where handler.
+	 */
 	public WhereHandler getWhereHandler() {
 		return whereHandler;
 	}
 
+	/**
+	 * Add the prolog handler contents to this prolog handler.
+	 * @param handler The prolog handler to add to this one.
+	 */
 	public void addAll(PrologHandler handler) {
 		prologHandler.addAll(handler);
 	}
 
+	/**
+	 * Add the aggregation handler contents to this prolog handler.
+	 * @param handler The aggregation handler to add to this one.
+	 */
 	public void addAll(AggregationHandler handler) {
 		aggHandler.addAll(handler);
 	}
 
+	/**
+	 * Add the construct handler contents to this prolog handler.
+	 * If this construct handler is null or the handler argument is null this method does nothing.
+	 * @param handler The construct handler to add to this one.
+	 */
 	public void addAll(ConstructHandler handler) {
-		if (constructHandler != null) {
+		if (constructHandler != null && handler!=null) {
 			constructHandler.addAll(handler);
 		}
 	}
 
+	/**
+	 * Add the dataset handler contents to this prolog handler.
+	 * @param handler The dataset handler to add to this one.
+	 */
 	public void addAll(DatasetHandler handler) {
 		datasetHandler.addAll(handler);
 	}
 
+	/**
+	 * Add the solution modifier handler contents to this prolog handler.
+	 * @param handler The solution modifier handler to add to this one.
+	 */
 	public void addAll(SolutionModifierHandler handler) {
 		modifierHandler.addAll(handler);
 	}
 
+	/**
+	 * Add the select handler contents to this prolog handler.
+	 * If this select handler is null or the handler argument is null this method does nothing.
+	 * @param handler The construct handler to add to this one.
+	 */
 	public void addAll(SelectHandler handler) {
-		if (selectHandler != null) {
+		if (selectHandler != null && handler!=null) {
 			selectHandler.addAll(handler);
 		}
 	}
 
+	/**
+	 * Add the where handler contents to this prolog handler.
+	 * @param handler The where handler to add to this one.
+	 */
 	public void addAll(WhereHandler handler) {
 		whereHandler.addAll(handler);
 	}
 	
+	/**
+	 * Add all of the handlers in the handler block to this one.
+	 * Any handler that is null or is null in the handler argument are properly skipped. 
+	 * @param handler The handler block to add to this one.
+	 */
 	public void addAll(HandlerBlock handler)
 	{
 		addAll(handler.aggHandler);
-		if (handler.constructHandler != null)
-		{
-			addAll(handler.constructHandler);
-		}
-		if (handler.selectHandler != null)
-		{
-			addAll(handler.selectHandler);
-		}
+		addAll(handler.constructHandler);
+		addAll(handler.selectHandler);
 		addAll( handler.datasetHandler);
 		addAll( handler.modifierHandler);
 		addAll( handler.prologHandler);
 		addAll( handler.whereHandler);
 	}
 
+	/**
+	 * Set the variables in all the enclosed handlers in the proper order.
+	 * @param values The map of values to set.
+	 */
 	public void setVars(Map<Var, Node> values) {
 		aggHandler.setVars(values);
 
 		if (constructHandler != null) {
 			constructHandler.setVars(values);
 		}
-
+		
 		datasetHandler.setVars(values);
-
 		prologHandler.setVars(values);
 
 		if (selectHandler != null) {
@@ -154,9 +214,11 @@ public class HandlerBlock {
 
 		modifierHandler.setVars(values);
 		whereHandler.setVars(values);
-
 	}
 	
+	/**
+	 * Build all the the enclosed handlers in the proper order.
+	 */
 	public void build() {
 		prologHandler.build();
 		

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/HandlerBlock.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/HandlerBlock.java
@@ -1,5 +1,21 @@
 package org.apache.jena.arq.querybuilder.handlers;
-
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import java.util.Map;
 import java.util.Stack;
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/HandlerBlock.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/HandlerBlock.java
@@ -1,4 +1,5 @@
 package org.apache.jena.arq.querybuilder.handlers;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
@@ -22,7 +23,8 @@ import org.apache.jena.query.Query;
 import org.apache.jena.sparql.core.Var;
 
 /**
- * A class to handle all the handlers of a query builder and keep them in sync as needed.
+ * A class to handle all the handlers of a query builder and keep them in sync
+ * as needed.
  *
  */
 public class HandlerBlock {
@@ -36,7 +38,9 @@ public class HandlerBlock {
 
 	/**
 	 * Constructor.
-	 * @param query The query we are working with.
+	 * 
+	 * @param query
+	 *            The query we are working with.
 	 */
 	public HandlerBlock(Query query) {
 		prologHandler = new PrologHandler(query);
@@ -44,7 +48,10 @@ public class HandlerBlock {
 		whereHandler = new WhereHandler(query);
 		datasetHandler = new DatasetHandler(query);
 		modifierHandler = new SolutionModifierHandler(query);
-		/* selecthandler and constructhandler may be null so processthem accordingly */
+		/*
+		 * selecthandler and constructhandler may be null so processthem
+		 * accordingly
+		 */
 		SelectHandler sTemp = null;
 		ConstructHandler cTemp = null;
 		if (query.isSelectType()) {
@@ -62,6 +69,7 @@ public class HandlerBlock {
 
 	/**
 	 * Get the aggregation handler.
+	 * 
 	 * @return the aggregation handler.
 	 */
 	public AggregationHandler getAggregationHandler() {
@@ -70,6 +78,7 @@ public class HandlerBlock {
 
 	/**
 	 * Get the construct handler.
+	 * 
 	 * @return the construct handler or null.
 	 */
 	public ConstructHandler getConstructHandler() {
@@ -78,6 +87,7 @@ public class HandlerBlock {
 
 	/**
 	 * Get the dataset handler.
+	 * 
 	 * @return the dataset handler.
 	 */
 	public DatasetHandler getDatasetHandler() {
@@ -86,6 +96,7 @@ public class HandlerBlock {
 
 	/**
 	 * Get the prolog handler.
+	 * 
 	 * @return the prolog handler.
 	 */
 	public PrologHandler getPrologHandler() {
@@ -94,6 +105,7 @@ public class HandlerBlock {
 
 	/**
 	 * Get the select handler.
+	 * 
 	 * @return the select handler or null.
 	 */
 	public SelectHandler getSelectHandler() {
@@ -102,6 +114,7 @@ public class HandlerBlock {
 
 	/**
 	 * Get the solution modifier handler.
+	 * 
 	 * @return the solution modifier handler.
 	 */
 	public SolutionModifierHandler getModifierHandler() {
@@ -110,6 +123,7 @@ public class HandlerBlock {
 
 	/**
 	 * Get the where handler.
+	 * 
 	 * @return the where handler.
 	 */
 	public WhereHandler getWhereHandler() {
@@ -118,7 +132,9 @@ public class HandlerBlock {
 
 	/**
 	 * Add the prolog handler contents to this prolog handler.
-	 * @param handler The prolog handler to add to this one.
+	 * 
+	 * @param handler
+	 *            The prolog handler to add to this one.
 	 */
 	public void addAll(PrologHandler handler) {
 		prologHandler.addAll(handler);
@@ -126,26 +142,33 @@ public class HandlerBlock {
 
 	/**
 	 * Add the aggregation handler contents to this prolog handler.
-	 * @param handler The aggregation handler to add to this one.
+	 * 
+	 * @param handler
+	 *            The aggregation handler to add to this one.
 	 */
 	public void addAll(AggregationHandler handler) {
 		aggHandler.addAll(handler);
 	}
 
 	/**
-	 * Add the construct handler contents to this prolog handler.
-	 * If this construct handler is null or the handler argument is null this method does nothing.
-	 * @param handler The construct handler to add to this one.
+	 * Add the construct handler contents to this prolog handler. If this
+	 * construct handler is null or the handler argument is null this method
+	 * does nothing.
+	 * 
+	 * @param handler
+	 *            The construct handler to add to this one.
 	 */
 	public void addAll(ConstructHandler handler) {
-		if (constructHandler != null && handler!=null) {
+		if (constructHandler != null && handler != null) {
 			constructHandler.addAll(handler);
 		}
 	}
 
 	/**
 	 * Add the dataset handler contents to this prolog handler.
-	 * @param handler The dataset handler to add to this one.
+	 * 
+	 * @param handler
+	 *            The dataset handler to add to this one.
 	 */
 	public void addAll(DatasetHandler handler) {
 		datasetHandler.addAll(handler);
@@ -153,50 +176,59 @@ public class HandlerBlock {
 
 	/**
 	 * Add the solution modifier handler contents to this prolog handler.
-	 * @param handler The solution modifier handler to add to this one.
+	 * 
+	 * @param handler
+	 *            The solution modifier handler to add to this one.
 	 */
 	public void addAll(SolutionModifierHandler handler) {
 		modifierHandler.addAll(handler);
 	}
 
 	/**
-	 * Add the select handler contents to this prolog handler.
-	 * If this select handler is null or the handler argument is null this method does nothing.
-	 * @param handler The construct handler to add to this one.
+	 * Add the select handler contents to this prolog handler. If this select
+	 * handler is null or the handler argument is null this method does nothing.
+	 * 
+	 * @param handler
+	 *            The construct handler to add to this one.
 	 */
 	public void addAll(SelectHandler handler) {
-		if (selectHandler != null && handler!=null) {
+		if (selectHandler != null && handler != null) {
 			selectHandler.addAll(handler);
 		}
 	}
 
 	/**
 	 * Add the where handler contents to this prolog handler.
-	 * @param handler The where handler to add to this one.
+	 * 
+	 * @param handler
+	 *            The where handler to add to this one.
 	 */
 	public void addAll(WhereHandler handler) {
 		whereHandler.addAll(handler);
 	}
-	
+
 	/**
-	 * Add all of the handlers in the handler block to this one.
-	 * Any handler that is null or is null in the handler argument are properly skipped. 
-	 * @param handler The handler block to add to this one.
+	 * Add all of the handlers in the handler block to this one. Any handler
+	 * that is null or is null in the handler argument are properly skipped.
+	 * 
+	 * @param handler
+	 *            The handler block to add to this one.
 	 */
-	public void addAll(HandlerBlock handler)
-	{
+	public void addAll(HandlerBlock handler) {
 		addAll(handler.aggHandler);
 		addAll(handler.constructHandler);
 		addAll(handler.selectHandler);
-		addAll( handler.datasetHandler);
-		addAll( handler.modifierHandler);
-		addAll( handler.prologHandler);
-		addAll( handler.whereHandler);
+		addAll(handler.datasetHandler);
+		addAll(handler.modifierHandler);
+		addAll(handler.prologHandler);
+		addAll(handler.whereHandler);
 	}
 
 	/**
 	 * Set the variables in all the enclosed handlers in the proper order.
-	 * @param values The map of values to set.
+	 * 
+	 * @param values
+	 *            The map of values to set.
 	 */
 	public void setVars(Map<Var, Node> values) {
 		aggHandler.setVars(values);
@@ -204,7 +236,7 @@ public class HandlerBlock {
 		if (constructHandler != null) {
 			constructHandler.setVars(values);
 		}
-		
+
 		datasetHandler.setVars(values);
 		prologHandler.setVars(values);
 
@@ -215,13 +247,13 @@ public class HandlerBlock {
 		modifierHandler.setVars(values);
 		whereHandler.setVars(values);
 	}
-	
+
 	/**
 	 * Build all the the enclosed handlers in the proper order.
 	 */
 	public void build() {
 		prologHandler.build();
-		
+
 		if (selectHandler != null) {
 			selectHandler.build();
 		}

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/PrologHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/PrologHandler.java
@@ -24,6 +24,7 @@ import org.apache.jena.graph.Node ;
 import org.apache.jena.query.Query ;
 import org.apache.jena.riot.system.IRIResolver;
 import org.apache.jena.shared.PrefixMapping ;
+import org.apache.jena.shared.impl.PrefixMappingImpl;
 import org.apache.jena.sparql.core.Var ;
 
 /**
@@ -82,6 +83,13 @@ public class PrologHandler implements Handler {
 	public void addPrefix(String pfx, String uri) {
 		query.setPrefix(canonicalPfx(pfx), uri);
 	}
+	
+	/**
+	 * Clear the prefix mapping.
+	 */
+	public void clearPrefixes() {
+		query.setPrefixMapping( new PrefixMappingImpl() );
+	}
 
 	/**
 	 * Add the map of prefixes to the query prefixes.
@@ -91,6 +99,10 @@ public class PrologHandler implements Handler {
 		for (Map.Entry<String, String> e : prefixes.entrySet()) {
 			addPrefix(e.getKey(), e.getValue());
 		}
+	}
+	
+	public PrefixMapping getPrefixes() {
+		return query.getPrefixMapping();
 	}
 
 	/**

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/SelectHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/SelectHandler.java
@@ -20,15 +20,12 @@ package org.apache.jena.arq.querybuilder.handlers;
 import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
-
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryParseException;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.Expr;
-import org.apache.jena.sparql.expr.ExprAggregator;
 import org.apache.jena.sparql.lang.arq.ARQParser;
 import org.apache.jena.sparql.lang.arq.ParseException;
 import org.apache.jena.sparql.lang.arq.TokenMgrError;
@@ -46,8 +43,7 @@ public class SelectHandler implements Handler {
 	/**
 	 * Constructor.
 	 * 
-	 * @param query
-	 *            The query to manage.
+	 * @param aggHandler The aggregate handler that wraps the query we want to handle.
 	 */
 	public SelectHandler(AggregationHandler aggHandler) {
 		this.query = aggHandler.getQuery();
@@ -149,7 +145,7 @@ public class SelectHandler implements Handler {
 	 * Add an Expression as variable to the select.
 	 * 
 	 * @param expr
-	 *            The expresson to add.
+	 *            The expression to add.
 	 * @param var
 	 *            The variable to add.
 	 */
@@ -177,7 +173,7 @@ public class SelectHandler implements Handler {
 	/**
 	 * Return the projected var expression list.
 	 * 
-	 * @return The proejct var expression list.
+	 * @return The projected var expression list.
 	 */
 	public VarExprList getProject() {
 		return query.getProject();
@@ -190,7 +186,6 @@ public class SelectHandler implements Handler {
 	 *            The select handler to copy the variables from.
 	 */
 	public void addAll(SelectHandler selectHandler) {
-
 		setReduced(selectHandler.query.isReduced());
 		setDistinct(selectHandler.query.isDistinct());
 		query.setQueryResultStar(selectHandler.query.isQueryResultStar());
@@ -216,14 +211,8 @@ public class SelectHandler implements Handler {
 			query.setQueryResultStar(true);
 		}
 		
-		VarExprList vel = query.getProject();
-		Map<Var, Expr> exprMap = vel.getExprs();
-
-		for (Map.Entry<Var, ExprAggregator> entry : aggHandler.getVarMap().entrySet()) {
-			if (exprMap.containsKey(entry.getKey())) {
-				exprMap.put(entry.getKey(), entry.getValue());
-			}
-		}
+		aggHandler.build();
+		
 		// handle the SELECT * case
 		query.getProjectVars();
 	}

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/WhereHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/WhereHandler.java
@@ -20,24 +20,14 @@ package org.apache.jena.arq.querybuilder.handlers;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
-
 import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
 import org.apache.jena.arq.querybuilder.SelectBuilder;
-import org.apache.jena.arq.querybuilder.clauses.ConstructClause;
-import org.apache.jena.arq.querybuilder.clauses.DatasetClause;
-import org.apache.jena.arq.querybuilder.clauses.SelectClause;
-import org.apache.jena.arq.querybuilder.clauses.SolutionModifierClause;
-import org.apache.jena.arq.querybuilder.clauses.WhereClause;
 import org.apache.jena.arq.querybuilder.rewriters.ElementRewriter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Query;
-import org.apache.jena.shared.PrefixMapping;
-import org.apache.jena.shared.impl.PrefixMappingImpl;
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.lang.sparql_11.ParseException;
 import org.apache.jena.sparql.syntax.*;
@@ -227,6 +217,10 @@ public class WhereHandler implements Handler {
 		getClause().addElement(opt);
 	}
 
+	/**
+	 * Add the contents of a where handler as an optional statement.
+	 * @param whereHandler The where handler to use as the optional statement.
+	 */
 	public void addOptional(WhereHandler whereHandler) {
 		getClause().addElement(new ElementOptional(whereHandler.getClause()));
 	}

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/rewriters/ElementRewriter.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/rewriters/ElementRewriter.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
+import org.apache.jena.query.Query;
 import org.apache.jena.sparql.core.TriplePath ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.engine.binding.Binding ;
@@ -190,8 +191,9 @@ public class ElementRewriter extends AbstractRewriter<Element> implements
 
 	@Override
 	public void visit(ElementSubQuery el) {
+		Query q = AbstractQueryBuilder.clone(el.getQuery());
 		push(new ElementSubQuery(AbstractQueryBuilder.rewrite(
-				AbstractQueryBuilder.clone(el.getQuery()), values)));
+				q, values)));
 	}
 
 }

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilderTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilderTest.java
@@ -19,11 +19,15 @@
 package org.apache.jena.arq.querybuilder;
 
 import static org.junit.Assert.*;
+
+import org.apache.jena.arq.querybuilder.handlers.HandlerBlock;
+import org.apache.jena.arq.querybuilder.handlers.PrologHandler;
 import org.apache.jena.graph.FrontsNode ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.graph.impl.LiteralLabel ;
 import org.apache.jena.graph.impl.LiteralLabelFactory ;
+import org.apache.jena.query.Query;
 import org.apache.jena.reasoner.rulesys.Node_RuleVariable ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.expr.ExprVar ;
@@ -41,9 +45,22 @@ public class AbstractQueryBuilderTest {
 	}
 
 	private class TestBuilder extends AbstractQueryBuilder<TestBuilder> {
+		private HandlerBlock handlerBlock;
+		
+		public TestBuilder()
+		{
+			super();
+			handlerBlock = new HandlerBlock( query );
+			
+		}
 		@Override
 		public String toString() {
 			return "TestBuilder";
+		}
+
+		@Override
+		public HandlerBlock getHandlerBlock() {
+			return handlerBlock;
 		}
 	}
 

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/clauses/WhereClauseTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/clauses/WhereClauseTest.java
@@ -144,7 +144,7 @@ public class WhereClauseTest<T extends WhereClause<?>> extends
 	}
 
 	@ContractTest
-	public void addSubQuery() {
+	public void testAddSubQuery() {
 		SelectBuilder sb = new SelectBuilder();
 		sb.addPrefix("pfx", "urn:uri").addVar("?x")
 				.addWhere("pfx:one", "pfx:two", "pfx:three");

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/handlers/SelectHandlerTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/handlers/SelectHandlerTest.java
@@ -38,7 +38,8 @@ public class SelectHandlerTest extends AbstractHandlerTest {
 	@Before
 	public void setup() {
 		query = new Query();
-		handler = new SelectHandler(query);
+		AggregationHandler aggHandler = new AggregationHandler(query);
+		handler = new SelectHandler(aggHandler);
 	}
 
 	@Test
@@ -166,7 +167,8 @@ public class SelectHandlerTest extends AbstractHandlerTest {
 
 	@Test
 	public void testAddAllResultStartReduced() {
-		SelectHandler sh = new SelectHandler(new Query());
+		AggregationHandler aggHandler = new AggregationHandler(new Query());
+		SelectHandler sh = new SelectHandler(aggHandler);
 		sh.addVar(null);
 		sh.setReduced(true);
 
@@ -177,7 +179,8 @@ public class SelectHandlerTest extends AbstractHandlerTest {
 
 	@Test
 	public void testAddAllVarsDistinct() {
-		SelectHandler sh = new SelectHandler(new Query());
+		AggregationHandler aggHandler = new AggregationHandler(new Query());
+		SelectHandler sh = new SelectHandler(aggHandler);
 		sh.addVar(Var.alloc("foo"));
 		sh.setDistinct(true);
 


### PR DESCRIPTION
FactoryRDF is an interface to abstract the creation of nodes, triples and quads from constituent elements, e.g. to create a URI Node, the operation takes a string for the URI. This allows different policies to be slotted in.  This PR covers the use of FactoryRDF by ParserProfile. A PR to follow will use a caching implementation of FactoryRDF as the default mechanism when parsing.