### PR TITLE
Fix Jena initialization in OSGi environments

### DIFF
--- a/apache-jena-osgi/jena-osgi-features/pom.xml
+++ b/apache-jena-osgi/jena-osgi-features/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.apache.jena</groupId>
+		<artifactId>apache-jena-osgi</artifactId>
+		<version>3.1.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>jena-osgi-features</artifactId>  
+	<packaging>bundle</packaging>
+	<name>Apache Jena - OSGi Karaf features</name>	
+	<description>Apache Karaf features (deplyoment configurations) for easy installation and integration testing.</description>
+	<build>
+		<pluginManagement>
+            <plugins>
+            	<plugin>
+                	<groupId>org.codehaus.mojo</groupId>
+                	<artifactId>build-helper-maven-plugin</artifactId>
+                	<version>1.8</version>
+            	</plugin>
+            </plugins>
+        </pluginManagement>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/resources</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>filter</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+			      <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/features.xml</file>
+                                    <type>xml</type>
+                                    <classifier>features</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+		</plugins>
+	</build>
+</project>

--- a/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
+++ b/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+  
+	<feature name="jena" version="3">
+		<bundle>mvn:org.apache.jena/jena-osgi/3.1.0-SNAPSHOT</bundle>
+		<feature version="3">jena_osgi_dependencies</feature>
+		<!-- This is normally exposed by Apache Karaf via root classloader -->
+		<!--<feature version="2.11.0">xerces</feature>-->
+	</feature>
+
+	<feature name="jena_osgi_dependencies" version="3">
+		<bundle>mvn:com.github.andrewoma.dexx/collection/0.6</bundle>
+		<bundle>mvn:com.github.jsonld-java/jsonld-java/0.8.2</bundle>
+		<bundle>mvn:com.fasterxml.jackson.core/jackson-core/2.7.3</bundle>
+		<bundle>mvn:com.fasterxml.jackson.core/jackson-databind/2.7.3</bundle>
+		<bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/2.7.3</bundle>
+		<bundle>mvn:org.apache.httpcomponents/httpcore-osgi/4.4.4</bundle>
+		<bundle>mvn:org.apache.httpcomponents/httpclient-osgi/4.5.2</bundle>
+		<bundle>mvn:org.apache.commons/commons-csv/1.2</bundle>
+		<bundle>mvn:org.apache.commons/commons-lang3/3.4</bundle>
+		<bundle>mvn:org.apache.thrift/libthrift/0.9.3</bundle>	
+	</feature>
+
+	<feature name="xerces" version="2.11.0">
+		<bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.11.0_1</bundle>
+		<bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/1.2_5</bundle>
+	</feature>
+
+</features>

--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -1,205 +1,93 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
-this work for additional information regarding copyright ownership.
-The ASF licenses this file to You under the Apache License, Version 2.0
-(the "License"); you may not use this file except in compliance with
-the License.  You may obtain a copy of the License at
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	You under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
 
-http://www.apache.org/licenses/LICENSE-2.0
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.apache.jena</groupId>
+		<artifactId>jena-parent</artifactId>
+		<version>16-SNAPSHOT</version>
+	</parent>
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
+	<artifactId>jena-osgi-test</artifactId>
+	<!-- Same as jena-osgi -->
+	<version>3.1.0-SNAPSHOT</version>
+	<name>Apache Jena - OSGi integration tests</name>
+	<description>Tests for jena-osgi as a bundle</description>
+	<packaging>bundle</packaging>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.apache.jena</groupId>
-    <artifactId>jena-parent</artifactId>
-    <version>15-SNAPSHOT</version>
-    <relativePath>../../jena-parent</relativePath>
-  </parent> 
+	<properties>
+		<pax.exam.version>4.4.0</pax.exam.version>
+	</properties>
 
-  <artifactId>jena-osgi-test</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
-  <name>Apache Jena - OSGi integration tests</name>
-  <description>Tests for jena-osgi as a bundle</description>
-  <packaging>bundle</packaging>
+	<repositories>
+		<repository>
+			<id>apache.snapshots</id>
+			<name>Apache Snapshot Repository</name>
+			<url>http://repository.apache.org/snapshots</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>		    
+	</repositories>
 
-  <properties>
-    <felix.version>4.6.0</felix.version>
-    <pax.exam.version>4.4.0</pax.exam.version>
-    <pax.url.version>1.6.0</pax.url.version>
-    <pax.logging.version>1.8.1</pax.logging.version>
-  </properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.jena</groupId>
+			<artifactId>jena-osgi</artifactId>
+			<version>3.1.0-SNAPSHOT</version>
+			<type>bundle</type>
+			<scope>test</scope>
+		</dependency>
 
-  <repositories>
-    <repository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>http://repository.apache.org/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-    </repository>
-  </repositories>
+		<dependency>
+			<groupId>org.ops4j.pax.exam</groupId>
+			<artifactId>pax-exam-container-karaf</artifactId>
+			<version>${pax.exam.version}</version>
+			<scope>test</scope>
+		</dependency>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-osgi</artifactId>
-      <version>${project.version}</version>
-      <type>bundle</type>
-      <scope>test</scope>
-    </dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.exam</groupId>
+			<artifactId>pax-exam-junit4</artifactId>
+			<version>${pax.exam.version}</version>
+			<scope>test</scope>
+		</dependency>
 
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.core</artifactId>
-      <version>5.0.0</version>
-      <scope>provided</scope>
-    </dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.exam</groupId>
+			<artifactId>pax-exam-link-mvn</artifactId>
+			<version>${pax.exam.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- needed to get a org.slf4j bundle for PAX 
-         as we exclude slf4j-log4j due to 
-         "Fragment bundle" warning -->
-    <dependency>
-      <groupId>org.ops4j.pax.logging</groupId>
-      <artifactId>pax-logging-log4j2</artifactId>
-      <version>${pax.logging.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ops4j.pax.logging</groupId>
-      <artifactId>pax-logging-api</artifactId>
-      <version>${pax.logging.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.ops4j.pax.exam</groupId>
-      <artifactId>pax-exam-container-native</artifactId>
-      <version>${pax.exam.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.ops4j.pax.exam</groupId>
-      <artifactId>pax-exam-junit4</artifactId>
-      <version>${pax.exam.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.ops4j.pax.exam</groupId>
-      <artifactId>pax-exam-link-mvn</artifactId>
-      <version>${pax.exam.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.ops4j.pax.url</groupId>
-      <artifactId>pax-url-aether</artifactId>
-      <version>${pax.url.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- OSGi Frameworks -->
-    <dependency>
-      <groupId>org.eclipse</groupId>
-      <artifactId>osgi</artifactId>
-      <version>3.9.1-v20140110-1610</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- NOTE: Make sure eclipse-osgi (equinox) is first -->
-    <dependency>
-      <groupId>org.apache.felix</groupId>
-      <artifactId>org.apache.felix.framework</artifactId>
-      <version>${felix.version}</version>
-      <scope>test</scope>
-    </dependency>
-    
-  </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <!-- re-enable extensions here for older Mavens -->
-        <extensions>true</extensions>
-      </plugin>
-      <plugin>
-        <!-- generate target/pax-exam-links -->
-        <groupId>org.ops4j.pax.exam</groupId>
-        <artifactId>exam-maven-plugin</artifactId>
-        <version>${pax.exam.version}</version>
-        <executions>
-          <execution>
-            <id>generate-link-files</id>
-            <goals>
-              <goal>generate-link-files</goal>
-            </goals>
-            <phase>generate-test-resources</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <execution>
-            <!-- delay test compilation until pre-integration-test phase -->
-            <id>default-testCompile</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <phase>pre-integration-test</phase>
-          </execution>
-        </executions>
-        <configuration>
-        </configuration>
-
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <classpathDependencyExcludes>
-            <classpathDependencyExclude>org.slf4j:slf4j-log4j12</classpathDependencyExclude>
-          </classpathDependencyExcludes>
-          <systemPropertyVariables>
-            <!-- So the test can find the current version of jena-osgi -->
-            <jena-osgi.version>${project.version}</jena-osgi.version>
-            <!-- not so noisy OSGi logging -->
-            <org.ops4j.pax.logging.DefaultServiceLog.level>WARN</org.ops4j.pax.logging.DefaultServiceLog.level>
-          </systemPropertyVariables>
-        </configuration>
-        <!-- Explicit execution to run in a phase after the OSGi bundle
-             has been created -->
-        <executions>
-          <execution>
-            <id>default-test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <!-- delay until integration-test phase -->
-            <phase>integration-test</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>verify</id>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/apache-jena-osgi/jena-osgi-test/pom.xml
+++ b/apache-jena-osgi/jena-osgi-test/pom.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-	license agreements. See the NOTICE file distributed with this work for additional 
-	information regarding copyright ownership. The ASF licenses this file to 
-	You under the Apache License, Version 2.0 (the "License"); you may not use 
-	this file except in compliance with the License. You may obtain a copy of 
-	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-	by applicable law or agreed to in writing, software distributed under the 
-	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-	OF ANY KIND, either express or implied. See the License for the specific 
-	language governing permissions and limitations under the License. -->
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -42,6 +48,14 @@
 	</repositories>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.apache.jena</groupId>
+			<artifactId>jena-osgi-features</artifactId>  
+			<version>3.1.0-SNAPSHOT</version>
+			<type>bundle</type>
+			<scope>test</scope>
+		</dependency>
+		
 		<dependency>
 			<groupId>org.apache.jena</groupId>
 			<artifactId>jena-osgi</artifactId>

--- a/apache-jena-osgi/jena-osgi-test/src/test/java/org/apache/jena/osgi/test/JenaOSGITest.java
+++ b/apache-jena-osgi/jena-osgi-test/src/test/java/org/apache/jena/osgi/test/JenaOSGITest.java
@@ -79,8 +79,7 @@ public class JenaOSGITest {
 								.artifactId("apache-karaf").type("zip")
 								.version("3.0.6")).useDeployFolder(false),
 				
-								mavenBundle("org.apache.aries.spifly",
-						"org.apache.aries.spifly.dynamic.bundle", "1.0.8"),
+				//mavenBundle("org.apache.aries.spifly","org.apache.aries.spifly.dynamic.bundle", "1.0.8"),
 
 				mavenBundle("org.apache.jena", "jena-osgi", "3.1.0-SNAPSHOT"),
 				mavenBundle("com.github.andrewoma.dexx", "collection", "0.6.0-SNAPSHOT"),

--- a/apache-jena-osgi/jena-osgi-test/src/test/java/org/apache/jena/osgi/test/JenaOSGITest.java
+++ b/apache-jena-osgi/jena-osgi-test/src/test/java/org/apache/jena/osgi/test/JenaOSGITest.java
@@ -83,23 +83,17 @@ public class JenaOSGITest {
 						"org.apache.aries.spifly.dynamic.bundle", "1.0.8"),
 
 				mavenBundle("org.apache.jena", "jena-osgi", "3.1.0-SNAPSHOT"),
-				mavenBundle("com.github.andrewoma.dexx", "collection", "0.4.0"),
+				mavenBundle("com.github.andrewoma.dexx", "collection", "0.6.0-SNAPSHOT"),
 				mavenBundle("com.github.jsonld-java", "jsonld-java", "0.8.0"),
-				mavenBundle("org.apache.httpcomponents", "httpcore-osgi",
-						"4.4.4"),
-				mavenBundle("org.apache.httpcomponents", "httpclient-osgi",
-						"4.5.1"),
+				mavenBundle("org.apache.httpcomponents", "httpcore-osgi","4.4.4"),
+				mavenBundle("org.apache.httpcomponents", "httpclient-osgi","4.5.1"),
 				mavenBundle("commons-cli", "commons-cli", "1.3.1"),
 				mavenBundle("org.apache.commons", "commons-csv", "1.2"),
 				mavenBundle("org.apache.commons", "commons-lang3", "3.4"),
 				mavenBundle("org.apache.thrift", "libthrift", "0.9.3"),
-
-				mavenBundle("com.fasterxml.jackson.core", "jackson-core",
-						"2.6.3"),
-				mavenBundle("com.fasterxml.jackson.core", "jackson-databind",
-						"2.6.3"),
-				mavenBundle("com.fasterxml.jackson.core",
-						"jackson-annotations", "2.6.3")
+				mavenBundle("com.fasterxml.jackson.core", "jackson-core","2.6.3"),
+				mavenBundle("com.fasterxml.jackson.core", "jackson-databind","2.6.3"),
+				mavenBundle("com.fasterxml.jackson.core","jackson-annotations", "2.6.3")
 
 		);
 

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -233,27 +233,29 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <!-- re-enable extensions here for older Mavens -->
         <extensions>true</extensions>
-        <configuration>
+        <configuration>		  
           <instructions>
-            <Export-Package>org.apache.jena.*,!org.apache.jena.ext.*</Export-Package>
+            <Export-Package>org.apache.jena.*,!org.apache.jena.ext.*</Export-Package>			
             <Embed-Dependency>artifactId=jena*;inline=true</Embed-Dependency>
-            <!--
+			<!--            
             <Embed-Dependency>artifactId=jena*;inline=true,artifactId=xercesImpl;inline=true,artifactId=xml-apis;inline=true</Embed-Dependency>
             -->
             <Embed-Transitive>true</Embed-Transitive>
-            <!-- Do not embed but import Xerces classes via OSGi -->
+            <!-- Do not embed but import Xerces classes via OSGi -->			
             <Import-Package>org.osgi.framework.*,org.apache.xml.*,org.apache.xerces.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
-            <!--
+			<!--
             <Import-Package>org.osgi.framework.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
-            -->
+			-->
             <Private-Package>org.apache.jena.ext.*</Private-Package>
-            <Bundle-Activator>org.apache.jena.osgi.Activator</Bundle-Activator>
+            <!--<Bundle-Activator>org.apache.jena.osgi.Activator</Bundle-Activator>-->
             <!-- Standard headers according to OSGi 133 Service Loader Mediator Specification -->
+			<!-- Not needed, if JenaSubsystemRegistryBasic (jena-core) uses an explicit classloader
 			<Require-Capability>
 			  osgi.extender; filter:="(|(osgi.extender=osgi.serviceloader.registrar)(osgi.extender=osgi.serviceloader.processor))",
 			  osgi.serviceloader; filter:="(osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle)";cardinality:=multiple						
 			</Require-Capability>
 			<Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle</Provide-Capability>						
+			-->
 			<!-- SPI-* headers work only with Apache Aries SPI Fly -->
             <!--
 				<SPI-Consumer>*</SPI-Consumer>

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>apache-jena-osgi</artifactId>
     <version>3.1.0-SNAPSHOT</version>
   </parent>
-  <artifactId>jena-osgi</artifactId>
+  <artifactId>jena-osgi</artifactId>  
   <packaging>bundle</packaging>
   <name>Apache Jena - OSGi bundle</name>
   <description>
@@ -236,22 +236,29 @@
         <configuration>
           <instructions>
             <Export-Package>org.apache.jena.*,!org.apache.jena.ext.*</Export-Package>
+            <Embed-Dependency>artifactId=jena*;inline=true</Embed-Dependency>
+            <!--
             <Embed-Dependency>artifactId=jena*;inline=true,artifactId=xercesImpl;inline=true,artifactId=xml-apis;inline=true</Embed-Dependency>
+            -->
             <Embed-Transitive>true</Embed-Transitive>
+            <!-- Do not embed but import Xerces classes via OSGi -->
+            <Import-Package>org.osgi.framework.*,org.apache.xml.*,org.apache.xerces.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
+            <!--
             <Import-Package>org.osgi.framework.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
+            -->
             <Private-Package>org.apache.jena.ext.*</Private-Package>
             <Bundle-Activator>org.apache.jena.osgi.Activator</Bundle-Activator>
             <!-- Standard headers according to OSGi 133 Service Loader Mediator Specification -->
-						<Require-Capability>
-						  osgi.extender; filter:="(|(osgi.extender=osgi.serviceloader.registrar)(osgi.extender=osgi.serviceloader.processor))",
-						  osgi.serviceloader; filter:="(osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle)";cardinality:=multiple						
-            </Require-Capability>
-						<Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle</Provide-Capability>						
-						<!-- SPI-* headers work only with Apache Aries SPI Fly -->
+			<Require-Capability>
+			  osgi.extender; filter:="(|(osgi.extender=osgi.serviceloader.registrar)(osgi.extender=osgi.serviceloader.processor))",
+			  osgi.serviceloader; filter:="(osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle)";cardinality:=multiple						
+			</Require-Capability>
+			<Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle</Provide-Capability>						
+			<!-- SPI-* headers work only with Apache Aries SPI Fly -->
             <!--
-            <SPI-Consumer>*</SPI-Consumer>
-						<SPI-Provider>*</SPI-Provider>
-						-->
+				<SPI-Consumer>*</SPI-Consumer>
+				<SPI-Provider>*</SPI-Provider>	
+			-->
           </instructions>
         </configuration>
       </plugin>

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -219,6 +219,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <version>5.0.0</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -233,8 +238,20 @@
             <Export-Package>org.apache.jena.*,!org.apache.jena.ext.*</Export-Package>
             <Embed-Dependency>artifactId=jena*;inline=true,artifactId=xercesImpl;inline=true,artifactId=xml-apis;inline=true</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
-            <Import-Package>!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
+            <Import-Package>org.osgi.framework.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
             <Private-Package>org.apache.jena.ext.*</Private-Package>
+            <Bundle-Activator>org.apache.jena.osgi.Activator</Bundle-Activator>
+            <!-- Standard headers according to OSGi 133 Service Loader Mediator Specification -->
+						<Require-Capability>
+						  osgi.extender; filter:="(|(osgi.extender=osgi.serviceloader.registrar)(osgi.extender=osgi.serviceloader.processor))",
+						  osgi.serviceloader; filter:="(osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle)";cardinality:=multiple						
+            </Require-Capability>
+						<Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle</Provide-Capability>						
+						<!-- SPI-* headers work only with Apache Aries SPI Fly -->
+            <!--
+            <SPI-Consumer>*</SPI-Consumer>
+						<SPI-Provider>*</SPI-Provider>
+						-->
           </instructions>
         </configuration>
       </plugin>

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -233,34 +233,21 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <!-- re-enable extensions here for older Mavens -->
         <extensions>true</extensions>
-        <configuration>		  
+        <configuration>
           <instructions>
-            <Export-Package>org.apache.jena.*,!org.apache.jena.ext.*</Export-Package>			
+            <Export-Package>org.apache.jena.*,!org.apache.jena.ext.*</Export-Package>            
             <Embed-Dependency>artifactId=jena*;inline=true</Embed-Dependency>
 			<!--            
             <Embed-Dependency>artifactId=jena*;inline=true,artifactId=xercesImpl;inline=true,artifactId=xml-apis;inline=true</Embed-Dependency>
             -->
             <Embed-Transitive>true</Embed-Transitive>
             <!-- Do not embed but import Xerces classes via OSGi -->			
-            <Import-Package>org.osgi.framework.*,org.apache.xml.*,org.apache.xerces.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
+            <Import-Package>org.osgi.framework.*,org.apache.xml.*,org.apache.xerces.*;version="2.11.0",!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
 			<!--
             <Import-Package>org.osgi.framework.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
 			-->
             <Private-Package>org.apache.jena.ext.*</Private-Package>
-            <!--<Bundle-Activator>org.apache.jena.osgi.Activator</Bundle-Activator>-->
-            <!-- Standard headers according to OSGi 133 Service Loader Mediator Specification -->
-			<!-- Not needed, if JenaSubsystemRegistryBasic (jena-core) uses an explicit classloader
-			<Require-Capability>
-			  osgi.extender; filter:="(|(osgi.extender=osgi.serviceloader.registrar)(osgi.extender=osgi.serviceloader.processor))",
-			  osgi.serviceloader; filter:="(osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle)";cardinality:=multiple						
-			</Require-Capability>
-			<Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.apache.jena.system.JenaSubsystemLifecycle</Provide-Capability>						
-			-->
-			<!-- SPI-* headers work only with Apache Aries SPI Fly -->
-            <!--
-				<SPI-Consumer>*</SPI-Consumer>
-				<SPI-Provider>*</SPI-Provider>	
-			-->
+            <Bundle-Activator>org.apache.jena.osgi.Activator</Bundle-Activator>
           </instructions>
         </configuration>
       </plugin>

--- a/apache-jena-osgi/jena-osgi/src/main/java/org/apache/jena/osgi/Activator.java
+++ b/apache-jena-osgi/jena-osgi/src/main/java/org/apache/jena/osgi/Activator.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.jena.osgi;
 
 import org.apache.jena.system.JenaSubsystemRegistry;
@@ -6,28 +24,11 @@ import org.apache.jena.system.JenaSystem;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
+// Sample bundle activator explicitly calling the static Jena initialization.
 public class Activator implements BundleActivator {
-	
-	/* 
-	 * Based on http://svn.apache.org/repos/asf/aries/trunk/spi-fly/spi-fly-examples/spi-fly-example-provider-consumer-bundle/src/main/java/org/apache/aries/spifly/pc/bundle/Activator.java
-	 * the Activator#start() waits for bundle extension by Aries SPI Fly, configures JenaSystem logging and requests for initialization.     
-	 */
+
 	public void start(BundleContext context) throws Exception {
 
-		Thread t = new Thread(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					Thread.sleep(500);
-				} catch (InterruptedException e) {
-				}				
-				setUpJena();
-			}
-		});
-		t.start();
-	}
-
-	private void setUpJena() {
 		JenaSubsystemRegistry r = new JenaSubsystemRegistryBasic() {
 			@Override
 			public void load() {
@@ -38,7 +39,6 @@ public class Activator implements BundleActivator {
 		JenaSystem.DEBUG_INIT = true;
 		JenaSystem.init();
 		System.out.println("Jena-OSGi bundle configuration done!");
-		
 	}
 
 	public void stop(BundleContext context) throws Exception {

--- a/apache-jena-osgi/jena-osgi/src/main/java/org/apache/jena/osgi/Activator.java
+++ b/apache-jena-osgi/jena-osgi/src/main/java/org/apache/jena/osgi/Activator.java
@@ -1,0 +1,47 @@
+package org.apache.jena.osgi;
+
+import org.apache.jena.system.JenaSubsystemRegistry;
+import org.apache.jena.system.JenaSubsystemRegistryBasic;
+import org.apache.jena.system.JenaSystem;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+public class Activator implements BundleActivator {
+	
+	/* 
+	 * Based on http://svn.apache.org/repos/asf/aries/trunk/spi-fly/spi-fly-examples/spi-fly-example-provider-consumer-bundle/src/main/java/org/apache/aries/spifly/pc/bundle/Activator.java
+	 * the Activator#start() waits for bundle extension by Aries SPI Fly, configures JenaSystem logging and requests for initialization.     
+	 */
+	public void start(BundleContext context) throws Exception {
+
+		Thread t = new Thread(new Runnable() {
+			@Override
+			public void run() {
+				try {
+					Thread.sleep(500);
+				} catch (InterruptedException e) {
+				}				
+				setUpJena();
+			}
+		});
+		t.start();
+	}
+
+	private void setUpJena() {
+		JenaSubsystemRegistry r = new JenaSubsystemRegistryBasic() {
+			@Override
+			public void load() {
+				super.load();
+			}
+		};
+		JenaSystem.setSubsystemRegistry(r);
+		JenaSystem.DEBUG_INIT = true;
+		JenaSystem.init();
+		System.out.println("Jena-OSGi bundle configuration done!");
+		
+	}
+
+	public void stop(BundleContext context) throws Exception {
+
+	}
+}

--- a/apache-jena-osgi/pom.xml
+++ b/apache-jena-osgi/pom.xml
@@ -49,6 +49,8 @@
       See JENA-913 - this breaks a clean build unless "install" is used.
     <module>jena-osgi-test</module>
     -->
+    <module>jena-osgi-features</module>
+    <module>jena-osgi-test</module>
   </modules>
   
 </project>

--- a/jena-core/src/main/java/org/apache/jena/system/JenaSubsystemRegistryBasic.java
+++ b/jena-core/src/main/java/org/apache/jena/system/JenaSubsystemRegistryBasic.java
@@ -40,7 +40,7 @@ public class JenaSubsystemRegistryBasic implements JenaSubsystemRegistry {
     public void load() {
         synchronized (registryLock) {
             // Find subsystems asking for initialization. 
-            ServiceLoader<JenaSubsystemLifecycle> sl = ServiceLoader.load(JenaSubsystemLifecycle.class) ;
+            ServiceLoader<JenaSubsystemLifecycle> sl = ServiceLoader.load(JenaSubsystemLifecycle.class,this.getClass().getClassLoader()) ;
             sl.forEach(this::add) ;
         }
     }


### PR DESCRIPTION
This is a suggestion to fix errors in static initialization of Jena 3 in OSGi environments folowing the OSGi ServiceLoader Mediator spec. The appropriate manifest headers and a bundle activator were added: 

 http://mail-archives.apache.org/mod_mbox/jena-users/201603.mbox/%3C2804-56ee5500-b-5266a380%40181641092%3E

The original integration test (jena-osgi-test) was ineffective. Missing a runtime configuration the test methods did not run/never failed on my side. It works for Apache Karaf now. 

Please install the uploaded, OSGi-fied dependency com.github.andrewoma.dexx:collection: 

mvn install:install-file -Dfile=collection-0.4.0.jar -DgroupId=com.github.andrewoma.dexx -DartifactId=collection -Dversion=0.4.0 -Dpackaging=jar

and run the integration test: mvn -Drat.ignoreErrors=true clean integration-test

If needed, I'll extend the test to cover other OSGi environments (Equinox etc.)

[collection-0.4.0.zip](https://github.com/apache/jena/files/202677/collection-0.4.0.zip)
