### PR TITLE
JENA-1222 and JENA-1224: Flush queue when large by byte size or by pending commits.

### DIFF
--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
@@ -264,6 +264,8 @@ public class Transaction
 
     public ReadWrite getMode()                      { return mode ; }
     public boolean   isRead()                       { return mode == ReadWrite.READ ; }
+    public boolean   isWrite()                      { return mode == ReadWrite.WRITE ; }
+
     public TxnState  getState()                     { return state ; }
     
     public long getTxnId()                          { return id ; }
@@ -296,7 +298,7 @@ public class Transaction
         if ( iterators != null )
             iterators.remove(iter) ;
         if ( count == 0 ) {
-            peekCount= 0 ;
+            peekCount = 0 ;
         }
     }
     
@@ -328,4 +330,5 @@ public class Transaction
     public String getLabel() {
         return label ;
     }
+
 }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
@@ -141,8 +141,9 @@ public class TransactionManager
     // "one exclusive, or many other" lock which happens to be called a ReadWriteLock
     private ReadWriteLock exclusivitylock = new ReentrantReadWriteLock() ;
     
-    // Delayes enacting transactions.
+    // Delays enacting transactions.
     private BlockingQueue<Transaction> queue = new LinkedBlockingDeque<>() ;
+    public long getQueueLength() { return queue.size() ; }
 
     private DatasetGraphTDB baseDataset ;
     private Journal journal ;
@@ -495,12 +496,11 @@ public class TransactionManager
                     releaseWriterLock();
             }
         }
-        //TODO
-//        // Imperfect in that writers may happen between releaseWriterLock and startExclusiveMode.
-//        if ( excessiveQueue ) {
-//            startExclusiveMode(true) ;
-//            finishExclusiveMode(); 
-//        }
+        // Imperfect in that writers may happen between releaseWriterLock and startExclusiveMode.
+        if ( excessiveQueue ) {
+            startExclusiveMode(true) ;
+            finishExclusiveMode(); 
+        }
     }
 
     synchronized

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
@@ -138,8 +138,11 @@ public class TransactionManager
     
     // All transactions need a "read" lock throughout their lifetime. 
     // Do not confuse with read/write transactions.  We need a 
-    // "one exclusive, or many other" lock which happens to be called a ReadWriteLock
-    private ReadWriteLock exclusivitylock = new ReentrantReadWriteLock() ;
+    // "one exclusive, or many other" lock which happens to be called a ReadWriteLock.
+    // Fair lock - approximately arrival order. 
+    // Stops "readers" (normal transactions, READ or WRITE) from locking
+    // out a "writer" (exclusive mode).  
+    private ReadWriteLock exclusivitylock = new ReentrantReadWriteLock(true) ;
     
     // Delays enacting transactions.
     private BlockingQueue<Transaction> queue = new LinkedBlockingDeque<>() ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TS_TransactionTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TS_TransactionTDB.java
@@ -42,6 +42,7 @@ import org.junit.runners.Suite ;
     , TestMiscTDB.class
     , TestTDBInternal.class
     , TestTransPromote.class
+    , TestTransControl.class
 })
 public class TS_TransactionTDB
 {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransControl.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransControl.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.tdb.transaction ;
+
+import static org.junit.Assert.assertEquals ;
+
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.system.Txn ;
+import org.apache.jena.tdb.TDB ;
+import org.apache.jena.tdb.TDBFactory ;
+import org.apache.jena.tdb.sys.SystemTDB ;
+import org.apache.jena.tdb.sys.TDBInternal ;
+import org.apache.log4j.Level ;
+import org.apache.log4j.Logger ;
+import org.junit.* ;
+
+/** Tests for transaction controls: batching, flushing on size, flushing on backlog of commits */ 
+public class TestTransControl {
+
+    // Currently,
+    // this feature is off and needs enabling via DatasetGraphTransaction.promotion
+    // promotiion is implicit whe a write happens.
+
+    // See beforeClass / afterClass.
+
+    private static Logger logger1 = Logger.getLogger(SystemTDB.errlog.getName()) ;
+    private static Level  level1 ;
+    private static Logger logger2 = Logger.getLogger(TDB.logInfoName) ;
+    private static Level  level2 ;
+    
+    private static int x_QueueBatchSize ;
+    private static int x_MaxQueueThreshold ;
+    private static int x_JournalThresholdSize ;
+
+    @BeforeClass
+    static public void beforeClass() {
+        level1 = logger1.getLevel() ;
+        level2 = logger2.getLevel() ;
+        
+        x_QueueBatchSize = TransactionManager.QueueBatchSize ;
+        x_MaxQueueThreshold = TransactionManager.MaxQueueThreshold ;
+        x_JournalThresholdSize = TransactionManager.JournalThresholdSize ;
+        
+        // logger1.setLevel(Level.ERROR) ;
+        // logger2.setLevel(Level.ERROR) ;
+    }
+
+    @AfterClass
+    static public void afterClass() {
+        // Restore logging setting.
+        logger2.setLevel(level2) ;
+        logger1.setLevel(level1) ;
+        TransactionManager.QueueBatchSize = x_QueueBatchSize ;
+        TransactionManager.MaxQueueThreshold = x_MaxQueueThreshold ;
+        TransactionManager.JournalThresholdSize = x_JournalThresholdSize ;
+        
+
+    }
+
+    @Before
+    public void before() {
+        // Set all "off"
+        TransactionManager.QueueBatchSize = 1000 ;
+        TransactionManager.MaxQueueThreshold = -1 ;
+        TransactionManager.JournalThresholdSize = -1 ;
+    }
+
+    @After
+    public void after() {
+    }
+    
+    
+    private static Quad q1 = SSE.parseQuad("(_ :s :p1 1)") ;
+    private static Quad q2 = SSE.parseQuad("(_ :s :p2 2)") ;
+    private static Quad q3 = SSE.parseQuad("(_ :s :p3 3)") ;
+
+    protected DatasetGraph create() {
+        return TDBFactory.createDatasetGraph() ;
+    }
+
+    // ---- JournalThresholdSize
+
+    // Flush on journal size / no spill. 
+    @Test public void journalThresholdSize_01() {
+        TransactionManager.QueueBatchSize = 100 ;
+        TransactionManager.MaxQueueThreshold = -1 ;
+        TransactionManager.JournalThresholdSize = 1000 ; // More than commit size, less than a block. 
+        DatasetGraph dsg = create() ;
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+
+        Txn.execWrite(dsg,  ()->{});    // About 20 bytes.
+        assertEquals(1, tMgr.getQueueLength()) ;
+    }
+    
+    // Flush on journal size / small setting.
+    @Test public void journalThresholdSize_02() {
+        TransactionManager.QueueBatchSize = 100 ;
+        TransactionManager.MaxQueueThreshold = -1 ;
+        TransactionManager.JournalThresholdSize = 10 ; // Less than commit size. 
+        DatasetGraph dsg = create() ;
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+        
+        txnAddData(dsg) ;
+        assertEquals(0, tMgr.getQueueLength()) ;
+    }
+
+    // Intermediate flush journal size.
+    @Test public void journalThresholdSize_03() {
+        TransactionManager.QueueBatchSize = 100 ;
+        TransactionManager.MaxQueueThreshold = -1 ;
+        TransactionManager.JournalThresholdSize = 1000 ; // More than commit size, less than block.
+        
+        DatasetGraph dsg = create() ;
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+        
+        Txn.execWrite(dsg,  ()->{});    // About 20 bytes.
+        assertEquals(1, tMgr.getQueueLength()) ;
+        txnAddData(dsg) ;
+        assertEquals(0, tMgr.getQueueLength()) ;
+    }
+    
+    // ---- QueueBatchSize
+    
+    @Test public void queueBatchSize_01() {
+        TransactionManager.QueueBatchSize = 0 ; // Immediate.
+        
+        DatasetGraph dsg = create() ;
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+
+        Txn.execWrite(dsg,  ()->{});
+        assertEquals(0, tMgr.getQueueLength()) ;
+        Txn.execWrite(dsg,  ()->{});
+        assertEquals(0, tMgr.getQueueLength()) ;
+    }
+
+    @Test public void queueBatchSize_02() {
+        TransactionManager.QueueBatchSize = 1 ;
+ 
+        DatasetGraph dsg = create() ;
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+
+        Txn.execWrite(dsg,  ()->{});
+        assertEquals(1, tMgr.getQueueLength()) ;
+        Txn.execWrite(dsg,  ()->{});
+        assertEquals(0, tMgr.getQueueLength()) ;
+    }
+
+    @Test public void queueBatchSize_03() {
+        TransactionManager.QueueBatchSize = 2 ;
+
+        DatasetGraph dsg = create() ;
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+
+        txnAddData(dsg) ;
+        assertEquals(1, tMgr.getQueueLength()) ;
+        txnAddData(dsg) ;
+        assertEquals(2, tMgr.getQueueLength()) ;
+        txnAddData(dsg) ;
+        assertEquals(0, tMgr.getQueueLength()) ;
+    }
+
+    // ---- MaxQueueThreshold
+    
+    @Test public void maxQueueThreshold_01() {
+        TransactionManager.MaxQueueThreshold = 1 ;
+        
+        DatasetGraph dsg = create() ;
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+
+        Txn.execWrite(dsg,  ()->{});
+        assertEquals(1, tMgr.getQueueLength()) ;
+        Txn.execWrite(dsg,  ()->{});
+        assertEquals(0, tMgr.getQueueLength()) ;
+    }
+    
+    @Test public void maxQueueThreshold_02() {
+        TransactionManager.MaxQueueThreshold = 2 ;
+ 
+        DatasetGraph dsg = create() ;
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+
+        txnAddData(dsg) ;
+        assertEquals(1, tMgr.getQueueLength()) ;
+        txnAddData(dsg) ;
+        assertEquals(2, tMgr.getQueueLength()) ;
+        Txn.execWrite(dsg,  ()->{});
+        assertEquals(0, tMgr.getQueueLength()) ;
+    }
+
+    private static void txnAddData(DatasetGraph dsg) {
+        // Unique blank node.
+        Quad q = SSE.parseQuad("(_ _:b :p 1)") ;
+        Txn.execWrite(dsg,  ()->dsg.add(q));
+    }
+}


### PR DESCRIPTION
This adds additional control over the queue in the journal.

If the journal gets large, as measured by the journal file size in bytes (JENA-1222) then try to flush the journal.

If the journal becomes excessive long in terms of pending commits (JENA-1224) then after a writer, flip to exclusive mode, flush the journal and flip back to normal mode.