### PR TITLE
JENA-1197 return exit code 1 when there is a problem validating a file with riot

### DIFF
--- a/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
+++ b/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
@@ -285,6 +285,9 @@ public abstract class CmdLangParse extends CmdGeneral
             // System.err.println("++++"+ex.getMessage());
             if ( modLangParse.stopOnBadTerm() )
                 return ;
+            if ( modLangParse.validate() )
+                // The error handler will print the exception. Here we throw it so that the command exit with 1
+                throw new CmdException();
         } finally {
             // Not close the output - we may write again to the underlying output stream in another call to parse a file.  
             IO.close(in) ;


### PR DESCRIPTION
A pull request with a simple approach for JENA-1197. When validate is checked, errors parsing a file will also be reported back, through a `CmdException`.

Quite hard to write a unit test for this, so did some simple regression test locally.

```
kinow@localhost:~/Development/java/jena/jena/apache-jena/bin$ JENA_HOME=/home/kinow/Desktop/JENA/apache-jena-3.1.1 ./riot --validate /tmp/invalid.ttl ; echo $?
23:34:46 ERROR riot                 :: [line: 1, col: 1 ] Out of place: [KEYWORD:I]
0
kinow@localhost:~/Development/java/jena/jena/apache-jena/bin$ JENA_HOME=../target/apache-jena-3.1.2-SNAPSHOT ./riot --validate /tmp/invalid.ttl ; echo $?
23:34:55 ERROR riot                 :: [line: 1, col: 1 ] Out of place: [KEYWORD:I]
1
kinow@localhost:~/Development/java/jena/jena/apache-jena/bin$ JENA_HOME=/home/kinow/Desktop/JENA/apache-jena-3.1.1 ./riot --validate ../../jena-sdb/testing/Assembler/graph-assembler.ttl ; echo $?
0
kinow@localhost:~/Development/java/jena/jena/apache-jena/bin$ JENA_HOME=../target/apache-jena-3.1.2-SNAPSHOT ./riot --validate ../../jena-sdb/testing/Assembler/graph-assembler.ttl ; echo $?
0
```

For invalid files, the new code prints the same as before, but exists with 1, rather than 0. For valid files, the behavior is consistent too.

Sending a pull request as we are in the middle of a release :-)

Cheers
Bruno
