### PR TITLE
jena-text-es: Separate module for ElasticSearch text search

### DIFF
--- a/jena-text-es/LICENSE
+++ b/jena-text-es/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/jena-text-es/NOTICE
+++ b/jena-text-es/NOTICE
@@ -1,0 +1,5 @@
+Apache Jena - jena-text module
+Copyright 2011-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/jena-text-es/pom.xml
+++ b/jena-text-es/pom.xml
@@ -18,7 +18,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>jena-text</artifactId>
+  <artifactId>jena-text-es</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - SPARQL Text Search</name>
   <version>3.3.0-SNAPSHOT</version>
@@ -37,23 +37,10 @@
 
   <dependencies>
 
-    <!-- All Jena libs (not Fuseki) -->
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>apache-jena-libs</artifactId>
+      <artifactId>jena-text</artifactId>
       <version>3.3.0-SNAPSHOT</version>
-      <type>pom</type>
-    </dependency>
-    
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-cmds</artifactId>
-      <version>3.3.0-SNAPSHOT</version>
-    </dependency>
-    
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
     </dependency>
     
     <!-- Testing support -->
@@ -65,43 +52,33 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Lucene dependencies -->
+    
+    <!-- Elasticsearch client -->
     <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-core</artifactId>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>transport</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-analyzers-common</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
     
     <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-queryparser</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
     </dependency>
-
+    
+    <!-- Convert commons logging to SLF4J -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+    
   </dependencies>
-
+  
   <build>
     
-    <resources>
-      <resource>
-        <filtering>true</filtering>
-        <directory>src/main/resources</directory>
-        <includes>
-          <include>org/apache/jena/query/text/properties.xml</include>
-        </includes>
-      </resource>
-      <resource>
-        <filtering>false</filtering>
-        <directory>src/main/resources</directory>
-        <excludes>
-          <exclude>org/apache/jena/query/text/properties.xml</exclude>
-        </excludes>
-      </resource>
-    </resources>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -112,13 +89,73 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <skip>false</skip>
-          <includes>
-            <include>**/TS_*.java</include>
-          </includes>
+          <!-- Skip the default running of this plug-in (or everything is run twice...see below) -->
+          <skip>true</skip>
         </configuration>
+        <executions>
+          <execution>
+            <id>unit-tests</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>false</skip>
+              <includes>
+                <include>**/TS_*.java</include>
+              </includes>
+              <excludes>
+                <exclude>**/*IT.java</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>integration-tests</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>false</skip>
+              <includes>
+                <include>**/*IT.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
-
+      <plugin>
+        <groupId>com.github.alexcojocaru</groupId>
+        <artifactId>elasticsearch-maven-plugin</artifactId>
+        <!-- REPLACE THE FOLLOWING WITH THE PLUGIN VERSION YOU NEED -->
+        <version>5.2</version>
+        <configuration>
+          <clusterName>elasticsearch</clusterName>
+          <transportPort>9500</transportPort>
+          <httpPort>9400</httpPort>
+        </configuration>
+        <executions>
+          <!--
+              The elasticsearch maven plugin goals are by default bound to the
+              pre-integration-test and post-integration-test phases
+          -->
+          <execution>
+            <id>start-elasticsearch</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>runforked</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>stop-elasticsearch</id>
+            <phase>post-integration-test</phase>
+            <goals>
+              <goal>stop</goal>
+                    </goals>
+          </execution>
+            </executions>
+      </plugin>
+      
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/jena-text-es/src/main/java/examples/JenaESTextExample.java
+++ b/jena-text-es/src/main/java/examples/JenaESTextExample.java
@@ -22,7 +22,7 @@ import org.apache.jena.query.*;
 import org.apache.jena.sparql.util.QueryExecUtils;
 
 /**
- * Simple example class to test the {@link org.apache.jena.query.text.assembler.TextIndexESAssembler}
+ * Simple example class to test the {@link org.apache.jena.query.text.es.assembler.TextIndexESAssembler}
  * For this class to work properly, an elasticsearch node should be up and running, otherwise it will fail.
  * You can find the details of downloading and running an ElasticSearch version here: https://www.elastic.co/downloads/past-releases/elasticsearch-5-2-1
  * Unzip the file in your favourite directory and then execute the appropriate file under the bin directory.
@@ -44,8 +44,7 @@ public class JenaESTextExample {
 
     private static Dataset createAssembler() {
         String assemblerFile = "text-config-es.ttl";
-        Dataset ds = DatasetFactory.assemble(assemblerFile,
-                "http://localhost/jena_example/#text_dataset") ;
+        Dataset ds = DatasetFactory.assemble(assemblerFile, "http://localhost/jena_example/#text_dataset") ;
         return ds;
     }
 
@@ -59,10 +58,7 @@ public class JenaESTextExample {
      * @param ds
      */
     private static void queryData(Dataset ds) {
-//        JenaTextExample1.queryData(ds);
         queryDataWithoutProperty(ds);
-
-
     }
 
     public static void queryDataWithoutProperty(Dataset dataset)

--- a/jena-text-es/src/main/java/org/apache/jena/query/text/es/ESSettings.java
+++ b/jena-text-es/src/main/java/org/apache/jena/query/text/es/ESSettings.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.jena.query.text;
+package org.apache.jena.query.text.es;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/jena-text-es/src/main/java/org/apache/jena/query/text/es/InitJenaTextES.java
+++ b/jena-text-es/src/main/java/org/apache/jena/query/text/es/InitJenaTextES.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text.es;
+
+import org.apache.jena.query.text.TextQuery;
+import org.apache.jena.system.JenaSubsystemLifecycle ;
+
+public class InitJenaTextES implements JenaSubsystemLifecycle {
+    @Override
+    public void start() {
+        TextQuery.init() ;
+    }
+
+    @Override
+    public void stop() {
+    }
+}
+

--- a/jena-text-es/src/main/java/org/apache/jena/query/text/es/TextESDatasetFactory.java
+++ b/jena-text-es/src/main/java/org/apache/jena/query/text/es/TextESDatasetFactory.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text.es;
+
+import org.apache.jena.query.Dataset ;
+import org.apache.jena.query.text.EntityDefinition;
+import org.apache.jena.query.text.TextDatasetFactory;
+import org.apache.jena.query.text.TextIndex;
+import org.apache.jena.query.text.TextIndexConfig;
+import org.apache.jena.system.JenaSystem ;
+
+public class TextESDatasetFactory
+{
+    static { JenaSystem.init(); }
+    
+    /**
+     * Create an ElasticSearch based Index and return a Dataset based on this index
+     * @param base the base {@link Dataset}
+     * @param config {@link TextIndexConfig} containing the {@link EntityDefinition}
+     * @param settings ElasticSearch specific settings for initializing and connecting to an ElasticSearch Cluster
+     * @return The config definition for the index instantiation
+     */
+    public static Dataset createES(Dataset base, TextIndexConfig config, ESSettings settings)
+    {
+        TextIndex index = createESIndex(config, settings) ;
+        return TextDatasetFactory.create(base, index, true) ;
+    }
+
+    /**
+     * Create an ElasticSearch based Index
+     * @param config {@link TextIndexConfig} containing the {@link EntityDefinition}
+     * @param settings ElasticSearch specific settings for initializing and connecting to an ElasticSearch Cluster
+     * @return a configured instance of TextIndexES
+     */
+    public static TextIndex createESIndex(TextIndexConfig config, ESSettings settings)
+    {
+        return new TextIndexES(config, settings) ;
+    }
+
+}
+

--- a/jena-text-es/src/main/java/org/apache/jena/query/text/es/TextIndexES.java
+++ b/jena-text-es/src/main/java/org/apache/jena/query/text/es/TextIndexES.java
@@ -16,11 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.jena.query.text;
+package org.apache.jena.query.text.es;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+import java.net.InetAddress;
+import java.util.*;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.text.*;
 import org.apache.jena.sparql.util.NodeFactoryExtra;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
@@ -41,11 +47,6 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.net.InetAddress;
-import java.util.*;
-
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 /**
  * Elastic Search Implementation of {@link TextIndex}

--- a/jena-text-es/src/main/java/org/apache/jena/query/text/es/assembler/TextIndexESAssembler.java
+++ b/jena-text-es/src/main/java/org/apache/jena/query/text/es/assembler/TextIndexESAssembler.java
@@ -16,12 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.jena.query.text.assembler;
+package org.apache.jena.query.text.es.assembler;
 
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.assembler.Mode;
 import org.apache.jena.assembler.assemblers.AssemblerBase;
-import org.apache.jena.query.text.*;
+import org.apache.jena.query.text.EntityDefinition;
+import org.apache.jena.query.text.TextIndex;
+import org.apache.jena.query.text.TextIndexConfig;
+import org.apache.jena.query.text.TextIndexException;
+import org.apache.jena.query.text.es.*;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.util.graph.GraphUtils;
 import org.slf4j.Logger;
@@ -105,7 +109,7 @@ public class TextIndexESAssembler extends AssemblerBase {
                     .indexName(indexName)
                     .build();
 
-            return TextDatasetFactory.createESIndex(config, settings) ;
+            return TextESDatasetFactory.createESIndex(config, settings) ;
         } catch (Exception e) {
             throw new TextIndexException("An exception occurred while trying to open/load the Assembler configuration. ", e);
         }

--- a/jena-text-es/src/main/resources/META-INF/LICENSE
+++ b/jena-text-es/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/jena-text-es/src/main/resources/META-INF/NOTICE
+++ b/jena-text-es/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,5 @@
+Apache Jena - jena-text module
+Copyright 2011-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/jena-text-es/src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
+++ b/jena-text-es/src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
@@ -1,0 +1,1 @@
+org.apache.jena.query.text.es.InitJenaTextES

--- a/jena-text-es/src/main/resources/data-es.ttl
+++ b/jena-text-es/src/main/resources/data-es.ttl
@@ -1,0 +1,46 @@
+   # Licensed to the Apache Software Foundation (ASF) under one
+   # or more contributor license agreements.  See the NOTICE file
+   # distributed with this work for additional information
+   # regarding copyright ownership.  The ASF licenses this file
+   # to you under the Apache License, Version 2.0 (the
+   # "License"); you may not use this file except in compliance
+   # with the License.  You may obtain a copy of the License at
+   #
+   #     http://www.apache.org/licenses/LICENSE-2.0
+   #
+   # Unless required by applicable law or agreed to in writing, software
+   # distributed under the License is distributed on an "AS IS" BASIS,
+   # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   # See the License for the specific language governing permissions and
+   # limitations under the License.
+
+@prefix :        <http://example/> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+:s a :Thing ;
+   :p :123 ;
+   rdfs:label "Thing 1"@en ;
+   rdfs:comment "It's a complicated comment"@en ;
+   rdfs:comment "this is another comment"@en ;
+   rdfs:comment "this is en GB comment"@en-GB ;
+   :id 123 .
+
+:s1 a :Thing ;
+   :p :123 ;
+   rdfs:label "Thing 2"@en ;
+   :id 123 .
+
+:s2 a :Thing ;
+   :p :123 ;
+   rdfs:label "Whatever"@en ;
+   :id 123 .
+
+   
+:x1 rdfs:label "X2 word"@en .
+:x1 rdfs:label "X1 another word" .
+:x2 rdfs:label "X2 word" .
+:x3 rdfs:label "X3 word" .
+:x3 rdfs:label "X4 word" .
+:x1 rdfs:label "X9 word" .

--- a/jena-text-es/src/main/resources/org/apache/jena/query/text/properties.xml
+++ b/jena-text-es/src/main/resources/org/apache/jena/query/text/properties.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<!--  Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0 -->
+<properties version="1.0">
+  <comment>jena-text system properties</comment>
+  <entry key="org.apache.jena.query.text.version">${project.version}</entry>
+  <entry key="org.apache.jena.query.text.datetime">${build.time.xsd}</entry>
+</properties>
+ 

--- a/jena-text-es/src/main/resources/text-config-es.ttl
+++ b/jena-text-es/src/main/resources/text-config-es.ttl
@@ -1,0 +1,64 @@
+    # Licensed to the Apache Software Foundation (ASF) under one
+    # or more contributor license agreements.  See the NOTICE file
+    # distributed with this work for additional information
+    # regarding copyright ownership.  The ASF licenses this file
+    # to you under the Apache License, Version 2.0 (the
+    # "License"); you may not use this file except in compliance
+    # with the License.  You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+ ## Example of a TDB dataset and text index for ElasticSearch
+
+@prefix :        <http://localhost/jena_example/#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb:     <http://jena.hpl.hp.com/2008/tdb#> .
+@prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix text:    <http://jena.apache.org/text#> .
+
+# TDB
+[] ja:loadClass "org.apache.jena.tdb.TDB" .
+tdb:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
+tdb:GraphTDB    rdfs:subClassOf  ja:Model .
+
+# Text
+[] ja:loadClass "org.apache.jena.query.text.TextQuery" .
+text:TextDataset      rdfs:subClassOf   ja:RDFDataset .
+text:TextIndexES      rdfs:subClassOf   text:TextIndex .
+
+## ---------------------------------------------------------------
+## This URI must be fixed - it's used to assemble the text dataset.
+
+:text_dataset rdf:type     text:TextDataset ;
+    text:dataset   <#dataset> ;
+    text:index     <#indexES> ;
+    .
+
+<#dataset> rdf:type      tdb:DatasetTDB ;
+    tdb:location "--mem--" ;
+    .
+
+<#indexES> a text:TextIndexES ;
+    text:serverList "127.0.0.1:9300" ; # A comma-separated list of Host:Port values of the ElasticSearch Cluster nodes.
+    text:clusterName "elasticsearch" ; # Name of the ElasticSearch Cluster. If not specified defaults to 'elasticsearch'
+    text:shards "1" ;                  # The number of shards for the index. Defaults to 1
+    text:replicas "1" ;                # The number of replicas for the index. Defaults to 1
+    text:indexName "jena-text" ;       # Name of the Index. defaults to jena-text
+    text:entityMap <#entMap> ;
+    .
+
+<#entMap> a text:EntityMap ;
+    text:entityField      "uri" ; # Defines the Document Type in the ES Index
+    text:defaultField     "text" ; ## Must be defined in the text:maps
+    text:map (
+         # rdfs:label            
+         [ text:field "text" ; text:predicate rdfs:label ]
+         [ text:field "comment" ; text:predicate rdfs:comment ]
+         ) .

--- a/jena-text-es/src/test/java/org/apache/jena/query/text/es/it/BaseESTest.java
+++ b/jena-text-es/src/test/java/org/apache/jena/query/text/es/it/BaseESTest.java
@@ -15,11 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.jena.query.text.it;
+package org.apache.jena.query.text.es.it;
 
 import org.apache.jena.query.text.EntityDefinition;
 import org.apache.jena.query.text.TextIndexConfig;
-import org.apache.jena.query.text.TextIndexES;
+import org.apache.jena.query.text.es.TextIndexES;
 import org.apache.jena.vocabulary.RDFS;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;

--- a/jena-text-es/src/test/java/org/apache/jena/query/text/es/it/TextIndexESIT.java
+++ b/jena-text-es/src/test/java/org/apache/jena/query/text/es/it/TextIndexESIT.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.jena.query.text.it;
+package org.apache.jena.query.text.es.it;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.text.Entity;
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Integration test class for {@link org.apache.jena.query.text.TextIndexES}
+ * Integration test class for {@link org.apache.jena.query.text.es.TextIndexES}
  */
 public class TextIndexESIT extends BaseESTest {
 

--- a/jena-text-es/src/test/resources/log4j.properties
+++ b/jena-text-es/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+log4j.rootLogger=WARN, stdlog
+
+log4j.appender.stdlog=org.apache.log4j.ConsoleAppender
+## log4j.appender.stdlog.target=System.err
+log4j.appender.stdlog.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdlog.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-25c{1} :: %m%n
+
+# Execution logging
+log4j.logger.org.apache.jena.arq.info=INFO
+log4j.logger.org.apache.jena.arq.exec=INFO

--- a/jena-text-es/testing/TextQuery/data.skos
+++ b/jena-text-es/testing/TextQuery/data.skos
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+    <skos:ConceptScheme rdf:about="http://example.com/dishes">
+        <dc:title>The Example Taxonomy</dc:title>
+        <dc:description>An example taxonomy to illustrate the use of the SKOS schema.</dc:description>
+    </skos:ConceptScheme>
+
+    <skos:Concept rdf:about="http://example.com/dishes#potatoBased">
+        <skos:prefLabel xml:lang="fr">Plats à base de pomme de terre</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">Potato based dishes</skos:prefLabel>
+        <skos:prefLabel xml:lang="de">Kartoffelgerichte</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://example.com/dishes"/>
+        <skos:topConceptOf rdf:resource="http://example.com/dishes"/>
+    </skos:Concept>
+
+    <skos:Concept rdf:about="http://example.com/dishes#fries">
+        <skos:prefLabel xml:lang="fr">Frites</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">French fries</skos:prefLabel>
+        <skos:prefLabel xml:lang="de">Französisch frites</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://example.com/dishes"/>
+        <skos:broader rdf:resource="http://example.com/dishes#potatoBased"/>
+    </skos:Concept>
+
+    <skos:Concept rdf:about="http://example.com/dishes#mashed">
+        <skos:prefLabel xml:lang="fr">Purée de pomme de terre</skos:prefLabel>
+        <skos:prefLabel xml:lang="en">Mashed potatoes</skos:prefLabel>
+        <skos:prefLabel xml:lang="de">Kartoffelpüree</skos:prefLabel>
+        <skos:inScheme rdf:resource="http://example.com/dishes"/>
+        <skos:broader rdf:resource="http://example.com/dishes#potatoBased"/>
+    </skos:Concept>
+</rdf:RDF>

--- a/jena-text-es/testing/TextQuery/data1.ttl
+++ b/jena-text-es/testing/TextQuery/data1.ttl
@@ -1,0 +1,26 @@
+@prefix :        <http://example/> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+
+:s a :Thing ;
+   :p :123 ;
+   rdfs:label "Thing 1" ;
+   :id 123 .
+
+:s1 a :Thing ;
+   :p :123 ;
+   rdfs:label "Thing 2" ;
+   :id 123 .
+
+:s2 a :Thing ;
+   :p :123 ;
+   rdfs:label "Whatever" ;
+   :id 123 .
+
+   
+:x1 rdfs:label "X1 word" .
+:x1 rdfs:label "X1 word" .
+:x2 rdfs:label "X2 word" .
+:x3 rdfs:label "X3 word" .
+:x1 rdfs:label "X9 word" .

--- a/jena-text-es/testing/TextQuery/text-config-union.ttl
+++ b/jena-text-es/testing/TextQuery/text-config-union.ttl
@@ -1,0 +1,44 @@
+ ## Example of a TDB dataset and text index
+
+@prefix :        <http://localhost/jena_example/#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb:     <http://jena.hpl.hp.com/2008/tdb#> .
+@prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix text:    <http://jena.apache.org/text#> .
+
+# TDB
+[] ja:loadClass "org.apache.jena.tdb.TDB" .
+tdb:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
+tdb:GraphTDB    rdfs:subClassOf  ja:Model .
+
+# Text
+[] ja:loadClass "org.apache.jena.query.text.TextQuery" .
+text:TextDataset      rdfs:subClassOf   ja:RDFDataset .
+text:TextIndexLucene  rdfs:subClassOf   text:TextIndex .
+
+## ---------------------------------------------------------------
+## This URI must be fixed - it's used to assemble the text dataset.
+
+:text_dataset rdf:type     text:TextDataset ;
+    text:dataset   <#dataset> ;
+    text:index     <#indexLucene> ;
+    .
+
+<#dataset> rdf:type      tdb:DatasetTDB ;
+    tdb:location "--mem--" ;
+    tdb:unionDefaultGraph true ;
+    .
+
+<#indexLucene> a text:TextIndexLucene ;
+    text:directory "mem" ;
+    text:entityMap <#entMap> ;
+    .
+
+<#entMap> a text:EntityMap ;
+    text:entityField      "uri" ;
+    text:defaultField     "text" ; ## Must be defined in the text:maps
+    text:map (
+         # rdfs:label            
+         [ text:field "text" ; text:predicate rdfs:label ]
+         ) .

--- a/jena-text-es/testing/TextQuery/text-config.ttl
+++ b/jena-text-es/testing/TextQuery/text-config.ttl
@@ -1,0 +1,43 @@
+ ## Example of a TDB dataset and text index
+
+@prefix :        <http://localhost/jena_example/#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb:     <http://jena.hpl.hp.com/2008/tdb#> .
+@prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix text:    <http://jena.apache.org/text#> .
+
+# TDB
+[] ja:loadClass "org.apache.jena.tdb.TDB" .
+tdb:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
+tdb:GraphTDB    rdfs:subClassOf  ja:Model .
+
+# Text
+[] ja:loadClass "org.apache.jena.query.text.TextQuery" .
+text:TextDataset      rdfs:subClassOf   ja:RDFDataset .
+text:TextIndexLucene  rdfs:subClassOf   text:TextIndex .
+
+## ---------------------------------------------------------------
+## This URI must be fixed - it's used to assemble the text dataset.
+
+:text_dataset rdf:type     text:TextDataset ;
+    text:dataset   <#dataset> ;
+    text:index     <#indexLucene> ;
+    .
+
+<#dataset> rdf:type      tdb:DatasetTDB ;
+    tdb:location "--mem--" ;
+    .
+
+<#indexLucene> a text:TextIndexLucene ;
+    text:directory "mem" ;
+    text:entityMap <#entMap> ;
+    .
+
+<#entMap> a text:EntityMap ;
+    text:entityField      "uri" ;
+    text:defaultField     "text" ; ## Must be defined in the text:maps
+    text:map (
+         # rdfs:label            
+         [ text:field "text" ; text:predicate rdfs:label ]
+         ) .

--- a/jena-text-es/text-config.ttl
+++ b/jena-text-es/text-config.ttl
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Example of a TDB dataset and text index
+
+@prefix :        <http://localhost/jena_example/#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb:     <http://jena.hpl.hp.com/2008/tdb#> .
+@prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix text:    <http://jena.apache.org/text#> .
+
+# TDB
+[] ja:loadClass "org.apache.jena.tdb.TDB" .
+tdb:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
+tdb:GraphTDB    rdfs:subClassOf  ja:Model .
+
+# Text
+[] ja:loadClass "org.apache.jena.query.text.TextQuery" .
+text:TextDataset      rdfs:subClassOf   ja:RDFDataset .
+text:TextIndexLucene  rdfs:subClassOf   text:TextIndex .
+
+## ---------------------------------------------------------------
+## This URI must be fixed - it's used to assemble the text dataset.
+
+:text_dataset rdf:type     text:TextDataset ;
+    text:dataset   <#dataset> ;
+    text:index     <#indexLucene> ;
+    .
+
+<#dataset> rdf:type      tdb:DatasetTDB ;
+    tdb:location "--mem--" ;
+    ## In the example, this would hide the real default graph.
+    ##tdb:unionDefaultGraph true ;
+    .
+
+<#indexLucene> a text:TextIndexLucene ;
+    #text:directory <file:Lucene> ;
+    text:directory "mem" ;
+    text:entityMap <#entMap> ;
+    .
+
+<#entMap> a text:EntityMap ;
+    text:entityField      "uri" ;
+    text:defaultField     "text" ; ## Must be defined in the text:maps
+    text:map (
+         # rdfs:label            
+         [ text:field "text" ; text:predicate rdfs:label ]
+         ) .

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextDatasetFactory.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextDatasetFactory.java
@@ -164,30 +164,5 @@ public class TextDatasetFactory
         TextIndex index = createLuceneIndex(directory, config) ;
         return create(base, index, true) ;
     }
-
-    /**
-     * Create an ElasticSearch based Index and return a Dataset based on this index
-     * @param base the base {@link Dataset}
-     * @param config {@link TextIndexConfig} containing the {@link EntityDefinition}
-     * @param settings ElasticSearch specific settings for initializing and connecting to an ElasticSearch Cluster
-     * @return The config definition for the index instantiation
-     */
-    public static Dataset createES(Dataset base, TextIndexConfig config, ESSettings settings)
-    {
-        TextIndex index = createESIndex(config, settings) ;
-        return create(base, index, true) ;
-    }
-
-    /**
-     * Create an ElasticSearch based Index
-     * @param config {@link TextIndexConfig} containing the {@link EntityDefinition}
-     * @param settings ElasticSearch specific settings for initializing and connecting to an ElasticSearch Cluster
-     * @return a configured instance of TextIndexES
-     */
-    public static TextIndex createESIndex(TextIndexConfig config, ESSettings settings)
-    {
-        return new TextIndexES(config, settings) ;
-    }
-
 }
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextAssembler.java
@@ -30,7 +30,6 @@ public class TextAssembler
         
         Assembler.general.implementWith(TextVocab.entityMap,        new EntityDefinitionAssembler()) ;
         Assembler.general.implementWith(TextVocab.textIndexLucene,  new TextIndexLuceneAssembler()) ;
-        Assembler.general.implementWith(TextVocab.textIndexES,  new TextIndexESAssembler()) ;
         Assembler.general.implementWith(TextVocab.standardAnalyzer, new StandardAnalyzerAssembler()) ;
         Assembler.general.implementWith(TextVocab.simpleAnalyzer,   new SimpleAnalyzerAssembler()) ;
         Assembler.general.implementWith(TextVocab.keywordAnalyzer,  new KeywordAnalyzerAssembler()) ;

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextVocab.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextVocab.java
@@ -78,8 +78,6 @@ public class TextVocab
     public static final Resource lowerCaseFilter    = Vocab.resource(NS, "LowerCaseFilter");
     public static final Resource asciiFoldingFilter = Vocab.resource(NS, "ASCIIFoldingFilter");
 
-    //Elasticsearch
-    public static final Resource textIndexES        = Vocab.resource(NS, "TextIndexES") ;
     public static final Property pServerList        = Vocab.property(NS, "serverList");
     public static final Property pClusterName       = Vocab.property(NS, "clusterName");
     public static final Property pShards            = Vocab.property(NS, "shards");

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,8 @@
         <module>apache-jena-libs</module>
         <module>jena-cmds</module>
         
-        <!--<module>jena-text</module>-->
+        <module>jena-text</module>
+        <!--<module>jena-text-es</module>-->
         <!--<module>jena-spatial</module>-->
         <!--<module>jena-fuseki1</module>-->
         <module>jena-fuseki2</module>
@@ -118,12 +119,13 @@
         <module>apache-jena-libs</module>
         <module>jena-cmds</module>
         <module>jena-text</module>
+        <!--<module>jena-text-es</module>-->
         <module>jena-spatial</module>
         <!--<module>jena-fuseki1</module>-->
         <module>jena-fuseki2</module>
       </modules>
     </profile>
-      
+    
     <profile>
       <!--
           This is the complete profile, it builds everything including slow
@@ -151,6 +153,9 @@
         <module>jena-cmds</module>
 
         <module>jena-text</module>
+        <!-- Move later? -->
+        <module>jena-text-es</module>
+
         <module>jena-spatial</module>
         <module>jena-csv</module>
 


### PR DESCRIPTION
This PR makes the ElasticSearch a separate module, that depends on jena-text.

Fuseki incorporates jena-text, not jena-text-es, and the server jar is 25M.

This is a proof-of-concept for discussion.
