### PR TITLE
JENA1249:  Default prefixes

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1508,6 +1508,16 @@ public class ParameterizedSparqlString implements PrefixMapping {
     }
 
     @Override
+    public boolean hasNoMappings() {
+        return this.prefixes.hasNoMappings();
+    }
+    
+    @Override
+    public int numPrefixes() {
+        return this.prefixes.numPrefixes();
+    }    
+    
+    @Override
     public PrefixMapping lock() {
         return this.prefixes.lock();
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphPrefixesProjection.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphPrefixesProjection.java
@@ -28,7 +28,11 @@ import org.apache.jena.sparql.core.DatasetPrefixStorage ;
 
 public class GraphPrefixesProjection extends PrefixMappingImpl
 {
-    // Own cache and completely replace PrefixMappingImpl?
+    // super.PrefixMappingImpl is the in-memory copy of the prefixes.
+    // It is a complete copy, rather than a cache.
+    // See JENA-81.
+    
+    // Maybe we should have own cache and completely replace using storage from PrefixMappingImpl?
 
     private String graphName ;
     private DatasetPrefixStorage prefixes ; 
@@ -37,6 +41,9 @@ public class GraphPrefixesProjection extends PrefixMappingImpl
     { 
         this.graphName = graphName ;
         this.prefixes = prefixes ;
+        // Force into in-memory copy.
+        // See JENA-81
+        getNsPrefixMap() ;
     }
 
     //@Override protected void regenerateReverseMapping() {}
@@ -64,7 +71,6 @@ public class GraphPrefixesProjection extends PrefixMappingImpl
             super.set(e.getKey(), e.getValue()) ;
         return m ;
     }
-
 
     @Override
     protected void set(String prefix, String uri)

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/PrefixMapping2.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/PrefixMapping2.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.sparql.util;
 
+import java.util.HashMap;
 import java.util.Map ;
 
 import org.apache.jena.shared.PrefixMapping ;
@@ -180,6 +181,22 @@ public class PrefixMapping2 implements PrefixMapping
         return null ;
     }
 
+    @Override
+    public boolean hasNoMappings() {
+        return pmapLocal.hasNoMappings() && pmapGlobal.hasNoMappings();
+    }
+    
+    @Override
+    public int numPrefixes() {
+        // Expensive but gets the right answer.
+        Map<String, String> x = new HashMap<>() ;
+        x.putAll(pmapLocal.getNsPrefixMap()) ;
+        x.putAll(pmapGlobal.getNsPrefixMap()) ;
+        return x.size() ;
+    }    
+    
+
+    
     /** @see org.apache.jena.shared.PrefixMapping#lock() */
     @Override
     public PrefixMapping lock()

--- a/jena-core/src/main/java/org/apache/jena/graph/compose/PolyadicPrefixMappingImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/compose/PolyadicPrefixMappingImpl.java
@@ -193,6 +193,16 @@ public class PolyadicPrefixMappingImpl extends PrefixMappingImpl implements Pref
         return s;
         }
     
+    
+    @Override
+    public boolean hasNoMappings()
+        { return getBaseMapping().hasNoMappings(); }
+
+    @Override
+    public int numPrefixes()
+        { return getBaseMapping().numPrefixes(); }
+    
+    
     @Override public String qnameFor( String uri )
         {
         String result = getBaseMapping().qnameFor( uri );

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
@@ -66,13 +66,17 @@ public class ModelFactory extends ModelFactoryBase
 
          @param pm the default prefixes to use
          @return the previous default prefix mapping
+         @deprecated This feature wil be removed from ModelFactory
     */
+    @Deprecated
     public static PrefixMapping setDefaultModelPrefixes( PrefixMapping pm )
         { return ModelCom.setDefaultModelPrefixes( pm ); }
 
     /**
         Answer the current default model prefixes PrefixMapping object.
+        @deprecated This feature wil be removed from ModelFactory
     */
+    @Deprecated
     public static PrefixMapping getDefaultModelPrefixes()
         { return ModelCom.getDefaultModelPrefixes(); }
 

--- a/jena-core/src/main/java/org/apache/jena/shared/PrefixMapping.java
+++ b/jena-core/src/main/java/org/apache/jena/shared/PrefixMapping.java
@@ -174,7 +174,20 @@ public interface PrefixMapping
          @return this mapping, locked against changes
     */
     PrefixMapping lock();
-
+    
+    // These can not be called the usual "isEmpty" and "size" because this interface is inherited
+    // in places where those names are in use for the main putrpose of the interface (e.g. Model).  
+    
+    /**
+        Return whether the prefix mapping has any defined prefixes.
+     */
+    default boolean hasNoMappings() { return numPrefixes() == 0 ; }
+    
+    /**
+         Return the number of defined prefixes.
+     */
+    int numPrefixes() ;
+    
     /**
         Exception to throw when the prefix argument to setNsPrefix is
         illegal for some reason.

--- a/jena-core/src/main/java/org/apache/jena/shared/impl/PrefixMappingImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/shared/impl/PrefixMappingImpl.java
@@ -253,6 +253,14 @@ public class PrefixMappingImpl implements PrefixMapping
             ;
         }
     
+    @Override
+    public boolean hasNoMappings()
+        { return prefixToURI.isEmpty(); }
+
+    @Override
+    public int numPrefixes()
+        { return prefixToURI.size(); }
+    
     protected boolean equals( PrefixMappingImpl other )
         { return other.sameAs( this ); }
     

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestModelFactory.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestModelFactory.java
@@ -98,12 +98,14 @@ public class TestModelFactory extends TestCase
 		// TODO Set ModelFactory.findAssemblerRoots( Model model )
 	}
 
-	public void testGetDefaultPrefixMapping()
+	@SuppressWarnings("deprecation")
+    public void testGetDefaultPrefixMapping()
 	{
 		Assert.assertSame(ModelCom.getDefaultModelPrefixes(),
 				ModelFactory.getDefaultModelPrefixes());
 	}
 
+    @SuppressWarnings("deprecation")
 	public void testSetDefaultPrefixMapping()
 	{
 		final PrefixMapping original = ModelCom.getDefaultModelPrefixes();

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestModelPrefixMapping.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestModelPrefixMapping.java
@@ -78,11 +78,13 @@ public class TestModelPrefixMapping extends AbstractTestPrefixMapping
 		return modelFactory.getPrefixMapping();
 	}
 
+	@SuppressWarnings("deprecation")
 	public void restorePrefixes()
 	{
 		ModelCom.setDefaultModelPrefixes(prevMap);
 	}
 
+	@SuppressWarnings("deprecation")
 	public void setPrefixes()
 	{
 		prevMap = ModelCom.setDefaultModelPrefixes(baseMap);
@@ -100,6 +102,7 @@ public class TestModelPrefixMapping extends AbstractTestPrefixMapping
 		restorePrefixes();
 	}
 
+	@SuppressWarnings("deprecation")
 	public void testGetDefault()
 	{
 		setPrefixes();

--- a/jena-core/src/test/java/org/apache/jena/shared/AbstractTestPrefixMapping.java
+++ b/jena-core/src/test/java/org/apache/jena/shared/AbstractTestPrefixMapping.java
@@ -416,7 +416,22 @@ public abstract class AbstractTestPrefixMapping extends GraphTestBase
         assertEquals( null, A.getNsURIPrefix(bURI) ) ;
     }
 
+    public void testNoMapping() {
+        String hURI = "http://test.prefixes/prefix#";
+        PrefixMapping A = getMapping();
+        assertTrue(A.hasNoMappings()) ;
+        A.setNsPrefix( "hr", hURI );
+        assertFalse(A.hasNoMappings()) ;
+    }
     
+    public void testNumPrefixes() {
+        String hURI = "http://test.prefixes/prefix#";
+        PrefixMapping A = getMapping();
+        assertEquals(0, A.numPrefixes()) ;
+        A.setNsPrefix( "hr", hURI );
+        assertEquals(1, A.numPrefixes()) ;
+    }
+
     public void testEquality()
         {
         testEquals( "" );

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/graph/impl/SecuredPrefixMappingImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/graph/impl/SecuredPrefixMappingImpl.java
@@ -148,6 +148,18 @@ public class SecuredPrefixMappingImpl extends SecuredItemImpl implements
 		checkRead();
 		return holder.getBaseItem().shortForm(uri);
 	}
+	
+    @Override
+    public boolean hasNoMappings() {
+        checkRead();
+        return holder.getBaseItem().hasNoMappings();
+    }
+
+    @Override
+    public int numPrefixes() {
+        checkRead();
+        return holder.getBaseItem().numPrefixes();
+    }
 
 	@Override
 	public SecuredPrefixMapping withDefaultMappings(final PrefixMapping map)

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/impl/SecuredItemImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/impl/SecuredItemImpl.java
@@ -52,7 +52,8 @@ public abstract class SecuredItemImpl implements SecuredItem {
 	// a key for the secured item.
 	private class CacheKey implements Comparable<CacheKey> {
 		private final Action action;
-		private final Node modelNode;
+		@SuppressWarnings("hiding")
+        private final Node modelNode;
 		private final Triple from;
 		private final Triple to;
 		private Integer hashCode;

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
@@ -1952,6 +1952,18 @@ public class SecuredModelImpl extends SecuredItemImpl implements SecuredModel {
 		checkRead();
 		return holder.getBaseItem().shortForm(uri);
 	}
+	
+    @Override
+    public boolean noMappings() {
+        checkRead();
+        return holder.getBaseItem().noMappings();
+    }
+
+    @Override
+    public int numPrefixes() {
+        checkRead();
+        return holder.getBaseItem().numPrefixes();
+    }
 
 	@Override
 	public long size() throws ReadDeniedException, AuthenticationRequiredException {

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
@@ -1954,9 +1954,9 @@ public class SecuredModelImpl extends SecuredItemImpl implements SecuredModel {
 	}
 	
     @Override
-    public boolean noMappings() {
+    public boolean hasNoMappings() {
         checkRead();
-        return holder.getBaseItem().noMappings();
+        return holder.getBaseItem().hasNoMappings();
     }
 
     @Override

--- a/jena-permissions/src/test/java/org/apache/jena/permissions/MockPrefixMapping.java
+++ b/jena-permissions/src/test/java/org/apache/jena/permissions/MockPrefixMapping.java
@@ -108,4 +108,9 @@ public class MockPrefixMapping implements PrefixMapping
 	{
 		throw new UnsupportedOperationException();
 	}
+
+    @Override
+    public int numPrefixes() {
+        return getNsPrefixMap().size() ;
+    }
 }

--- a/jena-permissions/src/test/java/org/apache/jena/permissions/model/SecuredModelDetailTest.java
+++ b/jena-permissions/src/test/java/org/apache/jena/permissions/model/SecuredModelDetailTest.java
@@ -275,9 +275,11 @@ public class SecuredModelDetailTest {
 		private Model model;
 		private RDFNode msgType = ResourceFactory
 				.createResource("http://example.com/msg");
-		private Property pTo = ResourceFactory
+		@SuppressWarnings("hiding")
+        private Property pTo = ResourceFactory
 				.createProperty("http://example.com/to");
-		private Property pFrom = ResourceFactory
+		@SuppressWarnings("hiding")
+        private Property pFrom = ResourceFactory
 				.createProperty("http://example.com/from");
 
 		/**

--- a/jena-permissions/src/test/java/org/apache/jena/permissions/query/DataSetTest.java
+++ b/jena-permissions/src/test/java/org/apache/jena/permissions/query/DataSetTest.java
@@ -77,8 +77,7 @@ public class DataSetTest {
 		try {
 			final String query = "prefix fn: <http://www.w3.org/2005/xpath-functions#>  " + " SELECT ?foo ?bar WHERE "
 					+ " { ?foo a <http://example.com/class> ; " + "?bar [] ." + "  } ";
-			final QueryExecution qexec = QueryExecutionFactory.create(query, dataset);
-			try {
+			try( QueryExecution qexec = QueryExecutionFactory.create(query, dataset)) {
 				final ResultSet results = qexec.execSelect();
 				int count = 0;
 				for (; results.hasNext();) {
@@ -86,8 +85,6 @@ public class DataSetTest {
 					results.nextSolution();
 				}
 				Assert.assertEquals(8, count);
-			} finally {
-				qexec.close();
 			}
 		} finally {
 			dataset.close();
@@ -124,8 +121,7 @@ public class DataSetTest {
 		try {
 			final String query = "prefix fn: <http://www.w3.org/2005/xpath-functions#>  " + " SELECT ?foo ?bar WHERE "
 					+ " { ?foo a <http://example.com/class> ; " + "?bar [] ." + "  } ";
-			final QueryExecution qexec = QueryExecutionFactory.create(query, dataset);
-			try {
+			try( QueryExecution qexec = QueryExecutionFactory.create(query, dataset) ) {
 				final ResultSet results = qexec.execSelect();
 				int count = 0;
 				for (; results.hasNext();) {
@@ -133,8 +129,6 @@ public class DataSetTest {
 					results.nextSolution();
 				}
 				Assert.assertEquals(4, count);
-			} finally {
-				qexec.close();
 			}
 		} finally {
 			dataset.close();
@@ -170,8 +164,7 @@ public class DataSetTest {
 
 		try {
 			String query = "SELECT ?s ?p ?o WHERE " + " { ?s ?p ?o } ";
-			QueryExecution qexec = QueryExecutionFactory.create(query, dataset);
-			try {
+			try ( QueryExecution qexec = QueryExecutionFactory.create(query, dataset) ) {
 				final ResultSet results = qexec.execSelect();
 				int count = 0;
 				for (; results.hasNext();) {
@@ -180,13 +173,10 @@ public class DataSetTest {
 				}
 				// 2x 3 values + type triple
 				Assert.assertEquals(8, count);
-			} finally {
-				qexec.close();
 			}
 
 			query = "SELECT ?g ?s ?p ?o WHERE " + " { GRAPH ?g {?s ?p ?o } }";
-			qexec = QueryExecutionFactory.create(query, dataset);
-			try {
+			try ( QueryExecution qexec = QueryExecutionFactory.create(query, dataset) ) {
 				final ResultSet results = qexec.execSelect();
 				int count = 0;
 				for (; results.hasNext();) {
@@ -196,8 +186,6 @@ public class DataSetTest {
 				// 2x 3 values + type triple
 				// all are in the base graph so no named graphs
 				Assert.assertEquals(0, count);
-			} finally {
-				qexec.close();
 			}
 		} finally {
 			dataset.close();

--- a/jena-permissions/src/test/java/org/apache/jena/permissions/query/QueryEngineTest.java
+++ b/jena-permissions/src/test/java/org/apache/jena/permissions/query/QueryEngineTest.java
@@ -122,9 +122,7 @@ public class QueryEngineTest {
 					+ " { ?foo a <http://example.com/class> ; "
 					+ "?bar [] ."
 					+ "  } ";
-			final QueryExecution qexec = QueryExecutionFactory.create(query,
-					model);
-			try {
+			try ( QueryExecution qexec = QueryExecutionFactory.create(query, model) ) {
 				final ResultSet results = qexec.execSelect();
 				int count = 0;
 				for (; results.hasNext();) {
@@ -132,8 +130,6 @@ public class QueryEngineTest {
 					results.nextSolution();
 				}
 				Assert.assertEquals(8, count);
-			} finally {
-				qexec.close();
 			}
 		} finally {
 			model.close();
@@ -164,9 +160,7 @@ public class QueryEngineTest {
 					+ " { ?foo a <http://example.com/class> ; "
 					+ "?bar [] ."
 					+ "  } ";
-			final QueryExecution qexec = QueryExecutionFactory.create(query,
-					model);
-			try {
+			try ( QueryExecution qexec = QueryExecutionFactory.create(query, model) ) {
 				final ResultSet results = qexec.execSelect();
 				int count = 0;
 				for (; results.hasNext();) {
@@ -174,8 +168,6 @@ public class QueryEngineTest {
 					results.nextSolution();
 				}
 				Assert.assertEquals(4, count);
-			} finally {
-				qexec.close();
 			}
 		} finally {
 			model.close();
@@ -201,8 +193,7 @@ public class QueryEngineTest {
 				"http://example.com/securedModel", baseModel);
 		try {
 			String query = "SELECT ?s ?p ?o WHERE " + " { ?s ?p ?o } ";
-			QueryExecution qexec = QueryExecutionFactory.create(query, model);
-			try {
+			try ( QueryExecution qexec = QueryExecutionFactory.create(query, model) ) {
 				final ResultSet results = qexec.execSelect();
 				int count = 0;
 				for (; results.hasNext();) {
@@ -211,13 +202,10 @@ public class QueryEngineTest {
 				}
 				// 2x 3 values + type triple
 				Assert.assertEquals(8, count);
-			} finally {
-				qexec.close();
 			}
 
 			query = "SELECT ?s ?p ?o WHERE " + " { GRAPH ?g {?s ?p ?o } }";
-			qexec = QueryExecutionFactory.create(query, model);
-			try {
+			try ( QueryExecution qexec = QueryExecutionFactory.create(query, model) ) {
 				final ResultSet results = qexec.execSelect();
 				int count = 0;
 				for (; results.hasNext();) {
@@ -227,8 +215,6 @@ public class QueryEngineTest {
 				// 2x 3 values + type triple
 				// no named graphs so no results.
 				Assert.assertEquals(0, count);
-			} finally {
-				qexec.close();
 			}
 		} finally {
 			model.close();

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/store/DatasetPrefixesTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/store/DatasetPrefixesTDB.java
@@ -171,11 +171,7 @@ public class DatasetPrefixesTDB implements DatasetPrefixStorage
     /** Return a PrefixMapping for a named graph */
     @Override
     public PrefixMapping getPrefixMapping(String graphName) { 
-        PrefixMapping pm = new GraphPrefixesProjection(graphName, this) ;
-        // Force into cache.
-        // See JENA-81
-        pm.getNsPrefixMap() ;
-        return pm ;
+        return new GraphPrefixesProjection(graphName, this) ;
     }
     
     @Override


### PR DESCRIPTION
This PR contains:

1. Change to ModelCom to not touch prefixes if the inclusion is empty
1. Deprecates default prefixes (ModelCom, ModelFactory)
1. Add `PrefixMapping.noMappings()` and `PrefixMapping.numPrefixes()`

In addition it has some changes to make initialization more robust.