### PR TITLE
JENA-1172: restore support for blank nodes in jena-text

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/TextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextQueryPF.java
@@ -232,18 +232,13 @@ public class TextQueryPF extends PropertyFunctionBase {
     }
 
     private QueryIterator concreteSubject(Binding binding, Node s, Node score, Node literal, StrMatch match, ExecutionContext execCxt) {
-        if (!s.isURI()) {
-            log.warn("Subject not a URI: " + s) ;
-            return IterLib.noResults(execCxt) ;
-        }
-
         String qs = match.getQueryString() ;
         ListMultimap<String,TextHit> x = query(match.getProperty(), match.getQueryString(), -1, execCxt) ;
         
         if ( x == null ) // null return value - empty result
             return IterLib.noResults(execCxt) ;
         
-        List<TextHit> r = x.get(s.getURI());
+        List<TextHit> r = x.get(TextQueryFuncs.subjectToString(s));
 
         return resultsToQueryIterator(binding, s, score, literal, r, execCxt);
     }
@@ -292,7 +287,7 @@ public class TextQueryPF extends PropertyFunctionBase {
             List<TextHit> resultList = textIndex.query(property, queryStr, limit) ;
             ListMultimap<String,TextHit> resultMultimap = LinkedListMultimap.create();
             for (TextHit result : resultList) {
-                resultMultimap.put(result.getNode().getURI(), result);
+                resultMultimap.put(TextQueryFuncs.subjectToString(result.getNode()), result);
             }
             return resultMultimap;
         });

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextTDB.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextTDB.java
@@ -200,6 +200,27 @@ public class TestTextTDB extends BaseTest
         assertEquals(1,x.size());
     }
 
+    @Test public void textDB_8_bnode_subject() {
+        Dataset ds = create() ;
+        data(ds, 
+            "(<ex:g1> _:s1 rdfs:label 'foo')");
+        
+        ds.begin(ReadWrite.READ) ;
+        String qs = StrUtils.strjoinNL(
+            "PREFIX text:   <http://jena.apache.org/text#>",
+            "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+            "SELECT *",
+            "FROM <ex:g1>",
+            "{ ?s text:query 'foo' }"
+            ) ;
+        Query q = QueryFactory.create(qs) ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        ds.end() ;
+        assertEquals(1,x.size());
+    }
+
     private static void data(Dataset ds, String... quadStrs) {
         for ( String qs : quadStrs ) {
             Quad quad = SSE.parseQuad(qs) ;


### PR DESCRIPTION
It seems that jena-text used to support blank nodes in the text index (there is some infrastructure to support this, particularly in TextQueryFuncs) but this was broken by JENA-999 (internal caching) or possibly even earlier. There were no unit tests involving blank nodes that would have caught this.

This PR restores support for blank node subjects. There are a couple of very basic unit tests that check the basic functionality.