### PR TITLE
Plain begin - read transactions promoting to write transactions.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphTrackActive.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphTrackActive.java
@@ -29,7 +29,7 @@ public abstract class DatasetGraphTrackActive extends DatasetGraphWrapper
     protected DatasetGraphTrackActive() { super(null) ; }
 
     /** Check the transaction state from the point of view of the caller
-     *  (usuually, for the current thread).
+     *  (usually, for the current thread).
      */
     protected abstract void checkActive() ;
     protected abstract void checkNotActive() ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphWrapper.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphWrapper.java
@@ -57,130 +57,142 @@ public class DatasetGraphWrapper implements DatasetGraph, Sync
      */
     protected DatasetGraph get() { return dsg ; }
 
+    /** For operations that only read the DatasetGraph. */ 
+    protected DatasetGraph getR() { return get() ; }
+    
+    /** For operations that write the DatasetGraph. */ 
+    protected DatasetGraph getW() { return get() ; }
+    
+    /** For operations that get a handle on a graph. */
+    protected DatasetGraph getG() { return get() ; }
+    
+    /** For operations that pass on transaction actions. */
+    protected DatasetGraph getT() { return get() ; }
+
     public DatasetGraphWrapper(DatasetGraph dsg) {
         this.dsg = dsg ;
     }
 
     @Override
     public boolean containsGraph(Node graphNode)
-    { return get().containsGraph(graphNode) ; }
+    { return getR().containsGraph(graphNode) ; }
 
     @Override
     public Graph getDefaultGraph()
-    { return get().getDefaultGraph(); }
+    { return getG().getDefaultGraph(); }
 
     @Override
     public Graph getGraph(Node graphNode)
-    { return get().getGraph(graphNode) ; }
+    { return getG().getGraph(graphNode) ; }
 
     @Override
     public void addGraph(Node graphName, Graph graph)
-    { get().addGraph(graphName, graph) ; }
+    { getW().addGraph(graphName, graph) ; }
 
     @Override
     public void removeGraph(Node graphName)
-    { get().removeGraph(graphName) ; }
+    { getW().removeGraph(graphName) ; }
 
     @Override
     public void setDefaultGraph(Graph g)
-    { get().setDefaultGraph(g) ; }
+    { getW().setDefaultGraph(g) ; }
 
     @Override
     public Lock getLock()
-    { return get().getLock() ; }
+    { return getR().getLock() ; }
 
     @Override
     public Iterator<Node> listGraphNodes()
-    { return get().listGraphNodes() ; }
+    { return getR().listGraphNodes() ; }
 
     @Override
     public void add(Quad quad)
-    { get().add(quad) ; }
+    { getW().add(quad) ; }
 
     @Override
     public void delete(Quad quad)
-    { get().delete(quad) ; }
+    { getW().delete(quad) ; }
 
     @Override
     public void add(Node g, Node s, Node p, Node o)
-    { get().add(g, s, p, o) ; }
+    { getW().add(g, s, p, o) ; }
 
     @Override
     public void delete(Node g, Node s, Node p, Node o)
-    { get().delete(g, s, p, o) ; }
+    { getW().delete(g, s, p, o) ; }
     
     @Override
     public void deleteAny(Node g, Node s, Node p, Node o)
-    { get().deleteAny(g, s, p, o) ; }
+    { getW().deleteAny(g, s, p, o) ; }
 
     @Override
     public void clear()
-    { get().clear() ; }
+    { getW().clear() ; }
     
     @Override
     public boolean isEmpty()
-    { return get().isEmpty() ; }
+    { return getR().isEmpty() ; }
     
     @Override
     public Iterator<Quad> find()
-    { return get().find() ; }
+    { return getR().find() ; }
 
     @Override
     public Iterator<Quad> find(Quad quad)
-    { return get().find(quad) ; }
+    { return getR().find(quad) ; }
 
     @Override
     public Iterator<Quad> find(Node g, Node s, Node p, Node o)
-    { return get().find(g, s, p, o) ; }
+    { return getR().find(g, s, p, o) ; }
 
     @Override
     public Iterator<Quad> findNG(Node g, Node s, Node p, Node o)
-    { return get().findNG(g, s, p, o) ; }
+    { return getR().findNG(g, s, p, o) ; }
 
     @Override
     public boolean contains(Quad quad)
-    { return get().contains(quad) ; }
+    { return getR().contains(quad) ; }
 
     @Override
     public boolean contains(Node g, Node s, Node p, Node o)
-    { return get().contains(g, s, p, o) ; }
+    { return getR().contains(g, s, p, o) ; }
 
     @Override
     public Context getContext()
-    { return get().getContext() ; }
+    { return getR().getContext() ; }
 
     @Override
     public long size()
-    { return get().size() ; }
+    { return getR().size() ; }
 
     @Override
     public void close()
-    { get().close() ; }
+    { getW().close() ; }
     
     @Override
-    public String toString() { return get().toString() ; }
+    public String toString() { return getR().toString() ; }
 
     @Override
     public void sync() {
         // Pass down sync.
-        SystemARQ.sync(get()) ; 
+        SystemARQ.sync(getW()) ; 
     }
 
     @Override
     public void begin(ReadWrite readWrite) 
-    { get().begin(readWrite) ; }
+    { getT().begin(readWrite) ; }
 
     @Override
     public void commit() 
-    { get().commit() ; }
+    { getT().commit() ; }
 
     @Override
     public void abort() 
-    { get().abort() ; }
+    { getT().abort() ; }
 
     @Override
     public void end()
-    { get().end() ; }
+    { getT().end() ; }
 
     @Override
     public boolean isInTransaction() 
@@ -188,12 +200,12 @@ public class DatasetGraphWrapper implements DatasetGraph, Sync
 
     @Override
     public boolean supportsTransactions() {
-        return get().supportsTransactions() ;
+        return getT().supportsTransactions() ;
     }
 
     @Override
     public boolean supportsTransactionAbort() {
-        return get().supportsTransactionAbort() ;
+        return getT().supportsTransactionAbort() ;
     }
     
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetImpl.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetImpl.java
@@ -44,7 +44,6 @@ public class DatasetImpl implements Dataset
     protected DatasetGraph dsg = null ;
     // Allow for an external transactional. 
     private Transactional transactional = null ;
-    private Model dftModel = null ;
 
     /** Wrap an existing DatasetGraph */
     public static Dataset wrap(DatasetGraph datasetGraph) {
@@ -67,7 +66,6 @@ public class DatasetImpl implements Dataset
     {
         this.dsg = DatasetGraphFactory.create(model.getGraph()) ;
         this.transactional = dsg ;
-        dftModel = model ;
     }
 
     /** Create a Dataset with a copy of the structure of another one,
@@ -81,9 +79,7 @@ public class DatasetImpl implements Dataset
 
     @Override
     public Model getDefaultModel() { 
-        if ( dftModel == null )
-            dftModel = ModelFactory.createModelForGraph(dsg.getDefaultGraph()) ; 
-        return dftModel ;
+        return ModelFactory.createModelForGraph(dsg.getDefaultGraph()) ; 
     }
 
     @Override
@@ -121,21 +117,18 @@ public class DatasetImpl implements Dataset
     public void commit() {
         checkTransactional();
         transactional.commit();
-        dftModel = null;
     }
 
     @Override
     public void abort() {
         checkTransactional();
         transactional.abort();
-        dftModel = null;
     }
 
     @Override
     public void end() {
         checkTransactional();
         transactional.end();
-        dftModel = null;
     }
 
     private void checkTransactional() {
@@ -199,7 +192,6 @@ public class DatasetImpl implements Dataset
     @Override
     public void close() {
         dsg.close() ;
-        dftModel = null ;
     }
     
     protected Model graph2model(final Graph graph) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/TransactionalLock.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/TransactionalLock.java
@@ -81,11 +81,6 @@ public class TransactionalLock implements Transactional {
         this.lock = lock ;
     }
 
-    /** Transactional MRSW */
-    private TransactionalLock() {
-        this(new LockMRSW()) ;
-    }
-
     @Override
     public void begin(ReadWrite readWrite) {
         if ( isInTransaction() )

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestAPI.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestAPI.java
@@ -19,6 +19,7 @@
 package org.apache.jena.sparql.api;
 
 import java.util.Iterator;
+import java.util.Set ;
 
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.junit.BaseTest;
@@ -95,13 +96,18 @@ public class TestAPI extends BaseTest
         }
     }
 
-    // This test is slightly dubious. It is testing that the model for the
-    // resource in the result is the same object as the model supplied ot the
-    // query.
+    // The original test (see commented out "assertSame) is test is now bogus.
+    // DatasetImpl no longer caches the default model as that caused problems.
     //
-    // It happens to be true for DatasetImpl and the default model but that's
-    // about it. It is not part of the contract of query/datasets.
-    //
+    // This is testing that the model for the resource in the result is the
+    // same object as the model supplied to the query.
+    // "Same" here means "same contents" includign blank nodes.
+    // 
+    // it used to be that this tested whether they were the same object. 
+    // That is dubious and no longer true even for DatasetImpl (teh default mode
+    // is not cached but recreated on demand so theer are no problems with
+    // transaction boundaries).    
+    // 
     // Left as an active test so the assumption is tested (it has been true for
     // many years). 
     //
@@ -115,7 +121,10 @@ public class TestAPI extends BaseTest
             assertTrue("No results", rs.hasNext()) ;
             QuerySolution qs = rs.nextSolution() ;
             Resource qr = qs.getResource("s") ;
-            assertSame("Not the same model as queried", qr.getModel(), m) ;
+            //assertSame("Not the same model as queried", qr.getModel(), m) ;
+            Set<Statement> s1 = qr.getModel().listStatements().toSet() ;
+            Set<Statement> s2 = m.listStatements().toSet() ;
+            assertEquals(s1,s2) ;
         }
     }
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateOperations.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateOperations.java
@@ -113,13 +113,13 @@ public class TestUpdateOperations extends BaseTest
             @Override
             public void add(Quad quad) { 
                 counterIns.incrementAndGet() ;
-                get().add(quad) ;
+                super.add(quad) ;
             }
 
             @Override
             public void delete(Quad quad) {
                 counterDel.incrementAndGet() ;
-                get().delete(quad) ; 
+                super.delete(quad) ; 
             }
         } ;
         

--- a/jena-cmds/src/main/java/tdb/cmdline/CmdTDBGraph.java
+++ b/jena-cmds/src/main/java/tdb/cmdline/CmdTDBGraph.java
@@ -20,13 +20,12 @@ package tdb.cmdline;
 
 import jena.cmd.ArgDecl;
 import jena.cmd.CmdException;
-
 import org.apache.jena.atlas.lib.Lib ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.rdf.model.Model ;
-import org.apache.jena.tdb.store.GraphTDB ;
+import org.apache.jena.tdb.store.GraphNonTxnTDB ;
 
 public abstract class CmdTDBGraph extends CmdTDB
 {
@@ -64,12 +63,12 @@ public abstract class CmdTDBGraph extends CmdTDB
     
     public Node getGraphName()  { return graphName == null ? null : NodeFactory.createURI(graphName) ; } 
     
-    protected GraphTDB getGraph()
+    protected GraphNonTxnTDB getGraph()
     {
         if ( graphName != null )
-            return (GraphTDB)tdbDatasetAssembler.getDataset().getNamedModel(graphName).getGraph() ;
+            return (GraphNonTxnTDB)tdbDatasetAssembler.getDataset().getNamedModel(graphName).getGraph() ;
         else
-            return (GraphTDB)tdbDatasetAssembler.getDataset().getDefaultModel().getGraph() ;
+            return (GraphNonTxnTDB)tdbDatasetAssembler.getDataset().getDefaultModel().getGraph() ;
     }
     
     @Override

--- a/jena-cmds/src/main/java/tdb/tdbloader.java
+++ b/jena-cmds/src/main/java/tdb/tdbloader.java
@@ -22,14 +22,12 @@ import java.util.List ;
 
 import jena.cmd.ArgDecl;
 import jena.cmd.CmdException;
-
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFLanguages ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.TDBLoader ;
-import org.apache.jena.tdb.store.GraphTDB ;
-
+import org.apache.jena.tdb.store.GraphNonTxnTDB ;
 import tdb.cmdline.CmdTDB ;
 import tdb.cmdline.CmdTDBGraph ;
 
@@ -126,7 +124,7 @@ public class tdbloader extends CmdTDBGraph {
 //    }
 
     void loadNamedGraph(List<String> urls) {
-        GraphTDB graph = getGraph() ;
+        GraphNonTxnTDB graph = getGraph() ;
         TDBLoader.load(graph, urls, showProgress) ;
         return ;
     }

--- a/jena-spatial/src/main/java/org/apache/jena/query/spatial/DatasetGraphSpatial.java
+++ b/jena-spatial/src/main/java/org/apache/jena/query/spatial/DatasetGraphSpatial.java
@@ -59,7 +59,7 @@ public class DatasetGraphSpatial extends DatasetGraphMonitor implements Transact
     @Override
     public void begin(ReadWrite readWrite)
     {
-        get().begin(readWrite) ;
+        super.begin(readWrite) ;
         //textIndex.begin(readWrite) ;
         if ( readWrite == ReadWrite.WRITE )
         {
@@ -82,10 +82,10 @@ public class DatasetGraphSpatial extends DatasetGraphMonitor implements Transact
             }
             needFinish = false ;
             //spatialIndex.commit() ;
-            get().commit() ;
+            super.commit() ;
         } catch (Throwable ex) { 
             log.warn("Exception in commit: "+ex.getMessage(), ex) ;
-            get().abort() ; 
+            super.abort() ; 
         }
     }
 
@@ -96,14 +96,14 @@ public class DatasetGraphSpatial extends DatasetGraphMonitor implements Transact
             if ( needFinish )
                 spatialIndex.abortIndexing() ;
             //spatialIndex.abort() ;
-            get().abort() ;
+            super.abort() ;
         } catch (Throwable ex) { log.warn("Exception in abort: "+ex.getMessage(), ex) ; }
     }
 
     @Override
     public boolean isInTransaction()
     {
-        return get().isInTransaction() ;
+        return super.isInTransaction() ;
     }
 
     @Override
@@ -111,13 +111,13 @@ public class DatasetGraphSpatial extends DatasetGraphMonitor implements Transact
     {
         try {
             //spatialIndex.end() ;
-            get().end() ;
+            super.end() ;
         } catch (Throwable ex) { log.warn("Exception in end: "+ex.getMessage(), ex) ; }
     }
     
     @Override
     public boolean supportsTransactions() {
-        return get().supportsTransactions() ;
+        return super.supportsTransactions() ;
     }
     
     /** Declare whether {@link #abort} is supported.
@@ -125,7 +125,7 @@ public class DatasetGraphSpatial extends DatasetGraphMonitor implements Transact
      */
     @Override
     public boolean supportsTransactionAbort() {
-        return get().supportsTransactionAbort() ;
+        return super.supportsTransactionAbort() ;
     }
 }
 

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/TDBLoader.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/TDBLoader.java
@@ -26,7 +26,7 @@ import org.apache.jena.atlas.lib.Timer ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.tdb.store.DatasetGraphTDB ;
-import org.apache.jena.tdb.store.GraphTDB ;
+import org.apache.jena.tdb.store.GraphNonTxnTDB ;
 import org.apache.jena.tdb.store.bulkloader.BulkLoader ;
 import org.slf4j.Logger ;
 
@@ -36,7 +36,7 @@ import org.slf4j.Logger ;
 public class TDBLoader
 {
     /** Load the contents of URL into a dataset.  URL must name a quads format file (NQuads or TriG - NTriples is also accepted).
-     *  To a triples format, use {@link #load(GraphTDB, String)}
+     *  To a triples format, use {@link #load(GraphNonTxnTDB, String)}
      *  or {@link #load(DatasetGraphTDB, List, boolean, boolean)}
     */
     public static void load(DatasetGraphTDB dataset, String url)
@@ -45,7 +45,7 @@ public class TDBLoader
     }
 
     /** Load the contents of URL into a dataset.  URL must name a quads format file (NQuads or TriG - NTriples is also accepted).
-     *  To a triples format, use {@link #load(GraphTDB, String, boolean)} 
+     *  To a triples format, use {@link #load(GraphNonTxnTDB, String, boolean)} 
      *  or {@link #load(DatasetGraphTDB, List, boolean, boolean)}
     */
     public static void load(DatasetGraphTDB dataset, String url, boolean showProgress)
@@ -54,7 +54,7 @@ public class TDBLoader
     }
 
     /** Load the contents of URL into a dataset.  URL must name a quads format file (NQuads or TriG - NTriples is also accepted).
-     *  To load a triples format, use {@link #load(GraphTDB, List, boolean)} 
+     *  To load a triples format, use {@link #load(GraphNonTxnTDB, List, boolean)} 
      *  or {@link #load(DatasetGraphTDB, List, boolean, boolean)} 
     */
     public static void load(DatasetGraphTDB dataset, List<String> urls)
@@ -63,7 +63,7 @@ public class TDBLoader
     }
     
     /** Load the contents of URL into a dataset.  URL must name a quads format file (NQuads or TriG - NTriples is also accepted).
-     *  To load a triples format, use {@link #load(GraphTDB, List, boolean)} 
+     *  To load a triples format, use {@link #load(GraphNonTxnTDB, List, boolean)} 
      *  or {@link #load(DatasetGraphTDB, List, boolean, boolean)} 
     */
     public static void load(DatasetGraphTDB dataset, List<String> urls, boolean showProgress, boolean generateStats)
@@ -86,25 +86,25 @@ public class TDBLoader
     }
     
     /** Load the contents of URL into a graph */
-    public static void load(GraphTDB graph, String url)
+    public static void load(GraphNonTxnTDB graph, String url)
     {
         load(graph, url, false) ;
     }
     
     /** Load the contents of URL into a graph */
-    public static void load(GraphTDB graph, String url, boolean showProgress)
+    public static void load(GraphNonTxnTDB graph, String url, boolean showProgress)
     {
         load(graph, asList(url), showProgress) ;
     }
 
     /** Load the contents of URL into a graph */
-    public static void load(GraphTDB graph, List<String> urls)
+    public static void load(GraphNonTxnTDB graph, List<String> urls)
     {
         load(graph, urls, false) ;
     }
     
     /** Load the contents of URL into a graph */
-    public static void load(GraphTDB graph, List<String> urls, boolean showProgress)
+    public static void load(GraphNonTxnTDB graph, List<String> urls, boolean showProgress)
     {
         TDBLoader loader = new TDBLoader() ;
         loader.setShowProgress(showProgress) ;
@@ -163,19 +163,19 @@ public class TDBLoader
     public TDBLoader() {}
 
     /** Load a graph from a URL - assumes URL names a triples format document*/
-    public void loadGraph(GraphTDB graph, String url)
+    public void loadGraph(GraphNonTxnTDB graph, String url)
     {
         loadGraph(graph, asList(url)) ;
     }
     
     /** Load a graph from a list of URL - assumes the URLs name triples format documents */
-    public void loadGraph(GraphTDB graph, List<String> urls)
+    public void loadGraph(GraphNonTxnTDB graph, List<String> urls)
     {
         loadGraph$(graph, urls, showProgress, generateStats) ;
     }
     
     /** Load a graph from a list of URL - assumes the URLs name triples format documents */
-    public void loadGraph(GraphTDB graph, InputStream in)
+    public void loadGraph(GraphNonTxnTDB graph, InputStream in)
     {
         loadGraph$(graph, in, showProgress, generateStats) ;
     }
@@ -225,20 +225,20 @@ public class TDBLoader
 //    public final void setLogger(Logger log)
 //    { this.loaderLog = log ; }
     
-    private static void loadGraph$(GraphTDB graph, List<String> urls, boolean showProgress, boolean collectStats) {
+    private static void loadGraph$(GraphNonTxnTDB graph, List<String> urls, boolean showProgress, boolean collectStats) {
         if ( graph.getGraphName() == null )
-            loadDefaultGraph$(graph.getDSG(), urls, showProgress, collectStats) ;
+            loadDefaultGraph$(graph.getDatasetGraphTDB(), urls, showProgress, collectStats) ;
         else
-            loadNamedGraph$(graph.getDSG(), graph.getGraphName(), urls, showProgress, collectStats) ;
+            loadNamedGraph$(graph.getDatasetGraphTDB(), graph.getGraphName(), urls, showProgress, collectStats) ;
     }
 
     // These are the basic operations for TDBLoader.
 
-    private static void loadGraph$(GraphTDB graph, InputStream input, boolean showProgress, boolean collectStats) {
+    private static void loadGraph$(GraphNonTxnTDB graph, InputStream input, boolean showProgress, boolean collectStats) {
         if ( graph.getGraphName() == null )
-            loadDefaultGraph$(graph.getDSG(), input, showProgress, collectStats) ;
+            loadDefaultGraph$(graph.getDatasetGraphTDB(), input, showProgress, collectStats) ;
         else
-            loadNamedGraph$(graph.getDSG(), graph.getGraphName(), input, showProgress, collectStats) ;
+            loadNamedGraph$(graph.getDatasetGraphTDB(), graph.getGraphName(), input, showProgress, collectStats) ;
     }
 
     private static void loadDefaultGraph$(DatasetGraphTDB dataset, List<String> urls, boolean showProgress, boolean collectStats) {

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/store/DatasetGraphTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/store/DatasetGraphTDB.java
@@ -61,7 +61,6 @@ public class DatasetGraphTDB extends DatasetGraphTriplesQuads
     private final ReorderTransformation transform ;
     private final StorageConfig config ;
     
-    private GraphTDB effectiveDefaultGraph ;
     private boolean closed = false ;
 
     public DatasetGraphTDB(TripleTable tripleTable, QuadTable quadTable, DatasetPrefixesTDB prefixes, 
@@ -71,7 +70,6 @@ public class DatasetGraphTDB extends DatasetGraphTriplesQuads
         this.prefixes = prefixes ;
         this.transform = transform ;
         this.config = config ;
-        this.effectiveDefaultGraph = getDefaultGraphTDB() ;
     }
 
     public QuadTable getQuadTable()         { return quadTable ; }
@@ -105,11 +103,11 @@ public class DatasetGraphTDB extends DatasetGraphTriplesQuads
     protected void deleteFromNamedGraph(Node g, Node s, Node p, Node o)
     { getQuadTable().delete(g, s, p, o) ; }
     
-    public GraphTDB getDefaultGraphTDB() 
-    { return (GraphTDB)getDefaultGraph() ; }
+    public GraphNonTxnTDB getDefaultGraphTDB() 
+    { return (GraphNonTxnTDB)getDefaultGraph() ; }
 
-    public GraphTDB getGraphTDB(Node graphNode)
-    { return (GraphTDB)getGraph(graphNode) ; }
+    public GraphNonTxnTDB getGraphTDB(Node graphNode)
+    { return (GraphNonTxnTDB)getGraph(graphNode) ; }
 
     @Override
     public void close() {
@@ -145,17 +143,15 @@ public class DatasetGraphTDB extends DatasetGraphTriplesQuads
         return result ;
     }
 
+    // When not yet transactional, these can be called??
+    
     @Override
     public Graph getDefaultGraph()
-    { return new GraphTDB(this, null) ; }
+    { return new GraphNonTxnTDB(this, null) ; }
 
     @Override
     public Graph getGraph(Node graphNode)
-    { return new GraphTDB(this, graphNode) ; }
-
-    //public void setEffectiveDefaultGraph(GraphTDB g)       { effectiveDefaultGraph = g ; }
-
-    public GraphTDB getEffectiveDefaultGraph()              { return effectiveDefaultGraph ; }
+    { return new GraphNonTxnTDB(this, graphNode) ; }
 
     public StorageConfig getConfig()                        { return config ; }
     

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/store/GraphNonTxnTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/store/GraphNonTxnTDB.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.tdb.store ;
+
+import org.apache.jena.atlas.lib.Closeable ;
+import org.apache.jena.atlas.lib.Sync ;
+import org.apache.jena.graph.Node ;
+
+/**
+ * Non-transactional version of {@link GraphTDB}. Handed out by DatasetGraphTDB when used
+ * directly.
+ * 
+ * @see GraphTDB
+ * @see GraphTxnTDB
+ */
+public class GraphNonTxnTDB extends GraphTDB implements Closeable, Sync {
+    private final DatasetGraphTDB    dataset ;
+
+    public GraphNonTxnTDB(DatasetGraphTDB dataset, Node graphName) {
+        super(dataset, graphName) ;
+        this.dataset = dataset ;
+    }
+
+    @Override
+    public DatasetGraphTDB getDatasetGraphTDB() {
+        return dataset ;
+    }
+
+    @Override
+    protected DatasetGraphTDB getBaseDatasetGraphTDB() {
+        return dataset ;
+    }
+}

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/store/GraphTxnTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/store/GraphTxnTDB.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.tdb.store ;
+
+import org.apache.jena.atlas.lib.Closeable ;
+import org.apache.jena.atlas.lib.Sync ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.TransactionHandler ;
+import org.apache.jena.tdb.graph.TransactionHandlerTDB ;
+import org.apache.jena.tdb.transaction.DatasetGraphTransaction ;
+
+/**
+ * Transaction version of {@link GraphTDB}.
+ * Valid across transactions excep where noted.
+ * 
+ * @see GraphTDB  
+ * @see GraphTxnTDB  
+
+ */
+public class GraphTxnTDB extends GraphTDB implements Closeable, Sync {
+    // [TXN] ??
+    private final TransactionHandler transactionHandler = new TransactionHandlerTDB(this) ;
+
+    private final DatasetGraphTransaction dataset ;
+
+    public GraphTxnTDB(DatasetGraphTransaction dataset, Node graphName) {
+        super(dataset, graphName) ;
+        this.dataset = dataset ;
+    }
+
+    @Override
+    public DatasetGraphTDB getDatasetGraphTDB() {
+        return dataset.getDatasetGraphToQuery() ;
+    }
+
+    // [TXN] Transaction prefixes.
+    
+    @Override
+    public TransactionHandler getTransactionHandler() {
+        return transactionHandler ;
+    }
+
+    @Override
+    protected DatasetGraphTDB getBaseDatasetGraphTDB() {
+        return dataset.getBaseDatasetGraph() ;
+    }
+}

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/DatasetGraphTransaction.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/DatasetGraphTransaction.java
@@ -86,7 +86,8 @@ import org.apache.jena.tdb.store.GraphTxnTDB ;
         return sConn.getBaseDataset() ;
     }
 
-    /*private*/public/*for development*/ static boolean promotion = false ; 
+    /*private*/public/*for development*/ static boolean promotion               = false ; 
+    /*private*/public/*for development*/ static boolean readCommittedPromotion   = true ;
     
     @Override public DatasetGraph getW() {
         if ( isInTransaction() ) {
@@ -94,7 +95,7 @@ import org.apache.jena.tdb.store.GraphTxnTDB ;
                 DatasetGraphTxn dsgTxn = txn.get() ;
                 if ( dsgTxn.getTransaction().isRead() ) {
                     TransactionManager txnMgr = dsgTxn.getTransaction().getTxnMgr() ;
-                    DatasetGraphTxn dsgTxn2 = txnMgr.promote(dsgTxn, true) ;
+                    DatasetGraphTxn dsgTxn2 = txnMgr.promote(dsgTxn, readCommittedPromotion) ;
                     txn.set(dsgTxn2); 
                 }
             }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/DatasetGraphTxn.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/DatasetGraphTxn.java
@@ -25,7 +25,7 @@ import org.apache.jena.tdb.store.DatasetGraphTDB;
 /**
  * A DatasetGraph that is a single transaction.
  * It does not support transactions.
- * It is the DatasetGraph apsect of a Transaction (single use).
+ * It is the DatasetGraph aspect of a Transaction (single use).
  */
 public class DatasetGraphTxn extends DatasetGraphWrapper {
     

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
@@ -269,16 +269,14 @@ public class Transaction
     
     public DatasetGraphTxn getActiveDataset()       { return activedsg ; }
 
-    public void setActiveDataset(DatasetGraphTxn activedsg) { 
+    /*package*/ void setActiveDataset(DatasetGraphTxn activedsg) { 
         this.activedsg = activedsg ;
         if ( activedsg.getTransaction() != this )
             Log.warn(this, "Active DSG does not point to this transaction; "+this) ;
     }
 
-    public Journal getJournal()                     { return journal ; }
+    /*package*/ Journal getJournal()                     { return journal ; }
 
-//    public List<Iterator<?>> iterators()            { return Collections.unmodifiableList(iterators) ; }
-//    
     private int count = 0 ;
     private int peekCount = 0 ;
 
@@ -307,11 +305,11 @@ public class Transaction
         return x ;
     }
     
-    public void addComponent(NodeTableTrans ntt) {
+    /*package*/ void addComponent(NodeTableTrans ntt) {
         nodeTableTrans.add(ntt) ;
     }
 
-    public void addComponent(BlockMgrJournal blkMgr) {
+    /*package*/ void addComponent(BlockMgrJournal blkMgr) {
         blkMgrs.add(blkMgr) ;
     }
 

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
@@ -41,6 +41,7 @@ public class Transaction
     private final List<BlockMgrJournal> blkMgrs = new ArrayList<>() ;
     // The dataset this is a transaction over - may be a commited, pending dataset.
     private final DatasetGraphTDB   basedsg ;
+    private final long version ;
 
     private final List<Iterator<?>> iterators ;     // Tracking iterators 
     private DatasetGraphTxn         activedsg ;
@@ -52,7 +53,7 @@ public class Transaction
     
     private boolean changesPending ;
     
-    public Transaction(DatasetGraphTDB dsg, ReadWrite mode, long id, String label, TransactionManager txnMgr) {
+    public Transaction(DatasetGraphTDB dsg, long version, ReadWrite mode, long id, String label, TransactionManager txnMgr) {
         this.id = id ;
         if (label == null )
             label = "Txn" ;
@@ -65,6 +66,7 @@ public class Transaction
         this.label = label ;
         this.txnMgr = txnMgr ;
         this.basedsg = dsg ;
+        this.version = version ;
         this.mode = mode ;
         this.journal = ( txnMgr == null ) ? null : txnMgr.getJournal() ;
         activedsg = null ;      // Don't know yet.
@@ -268,6 +270,7 @@ public class Transaction
     public TransactionManager getTxnMgr()           { return txnMgr ; }
     
     public DatasetGraphTxn getActiveDataset()       { return activedsg ; }
+    public long getVersion()                        { return version ; }
 
     /*package*/ void setActiveDataset(DatasetGraphTxn activedsg) { 
         this.activedsg = activedsg ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
@@ -339,16 +339,17 @@ public class TransactionManager
         }           
         
         // Don't promote if the database has moved on.
+
         // 1/ No active writers.
-        //    Ideally, wiait to see if it aborts but abort is uncommon. 
+        //    Ideally, wait to see if it aborts but abort is uncommon.
+        //    We can not grab the write lock here - we have the TM sync lock
+        //    so an active writer can not commit.s
+        
         // Easy implementation -- if any active writers, don't promote.
         if ( activeWriters.get() > 0 )
-            throw new TDBTransactionException("Dataset may be changing - active writer - can't promote") ;
-//            // Would this block corrctly? ... drops the sync lock?
-//            acquireWriterLock(true) ;
+             throw new TDBTransactionException("Dataset may be changing - active writer - can't promote") ;
 
         // 2/ Check the database view has not moved on. No active writers at the moment.
-        
         if ( txn.getVersion() != version.get() )
             throw new TDBTransactionException("Dataset changed - can't promote") ;
 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/assembler/TestTDBAssembler.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/assembler/TestTDBAssembler.java
@@ -103,7 +103,7 @@ public class TestTDBAssembler extends BaseTest
         Graph graph = ((Model)thing).getGraph() ;
         assertTrue(graph instanceof GraphTDB) ; 
 
-        DatasetGraphTDB ds = ((GraphTDB)graph).getDSG() ;
+        DatasetGraphTDB ds = ((GraphTDB)graph).getDatasetGraphTDB() ;
         if ( ds != null )
             ds.close();
     }
@@ -138,7 +138,7 @@ public class TestTDBAssembler extends BaseTest
         
         assertTrue(graph instanceof GraphTDB) ; 
         
-        DatasetGraphTDB ds = ((GraphTDB)graph).getDSG() ;
+        DatasetGraphTDB ds = ((GraphTDB)graph).getDatasetGraphTDB() ;
         if ( ds != null )
             ds.close();
     }

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestLoader.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestLoader.java
@@ -34,8 +34,6 @@ import org.apache.jena.tdb.ConfigTest ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.TDBLoader ;
 import org.apache.jena.tdb.base.file.Location ;
-import org.apache.jena.tdb.store.DatasetGraphTDB ;
-import org.apache.jena.tdb.store.GraphTDB ;
 import org.apache.jena.tdb.sys.TDBMaker ;
 import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
@@ -148,7 +146,7 @@ public class TestLoader extends BaseTest {
     @Test
     public void load_graph_05() {
         DatasetGraphTDB dsg = fresh() ;
-        GraphTDB graph = dsg.getDefaultGraphTDB() ;
+        GraphNonTxnTDB graph = dsg.getDefaultGraphTDB() ;
         TDBLoader.load(graph, DIR + "data-4.ttl", false) ;
         String uri = dsg.getDefaultGraph().getPrefixMapping().getNsPrefixURI("") ;
         assertEquals("http://example/", uri) ;
@@ -157,7 +155,7 @@ public class TestLoader extends BaseTest {
     @Test
     public void load_graph_06() {
         DatasetGraphTDB dsg = fresh() ;
-        GraphTDB graph = dsg.getGraphTDB(g) ;
+        GraphNonTxnTDB graph = dsg.getGraphTDB(g) ;
         TDBLoader.load(graph, DIR + "data-4.ttl", false) ;
         String uri1 = dsg.getGraph(g).getPrefixMapping().getNsPrefixURI("") ;
         assertEquals("http://example/", uri1) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestNodeTableTrans.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestNodeTableTrans.java
@@ -72,7 +72,7 @@ public abstract class AbstractTestNodeTableTrans extends BaseTest
     
     Transaction createTxn(long id) 
     {
-        return new Transaction(null, ReadWrite.WRITE, id, null, null) ; 
+        return new Transaction(null, 99, ReadWrite.WRITE, id, null, null) ; 
     }
     
     @Test public void nodetrans_01()

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTrans.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTrans.java
@@ -49,7 +49,7 @@ public abstract class AbstractTestObjectFileTrans extends BaseTest
     @Before
     public void setup()
     {
-        txn = new Transaction(null, ReadWrite.WRITE, ++count, null, tm) ;
+        txn = new Transaction(null, 5, ReadWrite.WRITE, ++count, null, tm) ;
         file1 = createFile("base") ;
         file2 = createFile("log") ;
     }

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TS_TransactionTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TS_TransactionTDB.java
@@ -41,6 +41,7 @@ import org.junit.runners.Suite ;
     , TestTransactionUnionGraph.class
     , TestMiscTDB.class
     , TestTDBInternal.class
+    , TestTransPromote.class
 })
 public class TS_TransactionTDB
 {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
@@ -29,6 +29,7 @@ import org.apache.jena.query.ReadWrite ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.system.ThreadAction ;
 import org.apache.jena.system.ThreadTxn ;
 import org.apache.jena.system.Txn ;
 import org.apache.jena.tdb.TDB ;
@@ -225,7 +226,7 @@ public class TestTransPromote {
         DatasetGraphTransaction.readCommittedPromotion = b ;
         DatasetGraph dsg = create() ;
         // Start long running reader.
-        ThreadTxn tt = ThreadTxn.threadTxnRead(dsg, () -> {
+        ThreadAction tt = ThreadTxn.threadTxnRead(dsg, () -> {
             long x = Iter.count(dsg.find()) ;
             if ( x != 0 )
                 throw new RuntimeException() ;
@@ -279,7 +280,7 @@ public class TestTransPromote {
         DatasetGraphTransaction.readCommittedPromotion = allowReadCommitted ;
         DatasetGraph dsg = create() ;
         
-        ThreadTxn tt = asyncCommit?
+        ThreadAction tt = asyncCommit?
             ThreadTxn.threadTxnWrite(dsg, () -> dsg.add(q3) ) :
             ThreadTxn.threadTxnWriteAbort(dsg, () -> dsg.add(q3)) ;
 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.tdb.transaction;
+
+import static org.junit.Assert.* ;
+
+import java.util.concurrent.Semaphore ;
+import java.util.concurrent.atomic.AtomicInteger ;
+
+import org.apache.jena.atlas.iterator.Iter ;
+import org.apache.jena.query.ReadWrite ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.system.ThreadTxn ;
+import org.apache.jena.system.Txn ;
+import org.apache.jena.tdb.TDBFactory ;
+import org.apache.jena.tdb.sys.SystemTDB ;
+import org.apache.jena.tdb.transaction.DatasetGraphTransaction ;
+import org.apache.log4j.Level ;
+import org.apache.log4j.Logger ;
+import org.junit.AfterClass ;
+import org.junit.BeforeClass ;
+import org.junit.Test ;
+
+/** Tests for transactions that start read and then promote to write */ 
+public class TestTransPromote {
+
+    // Currently,
+    //    this feature is off and needs enabling via DatasetGraphTransaction.promotion
+    //    promotiion is implicit whe a write happens.  
+    
+    
+    
+    // See beforeClass / afterClass.
+    
+    private static Logger logger = Logger.getLogger(SystemTDB.errlog.getName()) ;
+    private static Level  level ;
+    static boolean oldPromotion ;
+    
+    @BeforeClass static public void beforeClass() {
+        oldPromotion = DatasetGraphTransaction.promotion ;
+        DatasetGraphTransaction.promotion = true ;
+        level  = logger.getLevel() ;
+        //logger.setLevel(Level.ERROR) ;
+    }
+    
+    @AfterClass static public void afterClass() {
+        // Restore logging setting.
+        logger.setLevel(level); 
+        DatasetGraphTransaction.promotion = oldPromotion ;
+    }
+    
+    private static Quad q1 = SSE.parseQuad("(_ :s :p1 1)") ;
+    private static Quad q2 = SSE.parseQuad("(_ :s :p2 2)") ;
+    private static Quad q3 = SSE.parseQuad("(_ :s :p3 3)") ;
+    
+    protected DatasetGraph create() { return TDBFactory.createDatasetGraph() ; } 
+    
+    protected static void assertCount(long expected, DatasetGraph dsg) {
+        dsg.begin(ReadWrite.READ);
+        long x = Iter.count(dsg.find()) ;
+        dsg.end() ;
+        assertEquals(expected, x) ;
+    }
+    
+    @Test public void promote_01() {
+        DatasetGraph dsg = create() ;
+        dsg.begin(ReadWrite.READ); 
+        dsg.add(q1) ;
+        dsg.commit();
+        dsg.end() ;
+    }
+    
+    @Test public void promote_02() {
+        DatasetGraph dsg = create() ;
+        dsg.begin(ReadWrite.READ); 
+        dsg.add(q1) ;
+        dsg.add(q2) ;
+        dsg.commit();
+        dsg.end() ;
+        assertCount(2, dsg) ;
+    }
+
+    // Causes the warning.
+    @Test public void promote_03() {
+        DatasetGraph dsg = create() ;
+        dsg.begin(ReadWrite.READ); 
+        dsg.add(q1) ;
+        
+        // bad - forced abort.
+        // Causes a WARN.
+        logger.setLevel(Level.ERROR) ;
+        dsg.end() ;
+        logger.setLevel(level)  ;
+        
+        assertCount(0, dsg) ;
+    }
+    
+    @Test public void promote_04() {
+        DatasetGraph dsg = create() ;
+        AtomicInteger a = new AtomicInteger(0) ;
+        
+        Semaphore sema = new Semaphore(0) ;
+        Thread t = new Thread(()->{
+            sema.release();
+            Txn.execWrite(dsg, ()->dsg.add(q3)) ;   
+            sema.release();
+        }) ;
+        
+        dsg.begin(ReadWrite.READ);
+        // Promote
+        dsg.add(q1) ;
+        t.start(); 
+        // First release.
+        sema.acquireUninterruptibly();
+        // Thread blocked. 
+        dsg.add(q2) ;
+        dsg.commit();
+        dsg.end() ;
+        
+        // Until thread exits.
+        sema.acquireUninterruptibly();
+        assertCount(3, dsg) ;
+    }
+    
+    @Test public void promote_05() {
+        DatasetGraph dsg = create() ;
+        // Start long running reader.
+        ThreadTxn tt = ThreadTxn.threadTxnRead(dsg, ()->{
+            long x = Iter.count(dsg.find()) ;
+            if ( x != 0 ) 
+                throw new RuntimeException() ;
+        }) ;
+    
+        // Start R->W here
+        dsg.begin(ReadWrite.READ); 
+        dsg.add(q1) ;
+        dsg.add(q2) ;
+        dsg.commit();
+        dsg.end() ;
+        tt.run();
+    }
+    
+    @Test public void promote_06() {
+        promoteRC(true) ;
+    }
+        
+    @Test(expected=TDBTransactionException.class)
+    public void promote_07() {
+        promoteRC(false) ;
+    }
+     
+    private void promoteRC(boolean allowReadCommitted) {
+        DatasetGraphTransaction.readCommittedPromotion = allowReadCommitted ;    
+        DatasetGraph dsg = create() ;
+
+        ThreadTxn tt = ThreadTxn.threadTxnWrite(dsg, ()->{dsg.add(q3) ;}) ;
+        
+        dsg.begin(ReadWrite.READ);
+        // Other runs
+        tt.run(); 
+        // Can  promote if readCommited
+        // Can't promote if not readCommited
+        dsg.add(q1) ;
+        assertTrue(dsg.contains(q3)) ;
+        dsg.commit();
+        dsg.end() ;
+    }
+
+}

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
@@ -16,9 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.jena.tdb.transaction;
+package org.apache.jena.tdb.transaction ;
 
-import static org.junit.Assert.* ;
+import static org.junit.Assert.assertEquals ;
+import static org.junit.Assert.fail ;
 
 import java.util.concurrent.Semaphore ;
 import java.util.concurrent.atomic.AtomicInteger ;
@@ -30,158 +31,298 @@ import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.apache.jena.system.ThreadTxn ;
 import org.apache.jena.system.Txn ;
+import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.TDBFactory ;
 import org.apache.jena.tdb.sys.SystemTDB ;
-import org.apache.jena.tdb.transaction.DatasetGraphTransaction ;
 import org.apache.log4j.Level ;
 import org.apache.log4j.Logger ;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
+import org.junit.* ;
 
-/** Tests for transactions that start read and then promote to write */ 
+/** Tests for transactions that start read and then promote to write */
 public class TestTransPromote {
 
     // Currently,
-    //    this feature is off and needs enabling via DatasetGraphTransaction.promotion
-    //    promotiion is implicit whe a write happens.  
-    
-    
-    
+    // this feature is off and needs enabling via DatasetGraphTransaction.promotion
+    // promotiion is implicit whe a write happens.
+
     // See beforeClass / afterClass.
-    
-    private static Logger logger = Logger.getLogger(SystemTDB.errlog.getName()) ;
-    private static Level  level ;
-    static boolean oldPromotion ;
-    
-    @BeforeClass static public void beforeClass() {
-        oldPromotion = DatasetGraphTransaction.promotion ;
-        DatasetGraphTransaction.promotion = true ;
-        level  = logger.getLevel() ;
-        //logger.setLevel(Level.ERROR) ;
+
+    private static Logger logger1 = Logger.getLogger(SystemTDB.errlog.getName()) ;
+    private static Level  level1 ;
+    private static Logger logger2 = Logger.getLogger(TDB.logInfoName) ;
+    private static Level  level2 ;
+    static boolean        stdPromotion ;
+    static boolean        stdReadCommitted ;
+
+    @BeforeClass
+    static public void beforeClass() {
+        stdPromotion = DatasetGraphTransaction.promotion ;
+        stdReadCommitted = DatasetGraphTransaction.readCommittedPromotion ;
+        level1 = logger1.getLevel() ;
+        level2 = logger2.getLevel() ;
+        
+        // logger1.setLevel(Level.ERROR) ;
+        // logger2.setLevel(Level.ERROR) ;
     }
-    
-    @AfterClass static public void afterClass() {
+
+    @AfterClass
+    static public void afterClass() {
         // Restore logging setting.
-        logger.setLevel(level); 
-        DatasetGraphTransaction.promotion = oldPromotion ;
+        logger2.setLevel(level2) ;
+        logger1.setLevel(level1) ;
+        DatasetGraphTransaction.promotion = stdPromotion ;
+        DatasetGraphTransaction.readCommittedPromotion = stdReadCommitted ;
     }
+
+    @Before
+    public void before() {
+        DatasetGraphTransaction.promotion = true ;
+        DatasetGraphTransaction.readCommittedPromotion = true ;
+    }
+
+    @After
+    public void after() {
+        DatasetGraphTransaction.promotion = true ;
+        DatasetGraphTransaction.readCommittedPromotion = true ;
+    }
+    
     
     private static Quad q1 = SSE.parseQuad("(_ :s :p1 1)") ;
     private static Quad q2 = SSE.parseQuad("(_ :s :p2 2)") ;
     private static Quad q3 = SSE.parseQuad("(_ :s :p3 3)") ;
-    
-    protected DatasetGraph create() { return TDBFactory.createDatasetGraph() ; } 
-    
+
+    protected DatasetGraph create() {
+        return TDBFactory.createDatasetGraph() ;
+    }
+
     protected static void assertCount(long expected, DatasetGraph dsg) {
-        dsg.begin(ReadWrite.READ);
+        dsg.begin(ReadWrite.READ) ;
         long x = Iter.count(dsg.find()) ;
         dsg.end() ;
         assertEquals(expected, x) ;
     }
+
+    // "strict" = don't see intermedioate changes.
+    // "readCommitted" = do see
+
+    // Subclass / parameterized
     
-    @Test public void promote_01() {
+    @Test public void promote_snapshot_01()         { run_01(false) ; }
+    @Test public void promote_readCommitted_01()    { run_01(true) ; }
+    
+    // READ-add
+    private void run_01(boolean b) {
+        DatasetGraphTransaction.readCommittedPromotion = b ;
         DatasetGraph dsg = create() ;
-        dsg.begin(ReadWrite.READ); 
+        
+        dsg.begin(ReadWrite.READ) ;
         dsg.add(q1) ;
-        dsg.commit();
+        dsg.commit() ;
         dsg.end() ;
     }
     
-    @Test public void promote_02() {
+    @Test public void promote_snapshot_02()         { run_02(false) ; }
+    @Test public void promote_readCommitted_02()    { run_02(true) ; }
+    
+    // Previous transaction then READ-add
+    private void run_02(boolean b) {
+        DatasetGraphTransaction.readCommittedPromotion = b ;
         DatasetGraph dsg = create() ;
-        dsg.begin(ReadWrite.READ); 
+        
+        dsg.begin(ReadWrite.READ) ;dsg.end() ;
+        
+        dsg.begin(ReadWrite.READ) ;
         dsg.add(q1) ;
-        dsg.add(q2) ;
-        dsg.commit();
+        dsg.commit() ;
         dsg.end() ;
-        assertCount(2, dsg) ;
+    }
+    
+    @Test public void promote_snapshot_03()         { run_03(false) ; }
+    @Test public void promote_readCommitted_03()    { run_03(true) ; }
+
+    private void run_03(boolean b) {
+        DatasetGraphTransaction.readCommittedPromotion = b ;
+        DatasetGraph dsg = create() ;
+        
+        dsg.begin(ReadWrite.WRITE) ;dsg.commit() ; dsg.end() ;
+        
+        dsg.begin(ReadWrite.READ) ;
+        dsg.add(q1) ;
+        dsg.commit() ;
+        dsg.end() ;
+    }
+    
+    @Test public void promote_snapshot_04()         { run_04(false) ; }
+    @Test public void promote_readCommitted_04()    { run_04(true) ; }
+
+    private void run_04(boolean b) {
+        DatasetGraphTransaction.readCommittedPromotion = b ;
+        DatasetGraph dsg = create() ;
+        
+        dsg.begin(ReadWrite.WRITE) ;dsg.abort() ; dsg.end() ;
+        
+        dsg.begin(ReadWrite.READ) ;
+        dsg.add(q1) ;
+        dsg.commit() ;
+        dsg.end() ;
     }
 
-    // Causes the warning.
-    @Test public void promote_03() {
+    @Test public void promote_snapshot_05()         { run_05(false) ; }
+    @Test public void promote_readCommitted_05()    { run_05(true) ; }
+    
+    private void run_05(boolean b) {
+        DatasetGraphTransaction.readCommittedPromotion = b ;
         DatasetGraph dsg = create() ;
-        dsg.begin(ReadWrite.READ); 
+        dsg.begin(ReadWrite.READ) ;
         dsg.add(q1) ;
-        
+
         // bad - forced abort.
         // Causes a WARN.
-        logger.setLevel(Level.ERROR) ;
+        logger1.setLevel(Level.ERROR) ;
         dsg.end() ;
-        logger.setLevel(level)  ;
-        
+        logger1.setLevel(level1) ;
+
         assertCount(0, dsg) ;
     }
+
+    @Test public void promote_snapshot_06()         { run_06(false) ; }
+    @Test public void promote_readCommitted_06()    { run_06(true) ; }
     
-    @Test public void promote_04() {
+    // Async writer after promotion.
+    private void run_06(boolean b) {
+        DatasetGraphTransaction.readCommittedPromotion = b ;
         DatasetGraph dsg = create() ;
         AtomicInteger a = new AtomicInteger(0) ;
-        
+
         Semaphore sema = new Semaphore(0) ;
-        Thread t = new Thread(()->{
-            sema.release();
-            Txn.execWrite(dsg, ()->dsg.add(q3)) ;   
-            sema.release();
+        Thread t = new Thread(() -> {
+            sema.release() ;
+            Txn.execWrite(dsg, () -> dsg.add(q3)) ;
+            sema.release() ;
         }) ;
-        
-        dsg.begin(ReadWrite.READ);
+
+        dsg.begin(ReadWrite.READ) ;
         // Promote
         dsg.add(q1) ;
-        t.start(); 
+        t.start() ;
         // First release.
-        sema.acquireUninterruptibly();
-        // Thread blocked. 
+        sema.acquireUninterruptibly() ;
+        // Thread blocked.
         dsg.add(q2) ;
-        dsg.commit();
+        dsg.commit() ;
         dsg.end() ;
-        
+
         // Until thread exits.
-        sema.acquireUninterruptibly();
+        sema.acquireUninterruptibly() ;
         assertCount(3, dsg) ;
     }
+
+    @Test public void promote_snapshot_07()         { run_07(false) ; }
+    @Test public void promote_readCommitted_07()    { run_07(true) ; }
     
-    @Test public void promote_05() {
+    // Async writer after promotion.
+    private void run_07(boolean b) {
+        DatasetGraphTransaction.readCommittedPromotion = b ;
         DatasetGraph dsg = create() ;
         // Start long running reader.
-        ThreadTxn tt = ThreadTxn.threadTxnRead(dsg, ()->{
+        ThreadTxn tt = ThreadTxn.threadTxnRead(dsg, () -> {
             long x = Iter.count(dsg.find()) ;
-            if ( x != 0 ) 
+            if ( x != 0 )
                 throw new RuntimeException() ;
         }) ;
-    
+
         // Start R->W here
-        dsg.begin(ReadWrite.READ); 
+        dsg.begin(ReadWrite.READ) ;
         dsg.add(q1) ;
         dsg.add(q2) ;
-        dsg.commit();
+        dsg.commit() ;
         dsg.end() ;
-        tt.run();
+        tt.run() ;
     }
     
-    @Test public void promote_06() {
-        promoteRC(true) ;
-    }
-        
-    @Test(expected=TDBTransactionException.class)
-    public void promote_07() {
-        promoteRC(false) ;
-    }
-     
-    private void promoteRC(boolean allowReadCommitted) {
-        DatasetGraphTransaction.readCommittedPromotion = allowReadCommitted ;    
+    @Test public void promote_snapshot_08()         { run_08(false) ; }
+    @Test public void promote_readCommitted_08()    { run_08(true) ; }
+    
+    // Async writer after promotion trasnaction ends.
+    private void run_08(boolean b) {
+        DatasetGraphTransaction.readCommittedPromotion = b ;
         DatasetGraph dsg = create() ;
+        // Start R->W here
+        dsg.begin(ReadWrite.READ) ;
+        dsg.add(q1) ;
+        dsg.add(q2) ;
+        dsg.commit() ;
+        dsg.end() ;
+        Txn.execRead(dsg, () -> {
+            long x = Iter.count(dsg.find()) ;
+            assertEquals(2, x) ;
+        }) ;
+    }
 
-        ThreadTxn tt = ThreadTxn.threadTxnWrite(dsg, ()->{dsg.add(q3) ;}) ;
+    // Tests for XXX Read-committed yes/no, and whether the other transaction commits or aborts.
+    
+    @Test
+    public void promote_10() { promote_readCommit_txnCommit(true, true) ; }
+
+    @Test
+    public void promote_11() { promote_readCommit_txnCommit(true, false) ; }
+    
+    @Test(expected = TDBTransactionException.class)
+    public void promote_12() { promote_readCommit_txnCommit(false, true) ; }
+
+    @Test
+    public void promote_13() { promote_readCommit_txnCommit(false, false) ; }
+
+    private void promote_readCommit_txnCommit(boolean allowReadCommitted, boolean asyncCommit) {
+        logger2.setLevel(Level.ERROR);
+        DatasetGraphTransaction.readCommittedPromotion = allowReadCommitted ;
+        DatasetGraph dsg = create() ;
         
-        dsg.begin(ReadWrite.READ);
+        ThreadTxn tt = asyncCommit?
+            ThreadTxn.threadTxnWrite(dsg, () -> dsg.add(q3) ) :
+            ThreadTxn.threadTxnWriteAbort(dsg, () -> dsg.add(q3)) ;
+
+        dsg.begin(ReadWrite.READ) ;
         // Other runs
-        tt.run(); 
-        // Can  promote if readCommited
+        tt.run() ;
+        // Can promote if readCommited
         // Can't promote if not readCommited
         dsg.add(q1) ;
-        assertTrue(dsg.contains(q3)) ;
-        dsg.commit();
+        if ( ! allowReadCommitted && asyncCommit )
+            fail("Should not be here") ;
+        
+        assertEquals(asyncCommit, dsg.contains(q3)) ;
+        dsg.commit() ;
+        dsg.end() ;
+        logger2.setLevel(level2);
+    }
+    
+    // Test whether a writer casuses a snapshot isolation
+    // promotion to fail like it should
+    @Test(expected=TDBTransactionException.class)
+    public void promote_clash_1() { 
+        DatasetGraphTransaction.readCommittedPromotion = false ;
+        DatasetGraph dsg = create() ;
+        Semaphore sema1 = new Semaphore(0) ;
+        Semaphore sema2 = new Semaphore(0) ;
+        Runnable r = ()->{
+            dsg.begin(ReadWrite.WRITE) ; 
+            sema1.release(1); 
+            sema2.acquireUninterruptibly(1) ;
+            dsg.commit() ; 
+            dsg.end() ; 
+        } ;
+        
+        // Create a writer that waits.
+        new Thread(r).start(); 
+        sema1.acquireUninterruptibly(); 
+        // The thread is in the write.
+        dsg.begin(ReadWrite.READ) ;
+        // If read commited this will block.
+        // If snapshot, this will though an exception due to the active writer.
+        dsg.add(q1) ;
+        fail("Should not be here") ;
+        dsg.commit() ;
         dsg.end() ;
     }
-
 }

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
@@ -259,7 +259,8 @@ public class TestTransPromote {
         }) ;
     }
 
-    // Tests for XXX Read-committed yes/no, and whether the other transaction commits or aborts.
+    // Tests for XXX Read-committed yes/no (false = snapshot isolation, true = read committed),
+    // and whether the other transaction commits (true) or aborts (false).
     
     @Test
     public void promote_10() { promote_readCommit_txnCommit(true, true) ; }
@@ -297,8 +298,9 @@ public class TestTransPromote {
         logger2.setLevel(level2);
     }
     
-    // Test whether a writer casuses a snapshot isolation
-    // promotion to fail like it should
+    // Test whether an active writer causes a snapshot isolation
+    // promotion to fail like it should.
+    // No equivalent read commiter version - it would block. 
     @Test(expected=TDBTransactionException.class)
     public void promote_clash_1() { 
         DatasetGraphTransaction.readCommittedPromotion = false ;
@@ -318,8 +320,9 @@ public class TestTransPromote {
         sema1.acquireUninterruptibly(); 
         // The thread is in the write.
         dsg.begin(ReadWrite.READ) ;
-        // If read commited this will block.
-        // If snapshot, this will though an exception due to the active writer.
+        // ++ If read commited, the promotion will block. ++
+        // because the other-thread writer is blocked. 
+        // If snapshot, this will cause an exception due to the active writer.
         dsg.add(q1) ;
         fail("Should not be here") ;
         dsg.commit() ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransactionTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransactionTDB.java
@@ -20,10 +20,13 @@ package org.apache.jena.tdb.transaction;
 
 import static org.apache.jena.query.ReadWrite.READ ;
 import static org.apache.jena.query.ReadWrite.WRITE ;
+
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.atlas.logging.LogCtl ;
+import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.query.Dataset ;
+import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.apache.jena.sparql.transaction.AbstractTestTransactionLifecycle ;
 import org.apache.jena.tdb.ConfigTest ;
@@ -78,6 +81,13 @@ public class TestTransactionTDB extends AbstractTestTransactionLifecycle
 
         ds2.begin(READ) ;
         // See ds1 updates
+        Graph g = ds2.getDefaultModel().getGraph() ;
+        DatasetGraph dsg = ds2.asDatasetGraph() ; 
+        g = dsg.getDefaultGraph() ;
+        
+        boolean b0 = g.isEmpty() ;
+        boolean b1 = ds2.getDefaultModel().isEmpty() ;
+        
         assertFalse(ds2.getDefaultModel().isEmpty()) ;
         assertEquals(1, ds2.getDefaultModel().size()) ;
         ds2.commit() ;

--- a/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
@@ -101,7 +101,7 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
     @Override
     public void begin(ReadWrite readWrite) {
         readWriteMode.set(readWrite);
-        get().begin(readWrite) ;
+        super.begin(readWrite) ;
         super.getMonitor().start() ;
     }
     
@@ -111,7 +111,7 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
     @Override
     public void abort() {
         // Roll back all both objects, discarding any exceptions that occur
-        try { get().abort(); } catch (Throwable t) { log.warn("Exception in abort: " + t.getMessage(), t); }
+        try { super.abort(); } catch (Throwable t) { log.warn("Exception in abort: " + t.getMessage(), t); }
         try { textIndex.rollback(); } catch (Throwable t) { log.warn("Exception in abort: " + t.getMessage(), t); }
         readWriteMode.set(null) ;
         super.getMonitor().finish() ;
@@ -146,7 +146,7 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
         
         // Phase 2
         try {
-            get().commit();
+            super.commit();
             if (readWriteMode.get() == ReadWrite.WRITE) {
                 textIndex.commit();
             }
@@ -177,7 +177,7 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
         }
         
         try {
-            get().end() ;
+            super.end() ;
         }
         catch (Throwable t) {
             log.warn("Exception in end: " + t.getMessage(), t) ;
@@ -189,7 +189,7 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
     
     @Override
     public boolean supportsTransactions() {
-        return get().supportsTransactions() ;
+        return super.supportsTransactions() ;
     }
     
     /** Declare whether {@link #abort} is supported.
@@ -197,7 +197,7 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
      */
     @Override
     public boolean supportsTransactionAbort() {
-        return get().supportsTransactionAbort() ;
+        return super.supportsTransactionAbort() ;
     }
     
     @Override


### PR DESCRIPTION
This PR is for discussion and is not yet ready for merging.

It adds to TDB the ability for a read transaction to promote to a write transaction.

Currently (to avoid general API changes outside TDB) this happens automatically in `DatasetGraphTransaction.getW()`.

It needs to be enabled with `DatasetGraphTransaction.promotion = true`

If this is useful, we can add new modes to `ReadWrite` and/or add `begin()` (no args).

There is a big design point: at the point at which a transaction becomes a writer their are two choices as to what to do if another write transaction happened between this one starting and this one promoting.

1. The transaction can now see changes made by the other writer. A limited form of "read committed" behaviour. Downside: results from actions during the read phase may be invalidated.
1. The transaction is blocked from promoting. This is purer (results are not invalidated; an error is returned) but the code must deal with it.

Having it as a choice is possible - one should be the default for `begin()`.
