### PR TITLE
JENA-1134: support AnalyzingQueryParser in jena-text

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexConfig.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexConfig.java
@@ -25,6 +25,7 @@ public class TextIndexConfig {
     EntityDefinition entDef;
     Analyzer analyzer;
     Analyzer queryAnalyzer;
+    String queryParser;
     boolean multilingualSupport;
     boolean valueStored;
 
@@ -50,6 +51,14 @@ public class TextIndexConfig {
 
     public void setQueryAnalyzer(Analyzer queryAnalyzer) {
         this.queryAnalyzer = queryAnalyzer;
+    }
+    
+    public String getQueryParser() {
+        return ((queryParser != null) ? queryParser : "QueryParser");
+    }
+    
+    public void setQueryParser(String queryParser) {
+        this.queryParser = queryParser;
     }
 
     public boolean isMultilingualSupport() {

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
@@ -289,21 +289,21 @@ public class TextIndexLucene implements TextIndex {
         }
     }
 
-    private static Query parseQuery(String queryString, String primaryField, Analyzer analyzer) throws ParseException {
-        QueryParser queryParser = new QueryParser(VER, primaryField, analyzer) ;
+    private Query parseQuery(String queryString, Analyzer analyzer) throws ParseException {
+        QueryParser queryParser = new QueryParser(VER, docDef.getPrimaryField(), analyzer) ;
         queryParser.setAllowLeadingWildcard(true) ;
         Query query = queryParser.parse(queryString) ;
         return query ;
     }
     
-    protected Query preParseQuery(String queryString, String primaryField, Analyzer analyzer) throws ParseException {
-        return parseQuery(queryString, primaryField, analyzer);
+    protected Query preParseQuery(String queryString, Analyzer analyzer) throws ParseException {
+        return parseQuery(queryString, analyzer);
     }
 
     private List<Map<String, Node>> get$(IndexReader indexReader, String uri) throws ParseException, IOException {
         String escaped = QueryParserBase.escape(uri) ;
         String qs = docDef.getEntityField() + ":" + escaped ;
-        Query query = preParseQuery(qs, docDef.getPrimaryField(), queryAnalyzer) ;
+        Query query = preParseQuery(qs, queryAnalyzer) ;
         IndexSearcher indexSearcher = new IndexSearcher(indexReader) ;
         ScoreDoc[] sDocs = indexSearcher.search(query, 1).scoreDocs ;
         List<Map<String, Node>> records = new ArrayList<Map<String, Node>>() ;
@@ -351,7 +351,7 @@ public class TextIndexLucene implements TextIndex {
 
     private List<TextHit> query$(IndexReader indexReader, Node property, String qs, int limit) throws ParseException, IOException {
         IndexSearcher indexSearcher = new IndexSearcher(indexReader) ;
-        Query query = preParseQuery(qs, docDef.getPrimaryField(), queryAnalyzer) ;
+        Query query = preParseQuery(qs, queryAnalyzer) ;
         if ( limit <= 0 )
             limit = MAX_N ;
         ScoreDoc[] sDocs = indexSearcher.search(query, limit).scoreDocs ;

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLuceneMultilingual.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLuceneMultilingual.java
@@ -64,12 +64,12 @@ public class TextIndexLuceneMultilingual extends TextIndexLucene {
     }
 
     @Override
-    protected Query preParseQuery(String queryString, String primaryField, Analyzer analyzer) throws ParseException {
+    protected Query preParseQuery(String queryString, Analyzer analyzer) throws ParseException {
         if (queryString.contains(getDocDef().getLangField() + ":")) {
             String lang = queryString.substring(queryString.lastIndexOf(":") + 1);
             if (!"*".equals(lang))
                 analyzer = Util.getLocalizedAnalyzer(lang);
         }
-        return super.preParseQuery(queryString, primaryField, analyzer);
+        return super.preParseQuery(queryString, analyzer);
     }
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextIndexLuceneAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextIndexLuceneAssembler.java
@@ -104,7 +104,6 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
                 }
                 Resource parserResource = (Resource) qpNode;
                 queryParser = parserResource.getLocalName();
-                System.out.println("query parser: " + queryParser);
             }
 
             boolean isMultilingualSupport = false;

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextIndexLuceneAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextIndexLuceneAssembler.java
@@ -94,6 +94,18 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
                 Resource analyzerResource = (Resource) qaNode;
                 queryAnalyzer = (Analyzer) a.open(analyzerResource);
             }
+            
+            String queryParser = null;
+            Statement queryParserStatement = root.getProperty(pQueryParser);
+            if (null != queryParserStatement) {
+                RDFNode qpNode = queryParserStatement.getObject();
+                if (! qpNode.isResource()) {
+                    throw new TextIndexException("Text query parser property is not a resource : " + qpNode);
+                }
+                Resource parserResource = (Resource) qpNode;
+                queryParser = parserResource.getLocalName();
+                System.out.println("query parser: " + queryParser);
+            }
 
             boolean isMultilingualSupport = false;
             Statement mlSupportStatement = root.getProperty(pMultilingualSupport);
@@ -120,6 +132,7 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
             TextIndexConfig config = new TextIndexConfig(docDef);
             config.setAnalyzer(analyzer);
             config.setQueryAnalyzer(queryAnalyzer);
+            config.setQueryParser(queryParser);
             config.setMultilingualSupport(isMultilingualSupport);
             config.setValueStored(storeValues);
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextVocab.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextVocab.java
@@ -42,6 +42,7 @@ public class TextVocab
     public static final Property pMultilingualSupport   = Vocab.property(NS, "multilingualSupport") ;
     public static final Property pStoreValues       = Vocab.property(NS, "storeValues") ;
     public static final Property pQueryAnalyzer     = Vocab.property(NS, "queryAnalyzer") ;
+    public static final Property pQueryParser       = Vocab.property(NS, "queryParser") ;
     public static final Property pEntityMap         = Vocab.property(NS, "entityMap") ;
     public static final Property pTokenizer         = Vocab.property(NS, "tokenizer") ;
     public static final Property pFilters           = Vocab.property(NS, "filters") ;

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -51,6 +51,7 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestLuceneWithMultipleThreads.class
     , TestDatasetWithLocalizedAnalyzer.class
     , TestDatasetWithConfigurableAnalyzer.class
+    , TestDatasetWithAnalyzingQueryParser.class
 })
 
 public class TS_Text

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithAnalyzingQueryParser.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithAnalyzingQueryParser.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text;
+
+import java.util.Set ;
+
+import org.apache.jena.atlas.lib.StrUtils ;
+import org.apache.jena.ext.com.google.common.collect.Sets ;
+import org.junit.Before ;
+import org.junit.Test ;
+
+/**
+ * This class defines a setup configuration for a dataset that uses an ASCII folding lowercase keyword analyzer with a Lucene index.
+ */
+public class TestDatasetWithAnalyzingQueryParser extends TestDatasetWithConfigurableAnalyzer {
+    @Override
+    @Before
+    public void before() {
+        init(StrUtils.strjoinNL(
+            "text:ConfigurableAnalyzer ;",
+            "text:tokenizer text:KeywordTokenizer ;",
+            "text:filters (text:ASCIIFoldingFilter text:LowerCaseFilter)"
+        ), "text:AnalyzingQueryParser");
+    }    
+    
+    @Test
+    public void testAnalyzingQueryParserAnalyzesWildcards() {
+        final String testName = "testAnalyzingQueryParserAnalyzesWildcards";
+        final String turtle = StrUtils.strjoinNL(
+                TURTLE_PROLOG,
+                "<" + RESOURCE_BASE + testName + ">",
+                "  rdfs:label 'éducation'@fr",
+                ".",
+                "<" + RESOURCE_BASE + "irrelevant>",
+                "  rdfs:label 'déjà vu'@fr",
+                "."
+                );
+        String queryString = StrUtils.strjoinNL(
+                QUERY_PROLOG,
+                "SELECT ?s",
+                "WHERE {",
+                "    ?s text:query ( rdfs:label 'édu*' 10 ) .",
+                "}"
+                );
+        Set<String> expectedURIs = Sets.newHashSet(RESOURCE_BASE + testName);
+        doTestSearch(turtle, queryString, expectedURIs);
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithKeywordAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithKeywordAnalyzer.java
@@ -44,7 +44,7 @@ public class TestDatasetWithKeywordAnalyzer extends AbstractTestDatasetWithTextI
     private static final String SPEC_ROOT_LOCAL = "lucene_text_dataset";
     private static final String SPEC_ROOT_URI = SPEC_BASE + SPEC_ROOT_LOCAL;
 
-    private static String makeSpec(String analyzer) {
+    private static String makeSpec(String analyzer, String parser) {
         return StrUtils.strjoinNL(
                     "prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> ",
                     "prefix ja:   <http://jena.hpl.hp.com/2005/11/Assembler#> ",
@@ -73,6 +73,7 @@ public class TestDatasetWithKeywordAnalyzer extends AbstractTestDatasetWithTextI
                     ":indexLucene",
                     "    a text:TextIndexLucene ;",
                     "    text:directory \"mem\" ;",
+                    "    text:queryParser " + parser + ";",
                     "    text:entityMap :entMap ;",
                     "    .",
                     "",
@@ -90,8 +91,8 @@ public class TestDatasetWithKeywordAnalyzer extends AbstractTestDatasetWithTextI
                     );
     }      
     
-    public void init(String analyzer) {
-        Reader reader = new StringReader(makeSpec(analyzer));
+    public void init(String analyzer, String parser) {
+        Reader reader = new StringReader(makeSpec(analyzer, parser));
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
         TextAssembler.init();            
@@ -99,6 +100,9 @@ public class TestDatasetWithKeywordAnalyzer extends AbstractTestDatasetWithTextI
         dataset = (Dataset) Assembler.general.open(root);
     }
     
+    public void init(String analyzer) {
+        init(analyzer, "text:QueryParser");
+    }   
     
     @Before
     public void before() {


### PR DESCRIPTION
This PR makes it possible to select either the standard Lucene QueryParser or the AnalyzingQueryParser using jena-text configuration like this:

```
<#indexLucene> a text:TextIndexLucene ;
    text:directory <file:Lucene> ;
    text:queryParser text:AnalyzingQueryParser ;
    text:queryAnalyzer [
        a text:ConfigurableAnalyzer ;
        text:tokenizer text:KeywordTokenizer ;
        text:filters (text:ASCIIFoldingFilter text:LowerCaseFilter)
    ] 
    text:entityMap <#entMap> ;
```

The main difference between these query parsers is that AnalyzingQueryParser performs analysis also for wildcard queries. For example, if you use ASCIIFoldingFilter as above, if you want a search for `édu*` to match `éducation` you need AnalyzingQueryParser.

One problem I had with the implementation is that the query parser needs to be constructed dynamically for every query, so I need to store the information about which query parser to use instead of just storing the QueryParser/AnalyzingQueryParser instance directly. I solved this by simply storing the type of query parser as a string, i.e. either `"QueryParser"` or `"AnalyzingQueryParser"`, and then dynamically construct the correct type of parser based on this information. I'm sure there are more elegant ways of doing this, e.g. creating Factories for each parser type and saving the correct kind of Factory, but I don't want to overengineer. Opinions?

This could rather easily be extended to other query parser types supported by Lucene, though I'm unsure how useful that would be in practice. ComplexPhraseQueryParser and/or PrecedenceQueryParser could perhaps be useful to somebody.