### PR TITLE
JENA-1294: Don't use contants during initialization.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
@@ -19,6 +19,7 @@
 package org.apache.jena.query;
 
 import org.apache.jena.riot.RIOT ;
+import org.apache.jena.riot.resultset.ResultSetLang;
 import org.apache.jena.riot.system.RiotLib ;
 import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.SystemARQ ;
@@ -579,7 +580,7 @@ public class ARQ
             JenaSystem.logLifecycle("ARQ.init - start") ;
             // Force constants to be set.  This should be independent of other initialization including jena core.
             ARQConstants.getGlobalPrefixMap();
-            
+            ResultSetLang.init();
             globalContext = defaultSettings() ;
             ARQMgt.init() ;         // After context and after PATH/NAME/VERSION/BUILD_DATE are set
             MappingRegistry.addPrefixMapping(ARQ.arqSymbolPrefix, ARQ.arqParamNS) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
@@ -76,8 +76,11 @@ public class AssemblerUtils
     /** Register an addition assembler */  
     static public void register(AssemblerGroup g, Resource r, Assembler a, Resource superType) {
         registerAssembler(g, r, a) ;
-        if ( superType != null && ! superType.equals(r) ) 
-            modelExtras.add(r, RDFS.subClassOf, superType) ;
+        if ( superType != null && ! superType.equals(r) ) {
+            // This is called during Jena-wide initialization.
+            // Use function for constant (JENA-1294)
+           modelExtras.add(r, RDFS.Init.subClassOf(), superType) ;
+        }
     }
     
     /** register */ 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/optimizer/reorder/ReorderFixed.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/optimizer/reorder/ReorderFixed.java
@@ -18,13 +18,13 @@
 
 package org.apache.jena.sparql.engine.optimizer.reorder;
 
+import static org.apache.jena.sparql.engine.optimizer.reorder.PatternElements.TERM;
+import static org.apache.jena.sparql.engine.optimizer.reorder.PatternElements.VAR;
+
 import org.apache.jena.sparql.engine.optimizer.Pattern ;
 import org.apache.jena.sparql.engine.optimizer.StatsMatcher ;
-import org.apache.jena.sparql.engine.optimizer.reorder.PatternTriple ;
-import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformationSubstitution ;
-import org.apache.jena.sparql.graph.NodeConst ;
 import org.apache.jena.sparql.sse.Item ;
-import static org.apache.jena.sparql.engine.optimizer.reorder.PatternElements.* ;
+import org.apache.jena.vocabulary.RDF;
 
 /** Fixed scheme for choosing based on the triple patterns, without
  *  looking at the data.  It gives a weight to a triple, with more grounded terms
@@ -58,7 +58,8 @@ public class ReorderFixed extends ReorderTransformationSubstitution {
 
     // This is called during Jena-wide initialization.
     // Use function for constant (JENA-1294)
-    private static Item  type() { return Item.createNode(NodeConst.nodeRDFType); }
+    private static Item  type() 
+    { return Item.createNode(RDF.Init.type().asNode()); }
 
     /** The number of triples used for the base scale */
     public static final int                MultiTermSampleSize = 100 ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/optimizer/reorder/ReorderFixed.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/optimizer/reorder/ReorderFixed.java
@@ -56,7 +56,9 @@ public class ReorderFixed extends ReorderTransformationSubstitution {
     
     public ReorderFixed() {}
 
-    private static Item              type                = Item.createNode(NodeConst.nodeRDFType) ;
+    // This is called during Jena-wide initialization.
+    // Use function for constant (JENA-1294)
+    private static Item  type() { return Item.createNode(NodeConst.nodeRDFType); }
 
     /** The number of triples used for the base scale */
     public static final int                MultiTermSampleSize = 100 ;
@@ -78,8 +80,8 @@ public class ReorderFixed extends ReorderTransformationSubstitution {
 
         // 1 : TERM type TERM is builtin (SPO).
         // matcherRdfType.addPattern(new Pattern(1, TERM, TERM, TERM)) ; 
-        matcherRdfType.addPattern(new Pattern(5, VAR, type, TERM)) ;
-        matcherRdfType.addPattern(new Pattern(50, VAR, type, VAR)) ;
+        matcherRdfType.addPattern(new Pattern(5, VAR, type(), TERM)) ;
+        matcherRdfType.addPattern(new Pattern(50, VAR, type(), VAR)) ;
         
         // SPO - built-in - not needed as a rule
         // matcher.addPattern(new Pattern(1, TERM, TERM, TERM)) ; 
@@ -99,7 +101,7 @@ public class ReorderFixed extends ReorderTransformationSubstitution {
     public double weight(PatternTriple pt) {
         // Special case rdf:type first to make it lower(worse) than 
         // VAR, TERM, TERM which would otherwise be used.
-        if ( type.equals(pt.predicate) ) {
+        if ( type().equals(pt.predicate) ) {
             double w = matcherRdfType.match(pt) ;
             if ( w > 0 )
                 return w ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/pfunction/StandardPropertyFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/pfunction/StandardPropertyFunctions.java
@@ -19,7 +19,7 @@
 package org.apache.jena.sparql.pfunction;
 
 import org.apache.jena.sparql.vocabulary.ListPFunction ;
-import org.apache.jena.vocabulary.RDFS ;
+import org.apache.jena.vocabulary.RDFS;
 
 public class StandardPropertyFunctions {
     @SuppressWarnings("deprecation")
@@ -36,7 +36,9 @@ public class StandardPropertyFunctions {
         add(registry, ListPFunction.listIndex.getURI() , org.apache.jena.sparql.pfunction.library.listIndex.class) ;
         add(registry, ListPFunction.listLength.getURI() , org.apache.jena.sparql.pfunction.library.listLength.class) ;
         
-        add(registry, RDFS.member.getURI(), org.apache.jena.sparql.pfunction.library.container.class) ;
+        // This is called during Jena-wide initialization.
+        // Use function for constant (JENA-1294)
+        add(registry, RDFS.Init.member().getURI(), org.apache.jena.sparql.pfunction.library.container.class) ;
     }
     
     private static void add(PropertyFunctionRegistry registry, String uri, Class<?> funcClass)

--- a/jena-core/src/main/java/org/apache/jena/assembler/assemblers/AssemblerGroup.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/assemblers/AssemblerGroup.java
@@ -18,12 +18,24 @@
 
 package org.apache.jena.assembler.assemblers;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
-import org.apache.jena.assembler.* ;
-import org.apache.jena.assembler.exceptions.* ;
-import org.apache.jena.rdf.model.* ;
-import org.apache.jena.vocabulary.RDFS ;
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.assembler.AssemblerHelp;
+import org.apache.jena.assembler.JA;
+import org.apache.jena.assembler.Mode;
+import org.apache.jena.assembler.exceptions.AmbiguousSpecificTypeException;
+import org.apache.jena.assembler.exceptions.AssemblerException;
+import org.apache.jena.assembler.exceptions.NoImplementationException;
+import org.apache.jena.assembler.exceptions.NoSpecificTypeException;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.vocabulary.RDFS;
 
 public abstract class AssemblerGroup extends AssemblerBase implements Assembler
     {    
@@ -89,7 +101,9 @@ public abstract class AssemblerGroup extends AssemblerBase implements Assembler
 
         @Override public AssemblerGroup implementWith( Resource type, Assembler a )
             {
-            implementTypes.add( type, RDFS.subClassOf, JA.Object );
+            // This is called during Jena-wide initialization.
+            // Use function for constant (JENA-1294)
+            implementTypes.add( type, RDFS.Init.subClassOf(), JA.Object );
             internal.implementWith( type, a );
             return this;
             }

--- a/jena-core/src/main/java/org/apache/jena/assembler/assemblers/OntModelAssembler.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/assemblers/OntModelAssembler.java
@@ -53,11 +53,11 @@ public class OntModelAssembler extends InfModelAssembler implements Assembler
         return result;
         }
 
-    private static final OntModelSpec defaultSpec = OntModelSpec.OWL_MEM_RDFS_INF;
+    /*package*/ static final OntModelSpec defaultSpec() { return OntModelSpec.OWL_MEM_RDFS_INF; }
 
     protected OntModelSpec getOntModelSpec( Assembler a, Resource root )
         {
         Resource r = getUniqueResource( root, JA.ontModelSpec );
-        return r == null ? defaultSpec : (OntModelSpec) a.open( r );
+        return r == null ? defaultSpec() : (OntModelSpec) a.open( r );
         }
     }

--- a/jena-core/src/main/java/org/apache/jena/assembler/assemblers/OntModelSpecAssembler.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/assemblers/OntModelSpecAssembler.java
@@ -36,9 +36,7 @@ import org.apache.jena.shared.NotFoundException ;
     in which case the defaults are taken from there.
 */
 public class OntModelSpecAssembler extends AssemblerBase implements Assembler
-    {
-    private static final OntModelSpec DEFAULT = OntModelSpec.OWL_MEM_RDFS_INF;
-
+{
     @Override
     public Object open( Assembler a, Resource root, Mode irrelevant )
         {
@@ -90,6 +88,7 @@ public class OntModelSpecAssembler extends AssemblerBase implements Assembler
     */
     private OntModelSpec getDefault( Resource root )
         {
+        OntModelSpec DEFAULT = OntModelAssembler.defaultSpec();
         if (root.isURIResource() && root.getNameSpace().equals( JA.uri ))
             {
             OntModelSpec oms = getOntModelSpecField( root.getLocalName() );

--- a/jena-core/src/main/java/org/apache/jena/vocabulary/OWL.java
+++ b/jena-core/src/main/java/org/apache/jena/vocabulary/OWL.java
@@ -28,137 +28,170 @@ import org.apache.jena.rdf.model.* ;
  * Vocabulary definitions from file:vocabularies/owl.owl
  */
 public class OWL {
-    // Using ResourceFactory to avoid initialization circularity problems.
-    // OWL is a central place where other classes go to get their constants
-    // causing potential circularity of initialization.
-    // If OWL starts the Jena initialization process
-    // (ModelFactory.createDefaultModel calls JenaSystem.init)
-    // then classes can easily see uninitialized constants. 
-
-    // Remove after Jena 3.0.1 or later.
-//    // ModelFactory.createDefaultModel calls JenaSystem.init
-//    /** <p>The RDF model that holds the vocabulary terms</p> */
-//    private static final Model m_model = ModelFactory.createDefaultModel();
-//
-//    protected static final Resource resource( String uri )
-//    { return m_model.createResource( uri ); }
-//
-//    protected static final Property property( String uri )
-//    { return m_model.createProperty( uri ); }
-
     // These will use ResourceFactory which creates Resource etc without a specific model.
     // This is safer for complex initialization paths.
     protected static final Resource resource( String uri )
-    { return ResourceFactory.createResource( uri ); }
+    { return ResourceFactory.createResource( NS+uri ); }
 
     protected static final Property property( String uri )
-    { return ResourceFactory.createProperty( uri ); }
+    { return ResourceFactory.createProperty( NS, uri ); }
 
-    /** <p>The namespace of the vocabulary as a string ({@value})</p> */
+    /** The namespace of the vocabulary as a string. */
     public static final String NS = "http://www.w3.org/2002/07/owl#";
     
-    /** <p>The namespace of the vocabulary as a string</p>
-     *  @see #NS */
+    /** The namespace of the vocabulary as a string */
     public static String getURI() {return NS;}
     
-    /** <p>The namespace of the vocabulary as a resource</p> */
-    public static final Resource NAMESPACE = resource( NS );
+    /** The namespace of the vocabulary as a resource */
+    public static final Resource NAMESPACE = ResourceFactory.createResource( NS );
     
     /** A resource that denotes the OWL-full sublanguage of OWL */
-    public static final Resource FULL_LANG = resource( getURI() );
+    public static final Resource FULL_LANG = ResourceFactory.createResource( getURI() );
     
     /** A resource, not officially sanctioned by WebOnt, that denotes the OWL-DL sublanguage of OWL */
-    public static final Resource DL_LANG = resource( "http://www.w3.org/TR/owl-features/#term_OWLDL" );
+    public static final Resource DL_LANG = ResourceFactory.createResource("http://www.w3.org/TR/owl-features/#term_OWLDL" );
     
     /** A resource, not officially sanctioned by WebOnt, that denotes the OWL-Lite sublanguage of OWL */
-    public static final Resource LITE_LANG = resource( "http://www.w3.org/TR/owl-features/#term_OWLLite" );
+    public static final Resource LITE_LANG = ResourceFactory.createResource("http://www.w3.org/TR/owl-features/#term_OWLLite" );
 
     // Vocabulary properties
     ///////////////////////////
 
-    public static final Property maxCardinality = property( "http://www.w3.org/2002/07/owl#maxCardinality" );
+    public static final Property maxCardinality = Init.maxCardinality();
     
-    public static final Property versionInfo = property( "http://www.w3.org/2002/07/owl#versionInfo" );
+    public static final Property versionInfo = Init.versionInfo();
     
-    public static final Property equivalentClass = property( "http://www.w3.org/2002/07/owl#equivalentClass" );
+    public static final Property equivalentClass = Init.equivalentClass();
     
-    public static final Property distinctMembers = property( "http://www.w3.org/2002/07/owl#distinctMembers" );
+    public static final Property distinctMembers = Init.distinctMembers();
     
-    public static final Property oneOf = property( "http://www.w3.org/2002/07/owl#oneOf" );
+    public static final Property oneOf = Init.oneOf();
     
-    public static final Property sameAs = property( "http://www.w3.org/2002/07/owl#sameAs" );
+    public static final Property sameAs = Init.sameAs();
     
-    public static final Property incompatibleWith = property( "http://www.w3.org/2002/07/owl#incompatibleWith" );
+    public static final Property incompatibleWith = Init.incompatibleWith();
     
-    public static final Property minCardinality = property( "http://www.w3.org/2002/07/owl#minCardinality" );
+    public static final Property minCardinality = Init.minCardinality();
     
-    public static final Property complementOf = property( "http://www.w3.org/2002/07/owl#complementOf" );
+    public static final Property complementOf = Init.complementOf();
     
-    public static final Property onProperty = property( "http://www.w3.org/2002/07/owl#onProperty" );
+    public static final Property onProperty = Init.onProperty();
     
-    public static final Property equivalentProperty = property( "http://www.w3.org/2002/07/owl#equivalentProperty" );
+    public static final Property equivalentProperty = Init.equivalentProperty();
     
-    public static final Property inverseOf = property( "http://www.w3.org/2002/07/owl#inverseOf" );
+    public static final Property inverseOf = Init.inverseOf();
     
-    public static final Property backwardCompatibleWith = property( "http://www.w3.org/2002/07/owl#backwardCompatibleWith" );
+    public static final Property backwardCompatibleWith = Init.backwardCompatibleWith();
     
-    public static final Property differentFrom = property( "http://www.w3.org/2002/07/owl#differentFrom" );
+    public static final Property differentFrom = Init.differentFrom();
     
-    public static final Property priorVersion = property( "http://www.w3.org/2002/07/owl#priorVersion" );
+    public static final Property priorVersion = Init.priorVersion();
     
-    public static final Property imports = property( "http://www.w3.org/2002/07/owl#imports" );
+    public static final Property imports = Init.imports();
     
-    public static final Property allValuesFrom = property( "http://www.w3.org/2002/07/owl#allValuesFrom" );
+    public static final Property allValuesFrom = Init.allValuesFrom();
     
-    public static final Property unionOf = property( "http://www.w3.org/2002/07/owl#unionOf" );
+    public static final Property unionOf = Init.unionOf();
     
-    public static final Property hasValue = property( "http://www.w3.org/2002/07/owl#hasValue" );
+    public static final Property hasValue = Init.hasValue();
     
-    public static final Property someValuesFrom = property( "http://www.w3.org/2002/07/owl#someValuesFrom" );
+    public static final Property someValuesFrom = Init.someValuesFrom();
     
-    public static final Property disjointWith = property( "http://www.w3.org/2002/07/owl#disjointWith" );
+    public static final Property disjointWith = Init.disjointWith();
     
-    public static final Property cardinality = property( "http://www.w3.org/2002/07/owl#cardinality" );
+    public static final Property cardinality = Init.cardinality();
     
-    public static final Property intersectionOf = property( "http://www.w3.org/2002/07/owl#intersectionOf" );
+    public static final Property intersectionOf = Init.intersectionOf();
 
     // Vocabulary classes
     ///////////////////////////
 
-    public static final Resource Thing = resource( "http://www.w3.org/2002/07/owl#Thing" );
+    public static final Resource Thing = Init.Thing();
     
-    public static final Resource DataRange = resource( "http://www.w3.org/2002/07/owl#DataRange" );
+    public static final Resource DataRange = Init.DataRange();
     
-    public static final Resource Ontology = resource( "http://www.w3.org/2002/07/owl#Ontology" );
+    public static final Resource Ontology = Init.Ontology();
     
-    public static final Resource DeprecatedClass = resource( "http://www.w3.org/2002/07/owl#DeprecatedClass" );
+    public static final Resource DeprecatedClass = Init.DeprecatedClass();
     
-    public static final Resource AllDifferent = resource( "http://www.w3.org/2002/07/owl#AllDifferent" );
+    public static final Resource AllDifferent = Init.AllDifferent();
     
-    public static final Resource DatatypeProperty = resource( "http://www.w3.org/2002/07/owl#DatatypeProperty" );
+    public static final Resource DatatypeProperty = Init.DatatypeProperty();
     
-    public static final Resource SymmetricProperty = resource( "http://www.w3.org/2002/07/owl#SymmetricProperty" );
+    public static final Resource SymmetricProperty = Init.SymmetricProperty();
     
-    public static final Resource TransitiveProperty = resource( "http://www.w3.org/2002/07/owl#TransitiveProperty" );
+    public static final Resource TransitiveProperty = Init.TransitiveProperty();
     
-    public static final Resource DeprecatedProperty = resource( "http://www.w3.org/2002/07/owl#DeprecatedProperty" );
+    public static final Resource DeprecatedProperty = Init.DeprecatedProperty();
     
-    public static final Resource AnnotationProperty = resource( "http://www.w3.org/2002/07/owl#AnnotationProperty" );
+    public static final Resource AnnotationProperty = Init.AnnotationProperty();
     
-    public static final Resource Restriction = resource( "http://www.w3.org/2002/07/owl#Restriction" );
+    public static final Resource Restriction = Init.Restriction();
     
-    public static final Resource Class = resource( "http://www.w3.org/2002/07/owl#Class" );
+    public static final Resource Class = Init.Class();
     
-    public static final Resource OntologyProperty = resource( "http://www.w3.org/2002/07/owl#OntologyProperty" );
+    public static final Resource OntologyProperty = Init.OntologyProperty();
     
-    public static final Resource ObjectProperty = resource( "http://www.w3.org/2002/07/owl#ObjectProperty" );
+    public static final Resource ObjectProperty = Init.ObjectProperty();
     
-    public static final Resource FunctionalProperty = resource( "http://www.w3.org/2002/07/owl#FunctionalProperty" );
+    public static final Resource FunctionalProperty = Init.FunctionalProperty();
     
-    public static final Resource InverseFunctionalProperty = resource( "http://www.w3.org/2002/07/owl#InverseFunctionalProperty" );
+    public static final Resource InverseFunctionalProperty = Init.InverseFunctionalProperty();
     
-    public static final Resource Nothing = resource( "http://www.w3.org/2002/07/owl#Nothing" );
-
+    public static final Resource Nothing = Init.Nothing();
+    
     // Vocabulary individuals
     ///////////////////////////
+    
+    /** OWL constants are used during Jena initialization.
+     * <p>
+     * If that initialization is triggered by touching the OWL class,
+     * then the constants are null.
+     * <p>
+     * So for these cases, call this helper class: Init.function()   
+     */
+    public static class Init {
+        // JENA-1294
+        // Version that calculate the constant when called. 
+        public static Property maxCardinality()             { return property( "maxCardinality" ); }
+        public static Property versionInfo()                { return property( "versionInfo" ); }
+        public static Property equivalentClass()            { return property( "equivalentClass" ); }
+        public static Property distinctMembers()            { return property( "distinctMembers" ); }
+        public static Property oneOf()                      { return property( "oneOf" ); }
+        public static Property sameAs()                     { return property( "sameAs" ); }
+        public static Property incompatibleWith()           { return property( "incompatibleWith" ); }
+        public static Property minCardinality()             { return property( "minCardinality" ); }
+        public static Property complementOf()               { return property( "complementOf" ); }
+        public static Property onProperty()                 { return property( "onProperty" ); }
+        public static Property equivalentProperty()         { return property( "equivalentProperty" ); }
+        public static Property inverseOf()                  { return property( "inverseOf" ); }
+        public static Property backwardCompatibleWith()     { return property( "backwardCompatibleWith" ); }
+        public static Property differentFrom()              { return property( "differentFrom" ); }
+        public static Property priorVersion()               { return property( "priorVersion" ); }
+        public static Property imports()                    { return property( "imports" ); }
+        public static Property allValuesFrom()              { return property( "allValuesFrom" ); }
+        public static Property unionOf()                    { return property( "unionOf" ); }
+        public static Property hasValue()                   { return property( "hasValue" ); }
+        public static Property someValuesFrom()             { return property( "someValuesFrom" ); }
+        public static Property disjointWith()               { return property( "disjointWith" ); }
+        public static Property cardinality()                { return property( "cardinality" ); }
+        public static Property intersectionOf()             { return property( "intersectionOf" ); }
+        public static Resource Thing()                      { return resource( "Thing" ); }
+        public static Resource DataRange()                  { return resource( "DataRange" ); }
+        public static Resource Ontology()                   { return resource( "Ontology" ); }
+        public static Resource DeprecatedClass()            { return resource( "DeprecatedClass" ); }
+        public static Resource AllDifferent()               { return resource( "AllDifferent" ); }
+        public static Resource DatatypeProperty()           { return resource( "DatatypeProperty" ); }
+        public static Resource SymmetricProperty()          { return resource( "SymmetricProperty" ); }
+        public static Resource TransitiveProperty()         { return resource( "TransitiveProperty" ); }
+        public static Resource DeprecatedProperty()         { return resource( "DeprecatedProperty" ); }
+        public static Resource AnnotationProperty()         { return resource( "AnnotationProperty" ); }
+        public static Resource Restriction()                { return resource( "Restriction" ); }
+        public static Resource Class()                      { return resource( "Class" ); }
+        public static Resource OntologyProperty()           { return resource( "OntologyProperty" ); }
+        public static Resource ObjectProperty()             { return resource( "ObjectProperty" ); }
+        public static Resource FunctionalProperty()         { return resource( "FunctionalProperty" ); }
+        public static Resource InverseFunctionalProperty()  { return resource( "InverseFunctionalProperty" ); }
+        public static Resource Nothing()                    { return resource( "Nothing" ); }
+    }
 }

--- a/jena-core/src/main/java/org/apache/jena/vocabulary/RDF.java
+++ b/jena-core/src/main/java/org/apache/jena/vocabulary/RDF.java
@@ -33,10 +33,10 @@ import org.apache.jena.rdf.model.ResourceFactory ;
 
 public class RDF{
 
-	/**
-	 * The namespace of the vocabulary as a string
-	 */
-	public static final String uri ="http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+    /**
+     * The namespace of the vocabulary as a string
+     */
+    public static final String uri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
 
     /** returns the URI for this schema
         @return the URI for this schema
@@ -53,35 +53,73 @@ public class RDF{
     public static Property li( int i )
         { return property( "_" + i ); }
 
-    public static final Resource Alt = resource( "Alt" );
-    public static final Resource Bag = resource( "Bag" );
-    public static final Resource Property = resource( "Property" );
-    public static final Resource Seq = resource( "Seq" );
-    public static final Resource Statement = resource( "Statement" );
-    public static final Resource List = resource( "List" );
-    public static final Resource nil = resource( "nil" );
+    public static final Resource    Alt          = Init.Alt();
+    public static final Resource    Bag          = Init.Bag();
+    public static final Resource    Property     = Init._Property();
+    public static final Resource    Seq          = Init.Seq();
+    public static final Resource    Statement    = Init.Statement();
+    public static final Resource    List         = Init.List();
+    public static final Resource    nil          = Init.nil();
 
-    public static final Property first = property( "first" );
-    public static final Property rest = property( "rest" );
-    public static final Property subject = property( "subject" );
-    public static final Property predicate = property( "predicate" );
-    public static final Property object = property( "object" );
-    public static final Property type = property( "type" );
-    public static final Property value = property( "value" );
-    
+    public static final Property    first        = Init.first();
+    public static final Property    rest         = Init.rest();
+    public static final Property    subject      = Init.subject();
+    public static final Property    predicate    = Init.predicate();
+    public static final Property    object       = Init.object();
+    public static final Property    type         = Init.type();
+    public static final Property    value        = Init.value();
+
     // RDF 1.1 - the datatypes of language strings
-    public static final Resource langString = ResourceFactory.createResource(RDFLangString.rdfLangString.getURI()) ;
-    
+    public static final Resource    langString   = Init.langString();
+
     // RDF 1.1 - rdf:HTML
-    public static final Resource HTML = ResourceFactory.createResource(RDFhtml.rdfHTML.getURI()) ;
+    public static final Resource    HTML         = Init.HTML();
 
     // rdf:XMLLiteral
-    public static final Resource xmlLiteral = ResourceFactory.createResource(XMLLiteralType.theXMLLiteralType.getURI()) ;
-    
-    public static final RDFDatatype dtRDFHTML    = RDFhtml.rdfHTML;
-    public static final RDFDatatype dtLangString = RDFLangString.rdfLangString;
-    public static final RDFDatatype dtXMLLiteral = XMLLiteralType.theXMLLiteralType;
+    public static final Resource    xmlLiteral   = Init.xmlLiteral();
 
+    public static final RDFDatatype dtRDFHTML    = Init.dtRDFHTML();
+    public static final RDFDatatype dtLangString = Init.dtLangString();
+    public static final RDFDatatype dtXMLLiteral = Init.dtXMLLiteral();
+
+    /** RDF constants are used during Jena initialization.
+     * <p>
+     * If that initialization is triggered by touching the RDF class,
+     * then the constants are null.
+     * <p>
+     * So for these cases, call this helper class: Init.function()   
+     */
+    public static class Init {
+        // JENA-1294
+        // Version that calculate the constant when called. 
+        public static Resource Alt()              { return resource( "Alt" ); }
+        public static Resource Bag()              { return resource( "Bag" ); }
+        // Java8 bug : https://bugzilla.redhat.com/show_bug.cgi?id=1423421
+        // Can't have a methdo called Property() - it crashes the javadoc generation.
+        //  https://bugzilla.redhat.com/show_bug.cgi?id=1423421 ==>
+        //  https://bugs.openjdk.java.net/browse/JDK-8061305
+        public static Resource _Property()         { return resource( "Property" ); }
+        public static Resource Seq()              { return resource( "Seq" ); }
+        public static Resource Statement()        { return resource( "Statement" ); }
+        public static Resource List()             { return resource( "List" ); }
+        public static Resource nil()              { return resource( "nil" ); }
+        public static Property first()            { return property( "first" ); }
+        public static Property rest()             { return property( "rest" ); }
+        public static Property subject()          { return property( "subject" ); }
+        public static Property predicate()        { return property( "predicate" ); }
+        public static Property object()           { return property( "object" ); }
+        public static Property type()             { return property( "type" ); }
+        public static Property value()            { return property( "value" ); }
+        
+        public static Resource langString()       { return ResourceFactory.createResource(dtLangString().getURI()) ; }
+        public static Resource HTML()             { return ResourceFactory.createResource(dtRDFHTML().getURI()) ; }
+        public static Resource xmlLiteral()       { return ResourceFactory.createResource(dtXMLLiteral().getURI()) ; }
+        
+        public static RDFDatatype dtRDFHTML()     { return RDFhtml.rdfHTML; }
+        public static RDFDatatype dtLangString()  { return RDFLangString.rdfLangString; }
+        public static RDFDatatype dtXMLLiteral()  { return XMLLiteralType.theXMLLiteralType; }
+    }
+    
     /**
         The same items of vocabulary, but at the Node level, parked inside a
         nested class so that there's a simple way to refer to them.
@@ -89,22 +127,22 @@ public class RDF{
     @SuppressWarnings("hiding") 
     public static final class Nodes
     {
-        public static final Node Alt        = RDF.Alt.asNode();
-        public static final Node Bag        = RDF.Bag.asNode();
-        public static final Node Property   = RDF.Property.asNode();
-        public static final Node Seq        = RDF.Seq.asNode();
-        public static final Node Statement  = RDF.Statement.asNode();
-        public static final Node List       = RDF.List.asNode();
-        public static final Node nil        = RDF.nil.asNode();
-        public static final Node first      = RDF.first.asNode();
-        public static final Node rest       = RDF.rest.asNode();
-        public static final Node subject    = RDF.subject.asNode();
-        public static final Node predicate  = RDF.predicate.asNode();
-        public static final Node object     = RDF.object.asNode();
-        public static final Node type       = RDF.type.asNode();
-        public static final Node value      = RDF.value.asNode();
-        public static final Node langString = RDF.langString.asNode();
-        public static final Node HTML       = RDF.HTML.asNode();
-        public static final Node xmlLiteral = RDF.xmlLiteral.asNode();
+        public static final Node Alt        = Init.Alt().asNode();
+        public static final Node Bag        = Init.Bag().asNode();
+        public static final Node Property   = Init._Property().asNode();
+        public static final Node Seq        = Init.Seq().asNode();
+        public static final Node Statement  = Init.Statement().asNode();
+        public static final Node List       = Init.List().asNode();
+        public static final Node nil        = Init.nil().asNode();
+        public static final Node first      = Init.first().asNode();
+        public static final Node rest       = Init.rest().asNode();
+        public static final Node subject    = Init.subject().asNode();
+        public static final Node predicate  = Init.predicate().asNode();
+        public static final Node object     = Init.object().asNode();
+        public static final Node type       = Init.type().asNode();
+        public static final Node value      = Init.value().asNode();
+        public static final Node langString = Init.langString().asNode();
+        public static final Node HTML       = Init.HTML().asNode();
+        public static final Node xmlLiteral = Init.xmlLiteral().asNode();
     }
 }

--- a/jena-core/src/main/java/org/apache/jena/vocabulary/RDFS.java
+++ b/jena-core/src/main/java/org/apache/jena/vocabulary/RDFS.java
@@ -37,49 +37,50 @@ public class RDFS {
     protected static final Property property( String local )
         { return ResourceFactory.createProperty( uri, local ); }
 
-    public static final Resource Class          = RDFS.Init.Class();
-    public static final Resource Datatype       = RDFS.Init.Datatype();
+    public static final Resource Class          = Init.Class();
+    public static final Resource Datatype       = Init.Datatype();
     
-    public static final Resource Container      = RDFS.Init.Container();
+    public static final Resource Container      = Init.Container();
     
-    public static final Resource ContainerMembershipProperty = RDFS.Init.ContainerMembershipProperty();
+    public static final Resource ContainerMembershipProperty = Init.ContainerMembershipProperty();
     
-    public static final Resource Literal        = RDFS.Init.Literal();
-    public static final Resource Resource       = RDFS.Init.Resource();
+    public static final Resource Literal        = Init.Literal();
+    public static final Resource Resource       = Init.Resource();
 
-    public static final Property comment        = RDFS.Init.comment();
-    public static final Property domain         = RDFS.Init.domain();
-    public static final Property label          = RDFS.Init.label();
-    public static final Property isDefinedBy    = RDFS.Init.isDefinedBy();
-    public static final Property range          = RDFS.Init.range();
-    public static final Property seeAlso        = RDFS.Init.seeAlso();
-    public static final Property subClassOf     = RDFS.Init.subClassOf();
-    public static final Property subPropertyOf  = RDFS.Init.subPropertyOf();
-    public static final Property member         = RDFS.Init.member();
+    public static final Property comment        = Init.comment();
+    public static final Property domain         = Init.domain();
+    public static final Property label          = Init.label();
+    public static final Property isDefinedBy    = Init.isDefinedBy();
+    public static final Property range          = Init.range();
+    public static final Property seeAlso        = Init.seeAlso();
+    public static final Property subClassOf     = Init.subClassOf();
+    public static final Property subPropertyOf  = Init.subPropertyOf();
+    public static final Property member         = Init.member();
 
-    /* RDFS constants are used during Jena initialization.
+    /** RDFS constants are used during Jena initialization.
      * <p>
      * If that initialization is triggered by touching the RDFS class,
      * then the constants are null.
      * <p>
-     * So for these cases, call this helper class: RDFS.Init.function()   
+     * So for these cases, call this helper class: Init.function()   
      */
     public static class Init {
-        public static Resource Class()          { return RDFS.resource( "Class"); }
-        public static Resource Datatype()       { return RDFS.resource( "Datatype"); }
-        public static Resource Container ()     { return RDFS.resource( "Container"); }
-        public static Resource ContainerMembershipProperty()    { return RDFS.resource( "ContainerMembershipProperty");   }
-        public static Resource Literal()        { return RDFS.resource( "Literal"); }
-        public static Resource Resource()       { return RDFS.resource( "Resource"); }
-        public static Property comment()        { return RDFS.property( "comment"); }
-        public static Property domain()         { return RDFS.property( "domain"); }
-        public static Property label()          { return RDFS.property( "label"); }
-        public static Property isDefinedBy()    { return RDFS.property( "isDefinedBy"); }
-        public static Property range()          { return RDFS.property( "range"); }
-        public static Property seeAlso()        { return RDFS.property( "seeAlso"); }
-        public static Property subClassOf ()    { return RDFS.property( "subClassOf"); }
-        public static Property subPropertyOf () { return RDFS.property( "subPropertyOf"); }
-        public static Property member ()        { return RDFS.property( "member"); }
+        public static Resource Class()          { return resource( "Class"); }
+        public static Resource Datatype()       { return resource( "Datatype"); }
+        public static Resource Container ()     { return resource( "Container"); }
+        public static Resource ContainerMembershipProperty()
+                                                { return resource( "ContainerMembershipProperty");   }
+        public static Resource Literal()        { return resource( "Literal"); }
+        public static Resource Resource()       { return resource( "Resource"); }
+        public static Property comment()        { return property( "comment"); }
+        public static Property domain()         { return property( "domain"); }
+        public static Property label()          { return property( "label"); }
+        public static Property isDefinedBy()    { return property( "isDefinedBy"); }
+        public static Property range()          { return property( "range"); }
+        public static Property seeAlso()        { return property( "seeAlso"); }
+        public static Property subClassOf ()    { return property( "subClassOf"); }
+        public static Property subPropertyOf () { return property( "subPropertyOf"); }
+        public static Property member ()        { return property( "member"); }
     }
     
     /**
@@ -87,22 +88,22 @@ public class RDFS {
     */
     @SuppressWarnings("hiding") public static class Nodes
         {
-        public static final Node Class = RDFS.Init.Class().asNode();
-        public static final Node Datatype = RDFS.Init.Datatype().asNode();
-        public static final Node Container  = RDFS.Init.Container().asNode();
+        public static final Node Class          = Init.Class().asNode();
+        public static final Node Datatype       = Init.Datatype().asNode();
+        public static final Node Container      = Init.Container().asNode();
         public static final Node ContainerMembershipProperty
-                                                         = RDFS.Init.ContainerMembershipProperty().asNode();
-        public static final Node Literal = RDFS.Init.Literal().asNode();
-        public static final Node Resource = RDFS.Init.Resource().asNode();
-        public static final Node comment = RDFS.Init.comment().asNode();
-        public static final Node domain = RDFS.Init.domain().asNode();
-        public static final Node label = RDFS.Init.label().asNode();
-        public static final Node isDefinedBy = RDFS.Init.isDefinedBy().asNode();
-        public static final Node range = RDFS.Init.range().asNode();
-        public static final Node seeAlso = RDFS.Init.seeAlso().asNode();
-        public static final Node subClassOf  = RDFS.Init.subClassOf().asNode();
-        public static final Node subPropertyOf  = RDFS.Init.subPropertyOf().asNode();
-        public static final Node member  = RDFS.Init.member().asNode();
+                                                = Init.ContainerMembershipProperty().asNode();
+        public static final Node Literal        = Init.Literal().asNode();
+        public static final Node Resource       = Init.Resource().asNode();
+        public static final Node comment        = Init.comment().asNode();
+        public static final Node domain         = Init.domain().asNode();
+        public static final Node label          = Init.label().asNode();
+        public static final Node isDefinedBy    = Init.isDefinedBy().asNode();
+        public static final Node range          = Init.range().asNode();
+        public static final Node seeAlso        = Init.seeAlso().asNode();
+        public static final Node subClassOf     = Init.subClassOf().asNode();
+        public static final Node subPropertyOf  = Init.subPropertyOf().asNode();
+        public static final Node member         = Init.member().asNode();
         }
 
     /**

--- a/jena-core/src/main/java/org/apache/jena/vocabulary/RDFS.java
+++ b/jena-core/src/main/java/org/apache/jena/vocabulary/RDFS.java
@@ -26,10 +26,10 @@ import org.apache.jena.rdf.model.* ;
  */
 public class RDFS {
 
-	/**
-	 * The namespace of the vocabulary as a string
-	 */
-	public static final String uri="http://www.w3.org/2000/01/rdf-schema#";
+    /**
+     * The namespace of the vocabulary as a string
+     */
+    public static final String uri="http://www.w3.org/2000/01/rdf-schema#";
 
     protected static final Resource resource( String local )
         { return ResourceFactory.createResource( uri + local ); }
@@ -37,48 +37,72 @@ public class RDFS {
     protected static final Property property( String local )
         { return ResourceFactory.createProperty( uri, local ); }
 
-    public static final Resource Class = resource( "Class");
-    public static final Resource Datatype = resource( "Datatype");
+    public static final Resource Class          = RDFS.Init.Class();
+    public static final Resource Datatype       = RDFS.Init.Datatype();
     
-    public static final Resource Container  = resource( "Container");
+    public static final Resource Container      = RDFS.Init.Container();
     
-    public static final Resource ContainerMembershipProperty
-                                                     = resource( "ContainerMembershipProperty");  
+    public static final Resource ContainerMembershipProperty = RDFS.Init.ContainerMembershipProperty();
     
-    public static final Resource Literal = resource( "Literal");
-    public static final Resource Resource = resource( "Resource");
+    public static final Resource Literal        = RDFS.Init.Literal();
+    public static final Resource Resource       = RDFS.Init.Resource();
 
-    public static final Property comment = property( "comment");
-    public static final Property domain = property( "domain");
-    public static final Property label = property( "label");
-    public static final Property isDefinedBy = property( "isDefinedBy");
-    public static final Property range = property( "range");
-    public static final Property seeAlso = property( "seeAlso");
-    public static final Property subClassOf  = property( "subClassOf");
-    public static final Property subPropertyOf  = property( "subPropertyOf");
-    public static final Property member  = property( "member");
+    public static final Property comment        = RDFS.Init.comment();
+    public static final Property domain         = RDFS.Init.domain();
+    public static final Property label          = RDFS.Init.label();
+    public static final Property isDefinedBy    = RDFS.Init.isDefinedBy();
+    public static final Property range          = RDFS.Init.range();
+    public static final Property seeAlso        = RDFS.Init.seeAlso();
+    public static final Property subClassOf     = RDFS.Init.subClassOf();
+    public static final Property subPropertyOf  = RDFS.Init.subPropertyOf();
+    public static final Property member         = RDFS.Init.member();
 
+    /* RDFS constants are used during Jena initialization.
+     * <p>
+     * If that initialization is triggered by touching the RDFS class,
+     * then the constants are null.
+     * <p>
+     * So for these cases, call this helper class: RDFS.Init.function()   
+     */
+    public static class Init {
+        public static Resource Class()          { return RDFS.resource( "Class"); }
+        public static Resource Datatype()       { return RDFS.resource( "Datatype"); }
+        public static Resource Container ()     { return RDFS.resource( "Container"); }
+        public static Resource ContainerMembershipProperty()    { return RDFS.resource( "ContainerMembershipProperty");   }
+        public static Resource Literal()        { return RDFS.resource( "Literal"); }
+        public static Resource Resource()       { return RDFS.resource( "Resource"); }
+        public static Property comment()        { return RDFS.property( "comment"); }
+        public static Property domain()         { return RDFS.property( "domain"); }
+        public static Property label()          { return RDFS.property( "label"); }
+        public static Property isDefinedBy()    { return RDFS.property( "isDefinedBy"); }
+        public static Property range()          { return RDFS.property( "range"); }
+        public static Property seeAlso()        { return RDFS.property( "seeAlso"); }
+        public static Property subClassOf ()    { return RDFS.property( "subClassOf"); }
+        public static Property subPropertyOf () { return RDFS.property( "subPropertyOf"); }
+        public static Property member ()        { return RDFS.property( "member"); }
+    }
+    
     /**
         The RDFS vocabulary, expressed for the SPI layer in terms of .graph Nodes.
     */
     @SuppressWarnings("hiding") public static class Nodes
         {
-        public static final Node Class = RDFS.Class.asNode();
-        public static final Node Datatype = RDFS.Datatype.asNode();
-        public static final Node Container  = RDFS.Container.asNode();
+        public static final Node Class = RDFS.Init.Class().asNode();
+        public static final Node Datatype = RDFS.Init.Datatype().asNode();
+        public static final Node Container  = RDFS.Init.Container().asNode();
         public static final Node ContainerMembershipProperty
-                                                         = RDFS.ContainerMembershipProperty.asNode();
-        public static final Node Literal = RDFS.Literal.asNode();
-        public static final Node Resource = RDFS.Resource.asNode();
-        public static final Node comment = RDFS.comment.asNode();
-        public static final Node domain = RDFS.domain.asNode();
-        public static final Node label = RDFS.label.asNode();
-        public static final Node isDefinedBy = RDFS.isDefinedBy.asNode();
-        public static final Node range = RDFS.range.asNode();
-        public static final Node seeAlso = RDFS.seeAlso.asNode();
-        public static final Node subClassOf  = RDFS.subClassOf.asNode();
-        public static final Node subPropertyOf  = RDFS.subPropertyOf.asNode();
-        public static final Node member  = RDFS.member.asNode();
+                                                         = RDFS.Init.ContainerMembershipProperty().asNode();
+        public static final Node Literal = RDFS.Init.Literal().asNode();
+        public static final Node Resource = RDFS.Init.Resource().asNode();
+        public static final Node comment = RDFS.Init.comment().asNode();
+        public static final Node domain = RDFS.Init.domain().asNode();
+        public static final Node label = RDFS.Init.label().asNode();
+        public static final Node isDefinedBy = RDFS.Init.isDefinedBy().asNode();
+        public static final Node range = RDFS.Init.range().asNode();
+        public static final Node seeAlso = RDFS.Init.seeAlso().asNode();
+        public static final Node subClassOf  = RDFS.Init.subClassOf().asNode();
+        public static final Node subPropertyOf  = RDFS.Init.subPropertyOf().asNode();
+        public static final Node member  = RDFS.Init.member().asNode();
         }
 
     /**

--- a/jena-core/src/test/java/org/apache/jena/test/RDFSJenaInitTestApp.java
+++ b/jena-core/src/test/java/org/apache/jena/test/RDFSJenaInitTestApp.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.test;
+
+import org.apache.jena.vocabulary.RDFS;
+
+// Invoked from TestSystemSetup 
+public class RDFSJenaInitTestApp {
+    public static void main(String[] args) {
+        System.out.printf("%s\n", RDFS.subClassOf);
+    }
+}

--- a/jena-core/src/test/java/org/apache/jena/test/TestSystemSetup.java
+++ b/jena-core/src/test/java/org/apache/jena/test/TestSystemSetup.java
@@ -20,7 +20,15 @@ package org.apache.jena.test;
 
 import junit.framework.TestCase ;
 import junit.framework.TestSuite ;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.jena.JenaRuntime ;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 public class TestSystemSetup extends TestCase {
 
@@ -33,6 +41,28 @@ public class TestSystemSetup extends TestCase {
         // This should be "true" in Jena3. 
         if ( ! JenaRuntime.isRDF11 )
             fail("RDF 1.0 mode enabled in Jena3 test run") ;
+    }
+
+    /** This test relies on forking a clean JVM */ 
+    public void testInitFromRDFS() throws IOException, InterruptedException {
+        String separator = System.getProperty("file.separator");
+        String classpath = System.getProperty("java.class.path");
+        String java = System.getProperty("java.home")
+                + separator + "bin" + separator + "java";
+        if (SystemUtils.IS_OS_WINDOWS)
+            java += ".exe";
+        
+
+        List<String> args = Arrays.asList(java, "-cp", classpath,
+                "org.apache.jena.test.RDFSJenaInitTestApp");
+        Process child = new ProcessBuilder().command(args)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .start();
+
+        Assert.assertEquals(0, child.waitFor());
+        Assert.assertEquals(RDFS.subClassOf.toString()+"\n",
+                IOUtils.toString(child.getInputStream()));
     }
 
 }

--- a/jena-core/src/test/java/org/apache/jena/test/TestSystemSetup.java
+++ b/jena-core/src/test/java/org/apache/jena/test/TestSystemSetup.java
@@ -51,7 +51,6 @@ public class TestSystemSetup extends TestCase {
                 + separator + "bin" + separator + "java";
         if (SystemUtils.IS_OS_WINDOWS)
             java += ".exe";
-        
 
         List<String> args = Arrays.asList(java, "-cp", classpath,
                 "org.apache.jena.test.RDFSJenaInitTestApp");

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/sys/TS_Sys.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/sys/TS_Sys.java
@@ -20,12 +20,15 @@ package org.apache.jena.tdb.sys;
 
 
 import org.apache.jena.tdb.sys.TestSys ;
+import org.apache.jena.test.TestSystemSetup;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses( {
     TestSys.class
+    // From jena-core ... includes initialization test.  
+    , TestSystemSetup.class
 })
 
 public class TS_Sys


### PR DESCRIPTION
Fixes for RDFS - use functions for constants during initialization.

This fixes initialization as reported (TestParameterizedSparqlString).

RDF and OWL still to do in the same style for some rather unusual ways to trigger the same effect.
