### PR TITLE
JENA-1223: Txn promotion for TIM (includes patch for JENA-1237)

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapTupleTable.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/PMapTupleTable.java
@@ -55,7 +55,7 @@ public abstract class PMapTupleTable<TupleMapType, TupleType, ConsumerType>
         return master;
     }
 
-    private final ThreadLocal<TupleMapType> local = withInitial(() -> master().get());
+    private final ThreadLocal<TupleMapType> local = withInitial(()->null);
 
     /**
      * @return a thread-local transactional reference to the internal table structure
@@ -88,7 +88,9 @@ public abstract class PMapTupleTable<TupleMapType, TupleType, ConsumerType>
      * {@link #local} is initialized via {@link #initial()}
      */
     @Override
-    public void begin(final ReadWrite rw) {}
+    public void begin(final ReadWrite rw) {
+        local.set(master().get());
+    }
 
     @Override
     public void end() {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TS_DatasetTxnMem.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TS_DatasetTxnMem.java
@@ -40,6 +40,7 @@ import org.junit.runners.Suite.SuiteClasses;
     
     TestDatasetGraphInMemoryFind.class,
     TestDatasetGraphInMemoryFindPattern.class,
-    TestDatasetGraphInMemoryIsolation.class
+    TestDatasetGraphInMemoryIsolation.class,
+    TestDatasetGraphInMemoryPromote.class
  })
 public class TS_DatasetTxnMem {}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryIsolation.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryIsolation.java
@@ -18,28 +18,13 @@
 
 package org.apache.jena.sparql.core.mem;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.transaction.AbstractTestTransactionIsolation ;
 
-/**
- * Tests for in-memory Dataset and its default implementation.
- *
- */
-@RunWith(Suite.class)
-@SuiteClasses({
-    TestQuadTableForms.class,
-    TestTripleTableForms.class,
-    TestHexTable.class,
-    TestTriTable.class,
-    TestDatasetGraphInMemoryBasic.class,
-    TestDatasetGraphInMemoryViews.class,
-    TestDatasetGraphInMemoryLock.class, 
-    TestDatasetGraphInMemoryThreading.class,
-    TestDatasetGraphInMemoryTransactions.class,
-    
-    TestDatasetGraphInMemoryFind.class,
-    TestDatasetGraphInMemoryFindPattern.class,
-    TestDatasetGraphInMemoryIsolation.class
- })
-public class TS_DatasetTxnMem {}
+public class TestDatasetGraphInMemoryIsolation extends AbstractTestTransactionIsolation {
+
+    @Override
+    protected DatasetGraph create() {
+        return new DatasetGraphInMemory() ;
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryPromote.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryPromote.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.core.mem ;
+
+import org.apache.jena.sparql.JenaTransactionException ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.transaction.AbstractTestTransPromote ;
+import org.apache.log4j.Logger ;
+
+/** Tests for transactions that start read and then promote to write -- TIM */
+public class TestDatasetGraphInMemoryPromote extends AbstractTestTransPromote {
+    public TestDatasetGraphInMemoryPromote() {
+        super(getLoggers()) ;
+    }
+
+    @Override
+    protected DatasetGraph create() {
+        return new DatasetGraphInMemory() ;
+    }
+
+    private static Logger[] getLoggers() {
+        return new Logger[]{ Logger.getLogger(DatasetGraphInMemory.class) } ;
+    }
+
+    @Override
+    protected void setPromotion(boolean b) {
+        DatasetGraphInMemory.promotion = b ;
+    }
+
+    @Override
+    protected boolean getPromotion() {
+        return DatasetGraphInMemory.promotion ;
+    }
+
+    @Override
+    protected void setReadCommitted(boolean b) {
+        DatasetGraphInMemory.readCommittedPromotion = b ;
+    }
+
+    @Override
+    protected boolean getReadCommitted() {
+        return DatasetGraphInMemory.readCommittedPromotion ;
+    }
+
+    @Override
+    protected Class<?> getTransactionExceptionClass() {
+        return JenaTransactionException.class ;
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryPromote.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryPromote.java
@@ -59,7 +59,7 @@ public class TestDatasetGraphInMemoryPromote extends AbstractTestTransPromote {
     }
 
     @Override
-    protected Class<?> getTransactionExceptionClass() {
+    protected Class<JenaTransactionException> getTransactionExceptionClass() {
         return JenaTransactionException.class ;
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransPromote.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransPromote.java
@@ -81,7 +81,7 @@ public abstract class AbstractTestTransPromote {
     // The exact class used by exceptions of the system under test.
     // TDB transctions are in the TDBException hierarchy
     // so can't be JenaTransactionException.
-    protected abstract Class<?> getTransactionExceptionClass() ;
+    protected abstract Class<? extends Exception> getTransactionExceptionClass() ;
     
     @Before
     public void before() {
@@ -287,7 +287,8 @@ public abstract class AbstractTestTransPromote {
                getTransactionExceptionClass()) ;
     }
     
-    private void expect(Runnable runnable, Class<?>...classes) {
+    @SafeVarargs
+    private final void expect(Runnable runnable, Class<? extends Exception>...classes) {
         try {
             runnable.run(); 
             fail("Exception expected") ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionIsolation.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionIsolation.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.transaction;
+
+import static org.apache.jena.query.ReadWrite.* ;
+
+import org.apache.jena.atlas.iterator.Iter ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.system.ThreadAction ;
+import org.apache.jena.system.ThreadTxn ;
+import org.junit.Assert ;
+import org.junit.Test ;
+
+/** Isolation tests */
+public abstract class AbstractTestTransactionIsolation {
+    
+    protected abstract DatasetGraph create() ; 
+    static Quad q1 = SSE.parseQuad("(_ :s :p 111)") ;
+    
+    @Test
+    public void isolation_01() {
+        // Start a read transaction on another thread.
+        // The transaction has begin() by the time threadTxnRead
+        // returns but the action of the ThreadTxn is not triggered
+        // until other.run() is called.
+        DatasetGraph dsg = create() ;
+        ThreadAction other = ThreadTxn.threadTxnRead(dsg, ()-> {
+            long x = Iter.count(dsg.find()) ;
+            Assert.assertEquals(0, x) ;
+        }) ;
+        dsg.begin(WRITE) ;
+        dsg.add(q1) ;
+        dsg.commit() ;
+        dsg.end() ;
+        other.run() ;
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionIsolation.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionIsolation.java
@@ -18,9 +18,8 @@
 
 package org.apache.jena.sparql.transaction;
 
-import static org.apache.jena.query.ReadWrite.* ;
+import static org.apache.jena.query.ReadWrite.WRITE ;
 
-import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.sse.SSE ;
@@ -42,10 +41,7 @@ public abstract class AbstractTestTransactionIsolation {
         // returns but the action of the ThreadTxn is not triggered
         // until other.run() is called.
         DatasetGraph dsg = create() ;
-        ThreadAction other = ThreadTxn.threadTxnRead(dsg, ()-> {
-            long x = Iter.count(dsg.find()) ;
-            Assert.assertEquals(0, x) ;
-        }) ;
+        ThreadAction other = ThreadTxn.threadTxnRead(dsg, ()-> Assert.assertTrue(dsg.isEmpty()) ) ;
         dsg.begin(WRITE) ;
         dsg.add(q1) ;
         dsg.commit() ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionLifecycle.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionLifecycle.java
@@ -252,8 +252,6 @@ public abstract class AbstractTestTransactionLifecycle extends BaseTest
     @Test 
     public void transaction_err_12()    { testAbortCommit(WRITE) ; }
 
-    
-    
     private void read1(Dataset ds) {
         ds.begin(ReadWrite.READ) ;
         assertTrue(ds.isInTransaction()) ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/store/nodetable/NodeTableReadonly.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/store/nodetable/NodeTableReadonly.java
@@ -24,14 +24,12 @@ import org.apache.jena.tdb.store.NodeId ;
 
 public class NodeTableReadonly extends NodeTableWrapper
 {
-    public NodeTableReadonly(NodeTable nodeTable)
-    {
+    public NodeTableReadonly(NodeTable nodeTable) {
         super(nodeTable) ;
     }
 
     @Override
-    public NodeId getAllocateNodeId(Node node)
-    {
+    public NodeId getAllocateNodeId(Node node) {
         NodeId nodeId = getNodeIdForNode(node) ;
         if ( NodeId.isDoesNotExist(nodeId) )
             throw new TDBException("Allocation attempt on NodeTableReadonly") ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/store/nodetable/NodeTableWrapper.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/store/nodetable/NodeTableWrapper.java
@@ -30,30 +30,26 @@ public class NodeTableWrapper implements NodeTable
     protected final NodeTable nodeTable ;
     @Override
     public final NodeTable wrapped() { return nodeTable ; } 
-    
-    protected NodeTableWrapper(NodeTable nodeTable)
-    {
+
+    protected NodeTableWrapper(NodeTable nodeTable) {
         this.nodeTable = nodeTable ;
     }
-    
+
     @Override
-    public NodeId getAllocateNodeId(Node node)
-    {
+    public NodeId getAllocateNodeId(Node node) {
         return nodeTable.getAllocateNodeId(node) ;
     }
 
     @Override
-    public NodeId getNodeIdForNode(Node node)
-    {
+    public NodeId getNodeIdForNode(Node node) {
         return nodeTable.getNodeIdForNode(node) ;
     }
 
     @Override
-    public Node getNodeForNodeId(NodeId id)
-    {
+    public Node getNodeForNodeId(NodeId id) {
         return nodeTable.getNodeForNodeId(id) ;
     }
-    
+
     @Override
     public boolean containsNode(Node node) {
         return nodeTable.containsNode(node) ;
@@ -61,27 +57,31 @@ public class NodeTableWrapper implements NodeTable
 
     @Override
     public boolean containsNodeId(NodeId nodeId) {
-        return nodeTable.containsNodeId(nodeId) ;    }
+        return nodeTable.containsNodeId(nodeId) ;
+    }
 
     @Override
-    public NodeId allocOffset()
-    {
+    public NodeId allocOffset() {
         return nodeTable.allocOffset() ;
     }
 
     @Override
-    public Iterator<Pair<NodeId, Node>> all()
-    {
-        return nodeTable.all();
+    public Iterator<Pair<NodeId, Node>> all() {
+        return nodeTable.all() ;
     }
 
     @Override
-    public boolean isEmpty()    { return nodeTable.isEmpty() ; }
-    
-    @Override
-    public void sync() { nodeTable.sync() ; } 
+    public boolean isEmpty() {
+        return nodeTable.isEmpty() ;
+    }
 
     @Override
-    public void close()
-    { nodeTable.close() ; }
+    public void sync() {
+        nodeTable.sync() ;
+    }
+
+    @Override
+    public void close() {
+        nodeTable.close() ;
+    }
 }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
@@ -380,7 +380,7 @@ public class TransactionManager
     synchronized
     private DatasetGraphTxn promote2$(DatasetGraphTxn dsgtxn, boolean readCommited) {
         Transaction txn = dsgtxn.getTransaction() ;
-        // Writers may have happened between the first check of  of the active writers may have committed.  
+        // Writers may have happened between the first check of the active writers may have committed.  
         if ( txn.getVersion() != version.get() ) {
             releaseWriterLock();
             throw new TDBTransactionException("Active writer changed the dataset - can't promote") ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TS_TransactionTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TS_TransactionTDB.java
@@ -43,6 +43,7 @@ import org.junit.runners.Suite ;
     , TestTDBInternal.class
     , TestTransPromote.class
     , TestTransControl.class
+    , TestTransIsolation.class
 })
 public class TS_TransactionTDB
 {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TS_TransactionTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TS_TransactionTDB.java
@@ -41,7 +41,7 @@ import org.junit.runners.Suite ;
     , TestTransactionUnionGraph.class
     , TestMiscTDB.class
     , TestTDBInternal.class
-    , TestTransPromote.class
+    , TestTransPromoteTDB.class
     , TestTransControl.class
     , TestTransIsolation.class
 })

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransIsolation.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransIsolation.java
@@ -16,30 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.core.mem;
+package org.apache.jena.tdb.transaction;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.transaction.AbstractTestTransactionIsolation ;
+import org.apache.jena.tdb.TDBFactory ;
 
-/**
- * Tests for in-memory Dataset and its default implementation.
- *
- */
-@RunWith(Suite.class)
-@SuiteClasses({
-    TestQuadTableForms.class,
-    TestTripleTableForms.class,
-    TestHexTable.class,
-    TestTriTable.class,
-    TestDatasetGraphInMemoryBasic.class,
-    TestDatasetGraphInMemoryViews.class,
-    TestDatasetGraphInMemoryLock.class, 
-    TestDatasetGraphInMemoryThreading.class,
-    TestDatasetGraphInMemoryTransactions.class,
-    
-    TestDatasetGraphInMemoryFind.class,
-    TestDatasetGraphInMemoryFindPattern.class,
-    TestDatasetGraphInMemoryIsolation.class
- })
-public class TS_DatasetTxnMem {}
+public class TestTransIsolation extends AbstractTestTransactionIsolation {
+
+    @Override
+    protected DatasetGraph create() {
+        return TDBFactory.createDatasetGraph() ;
+    }
+
+}

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromote.java
@@ -45,7 +45,7 @@ public class TestTransPromote {
 
     // Currently,
     // this feature is off and needs enabling via DatasetGraphTransaction.promotion
-    // promotiion is implicit whe a write happens.
+    // promotion is implicit when a write happens.
 
     // See beforeClass / afterClass.
 
@@ -62,9 +62,6 @@ public class TestTransPromote {
         stdReadCommitted = DatasetGraphTransaction.readCommittedPromotion ;
         level1 = logger1.getLevel() ;
         level2 = logger2.getLevel() ;
-        
-        // logger1.setLevel(Level.ERROR) ;
-        // logger2.setLevel(Level.ERROR) ;
     }
 
     @AfterClass

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromoteTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromoteTDB.java
@@ -66,7 +66,7 @@ public class TestTransPromoteTDB extends AbstractTestTransPromote {
     }
 
     @Override
-    protected Class<?> getTransactionExceptionClass() {
+    protected Class<TDBTransactionException> getTransactionExceptionClass() {
         return TDBTransactionException.class ;
     }
 }

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromoteTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransPromoteTDB.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.tdb.transaction ;
+
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.transaction.AbstractTestTransPromote ;
+import org.apache.jena.tdb.TDB ;
+import org.apache.jena.tdb.TDBFactory ;
+import org.apache.jena.tdb.sys.SystemTDB ;
+import org.apache.jena.tdb.transaction.DatasetGraphTransaction ;
+import org.apache.jena.tdb.transaction.TDBTransactionException ;
+import org.apache.log4j.Logger ;
+
+/** Tests for transactions that start read and then promote to write -- TDB */
+public class TestTransPromoteTDB extends AbstractTestTransPromote {
+    public TestTransPromoteTDB() {
+        super(getLoggers()) ;
+    }
+
+    @Override
+    protected DatasetGraph create() {
+        return TDBFactory.createDatasetGraph() ;
+    }
+
+    private static Logger[] getLoggers() {
+        return new Logger[]{
+            Logger.getLogger(SystemTDB.errlog.getName()),
+            Logger.getLogger(TDB.logInfoName)
+        } ;
+    }
+
+    @Override
+    protected void setPromotion(boolean b) {
+        DatasetGraphTransaction.promotion = b ;
+    }
+
+    @Override
+    protected boolean getPromotion() {
+        return DatasetGraphTransaction.promotion ;
+    }
+
+    @Override
+    protected void setReadCommitted(boolean b) {
+        DatasetGraphTransaction.readCommittedPromotion = b ;
+    }
+
+    @Override
+    protected boolean getReadCommitted() {
+        return DatasetGraphTransaction.readCommittedPromotion ;
+    }
+
+    @Override
+    protected Class<?> getTransactionExceptionClass() {
+        return TDBTransactionException.class ;
+    }
+}


### PR DESCRIPTION
Machinery for transaction promotion for the in-memory transactional dataset.
