### PR TITLE
JENA-1313: compare using a Collator when both literals are tagged with same language

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -27,8 +27,10 @@ import java.io.FileInputStream ;
 import java.io.InputStream ;
 import java.math.BigDecimal ;
 import java.math.BigInteger ;
+import java.text.Collator;
 import java.util.Calendar ;
 import java.util.Iterator ;
+import java.util.Locale;
 import java.util.Properties ;
 import java.util.ServiceLoader ;
 
@@ -784,10 +786,15 @@ public abstract class NodeValue extends ExprNode
                     return x ;
                 }
 
-                // same lang tag (case insensitive)
-                x = StrUtils.strCompare(node1.getLiteralLexicalForm(), node2.getLiteralLexicalForm()) ;
+                // same lang tag, handle collation
+                // TBD: cache locales? cache collators? pre define both/any? a simple in-memory lru-map-cache?
+                Locale desiredLocale = Locale.forLanguageTag(node1.getLiteralLanguage());
+                Collator collator = Collator.getInstance(desiredLocale);
+
+                x = collator.compare(node1.getLiteralLexicalForm(), node2.getLiteralLexicalForm());
                 if ( x != Expr.CMP_EQUAL )
                     return x ;
+
                 // Same lexical forms, same lang tag by value
                 // Try to split by syntactic lang tags.
                 x = StrUtils.strCompare(node1.getLiteralLanguage(), node2.getLiteralLanguage()) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -27,10 +27,8 @@ import java.io.FileInputStream ;
 import java.io.InputStream ;
 import java.math.BigDecimal ;
 import java.math.BigInteger ;
-import java.text.Collator;
 import java.util.Calendar ;
 import java.util.Iterator ;
-import java.util.Locale;
 import java.util.Properties ;
 import java.util.ServiceLoader ;
 
@@ -774,19 +772,10 @@ public abstract class NodeValue extends ExprNode
             }
             case VSPACE_SORTKEY :
             {
-                int cmp = 0;
-                String c1 = nv1.getCollation();
-                String c2 = nv2.getCollation();
-                if (c1 != null && c2 != null && c1.equals(c2)) {
-                    // locales are parsed. Here we could think about caching if necessary
-                    Locale desiredLocale = Locale.forLanguageTag(c1);
-                    // collators are already stored in a concurrent map by the JVM, with <locale, softref<collator>>
-                    Collator collator = Collator.getInstance(desiredLocale);
-                    cmp = collator.compare(nv1.getString(), nv2.getString());
-                } else {
-                    cmp = XSDFuncOp.compareString(nv1, nv2) ;
+                if (!(nv1 instanceof NodeValueSortKey) || !(nv2 instanceof NodeValueSortKey)) {
+                    raise(new ExprNotComparableException("Can't compare (not node value sort keys) "+nv1+" and "+nv2)) ;
                 }
-                return cmp;
+                return ((NodeValueSortKey) nv1).compareTo((NodeValueSortKey) nv2);
             }
             case VSPACE_BOOLEAN:    return XSDFuncOp.compareBoolean(nv1, nv2) ;
             
@@ -978,7 +967,6 @@ public abstract class NodeValue extends ExprNode
     public boolean     getBoolean()     { raise(new ExprEvalTypeException("Not a boolean: "+this)) ; return false ; }
     public String      getString()      { raise(new ExprEvalTypeException("Not a string: "+this)) ; return null ; }
     public String      getLang()        { raise(new ExprEvalTypeException("Not a string: "+this)) ; return null ; }
-    public String      getCollation()   { raise(new ExprEvalTypeException("Not a sort key: "+this)) ; return null ; }
 
     public BigInteger  getInteger()     { raise(new ExprEvalTypeException("Not an integer: "+this)) ; return null ; }
     public BigDecimal  getDecimal()     { raise(new ExprEvalTypeException("Not a decimal: "+this)) ; return null ; }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -27,10 +27,8 @@ import java.io.FileInputStream ;
 import java.io.InputStream ;
 import java.math.BigDecimal ;
 import java.math.BigInteger ;
-import java.text.Collator;
 import java.util.Calendar ;
 import java.util.Iterator ;
-import java.util.Locale;
 import java.util.Properties ;
 import java.util.ServiceLoader ;
 
@@ -786,15 +784,10 @@ public abstract class NodeValue extends ExprNode
                     return x ;
                 }
 
-                // same lang tag, handle collation
-                // TBD: cache locales? cache collators? pre define both/any? a simple in-memory lru-map-cache?
-                Locale desiredLocale = Locale.forLanguageTag(node1.getLiteralLanguage());
-                Collator collator = Collator.getInstance(desiredLocale);
-
-                x = collator.compare(node1.getLiteralLexicalForm(), node2.getLiteralLexicalForm());
+                // same lang tag (case insensitive)
+                x = StrUtils.strCompare(node1.getLiteralLexicalForm(), node2.getLiteralLexicalForm()) ;
                 if ( x != Expr.CMP_EQUAL )
                     return x ;
-
                 // Same lexical forms, same lang tag by value
                 // Try to split by syntactic lang tags.
                 x = StrUtils.strCompare(node1.getLiteralLanguage(), node2.getLiteralLanguage()) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -27,8 +27,10 @@ import java.io.FileInputStream ;
 import java.io.InputStream ;
 import java.math.BigDecimal ;
 import java.math.BigInteger ;
+import java.text.Collator;
 import java.util.Calendar ;
 import java.util.Iterator ;
+import java.util.Locale;
 import java.util.Properties ;
 import java.util.ServiceLoader ;
 
@@ -243,8 +245,12 @@ public abstract class NodeValue extends ExprNode
     public static NodeValue makeDouble(double d)
     { return new NodeValueDouble(d) ; }
 
-    public static NodeValue makeString(String s) 
+    public static NodeValue makeString(String s)
     { return new NodeValueString(s) ; }
+
+    // instead of changing makeString, we can add another method like makeCollatedString
+    public static NodeValue makeString(String s, String collation)
+    { return new NodeValueString(s, collation) ; }
 
     public static NodeValue makeLangString(String s, String lang) 
     { return new NodeValueLang(s, lang) ; }
@@ -750,7 +756,18 @@ public abstract class NodeValue extends ExprNode
             case VSPACE_NUM:        return XSDFuncOp.compareNumeric(nv1, nv2) ;
             case VSPACE_STRING:
             {
-                int cmp = XSDFuncOp.compareString(nv1, nv2) ;
+                // Not sure if this would fit in XSDFuncOp, maybe passing a locale string or Collator object
+                // to compareString
+                int cmp = 0;
+                String c1 = nv1.getCollation();
+                String c2 = nv2.getCollation();
+                if (c1 != null && c2 != null && c1.equals(c2)) {
+                    Locale desiredLocale = Locale.forLanguageTag(c1);
+                    Collator collator = Collator.getInstance(desiredLocale);
+                    cmp = collator.compare(nv1.getString(), nv2.getString());
+                } else {
+                    cmp = XSDFuncOp.compareString(nv1, nv2) ;
+                }
                 
                 // Split plain literals and xsd:strings for sorting purposes.
                 if ( ! sortOrderingCompare )
@@ -954,7 +971,8 @@ public abstract class NodeValue extends ExprNode
     public boolean     getBoolean()     { raise(new ExprEvalTypeException("Not a boolean: "+this)) ; return false ; }
     public String      getString()      { raise(new ExprEvalTypeException("Not a string: "+this)) ; return null ; }
     public String      getLang()        { raise(new ExprEvalTypeException("Not a string: "+this)) ; return null ; }
-    
+    public String      getCollation()   { raise(new ExprEvalTypeException("Not a collation: "+this)) ; return null ; }
+
     public BigInteger  getInteger()     { raise(new ExprEvalTypeException("Not an integer: "+this)) ; return null ; }
     public BigDecimal  getDecimal()     { raise(new ExprEvalTypeException("Not a decimal: "+this)) ; return null ; }
     public float       getFloat()       { raise(new ExprEvalTypeException("Not a float: "+this)) ; return Float.NaN ; }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeFunctions.java
@@ -188,6 +188,11 @@ public class NodeFunctions {
         return NodeValue.makeString(str(nv.asNode())) ;
     }
 
+    // or instead or can create another utility method like strCollation(NodeValue, String)
+    public static NodeValue str(NodeValue nv, String collation) {
+        return NodeValue.makeString(str(nv.asNode()), collation) ;
+    }
+
     public static String str(Node node) {
         if ( node.isLiteral() )
             return node.getLiteral().getLexicalForm() ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeFunctions.java
@@ -188,11 +188,6 @@ public class NodeFunctions {
         return NodeValue.makeString(str(nv.asNode())) ;
     }
 
-    // or instead or can create another utility method like strCollation(NodeValue, String)
-    public static NodeValue str(NodeValue nv, String collation) {
-        return NodeValue.makeString(str(nv.asNode()), collation) ;
-    }
-
     public static String str(Node node) {
         if ( node.isLiteral() )
             return node.getLiteral().getLexicalForm() ;
@@ -205,6 +200,12 @@ public class NodeFunctions {
 
         NodeValue.raise(new ExprEvalException("Not a string: " + node)) ;
         return "[undef]" ;
+    }
+
+    // -------- sort key (collation)
+
+    public static NodeValue sortKey(NodeValue nv, String collation) {
+        return NodeValue.makeSortKey(str(nv.asNode()), collation) ;
     }
 
     // -------- datatype

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeValueSortKey.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeValueSortKey.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.expr.nodevalue;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.util.FmtUtils;
+
+/**
+ * A {@link NodeValue} that supports collation value for a string. This allows query values
+ * to be sorted following rules for a specific collation.
+ */
+public class NodeValueSortKey extends NodeValue {
+
+    /**
+     * Node value text.
+     */
+    private final String string;
+    /**
+     * Node value collation language tag (e.g. fi, pt-BR, en, en-CA, etc).
+     */
+    private final String collation;
+
+    public NodeValueSortKey(final String string, final String collation) {
+        this.string = string;
+        this.collation = collation;
+    }
+
+    public NodeValueSortKey(final String string, final String collation, Node n) {
+        super(n);
+        this.string = string;
+        this.collation = collation;
+    }
+
+    @Override
+    public boolean isSortKey() {
+        return Boolean.TRUE;
+    }
+
+    @Override
+    public String getString() {
+        return string;
+    }
+
+    @Override
+    public String asString() {
+        return string;
+    }
+
+    @Override
+    public String getCollation() {
+        return collation;
+    }
+
+    @Override
+    protected Node makeNode() {
+        return NodeFactory.createLiteral(string);
+    }
+
+    @Override
+    public void visit(NodeValueVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String toString()
+    { 
+        if (getNode() != null) {
+            return FmtUtils.stringForNode(getNode()) ;
+        }
+        return "'"+getString()+"'";
+    }
+
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeValueString.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeValueString.java
@@ -29,14 +29,9 @@ public class NodeValueString extends NodeValue
     // A plain string, with no language tag, or an xsd:string.
     
     private String string ; 
-    // Here we are adding a new feature to a NodeValueString. Instead, we could try to create a new type
-    // that extends NodeValue. e.g. NodeValueCollatedString, moving this property and half constructors away
-    private final String collation;
-
-    public NodeValueString(String str)         { this(str, (String) null); }
-    public NodeValueString(String str, String collation)         { string = str ; this.collation = collation; }
-    public NodeValueString(String str, Node n) { this(str, n, (String) null); }
-    public NodeValueString(String str, Node n, String collation) { super(n) ; string = str ; this.collation = collation; }
+    
+    public NodeValueString(String str)         { string = str ; } 
+    public NodeValueString(String str, Node n) { super(n) ; string = str ; }
     
     @Override
     public boolean isString() { return true ; }
@@ -46,10 +41,7 @@ public class NodeValueString extends NodeValue
 
     @Override
     public String asString() { return string ; }
-
-    @Override
-    public String getCollation() { return collation ; }
-
+    
     @Override
     public String toString()
     { 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeValueString.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeValueString.java
@@ -29,9 +29,14 @@ public class NodeValueString extends NodeValue
     // A plain string, with no language tag, or an xsd:string.
     
     private String string ; 
-    
-    public NodeValueString(String str)         { string = str ; } 
-    public NodeValueString(String str, Node n) { super(n) ; string = str ; }
+    // Here we are adding a new feature to a NodeValueString. Instead, we could try to create a new type
+    // that extends NodeValue. e.g. NodeValueCollatedString, moving this property and half constructors away
+    private final String collation;
+
+    public NodeValueString(String str)         { this(str, (String) null); }
+    public NodeValueString(String str, String collation)         { string = str ; this.collation = collation; }
+    public NodeValueString(String str, Node n) { this(str, n, (String) null); }
+    public NodeValueString(String str, Node n, String collation) { super(n) ; string = str ; this.collation = collation; }
     
     @Override
     public boolean isString() { return true ; }
@@ -41,7 +46,10 @@ public class NodeValueString extends NodeValue
 
     @Override
     public String asString() { return string ; }
-    
+
+    @Override
+    public String getCollation() { return collation ; }
+
     @Override
     public String toString()
     { 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeValueVisitor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeValueVisitor.java
@@ -30,6 +30,7 @@ public interface NodeValueVisitor
     public void visit(NodeValueNode nv) ;
     public void visit(NodeValueLang nv) ;
     public void visit(NodeValueString nv) ;
+    public void visit(NodeValueSortKey nv) ;
     public void visit(NodeValueDT nv) ;
 //    public void visit(NodeValueTime nv) ;
 	public void visit(NodeValueDuration nodeValueDuration);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
@@ -95,6 +95,9 @@ public class StandardFunctions
         addCastTemporal(registry, XSDDatatype.XSDgMonthDay) ;
         addCastTemporal(registry, XSDDatatype.XSDgDay) ;
 
+        // Using ARQ prefix http://jena.apache.org/ARQ/function#
+        add(registry, ARQConstants.ARQFunctionLibraryURI+"collation",        FN_Collation.class) ;
+
         //TODO op:numeric-greater-than etc.
         //TODO sparql:* for all the SPARQL builtins.
         

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_Collation.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_Collation.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.function.library;
+
+import java.text.Collator;
+import java.util.Locale;
+
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
+import org.apache.jena.sparql.expr.nodevalue.NodeValueLang;
+import org.apache.jena.sparql.function.FunctionBase2;
+
+/**
+ * Collation function. Takes two parameters. First is the collation, second the
+ * Node, that is an {@link Expr} (ExprVar, ExprFunctionN, NodeValue, etc).
+ *
+ * <p>Called with a prefix @{code p}, e.g. {@code ORDER BY p:collation("fi", ?label);}.
+ * The first argument (in this case, "fi") is then resolved to a {@link Locale}, that is
+ * used to build a {@link Collator}. If a locale does not match any known collator, then
+ * a rule based collator ({@link RuleBasedCollator}) is returned, but with no rules,
+ * returning values in natural order, not applying any specific collation order.</p>
+ *
+ * <p>The second argument, which is an {@link Expr}, will have its literal string value
+ * extracted (or will raise an error if it is not possible). This means that if the
+ * expr is a {@link NodeValueLang} (e.g. rendered from "Casa"@pt), the language tag will
+ * be discarded, and only the literal string value (i.e. Casa) will be taken into account
+ * for this function.</p>
+ */
+public class FN_Collation extends FunctionBase2 {
+
+    public FN_Collation() {
+        super();
+    }
+
+    @Override
+    public NodeValue exec(NodeValue v1, NodeValue v2) {
+        // retrieve collation value
+        String collation = NodeFunctions.str(v1.asNode());
+        // return a NodeValue that contains the v2 literal string, plus the given collation
+        return NodeFunctions.str(v2, collation);
+    }
+
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_Collation.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_Collation.java
@@ -19,11 +19,14 @@
 package org.apache.jena.sparql.function.library;
 
 import java.text.Collator;
+import java.text.RuleBasedCollator;
 import java.util.Locale;
 
+import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
 import org.apache.jena.sparql.expr.nodevalue.NodeValueLang;
+import org.apache.jena.sparql.expr.nodevalue.NodeValueSortKey;
 import org.apache.jena.sparql.function.FunctionBase2;
 
 /**
@@ -41,6 +44,8 @@ import org.apache.jena.sparql.function.FunctionBase2;
  * expr is a {@link NodeValueLang} (e.g. rendered from "Casa"@pt), the language tag will
  * be discarded, and only the literal string value (i.e. Casa) will be taken into account
  * for this function.</p>
+ *
+ * @see {@link NodeValueSortKey}
  */
 public class FN_Collation extends FunctionBase2 {
 
@@ -53,7 +58,7 @@ public class FN_Collation extends FunctionBase2 {
         // retrieve collation value
         String collation = NodeFunctions.str(v1.asNode());
         // return a NodeValue that contains the v2 literal string, plus the given collation
-        return NodeFunctions.str(v2, collation);
+        return NodeFunctions.sortKey(v2, collation);
     }
 
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/nodevalue/TestNodeFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/nodevalue/TestNodeFunctions.java
@@ -16,25 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.expr;
+package org.apache.jena.sparql.expr.nodevalue;
 
-public enum ValueSpaceClassification {
-    VSPACE_NODE,
-    VSPACE_NUM, 
-    VSPACE_DATETIME, 
-    VSPACE_DATE,
-    VSPACE_TIME,
-    VSPACE_DURATION,
-    
-    // Collapse to VSPACE_DATETIME?
-    VSPACE_G_YEAR,
-    VSPACE_G_YEARMONTH,
-    VSPACE_G_MONTHDAY,
-    VSPACE_G_MONTH,    
-    VSPACE_G_DAY,
-    
-    VSPACE_STRING, VSPACE_LANG, VSPACE_SORTKEY,
-    VSPACE_BOOLEAN,
-    VSPACE_UNKNOWN,
-    VSPACE_DIFFERENT
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.sparql.expr.NodeValue;
+import org.junit.Test;
+
+/**
+ * Tests for {@link NodeFunctions}.
+ */
+public class TestNodeFunctions {
+
+    @Test
+    public void testSortKeyNodeValue() {
+        NodeValue noveValue = NodeValue.makeString("Casa");
+        NodeValue nv = NodeFunctions.sortKey(noveValue, "es");
+        assertTrue(nv instanceof NodeValueSortKey);
+        assertEquals("es", ((NodeValueSortKey) nv).getCollation());
+    }
+
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/nodevalue/TestNodeValueSortKey.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/nodevalue/TestNodeValueSortKey.java
@@ -71,4 +71,16 @@ public class TestNodeValueSortKey {
         NodeValueSortKey nv = new NodeValueSortKey("Tutte", "it");
         assertEquals("'Tutte'", nv.toString());
     }
+
+    @Test
+    public void testCompareTo() {
+        final String languageTag = "pt";
+        NodeValueSortKey nv = new NodeValueSortKey("Bonito", languageTag);
+        assertEquals(0, nv.compareTo(null));
+        assertEquals(1, nv.compareTo(new NodeValueSortKey("Bonita", languageTag)));
+        assertEquals(-1, nv.compareTo(new NodeValueSortKey("Bonitos", languageTag)));
+        // comparing string, regardless of the collations
+        assertEquals(1, nv.compareTo(new NodeValueSortKey("Bonita", "es")));
+        assertEquals(0, nv.compareTo(new NodeValueSortKey("Bonito", "es")));
+    }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/nodevalue/TestNodeValueSortKey.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/nodevalue/TestNodeValueSortKey.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.expr.nodevalue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.graph.Node;
+import org.junit.Test;
+
+/**
+ * Tests for {@link NodeValueSortKey}.
+ */
+public class TestNodeValueSortKey {
+
+    @Test
+    public void testCreateNodeValueSortKey() {
+        NodeValueSortKey nv = new NodeValueSortKey("", null);
+        assertTrue(nv.isSortKey());
+    }
+
+    @Test
+    public void testCreateNodeValueSortKeyWithNode() {
+        Node n = Node.ANY;
+        NodeValueSortKey nv = new NodeValueSortKey("", null, n);
+        assertEquals(n, nv.getNode());
+    }
+
+    @Test
+    public void testGetCollation() {
+        NodeValueSortKey nv = new NodeValueSortKey("", null);
+        assertNull(nv.getCollation());
+        nv = new NodeValueSortKey("", "fi");
+        assertEquals("fi", nv.getCollation());
+    }
+
+    @Test
+    public void testGetString() {
+        NodeValueSortKey nv = new NodeValueSortKey("Casa", "pt-BR");
+        assertEquals("Casa", nv.asString());
+        assertEquals("Casa", nv.getString());
+    }
+
+    @Test
+    public void testMakeNode() {
+        NodeValueSortKey nv = new NodeValueSortKey("Casa", "pt-BR");
+        Node n = nv.makeNode();
+        assertTrue(n.isLiteral());
+        assertEquals("Casa", n.getLiteral().toString());
+    }
+
+    @Test
+    public void testToString() {
+        NodeValueSortKey nv = new NodeValueSortKey("Tutte", "it");
+        assertEquals("'Tutte'", nv.toString());
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/function/library/TestFunctionCollation.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/function/library/TestFunctionCollation.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.function.library;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.jena.sparql.expr.NodeValue;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link FN_Collation}.
+ */
+public class TestFunctionCollation {
+
+    private FN_Collation function = null;
+
+    @Before
+    public void setUp() {
+        function = new FN_Collation();
+    }
+
+    @Test
+    public void testFunctionCollationExec() {
+        NodeValue collation = NodeValue.makeString("fi");
+        
+        final String[] unordered = new String[]
+                {"tšekin kieli", "tulun kieli", "töyhtöhyyppä", "tsahurin kieli", "tsahurin kieli", "tulun kieli"};
+        String[] ordered = new String[]
+                {"'tsahurin kieli'", "'tsahurin kieli'", "'tšekin kieli'",
+                        "'tulun kieli'", "'tulun kieli'", "'töyhtöhyyppä'"};
+        // tests collation sort order with Danish words, but New Zealand English collation rules
+        List<NodeValue> nodeValues = new LinkedList<>();
+        for (String string : unordered) {
+            nodeValues.add(function.exec(collation, NodeValue.makeString(string)));
+        }
+        nodeValues.sort(new Comparator<NodeValue>() {
+            @Override
+            public int compare(NodeValue o1, NodeValue o2) {
+                return NodeValue.compare(o1, o2);
+            }
+        });
+        List<String> result = new LinkedList<>();
+        for (NodeValue nv : nodeValues) {
+            String s = nv.toString();
+            result.add(s);
+        }
+        assertArrayEquals(ordered, result.toArray(new String[0]));
+    }
+}

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/rewriters/NodeValueRewriter.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/rewriters/NodeValueRewriter.java
@@ -74,6 +74,11 @@ class NodeValueRewriter extends AbstractRewriter<NodeValue> implements
 		push(new NodeValueString(nv.getString(), changeNode(nv.getNode())));
 	}
 
+    @Override
+    public void visit(NodeValueSortKey nv) {
+        push(new NodeValueString(nv.getString(), changeNode(nv.getNode())));
+    }
+
 	@Override
 	public void visit(NodeValueDT nv) {
 		push(new NodeValueDT(nv.getDateTime().toXMLFormat(),


### PR DESCRIPTION
Mimics the behaviour of Dydra described [here](http://blog.dydra.com/2015/05/06/collation).

When there are strings with the same language, then instead of simply comparing the text, it uses [java.text.Collator](https://docs.oracle.com/javase/7/docs/api/java/text/Collator.html) and the language locale to compare strings.

This does not create a collate:collate function as described in JENA-1313 as a possible solution, but could be still useful for users that expect the sort results to follow the values' language collation.

Needs further tests and discussion.