### PR TITLE
Logging fatal to error

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ResultSetFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ResultSetFactory.java
@@ -197,7 +197,7 @@ public class ResultSetFactory {
         }
 
         if (format.equals(ResultsFormat.FMT_TEXT)) {
-            Log.fatal(ResultSet.class, "Can't read a text result set");
+            Log.error(ResultSet.class, "Can't read a text result set");
             throw new ResultSetException("Can't read a text result set");
         }
 
@@ -229,7 +229,7 @@ public class ResultSetFactory {
         if (ResultsFormat.isRDFGraphSyntax(format))
             return FileManager.get().readModel(model, filenameOrURI);
 
-        Log.fatal(ResultSet.class, "Unknown result set syntax: " + format);
+        Log.error(ResultSet.class, "Unknown result set syntax: " + format);
         return null;
     }
 
@@ -255,7 +255,7 @@ public class ResultSetFactory {
         }
 
         if (format.equals(ResultsFormat.FMT_TEXT)) {
-            Log.fatal(ResultSet.class, "Can't read a text result set");
+            Log.error(ResultSet.class, "Can't read a text result set");
             throw new ResultSetException("Can't read a text result set");
         }
 
@@ -293,7 +293,7 @@ public class ResultSetFactory {
             return new SPARQLResult(model);
         }
 
-        Log.fatal(ResultSet.class, "Unknown result set syntax: " + format);
+        Log.error(ResultSet.class, "Unknown result set syntax: " + format);
         return null;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/query/SortCondition.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/SortCondition.java
@@ -51,7 +51,7 @@ public class SortCondition extends PrintSerializableBase
         direction = dir ;
         
         if ( dir != Query.ORDER_ASCENDING && dir != Query.ORDER_DESCENDING && dir != Query.ORDER_DEFAULT )
-            Log.fatal(this, "Unknown sort direction") ;
+            Log.error(this, "Unknown sort direction") ;
     }
     
     public void format(FmtExprSPARQL fmt,

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterCommonParent.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterCommonParent.java
@@ -69,7 +69,7 @@ public class QueryIterCommonParent extends QueryIterConvert
                         Log.warn(this, "Binding already for "+v+" (same value)" ) ;
                     else
                     {
-                        Log.fatal(this, "Binding already for "+v+" (different values)" ) ;
+                        Log.error(this, "Binding already for "+v+" (different values)" ) ;
                         throw new ARQInternalErrorException("Incompatible bindings for "+v) ;
                     }
                 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterRepeatApply.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterRepeatApply.java
@@ -41,7 +41,7 @@ public abstract class QueryIterRepeatApply extends QueryIter1
         
         if ( input == null )
         {
-            Log.fatal(this, "[QueryIterRepeatApply] Repeated application to null input iterator") ;
+            Log.error(this, "[QueryIterRepeatApply] Repeated application to null input iterator") ;
             return ;
         }
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIteratorBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIteratorBase.java
@@ -118,7 +118,7 @@ public abstract class QueryIteratorBase
                 close() ;
             } catch (QueryFatalException ex)
             { 
-                Log.fatal(this, "Fatal exception: "+ex.getMessage() ) ;
+                Log.error(this, "Fatal exception: "+ex.getMessage() ) ;
                 throw ex ;      // And pass on up the exception.
             }
         return r ;
@@ -167,7 +167,7 @@ public abstract class QueryIteratorBase
             return obj ;
         } catch (QueryFatalException ex)
         { 
-            Log.fatal(this, "QueryFatalException", ex) ; 
+            Log.error(this, "QueryFatalException", ex) ; 
             throw ex ; 
         }
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/StageGeneratorGeneric.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/StageGeneratorGeneric.java
@@ -42,7 +42,7 @@ public class StageGeneratorGeneric implements StageGenerator {
     @Override
     public QueryIterator execute(BasicPattern pattern, QueryIterator input, ExecutionContext execCxt) {
         if ( input == null )
-            Log.fatal(this, "Null input to " + Lib.classShortName(this.getClass())) ;
+            Log.error(this, "Null input to " + Lib.classShortName(this.getClass())) ;
 
         Graph graph = execCxt.getActiveGraph() ;
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/optimizer/reorder/ReorderProcIndexes.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/optimizer/reorder/ReorderProcIndexes.java
@@ -41,7 +41,7 @@ public class ReorderProcIndexes implements ReorderProc
         if ( indexes.length != bgp.size() )
         {
             String str = String.format("Expected size = %d : actual basic pattern size = %d", indexes.length, bgp.size()) ;
-            Log.fatal(this, str) ;
+            Log.error(this, str) ;
             throw new ARQException(str) ; 
         }        
         

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/ParserARQUpdate.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/ParserARQUpdate.java
@@ -83,7 +83,7 @@ public class ParserARQUpdate extends UpdateParser
         }
         catch (Throwable th)
         {
-            Log.fatal(this, "Unexpected throwable: ",th) ;
+            Log.error(this, "Unexpected throwable: ",th) ;
             throw new QueryException(th.getMessage(), th) ;
         }
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/ParserSPARQL11Update.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/ParserSPARQL11Update.java
@@ -80,7 +80,7 @@ public class ParserSPARQL11Update extends UpdateParser
         }
         catch (Throwable th)
         {
-            Log.fatal(this, "Unexpected throwable: ",th) ;
+            Log.error(this, "Unexpected throwable: ",th) ;
             throw new QueryException(th.getMessage(), th) ;
         }
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lib/Metadata.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lib/Metadata.java
@@ -68,7 +68,7 @@ public class Metadata
 
             if ( classLoader == null )
             {
-                Log.fatal(Metadata.class, "No classloader") ;
+                Log.error(Metadata.class, "No classloader") ;
                 return ;
             }
 
@@ -86,7 +86,7 @@ public class Metadata
         }
         catch (Throwable ex)
         {
-            Log.fatal(Metadata.class, "Unexpected Thorwable", ex) ;
+            Log.error(Metadata.class, "Unexpected Thorwable", ex) ;
             return ;
         }
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementService.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementService.java
@@ -45,7 +45,7 @@ public class ElementService extends Element
     public ElementService(Node n, Element el, boolean silent)
     {
         if ( ! n.isURI() && ! n.isVariable() )
-            Log.fatal(this, "Must be a URI (or variable which will be bound) for a service endpoint") ;
+            Log.error(this, "Must be a URI (or variable which will be bound) for a service endpoint") ;
         this.serviceNode = n ;
         this.element = el ;
         this.silent = silent ;

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
@@ -49,20 +49,23 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     protected Writer out = null ;
     
     protected static final int INDENT = 2 ;
+    
+    // Configuration.
     protected int unitIndent = INDENT ;
+    private char padChar = ' ' ;
+    private String padString = null ;
+    private String linePrefix = null ;
+    protected boolean lineNumbers = false ;
+    protected boolean flatMode = false ;
+    private boolean flushOnNewline = false ;
+
+    // Internal state.
+    protected boolean startingNewLine = true ;
+    private String endOfLineMarker = null ;
     protected int currentIndent = 0 ;
     protected int column = 0 ;
     protected int row = 1 ;
-    protected boolean lineNumbers = false ;
-    protected boolean startingNewLine = true ;
-    private char padChar = ' ' ;
-    private String endOfLineMarker = null ;     // Null means none.
-    private String padString = null ;
-    private String linePrefix = null ;
-
     
-    protected boolean flatMode = false ;
-    private boolean flushOnNewline = false ;
     
     /** Construct a UTF8 IndentedWriter around an OutputStream */
     public IndentedWriter(OutputStream outStream) { this(outStream, false) ; }
@@ -70,6 +73,27 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     /** Construct a UTF8 IndentedWriter around an OutputStream */
     public IndentedWriter(OutputStream outStream, boolean withLineNumbers) {
         this(makeWriter(outStream), withLineNumbers) ;
+    }
+
+    /** Create an independent copy of the {@code IndentedWriter}.
+     *  Changes to the configuration of the copy will not affect the original {@code IndentedWriter}.
+     *  This include indentation level.
+     *  <br/>Row and column counters are reset.
+     *  <br/>Indent is initially. zero.
+     *  <br/>They do share the underlying output {@link Writer}.  
+     *  @param other
+     *  @return IndentedWriter
+     */
+    public IndentedWriter clone(IndentedWriter other) {
+        IndentedWriter dup = new IndentedWriter(other.out);
+        dup.unitIndent      = other.unitIndent;
+        dup.padChar         = other.padChar;
+        dup.padString       = other.padString;
+        dup.linePrefix      = other.linePrefix;
+        dup.lineNumbers     = other.lineNumbers;
+        dup.flatMode        = other.flatMode;
+        dup.flushOnNewline  = other.flushOnNewline;
+        return dup;
     }
 
     private static Writer makeWriter(OutputStream out) {

--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/Log.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/Log.java
@@ -88,22 +88,52 @@ public class Log {
         log(cls).warn(msg, th) ;
     }
 
+    static public void error(Object caller, String msg) {
+        error(caller.getClass(), msg) ;
+    }
+
+    static public void error(Class<? > cls, String msg) {
+        log(cls).error(msg) ;
+    }
+
+    static public void error(Object caller, String msg, Throwable th) {
+        error(caller.getClass(), msg, th) ;
+    }
+
+    static public void error(Class<? > cls, String msg, Throwable th) {
+        log(cls).error(msg, th) ;
+    }
+
+    static public void error(String caller, String msg) {
+        log(caller).error(msg) ;
+    }
+
+    /** @deprecated Use {@code error}. */
+    @Deprecated
     static public void fatal(Object caller, String msg) {
         fatal(caller.getClass(), msg) ;
     }
 
+    /** @deprecated Use {@code error}. */
+    @Deprecated
     static public void fatal(Class<? > cls, String msg) {
         log(cls).error(msg) ;
     }
 
+    /** @deprecated Use {@code error}. */
+    @Deprecated
     static public void fatal(Object caller, String msg, Throwable th) {
         fatal(caller.getClass(), msg, th) ;
     }
 
+    /** @deprecated Use {@code error}. */
+    @Deprecated
     static public void fatal(Class<? > cls, String msg, Throwable th) {
         log(cls).error(msg, th) ;
     }
 
+    /** @deprecated Use {@code error}. */
+    @Deprecated
     static public void fatal(String caller, String msg) {
         log(caller).error(msg) ;
     }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFReaderFImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFReaderFImpl.java
@@ -90,7 +90,7 @@ public class RDFReaderFImpl extends Object implements RDFReaderF {
     @Deprecated
     public static String setBaseReaderClassName(String lang, String className) {
         if ( rewiredAlternative != null )
-            Log.fatal(RDFReaderFImpl.class, "Rewired RDFReaderFImpl - configuration changes have no effect on reading");
+            Log.error(RDFReaderFImpl.class, "Rewired RDFReaderFImpl - configuration changes have no effect on reading");
             
         String oldClassName = currentEntry(lang);
         try {
@@ -152,7 +152,7 @@ public class RDFReaderFImpl extends Object implements RDFReaderF {
 
     private static String remove(String lang) {
         if ( rewiredAlternative != null )
-            Log.fatal(RDFReaderFImpl.class, "Rewired RDFReaderFImpl - configuration changes have no effect on reading");
+            Log.error(RDFReaderFImpl.class, "Rewired RDFReaderFImpl - configuration changes have no effect on reading");
 
         String oldClassName = currentEntry(lang);
         custom.remove(lang);

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFWriterFImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFWriterFImpl.java
@@ -90,7 +90,7 @@ public class RDFWriterFImpl extends Object implements RDFWriterF {
     @Deprecated
     public static String setBaseWriterClassName(String lang, String className) {
         if ( rewiredAlternative != null )
-            Log.fatal(RDFWriterFImpl.class, "Rewired RDFWriterFImpl2 - configuration changes have no effect on writing");
+            Log.error(RDFWriterFImpl.class, "Rewired RDFWriterFImpl2 - configuration changes have no effect on writing");
         String oldClassName = currentEntry(lang);
         try {
             @SuppressWarnings("unchecked")
@@ -155,7 +155,7 @@ public class RDFWriterFImpl extends Object implements RDFWriterF {
 
     private static String remove(String lang) {
         if ( rewiredAlternative != null )
-            Log.fatal(RDFWriterFImpl.class, "Rewired RDFWriterFImpl2 - configuration changes have no effect on writing");
+            Log.error(RDFWriterFImpl.class, "Rewired RDFWriterFImpl2 - configuration changes have no effect on writing");
         String oldClassName = currentEntry(lang);
         custom.remove(lang);
         return oldClassName;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/base/objectfile/ObjectFileStorage.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/base/objectfile/ObjectFileStorage.java
@@ -99,7 +99,7 @@ public class ObjectFileStorage implements ObjectFile
         log("W") ;
         
         if ( inAllocWrite )
-            Log.fatal(this, "In the middle of an alloc-write") ;
+            Log.error(this, "In the middle of an alloc-write") ;
         inAllocWrite = false ;
         if ( writeBuffer == null )
         {
@@ -158,7 +158,7 @@ public class ObjectFileStorage implements ObjectFile
     {
         //log.info("AW("+bytesSpace+"):"+state()) ;
         if ( inAllocWrite )
-            Log.fatal(this, "In the middle of an alloc-write") ;
+            Log.error(this, "In the middle of an alloc-write") ;
         
         // Include space for length.
         int spaceRequired = bytesSpace + SizeOfInt ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/base/page/PageBase.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/base/page/PageBase.java
@@ -43,7 +43,7 @@ public abstract class PageBase implements Page
     final public void reset(Block block2)
     { 
         if ( block2.getId() != id )
-            Log.fatal(this, "Block id changed: "+id+" => "+block2.getId()) ;
+            Log.error(this, "Block id changed: "+id+" => "+block2.getId()) ;
         _reset(block2) ; 
         this.block = block2 ;
     } 

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/base/recordbuffer/RecordRangeIterator.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/base/recordbuffer/RecordRangeIterator.java
@@ -37,7 +37,7 @@ class RecordRangeIterator implements Iterator<Record>, Closeable
     {
         if ( ! pageMgr.valid(pageId) ) {
             String msg = "RecordRangeIterator.iterator -- No such block (pageId="+pageId+", fromRec="+fromRec+", toRec="+toRec+ ")" ;
-            Log.fatal(RecordRangeIterator.class, msg);
+            Log.error(RecordRangeIterator.class, msg);
             throw new BlockException(msg) ;
         }
         return new RecordRangeIterator(pageId, fromRec, toRec, pageMgr) ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/index/bplustree/BPlusTreeParams.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/index/bplustree/BPlusTreeParams.java
@@ -135,7 +135,7 @@ public class BPlusTreeParams
             return new BPlusTreeParams(pOrder, pKeyLen, pRecLen) ;
         } catch (NumberFormatException ex)
         {
-            Log.fatal(BPlusTreeParams.class, "Badly formed metadata for B+Tree") ;
+            Log.error(BPlusTreeParams.class, "Badly formed metadata for B+Tree") ;
             throw new TDBException("Failed to read metadata") ;
         }
     }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/lib/NodeLib.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/lib/NodeLib.java
@@ -191,7 +191,7 @@ public class NodeLib
             deallocDigest(digest) ;
             return ;
         }
-        catch (DigestException ex) { Log.fatal(NodeLib.class, "DigestException", ex); } 
+        catch (DigestException ex) { Log.error(NodeLib.class, "DigestException", ex); } 
     }
     
     public static NodeId getNodeId(Record r, int idx)

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/solver/BindingTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/solver/BindingTDB.java
@@ -125,7 +125,7 @@ public class BindingTDB extends BindingBase
             return n ;
         } catch (Exception ex)
         {
-            Log.fatal(this, String.format("get1(%s)", var), ex) ;
+            Log.error(this, String.format("get1(%s)", var), ex) ;
             return null ;
         }
     }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/store/nodetable/NodecLib.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/store/nodetable/NodecLib.java
@@ -87,7 +87,7 @@ public class NodecLib
             return n ;
         } catch (SSEParseException ex)
         {
-            Log.fatal(NodeLib.class, "decode: Failed to parse: "+s) ;
+            Log.error(NodeLib.class, "decode: Failed to parse: "+s) ;
             throw ex ;
         }
     }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/sys/FileRef.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/sys/FileRef.java
@@ -133,7 +133,7 @@ public class FileRef
         FileRef f = id2name.get(fileId) ;
         if ( f == null )
         {
-            Log.fatal(FileRef.class, "No FileRef registered for id: "+fileId) ;
+            Log.error(FileRef.class, "No FileRef registered for id: "+fileId) ;
             throw new TDBException("No FileRef registered for id: "+fileId) ;
         }
         return f ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/sys/SystemTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/sys/SystemTDB.java
@@ -247,7 +247,7 @@ public class SystemTDB
     
     public static void panic(Class<?> clazz, String string)
     {
-        Log.fatal(clazz, string) ;
+        Log.error(clazz, string) ;
         throw new TDBException(string) ;
     }
     

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/BlockMgrJournal.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/BlockMgrJournal.java
@@ -294,16 +294,16 @@ public class BlockMgrJournal implements BlockMgr, TransactionLifecycle
     private void checkIfClosed()
     {
         if ( closed )
-            Log.fatal(this, "Already closed: "+transaction.getTxnId()) ;
+            Log.error(this, "Already closed: "+transaction.getTxnId()) ;
     }
 
     private void checkActive()
     {
         if ( ! active )
-            Log.fatal(this, "Not active: "+transaction.getTxnId()) ;
+            Log.error(this, "Not active: "+transaction.getTxnId()) ;
         TxnState state = transaction.getState() ; 
         if ( state != TxnState.ACTIVE && state != TxnState.PREPARING )
-            Log.fatal(this, "**** Not active: "+transaction.getTxnId()) ;
+            Log.error(this, "**** Not active: "+transaction.getTxnId()) ;
     }
 
 

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/JournalEntryType.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/JournalEntryType.java
@@ -39,7 +39,7 @@ public enum JournalEntryType
         else if ( x == Checkpoint.id )      return Checkpoint ;
         else
         {
-            Log.fatal(JournalEntryType.class, "Unknown type: "+x) ;
+            Log.error(JournalEntryType.class, "Unknown type: "+x) ;
             throw new InternalErrorException("Unknown type: "+x) ;
         }
     }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionManager.java
@@ -750,7 +750,7 @@ public class TransactionManager
                 enactTransaction(txn2) ;
                 commitedAwaitingFlush.remove(txn2) ;
             } catch (InterruptedException ex)
-            { Log.fatal(this, "Interruped!", ex) ; }
+            { Log.error(this, "Interruped!", ex) ; }
         }
 
         checkReplaySafe() ;
@@ -894,7 +894,7 @@ public class TransactionManager
                         commitedAwaitingFlush.remove(txn) ;
                     }
                 } catch (InterruptedException ex)
-                { Log.fatal(this, "Interruped!", ex) ; }
+                { Log.error(this, "Interruped!", ex) ; }
             }
         }
     }


### PR DESCRIPTION
This PR renames the helper `Log` operations from `fatal` to `error` as being the more usual naming these days.

It also contains adding a clone operation to `IndentedWriter` which makes it much easier necessary to create an `IndentedWriter` for stdout/stderr by cloning the standard ones. The clone can be used to indent etc without affecting the system provided ones.

(both these come from working with some complex multiline logging needs mixing 
the usual one line logging and multiline datastructures)