### PR TITLE
RDFParser refinements.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
@@ -898,7 +898,7 @@ public class RDFDataMgr
         ReaderRIOTFactory r = RDFParserRegistry.getFactory(lang) ;
         if ( r == null )
             return null ;
-        return r.create(lang, profile) ;
+        return r.create(lang, profile) ;//, profile.getHandler()); 
     }
 
     // Operations to remove "null"s in the code.

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
@@ -30,10 +30,7 @@ import java.util.Set ;
 import org.apache.jena.atlas.lib.InternalErrorException ;
 import org.apache.jena.atlas.web.ContentType ;
 import org.apache.jena.riot.lang.* ;
-import org.apache.jena.riot.system.ErrorHandler ;
-import org.apache.jena.riot.system.ErrorHandlerFactory ;
-import org.apache.jena.riot.system.ParserProfile ;
-import org.apache.jena.riot.system.StreamRDF ;
+import org.apache.jena.riot.system.*;
 import org.apache.jena.riot.thrift.BinRDF ;
 import org.apache.jena.sparql.util.Context ;
 
@@ -156,11 +153,6 @@ public class RDFParserRegistry
     private static class ReaderRIOTFactoryImpl implements ReaderRIOTFactory
     {
         @Override
-        public ReaderRIOT create(Lang lang) {
-            return new ReaderRIOTLang(lang) ;
-        }
-        
-        @Override
         public ReaderRIOT create(Lang lang, ParserProfile parserProfile) {
             return new ReaderRIOTLang(lang, parserProfile) ;
         }
@@ -213,23 +205,14 @@ public class RDFParserRegistry
 
     private static class ReaderRIOTFactoryJSONLD implements ReaderRIOTFactory {
         @Override
-        public ReaderRIOT create(Lang language) {
+        public ReaderRIOT create(Lang language, ParserProfile profile) {
             if ( !Lang.JSONLD.equals(language) )
                 throw new InternalErrorException("Attempt to parse " + language + " as JSON-LD") ;
-            return new JsonLDReader() ;
-        }
-        
-        @Override
-        public ReaderRIOT create(Lang language, ParserProfile profile) {
-            return create(language);
+            return new JsonLDReader(language, profile, profile.getHandler());
         }
     }
  
     private static class ReaderRIOTFactoryThrift implements ReaderRIOTFactory {
-        @Override
-        public ReaderRIOT create(Lang language) {
-            return new ReaderRDFThrift() ;
-        }
         @Override
         public ReaderRIOT create(Lang language, ParserProfile profile) {
             return new ReaderRDFThrift() ;
@@ -267,25 +250,15 @@ public class RDFParserRegistry
 
     private static class ReaderRIOTFactoryTriX implements ReaderRIOTFactory {
         @Override
-        public ReaderRIOT create(Lang language) {
-            return new ReaderTriX() ;
-        }
-        
-        @Override
         public ReaderRIOT create(Lang language, ParserProfile profile) {
-            return create(language);
+            return new ReaderTriX(profile, profile.getHandler());
         }
     }
 
     private static class ReaderRIOTFactoryRDFNULL implements ReaderRIOTFactory {
         @Override
-        public ReaderRIOT create(Lang language) {
-            return new ReaderRDFNULL() ;
-        }
-        
-        @Override
         public ReaderRIOT create(Lang language, ParserProfile profile) {
-            return create(language);
+            return new ReaderRDFNULL();
         }
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/ReaderRIOTFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/ReaderRIOTFactory.java
@@ -19,14 +19,20 @@
 package org.apache.jena.riot;
 
 import org.apache.jena.riot.system.ParserProfile;
+import org.apache.jena.riot.system.RiotLib;
 
 public interface ReaderRIOTFactory
 {
-    public ReaderRIOT create(Lang language);
-    
-    public default ReaderRIOT create(Lang language, ParserProfile profile) {
-        ReaderRIOT r = create(language);
-        r.setParserProfile(profile);
-        return r;
+    public default ReaderRIOT create(Lang language) {
+        return create(language, RiotLib.profile(language, null));
     }
+    
+    public ReaderRIOT create(Lang language, ParserProfile profile);
+    
+//    public default ReaderRIOT create(Lang language, ParserProfile profile) {
+//        return create(language, profile, profile.getHandler());
+//    }
+//
+//    /** Create a parser engine (a {@link ReaderRIOT}) */
+//    public ReaderRIOT create(Lang language, MakerRDF maker, ErrorHandler errorHandler);  
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangBase.java
@@ -25,39 +25,34 @@ import org.apache.jena.riot.tokens.Tokenizer ;
 
 public abstract class LangBase extends LangEngine implements LangRIOT
 {
-    protected final StreamRDF dest ; 
+    protected final StreamRDF dest;
 
-    protected LangBase(Tokenizer tokens, ParserProfile profile, StreamRDF dest)
-    {
-        super(tokens, profile) ;
-        this.dest = dest ;
+    protected LangBase(Tokenizer tokens, ParserProfile profile, StreamRDF dest) {
+        super(tokens, profile);
+        this.dest = dest;
     }
 
     @Override
-    public void parse()
-    {
-        dest.base(profile.getPrologue().getBaseURI()) ;
-        dest.start() ;
-        try { 
-            runParser() ;
+    public void parse() {
+        dest.start();
+        try {
+            runParser();
         } finally {
-            dest.finish() ;
+            dest.finish();
             tokens.close();
         }
     }
-    
+
     /** Run the parser - events have been handled. */
-    protected abstract void runParser() ;
+    protected abstract void runParser();
 
     @Override
-    public ParserProfile getProfile()
-    {
-        return profile ;
+    public ParserProfile getProfile() {
+        return profile;
     }
 
     @Override
-    public void setProfile(ParserProfile profile)
-    {
-        super.profile = profile ; 
+    public void setProfile(ParserProfile profile) {
+        super.profile = profile;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/ReaderTriX.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/ReaderTriX.java
@@ -72,9 +72,14 @@ public class ReaderTriX implements ReaderRIOT {
 <!ATTLIST typedLiteral datatype CDATA #REQUIRED> 
      */
     
-    private ErrorHandler errorHandler = ErrorHandlerFactory.getDefaultErrorHandler() ;
-    private ParserProfile parserProfile = null ;
+    private final ErrorHandler errorHandler;
+    private final MakerRDF maker;
     
+    public ReaderTriX(MakerRDF maker, ErrorHandler errorHandler) {
+        this.maker = maker;
+        this.errorHandler = errorHandler;
+    }
+
     @Override
     public void read(InputStream in, String baseURI, ContentType ct, StreamRDF output, Context context) {
         XMLInputFactory xf = XMLInputFactory.newInstance() ;
@@ -103,12 +108,6 @@ public class ReaderTriX implements ReaderRIOT {
     enum State { OUTER, TRIX, GRAPH, TRIPLE }
     
     private void read(XMLStreamReader parser, String baseURI, StreamRDF output) {
-        ParserProfile profile = parserProfile ;
-        if ( profile == null )
-            profile = RiotLib.profile(baseURI, false, false, errorHandler) ; 
-        if ( errorHandler == null )
-            setErrorHandler(profile.getHandler()) ;
-        
         State state = OUTER ;
         Node g = null ;
         List<Node> terms = new ArrayList<>() ; 
@@ -140,13 +139,13 @@ public class ReaderTriX implements ReaderRIOT {
                                 if ( s.isLiteral() )
                                     staxError(parser.getLocation(), "Subject is a literal") ;
                                 if ( g == null ) {
-                                    Triple t = profile.createTriple(s, p, o, line, col) ;
+                                    Triple t = maker.createTriple(s, p, o, line, col) ;
                                     output.triple(t) ;
                                 }
                                 else {
                                     if ( g.isLiteral() )
                                         staxError(parser.getLocation(), "graph name is a literal") ;
-                                    Quad q = profile.createQuad(g, s, p, o, line, col) ;
+                                    Quad q = maker.createQuad(g, s, p, o, line, col) ;
                                     output.quad(q) ;
                                 }
                                 terms.clear();
@@ -195,7 +194,7 @@ public class ReaderTriX implements ReaderRIOT {
                             case TriX.tagURI: {
                                 if ( state != GRAPH && state != TRIPLE )
                                     staxErrorOutOfPlaceElement(parser) ;
-                                Node n = term(parser, profile) ;
+                                Node n = term(parser, maker) ;
                                 if ( state == GRAPH ) {
                                     if ( g != null )
                                         staxError(parser.getLocation(), "Duplicate graph name") ;
@@ -212,7 +211,7 @@ public class ReaderTriX implements ReaderRIOT {
                             case TriX.tagTypedLiteral: {    
                                 if ( state != TRIPLE )
                                     staxErrorOutOfPlaceElement(parser) ;
-                                Node n = term(parser, profile) ;
+                                Node n = term(parser, maker) ;
                                 add(terms, n, 3, parser) ;
                                 break ;
                             }
@@ -240,7 +239,7 @@ public class ReaderTriX implements ReaderRIOT {
         staxError(parser.getLocation(), "Out of place XML element: "+tagName(parser)) ; 
     }    
 
-    private Node term(XMLStreamReader parser, ParserProfile profile) throws XMLStreamException {
+    private Node term(XMLStreamReader parser, MakerRDF maker) throws XMLStreamException {
         String tag = parser.getLocalName() ;
         int line = parser.getLocation().getLineNumber() ;
         int col = parser.getLocation().getColumnNumber() ;
@@ -249,7 +248,7 @@ public class ReaderTriX implements ReaderRIOT {
             case TriX.tagURI: {
                 // Two uses!
                 String x = parser.getElementText() ;
-                Node n = profile.createURI(x, line, col) ;
+                Node n = maker.createURI(x, line, col) ;
                 return n ; 
             }
             case TriX.tagQName: {
@@ -260,11 +259,11 @@ public class ReaderTriX implements ReaderRIOT {
                 String[] y = x.split(":", 2) ;  // Allows additional ':'
                 String prefUri = parser.getNamespaceURI(y[0]) ;
                 String local = y[1] ; 
-                return profile.createURI(prefUri+local, line, col) ;
+                return maker.createURI(prefUri+local, line, col) ;
             }
             case TriX.tagId: {
                 String x = parser.getElementText() ;
-                return profile.createBlankNode(null, x, line, col) ;
+                return maker.createBlankNode(null, x, line, col) ;
             }
             case TriX.tagPlainLiteral: {
                 // xml:lang
@@ -277,9 +276,9 @@ public class ReaderTriX implements ReaderRIOT {
                     lang = attribute(parser, nsXML0, TriX.attrXmlLang) ;
                 String lex = parser.getElementText() ;
                 if ( lang == null )
-                    return profile.createStringLiteral(lex, line, col) ;
+                    return maker.createStringLiteral(lex, line, col) ;
                 else
-                    return profile.createLangLiteral(lex, lang, line, col) ;
+                    return maker.createLangLiteral(lex, lang, line, col) ;
             }
             case TriX.tagTypedLiteral: {
                 int nAttr = parser.getAttributeCount() ;
@@ -293,7 +292,7 @@ public class ReaderTriX implements ReaderRIOT {
                 String lex = (rdfXMLLiteral.equals(dt)) 
                     ? slurpRDFXMLLiteral(parser)
                     : parser.getElementText() ;
-                return profile.createTypedLiteral(lex, rdt, line, col) ;                    
+                return maker.createTypedLiteral(lex, rdt, line, col) ;                    
             }
             default: {
                 QName qname = parser.getName() ;
@@ -416,7 +415,7 @@ public class ReaderTriX implements ReaderRIOT {
     }
 
     private void staxError(int line, int col, String msg) {
-        getErrorHandler().error(msg, line, col) ;
+        errorHandler.error(msg, line, col) ;
     }
 
     @Override
@@ -425,14 +424,12 @@ public class ReaderTriX implements ReaderRIOT {
     }
 
     @Override
-    public void setErrorHandler(ErrorHandler errorHandler) { this.errorHandler = errorHandler ; }
+    public void setErrorHandler(ErrorHandler errorHandler) { throw new UnsupportedOperationException(); }
 
     @Override
-    public ParserProfile getParserProfile() {
-        return parserProfile ;
-    }
+    public ParserProfile getParserProfile() { throw new UnsupportedOperationException(); }
 
     @Override
-    public void setParserProfile(ParserProfile profile) { this.parserProfile = profile ; }
+    public void setParserProfile(ParserProfile profile) { throw new UnsupportedOperationException(); }
 }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/RiotParsers.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/RiotParsers.java
@@ -49,7 +49,8 @@ import org.apache.jena.sparql.core.Quad ;
  * <b>This class is internal to RIOT.</b>
  */
 public class RiotParsers {
-    /*package*/ RiotParsers() {}
+    // package statics -- for the tests to create exactly what they test.
+    private RiotParsers() {}
     
     /** Create a parser 
      * Use {@link RDFDataMgr#createReader(Lang)}
@@ -93,93 +94,53 @@ public class RiotParsers {
         return createParserNQuads(input, dest) ;
     }
 
-    /*package*/ static LangTurtle createParserTurtle(InputStream input, String baseIRI, StreamRDF dest) {
-        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input) ;
-        return createParserTurtle(tokenizer, baseIRI, dest) ;
-    }
-
-    /*package*/ static LangTurtle createParserTurtle(Tokenizer tokenizer, String baseIRI, StreamRDF dest) {
-        ParserProfile profile = RiotLib.profile(RDFLanguages.TURTLE, baseIRI) ;
-        LangTurtle parser = new LangTurtle(tokenizer, profile, dest) ;
-        return parser ;
-    }
-
-    /*package*/ static LangRDFXML createParserRDFXML(InputStream input, String baseIRI, StreamRDF dest) {
+    private static LangRDFXML createParserRDFXML(InputStream input, String baseIRI, StreamRDF dest) {
         baseIRI = baseURI_RDFXML(baseIRI) ;
         LangRDFXML parser = LangRDFXML.create(input, baseIRI, baseIRI, ErrorHandlerFactory.getDefaultErrorHandler(), dest) ;
         return parser ;
     }
 
-    /*package*/ static LangRDFXML createParserRDFXML(Reader input, String baseIRI, StreamRDF dest) {
+    private static LangRDFXML createParserRDFXML(Reader input, String baseIRI, StreamRDF dest) {
         baseIRI = baseURI_RDFXML(baseIRI) ;
         LangRDFXML parser = LangRDFXML.create(input, baseIRI, baseIRI, ErrorHandlerFactory.getDefaultErrorHandler(), dest) ;
         return parser ;
     }
-    
-    /** Sort out the base URI for RDF/XML parsing. */
-    private static String baseURI_RDFXML(String baseIRI) {
-        // LangRIOT derived from LangEngine do this in ParserProfile 
-        if ( baseIRI == null )
-            return SysRIOT.chooseBaseIRI() ;
-        else
-            // This normalizes the URI.
-            return SysRIOT.chooseBaseIRI(baseIRI) ;
-    }
 
-    /*package*/ static LangRDFJSON createParserRdfJson(Tokenizer tokenizer, StreamRDF dest) {
-        ParserProfile profile = RiotLib.profile(RDFLanguages.RDFJSON, null);
-        LangRDFJSON parser = new LangRDFJSON(tokenizer, profile, dest) ;
-    	return parser;
-    }
+//    /*package*/ static LangTurtle createParserTurtle(InputStream input, String baseIRI, StreamRDF dest) {
+//        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input) ;
+//        return createParserTurtle(tokenizer, baseIRI, dest) ;
+//    }
 
-    /*package*/ static LangRDFJSON createParserRdfJson(InputStream input, StreamRDF dest) {
-        TokenizerJSON tokenizer = new TokenizerJSON(PeekReader.makeUTF8(input)) ;
-        return createParserRdfJson(tokenizer, dest) ;
-    }
-
-    /*package*/ static LangTriG createParserTriG(InputStream input, String baseIRI, StreamRDF dest) {
-        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input) ;
-        return createParserTriG(tokenizer, baseIRI, dest) ;
-    }
-
-    /*package*/ static LangTriG createParserTriG(Tokenizer tokenizer, String baseIRI, StreamRDF dest) {
-        ParserProfile profile = RiotLib.profile(RDFLanguages.TRIG, baseIRI);
-        LangTriG parser = new LangTriG(tokenizer, profile, dest) ;
-        return parser ;
-    }
-
-    /*package*/ static LangNTriples createParserNTriples(InputStream input, StreamRDF dest) {
+//    /*package*/ static LangRDFJSON createParserRdfJson(InputStream input, StreamRDF dest) {
+//        TokenizerJSON tokenizer = new TokenizerJSON(PeekReader.makeUTF8(input)) ;
+//        return createParserRdfJson(tokenizer, dest) ;
+//    }
+//
+//    /*package*/ static LangTriG createParserTriG(InputStream input, String baseIRI, StreamRDF dest) {
+//        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input) ;
+//        return createParserTriG(tokenizer, baseIRI, dest) ;
+//    }
+//
+    private static LangNTriples createParserNTriples(InputStream input, StreamRDF dest) {
         return createParserNTriples(input, CharSpace.UTF8, dest);
     }
 
-    /*package*/ static  LangNTriples createParserNTriples(InputStream input, CharSpace charSpace, StreamRDF dest) {
+    private static  LangNTriples createParserNTriples(InputStream input, CharSpace charSpace, StreamRDF dest) {
         Tokenizer tokenizer = charSpace == CharSpace.ASCII
             ? TokenizerFactory.makeTokenizerASCII(input) : TokenizerFactory.makeTokenizerUTF8(input);
         return createParserNTriples(tokenizer, dest) ;
     }
 
-    /*package*/ static LangNTriples createParserNTriples(Tokenizer tokenizer, StreamRDF dest) {
-        ParserProfile profile = RiotLib.profile(RDFLanguages.NTRIPLES, null) ;
-        LangNTriples parser = new LangNTriples(tokenizer, profile, dest) ;
-        return parser ;
-    }
-
-    /*package*/ static LangNQuads createParserNQuads(InputStream input, StreamRDF dest) {
+    private static LangNQuads createParserNQuads(InputStream input, StreamRDF dest) {
         return createParserNQuads(input, CharSpace.UTF8, dest) ;
     }
 
-    /*package*/ static LangNQuads createParserNQuads(InputStream input, CharSpace charSpace, StreamRDF dest) {
+    private static LangNQuads createParserNQuads(InputStream input, CharSpace charSpace, StreamRDF dest) {
         Tokenizer tokenizer = charSpace == CharSpace.ASCII ? TokenizerFactory.makeTokenizerASCII(input) : TokenizerFactory.makeTokenizerUTF8(input) ;
         return createParserNQuads(tokenizer, dest) ;
     }
 
-    /*package*/ static LangNQuads createParserNQuads(Tokenizer tokenizer, StreamRDF dest) {
-        ParserProfile profile = RiotLib.profile(RDFLanguages.NQUADS, null) ;
-        LangNQuads parser = new LangNQuads(tokenizer, profile, dest) ;
-        return parser ;
-    }
-
-    /*package*/ static LangRIOT createParser(Tokenizer tokenizer, Lang lang, String baseIRI, StreamRDF dest) {
+    private static LangRIOT createParser(Tokenizer tokenizer, Lang lang, String baseIRI, StreamRDF dest) {
         if ( RDFLanguages.sameLang(RDFXML, lang) )
             throw new RiotException("Not possible - can't parse RDF/XML from a RIOT token stream") ;
         if ( RDFLanguages.sameLang(TURTLE, lang) || RDFLanguages.sameLang(N3,  lang) ) 
@@ -195,6 +156,46 @@ public class RiotParsers {
         if ( RDFLanguages.sameLang(TRIG, lang) )
             return createParserTriG(tokenizer, baseIRI, dest) ;
         return null ;
+    }
+
+    /*package*/ static LangNTriples createParserNTriples(Tokenizer tokenizer, StreamRDF dest) {
+        /* XXX */ ParserProfile profile = RiotLib.profile(RDFLanguages.NTRIPLES, null) ;
+        LangNTriples parser = new LangNTriples(tokenizer, profile, dest) ;
+        return parser ;
+    }
+
+    /*package*/ static LangNQuads createParserNQuads(Tokenizer tokenizer, StreamRDF dest) {
+        /* XXX */ ParserProfile profile = RiotLib.profile(RDFLanguages.NQUADS, null) ;
+        LangNQuads parser = new LangNQuads(tokenizer, profile, dest) ;
+        return parser ;
+    }
+
+    /*package*/ static LangTurtle createParserTurtle(Tokenizer tokenizer, String baseIRI, StreamRDF dest) {
+        /* XXX */ ParserProfile profile = RiotLib.profile(RDFLanguages.TURTLE, baseIRI) ;
+        LangTurtle parser = new LangTurtle(tokenizer, profile, dest) ;
+        return parser ;
+    }
+
+    /*package*/ static LangTriG createParserTriG(Tokenizer tokenizer, String baseIRI, StreamRDF dest) {
+        /* XXX */ ParserProfile profile = RiotLib.profile(RDFLanguages.TRIG, baseIRI);
+        LangTriG parser = new LangTriG(tokenizer, profile, dest) ;
+        return parser ;
+    }
+
+    /*package*/ static LangRDFJSON createParserRdfJson(Tokenizer tokenizer, StreamRDF dest) {
+        /* XXX */ ParserProfile profile = RiotLib.profile(RDFLanguages.RDFJSON, null);
+        LangRDFJSON parser = new LangRDFJSON(tokenizer, profile, dest) ;
+    	return parser;
+    }
+
+    /** Sort out the base URI for RDF/XML parsing. */
+    private static String baseURI_RDFXML(String baseIRI) {
+        // LangRIOT derived from LangEngine do this in ParserProfile 
+        if ( baseIRI == null )
+            return SysRIOT.chooseBaseIRI() ;
+        else
+            // This normalizes the URI.
+            return SysRIOT.chooseBaseIRI(baseIRI) ;
     }
 }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/process/StreamRDFApplyObject.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/process/StreamRDFApplyObject.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.process;
+
+import java.util.function.Function;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.riot.system.StreamRDFWrapper;
+import org.apache.jena.sparql.core.Quad;
+
+public class StreamRDFApplyObject extends StreamRDFWrapper {
+    private final Function<Node, Node> function;
+
+    public StreamRDFApplyObject(StreamRDF other, Function<Node, Node> function) {
+        super(other);
+        this.function = function;
+    }
+    
+    @Override
+    public void triple(Triple triple) {
+        Node obj = triple.getObject();
+        Node obj2 = function.apply(obj);
+        if ( obj != obj2 ) {
+            triple = Triple.create(triple.getSubject(), triple.getPredicate(), obj2);
+        }
+        super.triple(triple);
+    }
+
+    @Override
+    public void quad(Quad quad) {
+        Node obj = quad.getObject();
+        Node obj2 = function.apply(obj);
+        if ( obj != obj2 ) {
+            quad = Quad.create(quad.getGraph(), quad.getSubject(), quad.getPredicate(), obj2);
+        }
+        super.quad(quad);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/CanonicalizeLiteral.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/CanonicalizeLiteral.java
@@ -30,6 +30,7 @@ import org.apache.jena.riot.web.LangTag ;
 import org.apache.jena.sparql.util.NodeUtils ;
 import org.apache.jena.vocabulary.RDF ;
 
+/** Convert literals to canonical form. */   
 public class CanonicalizeLiteral implements Function<Node, Node>    
 {
     private static final CanonicalizeLiteral singleton = new CanonicalizeLiteral(); 
@@ -42,6 +43,10 @@ public class CanonicalizeLiteral implements Function<Node, Node>
     public Node apply(Node node) {
         if ( ! node.isLiteral() )
             return node ;
+
+        if ( ! node.getLiteralDatatype().isValid(node.getLiteralLexicalForm()) )
+            // Invalid lexicakl form for the datatype - do nothing.
+            return node;
             
         RDFDatatype dt = node.getLiteralDatatype() ;
         Node n2 ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/DatatypeHandler.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/DatatypeHandler.java
@@ -24,5 +24,5 @@ import org.apache.jena.graph.Node ;
 @FunctionalInterface
 interface DatatypeHandler
 {
-    Node handle(Node node, String lexicalForm, RDFDatatype datatype) ;
+    Node handle(Node node, String lexicalForm, RDFDatatype datatype);
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/NormalizeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/NormalizeValue.java
@@ -28,14 +28,13 @@ import java.util.Locale ;
 import javax.xml.datatype.XMLGregorianCalendar ;
 
 import org.apache.jena.datatypes.RDFDatatype ;
-import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.sparql.expr.NodeValue ;
 import org.apache.jena.sparql.graph.NodeConst ;
 import org.apache.jena.sparql.util.DateTimeStruct ;
 
-/** Operation to convert the given Node to a normalized form */ 
+/** Operations to convert the given Node to a normalized form */ 
 class NormalizeValue
 {
     /** Handler that makes no changes and returns the input node */ 
@@ -123,7 +122,7 @@ class NormalizeValue
             lex2 = lex2.substring(1) ;
 
         if ( lex2.length() > 8 )
-            // Maybe large than an int so do carefully.
+            // Maybe larger than an int so do carefully.
             lex2 = new BigInteger(lexicalForm).toString() ;
         else
         {
@@ -132,16 +131,18 @@ class NormalizeValue
             lex2 = Integer.toString(x) ;
         }
 
-        // If it's a subtype of integer, then output a new node of datatype integer.
-        if ( datatype.equals(XSDDatatype.XSDinteger) && lex2.equals(lexicalForm) )
+        if ( lex2.equals(lexicalForm) )
             return node ;
-        return NodeFactory.createLiteral(lex2, XSDDatatype.XSDinteger) ;
+        return NodeFactory.createLiteral(lex2, datatype) ;
     } ;
 
     static DatatypeHandler dtDecimal = (Node node, String lexicalForm, RDFDatatype datatype) -> {
         BigDecimal bd = new BigDecimal(lexicalForm).stripTrailingZeros() ;
         String lex2 = bd.toPlainString() ;
 
+        // XSD canonical is "1"
+        // but in Turtle the ".0" is need for short print form.
+        
         // Ensure there is a "."
         //if ( bd.scale() <= 0 )
         if ( lex2.indexOf('.') == -1 )

--- a/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/StreamCanonicalLiterals.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/StreamCanonicalLiterals.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.process.normalize;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.RDFParserBuilder;
+import org.apache.jena.riot.process.StreamRDFApplyObject;
+import org.apache.jena.riot.process.normalize.CanonicalizeLiteral;
+import org.apache.jena.riot.system.StreamRDF;
+
+/** Canoncialize literals (in the object position).
+ * Canoncialize literals use the same RDF term (same lexcial form) for a given value.
+ * So {@code "+01"^^xsd:integer} is converted to {@code "1"^^xsd:integer}.
+ * Language tags are canonicalized for case as well. 
+ * 
+ * See {@link RDFParserBuilder#canonicalLiterals(boolean)} for details.
+ */
+public class StreamCanonicalLiterals extends StreamRDFApplyObject {
+    public StreamCanonicalLiterals(StreamRDF other) {
+        super(other, StreamCanonicalLiterals::canonical);
+    }
+
+    private static Node canonical(Node n) {
+        if ( ! n.isLiteral() )
+            return n;
+        // Lang tag - done in CanonicalizeLiteral anyway.
+//        if ( Util.isLangString(n) ) {
+//            String lang = n.getLiteralLanguage();
+//            String lang2 = LangTag.canonical(lang);
+//            if ( lang == lang2 )
+//                return n ;
+//            return NodeFactory.createLiteral(n.getLiteralLexicalForm(), lang2);
+//        }
+        // Include LangTag (but check).
+        Node obj2 = CanonicalizeLiteral.get().apply(n);
+        return obj2;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/MakerRDFStd.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/MakerRDFStd.java
@@ -99,11 +99,6 @@ public class MakerRDFStd implements MakerRDF /*To be removed*/, ParserProfile/* 
 //        return factory;
 //    }
 
-    @Override
-    public void setFactoryRDF(FactoryRDF factory) {
-        this.factory = factory;
-    }
-
     // XXX ??? @Override
     public Context getContext() {
         return context;
@@ -117,11 +112,6 @@ public class MakerRDFStd implements MakerRDF /*To be removed*/, ParserProfile/* 
     @Override
     public boolean isStrictMode() {
         return strictMode;
-    }
-
-    @Override
-    public void setStrictMode(boolean mode) {
-        this.strictMode = mode;
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
@@ -61,8 +61,8 @@ public interface ParserProfile extends MakerRDF
     public void setPrologue(Prologue prologue) ;
     
     //public FactoryRDF getFactoryRDF() ;
-    public void setFactoryRDF(FactoryRDF factory) ;
+    //public void setFactoryRDF(FactoryRDF factory) ;
     
     public boolean isStrictMode() ;
-    public void setStrictMode(boolean mode) ;
+//    public void setStrictMode(boolean mode) ;
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileBase.java
@@ -77,11 +77,6 @@ public class ParserProfileBase implements ParserProfile {
     }
 
     @Override
-    public void setFactoryRDF(FactoryRDF factory) {
-        this.factory = factory;
-    }
-   
-    @Override
     public String resolveIRI(String uriStr, long line, long col) {
         return prologue.getResolver().resolveToString(uriStr) ;
     }
@@ -221,10 +216,4 @@ public class ParserProfileBase implements ParserProfile {
     public boolean isStrictMode() {
         return strictMode ;
     }
-
-    @Override
-    public void setStrictMode(boolean mode) {
-        strictMode = mode ;
-    }
-
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
@@ -108,9 +108,9 @@ public class RiotLib
         return fixupPrefixes.apply(prefixedName) ;
     }
     
-    private static ParserProfile profile = profile(RDFLanguages.TURTLE, null, ErrorHandlerFactory.errorHandlerStd) ;
-    static {
-        PrefixMap pmap = profile.getPrologue().getPrefixMap() ;
+    /** Internal MakerRDF used to create nodes from strings. */ 
+    private static MakerRDF setupInternalMakerRDF() {
+        PrefixMap pmap = PrefixMapFactory.createForInput();
         pmap.add("rdf",  ARQConstants.rdfPrefix) ;
         pmap.add("rdfs", ARQConstants.rdfsPrefix) ;
         pmap.add("xsd",  ARQConstants.xsdPrefix) ;
@@ -119,16 +119,25 @@ public class RiotLib
         pmap.add("op" ,  ARQConstants.fnPrefix) ; 
         pmap.add("ex" ,  "http://example/ns#") ;
         pmap.add("" ,    "http://example/") ;
+        
+        return new MakerRDFStd(RiotLib.factoryRDF(), 
+                               ErrorHandlerFactory.errorHandlerStd,
+                               IRIResolver.create(),
+                               pmap,
+                               RIOT.getContext().copy(),
+                               true, false) ;
     }
     
-    /** Parse a string to get one Node (the first token in the string) */ 
+    private static MakerRDF maker = setupInternalMakerRDF();
+    
+    /** Parse a string to get one Node (the first token in the string) */
     public static Node parse(String string)
     {
         Tokenizer tokenizer = TokenizerFactory.makeTokenizerString(string) ;
         if ( ! tokenizer.hasNext() )
             return null ;
         Token t = tokenizer.next();
-        Node n = profile.create(null, t) ;
+        Node n = maker.create(null, t) ;
         if ( tokenizer.hasNext() )
             Log.warn(RiotLib.class, "String has more than one token in it: "+string) ;
         return n ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
@@ -159,7 +159,9 @@ public class RiotLib
      * @param handler       Error handler
      * @return ParserProfile
      * @see #profile for per-language setup
+     * @deprecated To be removed.
      */
+    @Deprecated
     public static ParserProfile profile(String baseIRI, boolean resolveIRIs, boolean checking, ErrorHandler handler)
     {
         LabelToNode labelToNode = true

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
@@ -31,10 +31,6 @@ import java.nio.file.Paths;
 
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
-import org.apache.jena.riot.RiotException;
-import org.apache.jena.riot.RiotNotFoundException;
 import org.apache.jena.riot.lang.LabelToNode;
 import org.apache.jena.riot.system.ErrorHandlerFactory;
 import org.apache.jena.riot.system.FactoryRDFStd;
@@ -56,33 +52,33 @@ public class TestRDFParser {
     @Test public void source_not_uri_02() {
         Graph graph = GraphFactory.createGraphMem();
         InputStream input = new ByteArrayInputStream(testdata.getBytes(StandardCharsets.UTF_8));
-        RDFParserBuilder.create().lang(Lang.TTL).source(input).parse(graph);
+        RDFParser.create().lang(Lang.TTL).source(input).parse(graph);
         assertEquals(1, graph.size());
     }
     
     @Test public void source_uri_01() {
         Graph graph = GraphFactory.createGraphMem();
-        RDFParserBuilder.create().source("file:"+DIR+"data.ttl").parse(graph);
+        RDFParser.create().source("file:"+DIR+"data.ttl").parse(graph);
         assertEquals(3, graph.size());
     }
 
     @Test(expected=RiotException.class)
     public void source_uri_02() {
         Graph graph = GraphFactory.createGraphMem();
-        RDFParserBuilder.create().source("file:"+DIR+"data.unknown").parse(graph);
+        RDFParser.create().source("file:"+DIR+"data.unknown").parse(graph);
     }
 
     @Test
     public void source_uri_03() {
         Graph graph = GraphFactory.createGraphMem();
-        RDFParserBuilder.create().source("file:"+DIR+"data.unknown").lang(Lang.TTL).parse(graph);
+        RDFParser.create().source("file:"+DIR+"data.unknown").lang(Lang.TTL).parse(graph);
         assertEquals(3, graph.size());
     }
 
     @Test
     public void source_uri_04() {
         Graph graph = GraphFactory.createGraphMem();
-        RDFParserBuilder.create()
+        RDFParser.create()
             .source(Paths.get(DIR+"data.ttl"))
             .parse(graph);
         assertEquals(3, graph.size());
@@ -92,18 +88,25 @@ public class TestRDFParser {
     public void source_uri_05() {
         // Last source wins.
         Graph graph = GraphFactory.createGraphMem();
-        RDFParserBuilder.create()
+        RDFParser.create()
             .source("http://example/")
             .source(DIR+"data.ttl")
             .parse(graph);
         assertEquals(3, graph.size());
     }
 
+    // Shortcut source
+    @Test public void source_shortcut_01() {
+        Graph graph = GraphFactory.createGraphMem();
+        RDFParser.source(new StringReader(testdata)).lang(Lang.TTL).parse(graph);
+        assertEquals(1, graph.size());
+    }
+    
     @Test(expected=RiotNotFoundException.class)
     public void source_notfound_1() {
         // Last source wins.
         Graph graph = GraphFactory.createGraphMem();
-        RDFParserBuilder.create()
+        RDFParser.create()
             .source(Paths.get(DIR+"data.nosuchfile.ttl"))
             .parse(graph);
         assertEquals(3, graph.size());
@@ -113,7 +116,7 @@ public class TestRDFParser {
     public void source_notfound_2() {
         // Last source wins.
         Graph graph = GraphFactory.createGraphMem();
-        RDFParserBuilder.create()
+        RDFParser.create()
             .source(DIR+"data.nosuchfile.ttl")
             .parse(graph);
         assertEquals(3, graph.size());
@@ -122,7 +125,7 @@ public class TestRDFParser {
     @Test(expected=RiotException.class)
     public void source_uri_hint_lang() {
         Graph graph = GraphFactory.createGraphMem();
-        RDFParserBuilder.create().source("file:data.rdf")
+        RDFParser.create().source("file:data.rdf")
             .lang(Lang.RDFXML)
             .errorHandler(ErrorHandlerFactory.errorHandlerNoLogging)
             .parse(graph);
@@ -133,7 +136,7 @@ public class TestRDFParser {
     public void errorHandler() {
         Graph graph = GraphFactory.createGraphMem();
         // This test file contains Turtle. 
-        RDFParserBuilder.create().source(DIR+"data.rdf")
+        RDFParser.create().source(DIR+"data.rdf")
             // and no test log output.  
             .errorHandler(ErrorHandlerFactory.errorHandlerNoLogging)
             .parse(graph);
@@ -142,7 +145,7 @@ public class TestRDFParser {
     @Test
     public void source_uri_force_lang() {
         Graph graph = GraphFactory.createGraphMem();
-        RDFParserBuilder.create().source("file:"+DIR+"data.rdf").forceLang(Lang.TTL).parse(graph);
+        RDFParser.create().source("file:"+DIR+"data.rdf").forceLang(Lang.TTL).parse(graph);
         assertEquals(3, graph.size());
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangNTuples.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangNTuples.java
@@ -46,162 +46,161 @@ abstract public class TestLangNTuples extends BaseTest
 {
     // Test streaming interface.
 
-    private static ErrorHandler errorhandler = null ;
-    @BeforeClass public static void beforeClass()
-    { 
-        errorhandler = getDefaultErrorHandler() ;
-        setDefaultErrorHandler(errorHandlerNoLogging) ;
+    private static ErrorHandler errorhandler = null;
+
+    @BeforeClass
+    public static void beforeClass() {
+        errorhandler = getDefaultErrorHandler();
+        setDefaultErrorHandler(errorHandlerNoLogging);
     }
 
-    @AfterClass public static void afterClass()
-    { 
-        setDefaultErrorHandler(errorhandler) ;
-    }
-    
-    @Test public void tuple_0()
-    {
-        long count = parseCount("") ;
-        assertEquals(0, count) ;
-    }
-    
-    @Test public void tuple_1()
-    {
-        long count = parseCount("<x> <y> <z>.") ;
-        assertEquals(1, count) ;
-    }
-    
-    @Test public void tuple_2()
-    {
-        long count = parseCount("<x> <y> \"z\".") ;
-        assertEquals(1, count) ;
-    }
-    
-    @Test public void tuple_3()
-    {
-        long count = parseCount("<x> <y> <z>. <x> <y> <z>.") ;
-        assertEquals(2, count) ;
+    @AfterClass
+    public static void afterClass() {
+        setDefaultErrorHandler(errorhandler);
     }
 
-    @Test public void tuple_4()
-    {
-        long count = parseCount("<x> <y> \"123\"^^<int>.") ;
-        assertEquals(1, count) ;
+    @Test
+    public void tuple_0() {
+        long count = parseCount("");
+        assertEquals(0, count);
     }
 
-    @Test public void tuple_5()
-    {
-        long count = parseCount("<x> <y> \"123\"@lang.") ;
-        assertEquals(1,count) ;
+    @Test
+    public void tuple_1() {
+        long count = parseCount("<x> <y> <z>.");
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void tuple_2() {
+        long count = parseCount("<x> <y> \"z\".");
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void tuple_3() {
+        long count = parseCount("<x> <y> <z>. <x> <y> <z>.");
+        assertEquals(2, count);
+    }
+
+    @Test
+    public void tuple_4() {
+        long count = parseCount("<x> <y> \"123\"^^<int>.");
+        assertEquals(1, count);
+    }
+
+    @Test
+    public void tuple_5() {
+        long count = parseCount("<x> <y> \"123\"@lang.");
+        assertEquals(1, count);
     }
     
-    // Test iterator interface.
-
     // Test parse errors interface.
-    @Test(expected=ExFatal.class)
-    public void tuple_bad_01()
-    {
-        parseCount("<x> <y> <z>") ;          // No DOT
+    @Test(expected = ExFatal.class)
+    public void tuple_bad_01() {
+        parseCount("<x> <y> <z>");          // No DOT
     }
     
-    @Test(expected=ExFatal.class)
-    public void tuple_bad_02()
-    {
-        parseCount("<x> _:a <z> .") ;        // Bad predicate
+    @Test(expected = ExFatal.class)
+    public void tuple_bad_02() {
+        parseCount("<x> _:a <z> .");        // Bad predicate
     }
 
-    @Test(expected=ExFatal.class)
-    public void tuple_bad_03()
-    {
-        parseCount("<x> \"p\" <z> .") ;      // Bad predicate 
+    @Test(expected = ExFatal.class)
+    public void tuple_bad_03() {
+        parseCount("<x> \"p\" <z> .");      // Bad predicate
     }
 
-    @Test(expected=ExFatal.class)
-    public void tuple_bad_4()
-    {
-        parseCount("\"x\" <p> <z> .") ;      // Bad subject
+    @Test(expected = ExFatal.class)
+    public void tuple_bad_4() {
+        parseCount("\"x\" <p> <z> .");      // Bad subject
     }
 
-    @Test(expected=ExFatal.class)
-    public void tuple_bad_5()
-    {
-        parseCount("<x> <p> ?var .") ;        // No variables 
+    @Test(expected = ExFatal.class)
+    public void tuple_bad_5() {
+        parseCount("<x> <p> ?var .");        // No variables
+    }
+
+    @Test(expected = ExFatal.class)
+    public void tuple_bad_6() {
+        parseCount("<x> <p> 123 .");        // No abbreviations.
     }
     
-    @Test(expected=ExFatal.class)
-    public void tuple_bad_6()
-    {
-        parseCount("<x> <p> 123 .") ;        // No abbreviations. 
+    @Test(expected = ExFatal.class)
+    public void tuple_bad_7() {
+        parseCount("<x> <p> x:y .");        // No prefixed names
     }
-    
-    @Test(expected=ExFatal.class)
-    public void tuple_bad_7()
-    {
-        parseCount("<x> <p> x:y .") ;        // No prefixed names 
-    }
-    
+
     // Bad terms - but accepted by default.
-    @Test(expected=ExFatal.class)
-    public void tuple_bad_10()       { parseCount("<x> <p> <bad uri> .") ; } 
+    @Test(expected = ExFatal.class)
+    public void tuple_bad_10() {
+        parseCount("<x> <p> <bad uri> .");
+    }
 
-    // Bad terms (value range) - but legal syntax 
-    @Test 
-    public void tuple_bad_11()       { parseCount("<x> <p> \"9000\"^^<http://www.w3.org/2001/XMLSchema#byte> .") ; } 
+    // Bad terms (value range) - but legal syntax
+    @Test
+    public void tuple_bad_11() {
+        parseCount("<x> <p> \"9000\"^^<http://www.w3.org/2001/XMLSchema#byte> .");
+    }
 
     // Bad - relative URI.
-    @Test(expected=ExError.class)
-    public void tuple_bad_21()       { parseCheck("<x> <p> <z> .") ; } 
+    @Test(expected = ExError.class)
+    public void tuple_bad_21() {
+        parseCheck("<x> <p> <z> .");
+    }
 
     // Bad terms
-    @Test(expected=ExFatal.class)
-    public void tuple_bad_22()       { parseCheck("<http://example/x> <http://example/p> \"abc\"^^<http://example/bad uri> .") ; } 
+    @Test(expected = ExFatal.class)
+    public void tuple_bad_22() {
+        parseCheck("<http://example/x> <http://example/p> \"abc\"^^<http://example/bad uri> .");
+    }
 
-    @Test(expected=ExWarning.class)
-    public void tuple_bad_23()       { parseCheck("<http://example/x> <http://example/p> \"9000\"^^<http://www.w3.org/2001/XMLSchema#byte> .") ; } 
-    
+    @Test(expected = ExWarning.class)
+    public void tuple_bad_23() {
+        parseCheck("<http://example/x> <http://example/p> \"9000\"^^<http://www.w3.org/2001/XMLSchema#byte> .");
+    }
+
     // ASCII vs UTF-8
     @Test
-    public void tuple_charset_1()
-    {
+    public void tuple_charset_1() {
         // E9 is e-acute
-        parseCheck("<http://example/x\\u00E9> <http://example/p> <http://example/s> .") ; 
+        parseCheck("<http://example/x\\u00E9> <http://example/p> <http://example/s> .");
     }
     
     @Test
-    public void tuple_charset_2()
-    {
-        parseCheck("<http://example/é> <http://example/p> \"é\" .") ; 
-    }
-    
-    static protected Tokenizer tokenizer(CharSpace charSpace, String string)
-    {
-        byte b[] = StrUtils.asUTF8bytes(string) ;
-        ByteArrayInputStream in = new ByteArrayInputStream(b) ;
-        Tokenizer tokenizer = charSpace == CharSpace.ASCII ? TokenizerFactory.makeTokenizerASCII(in) : TokenizerFactory.makeTokenizerUTF8(in) ;
-        return tokenizer ;
-    }
-    
-    static protected Tokenizer tokenizer(String string)
-    {
-        // UTF-8
-        byte b[] = StrUtils.asUTF8bytes(string) ;
-        ByteArrayInputStream in = new ByteArrayInputStream(b) ;
-        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(in) ;
-        return tokenizer ;
+    public void tuple_charset_2() {
+        parseCheck("<http://example/é> <http://example/p> \"é\" .");
     }
 
-    final protected void parseCheck(String... strings)
-    {
-        String string = String.join("\n", strings) ;
-        Tokenizer tokenizer = tokenizer(string) ;
-        StreamRDFCounting sink = StreamRDFLib.count() ;
-        LangRIOT x = RiotParsers.createParserNQuads(tokenizer, sink) ;
-        x.setProfile(RiotLib.profile(null, false, true, new ErrorHandlerEx())) ;
-        x.parse() ;
+    static protected Tokenizer tokenizer(CharSpace charSpace, String string) {
+        byte b[] = StrUtils.asUTF8bytes(string);
+        ByteArrayInputStream in = new ByteArrayInputStream(b);
+        Tokenizer tokenizer = charSpace == CharSpace.ASCII
+            ? TokenizerFactory.makeTokenizerASCII(in) : TokenizerFactory.makeTokenizerUTF8(in);
+        return tokenizer;
     }
-    
-    protected abstract Lang getLang() ;
-    
+
+    static protected Tokenizer tokenizer(String string) {
+        // UTF-8
+        byte b[] = StrUtils.asUTF8bytes(string);
+        ByteArrayInputStream in = new ByteArrayInputStream(b);
+        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(in);
+        return tokenizer;
+    }
+
+    @SuppressWarnings("deprecation")
+    final protected void parseCheck(String... strings) {
+        String string = String.join("\n", strings);
+        Tokenizer tokenizer = tokenizer(string);
+        StreamRDFCounting sink = StreamRDFLib.count();
+        LangRIOT x = RiotParsers.createParserNQuads(tokenizer, sink);
+        x.setProfile(RiotLib.profile(null, false, true, new ErrorHandlerEx()));
+        x.parse();
+    }
+
+    protected abstract Lang getLang();
+
     protected long parseCount(String... strings) {
-        return ParserTestBaseLib.parseCount(getLang(), strings) ;
+        return ParserTestBaseLib.parseCount(getLang(), strings);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestTriXReader.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestTriXReader.java
@@ -26,10 +26,7 @@ import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.riot.ReaderRIOT ;
-import org.apache.jena.riot.system.ErrorHandler ;
-import org.apache.jena.riot.system.ErrorHandlerFactory ;
-import org.apache.jena.riot.system.StreamRDF ;
-import org.apache.jena.riot.system.StreamRDFLib ;
+import org.apache.jena.riot.system.*;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.DatasetGraphFactory ;
 import org.apache.jena.sparql.util.IsoMatcher ;
@@ -80,7 +77,7 @@ public class TestTriXReader extends BaseTest {
     
     @Test
     public void trix_direct() {
-        ReaderRIOT r = new ReaderTriX() ;
+        ReaderRIOT r = new ReaderTriX(RiotLib.dftMakerRDF(), ErrorHandlerFactory.errorHandlerNoWarnings);
         InputStream in = IO.openFile(fInput) ;
         DatasetGraph dsg = DatasetGraphFactory.create() ;
         //StreamRDF stream = StreamRDFLib.writer(System.out) ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/process/TestNormalization.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/process/TestNormalization.java
@@ -18,13 +18,13 @@
 
 package org.apache.jena.riot.process;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.*;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.riot.process.normalize.CanonicalizeLiteral ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.junit.Test ;
 
-public class TestNormalization extends BaseTest
+public class TestNormalization
 {
     @Test public void normalize_int_01()        { normalize("23", "23") ; }
     @Test public void normalize_int_02()        { normalize("023", "23") ; }
@@ -39,12 +39,12 @@ public class TestNormalization extends BaseTest
     @Test public void normalize_int_11()        { normalize("-000", "0") ; }
     
     // Subtypes of integer
-    @Test public void normalize_int_20()        { normalize("'-000'^^xsd:int", "0") ; }
-    @Test public void normalize_int_21()        { normalize("'0'^^xsd:int", "0") ; }
-    @Test public void normalize_int_22()        { normalize("'1'^^xsd:long", "1") ; }
-    @Test public void normalize_int_23()        { normalize("'100'^^xsd:unsignedInt", "100") ; }
-    @Test public void normalize_int_24()        { normalize("'-100'^^xsd:nonPositiveInteger", "-100") ; }
-    @Test public void normalize_int_25()        { normalize("'+100'^^xsd:positiveInteger", "100") ; }
+    @Test public void normalize_int_20()        { normalize("'-000'^^xsd:int", "'0'^^xsd:int") ; }
+    @Test public void normalize_int_21()        { normalize("'0'^^xsd:int", "'0'^^xsd:int") ; }
+    @Test public void normalize_int_22()        { normalize("'1'^^xsd:long", "'1'^^xsd:long") ; }
+    @Test public void normalize_int_23()        { normalize("'0100'^^xsd:unsignedInt", "'100'^^xsd:unsignedInt") ; }
+    @Test public void normalize_int_24()        { normalize("'-100'^^xsd:nonPositiveInteger", "'-100'^^xsd:nonPositiveInteger") ; }
+    @Test public void normalize_int_25()        { normalize("'+100'^^xsd:positiveInteger", "'100'^^xsd:positiveInteger") ; }
     
     @Test public void normalize_decimal_01()    { normalize("0.0", "0.0") ; }
     @Test public void normalize_decimal_02()    { normalize("'0'^^xsd:decimal", "0.0") ; }
@@ -98,42 +98,34 @@ public class TestNormalization extends BaseTest
     @Test public void normalize_lang_05()       { normalizeLang("'abc'@EN", "'abc'@EN", false) ; }
     @Test public void normalize_lang_06()       { normalizeLang("'abc'@EN-UK", "'abc'@en-uk", false) ; }
 
-    private static void normalize(String input, String expected)
-    {
-        Node n1 = NodeFactoryExtra.parseNode(input) ;
+    private static void normalize(String input, String expected) {
+        Node n1 = NodeFactoryExtra.parseNode(input);
         assertTrue("Invalid lexical form", n1.getLiteralDatatype().isValid(n1.getLiteralLexicalForm()));
-        
-        Node n2 = CanonicalizeLiteral.get().apply(n1) ;
-        Node n3 = NodeFactoryExtra.parseNode(expected) ;
-        assertEquals("Invalid canonicalization (lex)", n3.getLiteralLexicalForm(), n2.getLiteralLexicalForm()) ;
-        assertEquals("Invalid canonicalization (node)", n3, n2) ;
+
+        Node n2 = CanonicalizeLiteral.get().apply(n1);
+        Node n3 = NodeFactoryExtra.parseNode(expected);
+        assertEquals("Different datatype", n3.getLiteralDatatype(), n2.getLiteralDatatype());
+        assertEquals("Invalid canonicalization (lex)", n3.getLiteralLexicalForm(), n2.getLiteralLexicalForm());
+        assertEquals("Invalid canonicalization (node)", n3, n2);
     }
 
     private static void normalizeLang(String input, String expected)
     { normalizeLang(input, expected, true) ; }
     
-    private static void normalizeLang(String input, String expected, boolean correct)
-    {
-        Node n1 = NodeFactoryExtra.parseNode(input) ;
-        Node n2 = CanonicalizeLiteral.get().apply(n1) ;
-        Node n3 = NodeFactoryExtra.parseNode(expected) ;
-        if ( correct )
-        {
-            assertEquals("Invalid canonicalization (lang)", n3.getLiteralLanguage(), n2.getLiteralLanguage()) ;
-            assertEquals("Invalid canonicalization (node)", n3, n2) ;
-        }
-        else
-        {
-            assertNotEquals("Invalid canonicalization (lang)", n3.getLiteralLanguage(), n2.getLiteralLanguage()) ;
-            assertNotEquals("Invalid canonicalization (node)", n3, n2) ;
+    private static void normalizeLang(String input, String expected, boolean correct) {
+        Node n1 = NodeFactoryExtra.parseNode(input);
+        Node n2 = CanonicalizeLiteral.get().apply(n1);
+        Node n3 = NodeFactoryExtra.parseNode(expected);
+        if ( correct ) {
+            assertEquals("Invalid canonicalization (lang)", n3.getLiteralLanguage(), n2.getLiteralLanguage());
+            assertEquals("Invalid canonicalization (node)", n3, n2);
+        } else {
+            assertNotEquals("Invalid canonicalization (lang)", n3.getLiteralLanguage(), n2.getLiteralLanguage());
+            assertNotEquals("Invalid canonicalization (node)", n3, n2);
         }
     }
     
-
-    private static void normalizeDT(String input, String expected)
-    {
-        normalize("'"+input+"'^^xsd:dateTime",
-                  "'"+expected+"'^^xsd:dateTime") ;
+    private static void normalizeDT(String input, String expected) {
+        normalize("'" + input + "'^^xsd:dateTime", "'" + expected + "'^^xsd:dateTime");
     }
-
 }

--- a/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
+++ b/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
@@ -228,11 +228,11 @@ public abstract class CmdLangParse extends CmdGeneral
         
         baseURI = SysRIOT.chooseBaseIRI(baseURI, filename) ;
         
+        RDFParserBuilder builder = RDFParser.create();
         boolean checking = true ;
         if ( modLangParse.explicitChecking() )  checking = true ;
         if ( modLangParse.explicitNoChecking() ) checking = false ;
-        
-        RDFParserBuilder builder = RDFParser.create();
+        builder.checking(checking);
 
         ErrorHandler errHandler = ErrorHandlerFactory.errorHandlerWarn ;
         if ( checking ) {


### PR DESCRIPTION
This PR:

- adds the ability to put in a "canonicalise literals" step into the parsing process (more for JENA-1306).
- adds `RDFParser.source` operations to create a parser builder and set the source in one step (reduces the need to see RDFParserBuilder for common cases)
- Removes explicit ReaderRIOTFactory.create(Language) which does not fit well with `RDFParser`, leaving a default method in the interface.
