### PR TITLE
Refactor TextIndex and TextQueryPF in jena-text (preparation for JENA-1305)

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
@@ -93,12 +93,17 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
 
     /** Search the text index on the text field associated with the predicate */
     public Iterator<TextHit> search(String queryString, Node predicate, int limit) {
+        return search(queryString, predicate, null, limit) ;
+    }
+
+    /** Search the text index on the text field associated with the predicate within graph */
+    public Iterator<TextHit> search(String queryString, Node predicate, String graphURI, int limit) {
         queryString = QueryParserBase.escape(queryString) ;
         if ( predicate != null ) {
             String f = textIndex.getDocDef().getField(predicate) ;
             queryString = f + ":" + queryString ;
         }
-        List<TextHit> results = textIndex.query(predicate, queryString, limit) ;
+        List<TextHit> results = textIndex.query(predicate, queryString, graphURI, limit) ;
         return results.iterator() ;
     }
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
@@ -93,17 +93,17 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
 
     /** Search the text index on the text field associated with the predicate */
     public Iterator<TextHit> search(String queryString, Node predicate, int limit) {
-        return search(queryString, predicate, null, limit) ;
+        return search(queryString, predicate, null, null, limit) ;
     }
 
     /** Search the text index on the text field associated with the predicate within graph */
-    public Iterator<TextHit> search(String queryString, Node predicate, String graphURI, int limit) {
+    public Iterator<TextHit> search(String queryString, Node predicate, String graphURI, String lang, int limit) {
         queryString = QueryParserBase.escape(queryString) ;
         if ( predicate != null ) {
             String f = textIndex.getDocDef().getField(predicate) ;
             queryString = f + ":" + queryString ;
         }
-        List<TextHit> results = textIndex.query(predicate, queryString, graphURI, limit) ;
+        List<TextHit> results = textIndex.query(predicate, queryString, graphURI, lang, limit) ;
         return results.iterator() ;
     }
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndex.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndex.java
@@ -46,9 +46,9 @@ public interface TextIndex extends Closeable //, Transactional
     /** Access the index - limit if -1 for as many as possible 
      * Throw QueryParseException for syntax errors in the query string.
      */ 
-    List<TextHit> query(Node property, String qs, int limit) ;
+    List<TextHit> query(Node property, String qs, String graphURI, int limit) ;
     
-    List<TextHit> query(Node property, String qs) ;
+    List<TextHit> query(Node property, String qs, String graphURI) ;
 
     EntityDefinition getDocDef() ;
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndex.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndex.java
@@ -46,9 +46,9 @@ public interface TextIndex extends Closeable //, Transactional
     /** Access the index - limit if -1 for as many as possible 
      * Throw QueryParseException for syntax errors in the query string.
      */ 
-    List<TextHit> query(Node property, String qs, String graphURI, int limit) ;
+    List<TextHit> query(Node property, String qs, String graphURI, String lang, int limit) ;
     
-    List<TextHit> query(Node property, String qs, String graphURI) ;
+    List<TextHit> query(Node property, String qs, String graphURI, String lang) ;
 
     EntityDefinition getDocDef() ;
 }

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
@@ -324,15 +324,6 @@ public class TextIndexLucene implements TextIndex {
     }
 
     private Query parseQuery(String queryString, Analyzer analyzer) throws ParseException {
-        if (this.isMultilingual) {
-            if (queryString.contains(getDocDef().getLangField() + ":")) {
-                String lang = queryString.substring(queryString.lastIndexOf(":") + 1);
-                if (!"*".equals(lang)) {
-                    // splice the language into the field name
-                    queryString = queryString.replaceFirst(":", "_" + lang + ":");
-                }
-            }
-        }
         QueryParser queryParser = getQueryParser(analyzer) ;
         queryParser.setAllowLeadingWildcard(true) ;
         Query query = queryParser.parse(queryString) ;
@@ -370,14 +361,14 @@ public class TextIndexLucene implements TextIndex {
     }
 
     @Override
-    public List<TextHit> query(Node property, String qs, String graphURI) {
-        return query(property, qs, graphURI, MAX_N) ;
+    public List<TextHit> query(Node property, String qs, String graphURI, String lang) {
+        return query(property, qs, graphURI, lang, MAX_N) ;
     }
 
     @Override
-    public List<TextHit> query(Node property, String qs, String graphURI, int limit) {
+    public List<TextHit> query(Node property, String qs, String graphURI, String lang, int limit) {
         try (IndexReader indexReader = DirectoryReader.open(directory)) {
-            return query$(indexReader, property, qs, graphURI, limit) ;
+            return query$(indexReader, property, qs, graphURI, lang, limit) ;
         }
         catch (ParseException ex) {
             throw new TextIndexParseException(qs, ex.getMessage()) ;
@@ -387,15 +378,43 @@ public class TextIndexLucene implements TextIndex {
         }
     }
 
-    private List<TextHit> query$(IndexReader indexReader, Node property, String qs, String graphURI, int limit) throws ParseException, IOException {
-        if (graphURI != null) {
-            String escaped = QueryParserBase.escape(graphURI) ;
-            String qs2 = getDocDef().getGraphField() + ":" + escaped ;
-            qs = "(" + qs + ") AND " + qs2 ;
+    private List<TextHit> query$(IndexReader indexReader, Node property, String qs, String graphURI, String lang, int limit)
+            throws ParseException, IOException {
+        String textField = docDef.getField(property);
+        String textClause;
+        String langClause = null;
+        String graphClause = null;
+
+        //for language-based search extension
+        if (getDocDef().getLangField() != null) {
+            String langField = getDocDef().getLangField();
+            if (lang != null) {
+                if (this.isMultilingual && !lang.equals("none")) {
+                    textField = textField + "_" + lang;
+                }
+                langClause = !"none".equals(lang)?
+                        langField + ":" + lang : "-" + langField + ":*";
+            }
         }
 
+        if (textField != null)
+            textClause = textField + ":" + qs ;
+        else
+            textClause = qs ;
+
+        if (graphURI != null) {
+            String escaped = QueryParserBase.escape(graphURI) ;
+            graphClause = getDocDef().getGraphField() + ":" + escaped ;
+        }
+
+        String queryString = textClause ;
+        if (langClause != null)
+            queryString = "(" + queryString + ") AND " + langClause ;
+        if (graphClause != null)
+            queryString = "(" + queryString + ") AND " + graphClause ;
+
         IndexSearcher indexSearcher = new IndexSearcher(indexReader) ;
-        Query query = parseQuery(qs, queryAnalyzer) ;
+        Query query = parseQuery(queryString, queryAnalyzer) ;
         if ( limit <= 0 )
             limit = MAX_N ;
         ScoreDoc[] sDocs = indexSearcher.search(query, limit).scoreDocs ;
@@ -413,13 +432,13 @@ public class TextIndexLucene implements TextIndex {
                 String lexical = lexicals[0];
                 String[] langs = doc.getValues(docDef.getLangField()) ;
                 if (langs.length > 0) {
-                    String lang = langs[0];
-                    if (lang.startsWith(DATATYPE_PREFIX)) {
-                        String datatype = lang.substring(DATATYPE_PREFIX.length());
+                    String doclang = langs[0];
+                    if (doclang.startsWith(DATATYPE_PREFIX)) {
+                        String datatype = doclang.substring(DATATYPE_PREFIX.length());
                         TypeMapper tmap = TypeMapper.getInstance();
                         literal = NodeFactory.createLiteral(lexical, tmap.getSafeTypeByName(datatype));
                     } else {
-                        literal = NodeFactory.createLiteral(lexical, lang);
+                        literal = NodeFactory.createLiteral(lexical, doclang);
                     }
                 } else {
                     literal = NodeFactory.createLiteral(lexical);

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
@@ -370,14 +370,14 @@ public class TextIndexLucene implements TextIndex {
     }
 
     @Override
-    public List<TextHit> query(Node property, String qs) {
-        return query(property, qs, MAX_N) ;
+    public List<TextHit> query(Node property, String qs, String graphURI) {
+        return query(property, qs, graphURI, MAX_N) ;
     }
 
     @Override
-    public List<TextHit> query(Node property, String qs, int limit) {
+    public List<TextHit> query(Node property, String qs, String graphURI, int limit) {
         try (IndexReader indexReader = DirectoryReader.open(directory)) {
-            return query$(indexReader, property, qs, limit) ;
+            return query$(indexReader, property, qs, graphURI, limit) ;
         }
         catch (ParseException ex) {
             throw new TextIndexParseException(qs, ex.getMessage()) ;
@@ -387,7 +387,13 @@ public class TextIndexLucene implements TextIndex {
         }
     }
 
-    private List<TextHit> query$(IndexReader indexReader, Node property, String qs, int limit) throws ParseException, IOException {
+    private List<TextHit> query$(IndexReader indexReader, Node property, String qs, String graphURI, int limit) throws ParseException, IOException {
+        if (graphURI != null) {
+            String escaped = QueryParserBase.escape(graphURI) ;
+            String qs2 = getDocDef().getGraphField() + ":" + escaped ;
+            qs = "(" + qs + ") AND " + qs2 ;
+        }
+
         IndexSearcher indexSearcher = new IndexSearcher(indexReader) ;
         Query query = parseQuery(qs, queryAnalyzer) ;
         if ( limit <= 0 )

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextQueryPF.java
@@ -45,7 +45,6 @@ import org.apache.jena.sparql.engine.iterator.QueryIterSlice ;
 import org.apache.jena.sparql.mgt.Explain ;
 import org.apache.jena.sparql.pfunction.PropFuncArg ;
 import org.apache.jena.sparql.pfunction.PropertyFunctionBase ;
-import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.IterLib ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.apache.jena.sparql.util.Symbol ;
@@ -105,8 +104,6 @@ public class TextQueryPF extends PropertyFunctionBase {
 
     private static TextIndex chooseTextIndex(DatasetGraph dsg) {
         
-        Context c = dsg.getContext() ; 
-        
         Object obj = dsg.getContext().get(TextQuery.textIndex) ;
 
         if (obj != null) {
@@ -155,8 +152,6 @@ public class TextQueryPF extends PropertyFunctionBase {
             // Not a text dataset - no-op
             return IterLib.result(binding, execCxt) ;
         }
-
-        DatasetGraph dsg = execCxt.getDataset() ;
 
         argSubject = Substitute.substitute(argSubject, binding) ;
         argObject = Substitute.substitute(argObject, binding) ;
@@ -232,7 +227,6 @@ public class TextQueryPF extends PropertyFunctionBase {
     }
 
     private QueryIterator concreteSubject(Binding binding, Node s, Node score, Node literal, StrMatch match, ExecutionContext execCxt) {
-        String qs = match.getQueryString() ;
         ListMultimap<String,TextHit> x = query(match.getProperty(), match.getQueryString(), -1, execCxt) ;
         
         if ( x == null ) // null return value - empty result


### PR DESCRIPTION
In the development of JENA-1305 (Elasticsearch backend for jena-text) it surfaced that the current division of labor between TextQueryPF and TextIndex is awkward. The Lucene (or Solr) query string is mostly formed already on the TextQueryPF side, which makes it difficult to implement a backend that uses a different query language.

I have refactored the TextIndex interface, separating out the graph and language information away from the query string into separate method parameters, and changed the code in TextQueryPF and TextIndexLucene correspondingly.

I'm opening this PR to ask for comments on the change. If there is no opposition, I will merge it to master within a few days.