### PR TITLE
JENA-508:  fn:format-number

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
@@ -31,12 +31,9 @@ public class StandardFunctions
     /* JENA-508
      * Missing: (July 2016)
      * 
-     *   fn:format-number
      *   fn:format-dateTime
      *   fn:format-date
      *   fn:format-time
-     *   fn:normalize-space
-     *  fn:normalize-unicode
      * 
      * and adapters to SPARQL operations that have keywords:
      *   fn:replace
@@ -45,13 +42,9 @@ public class StandardFunctions
      */
     
     /* Implementation notes
-     * fn:normalize-space   : leading and trailing whitespace removed, 
-     *                        sequences of internal whitespace reduced to a single space character.
-     *                        Whitespace is "Character.isWhitespace" 
-     *                        Regex \v \h (check). 
-     * fn:normalize-unicode : Java Normalizer.normalize applies the rules.
-     * fn:format-number     : Java NumberFormat picture strings.
-     * fn:format-dateTime/fn:format-time/fn:format-date : Java SimpleDateFormat
+     *   fn:format-dateTime / fn:format-time / fn:format-date
+     *   This is not Java's SimpleDateFormat.
+     *   It has its own picture syntax.
      *     Like adjust-* we may need only one function. 
      */
     
@@ -103,7 +96,7 @@ public class StandardFunctions
         addCastTemporal(registry, XSDDatatype.XSDgDay) ;
 
         //TODO op:numeric-greater-than etc.
-        //TODO sparql:* for al the SPARQL builtins.
+        //TODO sparql:* for all the SPARQL builtins.
         
         // Sections refer to XQ/XP Expression 3.1
         // https://www.w3.org/TR/xpath-functions-3/
@@ -149,6 +142,8 @@ public class StandardFunctions
         // fn:tokenize -> sequence
         
 //        4.7.2 fn:format-number
+        add(registry, xfn+"format-number",  FN_FormatNumber.class) ;
+        
 
 //        4.4.1 fn:abs
 //        4.4.2 fn:ceiling

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_FormatNumber.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_FormatNumber.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.function.library;
+
+import java.util.List ;
+
+import org.apache.jena.atlas.lib.Lib ;
+import org.apache.jena.query.QueryBuildException ;
+import org.apache.jena.sparql.expr.ExprEvalException ;
+import org.apache.jena.sparql.expr.ExprList ;
+import org.apache.jena.sparql.expr.NodeValue ;
+import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp ;
+import org.apache.jena.sparql.function.FunctionBase ;
+
+/** fn:format-number : 2 or 3 arguments.
+ * The 3rd argument, decimal-format-name, is here a IETF BCP 47 language tag string.
+ */
+public class FN_FormatNumber extends FunctionBase {
+    @Override
+    public void checkBuild(String uri, ExprList args) {
+        if ( args.size() != 2 && args.size() != 3 )
+            throw new QueryBuildException("Function '"+Lib.className(this)+"' takes two or three arguments") ;
+    }
+    
+    @Override
+    public NodeValue exec(List<NodeValue> args) {
+        if ( args.size() != 2 && args.size() != 3 )
+            throw new ExprEvalException("Function '"+Lib.className(this)+"' takes two or three arguments") ;
+        NodeValue value = args.get(0) ; 
+        NodeValue picture = args.get(1) ;
+        NodeValue decimalFormatName = null ;
+        if ( args.size() == 3)
+            decimalFormatName = args.get(2) ;
+        return XSDFuncOp.formatNumber(value, picture, decimalFormatName) ;
+    }
+}


### PR DESCRIPTION
Implementation and tests for `fn:format-number`.

For the "decimal-format-name	" third argument.  F&O says it is something defined in the static context but does not provide any more guidance.