### PR TITLE
JENA-1147 : Introduce FactoryRDF 

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangEngine.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangEngine.java
@@ -20,9 +20,9 @@ package org.apache.jena.riot.lang;
 
 import static org.apache.jena.riot.tokens.TokenType.EOF ;
 import static org.apache.jena.riot.tokens.TokenType.NODE ;
+
 import org.apache.jena.atlas.AtlasException ;
 import org.apache.jena.atlas.iterator.PeekIterator ;
-import org.apache.jena.graph.Node ;
 import org.apache.jena.riot.RiotParseException ;
 import org.apache.jena.riot.system.ErrorHandler ;
 import org.apache.jena.riot.system.ParserProfile ;
@@ -117,11 +117,11 @@ public class LangEngine
         }
     }
 
-    protected final Node scopedBNode(Node scopeNode, String label)
-    {
-        return profile.getLabelToNode().get(scopeNode, label) ;
-    }
-    
+//    protected final Node scopedBNode(Node scopeNode, String label)
+//    {
+//        return profile.getLabelToNode().get(scopeNode, label) ;
+//    }
+//    
     protected final void expectOrEOF(String msg, TokenType tokenType)
     {
         // DOT or EOF

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDF.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.datatypes.RDFDatatype ;
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.Quad ;
+
+/**
+ * Create core RDF objects: {@link Node}s, {@link Triple}s, {@link Quad}s,
+ * {@link Graph}, {@link DatasetGraph}s.
+ * <p>
+ */
+public interface FactoryRDF {
+    // ?? Are these too varied?
+    public Graph createGraph() ;
+    // ?? Are these too varied?
+    public DatasetGraph createDatasetGraph() ;
+    public Triple createTriple(Node subject, Node predicate, Node object) ;
+    public Quad createQuad(Node graph, Node subject, Node predicate, Node object) ;
+    public Node createURI(String uriStr) ;
+    public Node createTypedLiteral(String lexical, RDFDatatype datatype) ;
+    public Node createLangLiteral(String lexical, String langTag) ;
+    public Node createStringLiteral(String lexical) ;
+    /** Create a blank node */
+    public Node createBlankNode() ;
+    /** Create a blank node with the given string as internal system id */ 
+    public Node createBlankNode(String label) ;
+    /** Create a blank with the internal system id taken from 128 bit number provided.
+     */
+    public Node createBlankNode(long mostSigBits, long leastSigBits) ;
+
+//    // Object for scope better?
+//    public Node createBlankNode(Node scope, String label) ;
+//    // Object for scope better?
+//    public Node createBlankNode(Node scope) ;
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFCaching.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFCaching.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import java.util.concurrent.ExecutionException ;
+
+import org.apache.jena.ext.com.google.common.cache.Cache ;
+import org.apache.jena.atlas.lib.cache.CacheInfo ;
+import org.apache.jena.datatypes.RDFDatatype ;
+import org.apache.jena.datatypes.xsd.XSDDatatype ;
+import org.apache.jena.ext.com.google.common.cache.CacheBuilder ;
+import org.apache.jena.ext.com.google.common.cache.CacheStats ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.riot.RiotException ;
+import org.apache.jena.riot.lang.LabelToNode ;
+import org.apache.jena.sparql.graph.NodeConst ;
+
+/** Adds some caching of created nodes - the caching is tuned to RIOT parser usage */ 
+public class FactoryRDFCaching extends FactoryRDFStd {
+    public static final int DftNodeCacheSize = 5000 ; 
+
+    // Control the setup - for one thread; start size = 50% of full size, no stats
+    private final Cache<String, Node> cache ;
+
+    public FactoryRDFCaching() {
+        this(DftNodeCacheSize) ;
+    }
+    
+    public FactoryRDFCaching(int cacheSize) {
+        super() ;
+        cache = setCache(cacheSize) ;
+    }
+
+    private Cache<String, Node> setCache(int cacheSize) {
+        return CacheBuilder.newBuilder()
+            .maximumSize(cacheSize)
+            .initialCapacity(cacheSize/2)
+            //.recordStats()
+            .concurrencyLevel(1)
+            .build() ;
+    }
+
+    public FactoryRDFCaching(int cacheSize, LabelToNode labelMapping) {
+        super(labelMapping) ;
+        cache = setCache(cacheSize) ;
+    }
+
+    @Override
+    public Node createURI(String uriStr) {
+        try {
+            return cache.get(uriStr, ()->RiotLib.createIRIorBNode(uriStr)) ;
+        }
+        catch (ExecutionException e) {
+            throw new RiotException("Execution exception filling cache <"+uriStr+">", e) ;
+        }
+    }
+
+    // A few constants
+    
+    @Override
+    public Node createTypedLiteral(String lexical, RDFDatatype datatype) {
+        if ( XSDDatatype.XSDinteger.equals(datatype) ) {
+            switch(lexical) {
+                case "0" : return NodeConst.nodeZero ; 
+                case "1" : return NodeConst.nodeOne ;
+                case "2" : return NodeConst.nodeTwo ;
+                case "-1" : return NodeConst.nodeMinusOne ;
+            }
+            // fallthrough.
+        } else if ( XSDDatatype.XSDboolean.equals(datatype) ) {
+            switch(lexical) {
+                case "true" : return NodeConst.nodeTrue ; 
+                case "false" : return NodeConst.nodeFalse ;
+            }
+            // fallthrough.
+        }
+        return super.createTypedLiteral(lexical, datatype) ;
+    }
+
+    @Override
+    public Node createStringLiteral(String lexical) {
+        if ( lexical.isEmpty() )
+            return NodeConst.emptyString ;
+        return super.createStringLiteral(lexical) ;
+    }
+
+    public CacheInfo stats() {
+        CacheStats stats = cache.stats() ;
+        if ( stats.missCount() == 0 && stats.hitCount() == 0 )
+            // Stats not enabled - all counts zero.
+            return null ;
+        return new CacheInfo(DftNodeCacheSize, stats) ;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFStd.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFStd.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.datatypes.RDFDatatype ;
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.NodeFactory ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.riot.lang.LabelToNode ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.DatasetGraphFactory ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.sparql.graph.GraphFactory ;
+
+public class FactoryRDFStd implements FactoryRDF {
+    // Needs reset?
+    private final LabelToNode labelMapping ;
+    
+    public FactoryRDFStd() {
+        this(SyntaxLabels.createLabelToNode()) ;
+    }
+    
+    public FactoryRDFStd(LabelToNode labelMapping) {
+        this.labelMapping = labelMapping ; 
+    }
+    
+    @Override
+    public Graph createGraph() {
+        return GraphFactory.createDefaultGraph() ;
+    }
+
+    @Override
+    public DatasetGraph createDatasetGraph() {
+        return DatasetGraphFactory.create(); // createTxnMem() ;
+    }
+
+    @Override
+    public Triple createTriple(Node subject, Node predicate, Node object) {
+        return Triple.create(subject, predicate, object);
+    }
+
+    @Override
+    public Quad createQuad(Node graph, Node subject, Node predicate, Node object) {
+        return Quad.create(graph, subject, predicate, object) ;
+    }
+
+    @Override
+    public Node createURI(String uriStr) {
+        return RiotLib.createIRIorBNode(uriStr) ;
+        //return NodeFactory.createURI(uriStr) ;
+    }
+
+    @Override
+    public Node createTypedLiteral(String lexical, RDFDatatype datatype) {
+        return NodeFactory.createLiteral(lexical, datatype) ;
+    }
+
+    @Override
+    public Node createLangLiteral(String lexical, String langTag) {
+        return NodeFactory.createLiteral(lexical, langTag) ;
+    }
+
+    @Override
+    public Node createStringLiteral(String lexical) {
+        return NodeFactory.createLiteral(lexical) ;
+    }
+
+    @Override
+    public Node createBlankNode(long mostSigBits, long leastSigBits) {
+        // XXX Style: Do this fast.  Guava? Apache commons? Special case for char[32]
+        // (Eventually, blank node Nodes will have two longs normally.)  
+        return createBlankNode(String.format("%08X%08X", mostSigBits, leastSigBits)) ;
+    }
+
+    // Fixed scope.
+    private static Node scope = NodeFactory.createURI("urn:jena:global_scope") ;
+    // Scope
+    @Override
+    public Node createBlankNode(String label) {
+        //return NodeFactory.createBlankNode(label) ;
+        return labelMapping.get(scope, label) ;
+    }
+
+    // Scope
+    @Override
+    public Node createBlankNode() {
+        //return NodeFactory.createBlankNode() ;
+        return labelMapping.create() ;
+    }
+    
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
@@ -18,12 +18,10 @@
 
 package org.apache.jena.riot.system;
 
-
 import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.iri.IRI ;
-import org.apache.jena.riot.lang.LabelToNode ;
 import org.apache.jena.riot.tokens.Token ;
 import org.apache.jena.sparql.core.Quad ;
 
@@ -55,20 +53,22 @@ public interface ParserProfile
     /** Create a fresh blank node */ 
     public Node createBlankNode(Node scope, long line, long col) ;
     
-    /** Make a node from a token - called after all else has been tried - return null for no such node */
+    /** Make a node from a token - called after all else has been tried to handle special cases 
+     *  Return null for "no special node recoginzed"
+     */
     public Node createNodeFromToken(Node scope, Token token, long line, long col) ;
     
     /** Make any node from a token as appropriate */
     public Node create(Node currentGraph, Token token) ;
-    
-    public LabelToNode getLabelToNode() ;
-    public void setLabelToNode(LabelToNode labelToNode) ;
-    
+
     public ErrorHandler getHandler() ;
     public void setHandler(ErrorHandler handler) ;
     
     public Prologue getPrologue() ;
     public void setPrologue(Prologue prologue) ;
+    
+    public FactoryRDF getFactoryRDF() ;
+    public void setFactoryRDF(FactoryRDF factory) ;
     
     public boolean isStrictMode() ;
     public void setStrictMode(boolean mode) ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileBase.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.riot.system ;
 
+import java.util.Objects ;
+
 import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
@@ -26,7 +28,6 @@ import org.apache.jena.graph.Triple ;
 import org.apache.jena.iri.IRI ;
 import org.apache.jena.riot.RiotException ;
 import org.apache.jena.riot.SysRIOT ;
-import org.apache.jena.riot.lang.LabelToNode ;
 import org.apache.jena.riot.tokens.Token ;
 import org.apache.jena.riot.tokens.TokenType ;
 import org.apache.jena.sparql.core.Quad ;
@@ -38,17 +39,20 @@ import org.apache.jena.sparql.core.Quad ;
 public class ParserProfileBase implements ParserProfile {
     protected ErrorHandler errorHandler ;
     protected Prologue     prologue ;
-    protected LabelToNode  labelMapping ;
     protected boolean      strictMode = SysRIOT.isStrictMode() ;
+    protected FactoryRDF   factory ;
 
     public ParserProfileBase(Prologue prologue, ErrorHandler errorHandler) {
-        this(prologue, errorHandler, SyntaxLabels.createLabelToNode()) ;
+        this(prologue, errorHandler, RiotLib.factoryRDF()) ;
     }
 
-    public ParserProfileBase(Prologue prologue, ErrorHandler errorHandler, LabelToNode labelMapping) {
+    public ParserProfileBase(Prologue prologue, ErrorHandler errorHandler, FactoryRDF factory) {
+        Objects.requireNonNull(prologue) ;
+        Objects.requireNonNull(errorHandler) ;
+        Objects.requireNonNull(factory) ;
         this.prologue = prologue ;
         this.errorHandler = errorHandler ;
-        this.labelMapping = labelMapping ;
+        this.factory = factory ;
     }
 
     @Override
@@ -72,15 +76,15 @@ public class ParserProfileBase implements ParserProfile {
     }
 
     @Override
-    public LabelToNode getLabelToNode() {
-        return labelMapping ;
+    public FactoryRDF getFactoryRDF() {
+        return factory;
     }
 
     @Override
-    public void setLabelToNode(LabelToNode mapper) {
-        labelMapping = mapper ;
+    public void setFactoryRDF(FactoryRDF factory) {
+        this.factory = factory;
     }
-
+   
     @Override
     public String resolveIRI(String uriStr, long line, long col) {
         return prologue.getResolver().resolveToString(uriStr) ;
@@ -93,44 +97,44 @@ public class ParserProfileBase implements ParserProfile {
 
     @Override
     public Quad createQuad(Node g, Node s, Node p, Node o, long line, long col) {
-        return new Quad(g, s, p, o) ;
+        return factory.createQuad(g, s, p, o);
     }
 
     @Override
     public Triple createTriple(Node s, Node p, Node o, long line, long col) {
-        return new Triple(s, p, o) ;
+        return factory.createTriple(s, p, o);
     }
 
     @Override
     public Node createURI(String uriStr, long line, long col) {
-        return RiotLib.createIRIorBNode(uriStr) ;
+        return factory.createURI(uriStr);
     }
 
     @Override
     public Node createBlankNode(Node scope, String label, long line, long col) {
-        return labelMapping.get(scope, label) ;
+        return factory.createBlankNode(label);
     }
 
     @Override
     public Node createBlankNode(Node scope, long line, long col) {
-        return labelMapping.create() ;
+        return factory.createBlankNode();
     }
 
     @Override
     public Node createTypedLiteral(String lexical, RDFDatatype dt, long line, long col) {
-        return NodeFactory.createLiteral(lexical, dt) ;
+        return factory.createTypedLiteral(lexical, dt);
     }
 
     @Override
     public Node createLangLiteral(String lexical, String langTag, long line, long col) {
-        return NodeFactory.createLiteral(lexical, langTag) ;
+        return factory.createLangLiteral(lexical, langTag);
     }
 
     @Override
     public Node createStringLiteral(String lexical, long line, long col) {
-        return NodeFactory.createLiteral(lexical) ;
+        return factory.createStringLiteral(lexical);
     }
-
+  
     /** Special token forms */
     @Override
     public Node createNodeFromToken(Node scope, Token token, long line, long col) {
@@ -144,27 +148,31 @@ public class ParserProfileBase implements ParserProfile {
 
     @Override
     public Node create(Node currentGraph, Token token) {
-        // Dispatches to the underlying operation
+        return create(this, currentGraph, token) ;
+    }
+        
+    private static Node create(ParserProfile pp, Node currentGraph, Token token) {
+        // Dispatches to the underlying ParserProfile operation
         long line = token.getLine() ;
         long col = token.getColumn() ;
         String str = token.getImage() ;
         switch (token.getType()) {
             case BNODE :
-                return createBlankNode(currentGraph, str, line, col) ;
+                return pp.createBlankNode(currentGraph, str, line, col) ;
             case IRI :
-                return createURI(str, line, col) ;
+                return pp.createURI(str, line, col) ;
             case PREFIXED_NAME : {
                 String prefix = str ;
                 String suffix = token.getImage2() ;
-                String expansion = expandPrefixedName(prefix, suffix, token) ;
-                return createURI(expansion, line, col) ;
+                String expansion = expandPrefixedName(pp, prefix, suffix, token) ;
+                return pp.createURI(expansion, line, col) ;
             }
             case DECIMAL :
-                return createTypedLiteral(str, XSDDatatype.XSDdecimal, line, col) ;
+                return pp.createTypedLiteral(str, XSDDatatype.XSDdecimal, line, col) ;
             case DOUBLE :
-                return createTypedLiteral(str, XSDDatatype.XSDdouble, line, col) ;
+                return pp.createTypedLiteral(str, XSDDatatype.XSDdouble, line, col) ;
             case INTEGER :
-                return createTypedLiteral(str, XSDDatatype.XSDinteger, line, col) ;
+                return pp.createTypedLiteral(str, XSDDatatype.XSDinteger, line, col) ;
             case LITERAL_DT : {
                 Token tokenDT = token.getSubToken2() ;
                 String uriStr ;
@@ -176,41 +184,41 @@ public class ParserProfileBase implements ParserProfile {
                     case PREFIXED_NAME : {
                         String prefix = tokenDT.getImage() ;
                         String suffix = tokenDT.getImage2() ;
-                        uriStr = expandPrefixedName(prefix, suffix, tokenDT) ;
+                        uriStr = expandPrefixedName(pp, prefix, suffix, tokenDT) ;
                         break ;
                     }
                     default :
                         throw new RiotException("Expected IRI for datatype: " + token) ;
                 }
 
-                uriStr = resolveIRI(uriStr, tokenDT.getLine(), tokenDT.getColumn()) ;
+                uriStr = pp.resolveIRI(uriStr, tokenDT.getLine(), tokenDT.getColumn()) ;
                 RDFDatatype dt = NodeFactory.getType(uriStr) ;
-                return createTypedLiteral(str, dt, line, col) ;
+                return pp.createTypedLiteral(str, dt, line, col) ;
             }
 
             case LITERAL_LANG :
-                return createLangLiteral(str, token.getImage2(), line, col) ;
+                return pp.createLangLiteral(str, token.getImage2(), line, col) ;
 
             case STRING :
             case STRING1 :
             case STRING2 :
             case LONG_STRING1 :
             case LONG_STRING2 :
-                return createStringLiteral(str, line, col) ;
+                return pp.createStringLiteral(str, line, col) ;
             default : {
-                Node x = createNodeFromToken(currentGraph, token, line, col) ;
+                Node x = pp.createNodeFromToken(currentGraph, token, line, col) ;
                 if (x != null)
                     return x ;
-                errorHandler.fatal("Not a valid token for an RDF term: " + token, line, col) ;
+                pp.getHandler().fatal("Not a valid token for an RDF term: " + token, line, col) ;
                 return null ;
             }
         }
     }
 
-    private String expandPrefixedName(String prefix, String localPart, Token token) {
-        String expansion = prologue.getPrefixMap().expand(prefix, localPart) ;
+    private static String expandPrefixedName(ParserProfile pp, String prefix, String localPart, Token token) {
+        String expansion = pp.getPrologue().getPrefixMap().expand(prefix, localPart) ;
         if (expansion == null)
-            errorHandler.fatal("Undefined prefix: " + prefix, token.getLine(), token.getColumn()) ;
+            pp.getHandler().fatal("Undefined prefix: " + prefix, token.getLine(), token.getColumn()) ;
         return expansion ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileChecker.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileChecker.java
@@ -26,7 +26,6 @@ import org.apache.jena.iri.IRI ;
 import org.apache.jena.riot.RiotException ;
 import org.apache.jena.riot.checker.CheckerIRI ;
 import org.apache.jena.riot.checker.CheckerLiterals ;
-import org.apache.jena.riot.lang.LabelToNode ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.util.FmtUtils ;
 
@@ -40,8 +39,7 @@ import org.apache.jena.sparql.util.FmtUtils ;
  * </ul>
  */
 
-public class ParserProfileChecker extends ParserProfileBase // implements
-                                                            // ParserProfile
+public class ParserProfileChecker extends ParserProfileBase // implements ParserProfile
 {
     private boolean checkLiterals = true ;
 
@@ -49,8 +47,8 @@ public class ParserProfileChecker extends ParserProfileBase // implements
         super(prologue, errorHandler) ;
     }
 
-    public ParserProfileChecker(Prologue prologue, ErrorHandler errorHandler, LabelToNode labelMapping) {
-        super(prologue, errorHandler, labelMapping) ;
+    public ParserProfileChecker(Prologue prologue, ErrorHandler errorHandler, FactoryRDF factory) {
+        super(prologue, errorHandler, factory) ;
     }
 
     @Override
@@ -105,19 +103,9 @@ public class ParserProfileChecker extends ParserProfileBase // implements
 
     @Override
     public Node createURI(String x, long line, long col) {
-        try {
-            if ( RiotLib.isBNodeIRI(x) )
-                return RiotLib.createIRIorBNode(x) ;
-            else {
-                String resolvedIRI = resolveIRI(x, line, col) ;
-                return NodeFactory.createURI(resolvedIRI) ;
-            }
-        }
-        catch (RiotException ex) {
-            // Error was handled.
-            // errorHandler.error(ex.getMessage(), line, col) ;
-            throw ex ;
-        }
+        if ( ! RiotLib.isBNodeIRI(x) )
+            x = resolveIRI(x, line, col) ;
+        return super.createURI(x, line, col) ;
     }
 
     @Override
@@ -134,14 +122,14 @@ public class ParserProfileChecker extends ParserProfileBase // implements
         return n ;
     }
 
-    @Override
-    public Node createStringLiteral(String lexical, long line, long col) {
-        return NodeFactory.createLiteral(lexical) ;
-    }
-
-    @Override
-    public Node createBlankNode(Node scope, String label, long line, long col) {
-        return labelMapping.get(scope, label) ;
-    }
-
+    // No checks
+//    @Override
+//    public Node createStringLiteral(String lexical, long line, long col) {
+//        return super.createStringLiteral(lexical, line, col) ;
+//    }
+//
+//    @Override
+//    public Node createBlankNode(Node scope, String label, long line, long col) {
+//        return super.createBlankNode(scope, label, line, col) ;
+//    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ProgressStreamRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ProgressStreamRDF.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.atlas.lib.ProgressMonitor ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.sparql.core.Quad ;
+
+/** Send ticks to a {@link ProgressMonitor} as triples and quads
+ * are sent along the {@link StreamRDF}.
+ */
+ 
+public class ProgressStreamRDF extends StreamRDFWrapper {
+
+    private final ProgressMonitor monitor ;
+    
+    public ProgressStreamRDF(StreamRDF other, ProgressMonitor monitor) {
+        super(other);
+        this.monitor = monitor ;
+    }
+
+    // Better that the app call start/finish on the monitor so that a number of
+    // inputs on the stream can call start/finish. i.e the monitor can be used
+    // for a batch of oeprations.
+    
+//    @Override
+//    public void start() {
+//        monitor.start();
+//        super.start();
+//    }
+//
+//    @Override
+//    public void finish() {
+//        super.finish();
+//        monitor.finish();
+//    }
+
+    @Override
+    public void triple(Triple triple) {
+        super.triple(triple);
+        monitor.tick();
+    }
+
+    @Override
+    public void quad(Quad quad) {
+        super.quad(quad);
+        monitor.tick();
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
@@ -38,10 +38,7 @@ import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.query.ARQ ;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.riot.SysRIOT ;
-import org.apache.jena.riot.WriterDatasetRIOT ;
+import org.apache.jena.riot.* ;
 import org.apache.jena.riot.lang.LabelToNode ;
 import org.apache.jena.riot.tokens.Token ;
 import org.apache.jena.riot.tokens.Tokenizer ;
@@ -82,7 +79,7 @@ public class RiotLib
         return skolomizedBNodes && iri.startsWith(bNodeLabelStart) ;
     }
     
-    private static ParserProfile profile = profile(RDFLanguages.TURTLE, null, null) ;
+    private static ParserProfile profile = profile(RDFLanguages.TURTLE, null, ErrorHandlerFactory.errorHandlerStd) ;
     static {
         PrefixMap pmap = profile.getPrologue().getPrefixMap() ;
         pmap.add("rdf",  ARQConstants.rdfPrefix) ;
@@ -147,9 +144,23 @@ public class RiotLib
             prologue = new Prologue(PrefixMapFactory.createForInput(), IRIResolver.createNoResolve()) ;
     
         if ( checking )
-            return new ParserProfileChecker(prologue, handler, labelToNode) ;
+            return new ParserProfileChecker(prologue, handler, factoryRDF(labelToNode)) ;
         else
-            return new ParserProfileBase(prologue, handler, labelToNode) ;
+            return new ParserProfileBase(prologue, handler, factoryRDF(labelToNode)) ;
+    }
+
+    /** Create a new (notinfluenced by anything else) FactoryRDF
+     * using the label to blank node scheme provided. 
+     */
+    public static FactoryRDF factoryRDF(LabelToNode labelMapping) {
+        return new FactoryRDFStd(labelMapping);
+    }
+
+    /** Create a new (not influenced by anything else) FactoryRDF
+     * using the label to blank node scheme scope by this FactoryRDF. 
+     */  
+    public static FactoryRDF factoryRDF() {
+        return factoryRDF(SyntaxLabels.createLabelToNode());
     }
 
     /** Get triples with the same subject */

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/SerializationFactoryFinder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/SerializationFactoryFinder.java
@@ -81,9 +81,11 @@ public class SerializationFactoryFinder
             @Override
             public Iterator<Triple> createDeserializer(InputStream in)
             {
-                Tokenizer tokenizer = TokenizerFactory.makeTokenizerASCII(in) ;
-                ParserProfileBase profile = new ParserProfileBase(new Prologue(null, IRIResolver.createNoResolve()), null, LabelToNode.createUseLabelEncoded()) ;
-                LangNTriples parser = new LangNTriples(tokenizer, profile, null) ;
+                Tokenizer tokenizer = TokenizerFactory.makeTokenizerASCII(in);
+                ParserProfileBase profile = new ParserProfileBase(new Prologue(null, IRIResolver.createNoResolve()), 
+                                                                  ErrorHandlerFactory.errorHandlerNoWarnings,
+                                                                  RiotLib.factoryRDF(LabelToNode.createUseLabelEncoded()));
+                LangNTriples parser = new LangNTriples(tokenizer, profile, null);
                 return parser ;
             }
             
@@ -110,7 +112,9 @@ public class SerializationFactoryFinder
             public Iterator<Quad> createDeserializer(InputStream in)
             {
                 Tokenizer tokenizer = TokenizerFactory.makeTokenizerASCII(in) ;
-                ParserProfileBase profile = new ParserProfileBase(new Prologue(null, IRIResolver.createNoResolve()), null, LabelToNode.createUseLabelEncoded()) ;
+                ParserProfileBase profile = new ParserProfileBase(new Prologue(null, IRIResolver.createNoResolve()), 
+                                                                  ErrorHandlerFactory.errorHandlerNoWarnings,
+                                                                  RiotLib.factoryRDF(LabelToNode.createUseLabelEncoded())) ;
                 LangNQuads parser = new LangNQuads(tokenizer, profile, null) ;
                 return parser ;
             }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingInputStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingInputStream.java
@@ -82,8 +82,8 @@ public class BindingInputStream extends LangEngine implements Iterator<Binding>,
         // Don't do anything with IRIs.
         Prologue prologue = new Prologue(PrefixMapFactory.createForInput(), IRIResolver.createNoResolve()) ;
         ErrorHandler handler = ErrorHandlerFactory.getDefaultErrorHandler() ;
-        ParserProfile profile = new ParserProfileBase(prologue, handler) ;
-        profile.setLabelToNode(LabelToNode.createUseLabelAsGiven()) ;
+        FactoryRDF factory = RiotLib.factoryRDF(LabelToNode.createUseLabelAsGiven()) ;
+        ParserProfile profile = new ParserProfileBase(prologue, handler, factory) ;
         // Include safe bNode labels.
         return profile ;
     }

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TS_RiotSystem.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TS_RiotSystem.java
@@ -30,6 +30,9 @@ import org.junit.runners.Suite.SuiteClasses ;
 @SuiteClasses({ 
     TestChecker.class
     , TestStreamRDF.class
+    , TestFactoryRDF.class
+    , TestFactoryRDFCaching.class
+
     // Prefix Map implementations
     , TestPrefixMap.class
     , TestPrefixMapWrapper.class
@@ -37,11 +40,13 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestFastAbbreviatingPrefixMap.class
     , TestPrefixMapExtended1.class
     , TestPrefixMapExtended2.class
+    
     , TestIO_JenaReaders.class
     , TestIO_JenaWriters.class
     , TestLangRegistration.class
     , TestFormatRegistration.class
     , TestJsonLDReadWrite.class         // Some simple testing of the jsonld-java engine. 
+    
     // May be subject to performance vagaries, with the improvements made
     // to the fast implementation this should be fairly safe
     //, TestAbbreviationPerformance.class

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDF.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDF.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import static org.junit.Assert.assertEquals ;
+import static org.junit.Assert.assertNotEquals ;
+import static org.junit.Assert.assertNotNull ;
+import static org.junit.Assert.assertTrue ;
+
+import org.apache.jena.datatypes.xsd.XSDDatatype ;
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.riot.lang.LabelToNode ;
+import org.apache.jena.riot.system.FactoryRDF ;
+import org.apache.jena.riot.system.FactoryRDFStd ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.vocabulary.RDF ;
+import org.junit.Test ;
+
+public class TestFactoryRDF {
+    protected FactoryRDF factory = new FactoryRDFStd(LabelToNode.createUseLabelAsGiven()) ;
+    
+    @Test public void factoryRDF_blanknode_01() {
+        Node n1 = factory.createBlankNode() ;
+        assertTrue(n1.isBlank()) ;
+        Node n2 = factory.createBlankNode() ;
+        assertNotEquals(n1, n2);
+    }
+    
+    @Test public void factoryRDF_blanknode_02() {
+        Node n1 = factory.createBlankNode("ABCDE") ;
+        assertTrue(n1.isBlank()) ;
+        Node n2 = factory.createBlankNode("ABCDE") ;
+        assertEquals(n1, n2);
+        assertEquals("ABCDE", n1.getBlankNodeLabel()) ;
+    }
+
+    @Test public void factoryRDF_blanknode_03() {
+        Node n1 = factory.createBlankNode(0x1234L, 0x5678L) ;
+        assertTrue(n1.isBlank()) ;
+        Node n2 = factory.createBlankNode(0x1234L, 0x5678L) ;
+        assertEquals(n1, n2);
+        assertEquals("0000123400005678", n1.getBlankNodeLabel()) ;
+    }
+
+    @Test public void factoryRDF_uri_02() {
+        Node n = factory.createURI("http://example/") ;
+        assertTrue(n.isURI()) ;
+        assertEquals("http://example/", n.getURI()) ; 
+    }
+
+    @Test public void factoryRDF_uri_03() {
+        Node n = factory.createURI("_:abc") ;   // Blank node!
+        assertTrue(n.isBlank()) ;
+        assertEquals("abc", n.getBlankNodeLabel()) ; 
+    }
+
+    @Test public void factoryRDF_literal_01() {
+        Node n = factory.createStringLiteral("hello") ;
+        assertTrue(n.isLiteral()) ;
+        assertEquals("hello", n.getLiteralLexicalForm()) ; 
+        assertEquals(XSDDatatype.XSDstring, n.getLiteralDatatype()) ;
+        assertEquals("", n.getLiteralLanguage()) ;
+    }
+
+    @Test public void factoryRDF_literal_02() {
+        Node n = factory.createLangLiteral("xyz", "en") ;
+        assertTrue(n.isLiteral()) ;
+        assertEquals("xyz", n.getLiteralLexicalForm()) ; 
+        assertEquals(RDF.dtLangString, n.getLiteralDatatype()) ;
+        assertEquals("en", n.getLiteralLanguage()) ;
+    }
+
+    @Test public void factoryRDF_literal_03() {
+        Node n = factory.createTypedLiteral("1", XSDDatatype.XSDinteger) ;
+        assertTrue(n.isLiteral()) ;
+        assertEquals("1", n.getLiteralLexicalForm()) ; 
+        assertEquals(XSDDatatype.XSDinteger, n.getLiteralDatatype()) ;
+        assertEquals("", n.getLiteralLanguage()) ;
+    }
+    
+    @Test public void factoryRDF_triple_01() {
+        Node s = factory.createURI("http://test/s") ;
+        Node p = factory.createURI("http://test/p") ;
+        Node o = factory.createURI("http://test/o") ;
+        Triple triple = factory.createTriple(s, p, o) ;
+        assertEquals(s, triple.getSubject()) ;
+        assertEquals(p, triple.getPredicate()) ;
+        assertEquals(o, triple.getObject()) ;
+    }
+
+    @Test public void factoryRDF_quad_01() {
+        Node g = factory.createURI("http://test/g") ;
+        Node s = factory.createURI("http://test/s") ;
+        Node p = factory.createURI("http://test/p") ;
+        Node o = factory.createURI("http://test/o") ;
+        Quad quad = factory.createQuad(g, s, p, o) ;
+        assertEquals(g, quad.getGraph()) ;
+        assertEquals(s, quad.getSubject()) ;
+        assertEquals(p, quad.getPredicate()) ;
+        assertEquals(o, quad.getObject()) ;
+    }
+    
+    @Test public void factoryRDF_graph_01() {
+        Graph graph = factory.createGraph() ;
+        assertNotNull(graph) ;
+    }
+
+    @Test public void factoryRDF_dataset_01() {
+        DatasetGraph dsg = factory.createDatasetGraph() ;
+        assertNotNull(dsg) ;
+    }
+}
+

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDFCaching.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestFactoryRDFCaching.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import static org.junit.Assert. * ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.riot.lang.LabelToNode ;
+import org.apache.jena.riot.system.FactoryRDFCaching ;
+import org.junit.Test ;
+
+public class TestFactoryRDFCaching extends TestFactoryRDF {
+ 
+    public TestFactoryRDFCaching() {
+        super.factory = new FactoryRDFCaching(100, LabelToNode.createUseLabelAsGiven()) ;
+    }
+    
+    @Test public void factory_cache_01() {
+        Node n1 = factory.createStringLiteral("") ;
+        Node n2 = factory.createStringLiteral("") ;
+        assertSame(n1, n2); 
+    }
+    
+    @Test public void factory_cache_02() {
+        Node n1 = factory.createURI("http://test/n1") ;
+        Node n2 = factory.createURI("http://test/n2") ;
+        Node n3 = factory.createURI("http://test/n1") ;
+        assertSame(n1, n3); 
+    }
+}
+
+

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheInfo.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheInfo.java
@@ -21,42 +21,28 @@ package org.apache.jena.atlas.lib.cache;
 import org.apache.jena.ext.com.google.common.cache.CacheStats ;
 
 /** Simplified version of Guava's CacheStats (and abstractign away from Guava cache implementation) */
-    public class CacheInfo {
-        public final long requests;
-        public final long hits;
-        public final long misses;
-        public final double hitRate;
-        public final int cacheSize;
+public class CacheInfo {
+    public final long requests;
+    public final long hits;
+    public final long misses;
+    public final double hitRate;
+    public final int cacheSize;
 
-        public CacheInfo(int cacheSize, CacheStats stats) {
-            this(cacheSize, stats.requestCount(), stats.hitCount(), stats.missCount(), stats.hitRate() ) ;
-        }
-        
-        public CacheInfo(int cacheSize, long requests, long hits, long misses, double hitRate) {
-            this.cacheSize = cacheSize ;
-            this.requests = requests ;
-            this.hits = hits ;
-            this.misses = misses ;
-            this.hitRate = hitRate ;
-        }
-
-        @Override
-        public String toString() {
-            return String.format("size=%,d  count=%,d  hits=%,d  misses=%,d  rate=%.1f",
-                                 cacheSize, requests, hits, misses, hitRate) ;
-        }
-        
-//      private void details(String label, CacheGuava<?, ?> cache, int cacheSize) {
-//      System.out.printf("%s [%,d]\n", label, cacheSize) ;
-//      CacheStats stats = ((CacheGuava<?, ?>)cache).stats() ;
-////      System.out.printf("  Cache usage:      %,d\n", cache.size()) ;
-//      System.out.printf("  Requests:         %,d\n", stats.requestCount()) ;
-//      System.out.printf("  Hit rate:         %.1f%%\n", 100*stats.hitRate()) ; 
-////      System.out.printf("  Hits:             %,d\n", stats.hitCount()) ;
-////      System.out.printf("  Misses:           %,d\n", stats.missCount()) ;
-////      if ( stats.loadSuccessCount() != stats.missCount() ) {
-////          System.out.printf("  Load success:     %,d\n", stats.loadSuccessCount()) ;
-////          System.out.printf("  Load ex:          %,d\n", stats.loadExceptionCount()) ;
-////      }
-
+    public CacheInfo(int cacheSize, CacheStats stats) {
+        this(cacheSize, stats.requestCount(), stats.hitCount(), stats.missCount(), stats.hitRate() ) ;
     }
+
+    public CacheInfo(int cacheSize, long requests, long hits, long misses, double hitRate) {
+        this.cacheSize = cacheSize ;
+        this.requests = requests ;
+        this.hits = hits ;
+        this.misses = misses ;
+        this.hitRate = hitRate ;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("size=%,d  count=%,d  hits=%,d  misses=%,d  rate=%.1f",
+                             cacheSize, requests, hits, misses, hitRate) ;
+    }
+}

--- a/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
+++ b/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
@@ -276,8 +276,11 @@ public abstract class CmdLangParse extends CmdGeneral
             } else
                 reader.setParserProfile(RiotLib.profile(baseURI, false, false, errHandler)) ;
 
-            if ( labelsAsGiven )
-                reader.getParserProfile().setLabelToNode(LabelToNode.createUseLabelAsGiven()) ;
+            if ( labelsAsGiven ) {
+                FactoryRDF f = RiotLib.factoryRDF(LabelToNode.createUseLabelAsGiven()) ;
+                reader.getParserProfile().setFactoryRDF(f);
+            }
+
             modTime.startTimer() ;
             sink.start() ;
             reader.read(in, baseURI, ct, sink, null) ;

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/util/RdfIOUtils.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/util/RdfIOUtils.java
@@ -24,12 +24,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.jena.hadoop.rdf.io.RdfIOConstants;
 import org.apache.jena.riot.lang.LabelToNode;
-import org.apache.jena.riot.system.ErrorHandlerFactory;
-import org.apache.jena.riot.system.IRIResolver;
-import org.apache.jena.riot.system.ParserProfile;
-import org.apache.jena.riot.system.ParserProfileBase;
-import org.apache.jena.riot.system.PrefixMapFactory;
-import org.apache.jena.riot.system.Prologue;
+import org.apache.jena.riot.system.* ;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +56,7 @@ public class RdfIOUtils {
         Prologue prologue = new Prologue(PrefixMapFactory.createForInput(), IRIResolver.createNoResolve());
         UUID seed = RdfIOUtils.getSeed(context, path);
         LabelToNode labelMapping = LabelToNode.createScopeByDocumentHash(seed);
-        return new ParserProfileBase(prologue, ErrorHandlerFactory.errorHandlerStd, labelMapping);
+        return new ParserProfileBase(prologue, ErrorHandlerFactory.errorHandlerStd, RiotLib.factoryRDF(labelMapping));
     }
 
     /**


### PR DESCRIPTION
FactoryRDF is an interface to abstract the creation of nodes, triples and quads from constituent elements, e.g. to create a URI Node, the operation takes a string for the URI. This allows different policies to be slotted in. This PR covers the use of FactoryRDF by ParserProfile.