### PR TITLE
Small optimization for writePrefixes()

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/n3/N3JenaWriterCommon.java
+++ b/jena-core/src/main/java/org/apache/jena/n3/N3JenaWriterCommon.java
@@ -372,8 +372,8 @@ public class N3JenaWriterCommon implements RDFWriter
     {
         for ( Entry<String, String> entry : prefixMap.entrySet() )
         {
-            String u = entry.getKey();
-            String p = entry.getValue();
+            String u = entry.getValue();
+	    String p = entry.getKey();            
 
 // BaseURI - <#>            
 //            // Special cases: N3 handling of base names.

--- a/jena-core/src/main/java/org/apache/jena/n3/N3JenaWriterCommon.java
+++ b/jena-core/src/main/java/org/apache/jena/n3/N3JenaWriterCommon.java
@@ -370,9 +370,10 @@ public class N3JenaWriterCommon implements RDFWriter
     
     protected void writePrefixes(Model model)
     {
-        for ( String p : prefixMap.keySet() )
+        for ( Entry<String, String> entry : prefixMap.entrySet() )
         {
-            String u = prefixMap.get( p );
+            String u = entry.getKey();
+            String p = entry.getValue();
 
 // BaseURI - <#>            
 //            // Special cases: N3 handling of base names.

--- a/jena-core/src/main/java/org/apache/jena/n3/N3JenaWriterCommon.java
+++ b/jena-core/src/main/java/org/apache/jena/n3/N3JenaWriterCommon.java
@@ -373,7 +373,7 @@ public class N3JenaWriterCommon implements RDFWriter
         for ( Entry<String, String> entry : prefixMap.entrySet() )
         {
             String u = entry.getValue();
-	    String p = entry.getKey();            
+            String p = entry.getKey();            
 
 // BaseURI - <#>            
 //            // Special cases: N3 handling of base names.


### PR DESCRIPTION
I made a small change to the N3JenaWriterCommon writePrefixes function so that it does not need to make a call from the hashmap.