### PR TITLE
Version bumps

### DIFF
--- a/jena-elephas/jena-elephas-mapreduce/src/test/java/org/apache/jena/hadoop/rdf/mapreduce/characteristics/CharacteristicSetReducerTest.java
+++ b/jena-elephas/jena-elephas-mapreduce/src/test/java/org/apache/jena/hadoop/rdf/mapreduce/characteristics/CharacteristicSetReducerTest.java
@@ -103,9 +103,10 @@ public class CharacteristicSetReducerTest
                 .getMapReduceDriver();
 
         this.createSet(driver, 2, 1, "http://predicate");
-
         driver.runTest(false);
-
+        
+        driver = getMapReduceDriver();
+        createSet(driver, 2, 1, "http://predicate");
         List<Pair<CharacteristicSetWritable, NullWritable>> results = driver.run();
         CharacteristicSetWritable cw = results.get(0).getFirst();
         Assert.assertEquals(2, cw.getCount().get());
@@ -139,9 +140,11 @@ public class CharacteristicSetReducerTest
 
         this.createSet(driver, 2, 1, "http://predicate");
         this.createSet(driver, 1, 1, "http://other");
-
         driver.runTest(false);
-
+        
+        driver = getMapReduceDriver();
+        createSet(driver, 2, 1, "http://predicate");
+        createSet(driver, 1, 1, "http://other");
         List<Pair<CharacteristicSetWritable, NullWritable>> results = driver.run();
         for (Pair<CharacteristicSetWritable, NullWritable> pair : results) {
             CharacteristicSetWritable cw = pair.getFirst();
@@ -178,9 +181,11 @@ public class CharacteristicSetReducerTest
 
         this.createSet(driver, 2, 1, "http://predicate", "http://other");
         this.createSet(driver, 1, 1, "http://other");
-
         driver.runTest(false);
-
+        
+        driver = getMapReduceDriver();
+        createSet(driver, 2, 1, "http://predicate", "http://other");
+        createSet(driver, 1, 1, "http://other");
         List<Pair<CharacteristicSetWritable, NullWritable>> results = driver.run();
         for (Pair<CharacteristicSetWritable, NullWritable> pair : results) {
             CharacteristicSetWritable cw = pair.getFirst();

--- a/jena-elephas/pom.xml
+++ b/jena-elephas/pom.xml
@@ -40,7 +40,7 @@
   <!-- Properties common across all profiles -->
   <properties>
     <plugin.compiler.version>2.6.0</plugin.compiler.version>
-    <mrunit.version>1.0.0</mrunit.version>
+    <mrunit.version>1.1.0</mrunit.version>
     <airline.version>2.1.1</airline.version>
   </properties>
 

--- a/jena-elephas/pom.xml
+++ b/jena-elephas/pom.xml
@@ -41,7 +41,7 @@
   <properties>
     <plugin.compiler.version>2.6.0</plugin.compiler.version>
     <mrunit.version>1.0.0</mrunit.version>
-    <airline.version>2.1.0</airline.version>
+    <airline.version>2.1.1</airline.version>
   </properties>
 
 	<!-- Profiles to allow building for different Hadoop versions -->

--- a/jena-parent/pom.xml
+++ b/jena-parent/pom.xml
@@ -47,7 +47,7 @@
   </organization>
 
   <properties>
-    <ver.slf4j>1.7.20</ver.slf4j>
+    <ver.slf4j>1.7.21</ver.slf4j>
     <ver.log4j>1.2.17</ver.log4j>
     <ver.junit>4.12</ver.junit>
     <ver.xerces>2.11.0</ver.xerces>
@@ -65,13 +65,13 @@
     <ver.httpcore-osgi>4.2.5</ver.httpcore-osgi>
     <ver.httpclient-osgi>4.2.6</ver.httpclient-osgi>
 
-    <ver.commons-codec>1.9</ver.commons-codec>
+    <ver.commons-codec>1.10</ver.commons-codec>
     <ver.lucene>4.9.1</ver.lucene>
     <ver.solr>4.9.1</ver.solr>
-    <ver.spatial4j>0.4.1</ver.spatial4j>
+    <ver.spatial4j>0.5</ver.spatial4j>
 
     <ver.mockito>1.9.5</ver.mockito>
-    <ver.awaitility>1.6.4</ver.awaitility>
+    <ver.awaitility>1.7.0</ver.awaitility>
 
     <jdk.version>1.8</jdk.version>
     <targetJdk>${jdk.version}</targetJdk> <!-- MPMD-86 workaround -->
@@ -154,7 +154,7 @@
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
-        <version>0.9.2</version>
+        <version>0.9.3</version>
         <exclusions>
           <!-- Use whatever version Jena is using -->
           <exclusion>
@@ -171,13 +171,13 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
-        <version>1.0</version>
+        <version>1.3</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.3.2</version>
+        <version>3.4</version>
       </dependency>
 
       <dependency>
@@ -189,7 +189,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.0</version>
+        <version>4.1</version>
       </dependency>
       
       <!-- supports persistent data structures -->


### PR DESCRIPTION
There are two commits in this PR. The first, I think, should be entirely straightforward. The second contains a minor version bump for `mrunit`. In order to do this, I updated `CharacteristicSetReducerTest` to meet what seems to be a slight change in the semantics for `mrunit`'s `TestDriver` type at this new version (it cannot be "reused" by calling `runTest()` and then `run()`, you have to use a new test driver). I believe I did this correctly, but it should be examined extra-carefully.