### PR TITLE
JENA-1258 NodeFmtLib calls JenaSystem initializer

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/out/NodeFmtLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/out/NodeFmtLib.java
@@ -34,6 +34,7 @@ import org.apache.jena.riot.system.* ;
 import org.apache.jena.shared.PrefixMapping ;
 import org.apache.jena.sparql.ARQConstants ;
 import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.system.JenaSystem;
 
 /** Presentation utilitiles for Nodes, Triples, Quads and more.
  * <p>
@@ -45,13 +46,14 @@ import org.apache.jena.sparql.core.Quad ;
 public class NodeFmtLib
 {
     // Replaces FmtUtils
-    // See OutputLangUtils.
     // See and use EscapeStr
-    
+ 
     private static final NodeFormatter plainFormatter = new NodeFormatterNT() ;
     
     private static PrefixMap dftPrefixMap = PrefixMapFactory.create() ;
+ 
     static {
+        JenaSystem.init();
         PrefixMapping pm = ARQConstants.getGlobalPrefixMap() ;
         Map<String, String> map = pm.getNsPrefixMap() ;
         for ( Map.Entry<String, String> e : map.entrySet() )

--- a/jena-arq/src/test/java/org/apache/jena/riot/out/TestNodeFmtInit.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/out/TestNodeFmtInit.java
@@ -15,21 +15,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.jena.riot.out;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
+import static org.junit.Assert.assertEquals;
 
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.junit.Test;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
-    TestNodeFmtInit.class
-    , TestQuotedStringOutput.class
-    , TestNodeFmt.class
-    , TestNodeFmtLib.class
-})
+/**
+ * Tests {@link NodeFmtLib} initialization
+ * 
+ * @see <a href="https://issues.apache.org/jira/browse/JENA-1258">JENA-1258</a>
+ */
+public class TestNodeFmtInit {
+    @Test
+    public void strWithoutJenaSystemInit() throws Exception {
+        // NOTE: Deliberately NOT calling first
+        // JenaSystem.init();
+        Node node = NodeFactory.createLiteral("Hello world", "en");
+        assertEquals("\"Hello world\"@en", NodeFmtLib.str(node));
+    }
 
-public class TS_Out
-{}
-
+}

--- a/jena-core/src/main/java/org/apache/jena/graph/NodeFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/NodeFactory.java
@@ -25,9 +25,14 @@ import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.datatypes.TypeMapper ;
 import org.apache.jena.graph.impl.LiteralLabel ;
 import org.apache.jena.graph.impl.LiteralLabelFactory ;
+import org.apache.jena.system.JenaSystem;
 
 public class NodeFactory {
 
+    static {
+        JenaSystem.init();
+    }
+    
     public static RDFDatatype getType(String s) {
         if ( s == null )
             return null ;


### PR DESCRIPTION
Fixes [JENA-1258](https://issues.apache.org/jira/browse/JENA-1258) in `NodeFmtLib`

Note that the added `TestNodeFmtInit` test case would not normally find the bug ran from Maven as earlier tests would have caused initialization, but it can be tested from say Eclipse.