### PR TITLE
JENA-967: afn:Sprintf implementation

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -352,6 +352,60 @@ public class XSDFuncOp
         }
     }
 
+    // expecting nvString = format | nvStart = value (int,float, string,....)
+    public static NodeValue javaSprintf(NodeValue nvFormat, NodeValue nvValue) {
+        try {
+            String formatForOutput = nvFormat.getString() ;
+            ValueSpaceClassification vlSpClass = nvValue.getValueSpace();
+            switch(vlSpClass){
+                case VSPACE_NUM:
+                    NumericType type = classifyNumeric("javaSprintf",nvValue);
+                    switch(type) {
+                        case OP_DECIMAL:
+                            BigDecimal decimalValue = nvValue.getDecimal();
+                            return NodeValue.makeString(String.format(formatForOutput,decimalValue)) ;
+                        case OP_INTEGER:
+                            BigInteger integerValue = nvValue.getInteger();
+                            return NodeValue.makeString(String.format(formatForOutput,integerValue)) ;
+                        case OP_DOUBLE:
+                            Double doubValue = nvValue.getDouble();
+                            return NodeValue.makeString(String.format(formatForOutput,doubValue)) ;
+                        case OP_FLOAT:
+                            Float floatValue = nvValue.getFloat();
+                            return NodeValue.makeString(String.format(formatForOutput,floatValue)) ;
+                    }
+                case VSPACE_DATE:
+                case VSPACE_DATETIME:
+                    XMLGregorianCalendar gregorianCalendarValue = nvValue.getDateTime();
+                    return NodeValue.makeString(String.format(formatForOutput,gregorianCalendarValue.toGregorianCalendar().getTime())) ;
+                case VSPACE_STRING:
+                    String strValue = nvValue.getString();
+                    return NodeValue.makeString(String.format(formatForOutput,strValue));
+                case VSPACE_BOOLEAN:
+                    Boolean boolValue = nvValue.getBoolean();
+                    return NodeValue.makeString(String.format(formatForOutput,boolValue));
+                case VSPACE_LANG:
+                    String langValue = nvValue.getLang();
+                    return NodeValue.makeString(String.format(formatForOutput,langValue));
+                default:
+/*              These cases for the moment are not supported. Maybe we could treat them all like strings.
+                case VSPACE_NODE:
+                case VSPACE_TIME:
+                case VSPACE_G_DAY:
+                case VSPACE_G_MONTH:
+                case VSPACE_G_MONTHDAY:
+                case VSPACE_G_YEAR:
+                case VSPACE_G_YEARMONTH:
+                case VSPACE_DURATION:
+                case VSPACE_UNKNOWN:
+*/
+                    throw new ARQInternalErrorException("Unrecognized sprintf type, value: "+nvValue);
+            }
+        } catch (IndexOutOfBoundsException ex) {
+            throw new ExprEvalException("IndexOutOfBounds", ex) ;
+        }
+    }
+
     public static NodeValue strlen(NodeValue nvString) {
         Node n = checkAndGetStringLiteral("strlen", nvString) ;
         String str = n.getLiteralLexicalForm();

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -33,6 +33,7 @@ import static org.apache.jena.sparql.expr.nodevalue.NumericType.OP_INTEGER ;
 
 import java.math.BigDecimal ;
 import java.math.BigInteger ;
+import java.util.ArrayList;
 import java.util.HashSet ;
 import java.util.List ;
 import java.util.Set ;
@@ -353,42 +354,46 @@ public class XSDFuncOp
     }
 
     // expecting nvString = format | nvStart = value (int,float, string,....)
-    public static NodeValue javaSprintf(NodeValue nvFormat, NodeValue nvValue) {
+    public static NodeValue javaSprintf(NodeValue nvFormat, List<NodeValue> valuesToPrint) {
         try {
             String formatForOutput = nvFormat.getString() ;
-            ValueSpaceClassification vlSpClass = nvValue.getValueSpace();
-            switch(vlSpClass){
-                case VSPACE_NUM:
-                    NumericType type = classifyNumeric("javaSprintf",nvValue);
-                    switch(type) {
-                        case OP_DECIMAL:
-                            BigDecimal decimalValue = nvValue.getDecimal();
-                            return NodeValue.makeString(String.format(formatForOutput,decimalValue)) ;
-                        case OP_INTEGER:
-                            BigInteger integerValue = nvValue.getInteger();
-                            return NodeValue.makeString(String.format(formatForOutput,integerValue)) ;
-                        case OP_DOUBLE:
-                            Double doubValue = nvValue.getDouble();
-                            return NodeValue.makeString(String.format(formatForOutput,doubValue)) ;
-                        case OP_FLOAT:
-                            Float floatValue = nvValue.getFloat();
-                            return NodeValue.makeString(String.format(formatForOutput,floatValue)) ;
-                    }
-                case VSPACE_DATE:
-                case VSPACE_DATETIME:
-                    XMLGregorianCalendar gregorianCalendarValue = nvValue.getDateTime();
-                    return NodeValue.makeString(String.format(formatForOutput,gregorianCalendarValue.toGregorianCalendar().getTime())) ;
-                case VSPACE_STRING:
-                    String strValue = nvValue.getString();
-                    return NodeValue.makeString(String.format(formatForOutput,strValue));
-                case VSPACE_BOOLEAN:
-                    Boolean boolValue = nvValue.getBoolean();
-                    return NodeValue.makeString(String.format(formatForOutput,boolValue));
-                case VSPACE_LANG:
-                    String langValue = nvValue.getLang();
-                    return NodeValue.makeString(String.format(formatForOutput,langValue));
-                default:
-/*              These cases for the moment are not supported. Maybe we could treat them all like strings.
+            List<Object> objVals = new ArrayList<>();
+            for(NodeValue nvValue:valuesToPrint) {
+                ValueSpaceClassification vlSpClass = nvValue.getValueSpace();
+                switch (vlSpClass) {
+                    case VSPACE_NUM:
+                        NumericType type = classifyNumeric("javaSprintf", nvValue);
+                        switch (type) {
+                            case OP_DECIMAL:
+                                objVals.add(nvValue.getDecimal());
+                                break;
+                            case OP_INTEGER:
+                                objVals.add(nvValue.getInteger());
+                                break;
+                            case OP_DOUBLE:
+                                objVals.add(nvValue.getDouble());
+                                break;
+                            case OP_FLOAT:
+                                objVals.add(nvValue.getFloat());
+                                break;
+                        }
+                        break;
+                    case VSPACE_DATE:
+                    case VSPACE_DATETIME:
+                        XMLGregorianCalendar gregorianCalendarValue = nvValue.getDateTime();
+                        objVals.add(gregorianCalendarValue.toGregorianCalendar().getTime());
+                        break;
+                    case VSPACE_STRING:
+                        objVals.add(nvValue.getString());
+                        break;
+                    case VSPACE_BOOLEAN:
+                        objVals.add(nvValue.getBoolean());
+                        break;
+                    case VSPACE_LANG:
+                        objVals.add(nvValue.getLang());
+                        break;
+                    default:
+/*              These cases for the moment are not supported. We treat them all like strings.
                 case VSPACE_NODE:
                 case VSPACE_TIME:
                 case VSPACE_G_DAY:
@@ -399,8 +404,13 @@ public class XSDFuncOp
                 case VSPACE_DURATION:
                 case VSPACE_UNKNOWN:
 */
-                    throw new ARQInternalErrorException("Unrecognized sprintf type, value: "+nvValue);
+                        objVals.add(NodeFunctions.str(nvValue));
+                        break;
+                }
             }
+
+            return NodeValue.makeString(String.format(formatForOutput,objVals.toArray()));
+
         } catch (IndexOutOfBoundsException ex) {
             throw new ExprEvalException("IndexOutOfBounds", ex) ;
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/sprintf.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/sprintf.java
@@ -1,0 +1,37 @@
+package org.apache.jena.sparql.function.library;
+
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.query.QueryBuildException;
+import org.apache.jena.sparql.expr.ExprEvalException;
+import org.apache.jena.sparql.expr.ExprList;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp;
+import org.apache.jena.sparql.function.FunctionBase;
+
+import java.util.List;
+
+/** sprintf(string,string) - Java style */
+
+public class sprintf extends FunctionBase
+{
+    public sprintf() { super() ; }
+
+    @Override
+    public void checkBuild(String uri, ExprList args) {
+        if ( args.size() != 2)
+            throw new QueryBuildException("Function '"+ Lib.className(this)+"' takes two or three arguments") ;
+    }
+
+    @Override
+    public NodeValue exec(List<NodeValue> args) {
+        if ( args.size() != 2 )
+            throw new ExprEvalException(Lib.className(this)+": Wrong number of arguments: "+
+                    args.size()+" : [wanted 2]") ;
+
+        NodeValue v1 = args.get(0) ;
+        NodeValue v2 = args.get(1) ;
+
+        return XSDFuncOp.javaSprintf(v1, v2) ;
+    }
+
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/sprintf.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/sprintf.java
@@ -8,6 +8,7 @@ import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp;
 import org.apache.jena.sparql.function.FunctionBase;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /** sprintf(string,string) - Java style */
@@ -18,20 +19,22 @@ public class sprintf extends FunctionBase
 
     @Override
     public void checkBuild(String uri, ExprList args) {
-        if ( args.size() != 2)
-            throw new QueryBuildException("Function '"+ Lib.className(this)+"' takes two or three arguments") ;
+        if(args.size() < 2)
+            throw new QueryBuildException("Function '"+ Lib.className(this)+"' takes at least two arguments") ;
     }
 
     @Override
     public NodeValue exec(List<NodeValue> args) {
-        if ( args.size() != 2 )
+        if ( args.size() < 2 )
             throw new ExprEvalException(Lib.className(this)+": Wrong number of arguments: "+
-                    args.size()+" : [wanted 2]") ;
+                    args.size()+" : [wanted at least 2]") ;
 
         NodeValue v1 = args.get(0) ;
-        NodeValue v2 = args.get(1) ;
+        List<NodeValue> allArgs = new ArrayList<NodeValue>();
+        for(int i = 1;i < args.size();i++)
+            allArgs.add(args.get(i));
 
-        return XSDFuncOp.javaSprintf(v1, v2) ;
+        return XSDFuncOp.javaSprintf(v1, allArgs) ;
     }
 
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -71,7 +71,23 @@ public class TestFunctions
     @Test public void exprJavaSubstring4() { test("<"+ARQConstants.ARQFunctionLibrary+"substr>('abc',0,1)", NodeValue.makeString("a")) ; }
     // Test from JENA-785
     @Test public void exprJavaSubstring5() { test("afn:substr('𐐈𐑌𐐻𐐪𐑉𐐿𐐻𐐮𐐿𐐲', 0, 1)", NodeValue.makeString("𐐈")) ; }
-    
+
+    // SPRINTF
+    @Test public void exprSprintf_01()      { test("afn:sprintf('%06d', 11)",NodeValue.makeString("000011")) ; }
+    @Test public void exprSprintf_02()      { test("afn:sprintf('%s', 'abcdefghi')",NodeValue.makeString("abcdefghi")) ; }
+    @Test public void exprSprintf_03()      { test("afn:sprintf('sometext %s', 'abcdefghi')",NodeValue.makeString("sometext abcdefghi")) ; }
+    @Test public void exprSprintf_04()      { test("afn:sprintf('%1$tm %1$te,%1$tY', '2016-03-17'^^xsd:date)",NodeValue.makeString("03 17,2016")) ; }
+    @Test public void exprSprintf_05()      {
+            String nodeStr = NodeValue.makeDateTime("2005-10-14T13:09:43Z").toString();
+            test("afn:sprintf('%1$tm %1$te,%1$tY', "+nodeStr+")",NodeValue.makeString("10 14,2005")) ;
+    }
+    @Test public void exprSprintf_06()      { test("afn:sprintf('this is %s', 'false'^^xsd:boolean)",NodeValue.makeString("this is false")) ; }
+    @Test public void exprSprintf_07()      { test("afn:sprintf('this number is equal to %.2f', '11.22'^^xsd:decimal)",NodeValue.makeString("this number is equal to 11.22")) ; }
+    @Test public void exprSprintf_08()      { test("afn:sprintf('%.3f', '1.23456789'^^xsd:float)",NodeValue.makeString("1.235")) ; }
+    @Test public void exprSprintf_09()      { test("afn:sprintf('this number is equal to %o in the octal system', '11'^^xsd:integer)",NodeValue.makeString("this number is equal to 13 in the octal system")) ; }
+    @Test public void exprSprintf_10()      { test("afn:sprintf('this number is equal to %.5f', '1.23456789'^^xsd:double)",NodeValue.makeString("this number is equal to 1.23457")) ; }
+
+
     @Test public void exprStrStart0() { test("fn:starts-with('abc', '')", TRUE) ; }
     @Test public void exprStrStart1() { test("fn:starts-with('abc', 'a')", TRUE) ; }
     @Test public void exprStrStart2() { test("fn:starts-with('abc', 'ab')", TRUE) ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -82,11 +82,12 @@ public class TestFunctions
             test("afn:sprintf('%1$tm %1$te,%1$tY', "+nodeStr+")",NodeValue.makeString("10 14,2005")) ;
     }
     @Test public void exprSprintf_06()      { test("afn:sprintf('this is %s', 'false'^^xsd:boolean)",NodeValue.makeString("this is false")) ; }
-    @Test public void exprSprintf_07()      { test("afn:sprintf('this number is equal to %.2f', '11.22'^^xsd:decimal)",NodeValue.makeString("this number is equal to 11.22")) ; }
-    @Test public void exprSprintf_08()      { test("afn:sprintf('%.3f', '1.23456789'^^xsd:float)",NodeValue.makeString("1.235")) ; }
+    @Test public void exprSprintf_07()      { test("afn:sprintf('this number is equal to %.2f', '11.22'^^xsd:decimal)",NodeValue.makeString("this number is equal to "+String.format("%.2f",11.22))) ; }
+    @Test public void exprSprintf_08()      { test("afn:sprintf('%.3f', '1.23456789'^^xsd:float)",NodeValue.makeString(String.format("%.3f",1.23456789))) ; }
     @Test public void exprSprintf_09()      { test("afn:sprintf('this number is equal to %o in the octal system', '11'^^xsd:integer)",NodeValue.makeString("this number is equal to 13 in the octal system")) ; }
-    @Test public void exprSprintf_10()      { test("afn:sprintf('this number is equal to %.5f', '1.23456789'^^xsd:double)",NodeValue.makeString("this number is equal to 1.23457")) ; }
-
+    @Test public void exprSprintf_10()      { test("afn:sprintf('this number is equal to %.5f', '1.23456789'^^xsd:double)",NodeValue.makeString("this number is equal to "+String.format("%.5f",1.23456789))) ; }
+    @Test public void exprSprintf_11()      { test("afn:sprintf('%.0f != %s', '12.23456789'^^xsd:double,'15')",NodeValue.makeString("12 != 15")) ; }
+    @Test public void exprSprintf_12()      { test("afn:sprintf('(%.0f,%s,%d) %4$tm %4$te,%4$tY', '12.23456789'^^xsd:double,'12',11,'2016-03-17'^^xsd:date)",NodeValue.makeString("(12,12,11) 03 17,2016")) ; }
 
     @Test public void exprStrStart0() { test("fn:starts-with('abc', '')", TRUE) ; }
     @Test public void exprStrStart1() { test("fn:starts-with('abc', 'a')", TRUE) ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions2.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions2.java
@@ -82,8 +82,8 @@ public class TestFunctions2 extends BaseTest
     | 'STRDT' '(' Expression ',' Expression ')'
     */
     
-    // Note in these tests, the rsult is written exactly as expected
-    // Any same value would do - we test for the exact lexcial form
+    // Note in these tests, the result is written exactly as expected
+    // Any same value would do - we test for the exact lexical form
     // of the implementation.
     
     @Test public void round_01()    { test("round(123)",    "123") ; }
@@ -289,7 +289,7 @@ public class TestFunctions2 extends BaseTest
     public void strends_20()            { test("strends(1816, '6'^^xsd:string)", "true") ; }
     @Test(expected=ExprEvalException.class)
     public void strends_21()            { test("strends('abc', 1066)", "true") ; }
-    
+
     // YEAR
     @Test public void year_01()         { test("year('2010-12-24T16:24:01.123'^^xsd:dateTime)", "2010") ; }
     @Test public void year_02()         { test("year('2010-12-24'^^xsd:date)", "2010") ; }


### PR DESCRIPTION
Hi,
I implemented the afn:sprintf function. In order to implement it, I had to:

- create a sprintf.java class in the sparql function part.

- implement in the XSDFuncOp.java a function dealing with making sprintf

- create a series of tests checking that the function is working correctly.

While implementing, I realized that the example described in the bug is just one of the possibilities (printing numbers) as by the Java specification, String.Format works with all types. I thus implemented the function to work with all the type that made sense in my opinion (we can discuss about this).

There is still one problem that I am not sure how to solve:
Test 04 and 07 and 08 depend on the user locale (it will be printed as 1.2.. or 1,2.. or with date the day or month depend on the locale). In order to solve this, we will need to show to String.Format the current locale but I could not find a way to do this from the XSDFuncOp class.