### PR TITLE
JENA-1306: RDFParser

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/atlas/web/TypedInputStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/atlas/web/TypedInputStream.java
@@ -32,7 +32,15 @@ public class TypedInputStream extends FilterInputStream
     // e.g. 303 redirection, mapped URI redirection 
     private String baseURI ;
     
-    public TypedInputStream(InputStream in)
+    public static TypedInputStream wrap(InputStream in) {
+        //Soemtimes this is used to intentional loose the content type (in tests).
+//        if ( in instanceof TypedInputStream ) {
+//            return (TypedInputStream)in;
+//        }
+        return new TypedInputStream(in);
+    }
+    
+    private TypedInputStream(InputStream in)
     { this(in, (ContentType)null, null) ; }
     
     public TypedInputStream(InputStream in, String contentType)
@@ -61,7 +69,7 @@ public class TypedInputStream extends FilterInputStream
     
     @Override
     public void close() {
-        try { super.close() ; }
-        catch (IOException ex) { IO.exception(ex) ; }
+        try { super.close(); }
+        catch (IOException ex) { IO.exception(ex); }
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
@@ -24,7 +24,6 @@ import java.util.Objects ;
 
 import org.apache.jena.atlas.io.IO ;
 import org.apache.jena.atlas.iterator.IteratorResourceClosing ;
-import org.apache.jena.atlas.lib.Lib ;
 import org.apache.jena.atlas.web.ContentType ;
 import org.apache.jena.atlas.web.TypedInputStream ;
 import org.apache.jena.graph.Graph ;
@@ -81,10 +80,10 @@ public class RDFDataMgr
     static { JenaSystem.init() ; }
     
     static Logger log = LoggerFactory.getLogger(RDFDataMgr.class) ;
-    private static String riotBase = "http://jena.apache.org/riot/" ;
     
-	private static String StreamManagerSymbolStr = riotBase+"streamManager" ;
-	public static Symbol streamManagerSymbol = Symbol.create(riotBase+"streamManager") ;
+    /** @deprecated Use {@link SysRIOT#sysStreamManager} */
+    @Deprecated
+    public static Symbol streamManagerSymbol = SysRIOT.sysStreamManager;
 
     /** Read triples into a Model from the given location. 
      *  The syntax is detemined from input source URI (content negotiation or extension). 
@@ -809,13 +808,7 @@ public class RDFDataMgr
      * @return TypedInputStream
      */
     public static TypedInputStream open(String filenameOrURI, Context context) {
-        StreamManager sMgr = StreamManager.get() ;
-        if ( context != null ) {
-            try { sMgr = (StreamManager)context.get(streamManagerSymbol, context) ; }
-            catch (ClassCastException ex) 
-            { log.warn("Context symbol '"+streamManagerSymbol+"' is not a "+Lib.classShortName(StreamManager.class)) ; }
-        }
-        
+        StreamManager sMgr = StreamManager.get(context) ;
         return open(filenameOrURI, sMgr) ;
     }
     

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
@@ -150,7 +150,9 @@ public class RDFDataMgr
      * @param uri       URI to read from (includes file: and a plain file name).
      * @param context   Content object to control reading process.
      * @throws RiotNotFoundException if the location is not found - the model is unchanged.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */ 
+    @Deprecated
     public static void read(Model model, String uri, Context context)   { read(model.getGraph(), uri, context) ; }
     
     /** Read triples into a Model from the given location, with some parameters for the reader
@@ -159,7 +161,9 @@ public class RDFDataMgr
      * @param uri       URI to read from (includes file: and a plain file name).
      * @param context   Content object to control reading process.
      * @throws RiotNotFoundException if the location is not found - the graph is unchanged.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */ 
+    @Deprecated
     public static void read(Graph graph, String uri, Context context)   { read(graph, uri, defaultLang(uri), context) ; }
     
     /** Read triples into a Model from the given location, with hint of language and the with some parameters for the reader 
@@ -169,7 +173,9 @@ public class RDFDataMgr
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
      * @throws RiotNotFoundException if the location is not found - the model is unchanged.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void read(Model model, String uri, Lang hintLang, Context context)
     { read(model, uri, defaultBase(uri), hintLang, context) ; }
     
@@ -180,7 +186,9 @@ public class RDFDataMgr
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
      * @throws RiotNotFoundException if the location is not found - the graph is unchanged.
-    */
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
+     */
+    @Deprecated
     public static void read(Graph graph, String uri, Lang hintLang, Context context)
     { read(graph, uri, defaultBase(uri), hintLang, context) ; }
     
@@ -193,7 +201,9 @@ public class RDFDataMgr
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
      * @throws RiotNotFoundException if the location is not found - the model is unchanged.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void read(Model model, String uri, String base, Lang hintLang, Context context)
 	{ read(model.getGraph(), uri, base, hintLang, context) ; }
 
@@ -205,7 +215,9 @@ public class RDFDataMgr
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
      * @throws RiotNotFoundException if the location is not found - the model is unchanged.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void read(Graph graph, String uri, String base, Lang hintLang, Context context)
     {
         StreamRDF dest = StreamRDFLib.graph(graph) ;
@@ -468,7 +480,9 @@ public class RDFDataMgr
      * @param dataset   Destination
      * @param uri       URI to read from (includes file: and a plain file name).
      * @param hintLang  Language syntax
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void read(Dataset dataset, String uri, Lang hintLang, Context context) {
         read(dataset.asDatasetGraph(), uri, hintLang, context) ;
     }
@@ -478,7 +492,9 @@ public class RDFDataMgr
      * @param dataset   Destination
      * @param uri       URI to read from (includes file: and a plain file name).
      * @param hintLang  Language syntax
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void read(DatasetGraph dataset, String uri, Lang hintLang, Context context) {
         read(dataset, uri, defaultBase(uri), hintLang, context) ;
     }
@@ -492,8 +508,9 @@ public class RDFDataMgr
 	 * @param context   Context for the reader
 	 * @throws RiotNotFoundException if the location is not found - the dataset is unchanged.
 	 * Throws parse errors depending on the language and reader; the dataset may be partially updated. 
-	 */ 
-
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
+     */
+    @Deprecated
     public static void read(Dataset dataset, String uri, String base, Lang hintLang, Context context) {
 		read(dataset.asDatasetGraph(), uri, defaultBase(uri), hintLang, context) ;
     }
@@ -507,8 +524,9 @@ public class RDFDataMgr
 	 * @param context   Context for the reader
 	 * @throws RiotNotFoundException if the location is not found - the dataset is unchanged.
 	 * Throws parse errors depending on the language and reader; the dataset may be partially updated. 
-	 */ 
-
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
+     */
+    @Deprecated
     public static void read(DatasetGraph dataset, String uri, String base, Lang hintLang, Context context) {
         StreamRDF sink = StreamRDFLib.dataset(dataset) ;
         parse(sink, uri, base, hintLang, context) ;
@@ -632,7 +650,9 @@ public class RDFDataMgr
      * @param uri       URI to read from (includes file: and a plain file name).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void parse(StreamRDF sink, String uri, Lang hintLang, Context context) {
         parse(sink, uri, defaultBase(uri), hintLang, context) ;
     }
@@ -653,7 +673,9 @@ public class RDFDataMgr
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void parse(StreamRDF sink, String uri, String base, Lang hintLang, Context context) {
         if ( uri == null )
             throw new IllegalArgumentException("URI to read from is null") ;
@@ -693,7 +715,9 @@ public class RDFDataMgr
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void parse(StreamRDF sink, InputStream in, String base, Lang hintLang, Context context) {
         process(sink, TypedInputStream.wrap(in), base, hintLang, context) ;
     }
@@ -723,7 +747,9 @@ public class RDFDataMgr
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void parse(StreamRDF sink, StringReader in, String base, Lang hintLang, Context context) {
         process(sink, in, base, hintLang, context) ;
     }
@@ -757,7 +783,7 @@ public class RDFDataMgr
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
-     * @deprecated     Use an InputStream or a StringReader. 
+     * @deprecated     To be removed.  Use {@code RDFParser.create().context(context)...}
      */
     @Deprecated
     public static void parse(StreamRDF sink, Reader in, String base, Lang hintLang, Context context) {
@@ -787,7 +813,9 @@ public class RDFDataMgr
      * @param in        Bytes to read.
      * @param base      Base URI
      * @param context   Content object to control reading process.
+     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
      */
+    @Deprecated
     public static void parse(StreamRDF sink, TypedInputStream in, String base, Context context) {
         Objects.requireNonNull(in, "TypedInputStream is null") ;
         Lang hintLang = RDFLanguages.contentTypeToLang(in.getMediaType()) ;
@@ -895,6 +923,7 @@ public class RDFDataMgr
 
     public static ReaderRIOT createReader(Lang lang, ParserProfile profile) {
         Objects.requireNonNull(lang,"Argument lang can not be null in RDFDataMgr.createReader") ;   
+        @SuppressWarnings("deprecation")
         ReaderRIOTFactory r = RDFParserRegistry.getFactory(lang) ;
         if ( r == null )
             return null ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
@@ -305,11 +305,14 @@ public class RDFLanguages
         return true ;
     }
     
-    /** return true if the language is registered as a triples language */
+    /** return true if the language is registered as a triples language. */
     public static boolean isTriples(Lang lang) { return RDFParserRegistry.isTriples(lang) ; }
     
-    /** return true if the language is registered as a quads language */
+    /** return true if the language is registered as a quads language. */
     public static boolean isQuads(Lang lang) { return RDFParserRegistry.isQuads(lang) ; }
+
+    /** return true if the language is registered for parsing as an RDF syntax. */
+    public static boolean hasRegisteredParser(Lang lang) { return RDFParserRegistry.isRegistered(lang); }
 
     /** Map a content type (without charset) to a {@link Lang} */
     public static Lang contentTypeToLang(String contentType)

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
@@ -147,6 +147,7 @@ public class RDFParser {
             ReaderRIOT reader;
             ContentType ct;
             if ( forceLang != null ) {
+                @SuppressWarnings("deprecation")
                 ReaderRIOTFactory r = RDFParserRegistry.getFactory(forceLang);
                 if ( r == null )
                     throw new RiotException("No parser registered for language: " + forceLang);
@@ -234,6 +235,7 @@ public class RDFParser {
         if ( lang == null )
             return null;
 
+        @SuppressWarnings("deprecation")
         ReaderRIOTFactory r = RDFParserRegistry.getFactory(lang);
         if ( r == null )
             return null;

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot;
+
+import static org.apache.jena.riot.RDFLanguages.NQUADS;
+import static org.apache.jena.riot.RDFLanguages.NTRIPLES;
+import static org.apache.jena.riot.RDFLanguages.RDFJSON;
+import static org.apache.jena.riot.RDFLanguages.sameLang;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import org.apache.http.client.HttpClient;
+import org.apache.jena.atlas.io.IO;
+import org.apache.jena.atlas.web.ContentType;
+import org.apache.jena.atlas.web.TypedInputStream;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.riot.system.*;
+import org.apache.jena.riot.system.stream.StreamManager;
+import org.apache.jena.riot.web.HttpOp;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.util.Context;
+
+/**
+ * An {@link RDFParser} is a process that will generate triples; {@link RDFParserBuilder}
+ * provides the means to setup the parser.
+ * <p>
+ * An {@link RDFParser} has a predefined source; the target for output is given when the
+ * "parse" method is called. It can be used multiple times in which case the same source
+ * is reread. The destination can vary. The application is responsible for concurrency of
+ * the destination of the parse operation.
+ * 
+ * The process is
+ * 
+ * <pre>
+ *    StreamRDF destination = ...
+ *    RDFParser parser = RDFParser.create().source("filename.ttl").build();
+ *    parser.parse(destination);
+ * </pre>
+ * or using an abbreviated form:
+ * <pre>
+ * RDFParser.create().source("filename.ttl").parse(destination);
+ * </pre>
+ * The {@code destination} {@link StreamRDF} and can be given as a
+ * {@link Graph} or {@link DatasetGraph} as well. 
+ */
+
+public class RDFParser {
+    private final String       uri;
+    private final Path         path;
+    private final InputStream  inputStream;
+    private final Reader       javaReader;
+    private final HttpClient   httpClient;
+    private final Lang         hintLang;
+    private final Lang         forceLang;
+    private final String       baseUri;
+    private final boolean      strict;
+    private final boolean      resolveURIs;
+    private final IRIResolver  resolver;
+    private final FactoryRDF   factory;
+    private final ErrorHandler errorHandler;
+    private final Context      context;
+
+    private boolean            canUse = true;
+
+    public static RDFParserBuilder create() {
+        return RDFParserBuilder.create();
+    }
+
+    /* package */ RDFParser(String uri, Path path, InputStream inputStream, Reader javaReader, HttpClient httpClient, Lang hintLang,
+                            Lang forceLang, String baseUri, boolean strict, boolean resolveURIs, IRIResolver resolver, FactoryRDF factory,
+                            ErrorHandler errorHandler, Context context) {
+        int x = countNonNull(uri, path, inputStream, javaReader);
+        if ( x >= 2 )
+            throw new IllegalArgumentException("Only one source allowed: At most one of uri, path, inputStream and javaReader can be set");
+        Objects.requireNonNull(factory);
+        Objects.requireNonNull(errorHandler);
+        
+        this.uri = uri;
+        this.path = path;
+        this.inputStream = inputStream;
+        this.javaReader = javaReader;
+        this.httpClient = httpClient;
+        this.hintLang = hintLang;
+        this.forceLang = forceLang;
+        this.baseUri = baseUri;
+        this.strict = strict;
+        this.resolveURIs = resolveURIs;
+        this.resolver = resolver;
+        this.factory = factory;
+        this.errorHandler = errorHandler;
+        this.context = context;
+    }
+
+    private int countNonNull(Object... objs) {
+        int x = 0;
+        for ( Object obj : objs )
+            if ( obj != null )
+                x++;
+        return x;
+    }
+
+    public void parse(StreamRDF destination) {
+        if ( !canUse )
+            throw new RiotException("Parser has been used once and can not be used again");
+        // Consuming mode.
+        canUse = (inputStream == null && javaReader == null);
+        // XXX FactoryRDF is stateful in the LabelToNode mapping.
+        // NB FactoryRDFCaching does not reset it's cache.
+        // factory.reset() ;
+
+        if ( inputStream != null || javaReader != null ) {
+            parseNotUri(destination);
+            return;
+        }
+        Objects.requireNonNull(baseUri);
+        parseURI(destination);
+    }
+
+    /** Parse when there is a URI to guide the choice of syntax */
+    private void parseURI(StreamRDF destination) {
+        // Source by uri or path.
+        try (TypedInputStream input = openTypedInputStream(uri, path)) {
+            ReaderRIOT reader;
+            ContentType ct;
+            if ( forceLang != null ) {
+                ReaderRIOTFactory r = RDFParserRegistry.getFactory(forceLang);
+                if ( r == null )
+                    throw new RiotException("No parser registered for language: " + forceLang);
+                ct = forceLang.getContentType();
+                reader = r.create(forceLang);
+            } else {
+                // Conneg and hint
+                ct = WebContent.determineCT(input.getContentType(), hintLang, baseUri);
+                if ( ct == null )
+                    throw new RiotException("Failed to determine the content type: (URI=" + baseUri + " : stream=" + input.getContentType()+")");
+                reader = getReader(ct);
+                if ( reader == null )
+                    throw new RiotException("No parser registered for content type: " + ct.getContentType());
+            }
+            reader.read(input, baseUri, ct, destination, context);
+        }
+    }
+
+    /** Parse when there is no URI to guide the choice of syntax */
+    private void parseNotUri(StreamRDF destination) {
+        // parse from bytes or chars, no indication of the syntax from the source.
+        Lang lang = hintLang;
+        if ( forceLang != null )
+            lang = forceLang;
+        ContentType ct = WebContent.determineCT(null, lang, baseUri);
+        if ( ct == null )
+            throw new RiotException("Failed to determine the RDF syntax");
+    
+        ReaderRIOT readerRiot = getReader(ct);
+        if ( readerRiot == null )
+            throw new RiotException("No parser registered for content type: " + ct.getContentType());
+    
+        if ( javaReader != null ) {
+            // try(javaRead;) in Java9
+            try ( Reader r = javaReader ) {
+                readerRiot.read(r, baseUri, ct, destination, context);
+            }
+            catch (IOException ex) {
+                IO.exception(ex);
+            }
+            return;
+        }
+    
+        // InputStream
+        try ( InputStream input = inputStream ) {
+            // XXX Setup.
+            readerRiot.read(input, baseUri, ct, destination, context);
+        }
+        catch (AccessDeniedException | NoSuchFileException | FileNotFoundException ex)
+        { throw new RiotNotFoundException() ;} 
+        catch (IOException ex) {
+            IO.exception(ex);
+        }
+        return;
+    }
+
+    @SuppressWarnings("resource")
+    private TypedInputStream openTypedInputStream(String urlStr, Path path) {
+        // If path, use that.
+        if ( path != null ) {
+            try {
+                InputStream in = Files.newInputStream(path);
+                ContentType ct = RDFLanguages.guessContentType(urlStr) ;
+                return new TypedInputStream(in, ct);
+            }
+            catch (NoSuchFileException | FileNotFoundException ex)
+            { throw new RiotNotFoundException() ;}
+            catch (IOException ex) { IO.exception(ex); }
+        }
+        
+        TypedInputStream in;
+        if ( urlStr.startsWith("http://") || urlStr.startsWith("https://") ) {
+            Objects.requireNonNull(httpClient);
+            // Remap.
+            urlStr = StreamManager.get(context).mapURI(urlStr);
+            in = HttpOp.execHttpGet(urlStr, null, httpClient, null);
+        } else { 
+            // StreamManager and Locators, based on urlStr.
+            StreamManager sMgr = StreamManager.get(context);
+            in = sMgr.open(urlStr);
+        }
+        if ( in == null )
+            throw new RiotNotFoundException("Not found: "+urlStr);
+        return in ;
+        
+    }
+
+    private ReaderRIOT getReader(ContentType ct) {
+        Lang lang = RDFLanguages.contentTypeToLang(ct);
+        if ( lang == null )
+            return null;
+
+        ReaderRIOTFactory r = RDFParserRegistry.getFactory(lang);
+        if ( r == null )
+            return null;
+        ReaderRIOT reader = r.create(lang);
+        
+        MakerRDF maker = makeMaker(lang);
+        // XXX
+        //reader.parserSetup(parserFactory);
+        // Back to old world.
+        reader.setParserProfile((MakerRDFStd)maker);
+        return reader ;
+    }
+
+    private MakerRDF makeMaker(Lang lang) {
+        boolean resolve = resolveURIs;
+        boolean checking = true;
+        
+        // Per language tweaks.
+        if ( sameLang(NTRIPLES, lang) || sameLang(NQUADS, lang) )
+            checking = SysRIOT.isStrictMode() ;
+        if ( sameLang(RDFJSON, lang) )
+            resolve = false;
+
+        IRIResolver resolver = this.resolver;
+        if ( resolver == null ) {
+            resolver = resolveURIs ? 
+                IRIResolver.create(baseUri) :
+                IRIResolver.createNoResolve() ;
+        }
+        PrefixMap prefixMap = PrefixMapFactory.createForInput();
+
+        MakerRDFStd parserFactory = new MakerRDFStd(factory, errorHandler, resolver, prefixMap, context, checking);
+        return parserFactory;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
@@ -207,10 +207,10 @@ public class RDFParserBuilder {
     }
 
     /**
-     * Set an HTTP header. Any previous setting is
+     * Set an HTTP header. Any previous setting is lost.
      * <p> 
-     * Consider setting up an {@link HttpClient} if more complicated setting to an HTTP
-     * request is required.
+     * Consider setting up an {@link HttpClient} if more complicated
+     * setting to an HTTP request is required.
      */
     public RDFParserBuilder httpHeader(String header, String value) {
         httpHeaders.put(header, value);
@@ -218,14 +218,22 @@ public class RDFParserBuilder {
     }
     
     /** Set the HttpClient to use.
-     *  This will override any HTTP header settings.
+     *  This will override any HTTP header settings set for this builder.
      */
     public RDFParserBuilder httpClient(HttpClient httpClient) {
         this.httpClient = httpClient;
         return this;
     }
 
+    /** Set the base URI for parsing.  The default is to have no base URI. */ 
     public RDFParserBuilder base(String base) { this.baseUri = base ; return this; }
+
+    /** Choose whether to resolve URIs.<br/>
+     *  This does not affect all langages: N-Triples and N-Quads never resolve URIs.<br/>
+     *  Relative URIs are bad data.<br/>
+     *  Only set this to false for debugging and development purposes. 
+     */ 
+    public RDFParserBuilder resolveURIs(boolean flag) { this.resolveURIs = flag ; return this; }
 
     /**
      * Set the {@link ErrorHandler} to use.
@@ -272,7 +280,7 @@ public class RDFParserBuilder {
      * <br/>
      * {@link SyntaxLabels#createLabelToNode} is the default policy.
      * <br>
-     * {@link LabelToNode#createUseLabelAsGiven()} uses the label in teh RDF syntax directly. 
+     * {@link LabelToNode#createUseLabelAsGiven()} uses the label in the RDF syntax directly. 
      * This does not produce safe RDF and should only be used for development and debugging.   
      * @see #factory
      * @param labelToNode
@@ -356,7 +364,6 @@ public class RDFParserBuilder {
             throw new RiotException("No source specified");
         
         // Setup the HTTP client.
-        // XXX HttpClientBuilder ?
         HttpClient client = buildHttpClient();
         FactoryRDF factory$ = buildFactoryRDF();
         ErrorHandler errorHandler$ = errorHandler;
@@ -368,8 +375,7 @@ public class RDFParserBuilder {
         if ( path == null && baseUri == null && uri != null )
             baseUri = uri;
         
-        // Can't build maker here as it is Lang/conneg dependent.
-        
+        // Can't build the maker here as it is Lang/conneg dependent.
         return new RDFParser(uri, path, inputStream, javaReader, client,
                              hintLang, forceLang,
                              baseUri, strict, resolveURIs,
@@ -414,7 +420,7 @@ public class RDFParserBuilder {
         builder.path =              this.path;
         builder.inputStream =       this.inputStream;
         builder.javaReader =        this.javaReader;
-        builder.httpHeaders =           new HashMap<>(this.httpHeaders);
+        builder.httpHeaders =       new HashMap<>(this.httpHeaders);
         builder.httpClient =        this.httpClient;
         builder.hintLang =          this.hintLang;
         builder.forceLang =         this.forceLang;

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.Header;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
+import org.apache.http.message.BasicHeader;
+import org.apache.jena.atlas.lib.IRILib;
+import org.apache.jena.graph.BlankNodeId;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.riot.lang.LabelToNode;
+import org.apache.jena.riot.system.*;
+import org.apache.jena.riot.web.HttpNames;
+import org.apache.jena.riot.web.HttpOp;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.util.Context;
+
+/**
+ * An {@link RDFParser} is a process that will generate triples; 
+ * {@link RDFParserBuilder} provides the means to setup the parser.
+ * <p>
+ * An {@link RDFParser} has a predefined source; the target for output is given when the "parse" method is called. 
+ * It can be used multiple times in which case the same source is reread. The destination can vary.
+ * The application is responsible for concurrency of the destination of the parse operation.
+ * 
+ * The process is
+ * <pre>
+ *     StreamRDF destination = ...
+ *     RDFParser parser = RDFParser.create()
+ *          .source("filename.ttl")
+ *          .build();
+ *     parser.parse(destination); 
+ * </pre>
+ * or using a short cut: 
+ * <pre>
+ *     RDFParser parser = RDFParser.create()
+ *          .source("filename.ttl")
+ *          .parse(destination); 
+ * </pre> 
+ */
+public class RDFParserBuilder {
+    // Source
+    private String uri = null;
+    private Path path = null;
+    private InputStream inputStream;
+    // StringReader - charset problems with any other kind.
+    private Reader javaReader = null;
+
+    // HTTP
+    private Map<String, String> httpHeaders = new HashMap<>(); 
+    private HttpClient httpClient = null;
+
+    // Syntax
+    private Lang hintLang = null;
+    private Lang forceLang = null;
+    
+    private String baseUri = null;
+    
+    // ---- Unused but left in case required in the future.
+    private boolean strict = false;
+    private boolean resolveURIs = true;
+    private IRIResolver resolver = null;
+    // ----
+    
+    // Construction for the StreamRDF 
+    private FactoryRDF factory = null;
+    private LabelToNode labelToNode = null;
+    
+    // Bad news.
+    private ErrorHandler errorHandler = null;
+    
+    // Parsing process
+    private Context context = null;
+    
+    public static RDFParserBuilder create() { return new RDFParserBuilder() ; }
+    private RDFParserBuilder() {}
+    
+    /** 
+     *  Set the source to {@link Path}. 
+     *  This clears any other source setting.
+     *  @param path
+     *  @return this
+     */
+    public RDFParserBuilder source(Path path) {
+        clearSource();
+        this.path = path;
+        return this;
+    }
+
+    /** 
+     *  Set the source to a URI; this includes OS file names.
+     *  File URL shoudl be of the form {@code file:///...}. 
+     *  This clears any other source setting.
+     *  @param uri
+     *  @return this
+     */
+    public RDFParserBuilder source(String uri) {
+        clearSource();
+        this.uri = uri;
+        return this;
+    }
+
+    /** 
+     *  Set the source to {@link InputStream}. 
+     *  This clears any other source setting.
+     *  The {@link InputStream} will be closed when the 
+     *  parser is called and the parser can not be reused.  
+     *  @param input
+     *  @return this
+     */
+    public RDFParserBuilder source(InputStream input) {
+        clearSource();
+        this.inputStream = input;
+        return this;
+    }
+
+    /** 
+     *  Set the source to {@link StringReader}. 
+     *  This clears any other source setting.
+     *  The {@link StringReader} will be closed when the 
+     *  parser is called and the parser can not be reused.  
+     *  @param reader
+     *  @return this
+     */
+    public RDFParserBuilder source(StringReader reader) {
+        clearSource();
+        this.javaReader = reader;
+        return this;
+    }
+
+    private void clearSource() {
+        this.uri = null;
+        this.inputStream = null;
+        this.path = null;
+        this.javaReader = null;
+    }
+
+    /**
+     * Set the hint {@link Lang}. This is the RDF syntax used when there is no way to
+     * deduce the syntax (e.g. read from a InputStream, no recognized file extension, no
+     * recognized HTTP Content-Type provided).
+     * 
+     * @param lang
+     * @return this
+     */
+    public RDFParserBuilder lang(Lang lang) { this.hintLang = lang ; return this; }
+
+    /**
+     * Force the choice RDF syntax to be {@code lang}, and ignore any indications such as file extension
+     * or HTTP Content-Type.
+     * @see Lang
+     * @param lang
+     * @return this
+     */
+    public RDFParserBuilder forceLang(Lang lang) { this.forceLang = lang ; return this; }
+    
+    /**
+     * Set the HTTP "Accept" header.
+     * The default if not set is {@link WebContent#defaultRDFAcceptHeader}.
+     * @param acceptHeader
+     * @return this
+     */
+    public RDFParserBuilder httpAccept(String acceptHeader) { 
+        httpHeader(HttpNames.hAccept, acceptHeader);
+        return this; 
+    }
+
+    /**
+     * Set an HTTP header. Any previous setting is
+     * <p> 
+     * Consider setting up an {@link HttpClient} if more complicated setting to an HTTP
+     * request is required.
+     */
+    public RDFParserBuilder httpHeader(String header, String value) {
+        httpHeaders.put(header, value);
+        return this;
+    }
+    
+    /** Set the HttpClient to use.
+     *  This will override any HTTP header settings.
+     */
+    public RDFParserBuilder httpClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+        return this;
+    }
+
+    public RDFParserBuilder base(String base) { this.baseUri = base ; return this; }
+
+    /**
+     * Set the {@link ErrorHandler} to use.
+     * This replaces any previous setting.
+     * The default is use slf4j logger "RIOT".   
+     * @param handler
+     * @return this
+     */
+    public RDFParserBuilder errorHandler(ErrorHandler handler) {
+        this.errorHandler = handler;
+        return this;
+    }
+    
+    /**
+     * Set the {@link FactoryRDF} to use. {@link FactoryRDF} control how parser output is
+     * turned into {@code Node} and how {@code Triple}s and {@code Quad}s are built. This
+     * replaces any previous setting. 
+     * <br/>
+     * The default is use {@link RiotLib#factoryRDF()} which is provides {@code Node}
+     * reuse. 
+     * <br/>
+     * The {@code FactoryRDF} also determines how blank node labels in RDF syntax are
+     * mapped to {@link BlankNodeId}. Use
+     * <pre>
+     *    new Factory(myLabelToNode) 
+     * </pre>
+     * to create an {@code FactoryRDF} and set the {@code LabelToNode} step.
+     * @see #labelToNode
+     * @param factory
+     * @return this
+     */
+    public RDFParserBuilder factory(FactoryRDF factory) {
+        this.factory = factory;
+        return this;
+    }
+    
+    /**
+     * Use the given {@link LabelToNode}, the policy for converting blank node labels in
+     * RDF syntax to Jena's {@code Node} objects (usually a blank node).
+     * <br/>
+     * Only applies when the {@link FactoryRDF} is not set in the
+     * {@code RDFParserBuilder}, otherwise the {@link FactoryRDF} controls the
+     * label-to-node process.
+     * <br/>
+     * {@link SyntaxLabels#createLabelToNode} is the default policy.
+     * <br>
+     * {@link LabelToNode#createUseLabelAsGiven()} uses the label in teh RDF syntax directly. 
+     * This does not produce safe RDF and should only be used for development and debugging.   
+     * @see #factory
+     * @param labelToNode
+     * @return this
+     */
+    public RDFParserBuilder labelToNode(LabelToNode labelToNode) {
+        this.labelToNode = labelToNode;
+        return this;
+    }
+    
+
+    // Deprecate ParseProfile as a visible class.
+    //public RDFParserBuilder setParserProfile(ParserProfile profile) { return this; }
+    
+    // Divide out the line/column makers in Parser profile.
+
+    // There are no strict/unstrict differences. 
+//    /**
+//     * Set "strict" mode.
+//     * @param strictMode
+//     * @return this
+//     */
+//    public RDFParserBuilder strict(boolean strictMode) {
+//        this.strict = strictMode;
+//        return this;
+//    }
+    
+    public RDFParserBuilder context(Context context) { this.context = context.copy() ; return this; }
+    //public Context context() { return this.context; }
+    
+    // ---- Terminals
+    // "parse" are short cuts for {@code build().parse(...)}.
+    
+    /** 
+     * Parse the source, sending the results to a {@link StreamRDF}.
+     * Short form for {@code build().parse(stream)}.
+     * @param stream
+     */
+    public void parse(StreamRDF stream) {
+        build().parse(stream);
+    }
+
+    /**
+     * Parse the source, sending the results to a {@link Graph}. The source must be for
+     * triples; any quads are discarded. 
+     * Short form for {@code build().parse(stream)}
+     * where {@code stream} sends tripes and prfixes to the {@code Graph}.
+     * 
+     * @param graph
+     */
+    public void parse(Graph graph) {
+        parse(StreamRDFLib.graph(graph));
+    }
+
+    /**
+     * Parse the source, sending the results to a {@link DatasetGraph}.
+     * Short form for {@code build().parse(stream)}
+     * where {@code stream} sends tripes and prefixes to the {@code DatasetGraph}.
+     * 
+     * @param dataset
+     */
+    public void parse(DatasetGraph dataset) {
+        parse(StreamRDFLib.dataset(dataset));
+    }
+
+    /** Build an {@link RDFParser}. The parser takes it's configuration from this builder and can not then be changed.
+     * The source must be set.
+     * When a parser is used, it is takes the source and sends output to an {@link StreamRDF}.
+     * <p>  
+     * Shortcuts:
+     * <ul>
+     * <li>{@link #parse(DatasetGraph)} - parse the source and output to a {@code DatasetGraph}
+     * <li>{@link #parse(Graph)} - parse the source and output to a {@code Graph}
+     * <li>{@link #parse(StreamRDF)} - parse the source and output to a {@code StreamRDF}
+     * </ul>
+     * 
+     * @return RDFParser
+     */
+    public RDFParser build() {
+        // Build what we can now - something have to be built in the parser.
+        
+        if ( uri == null && path == null && inputStream == null && javaReader == null )
+            throw new RiotException("No source specified");
+        
+        // Setup the HTTP client.
+        // XXX HttpClientBuilder ?
+        HttpClient client = buildHttpClient();
+        FactoryRDF factory$ = buildFactoryRDF();
+        ErrorHandler errorHandler$ = errorHandler;
+        if ( errorHandler$ == null )
+            errorHandler$ = ErrorHandlerFactory.getDefaultErrorHandler();
+
+        if ( path != null && baseUri == null )
+            baseUri = IRILib.filenameToIRI(path.toString());
+        if ( path == null && baseUri == null && uri != null )
+            baseUri = uri;
+        
+        // Can't build maker here as it is Lang/conneg dependent.
+        
+        return new RDFParser(uri, path, inputStream, javaReader, client,
+                             hintLang, forceLang,
+                             baseUri, strict, resolveURIs,
+                             resolver, factory$, errorHandler$, context);
+    }
+
+    private FactoryRDF buildFactoryRDF() {
+        FactoryRDF factory$ = factory;
+        if ( factory$ == null ) { 
+            if ( labelToNode != null )
+                factory$ = RiotLib.factoryRDF(labelToNode);
+            else
+                factory$ = RiotLib.factoryRDF();
+        }
+        return factory$;
+    }
+
+    private HttpClient buildHttpClient() {
+        if ( httpClient != null )
+            return httpClient;
+        if ( httpHeaders.isEmpty() )
+            // System default.
+            return HttpOp.getDefaultHttpClient();
+        List<Header> hdrs = new ArrayList<>();
+        httpHeaders.forEach((k,v)->{
+            Header header = new BasicHeader(k, v);
+            hdrs.add(header);
+        });
+        HttpClient hc = CachingHttpClientBuilder.create().setDefaultHeaders(hdrs).build();
+        return hc;
+    }
+
+    /**
+     * Duplicate this builder with current settings.
+     * Changes to setting to this builder do not affect the clone. 
+     */
+    @Override
+    public RDFParserBuilder clone() { 
+        RDFParserBuilder builder = new RDFParserBuilder();
+        builder.uri =               this.uri;
+        builder.path =              this.path;
+        builder.inputStream =       this.inputStream;
+        builder.javaReader =        this.javaReader;
+        builder.httpHeaders =           new HashMap<>(this.httpHeaders);
+        builder.httpClient =        this.httpClient;
+        builder.hintLang =          this.hintLang;
+        builder.forceLang =         this.forceLang;
+        builder.baseUri =           this.baseUri;
+        builder.strict =            this.strict;
+        builder.resolveURIs =       this.resolveURIs;
+        builder.resolver =          this.resolver;
+        builder.factory =           this.factory;
+        builder.labelToNode =       this.labelToNode;
+        builder.errorHandler =      this.errorHandler;
+        builder.context =           this.context;
+        return builder;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
@@ -133,7 +133,10 @@ public class RDFParserRegistry
         langToParserFactory.remove(lang) ;
     }
     
-    /** Return the parser factory for the language, or null if not registered */
+    /** Return the parser factory for the language, or null if not registered.
+     * @deprecated To be removed or made package scoped. Use {@code RDFParser.create() ... .build()}
+     */
+    @Deprecated
     public static ReaderRIOTFactory getFactory(Lang language)
     {
         return langToParserFactory.get(language) ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
@@ -156,6 +156,12 @@ public class RDFParserRegistry
         public ReaderRIOT create(Lang lang) {
             return new ReaderRIOTLang(lang) ;
         }
+        
+        @Override
+        public ReaderRIOT create(Lang lang, ParserProfile parserProfile) {
+            return new ReaderRIOTLang(lang, parserProfile) ;
+        }
+
     }
 
     private static class ReaderRIOTLang implements ReaderRIOT
@@ -167,6 +173,12 @@ public class RDFParserRegistry
         ReaderRIOTLang(Lang lang) {
             this.lang = lang ;
             errorHandler = ErrorHandlerFactory.getDefaultErrorHandler() ;
+        }
+
+        ReaderRIOTLang(Lang lang, ParserProfile parserProfile) {
+            this.lang = lang ;
+            this.parserProfile = parserProfile;
+            this.errorHandler = parserProfile.getHandler();
         }
 
         @Override
@@ -209,7 +221,12 @@ public class RDFParserRegistry
         @Override
         public ReaderRIOT create(Lang language) {
             return new ReaderRDFThrift() ;
-        }}
+        }
+        @Override
+        public ReaderRIOT create(Lang language, ParserProfile profile) {
+            return new ReaderRDFThrift() ;
+        }
+    }
     
     private static class ReaderRDFThrift implements ReaderRIOT {
         @Override

--- a/jena-arq/src/main/java/org/apache/jena/riot/ReaderRIOTFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/ReaderRIOTFactory.java
@@ -18,7 +18,15 @@
 
 package org.apache.jena.riot;
 
+import org.apache.jena.riot.system.ParserProfile;
+
 public interface ReaderRIOTFactory
 {
     public ReaderRIOT create(Lang language) ;
+    
+    public default ReaderRIOT create(Lang language, ParserProfile profile) {
+        ReaderRIOT r = create(language);
+        r.setParserProfile(profile);
+        return r ;
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/ResultSetMgr.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/ResultSetMgr.java
@@ -52,7 +52,7 @@ public class ResultSetMgr {
      * @return ResultSet
      */
     public static ResultSet read(InputStream in, Lang lang) {
-        return process(new TypedInputStream(in), null, lang, null) ;
+        return process(TypedInputStream.wrap(in), null, lang, null) ;
     }
     
     /** Read a result set from the URI */

--- a/jena-arq/src/main/java/org/apache/jena/riot/SysRIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/SysRIOT.java
@@ -19,9 +19,7 @@
 package org.apache.jena.riot;
 
 import org.apache.jena.atlas.lib.IRILib ;
-import org.apache.jena.rdf.model.RDFWriter;
 import org.apache.jena.riot.system.IRIResolver ;
-import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.Symbol ;
 import org.apache.jena.util.FileUtils ;
 import org.slf4j.Logger ;
@@ -47,6 +45,8 @@ public class SysRIOT
     public static final boolean AbsURINoNormalization   = false ;
     public static final String BNodeGenIdPrefix         = "genid" ;
     
+    private static String riotBase = "http://jena.apache.org/riot/" ;
+
     /**
      * Context key for old style RDFWriter properties. The value of this in a
      * {@link Context} must be a {@code Map<String, Object>}. The entries of the
@@ -54,7 +54,16 @@ public class SysRIOT
      * {@link RDFWriter} is called. Only has any effect on RDF/XML and
      * RDF/XML-ABBREV.
      */
-    public static final Symbol rdfWriterProperties      = Symbol.create("riot.rdfWriter_properties") ;
+
+    /** Context key for old style RDFWriter properties */ 
+    public static final Symbol sysRdfWriterProperties      = Symbol.create(riotBase+"rdfWriter_properties") ;
+    
+    /** @deprecated Use {@link #sysRdfWriterProperties} */
+    @Deprecated
+    public static final Symbol rdfWriterProperties      = sysRdfWriterProperties ;
+    
+    /** Context key for the StreamManager */ 
+    public static Symbol sysStreamManager = Symbol.create(riotBase+"streamManager") ;
     
     public static void setStrictMode(boolean state) {
         SysRIOT.strictMode = state ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/adapters/AdapterRDFWriter.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/adapters/AdapterRDFWriter.java
@@ -67,7 +67,7 @@ public abstract class AdapterRDFWriter extends WriterGraphRIOTBase
     private static void setProperties(RDFWriter w, Context context) {
         try { 
             @SuppressWarnings("unchecked")
-            Map<String, Object> p = (Map<String, Object>)(context.get(SysRIOT.rdfWriterProperties)) ;
+            Map<String, Object> p = (Map<String, Object>)(context.get(SysRIOT.sysRdfWriterProperties)) ;
             if ( p != null )
                 p.forEach((k,v) -> w.setProperty(k, v)) ;
         } catch (Throwable ex) {

--- a/jena-arq/src/main/java/org/apache/jena/riot/adapters/RDFWriterRIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/adapters/RDFWriterRIOT.java
@@ -57,7 +57,7 @@ public class RDFWriterRIOT implements RDFWriter
     public RDFWriterRIOT(String jenaName) {
         this.basename = "org.apache.jena.riot.writer." + jenaName.toLowerCase(Locale.ROOT);
         this.jenaName = jenaName;
-        context.put(SysRIOT.rdfWriterProperties, properties);
+        context.put(SysRIOT.sysRdfWriterProperties, properties);
     }
 
     private WriterGraphRIOT writer() {

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LabelToNode.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LabelToNode.java
@@ -123,7 +123,7 @@ public class LabelToNode extends MapWithScope<String, Node, Node>
     {
         super(scopePolicy, allocator) ;
     }
-
+    
     // ======== Scope Policies
     
     /** Single scope */

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangTurtleBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangTurtleBase.java
@@ -37,6 +37,7 @@ import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.iri.IRI ;
 import org.apache.jena.riot.system.ParserProfile ;
+import org.apache.jena.riot.system.Prologue;
 import org.apache.jena.riot.system.StreamRDF ;
 import org.apache.jena.riot.tokens.Token ;
 import org.apache.jena.riot.tokens.TokenType ;
@@ -172,7 +173,12 @@ public abstract class LangTurtleBase extends LangBase {
         IRI baseIRI = profile.makeIRI(baseStr, currLine, currCol) ;
         emitBase(baseIRI.toString()) ;
         nextToken() ;
-        profile.getPrologue().setBaseURI(baseIRI) ;
+        //profile.getPrologue().setBaseURI(baseIRI) ;
+        // XXX [ParserRDF]
+        // This creates a new resolver but MakerRDFStd has a copy of the resolver object
+        Prologue prologue = profile.getPrologue();
+        prologue.setBaseURI(baseIRI);
+        profile.setPrologue(prologue);
     }
 
     

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDF.java
@@ -54,4 +54,7 @@ public interface FactoryRDF {
      *  @see <a href="http://www.ietf.org/rfc/rfc4122.txt" ><i>RFC&nbsp;4122: A Universally Unique IDentifier (UUID) URN Namespace</i></a>
      */
     public Node createBlankNode(long mostSigBits, long leastSigBits) ;
+    
+    /** Reset any internal state that should not be carried across parse runs (e.g. blank node labels). */
+    public void reset();
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFCaching.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFCaching.java
@@ -104,6 +104,12 @@ public class FactoryRDFCaching extends FactoryRDFStd {
         return super.createStringLiteral(lexical) ;
     }
 
+    // The cache is not reset.  It can be carried across parser runs.
+//    @Override
+//    public void reset() {
+//        super.reset();
+//    }
+    
     public CacheInfo stats() {
         CacheStats stats = cache.stats() ;
         if ( stats.missCount() == 0 && stats.hitCount() == 0 )

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFStd.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/FactoryRDFStd.java
@@ -96,5 +96,9 @@ public class FactoryRDFStd implements FactoryRDF {
     public Node createBlankNode() {
         return labelMapping.create() ;
     }
-    
+
+    @Override
+    public void reset() {
+        labelMapping.clear();
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/MakerRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/MakerRDF.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.iri.IRI;
+import org.apache.jena.riot.tokens.Token;
+import org.apache.jena.sparql.core.Quad;
+
+/**
+ * {@code MakerRDF} is specific to parsing, providing the operations needed by a parser to
+ * create IRIs/Nodes/Triples/Quads at the point in the parsing process when the line and
+ * column are available to put in error messages.
+ * <p>
+ * {@link MakerRDFStd} uses a {@link FactoryRDF} to create items in the parsing
+ * process.
+ * 
+ * @see FactoryRDF
+ */
+public interface MakerRDF {
+    /** Resolve a URI returning a string */
+    public String resolveIRI(String uriStr, long line, long col);
+
+    /** Create an IRI */
+    public IRI makeIRI(String uriStr, long line, long col);
+
+    /** Create a triple */
+    public Triple createTriple(Node subject, Node predicate, Node object, long line, long col);
+
+    /** Create a Quad */
+    public Quad createQuad(Node graph, Node subject, Node predicate, Node object, long line, long col);
+
+    /** Create a URI Node */
+    public Node createURI(String uriStr, long line, long col);
+
+    /** Create a literal for a string+datatype */
+    public Node createTypedLiteral(String lexical, RDFDatatype datatype, long line, long col);
+
+    /** Create a literal for a string+language */
+    public Node createLangLiteral(String lexical, String langTag, long line, long col);
+
+    /** Create a literal for a string */
+    public Node createStringLiteral(String lexical, long line, long col);
+
+    /** Create a fresh blank node based on scope and label */
+    public Node createBlankNode(Node scope, String label, long line, long col);
+
+    /** Create a fresh blank node */
+    public Node createBlankNode(Node scope, long line, long col);
+
+    /**
+     * Make a node from a token - called after all else has been tried to handle
+     * special cases Return null for "no special node recoginzed"
+     */
+    public Node createNodeFromToken(Node scope, Token token, long line, long col);
+
+    /** Make any node from a token as appropriate */
+    public Node create(Node currentGraph, Token token);
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/MakerRDFStd.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/MakerRDFStd.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.atlas.lib.InternalErrorException;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.iri.IRI;
+import org.apache.jena.query.ARQ;
+import org.apache.jena.riot.RiotException;
+import org.apache.jena.riot.checker.CheckerIRI;
+import org.apache.jena.riot.checker.CheckerLiterals;
+import org.apache.jena.riot.tokens.Token;
+import org.apache.jena.riot.tokens.TokenType;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sparql.util.FmtUtils;
+
+/** 
+ * {@link MakerRDFStd} uses a {@link FactoryRDF} to 
+ * create items in the parsing process.
+ */
+public class MakerRDFStd implements MakerRDF /*To be removed*/, ParserProfile/* Old World */
+{
+    private /* final */ FactoryRDF   factory;
+    private /* final */ ErrorHandler errorHandler;
+    private /* final */ Context      context;
+    private final IRIResolver        resolver;
+    private final PrefixMap          prefixMap;
+    private boolean                  strictMode = true;
+    private final boolean            checking;
+
+    public MakerRDFStd(FactoryRDF factory, ErrorHandler errorHandler, IRIResolver resolver, PrefixMap prefixMap, Context context, boolean checking) {
+        this.factory = factory;
+        this.errorHandler = errorHandler;
+        this.resolver = resolver;
+        this.prefixMap = prefixMap;
+        this.context = context;
+        this.checking = true;
+    }
+    
+    @Deprecated @Override /* ParserProfile - to be removed */
+    public Prologue getPrologue() {
+        return new Prologue(prefixMap, resolver);
+    }
+
+    @Deprecated @Override /* ParserProfile - to be removed */
+    public void setPrologue(Prologue prologue) {
+        throw new InternalErrorException();
+    }
+
+    @Deprecated @Override /* ParserProfile - to be removed */
+    public ErrorHandler getHandler() {
+        return getErrorHandler();
+    }
+
+    @Deprecated @Override /* ParserProfile - to be removed */
+    public void setHandler(ErrorHandler handler) {
+        //Ignore
+    }
+
+    // XXX @Override?
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
+
+//    // XXX @Override
+//    public void setErrorHandler(ErrorHandler errorHandler) {
+//        this.errorHandler = errorHandler;
+//    }
+
+    @Override
+    public FactoryRDF getFactoryRDF() {
+        return factory;
+    }
+
+    @Override
+    public void setFactoryRDF(FactoryRDF factory) {
+        this.factory = factory;
+    }
+
+    // XXX ??? @Override
+    public Context getContext() {
+        return context;
+    }
+
+    // XXX ??? @Override
+    public void setContext(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public boolean isStrictMode() {
+        return strictMode;
+    }
+
+    @Override
+    public void setStrictMode(boolean mode) {
+        this.strictMode = mode;
+    }
+
+    @Override
+    public String resolveIRI(String uriStr, long line, long col) {
+        return makeIRI(uriStr, line, col).toString();
+    }
+
+    @Override
+    public IRI makeIRI(String uriStr, long line, long col) {
+        IRI iri = resolver.resolveSilent(uriStr);
+        if ( false /* always checks IRIs */ && !checking )
+            return iri;
+
+        // Some specific problems and specific error messages,.
+        if ( uriStr.contains(" ") ) {
+            // Specific check for spaces.
+            errorHandler.warning("Bad IRI: <" + uriStr + "> Spaces are not legal in URIs/IRIs.", line, col);
+            return iri;
+        }
+
+        // At this point, IRI "errors" are warnings.
+        // A tuned set of checking.
+        CheckerIRI.iriViolations(iri, errorHandler, line, col);
+        return iri;
+    }
+
+    @Override
+    public Triple createTriple(Node subject, Node predicate, Node object, long line, long col) {
+        if ( checking )
+            checkTriple(subject, predicate, object, line, col);
+        return factory.createTriple(subject, predicate, object);
+    }
+
+    @Override
+    public Quad createQuad(Node graph, Node subject, Node predicate, Node object, long line, long col) {
+        if ( checking )
+            checkQuad(graph, subject, predicate, object, line, col);
+        return factory.createQuad(graph, subject, predicate, object);
+    }
+
+    @Override
+    public Node createURI(String x, long line, long col) {
+        // Special cases that don't resolve.
+        //   <_:....> is a blank node.
+        //   <::...> is "don't touch" used for a fixed-up prefix name 
+        if ( !RiotLib.isBNodeIRI(x) && !RiotLib.isPrefixIRI(x) )
+            // Really is an URI!
+            x = resolveIRI(x, line, col);
+        return factory.createURI(x);
+    }
+
+    @Override
+    public Node createTypedLiteral(String lexical, RDFDatatype datatype, long line, long col) {
+        if ( checking )
+            CheckerLiterals.checkLiteral(lexical, datatype, errorHandler, line, col);
+        return factory.createTypedLiteral(lexical, datatype);
+    }
+
+    @Override
+    public Node createLangLiteral(String lexical, String langTag, long line, long col) {
+        if ( checking )
+            CheckerLiterals.checkLiteral(lexical, langTag, errorHandler, line, col);
+        return factory.createLangLiteral(lexical, langTag);
+    }
+
+    @Override
+    public Node createStringLiteral(String lexical, long line, long col) {
+        // No checks
+        return factory.createStringLiteral(lexical);
+    }
+
+    /** Special token forms */
+    @Override
+    public Node createNodeFromToken(Node scope, Token token, long line, long col) {
+        // OFF - Don't produce Node.ANY by default.
+        if ( false && token.getType() == TokenType.KEYWORD ) {
+            if ( Token.ImageANY.equals(token.getImage()) )
+                return Node.ANY;
+        }
+        return null;
+    }
+
+    @Override
+    public Node createBlankNode(Node scope, String label, long line, long col) {
+        // No checks
+        return factory.createBlankNode(label);
+    }
+
+    @Override
+    public Node createBlankNode(Node scope, long line, long col) {
+        // No checks
+        return factory.createBlankNode();
+    }
+
+    @Override
+    public Node create(Node currentGraph, Token token) {
+        // Dispatches to the underlying ParserFactory operation
+        long line = token.getLine();
+        long col = token.getColumn();
+        String str = token.getImage();
+        switch (token.getType()) {
+            case BNODE :
+                return createBlankNode(currentGraph, str, line, col);
+            case IRI :
+                return createURI(str, line, col);
+            case PREFIXED_NAME : {
+                String prefix = str;
+                String suffix = token.getImage2();
+                String expansion = expandPrefixedName(prefix, suffix, token);
+                return createURI(expansion, line, col);
+            }
+            case DECIMAL :
+                return createTypedLiteral(str, XSDDatatype.XSDdecimal, line, col);
+            case DOUBLE :
+                return createTypedLiteral(str, XSDDatatype.XSDdouble, line, col);
+            case INTEGER :
+                return createTypedLiteral(str, XSDDatatype.XSDinteger, line, col);
+            case LITERAL_DT : {
+                Token tokenDT = token.getSubToken2();
+                String uriStr;
+
+                switch (tokenDT.getType()) {
+                    case IRI :
+                        uriStr = tokenDT.getImage();
+                        break;
+                    case PREFIXED_NAME : {
+                        String prefix = tokenDT.getImage();
+                        String suffix = tokenDT.getImage2();
+                        uriStr = expandPrefixedName(prefix, suffix, tokenDT);
+                        break;
+                    }
+                    default :
+                        throw new RiotException("Expected IRI for datatype: " + token);
+                }
+
+                uriStr = resolveIRI(uriStr, tokenDT.getLine(), tokenDT.getColumn());
+                RDFDatatype dt = NodeFactory.getType(uriStr);
+                return createTypedLiteral(str, dt, line, col);
+            }
+
+            case LITERAL_LANG :
+                return createLangLiteral(str, token.getImage2(), line, col);
+
+            case STRING :
+                return createStringLiteral(str, line, col);
+            default : {
+                Node x = createNodeFromToken(currentGraph, token, line, col);
+                if ( x != null )
+                    return x;
+                errorHandler.fatal("Not a valid token for an RDF term: " + token, line, col);
+                return null;
+            }
+        }
+    }
+
+    private String expandPrefixedName(String prefix, String localPart, Token token) {
+        String expansion = prefixMap.expand(prefix, localPart);
+        if ( expansion == null ) {
+            if ( ARQ.isTrue(ARQ.fixupUndefinedPrefixes) )
+                return RiotLib.fixupPrefixIRI(prefix, localPart);
+            errorHandler.fatal("Undefined prefix: " + prefix, token.getLine(), token.getColumn());
+        }
+        return expansion;
+    }
+
+    private void checkTriple(Node subject, Node predicate, Node object, long line, long col) {
+        if ( subject == null || (!subject.isURI() && !subject.isBlank()) ) {
+            errorHandler.error("Subject is not a URI or blank node", line, col);
+            throw new RiotException("Bad subject: " + subject);
+        }
+        if ( predicate == null || (!predicate.isURI()) ) {
+            errorHandler.error("Predicate not a URI", line, col);
+            throw new RiotException("Bad predicate: " + predicate);
+        }
+        if ( object == null || (!object.isURI() && !object.isBlank() && !object.isLiteral()) ) {
+            errorHandler.error("Object is not a URI, blank node or literal", line, col);
+            throw new RiotException("Bad object: " + object);
+        }
+    }
+
+    private void checkQuad(Node graph, Node subject, Node predicate, Node object, long line, long col) {
+        // Allow blank nodes - syntax may restrict more.
+        if ( graph != null && !graph.isURI() && !graph.isBlank() ) {
+            errorHandler.error("Graph name is not a URI or blank node: " + FmtUtils.stringForNode(graph), line, col);
+            throw new RiotException("Bad graph name: " + graph);
+        }
+        checkTriple(subject, predicate, object, line, col);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
@@ -18,48 +18,41 @@
 
 package org.apache.jena.riot.system;
 
-import org.apache.jena.datatypes.RDFDatatype ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.iri.IRI ;
-import org.apache.jena.riot.tokens.Token ;
-import org.apache.jena.sparql.core.Quad ;
-
-public interface ParserProfile
+public interface ParserProfile extends MakerRDF
 {
-    public String resolveIRI(String uriStr, long line, long col) ;
-    public IRI makeIRI(String uriStr, long line, long col) ;
-    
-    /** Create a triple */
-    public Triple createTriple(Node subject, Node predicate, Node object, long line, long col) ;
-
-    /** Create a Quad */
-    public Quad createQuad(Node graph, Node subject, Node predicate, Node object, long line, long col) ;
-    
-    /** Create a URI Node */
-    public Node createURI(String uriStr, long line, long col) ;
-    
-    /** Create a literal for a string+datatype */
-    public Node createTypedLiteral(String lexical, RDFDatatype datatype, long line, long col) ;
-    
-    /** Create a literal for a string+language */
-    public Node createLangLiteral(String lexical, String langTag, long line, long col) ;
-    
-    /** Create a literal for a string */ 
-    public Node createStringLiteral(String lexical, long line, long col) ;
-    
-    /** Create a fresh blank node based on scope and label */ 
-    public Node createBlankNode(Node scope, String label, long line, long col) ;
-    /** Create a fresh blank node */ 
-    public Node createBlankNode(Node scope, long line, long col) ;
-    
-    /** Make a node from a token - called after all else has been tried to handle special cases 
-     *  Return null for "no special node recoginzed"
-     */
-    public Node createNodeFromToken(Node scope, Token token, long line, long col) ;
-    
-    /** Make any node from a token as appropriate */
-    public Node create(Node currentGraph, Token token) ;
+//    public String resolveIRI(String uriStr, long line, long col) ;
+//    public IRI makeIRI(String uriStr, long line, long col) ;
+//    
+//    /** Create a triple */
+//    public Triple createTriple(Node subject, Node predicate, Node object, long line, long col) ;
+//
+//    /** Create a Quad */
+//    public Quad createQuad(Node graph, Node subject, Node predicate, Node object, long line, long col) ;
+//    
+//    /** Create a URI Node */
+//    public Node createURI(String uriStr, long line, long col) ;
+//    
+//    /** Create a literal for a string+datatype */
+//    public Node createTypedLiteral(String lexical, RDFDatatype datatype, long line, long col) ;
+//    
+//    /** Create a literal for a string+language */
+//    public Node createLangLiteral(String lexical, String langTag, long line, long col) ;
+//    
+//    /** Create a literal for a string */ 
+//    public Node createStringLiteral(String lexical, long line, long col) ;
+//    
+//    /** Create a fresh blank node based on scope and label */ 
+//    public Node createBlankNode(Node scope, String label, long line, long col) ;
+//    /** Create a fresh blank node */ 
+//    public Node createBlankNode(Node scope, long line, long col) ;
+//    
+//    /** Make a node from a token - called after all else has been tried to handle special cases 
+//     *  Return null for "no special node recoginzed"
+//     */
+//    public Node createNodeFromToken(Node scope, Token token, long line, long col) ;
+//    
+//    /** Make any node from a token as appropriate */
+//    public Node create(Node currentGraph, Token token) ;
 
     public ErrorHandler getHandler() ;
     public void setHandler(ErrorHandler handler) ;
@@ -67,7 +60,7 @@ public interface ParserProfile
     public Prologue getPrologue() ;
     public void setPrologue(Prologue prologue) ;
     
-    public FactoryRDF getFactoryRDF() ;
+    //public FactoryRDF getFactoryRDF() ;
     public void setFactoryRDF(FactoryRDF factory) ;
     
     public boolean isStrictMode() ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileBase.java
@@ -77,11 +77,6 @@ public class ParserProfileBase implements ParserProfile {
     }
 
     @Override
-    public FactoryRDF getFactoryRDF() {
-        return factory;
-    }
-
-    @Override
     public void setFactoryRDF(FactoryRDF factory) {
         this.factory = factory;
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/Prologue.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/Prologue.java
@@ -21,7 +21,6 @@ package org.apache.jena.riot.system;
 import org.apache.jena.iri.IRI ;
 import org.apache.jena.shared.PrefixMapping ;
 
-
 public class Prologue
 {
     protected boolean seenBaseURI = false ;     // Implicit or set.
@@ -153,8 +152,8 @@ public class Prologue
 
     /** Return the prefix map from the parsed query */ 
     public PrefixMap getPrefixMap() { return prefixMap ; }
-    /** Set the mapping */
-    public void setPrefixMapping(PrefixMap pmap ) { prefixMap = pmap ; }
+//    /** Set the mapping */
+//    public void setPrefixMapping(PrefixMap pmap ) { prefixMap = pmap ; }
 
 //    /** Reverse lookup of a URI to get a prefix */
 //    public String getPrefix(String uriStr)

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
@@ -192,14 +192,14 @@ public class RiotLib
         return factoryRDF(SyntaxLabels.createLabelToNode());
     }
 
-    /** Create an {@link MakerRDF} with defautlt settings. */ 
+    /** Create an {@link MakerRDF} with default settings. */ 
     public static MakerRDF dftMakerRDF() {
         return new MakerRDFStd(RiotLib.factoryRDF(), 
                                ErrorHandlerFactory.errorHandlerStd,
                                IRIResolver.create(),
                                PrefixMapFactory.createForInput(),
                                RIOT.getContext().copy(),
-                               true) ;
+                               true, false) ;
     }
 
     /** Get triples with the same subject */

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
@@ -40,10 +40,7 @@ import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.query.ARQ ;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.riot.SysRIOT ;
-import org.apache.jena.riot.WriterDatasetRIOT ;
+import org.apache.jena.riot.*;
 import org.apache.jena.riot.lang.LabelToNode ;
 import org.apache.jena.riot.tokens.Token ;
 import org.apache.jena.riot.tokens.Tokenizer ;
@@ -193,6 +190,16 @@ public class RiotLib
      */  
     public static FactoryRDF factoryRDF() {
         return factoryRDF(SyntaxLabels.createLabelToNode());
+    }
+
+    /** Create an {@link MakerRDF} with defautlt settings. */ 
+    public static MakerRDF dftMakerRDF() {
+        return new MakerRDFStd(RiotLib.factoryRDF(), 
+                               ErrorHandlerFactory.errorHandlerStd,
+                               IRIResolver.create(),
+                               PrefixMapFactory.createForInput(),
+                               RIOT.getContext().copy(),
+                               true) ;
     }
 
     /** Get triples with the same subject */

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocatorStdin.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocatorStdin.java
@@ -25,7 +25,7 @@ public class LocatorStdin implements Locator {
     @Override
     public TypedInputStream open(String uri) {
         if ( uri.equals("-") )
-            return new TypedInputStream(System.in) ;
+            return TypedInputStream.wrap(System.in) ;
         return null ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/stream/StreamManager.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/stream/StreamManager.java
@@ -22,8 +22,11 @@ import java.util.ArrayList ;
 import java.util.Collections ;
 import java.util.List ;
 
+import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.atlas.web.TypedInputStream ;
 import org.apache.jena.riot.RiotNotFoundException ;
+import org.apache.jena.riot.SysRIOT;
+import org.apache.jena.sparql.util.Context;
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
 
@@ -74,10 +77,35 @@ public class StreamManager {
         return streamManager ;
     }
 
+    /**
+     * Return the global {@code StreamManager}.
+     */
     public static StreamManager get() {
         return globalStreamManager ;
     }
 
+    /**
+     * Return the {@code StreamManager} in a context, or the global one if the context is
+     * null or does not contain an entry for a {@code StreamManager}.
+     * <p>
+     * The {@code StreamManager} is keyed in the context by
+     * {@link SysRIOT#sysStreamManager}.
+     */
+    public static StreamManager get(Context context) {
+        if ( context == null )
+            return get();
+        try {
+            return (StreamManager)context.get(SysRIOT.sysStreamManager, context);
+        }
+        catch (ClassCastException ex) {
+            log.warn("Context symbol '" + SysRIOT.sysStreamManager + "' is not a " + Lib.classShortName(StreamManager.class));
+        }
+        return get();
+    }
+
+    /**
+     * Set the global {@code StreamManager}.
+     */
     public static void setGlobal(StreamManager streamManager) {
         globalStreamManager = streamManager ;
     }
@@ -85,8 +113,8 @@ public class StreamManager {
     static { setGlobal(makeDefaultStreamManager()) ; }
 
     /**
-     * Open a file using the locators of this FileManager. Returns null if not
-     * found.
+     * Open a file using the locators of this StreamManager.
+     * Returns null if not found.
      */
     public TypedInputStream open(String filenameOrURI) {
         if ( log.isDebugEnabled() )

--- a/jena-arq/src/test/java/org/apache/jena/riot/TS_LangSuite.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TS_LangSuite.java
@@ -34,7 +34,7 @@ public class TS_LangSuite
     static public TestSuite suite()
     {
         JenaSystem.init() ;
-        TestSuite ts = new TestSuite("RIOT Lang") ;
+        TestSuite ts = new TestSuite(TS_LangSuite.class.getName()) ;
         ts.addTest(FactoryTestRiot.make(manifest1, null, null)) ;
         return ts ;
     }

--- a/jena-arq/src/test/java/org/apache/jena/riot/TS_RiotGeneral.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TS_RiotGeneral.java
@@ -30,6 +30,7 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestJenaReaderRIOT.class
     , TestReadData.class
     , TestRiotReader.class
+    , TestRDFParser.class
     , TestParserRegistry.class
     , TestSysRIOT.class
 })

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestJenaReaderRIOT.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestJenaReaderRIOT.java
@@ -79,7 +79,6 @@ public class TestJenaReaderRIOT extends BaseTest
 
         TypedInputStream in1 = RDFDataMgr.open(filename("D-not-TTL.ttl") );
         Model m1 = ModelFactory.createDefaultModel() ;
-        // Fails until integration with jena-core as hintlang gets lost.
         m1.read(in1, null, "RDF/XML") ;
     }
     
@@ -129,8 +128,8 @@ public class TestJenaReaderRIOT extends BaseTest
     @Test public void read_input_2() throws IOException
     { jenaread_stream("D.rdf", "RDF/XML") ; }
     
-    private static String plainRelFnTTL = directory+"/D.ttl" ; 
-    private static String plainRelFnRDFXML = directory+"/D.rdf" ; 
+    private static final String plainRelFnTTL = directory+"/D.ttl" ; 
+    private static final String plainRelFnRDFXML = directory+"/D.rdf" ; 
     
     // Ways to pass in the filename.
     // The RDF/XML path is slightly different so test it as well.

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
@@ -26,17 +26,16 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.github.jsonldjava.utils.JsonUtils;
+
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.riot.system.StreamRDFLib;
 import org.apache.jena.sparql.util.Context;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Test;
-
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.github.jsonldjava.utils.JsonUtils;
 
 public class TestJsonLDReader {
 
@@ -123,7 +122,11 @@ public class TestJsonLDReader {
         //        }
 
         try (InputStream in = new ByteArrayInputStream(jsonld.getBytes(StandardCharsets.UTF_8))) {
-            RDFDataMgr.parse(StreamRDFLib.dataset(ds.asDatasetGraph()), in, null, Lang.JSONLD, jenaCtx);
+            RDFParser.create()
+                .source(in)
+                .lang(Lang.JSONLD)
+                .context(jenaCtx)
+                .parse(ds.asDatasetGraph());
         }
 
         return ds;

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RiotException;
+import org.apache.jena.riot.RiotNotFoundException;
+import org.apache.jena.riot.lang.LabelToNode;
+import org.apache.jena.riot.system.ErrorHandlerFactory;
+import org.apache.jena.riot.system.FactoryRDFStd;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.junit.Test;
+
+public class TestRDFParser {
+    
+    // Location of test files.
+    private static String DIR = "testing/RIOT/Parser/";
+    private static String testdata = "@prefix : <http://example/ns#> . :x :x _:b .";  
+    
+    @Test public void source_not_uri_01() {
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create().lang(Lang.TTL).source(new StringReader(testdata)).parse(graph);
+        assertEquals(1, graph.size());
+    }
+    
+    @Test public void source_not_uri_02() {
+        Graph graph = GraphFactory.createGraphMem();
+        InputStream input = new ByteArrayInputStream(testdata.getBytes(StandardCharsets.UTF_8));
+        RDFParserBuilder.create().lang(Lang.TTL).source(input).parse(graph);
+        assertEquals(1, graph.size());
+    }
+    
+    @Test public void source_uri_01() {
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create().source("file:"+DIR+"data.ttl").parse(graph);
+        assertEquals(3, graph.size());
+    }
+
+    @Test(expected=RiotException.class)
+    public void source_uri_02() {
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create().source("file:"+DIR+"data.unknown").parse(graph);
+    }
+
+    @Test
+    public void source_uri_03() {
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create().source("file:"+DIR+"data.unknown").lang(Lang.TTL).parse(graph);
+        assertEquals(3, graph.size());
+    }
+
+    @Test
+    public void source_uri_04() {
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create()
+            .source(Paths.get(DIR+"data.ttl"))
+            .parse(graph);
+        assertEquals(3, graph.size());
+    }
+
+    @Test
+    public void source_uri_05() {
+        // Last source wins.
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create()
+            .source("http://example/")
+            .source(DIR+"data.ttl")
+            .parse(graph);
+        assertEquals(3, graph.size());
+    }
+
+    @Test(expected=RiotNotFoundException.class)
+    public void source_notfound_1() {
+        // Last source wins.
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create()
+            .source(Paths.get(DIR+"data.nosuchfile.ttl"))
+            .parse(graph);
+        assertEquals(3, graph.size());
+    }
+
+    @Test(expected=RiotNotFoundException.class)
+    public void source_notfound_2() {
+        // Last source wins.
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create()
+            .source(DIR+"data.nosuchfile.ttl")
+            .parse(graph);
+        assertEquals(3, graph.size());
+    }
+
+    @Test(expected=RiotException.class)
+    public void source_uri_hint_lang() {
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create().source("file:data.rdf")
+            .lang(Lang.RDFXML)
+            .errorHandler(ErrorHandlerFactory.errorHandlerNoLogging)
+            .parse(graph);
+        assertEquals(3, graph.size());
+    }
+
+    @Test(expected=RiotException.class)
+    public void errorHandler() {
+        Graph graph = GraphFactory.createGraphMem();
+        // This test file contains Turtle. 
+        RDFParserBuilder.create().source(DIR+"data.rdf")
+            // and no test log output.  
+            .errorHandler(ErrorHandlerFactory.errorHandlerNoLogging)
+            .parse(graph);
+    }
+
+    @Test
+    public void source_uri_force_lang() {
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParserBuilder.create().source("file:"+DIR+"data.rdf").forceLang(Lang.TTL).parse(graph);
+        assertEquals(3, graph.size());
+    }
+
+    private static class TestingFactoryRDF extends FactoryRDFStd {
+        int counter = 0;
+        @Override
+        public Node createURI(String uriStr) {
+            counter++;
+            return super.createURI(uriStr);
+        }
+    }
+    
+    private RDFParserBuilder builder() {
+        InputStream input = new ByteArrayInputStream(testdata.getBytes(StandardCharsets.UTF_8));
+        return RDFParserBuilder.create().lang(Lang.TTL).source(input);
+    }
+    
+    @Test public void labels_01() {
+        Graph graph = GraphFactory.createGraphMem();
+        //LabelToNode.createUseLabelEncoded() ;
+        
+        builder()
+            .labelToNode(LabelToNode.createUseLabelAsGiven())
+            .parse(graph);
+        assertEquals(1, graph.size());
+        StringWriter sw = new StringWriter();
+        RDFDataMgr.write(sw, graph, Lang.NT);
+        String s = sw.toString();
+        assertTrue(s.contains("_:Bb"));
+    }
+
+    @Test public void factory_01() {
+        TestingFactoryRDF f = new TestingFactoryRDF();
+        Graph graph = GraphFactory.createGraphMem();
+        builder()
+            .factory(f)
+            .parse(graph);
+        assertEquals(1, graph.size());
+        assertNotEquals(0, f.counter);
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/ParserTestBaseLib.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/ParserTestBaseLib.java
@@ -23,10 +23,7 @@ import java.io.StringReader ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.riot.ErrorHandlerTestLib.ErrorHandlerEx ;
 import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFDataMgr ;
-import org.apache.jena.riot.ReaderRIOT ;
-import org.apache.jena.riot.system.ParserProfile ;
-import org.apache.jena.riot.system.RiotLib ;
+import org.apache.jena.riot.RDFParser;
 import org.apache.jena.riot.system.StreamRDF ;
 import org.apache.jena.riot.system.StreamRDFLib ;
 import org.apache.jena.sparql.core.DatasetGraph ;
@@ -57,12 +54,12 @@ class ParserTestBaseLib {
         String string = String.join("\n", strings) ;
         StringReader reader = new StringReader(string) ;
         String baseIRI = "http://base/" ;
-        ReaderRIOT r = RDFDataMgr.createReader(lang) ;
-        //ParserProfile profile = RiotLib.profile(lang, baseIRI, new ErrorHandlerEx());
-        ParserProfile profile = RiotLib.profile(baseIRI, false, true, new ErrorHandlerEx());
-        r.setParserProfile(profile) ;
-        r.setErrorHandler(new ErrorHandlerEx()); // WHY?
-        r.read(reader, baseIRI, null, dest, null);
+        RDFParser.create()
+            .source(reader)
+            .base(baseIRI)
+            .errorHandler(new ErrorHandlerEx())
+            .lang(lang)
+            .parse(dest);
     }
 
     /** Parse for a language - convert errors.wranigns to ErrorHandlerEx */

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestPipedRDFIterators.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestPipedRDFIterators.java
@@ -396,7 +396,7 @@ public class TestPipedRDFIterators {
                 Charset utf8 = StandardCharsets.UTF_8 ;
                 ByteArrayInputStream input = new ByteArrayInputStream(data.getBytes(utf8));
                 try {
-                    RDFDataMgr.parse(out, input, null, RDFLanguages.TURTLE, null);
+                    RDFDataMgr.parse(out, input, RDFLanguages.TURTLE);
                 } catch (Throwable t) {
                     // Ignore the error
                 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/stream/TestStreamManager.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/stream/TestStreamManager.java
@@ -27,6 +27,7 @@ import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.riot.RiotNotFoundException ;
+import org.apache.jena.riot.SysRIOT;
 import org.apache.jena.riot.system.stream.LocatorFile ;
 import org.apache.jena.riot.system.stream.LocatorHTTP ;
 import org.apache.jena.riot.system.stream.StreamManager ;
@@ -69,7 +70,7 @@ public class TestStreamManager extends BaseTest
     private static Context context(StreamManager streamMgr)
     {
         Context context = new Context() ;
-        context.put(RDFDataMgr.streamManagerSymbol, streamMgr) ;
+        context.put(SysRIOT.sysStreamManager, streamMgr) ;
         return context ;
     }
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestLangRegistration.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestLangRegistration.java
@@ -78,11 +78,14 @@ public class TestLangRegistration extends BaseTest
             assertTrue(RDFLanguages.isQuads(lang)) ;
         else
             assertFalse(RDFLanguages.isQuads(lang)) ;
-        
     }
+    
+    @SuppressWarnings("deprecation")
     @Test public void jenaSystem_read_2() {
-        if ( ! Lang.RDFNULL.equals(lang) )
+        if ( ! Lang.RDFNULL.equals(lang) ) {
+            assertTrue(RDFParserRegistry.isRegistered(lang));
             assertNotNull(RDFParserRegistry.getFactory(lang)) ;
+        }
     }
     
     @Test public void jenaSystem_write_1() {

--- a/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestThriftSetup.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestThriftSetup.java
@@ -35,9 +35,11 @@ public class TestThriftSetup extends BaseTest {
         assertEquals(lang, THRIFT) ;
     }
 
+    @SuppressWarnings("deprecation")
     @Test public void setup_03() {
         assertTrue(RDFParserRegistry.isQuads(THRIFT)) ;
         assertTrue(RDFParserRegistry.isTriples(THRIFT)) ;
+        assertTrue(RDFParserRegistry.isRegistered(THRIFT));
         assertNotNull(RDFParserRegistry.getFactory(THRIFT)) ;
     }
     

--- a/jena-arq/testing/ARQ/Construct/results-construct-quad-syntax-3.ttl
+++ b/jena-arq/testing/ARQ/Construct/results-construct-quad-syntax-3.ttl
@@ -1,2 +1,2 @@
 @prefix :      <http://example.org/ns#> .
-:s :p :o
+:s :p :o .

--- a/jena-arq/testing/ARQ/Construct/results-construct-quad-syntax-7.ttl
+++ b/jena-arq/testing/ARQ/Construct/results-construct-quad-syntax-7.ttl
@@ -1,2 +1,2 @@
 @prefix :      <http://example.org/ns#> .
-:s :p :o
+:s :p :o .

--- a/jena-arq/testing/RIOT/Lang/TrigStd/trig-syntax-bad-list-02.trig
+++ b/jena-arq/testing/RIOT/Lang/TrigStd/trig-syntax-bad-list-02.trig
@@ -1,2 +1,2 @@
 # RDF collection without predicate-object-list
-( 1 2 3 ) .
+( ) .

--- a/jena-arq/testing/RIOT/Parser/data.rdf
+++ b/jena-arq/testing/RIOT/Parser/data.rdf
@@ -1,0 +1,5 @@
+PREFIX ex: <http://example/>
+
+_:ab ex:p "foo"@en-gb .
+ex:ab ex:p "foo"@en-GB .
+ex:ab ex:p 123 .

--- a/jena-arq/testing/RIOT/Parser/data.ttl
+++ b/jena-arq/testing/RIOT/Parser/data.ttl
@@ -1,0 +1,5 @@
+PREFIX ex: <http://example/>
+
+_:ab ex:p "foo"@en-gb .
+ex:ab ex:p "foo"@en-GB .
+ex:ab ex:p 123 .

--- a/jena-arq/testing/RIOT/Parser/data.unknown
+++ b/jena-arq/testing/RIOT/Parser/data.unknown
@@ -1,0 +1,5 @@
+PREFIX ex: <http://example/>
+
+_:ab ex:p "foo"@en-gb .
+ex:ab ex:p "foo"@en-GB .
+ex:ab ex:p 123 .

--- a/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
+++ b/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
@@ -209,7 +209,7 @@ public abstract class CmdLangParse extends CmdGeneral
         if ( filename.equals("-") ) {
             if ( baseURI == null )
                 baseURI = "http://base/";
-            TypedInputStream in = new TypedInputStream(System.in) ;
+            TypedInputStream in = TypedInputStream.wrap(System.in) ;
             return parseRIOT(baseURI, "stdin", in) ;
         } else {
             try ( TypedInputStream in = RDFDataMgr.open(filename) ) {
@@ -266,16 +266,18 @@ public abstract class CmdLangParse extends CmdGeneral
         StreamRDFCounting sink = StreamRDFLib.count(s) ;
         s = null ;
         
-        ReaderRIOT reader = RDFDataMgr.createReader(lang) ;
         boolean successful = true;
 
+        ParserProfile pp;
         if ( checking ) {
             if ( lang == RDFLanguages.NTRIPLES || lang == RDFLanguages.NQUADS )
-                reader.setParserProfile(RiotLib.profile(baseURI, false, true, errHandler)) ;
+                pp = RiotLib.profile(baseURI, false, true, errHandler) ;
             else
-                reader.setParserProfile(RiotLib.profile(baseURI, true, true, errHandler)) ;
+                pp = RiotLib.profile(baseURI, true, true, errHandler) ;
         } else
-            reader.setParserProfile(RiotLib.profile(baseURI, false, false, errHandler)) ;
+            pp = RiotLib.profile(baseURI, false, false, errHandler);
+        ReaderRIOT reader = RDFDataMgr.createReader(lang, pp) ;
+        reader.setParserProfile(pp) ;
 
         if ( labelsAsGiven ) {
             FactoryRDF f = RiotLib.factoryRDF(LabelToNode.createUseLabelAsGiven()) ;

--- a/jena-cmds/src/main/java/riotcmd/infer.java
+++ b/jena-cmds/src/main/java/riotcmd/infer.java
@@ -141,7 +141,7 @@ public class infer extends CmdGeneral
         Lang lang = filename.equals("-") ? RDFLanguages.NQUADS : RDFLanguages.filenameToLang(filename, RDFLanguages.NQUADS) ;
 
         if ( filename.equals("-") )
-            RDFDataMgr.parse(sink, System.in, null, RDFLanguages.NQUADS, null) ;
+            RDFDataMgr.parse(sink, System.in, null, RDFLanguages.NQUADS) ;
         else
             RDFDataMgr.parse(sink, filename) ;
     }

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractBlockBasedNodeTupleReader.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractBlockBasedNodeTupleReader.java
@@ -192,6 +192,8 @@ public abstract class AbstractBlockBasedNodeTupleReader<TValue, T extends Abstra
             @Override
             public void run() {
                 try {
+                    @SuppressWarnings("deprecation")
+                    // Only needed because of ParserProfile setting errorhandler and label mapping - see RdfIOUtils.createParserProfile
                     ReaderRIOT riotReader = RDFDataMgr.createReader(lang);
                     riotReader.setParserProfile(profile);
                     riotReader.read(input, null, lang.getContentType(), stream, null);

--- a/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractWholeFileNodeTupleReader.java
+++ b/jena-elephas/jena-elephas-io/src/main/java/org/apache/jena/hadoop/rdf/io/input/readers/AbstractWholeFileNodeTupleReader.java
@@ -180,6 +180,8 @@ public abstract class AbstractWholeFileNodeTupleReader<TValue, T extends Abstrac
             @Override
             public void run() {
                 try {
+                    @SuppressWarnings("deprecation")
+                    // Only needed because of ParserProfile setting errorhandler and label mapping - see RdfIOUtils.createParserProfile
                     ReaderRIOT riotReader = RDFDataMgr.createReader(lang);
                     riotReader.setParserProfile(profile);
                     riotReader.read(input, null, lang.getContentType(), stream, null);

--- a/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/output/AbstractNodeTupleOutputFormatTests.java
+++ b/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/output/AbstractNodeTupleOutputFormatTests.java
@@ -110,7 +110,7 @@ public abstract class AbstractNodeTupleOutputFormatTests<TValue, T extends Abstr
      */
     protected final long countTuples(File f) {
         StreamRDFCounting counter = StreamRDFLib.count();
-        RDFDataMgr.parse(counter, f.getAbsolutePath(), this.getRdfLanguage(), null);
+        RDFDataMgr.parse(counter, f.getAbsolutePath(), this.getRdfLanguage());
         return counter.count();
     }
 

--- a/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/output/trig/TriGBlankNodeOutputTests.java
+++ b/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/output/trig/TriGBlankNodeOutputTests.java
@@ -80,7 +80,7 @@ public class TriGBlankNodeOutputTests extends StreamedTriGOutputTest {
 	@Override
 	protected Iterator<QuadWritable> generateTuples(int num) {
 		List<QuadWritable> qs = new ArrayList<QuadWritable>();
-		Node subject = NodeFactory.createAnon();
+		Node subject = NodeFactory.createBlankNode();
 		for (int i = 0; i < num; i++) {
 			Quad t = new Quad(
 					NodeFactory.createURI("http://example.org/graphs/" + i),

--- a/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/output/turtle/TurtleBlankNodeOutputTests.java
+++ b/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/output/turtle/TurtleBlankNodeOutputTests.java
@@ -80,7 +80,7 @@ public class TurtleBlankNodeOutputTests extends StreamedTurtleOutputTest {
 	@Override
 	protected Iterator<TripleWritable> generateTuples(int num) {
 		List<TripleWritable> ts = new ArrayList<TripleWritable>();
-		Node subject = NodeFactory.createAnon();
+		Node subject = NodeFactory.createBlankNode();
 		for (int i = 0; i < num; i++) {
 			Triple t = new Triple(subject,
 					NodeFactory.createURI("http://example.org/predicate"),

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads.java
@@ -34,9 +34,6 @@ import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.riot.ReaderRIOT ;
-import org.apache.jena.riot.system.StreamRDF ;
-import org.apache.jena.riot.system.StreamRDFLib ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 
 /** 
@@ -142,9 +139,7 @@ public class REST_Quads extends SPARQL_REST
         try {
             String name = action.request.getRequestURL().toString() ;
             DatasetGraph dsg = action.getActiveDSG() ;
-            StreamRDF dest = StreamRDFLib.dataset(dsg) ;
-            ReaderRIOT reader = RDFDataMgr.createReader(lang) ;
-            reader.read(action.request.getInputStream(), name, null, dest, null);
+            RDFDataMgr.read(dsg, action.request.getInputStream(), name, lang);
             action.commit();
             success(action) ;
         } catch (IOException ex) { action.abort() ; } 
@@ -158,13 +153,11 @@ public class REST_Quads extends SPARQL_REST
         action.beginWrite() ;
         try {
             DatasetGraph dsg = action.getActiveDSG() ;
-            // This should not be anythign other than the datasets name via this route.  
+            // This should not be anything other than the datasets name via this route.  
             String name = action.request.getRequestURL().toString() ;
             //log.info(format("[%d] ** Content-length: %d", action.id, action.request.getContentLength())) ;  
             Graph g = dsg.getDefaultGraph() ;
-            StreamRDF dest = StreamRDFLib.graph(g) ;
-            ReaderRIOT reader = RDFDataMgr.createReader(lang) ;
-            reader.read(action.request.getInputStream(), name, null, dest, null);
+            RDFDataMgr.read(g, action.request.getInputStream(), name, lang);
             action.commit();
             success(action) ;
         } catch (IOException ex) { action.abort() ; } 
@@ -184,9 +177,7 @@ public class REST_Quads extends SPARQL_REST
             name = name+(++counter) ;
             Node gn = NodeFactory.createURI(name) ;
             Graph g = dsg.getGraph(gn) ;
-            StreamRDF dest = StreamRDFLib.graph(g) ;
-            ReaderRIOT reader = RDFDataMgr.createReader(lang) ;
-            reader.read(action.request.getInputStream(), name, null, dest, null);
+            RDFDataMgr.read(g, action.request.getInputStream(), name, lang);
             log.info(format("[%d] Location: %s", action.id, name)) ;
             action.response.setHeader("Location",  name) ;
             action.commit();

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_REST.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_REST.java
@@ -32,10 +32,7 @@ import org.apache.jena.fuseki.server.CounterName ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFDataMgr ;
-import org.apache.jena.riot.ReaderRIOT ;
-import org.apache.jena.riot.RiotException ;
+import org.apache.jena.riot.*;
 import org.apache.jena.riot.system.ErrorHandler ;
 import org.apache.jena.riot.system.ErrorHandlerFactory ;
 import org.apache.jena.riot.system.IRIResolver ;
@@ -290,11 +287,15 @@ public abstract class SPARQL_REST extends SPARQL_ServletBase
     // Check for all RiotReader
     public static void parse(HttpAction action, StreamRDF dest, InputStream input, Lang lang, String base) {
         try {
-            ReaderRIOT r = RDFDataMgr.createReader(lang) ;
-            if ( r == null )
+            if ( ! RDFLanguages.hasRegisteredParser(lang) ) {
                 errorBadRequest("No parser for language '"+lang.getName()+"'") ;
-            r.setErrorHandler(errorHandler); 
-            r.read(input, base, null, dest, null) ; 
+            }
+            RDFParser.create()
+                .source(input)
+                .lang(lang)
+                .base(base)
+                .errorHandler(errorHandler)
+                .parse(dest);
         } 
         catch (RiotException ex) { errorBadRequest("Parse error: "+ex.getMessage()) ; }
     }

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/validation/DataValidator.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/validation/DataValidator.java
@@ -84,26 +84,31 @@ public class DataValidator extends ValidatorBase
             OutputStream output1 = new OutputStreamNoHTML(new BufferedOutputStream(outStream)) ;
             StreamRDF output = StreamRDFWriter.getWriterStream(output1, Lang.NQUADS) ;
             try {
-                ReaderRIOT parser = setupParser(language, errorHandler) ;
                 startFixed(outStream) ;
+                RDFParser parser = RDFParser.create()
+                    .lang(language)
+                    .errorHandler(errorHandler)
+                    .resolveURIs(false)
+                    .build();
                 RiotException exception = null ;
+                startFixed(outStream) ;
                 try {
                     output.start();
-                    parser.read(input, null, null, output, null);
+                    parser.parse(output);
                     output.finish();
                     output1.flush();
                     outStream.flush(); 
                     System.err.flush() ;
                 } catch (RiotException ex) {
                     ex.printStackTrace(stderr); 
-                    exception = ex ; }
+                    exception = ex ;
+                }
             } finally 
             {
                 finishFixed(outStream) ;
                 System.err.flush() ;
                 System.setErr(stderr) ;
             }
-            
             
             outStream.println("</body>") ;
             outStream.println("</html>") ;
@@ -142,15 +147,6 @@ public class DataValidator extends ValidatorBase
     }
     
     
-    private ReaderRIOT setupParser(Lang language, ErrorHandler errorHandler)
-    {
-        // Don't resolve IRIs.  Do checking.
-        ParserProfile profile = RiotLib.profile(null, false, true, errorHandler) ; 
-        ReaderRIOT reader = RDFDataMgr.createReader(language) ;
-        reader.setParserProfile(profile);
-        return reader ;
-    }
-
     // Error handler that records messages
     private static class ErrorHandlerMsg implements ErrorHandler
     {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionSPARQL.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionSPARQL.java
@@ -28,10 +28,7 @@ import org.apache.jena.atlas.RuntimeIOException ;
 import org.apache.jena.fuseki.Fuseki ;
 import org.apache.jena.fuseki.server.* ;
 import org.apache.jena.query.QueryCancelledException ;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFDataMgr ;
-import org.apache.jena.riot.ReaderRIOT ;
-import org.apache.jena.riot.RiotException ;
+import org.apache.jena.riot.*;
 import org.apache.jena.riot.system.ErrorHandler ;
 import org.apache.jena.riot.system.ErrorHandlerFactory ;
 import org.apache.jena.riot.system.StreamRDF ;
@@ -199,12 +196,15 @@ public abstract class ActionSPARQL extends ActionBase
 
     public static void parse(HttpAction action, StreamRDF dest, InputStream input, Lang lang, String base) {
         try {
-            ReaderRIOT r = RDFDataMgr.createReader(lang) ;
-            if ( r == null )
+            if ( ! RDFParserRegistry.isRegistered(lang) )
                 ServletOps.errorBadRequest("No parser for language '"+lang.getName()+"'") ;
             ErrorHandler errorHandler = ErrorHandlerFactory.errorHandlerStd(action.log);
-            r.setErrorHandler(errorHandler); 
-            r.read(input, base, null, dest, null) ; 
+            RDFParser.create()
+                .errorHandler(errorHandler)
+                .source(input)
+                .lang(lang)
+                .base(base)
+                .parse(dest);
         } 
         catch (RiotException ex) { ServletOps.errorBadRequest("Parse error: "+ex.getMessage()) ; }
     }


### PR DESCRIPTION
`RDFParser` / `RDFParserBuilder` is a new API to build and execute parsing steps. It provides complete control of the parser setup.

As such it is too detailed for general use. `RDFDataMgr` or `Model.read` remains the normal way to ingest RDF syntax. 

In this PR, `RDFDataMgr` has been changed to use `RDFParser`.

`ReaderRIOT` remains the interface to plugging in parser processes.

Parsing speed is not affected.
