### PR TITLE
JENA-508: implemented fn:adjust-datetime-to-timezone, fn:adjust-date-to-timezone and fn:adjust-time-to-timezone

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -1423,9 +1423,10 @@ public class XSDFuncOp
         return NodeValue.makeString(dts.timezone) ;
     }
 
-    private static NodeValue fromTimezoneToDuration(DateTimeStruct dts){
+    public static NodeValue dtGetTimezone(NodeValue nv) {
+        DateTimeStruct dts = parseAnyDT(nv) ;
         if ( dts == null || dts.timezone == null )
-            return null;
+            throw new ExprEvalException("Not a datatype with a timezone: " + nv) ;
         if ( "".equals(dts.timezone) )
             return null ;
         if ( "Z".equals(dts.timezone) ) {
@@ -1454,13 +1455,6 @@ public class XSDFuncOp
         digitsTwo(s, idx, sb, 'M') ;
         idx += 2 ;
         return NodeValue.makeNode(sb.toString(), null, XSDDatatype.XSD + "#dayTimeDuration") ;
-    }
-
-    public static NodeValue dtGetTimezone(NodeValue nv) {
-        DateTimeStruct dts = parseAnyDT(nv) ;
-        if ( dts == null || dts.timezone == null )
-            throw new ExprEvalException("Not a datatype with a timezone: " + nv) ;
-        return fromTimezoneToDuration(dts);
     }
 
     private static void digitsTwo(String s, int idx, StringBuilder sb, char indicator) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -1590,6 +1590,11 @@ public class XSDFuncOp
             }
             Duration tzDuration = nv2.getDuration();
             tzOffset = tzDuration.getSign()*(tzDuration.getMinutes() + 60*tzDuration.getHours());
+            if(tzDuration.getSeconds() > 0)
+                throw new ExprEvalException("The timezone duration should be an integral number of minutes");
+            int absTzOffset = java.lang.Math.abs(tzOffset);
+            if(absTzOffset > 14*60)
+                throw new ExprEvalException("The timezone should be a duration between -PT14H and PT14H.");
         }
         String tzSign = (tzOffset-inputOffset) > 0 ? "" : "-";
         Duration durToAdd = NodeValue.makeDuration(tzSign+"PT"+java.lang.Math.abs(tzOffset-inputOffset)+"M").getDuration();

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -1567,7 +1567,7 @@ public class XSDFuncOp
             inputOffset = calValue.getTimezone();
         }
 
-        int tzOffset = TimeZone.getDefault().getRawOffset() / (1000*60);
+        int tzOffset = 0;
         if(nv2 != null){
             if(!nv2.isDuration()) {
                 String nv2StrValue = nv2.getString();
@@ -1590,8 +1590,10 @@ public class XSDFuncOp
             if(absTzOffset > 14*60)
                 throw new ExprEvalException("The timezone should be a duration between -PT14H and PT14H.");
         }
-        String tzSign = (tzOffset-inputOffset) > 0 ? "" : "-";
-        Duration durToAdd = NodeValue.makeDuration(tzSign+"PT"+java.lang.Math.abs(tzOffset-inputOffset)+"M").getDuration();
+        else{
+            tzOffset = TimeZone.getDefault().getOffset(new Date().getTime())/(1000*60);
+        }
+        Duration durToAdd = NodeValue.xmlDatatypeFactory.newDurationDayTime((tzOffset-inputOffset) > 0,0,0,java.lang.Math.abs(tzOffset-inputOffset),0);
         if(hasTz)
             calValue.add(durToAdd);
         calValue.setTimezone(tzOffset);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -1556,8 +1556,8 @@ public class XSDFuncOp
         if(nv1 == null)
             return null;
 
-        if(!nv1.isDateTime() && !nv1.isDate()){
-            throw new ExprEvalException("Not a valid date or datetime:"+nv1);
+        if(!nv1.isDateTime() && !nv1.isDate() && !nv1.isTime()){
+            throw new ExprEvalException("Not a valid date, datetime or time:"+nv1);
         }
 
         XMLGregorianCalendar calValue = nv1.getDateTime();
@@ -1575,6 +1575,8 @@ public class XSDFuncOp
                     calValue.setTimezone(DatatypeConstants.FIELD_UNDEFINED);
                     if(nv1.isDateTime())
                         return NodeValue.makeDateTime(calValue);
+                    else if(nv1.isTime())
+                        return NodeValue.makeNode(calValue.toXMLFormat(),XSDDatatype.XSDtime);
                     else
                         return NodeValue.makeDate(calValue);
                 }
@@ -1595,6 +1597,8 @@ public class XSDFuncOp
         calValue.setTimezone(tzOffset);
         if(nv1.isDateTime())
             return NodeValue.makeDateTime(calValue);
+        else if(nv1.isTime())
+            return NodeValue.makeNode(calValue.toXMLFormat(),XSDDatatype.XSDtime);
         else
             return NodeValue.makeDate(calValue);
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -1565,14 +1565,12 @@ public class XSDFuncOp
         if(!nv1.isDateTime() && !nv1.isDate()){
             throw new ExprEvalException("Not a valid date or datetime:"+nv1);
         }
-        DateTimeStruct dts = parseAnyDT(nv1);
-        NodeValue inputTimezone = fromTimezoneToDuration(dts);
-        Boolean hasTz = inputTimezone == null ? false : true;
+
         XMLGregorianCalendar calValue = nv1.getDateTime();
+        Boolean hasTz = calValue.getTimezone() != DatatypeConstants.FIELD_UNDEFINED;
         int inputOffset = 0;
         if(hasTz){
-            Duration inputDuration = inputTimezone.getDuration();
-            inputOffset = inputDuration.getSign()*(inputDuration.getMinutes() + 60*inputDuration.getHours());
+            inputOffset = calValue.getTimezone();
         }
 
         int tzOffset = TimeZone.getDefault().getRawOffset() / (1000*60);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
@@ -164,6 +164,7 @@ public class StandardFunctions
         
         // XQ/XP 3.
 //        9.6.1 fn:adjust-dateTime-to-timezone
+        add(registry, xfn+"adjust-dateTime-to-timezone",  FN_AdjustDatetimeToTimezone.class) ;
 //        9.6.2 fn:adjust-date-to-timezone
 //        9.6.3 fn:adjust-time-to-timezone
 //        9.8.1 fn:format-dateTime

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
@@ -166,6 +166,7 @@ public class StandardFunctions
 //        9.6.1 fn:adjust-dateTime-to-timezone
         add(registry, xfn+"adjust-dateTime-to-timezone",  FN_AdjustDatetimeToTimezone.class) ;
 //        9.6.2 fn:adjust-date-to-timezone
+        add(registry, xfn+"adjust-date-to-timezone",  FN_AdjustDatetimeToTimezone.class) ;
 //        9.6.3 fn:adjust-time-to-timezone
 //        9.8.1 fn:format-dateTime
 //        9.8.2 fn:format-date

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
@@ -168,6 +168,7 @@ public class StandardFunctions
 //        9.6.2 fn:adjust-date-to-timezone
         add(registry, xfn+"adjust-date-to-timezone",  FN_AdjustDatetimeToTimezone.class) ;
 //        9.6.3 fn:adjust-time-to-timezone
+        add(registry, xfn+"adjust-time-to-timezone",  FN_AdjustDatetimeToTimezone.class) ;
 //        9.8.1 fn:format-dateTime
 //        9.8.2 fn:format-date
 //        9.8.3 fn:format-time

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_AdjustDatetimeToTimezone.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_AdjustDatetimeToTimezone.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.sparql.function.library;
+
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.query.QueryBuildException;
+import org.apache.jena.sparql.expr.ExprEvalException;
+import org.apache.jena.sparql.expr.ExprList;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp;
+import org.apache.jena.sparql.function.FunctionBase;
+
+import java.util.List;
+
+public class FN_AdjustDatetimeToTimezone extends FunctionBase {
+    public FN_AdjustDatetimeToTimezone(){super();}
+
+    @Override
+    public void checkBuild(String uri, ExprList args)
+    {
+        if ( args.size() != 1 && args.size() != 2 )
+            throw new QueryBuildException("Function '"+ Lib.className(this)+"' takes one or two arguments") ;
+    }
+    @Override
+    public NodeValue exec(List<NodeValue> args)
+    {
+        if ( args.size() != 1 && args.size() != 2 )
+            throw new ExprEvalException("FN_StrNormalizeUnicode: Wrong number of arguments: "+args.size()+" : [wanted 1 or 2]") ;
+
+        NodeValue v1 = args.get(0) ;
+
+        if ( args.size() == 2 )
+        {
+            NodeValue v2 = args.get(1) ;
+            return XSDFuncOp.adjustDatetimeToTimezone(v1, v2) ;
+        }
+
+        return XSDFuncOp.adjustDatetimeToTimezone(v1, null) ;
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -349,8 +349,11 @@ public class TestFunctions
     @Test public void exprRoundHalfEven_08()    { test("fn:round-half-to-even('150.015'^^xsd:float, 2)",     NodeValue.makeFloat((float)150.01)) ; }
 
     private String getDynamicDurationString(){
-        int tzOffset = TimeZone.getDefault().getRawOffset() / (1000*60);
-        return "PT"+tzOffset+"M";
+        int tzOffset = TimeZone.getDefault().getOffset(new Date().getTime()) / (1000*60);
+        String off = "PT"+Math.abs(tzOffset)+"M";
+        if(tzOffset < 0)
+            off = "-"+off;
+        return off;
     }
 
     @Test public void exprAdjustDatetimeToTz_01(){

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -396,6 +396,28 @@ public class TestFunctions
     @Test public void exprAdjustDateToTz_05(){test("fn:adjust-date-to-timezone('2002-03-07'^^xsd:date,'')",NodeValue.makeDate("2002-03-07"));}
 
     @Test public void exprAdjustDateToTz_06(){test("fn:adjust-date-to-timezone('2002-03-07-07:00'^^xsd:date,'')",NodeValue.makeDate("2002-03-07"));}
+
+    @Test public void exprAdjustTimeToTz_01(){
+        testEqual(
+                "fn:adjust-time-to-timezone('10:00:00'^^xsd:time)",
+                "fn:adjust-time-to-timezone('10:00:00'^^xsd:time,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+    }
+
+    @Test public void exprAdjustTimeToTz_02(){
+        testEqual(
+                "fn:adjust-time-to-timezone('10:00:00-07:00'^^xsd:time)",
+                "fn:adjust-time-to-timezone('10:00:00-07:00'^^xsd:time,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+    }
+
+    @Test public void exprAdjustTimeToTz_03(){test("fn:adjust-time-to-timezone('10:00:00'^^xsd:time,'-PT10H'^^xsd:dayTimeDuration)",NodeValue.makeNode("10:00:00-10:00",XSDDatatype.XSDtime));}
+
+    @Test public void exprAdjustTimeToTz_04(){test("fn:adjust-time-to-timezone('10:00:00-07:00'^^xsd:time,'-PT10H'^^xsd:dayTimeDuration)",NodeValue.makeNode("07:00:00-10:00",XSDDatatype.XSDtime));}
+
+    @Test public void exprAdjustTimeToTz_05(){test("fn:adjust-time-to-timezone('10:00:00'^^xsd:time,'')",NodeValue.makeNode("10:00:00",XSDDatatype.XSDtime));}
+
+    @Test public void exprAdjustTimeToTz_06(){test("fn:adjust-time-to-timezone('10:00:00-07:00'^^xsd:time,'')",NodeValue.makeNode("10:00:00",XSDDatatype.XSDtime));}
+
+    @Test public void exprAdjustTimeToTz_07(){test("fn:adjust-time-to-timezone('10:00:00-07:00'^^xsd:time,'PT10H'^^xsd:dayTimeDuration)",NodeValue.makeNode("03:00:00+10:00",XSDDatatype.XSDtime));}
     //@Test public void exprStrJoin()      { test("fn:string-join('a', 'b')", NodeValue.makeString("ab")) ; }
     
     @Test public void exprSameTerm1()     { test("sameTerm(1,1)",           TRUE) ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -348,6 +348,35 @@ public class TestFunctions
     // counter-intuitive -- would fail if float/double not translated to decimal
     @Test public void exprRoundHalfEven_08()    { test("fn:round-half-to-even('150.015'^^xsd:float, 2)",     NodeValue.makeFloat((float)150.01)) ; }
 
+    private String getDynamicDurationString(){
+        int tzOffset = TimeZone.getDefault().getRawOffset() / (1000*60);
+        return "PT"+tzOffset+"M";
+    }
+
+    @Test public void exprAdjustDatetimeToTz_01(){
+        testEqual(
+                "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00'^^xsd:dateTime)",
+                "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00'^^xsd:dateTime,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+    }
+
+    @Test public void exprAdjustDatetimeToTz_02(){
+        testEqual(
+                "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00-07:00'^^xsd:dateTime)",
+                "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00-07:00'^^xsd:dateTime,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+    }
+
+    @Test public void exprAdjustDatetimeToTz_03(){test("fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00'^^xsd:dateTime,'-PT10H'^^xsd:dayTimeDuration)",NodeValue.makeDateTime("2002-03-07T10:00:00-10:00"));}
+
+    @Test public void exprAdjustDatetimeToTz_04(){test("fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00-07:00'^^xsd:dateTime,'-PT10H'^^xsd:dayTimeDuration)",NodeValue.makeDateTime("2002-03-07T07:00:00-10:00"));}
+
+    @Test public void exprAdjustDatetimeToTz_05(){test("fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00-07:00'^^xsd:dateTime,'PT10H'^^xsd:dayTimeDuration)",NodeValue.makeDateTime("2002-03-08T03:00:00+10:00"));}
+
+    @Test public void exprAdjustDatetimeToTz_06(){test("fn:adjust-dateTime-to-timezone('2002-03-07T00:00:00+01:00'^^xsd:dateTime,'-PT8H'^^xsd:dayTimeDuration)",NodeValue.makeDateTime("2002-03-06T15:00:00-08:00"));}
+
+    @Test public void exprAdjustDatetimeToTz_07(){test("fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00'^^xsd:dateTime,'')",NodeValue.makeDateTime("2002-03-07T10:00:00"));}
+
+    @Test public void exprAdjustDatetimeToTz_08(){test("fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00-07:00'^^xsd:dateTime,'')",NodeValue.makeDateTime("2002-03-07T10:00:00"));}
+
     //@Test public void exprStrJoin()      { test("fn:string-join('a', 'b')", NodeValue.makeString("ab")) ; }
     
     @Test public void exprSameTerm1()     { test("sameTerm(1,1)",           TRUE) ; }
@@ -402,7 +431,14 @@ public class TestFunctions
         NodeValue r = expr.eval(null, FunctionEnvBase.createTest()) ;
         assertEquals(result, r) ;
     }
-    
+
+    private void testEqual(String exprStr, String exprStrExpected)
+    {
+        Expr expr = ExprUtils.parse(exprStrExpected) ;
+        NodeValue rExpected = expr.eval(null, FunctionEnvBase.createTest()) ;
+        test(exprStr,rExpected);
+    }
+
     private void testEvalException(String exprStr)
     {
         Expr expr = ExprUtils.parse(exprStr) ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -377,6 +377,25 @@ public class TestFunctions
 
     @Test public void exprAdjustDatetimeToTz_08(){test("fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00-07:00'^^xsd:dateTime,'')",NodeValue.makeDateTime("2002-03-07T10:00:00"));}
 
+    @Test public void exprAdjustDateToTz_01(){
+        testEqual(
+                "fn:adjust-date-to-timezone('2002-03-07'^^xsd:date)",
+                "fn:adjust-date-to-timezone('2002-03-07'^^xsd:date,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+    }
+
+    @Test public void exprAdjustDateToTz_02(){
+        testEqual(
+                "fn:adjust-date-to-timezone('2002-03-07-07:00'^^xsd:date)",
+                "fn:adjust-date-to-timezone('2002-03-07-07:00'^^xsd:date,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+    }
+
+    @Test public void exprAdjustDateToTz_03(){test("fn:adjust-date-to-timezone('2002-03-07'^^xsd:date,'-PT10H'^^xsd:dayTimeDuration)",NodeValue.makeDate("2002-03-07-10:00"));}
+
+    @Test public void exprAdjustDateToTz_04(){test("fn:adjust-date-to-timezone('2002-03-07-07:00'^^xsd:date,'-PT10H'^^xsd:dayTimeDuration)",NodeValue.makeDate("2002-03-06-10:00"));}
+
+    @Test public void exprAdjustDateToTz_05(){test("fn:adjust-date-to-timezone('2002-03-07'^^xsd:date,'')",NodeValue.makeDate("2002-03-07"));}
+
+    @Test public void exprAdjustDateToTz_06(){test("fn:adjust-date-to-timezone('2002-03-07-07:00'^^xsd:date,'')",NodeValue.makeDate("2002-03-07"));}
     //@Test public void exprStrJoin()      { test("fn:string-join('a', 'b')", NodeValue.makeString("ab")) ; }
     
     @Test public void exprSameTerm1()     { test("sameTerm(1,1)",           TRUE) ; }


### PR DESCRIPTION
I implemented two new XPath 3 functions: fn:adjust-datetime-to-timezone, fn:adjust-date-to-timezone and fn:adjust-time-to-timezone. I used the examples of the specification for the tests + I decided to implement both using the same underlying function as it seems to me that in jena there is no distinction between date and datetime (date and datetime are using the same object and from the time we can also get the same object).