### PR TITLE
Solving a memory leak from LPRuleEngine

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/ConsumerChoicePointFrame.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/ConsumerChoicePointFrame.java
@@ -164,8 +164,11 @@ public class ConsumerChoicePointFrame extends GenericTripleMatchFrame
     @Override
     public void close() {    	
     	super.close();
-    	if (generator != null && generator.interpreter != null) {
-    		generator.interpreter.close();
+    	if (generator != null) {
+            if(generator.interpreter != null) {
+                generator.interpreter.close();
+            }
+            generator.removeConsumer(this);
     		// .. but NOT 
     		//generator.setComplete();
     		// as it seems to cause other tests to fail


### PR DESCRIPTION
Each time a `LPRuleEngine` gets called to find a triple for which a cached `Generator` exists in `tabledGoals` a new `ConsumerChoicePointFrame` is registered as a consumer of this Generator.
The leak is that it is never unregistered from the consumer, the solution was simply to call the unregistering from the `close()` method of the `ConsumerChoicePointFrame`