### PR TITLE
JENA-1319: Use ExprEvalException; don't produce a stacktrace.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Regex.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Regex.java
@@ -71,11 +71,19 @@ public class E_Regex extends ExprFunctionN
     
     private void init(Expr pattern, Expr flags)
     {
+        try {
         if ( pattern.isConstant() && pattern.getConstant().isString() && ( flags==null || flags.isConstant() ) )
             regexEngine = makeRegexEngine(pattern.getConstant(), (flags==null)?null:flags.getConstant()) ;
+        } catch (ExprEvalException ex) {
+            // Here, we are doing static compilation of the pattern.
+            // ExprEvalException does not have a stacktrace. 
+            // We could throw a non-eval exception.
+            throw ex; //new ExprException(ex.getMessage(), ex.getCause());
+        }
     }
-    
 
+    private String currentFailMessage = null;
+    
     @Override
     public NodeValue eval(List<NodeValue> args)
     {
@@ -84,8 +92,20 @@ public class E_Regex extends ExprFunctionN
         NodeValue vFlags = ( args.size() == 2 ? null : args.get(2) ) ;
         
         RegexEngine regex = regexEngine ;
-        if ( regex == null  )
-            regex = makeRegexEngine(vPattern, vFlags) ;
+        if ( regex == null  ) {
+            // Execution time regex compile (not a constant pattern).
+            try {
+                regex = makeRegexEngine(vPattern, vFlags) ;
+            } catch (ExprEvalException ex) {
+                // Avoid multiple logging of the same message. 
+                String m = ex.getMessage();
+                if ( m != null && ! m.equals(currentFailMessage) )
+                    Log.warn(this, m);
+                currentFailMessage = m;
+                // This becomes an eval error, the FILTER is false and the current row rejected. 
+                throw ex;
+            }
+        }
         
         boolean b = regex.match(arg.getLiteralLexicalForm()) ;
         

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Regex.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Regex.java
@@ -97,7 +97,7 @@ public class E_Regex extends ExprFunctionN
             try {
                 regex = makeRegexEngine(vPattern, vFlags) ;
             } catch (ExprEvalException ex) {
-                // Avoid multiple logging of the same message. 
+                // Avoid multiple logging of the same message (at least if adjacent) 
                 String m = ex.getMessage();
                 if ( m != null && ! m.equals(currentFailMessage) )
                     Log.warn(this, m);
@@ -106,10 +106,8 @@ public class E_Regex extends ExprFunctionN
                 throw ex;
             }
         }
-        
         boolean b = regex.match(arg.getLiteralLexicalForm()) ;
-        
-        return b ?  NodeValue.TRUE : NodeValue.FALSE ; 
+        return b ? NodeValue.TRUE : NodeValue.FALSE ; 
     }
 
     public static RegexEngine makeRegexEngine(NodeValue vPattern, NodeValue vFlags)

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/RegexJava.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/RegexJava.java
@@ -22,8 +22,6 @@ import java.util.regex.Matcher ;
 import java.util.regex.Pattern ;
 import java.util.regex.PatternSyntaxException ;
 
-import org.apache.jena.query.QueryParseException ;
-
 public class RegexJava implements RegexEngine
 {
     Pattern regexPattern ;
@@ -49,7 +47,7 @@ public class RegexJava implements RegexEngine
             return Pattern.compile(patternStr, mask) ;
         } 
         catch (PatternSyntaxException pEx)
-        { throw new ExprException("Regex: Pattern exception: "+pEx) ; }
+        { throw new ExprEvalException("Regex: Pattern exception: "+pEx) ; }
     }
 
 
@@ -63,7 +61,6 @@ public class RegexJava implements RegexEngine
         {
             switch(modifiers.charAt(i))
             {
-                //case 'i' : newMask |= Pattern.CASE_INSENSITIVE;     break ;
                 case 'i' : 
                     // Need both (Java 1.4)
                     newMask |= Pattern.UNICODE_CASE ;
@@ -73,8 +70,8 @@ public class RegexJava implements RegexEngine
                 case 's' : newMask |= Pattern.DOTALL ;              break ;
                 //case 'x' : newMask |= Pattern.;  break ;
                 
-                default  : 
-                    throw new QueryParseException("Illegal flag in regex modifiers: "+modifiers.charAt(i), -1, -1) ;
+                default: 
+                    throw new ExprEvalException("Illegal flag in regex modifiers: "+modifiers.charAt(i)) ;
             }
         }
         return newMask ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/RegexXerces.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/RegexXerces.java
@@ -41,9 +41,9 @@ public class RegexXerces implements RegexEngine
         // Input : only  m s i x
         // Check/modify flags.
         // Always "u", never patternStr
-        //x: Remove whitespace characters (#x9, #xA, #xD and #x20) unless in [] classes
+        // x: Remove whitespace characters (#x9, #xA, #xD and #x20) unless in [] classes
         try { return new RegularExpression(patternStr, flags) ; }
         catch (ParseException pEx)
-        { throw new ExprException("Regex: Pattern exception: "+pEx) ; }
+        { throw new ExprEvalException("Regex: Pattern exception: "+pEx) ; }
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/sse/builders/ExprBuildException.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/sse/builders/ExprBuildException.java
@@ -20,10 +20,7 @@ package org.apache.jena.sparql.sse.builders;
 
 
 public class ExprBuildException extends BuildException
-    {
-
-//        public OpBuildException(Throwable cause) { super(cause) ; }
-//        public OpBuildException() { super() ; }
-        public ExprBuildException (String msg) { super(msg) ; }
-//        public OpBuildException (String msg, Throwable cause) { super(msg, cause) ; }
-    }
+{
+    public ExprBuildException (String msg) { super(msg) ; }
+    public ExprBuildException (String msg, Throwable cause) { super(msg, cause) ; }
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestRegex.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestRegex.java
@@ -63,5 +63,12 @@ public class TestRegex extends BaseTest
         tmp = tmp + ")" ;
         return tmp ; 
     }
+
+    // Bad regex
+    @Test(expected=ExprEvalException.class)
+    public void testRegexErr1() { regexTest("ABC", "(", null, false) ; }
     
+    // No such flag
+    @Test(expected=ExprEvalException.class)
+    public void testRegexErr2() { regexTest("ABC", "abc", "g", false) ; }
 }


### PR DESCRIPTION
Changes for:

"runtime regex pattern and many many log messages"
https://lists.apache.org/thread.html/0d6042871739323716346ebfff76e64ede7c39a52eacbc0ab17d6d3c@%3Cdev.jena.apache.org%3E