### PR TITLE
JENA-1321: Exception rewrapping in HttpQuery masks error response from the server

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/HttpQuery.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/HttpQuery.java
@@ -358,23 +358,23 @@ public class HttpQuery extends Params {
     }
     
     private QueryExceptionHTTP rewrap(HttpException httpEx) {
-    	// The historical contract of HTTP Queries has been to throw QueryExceptionHTTP however using the standard
-    	// ARQ HttpOp machinery we use these days means the internal HTTP errors come back as HttpException
-        // Therefore we need to unnwrap and re-wrap  appropriately
+        // The historical contract of HTTP Queries has been to throw QueryExceptionHTTP however using the standard
+    	    // ARQ HttpOp machinery we use these days means the internal HTTP errors come back as HttpException
+        // Therefore we need to wrap appropriately
         responseCode = httpEx.getResponseCode();
         if (responseCode != -1) {
         	// Was an actual HTTP error
         	String responseLine = httpEx.getStatusLine() != null ? httpEx.getStatusLine() : "No Status Line";
-        	return new QueryExceptionHTTP(responseCode, "HTTP " + responseCode + " error making the query: " + responseLine, httpEx.getCause());
+        	return new QueryExceptionHTTP(responseCode, "HTTP " + responseCode + " error making the query: " + responseLine, httpEx);
         } else if (httpEx.getMessage() != null) {
         	// Some non-HTTP error with a valid message e.g. Socket Communications failed, IO error
-        	return new QueryExceptionHTTP("Unexpected error making the query: " + httpEx.getMessage(), httpEx.getCause());
+        	return new QueryExceptionHTTP(responseCode, "Unexpected error making the query: " + httpEx.getMessage(), httpEx);
         } else if (httpEx.getCause() != null) {
         	// Some other error with a cause e.g. Socket Communications failed, IO error
-        	return new QueryExceptionHTTP("Unexpected error making the query, see cause for further details", httpEx.getCause());
+        	return new QueryExceptionHTTP(responseCode, "Unexpected error making the query, see cause for further details", httpEx);
         } else {
         	// Some other error with no message and no further cause
-        	return new QueryExceptionHTTP("Unexpected error making the query", httpEx);
+        	return new QueryExceptionHTTP(responseCode, "Unexpected error making the query", httpEx);
         }
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryExceptionHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryExceptionHTTP.java
@@ -18,16 +18,19 @@
 
 package org.apache.jena.sparql.engine.http;
 
+import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.query.QueryException ;
 
 /** Exception class for all operations in the SPARQL client library.
  *  Error codes are as HTTP status codes. */
 public class QueryExceptionHTTP extends QueryException
 {
-    private static final long serialVersionUID = 99L;  // Serilizable.
+    private static final long serialVersionUID = 99L;  // Serializable.
     public static final int noResponseCode = -1234 ;
     private int responseCode = noResponseCode ;
-    private String responseMessage = null ;
+    private final String responseMessage ;
+    private String statusLine ;
+    private String response;
 
     // Codes for extra errors.  We use HTTP error codes so
     // these are negative to avoid clashes
@@ -63,10 +66,20 @@ public class QueryExceptionHTTP extends QueryException
     public int getResponseCode() { return responseCode ; }
     
     
-    /** The messge for the reason for this exception
+    /** The message for the reason for this exception
      * @return message
      */  
     public String getResponseMessage() { return responseMessage ; }
+
+    /** The response for this exception
+     * @return response
+     */  
+    public String getResponse() { return response ; }
+
+    /** The status line for the response for this exception
+     * @return status line
+     */  
+    public String getStatusLine() { return statusLine ; }
 
     /**
      * Constructor for HttpException used for some unexpected execution error.
@@ -87,11 +100,16 @@ public class QueryExceptionHTTP extends QueryException
     }
     
     public QueryExceptionHTTP(int responseCode, String message, Throwable cause) {
-        super(message, cause);
+        this(message, cause);
         this.responseCode = responseCode;
     }
 
-
+    public QueryExceptionHTTP(int responseCode, String message, final HttpException ex) {
+        this(responseCode, message, ex.getCause());
+        this.statusLine = ex.getStatusLine();
+        this.response = ex.getResponse();
+    }
+    
     @Override
     public String toString()
     {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryExceptionHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryExceptionHTTP.java
@@ -71,13 +71,13 @@ public class QueryExceptionHTTP extends QueryException
      */  
     public String getResponseMessage() { return responseMessage ; }
 
-    /** The response for this exception
-     * @return response
+    /** The response for this exception if available from HTTP
+     * @return response or {@code null} if no HTTP response was received
      */  
     public String getResponse() { return response ; }
 
-    /** The status line for the response for this exception
-     * @return status line
+    /** The status line for the response for this exception if available from HTTP
+     * @return status line or {@code null} if no HTTP response was received
      */  
     public String getStatusLine() { return statusLine ; }
 


### PR DESCRIPTION
It's a bit odd-feeling to couple `HttpException` so tightly, but given that it is an Atlas type, I don't feel terrible about it.