### PR TITLE
[JENA-1204] support for multiple BuiltinRegistry for different rule sets

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/Builtin.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/Builtin.java
@@ -31,7 +31,7 @@ import org.apache.jena.graph.* ;
  * <p>
  * The mapping from the rule definition (which uses functors to hold the parsed call)
  * to the java implementation of the builtin is done via the 
- * {@link BuiltinRegistry BuiltinRegistry} which can
+ * {@link MapBuiltinRegistry BuiltinRegistry} which can
  * be user extended.
  */
 public interface Builtin {

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/BuiltinRegistry.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/BuiltinRegistry.java
@@ -1,3 +1,7 @@
+package org.apache.jena.reasoner.rulesys;
+
+import org.apache.jena.reasoner.rulesys.builtins.*;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,35 +20,11 @@
  * limitations under the License.
  */
 
-package org.apache.jena.reasoner.rulesys;
-
-import java.util.*;
-
-import org.apache.jena.reasoner.rulesys.builtins.* ;
-
-/** * A registry for mapping functor names on java objects (instances 
- * of subclasses of Builtin) which implement their behvaiour.
- * <p>
- * This is currently implemented as a singleton to simply any future
- * move to support different sets of builtins.
- * 
- * @see Builtin
- */
-public class BuiltinRegistry {
-
-    /** The single global static registry */
+public abstract class BuiltinRegistry {
+    /** The default base registry */
     public static BuiltinRegistry theRegistry;
-    
-    /** Mapping from functor name to Builtin implementing it */
-    protected Map<String,Builtin> builtins = new HashMap<>();
-    
-    /** Mapping from URI of builtin to implementation */
-    protected Map<String,Builtin> builtinsByURI = new HashMap<>();
-    
-    // Static initilizer for the singleton instance
     static {
-        theRegistry = new BuiltinRegistry();
-        
+        theRegistry=new MapBuiltinRegistry();
         theRegistry.register(new Print());
         theRegistry.register(new AddOne());
         theRegistry.register(new LessThan());
@@ -82,66 +62,54 @@ public class BuiltinRegistry {
         theRegistry.register(new ListNotContains());
         theRegistry.register(new ListMapAsSubject());
         theRegistry.register(new ListMapAsObject());
-        
+
         theRegistry.register(new MakeInstance());
         theRegistry.register(new Table());
         theRegistry.register(new TableAll());
-        
+
         theRegistry.register(new MakeSkolem());
-        
+
         theRegistry.register(new Hide());
-        
+
         theRegistry.register(new StrConcat());
         theRegistry.register(new UriConcat());
         theRegistry.register(new Regex());
-        
+
         theRegistry.register(new Now());
-        
+
         // Special purposes support functions for OWL
         theRegistry.register(new AssertDisjointPairs());
+
     }
-    
+
     /**
-     * Construct an empty registry
+     * Register an implementation for a given builtin using its default name.
+     * @param impl the implementation of the builtin
      */
-    public BuiltinRegistry() {
-    }
-    
+
+    public abstract void register(Builtin impl);
     /**
      * Register an implementation for a given builtin functor.
      * @param functor the name of the functor used to invoke the builtin
      * @param impl the implementation of the builtin
      */
-    public void register(String functor, Builtin impl) {
-        builtins.put(functor, impl);
-        builtinsByURI.put(impl.getURI(), impl);
-    }
-   
-    /**
-     * Register an implementation for a given builtin using its default name.
-     * @param impl the implementation of the builtin
-     */
-    public void register(Builtin impl) {
-        builtins.put(impl.getName(), impl);
-        builtinsByURI.put(impl.getURI(), impl);
-    }
-    
+
+    public abstract void register(String functor, Builtin impl);
     /**
      * Find the implementation of the given builtin functor.
      * @param functor the name of the functor being invoked.
      * @return a Builtin or null if there is none registered under that name
      */
-    public Builtin getImplementation(String functor) {
-        return builtins.get(functor);
-    }
-    
+
+    public abstract Builtin getImplementation(String functor);
+
     /**
      * Find the implementation of the given builtin functor.
      * @param uri the URI of the builtin to be retrieved
      * @return a Builtin or null if there is none registered under that name
      */
-    public Builtin getImplementationByURI(String uri) {
-        return builtinsByURI.get(uri);
-    }
-    
+
+    public abstract Builtin getImplementationByURI(String uri);
+
+
 }

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/FBRuleReasoner.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/FBRuleReasoner.java
@@ -280,7 +280,7 @@ public class FBRuleReasoner implements RuleReasoner {
         // Create a dummy rule which tables the predicate ...
         Rule tablePredicateRule = new Rule("", 
                 new ClauseEntry[]{
-                    new Functor("table", new Node[] { predicate })
+                    new Functor("table", new Node[] { predicate },BuiltinRegistry.theRegistry)
                 }, 
                 new ClauseEntry[]{});
         // ... end append the rule to the ruleset

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/Functor.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/Functor.java
@@ -54,17 +54,7 @@ public class Functor implements ClauseEntry {
             };
     
     protected static Logger logger = LoggerFactory.getLogger(Functor.class);
-    
-    /**
-     * Constructor. 
-     * @param name the name of the functor
-     * @param args a list of nodes defining the arguments
-     */
-    public Functor(String name, List<Node> args) {
-        this.name = name;
-        this.args = args.toArray(new Node[]{});
-    }
-    
+
     /**
      * Constructor. 
      * @param name the name of the functor
@@ -80,13 +70,48 @@ public class Functor implements ClauseEntry {
      * Constructor
      * @param name the name of the functor
      * @param args a list of nodes defining the arguments
-     * @param registry a table of builtins to consult to check for 
+     * @param registry a table of builtins to consult to check for
      * implementations of this functor when used as a rule clause
      */
     public Functor(String name, List<Node> args, BuiltinRegistry registry) {
+        this(name, args,registry.getImplementation(name));
+    }
+
+    /**
+     * Constructor
+     * @param name the name of the functor
+     * @param args an array of nodes defining the arguments
+     * @param registry a table of builtins to consult to check for
+     * implementations of this functor when used as a rule clause
+     */
+    public Functor(String name,Node[] args, BuiltinRegistry registry) {
+        this(name, args,registry.getImplementation(name));
+    }
+
+    /**
+     * Constructor
+     * @param name the name of the functor
+     * @param args a list of nodes defining the arguments
+     * @param impl a specific builtin implementation of this functor
+     *
+     */
+    public Functor(String name, List<Node> args, Builtin impl) {
         this.name = name;
         this.args = args.toArray(new Node[]{});
-        this.implementor = registry.getImplementation(name);
+        this.implementor = impl;
+    }
+
+    /**
+     * Constructor
+     * @param name the name of the functor
+     * @param args a list of nodes defining the arguments
+     * @param impl a specific builtin implementation of this functor
+     *
+     */
+    public Functor(String name, Node[] args, Builtin impl) {
+        this.name = name;
+        this.args = args;
+        this.implementor = impl;
     }
     
     /**
@@ -262,7 +287,7 @@ public class Functor implements ClauseEntry {
         }
         return false;
     }
-    
+
     /**
      * Create a functor and wrap it up as a Literal node
      * @param name the name of the functor
@@ -270,9 +295,9 @@ public class Functor implements ClauseEntry {
      * accidental structure sharing
      */
     public static Node makeFunctorNode(String name, Node[] args) {
-        return makeFunctorNode( new Functor( name, args ) );
+        return makeFunctorNode( new Functor( name, args, BuiltinRegistry.theRegistry ) );
     }
-    
+
     /**
      * Wrap  a functor as a Literal node
      * @param f the functor data structure to be wrapped in a node.

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/MapBuiltinRegistry.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/MapBuiltinRegistry.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.reasoner.rulesys;
+
+import java.util.*;
+
+import org.apache.jena.reasoner.rulesys.builtins.* ;
+
+/** * A registry for mapping functor names on java objects (instances 
+ * of subclasses of Builtin) which implement their behvaiour.
+ * <p>
+ * This is currently implemented as a singleton to simply any future
+ * move to support different sets of builtins.
+ * 
+ * @see Builtin
+ */
+public class MapBuiltinRegistry extends BuiltinRegistry {
+
+    /** Mapping from functor name to Builtin implementing it */
+    protected Map<String,Builtin> builtins = new HashMap<>();
+    
+    /** Mapping from URI of builtin to implementation */
+    protected Map<String,Builtin> builtinsByURI = new HashMap<>();
+
+    /**
+     * Construct an empty registry
+     */
+    public MapBuiltinRegistry() {
+    }
+
+    @Override
+    public void register(String functor, Builtin impl) {
+        builtins.put(functor, impl);
+        builtinsByURI.put(impl.getURI(), impl);
+    }
+
+    @Override
+    public void register(Builtin impl) {
+        builtins.put(impl.getName(), impl);
+        builtinsByURI.put(impl.getURI(), impl);
+    }
+    
+    @Override
+    public Builtin getImplementation(String functor) {
+        return builtins.get(functor);
+    }
+    
+    @Override
+    public Builtin getImplementationByURI(String uri) {
+        return builtinsByURI.get(uri);
+    }
+    
+}

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/OverrideBuiltinRegistry.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/OverrideBuiltinRegistry.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.reasoner.rulesys;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class OverrideBuiltinRegistry extends BuiltinRegistry {
+
+    /** Mapping from functor name to Builtin implementing it */
+    final protected Map<String,Builtin> builtins = new HashMap<>();
+
+    /** Mapping from URI of builtin to implementation */
+    final protected Map<String,Builtin> builtinsByURI = new HashMap<>();
+
+    final protected BuiltinRegistry innerRegistry;
+
+    public OverrideBuiltinRegistry(BuiltinRegistry innerRegistry) {
+        this.innerRegistry = innerRegistry;
+    }
+
+    @Override
+    public void register(String functor, Builtin impl) {
+        builtins.put(functor, impl);
+        builtinsByURI.put(impl.getURI(), impl);
+    }
+
+    @Override
+    public void register(Builtin impl) {
+        builtins.put(impl.getName(), impl);
+        builtinsByURI.put(impl.getURI(), impl);
+    }
+
+    @Override
+    public Builtin getImplementation(String functor) {
+        Builtin that=builtins.get(functor);
+        return that==null ? innerRegistry.getImplementation(functor) : that;
+    }
+
+    @Override
+    public Builtin getImplementationByURI(String uri) {
+        Builtin that=builtinsByURI.get(uri);
+        return that==null ? innerRegistry.getImplementationByURI(uri) : that;
+    }
+}

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BindingStack.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BindingStack.java
@@ -137,7 +137,7 @@ public class BindingStack implements BindingEnvironment {
                 }
                 boundargs.add( binding );
             }
-            Functor newf = new Functor(functor.getName(), boundargs);
+            Functor newf = new Functor(functor.getName(), boundargs, functor.getImplementor());
             return Functor.makeFunctorNode( newf );
         } else {
             return node;

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BindingVector.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BindingVector.java
@@ -98,7 +98,7 @@ public class BindingVector implements BindingEnvironment {
                 }
                 boundargs.add( binding );
             }
-            Functor newf = new Functor( functor.getName(), boundargs );
+            Functor newf = new Functor( functor.getName(), boundargs, functor.getImplementor() );
             return Functor.makeFunctorNode( newf );
         } else {
             return node;

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestBugs.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestBugs.java
@@ -635,7 +635,7 @@ public class TestBugs extends TestCase {
      */
     public void testGroundClosure2() {
         Flag myFlag = new Flag();
-        BuiltinRegistry.theRegistry.register(myFlag);
+        MapBuiltinRegistry.theRegistry.register(myFlag);
         List<Rule> rules = Rule.rulesFromURL("file:testing/reasoners/bugs/groundClosure2.rules");
         GenericRuleReasoner reasoner = new GenericRuleReasoner( rules );
         InfModel inf = ModelFactory.createInfModel(reasoner, ModelFactory.createDefaultModel());
@@ -792,7 +792,7 @@ public class TestBugs extends TestCase {
         assertEquals( culprit, ResourceFactory.createTypedLiteral( new Integer(42) ));
         culprit = doTestLiteralsInErrorReports("-> (eg:a eg:p 'foo').  (?X rb:violation error('test', 'arg')) <- (?S eg:p ?X).");
         assertEquals( culprit, ResourceFactory.createPlainLiteral("foo"));
-        BuiltinRegistry.theRegistry.register( new SomeTriple() );
+        MapBuiltinRegistry.theRegistry.register( new SomeTriple() );
         culprit = doTestLiteralsInErrorReports("-> (eg:a eg:p 42).  (?X rb:violation error('test', 'arg')) <- (?S eg:p ?Y), someTriple(?X).");
         assertTrue( culprit.isLiteral() );
         Object val = ((Literal)culprit).getValue();


### PR DESCRIPTION
This patch introduces support for multiple BuiltinRegistry classes implemented in a simple way which is parallel to the existing architecture.  (i.e. the BuiltinRegistry is a property of the Rules Engine parser,  not the Reasoner)