### PR TITLE
JENA-1225: Remove prefix map when graph is deleted in TIM

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
@@ -288,6 +288,7 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
     @Override
     public void removeGraph(final Node graphName) {
         mutate(removeGraph, getGraph(graphName));
+        prefixes().getPrefixMapping(graphName.getURI()).clearNsPrefixMap();
     }
 
     /**


### PR DESCRIPTION
JENA-1225: Remove prefix map when graph is deleted in TIM