### PR TITLE
JENA-1180: Add support for ComplexPhraseQueryParser to jena-text

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
@@ -68,11 +68,16 @@ public class AssemblerUtils
         register(ConstAssembler.general(), r, a, DatasetAssembler.getType()) ;
     }
 
+    /** Register an assembler that creates a dataset */
+    static public void registerModel(Resource r, Assembler a) {
+        register(ConstAssembler.general(), r, a, JA.Model) ;
+    }
+
     /** Register an addition assembler */  
     static public void register(AssemblerGroup g, Resource r, Assembler a, Resource superType) {
         registerAssembler(g, r, a) ;
         if ( superType != null && ! superType.equals(r) ) 
-            modelExtras.add(r, RDFS.subClassOf, DatasetAssembler.getType()) ;
+            modelExtras.add(r, RDFS.subClassOf, superType) ;
     }
     
     /** register */ 

--- a/jena-cmds/pom.xml
+++ b/jena-cmds/pom.xml
@@ -87,9 +87,8 @@
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency> 
-    
-    <!-- Testing -->
 
+    <!-- Testing -->
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-arq</artifactId>

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/assembler/VocabTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/assembler/VocabTDB.java
@@ -71,6 +71,6 @@ public class VocabTDB
             return;
         initialized = true;
         AssemblerUtils.registerDataset(tDatasetTDB, new DatasetAssemblerTDB());
-        AssemblerUtils.register(ConstAssembler.general(), tGraphTDB, new TDBGraphAssembler(), JA.Model);
+        AssemblerUtils.registerModel(tGraphTDB, new TDBGraphAssembler());
     }
 }

--- a/jena-tdb/testing/Assembler/tdb-dataset-embed.ttl
+++ b/jena-tdb/testing/Assembler/tdb-dataset-embed.ttl
@@ -18,10 +18,6 @@
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
 
-[] ja:loadClass "org.apache.jena.tdb.TDB" .
-tdb:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
-## tdb:GraphTDB    rdfs:subClassOf  ja:Model .
-
 <#dataset> rdf:type      tdb:DatasetTDB ;
     tdb:location "--mem--" ;
     .

--- a/jena-tdb/testing/Assembler/tdb-dataset.ttl
+++ b/jena-tdb/testing/Assembler/tdb-dataset.ttl
@@ -17,8 +17,6 @@
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
 
-[] ja:loadClass "org.apache.jena.tdb.TDB" .
-
 <#dataset> rdf:type      tdb:DatasetTDB ;
     # Do at least one the long way.
     tdb:location "target/tdb-testing/DB" ;

--- a/jena-tdb/testing/Assembler/tdb-graph-embed.ttl
+++ b/jena-tdb/testing/Assembler/tdb-graph-embed.ttl
@@ -18,10 +18,6 @@
 @prefix rdfs:	    <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
 
-[] ja:loadClass "org.apache.jena.tdb.TDB" .
-## tdb:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
-tdb:GraphTDB    rdfs:subClassOf  ja:Model .
-
 <#dataset> rdf:type      ja:RDFDataset ;
     ja:defaultGraph <#graph> ;
     . 

--- a/jena-tdb/testing/Assembler/tdb-graph-ref-dataset.ttl
+++ b/jena-tdb/testing/Assembler/tdb-graph-ref-dataset.ttl
@@ -17,8 +17,6 @@
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
 
-[] ja:loadClass "org.apache.jena.tdb.TDB" .
-
 <#dataset> rdf:type      ja:RDFDataset ;
     ja:defaultGraph <#graph> ;
     . 

--- a/jena-tdb/testing/Assembler/tdb-graph.ttl
+++ b/jena-tdb/testing/Assembler/tdb-graph.ttl
@@ -17,8 +17,6 @@
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
 
-[] ja:loadClass "org.apache.jena.tdb.TDB" .
-
 <#dataset> rdf:type      ja:RDFDataset ;
     ja:defaultGraph <#graph> ;
     . 

--- a/jena-tdb/testing/Assembler/tdb-named-graph-1.ttl
+++ b/jena-tdb/testing/Assembler/tdb-named-graph-1.ttl
@@ -17,8 +17,6 @@
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
 
-[] ja:loadClass "org.apache.jena.tdb.TDB" .
-
 <#dataset> rdf:type      ja:RDFDataset ;
     ja:defaultGraph <#graph> ;
     . 

--- a/jena-tdb/testing/Assembler/tdb-named-graph-2.ttl
+++ b/jena-tdb/testing/Assembler/tdb-named-graph-2.ttl
@@ -17,8 +17,6 @@
 @prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
 
-[] ja:loadClass "org.apache.jena.tdb.TDB" .
-
 <#dataset> rdf:type      ja:RDFDataset ;
     ja:defaultGraph <#graph> ;
     . 

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
@@ -35,6 +35,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer ;
 import org.apache.lucene.document.* ;
 import org.apache.lucene.index.* ;
 import org.apache.lucene.queryparser.analyzing.AnalyzingQueryParser ;
+import org.apache.lucene.queryparser.complexPhrase.ComplexPhraseQueryParser ;
 import org.apache.lucene.queryparser.classic.ParseException ;
 import org.apache.lucene.queryparser.classic.QueryParser ;
 import org.apache.lucene.queryparser.classic.QueryParserBase ;
@@ -291,13 +292,15 @@ public class TextIndexLucene implements TextIndex {
             throw new TextIndexException(ex) ;
         }
     }
-    
+
     private QueryParser getQueryParser(Analyzer analyzer) {
         switch(queryParserType) {
             case "QueryParser":
                 return new QueryParser(VER, docDef.getPrimaryField(), analyzer) ;
             case "AnalyzingQueryParser":
                 return new AnalyzingQueryParser(VER, docDef.getPrimaryField(), analyzer) ;
+            case "ComplexPhraseQueryParser":
+                return new ComplexPhraseQueryParser(VER, docDef.getPrimaryField(), analyzer);
             default:
                 log.warn("Unknown query parser type '" + queryParserType + "'. Defaulting to standard QueryParser") ;
                 return new QueryParser(VER, docDef.getPrimaryField(), analyzer) ;
@@ -310,7 +313,7 @@ public class TextIndexLucene implements TextIndex {
         Query query = queryParser.parse(queryString) ;
         return query ;
     }
-    
+
     protected Query preParseQuery(String queryString, Analyzer analyzer) throws ParseException {
         return parseQuery(queryString, analyzer);
     }

--- a/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithAnalyzer.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text;
+
+import java.io.Reader ;
+import java.io.StringReader ;
+
+import org.apache.jena.assembler.Assembler ;
+import org.apache.jena.atlas.lib.StrUtils ;
+import org.apache.jena.query.Dataset ;
+import org.apache.jena.query.text.assembler.TextAssembler ;
+import org.apache.jena.rdf.model.Model ;
+import org.apache.jena.rdf.model.ModelFactory ;
+import org.apache.jena.rdf.model.Resource ;
+import org.junit.After ;
+import org.junit.Before ;
+
+/**
+ * This abstract class defines a setup configuration for a dataset that uses a specific analyzer with a Lucene index.
+ */
+public abstract class AbstractTestDatasetWithAnalyzer extends AbstractTestDatasetWithTextIndexBase {
+
+    private static final String SPEC_BASE = "http://example.org/spec#";
+    private static final String SPEC_ROOT_LOCAL = "lucene_text_dataset";
+    private static final String SPEC_ROOT_URI = SPEC_BASE + SPEC_ROOT_LOCAL;
+
+    private static String makeSpec(String analyzer, String parser) {
+        return StrUtils.strjoinNL(
+                    "prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> ",
+                    "prefix ja:   <http://jena.hpl.hp.com/2005/11/Assembler#> ",
+                    "prefix tdb:  <http://jena.hpl.hp.com/2008/tdb#>",
+                    "prefix text: <http://jena.apache.org/text#>",
+                    "prefix :     <" + SPEC_BASE + ">",
+                    "",
+                    "[] ja:loadClass    \"org.apache.jena.query.text.TextQuery\" .",
+                    "text:TextDataset      rdfs:subClassOf   ja:RDFDataset .",
+                    "text:TextIndexLucene  rdfs:subClassOf   text:TextIndex .",
+                    
+                    ":" + SPEC_ROOT_LOCAL,
+                    "    a              text:TextDataset ;",
+                    "    text:dataset   :dataset ;",
+                    "    text:index     :indexLucene ;",
+                    "    .",
+                    "",
+                    ":dataset",
+                    "    a               ja:RDFDataset ;",
+                    "    ja:defaultGraph :graph ;",
+                    ".",
+                    ":graph",
+                    "    a               ja:MemoryModel ;",
+                    ".",
+                    "",
+                    ":indexLucene",
+                    "    a text:TextIndexLucene ;",
+                    "    text:directory \"mem\" ;",
+                    "    text:queryParser " + parser + ";",
+                    "    text:entityMap :entMap ;",
+                    "    .",
+                    "",
+                    ":entMap",
+                    "    a text:EntityMap ;",
+                    "    text:entityField      \"uri\" ;",
+                    "    text:defaultField     \"label\" ;",
+                    "    text:map (",
+                    "         [ text:field \"label\" ; ",
+                    "           text:predicate rdfs:label ;",
+                    "           text:analyzer [ a " + analyzer + " ]",
+                    "         ]",
+                    "         [ text:field \"comment\" ; text:predicate rdfs:comment ]",
+                    "         ) ."
+                    );
+    }      
+    
+    public void init(String analyzer, String parser) {
+        Reader reader = new StringReader(makeSpec(analyzer, parser));
+        Model specModel = ModelFactory.createDefaultModel();
+        specModel.read(reader, "", "TURTLE");
+        TextAssembler.init();            
+        Resource root = specModel.getResource(SPEC_ROOT_URI);
+        dataset = (Dataset) Assembler.general.open(root);
+    }
+    
+    public void init(String analyzer) {
+        init(analyzer, "text:QueryParser");
+    }   
+    
+    @Before
+    abstract public void before();
+    
+    @After
+    public void after() {
+        dataset.close();
+    }
+
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -36,9 +36,9 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestDatasetWithLuceneTextIndexDeletionSupport.class
     , TestDatasetWithLuceneStoredLiterals.class
 
-    // Embedded solr not supported 
+    // Embedded solr not supported
     //, TestDatasetWithEmbeddedSolrTextIndex.class
-    
+
     , TestEntityMapAssembler.class
     , TestTextDatasetAssembler.class
     , TestTextIndexLuceneAssembler.class
@@ -52,6 +52,7 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestDatasetWithLocalizedAnalyzer.class
     , TestDatasetWithConfigurableAnalyzer.class
     , TestDatasetWithAnalyzingQueryParser.class
+    , TestDatasetWithComplexPhraseQueryParser.class
 })
 
 public class TS_Text

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithComplexPhraseQueryParser.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithComplexPhraseQueryParser.java
@@ -36,68 +36,7 @@ import org.junit.Test ;
 /**
  * This class defines a setup configuration for a dataset that uses a standard analyzer with a Lucene index.
  */
-public class TestDatasetWithComplexPhraseQueryParser extends AbstractTestDatasetWithTextIndexBase {
-
-    private static final String SPEC_BASE = "http://example.org/spec#";
-    private static final String SPEC_ROOT_LOCAL = "lucene_text_dataset";
-    private static final String SPEC_ROOT_URI = SPEC_BASE + SPEC_ROOT_LOCAL;
-
-    private static String makeSpec(String analyzer, String parser) {
-        return StrUtils.strjoinNL(
-                    "prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> ",
-                    "prefix ja:   <http://jena.hpl.hp.com/2005/11/Assembler#> ",
-                    "prefix tdb:  <http://jena.hpl.hp.com/2008/tdb#>",
-                    "prefix text: <http://jena.apache.org/text#>",
-                    "prefix :     <" + SPEC_BASE + ">",
-                    "",
-                    "[] ja:loadClass    \"org.apache.jena.query.text.TextQuery\" .",
-                    "text:TextDataset      rdfs:subClassOf   ja:RDFDataset .",
-                    "text:TextIndexLucene  rdfs:subClassOf   text:TextIndex .",
-
-                    ":" + SPEC_ROOT_LOCAL,
-                    "    a              text:TextDataset ;",
-                    "    text:dataset   :dataset ;",
-                    "    text:index     :indexLucene ;",
-                    "    .",
-                    "",
-                    ":dataset",
-                    "    a               ja:RDFDataset ;",
-                    "    ja:defaultGraph :graph ;",
-                    ".",
-                    ":graph",
-                    "    a               ja:MemoryModel ;",
-                    ".",
-                    "",
-                    ":indexLucene",
-                    "    a text:TextIndexLucene ;",
-                    "    text:directory \"mem\" ;",
-                    "    text:queryParser " + parser + ";",
-                    "    text:entityMap :entMap ;",
-                    "    .",
-                    "",
-                    ":entMap",
-                    "    a text:EntityMap ;",
-                    "    text:entityField      \"uri\" ;",
-                    "    text:defaultField     \"label\" ;",
-                    "    text:map (",
-                    "         [ text:field \"label\" ; ",
-                    "           text:predicate rdfs:label ;",
-                    "           text:analyzer [ a " + analyzer + " ]",
-                    "         ]",
-                    "         [ text:field \"comment\" ; text:predicate rdfs:comment ]",
-                    "         ) ."
-                    );
-    }
-
-    public void init(String analyzer, String parser) {
-        Reader reader = new StringReader(makeSpec(analyzer, parser));
-        Model specModel = ModelFactory.createDefaultModel();
-        specModel.read(reader, "", "TURTLE");
-        TextAssembler.init();
-        Resource root = specModel.getResource(SPEC_ROOT_URI);
-        dataset = (Dataset) Assembler.general.open(root);
-    }
-
+public class TestDatasetWithComplexPhraseQueryParser extends AbstractTestDatasetWithAnalyzer {
     @Before
     public void before() {
         init("text:StandardAnalyzer", "text:ComplexPhraseQueryParser");

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithComplexPhraseQueryParser.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithComplexPhraseQueryParser.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text;
+
+import java.io.Reader ;
+import java.io.StringReader ;
+import java.util.Set ;
+
+import org.apache.jena.assembler.Assembler ;
+import org.apache.jena.atlas.lib.StrUtils ;
+import org.apache.jena.query.Dataset ;
+import org.apache.jena.query.text.assembler.TextAssembler ;
+import org.apache.jena.rdf.model.Model ;
+import org.apache.jena.rdf.model.ModelFactory ;
+import org.apache.jena.rdf.model.Resource ;
+import org.apache.jena.ext.com.google.common.collect.Sets ;
+import org.junit.Before ;
+import org.junit.Test ;
+
+/**
+ * This class defines a setup configuration for a dataset that uses a standard analyzer with a Lucene index.
+ */
+public class TestDatasetWithComplexPhraseQueryParser extends AbstractTestDatasetWithTextIndexBase {
+
+    private static final String SPEC_BASE = "http://example.org/spec#";
+    private static final String SPEC_ROOT_LOCAL = "lucene_text_dataset";
+    private static final String SPEC_ROOT_URI = SPEC_BASE + SPEC_ROOT_LOCAL;
+
+    private static String makeSpec(String analyzer, String parser) {
+        return StrUtils.strjoinNL(
+                    "prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> ",
+                    "prefix ja:   <http://jena.hpl.hp.com/2005/11/Assembler#> ",
+                    "prefix tdb:  <http://jena.hpl.hp.com/2008/tdb#>",
+                    "prefix text: <http://jena.apache.org/text#>",
+                    "prefix :     <" + SPEC_BASE + ">",
+                    "",
+                    "[] ja:loadClass    \"org.apache.jena.query.text.TextQuery\" .",
+                    "text:TextDataset      rdfs:subClassOf   ja:RDFDataset .",
+                    "text:TextIndexLucene  rdfs:subClassOf   text:TextIndex .",
+
+                    ":" + SPEC_ROOT_LOCAL,
+                    "    a              text:TextDataset ;",
+                    "    text:dataset   :dataset ;",
+                    "    text:index     :indexLucene ;",
+                    "    .",
+                    "",
+                    ":dataset",
+                    "    a               ja:RDFDataset ;",
+                    "    ja:defaultGraph :graph ;",
+                    ".",
+                    ":graph",
+                    "    a               ja:MemoryModel ;",
+                    ".",
+                    "",
+                    ":indexLucene",
+                    "    a text:TextIndexLucene ;",
+                    "    text:directory \"mem\" ;",
+                    "    text:queryParser " + parser + ";",
+                    "    text:entityMap :entMap ;",
+                    "    .",
+                    "",
+                    ":entMap",
+                    "    a text:EntityMap ;",
+                    "    text:entityField      \"uri\" ;",
+                    "    text:defaultField     \"label\" ;",
+                    "    text:map (",
+                    "         [ text:field \"label\" ; ",
+                    "           text:predicate rdfs:label ;",
+                    "           text:analyzer [ a " + analyzer + " ]",
+                    "         ]",
+                    "         [ text:field \"comment\" ; text:predicate rdfs:comment ]",
+                    "         ) ."
+                    );
+    }
+
+    public void init(String analyzer, String parser) {
+        Reader reader = new StringReader(makeSpec(analyzer, parser));
+        Model specModel = ModelFactory.createDefaultModel();
+        specModel.read(reader, "", "TURTLE");
+        TextAssembler.init();
+        Resource root = specModel.getResource(SPEC_ROOT_URI);
+        dataset = (Dataset) Assembler.general.open(root);
+    }
+
+    @Before
+    public void before() {
+        init("text:StandardAnalyzer", "text:ComplexPhraseQueryParser");
+    }
+
+    @Test
+    public void testComplexPhraseQueryParserPerformsPhraseFuzzyQuery() {
+        final String testName = "testComplexPhraseQueryParserPerformsPhraseFuzzyQuery";
+        final String turtle = StrUtils.strjoinNL(
+                TURTLE_PROLOG,
+                "<" + RESOURCE_BASE + testName + ">",
+                "  rdfs:label 'secondary education'",
+                ".",
+                "<" + RESOURCE_BASE + "irrelevant>",
+                "  rdfs:label 'tertiary elucidation'",
+                "."
+                );
+        String queryString = StrUtils.strjoinNL(
+                QUERY_PROLOG,
+                "SELECT ?s",
+                "WHERE {",
+                "    ?s text:query ( rdfs:label 'scondar~ edcation~' 10 ) .",
+                "}"
+                );
+        Set<String> expectedURIs = Sets.newHashSet(RESOURCE_BASE + testName);
+        doTestSearch(turtle, queryString, expectedURIs);
+    }
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithKeywordAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithKeywordAnalyzer.java
@@ -18,100 +18,21 @@
 
 package org.apache.jena.query.text;
 
-import java.io.Reader ;
-import java.io.StringReader ;
 import java.util.Arrays ;
 import java.util.HashSet ;
 import java.util.Set ;
 
-import org.apache.jena.assembler.Assembler ;
 import org.apache.jena.atlas.lib.StrUtils ;
-import org.apache.jena.query.Dataset ;
-import org.apache.jena.query.text.assembler.TextAssembler ;
-import org.apache.jena.rdf.model.Model ;
-import org.apache.jena.rdf.model.ModelFactory ;
-import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
 /**
  * This class defines a setup configuration for a dataset that uses a keyword analyzer with a Lucene index.
  */
-public class TestDatasetWithKeywordAnalyzer extends AbstractTestDatasetWithTextIndexBase {
-    
-    private static final String SPEC_BASE = "http://example.org/spec#";
-    private static final String SPEC_ROOT_LOCAL = "lucene_text_dataset";
-    private static final String SPEC_ROOT_URI = SPEC_BASE + SPEC_ROOT_LOCAL;
-
-    private static String makeSpec(String analyzer, String parser) {
-        return StrUtils.strjoinNL(
-                    "prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> ",
-                    "prefix ja:   <http://jena.hpl.hp.com/2005/11/Assembler#> ",
-                    "prefix tdb:  <http://jena.hpl.hp.com/2008/tdb#>",
-                    "prefix text: <http://jena.apache.org/text#>",
-                    "prefix :     <" + SPEC_BASE + ">",
-                    "",
-                    "[] ja:loadClass    \"org.apache.jena.query.text.TextQuery\" .",
-                    "text:TextDataset      rdfs:subClassOf   ja:RDFDataset .",
-                    "text:TextIndexLucene  rdfs:subClassOf   text:TextIndex .",
-                    
-                    ":" + SPEC_ROOT_LOCAL,
-                    "    a              text:TextDataset ;",
-                    "    text:dataset   :dataset ;",
-                    "    text:index     :indexLucene ;",
-                    "    .",
-                    "",
-                    ":dataset",
-                    "    a               ja:RDFDataset ;",
-                    "    ja:defaultGraph :graph ;",
-                    ".",
-                    ":graph",
-                    "    a               ja:MemoryModel ;",
-                    ".",
-                    "",
-                    ":indexLucene",
-                    "    a text:TextIndexLucene ;",
-                    "    text:directory \"mem\" ;",
-                    "    text:queryParser " + parser + ";",
-                    "    text:entityMap :entMap ;",
-                    "    .",
-                    "",
-                    ":entMap",
-                    "    a text:EntityMap ;",
-                    "    text:entityField      \"uri\" ;",
-                    "    text:defaultField     \"label\" ;",
-                    "    text:map (",
-                    "         [ text:field \"label\" ; ",
-                    "           text:predicate rdfs:label ;",
-                    "           text:analyzer [ a " + analyzer + " ]",
-                    "         ]",
-                    "         [ text:field \"comment\" ; text:predicate rdfs:comment ]",
-                    "         ) ."
-                    );
-    }      
-    
-    public void init(String analyzer, String parser) {
-        Reader reader = new StringReader(makeSpec(analyzer, parser));
-        Model specModel = ModelFactory.createDefaultModel();
-        specModel.read(reader, "", "TURTLE");
-        TextAssembler.init();            
-        Resource root = specModel.getResource(SPEC_ROOT_URI);
-        dataset = (Dataset) Assembler.general.open(root);
-    }
-    
-    public void init(String analyzer) {
-        init(analyzer, "text:QueryParser");
-    }   
-    
+public class TestDatasetWithKeywordAnalyzer extends AbstractTestDatasetWithAnalyzer {
     @Before
     public void before() {
         init("text:KeywordAnalyzer");
-    }
-    
-    @After
-    public void after() {
-        dataset.close();
     }
     
     @Test


### PR DESCRIPTION
This PR expands on JENA-1134, which added support for new query parsers in jean-text. ComplexQueryParser is useful for performing wildcard or fuzzy search on terms in phrases.

I’ve attempted to follow the pattern for adding a query parser as in JENA-1134, but I may have duplicated some functionality in the unit test, when I should have restructured instead.

The test needs to specify the TTL spec analyzer and parser, which is available in TestDatasetWithConfigurableAnalyzer’s method makeSpec. However, TestDatasetWithConfigurableAnalyzer inherits from TestDatasetWithKeywordAnalyzer, which isn’t the analyzer the ComplexPhraseQuery needs to test.