### PR TITLE
Query string in URLs; uniform HttpClient/HttpContext usage.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
@@ -20,6 +20,7 @@ package org.apache.jena.query;
 import java.util.List ;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.protocol.HttpContext;
 import org.apache.jena.atlas.logging.Log ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.sparql.core.DatasetGraph ;
@@ -281,13 +282,17 @@ public class QueryExecutionFactory
         return sparqlService(service, query, (HttpClient)null) ;
     }
     
-    /** Create a QueryExecution that will access a SPARQL service over HTTP
+    static public QueryExecution sparqlService(String service, String query, HttpClient client) {
+        return sparqlService(service, query, client, null);
+    }
+        /** Create a QueryExecution that will access a SPARQL service over HTTP
      * @param service   URL of the remote service 
      * @param query     Query string to execute 
      * @param client    HTTP client
+     * @param httpContext HTTP Context
      * @return QueryExecution
      */ 
-    static public QueryExecution sparqlService(String service, String query, HttpClient client) {
+    static public QueryExecution sparqlService(String service, String query, HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
         checkArg(query) ;
         return sparqlService(service, QueryFactory.create(query), client) ;
@@ -311,10 +316,22 @@ public class QueryExecutionFactory
      * @return QueryExecution
      */ 
     static public QueryExecution sparqlService(String service, String query, String defaultGraph, HttpClient client) {
+        return sparqlService(service, query, defaultGraph, client, null) ;
+    }
+
+    /** Create a QueryExecution that will access a SPARQL service over HTTP
+     * @param service       URL of the remote service 
+     * @param query         Query string to execute
+     * @param defaultGraph  URI of the default graph
+     * @param client        HTTP client
+     * @param httpContext   HTTP Context
+     * @return QueryExecution
+     */ 
+    static public QueryExecution sparqlService(String service, String query, String defaultGraph, HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
         // checkNotNull(defaultGraph, "IRI for default graph is null") ;
         checkArg(query) ;
-        return sparqlService(service, QueryFactory.create(query), defaultGraph, client) ;
+        return sparqlService(service, QueryFactory.create(query), defaultGraph, client, httpContext) ;
     }
     
     /** Create a QueryExecution that will access a SPARQL service over HTTP
@@ -338,11 +355,25 @@ public class QueryExecutionFactory
      */ 
     static public QueryExecution sparqlService(String service, String query, List<String> defaultGraphURIs, List<String> namedGraphURIs,
                                                HttpClient client) {
+        return sparqlService(service, query, defaultGraphURIs, namedGraphURIs, client, null) ;
+    }
+    
+    /** Create a QueryExecution that will access a SPARQL service over HTTP
+     * @param service           URL of the remote service 
+     * @param query             Query string to execute
+     * @param defaultGraphURIs  List of URIs to make up the default graph
+     * @param namedGraphURIs    List of URIs to make up the named graphs
+     * @param client            HTTP client
+     * @param httpContext HTTP Context
+     * @return QueryExecution
+     */ 
+    static public QueryExecution sparqlService(String service, String query, List<String> defaultGraphURIs, List<String> namedGraphURIs,
+                                               HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
         // checkNotNull(defaultGraphURIs, "List of default graph URIs is null") ;
         // checkNotNull(namedGraphURIs, "List of named graph URIs is null") ;
         checkArg(query) ;
-        return sparqlService(service, QueryFactory.create(query), defaultGraphURIs, namedGraphURIs, client) ;
+        return sparqlService(service, QueryFactory.create(query), defaultGraphURIs, namedGraphURIs, client, httpContext) ;
     }
     
     /** Create a QueryExecution that will access a SPARQL service over HTTP
@@ -367,6 +398,18 @@ public class QueryExecutionFactory
     }
     
     /** Create a QueryExecution that will access a SPARQL service over HTTP
+     * @param service   URL of the remote service 
+     * @param query     Query to execute 
+     * @param client    HTTP client
+     * @return QueryExecution
+     */ 
+    static public QueryExecution sparqlService(String service, Query query, HttpClient client, HttpContext httpContext) {
+        checkNotNull(service, "URL for service is null") ;
+        checkArg(query) ;
+        return createServiceRequest(service, query, client, httpContext) ;
+    }
+    
+    /** Create a QueryExecution that will access a SPARQL service over HTTP
      * @param service           URL of the remote service 
      * @param query             Query to execute
      * @param defaultGraphURIs  List of URIs to make up the default graph
@@ -374,7 +417,7 @@ public class QueryExecutionFactory
      * @return QueryExecution
      */ 
     static public QueryExecution sparqlService(String service, Query query, List<String> defaultGraphURIs, List<String> namedGraphURIs) {
-        return sparqlService(service, query, defaultGraphURIs, namedGraphURIs, null) ;
+        return sparqlService(service, query, defaultGraphURIs, namedGraphURIs, null, null) ;
     }
 
     /** Create a QueryExecution that will access a SPARQL service over HTTP
@@ -385,8 +428,21 @@ public class QueryExecutionFactory
      * @param client            HTTP client
      * @return QueryExecution
      */ 
+    static public QueryExecution sparqlService(String service, Query query, List<String> defaultGraphURIs, List<String> namedGraphURIs, HttpClient client) {
+        return sparqlService(service, query, defaultGraphURIs, namedGraphURIs, client, null);
+    }
+
+    /** Create a QueryExecution that will access a SPARQL service over HTTP
+     * @param service           URL of the remote service 
+     * @param query             Query to execute
+     * @param defaultGraphURIs  List of URIs to make up the default graph
+     * @param namedGraphURIs    List of URIs to make up the named graphs
+     * @param client            HTTP client
+     * @param httpContext       HTTP Context
+     * @return QueryExecution
+     */
     static public QueryExecution sparqlService(String service, Query query, List<String> defaultGraphURIs, List<String> namedGraphURIs,
-                                               HttpClient client) {
+                                               HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
         // checkNotNull(defaultGraphURIs, "List of default graph URIs is null") ;
         // checkNotNull(namedGraphURIs, "List of named graph URIs is null") ;
@@ -417,14 +473,24 @@ public class QueryExecutionFactory
      * @return QueryExecution
      */ 
     static public QueryExecution sparqlService(String service, Query query, String defaultGraph, HttpClient client) {
+       return sparqlService(service, query, client, null);
+    }
+    
+    /** Create a QueryExecution that will access a SPARQL service over HTTP
+     * @param service       URL of the remote service 
+     * @param query         Query to execute
+     * @param defaultGraph  URI of the default graph
+     * @param client        HTTP client
+     * @return QueryExecution
+     */ 
+    static public QueryExecution sparqlService(String service, Query query, String defaultGraph, HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
         // checkNotNull(defaultGraph, "IRI for default graph is null") ;
         checkArg(query) ;
-        QueryEngineHTTP qe = createServiceRequest(service, query, client) ;
+        QueryEngineHTTP qe = createServiceRequest(service, query, client, httpContext) ;
         qe.addDefaultGraph(defaultGraph) ;
         return qe ;
     }
-
     /** Create a service request for remote execution over HTTP.  The returned class,
      * {@link QueryEngineHTTP},
      * allows various HTTP specific parameters to be set. 
@@ -446,6 +512,20 @@ public class QueryExecutionFactory
      */
     static public QueryEngineHTTP createServiceRequest(String service, Query query, HttpClient client) {
         QueryEngineHTTP qe = new QueryEngineHTTP(service, query, client) ;
+        return qe ;
+    }
+
+    /** Create a service request for remote execution over HTTP.  The returned class,
+     * {@link QueryEngineHTTP},
+     * allows various HTTP specific parameters to be set. 
+     * @param service Endpoint URL
+     * @param query Query
+     * @param client HTTP client 
+     * @param httpContext HTTP Context
+     * @return Remote Query Engine
+     */
+    static public QueryEngineHTTP createServiceRequest(String service, Query query, HttpClient client, HttpContext httpContext) {
+        QueryEngineHTTP qe = new QueryEngineHTTP(service, query, client, httpContext) ;
         return qe ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessRemote.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessRemote.java
@@ -19,6 +19,7 @@
 package org.apache.jena.sparql.modify;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.protocol.HttpContext;
 import org.apache.jena.riot.WebContent ;
 import org.apache.jena.riot.web.HttpOp ;
 import org.apache.jena.sparql.ARQException ;
@@ -47,14 +48,16 @@ public class UpdateProcessRemote extends UpdateProcessRemoteBase
      * @param endpoint Update endpoint
      * @param context Context
      * @param client HTTP client
+     * @param httpContext HTTP Context 
      */
-    public UpdateProcessRemote(UpdateRequest request, String endpoint, Context context, HttpClient client)
+    public UpdateProcessRemote(UpdateRequest request, String endpoint, Context context, HttpClient client, HttpContext httpContext)
     {
         this(request, endpoint, context);
         // Don't want to overwrite config we may have picked up from
         // service context in the parent constructor if the specified
         // client is null
         if (client != null) this.setClient(client);
+        if (httpContext != null) this.setHttpContext(httpContext);
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessRemoteForm.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessRemoteForm.java
@@ -21,6 +21,7 @@ package org.apache.jena.sparql.modify;
 import static org.apache.jena.riot.web.HttpOp.execHttpPostForm;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.protocol.HttpContext;
 import org.apache.jena.riot.web.HttpResponseLib;
 import org.apache.jena.sparql.ARQException ;
 import org.apache.jena.sparql.engine.http.HttpParams ;
@@ -62,13 +63,17 @@ public class UpdateProcessRemoteForm extends UpdateProcessRemoteBase {
      *            Context
      * @param client
      *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+
      */
-    public UpdateProcessRemoteForm(UpdateRequest request, String endpoint, Context context, HttpClient client) {
+    public UpdateProcessRemoteForm(UpdateRequest request, String endpoint, Context context, HttpClient client, HttpContext httpContext) {
         this(request, endpoint, context);
         // Don't want to overwrite config we may have picked up from
         // service context in the parent constructor if the specified
         // client is null
         if (client != null) this.setClient(client);
+        if (httpContext != null) this.setHttpContext(httpContext);
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionFactory.java
@@ -19,6 +19,7 @@
 package org.apache.jena.update;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.protocol.HttpContext;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.QuerySolution ;
@@ -275,8 +276,6 @@ public class UpdateExecutionFactory
         return uProc;
     }
     
-    
-    
     /** Create an UpdateProcessor that sends the update to a remote SPARQL Update service.
      * @param update Updates
      * @param remoteEndpoint Endpoint URL
@@ -284,7 +283,7 @@ public class UpdateExecutionFactory
      */
     public static UpdateProcessor createRemote(Update update, String remoteEndpoint)
     {
-        return createRemote(new UpdateRequest(update), remoteEndpoint, null, null) ;
+        return createRemote(new UpdateRequest(update), remoteEndpoint, null, null, null) ;
     }
     
     /** Create an UpdateProcessor that sends the update to a remote SPARQL Update service.
@@ -295,7 +294,18 @@ public class UpdateExecutionFactory
      */
     public static UpdateProcessor createRemote(Update update, String remoteEndpoint, HttpClient client)
     {
-        return createRemote(new UpdateRequest(update), remoteEndpoint, null, client) ;
+        return createRemote(update, remoteEndpoint, client, null);
+    }
+    
+    /** Create an UpdateProcessor that sends the update to a remote SPARQL Update service.
+     * @param update Updates
+     * @param remoteEndpoint Endpoint URL
+     * @param client HTTP client
+     * @return Remote Update processor
+     */
+    public static UpdateProcessor createRemote(Update update, String remoteEndpoint, HttpClient client, HttpContext httpContext)
+    {
+        return createRemote(new UpdateRequest(update), remoteEndpoint, null, client, httpContext) ;
     }
     
     /** Create an UpdateProcessor that sends the update to a remote SPARQL Update service.
@@ -318,6 +328,19 @@ public class UpdateExecutionFactory
      */
     public static UpdateProcessor createRemote(Update update, String remoteEndpoint, Context context, HttpClient client)
     {
+        return createRemote(update, remoteEndpoint, context, client, null);
+    }
+        
+    /** Create an UpdateProcessor that sends the update to a remote SPARQL Update service.
+     * @param update Updates
+     * @param remoteEndpoint Endpoint URL
+     * @param context Context
+     * @param client HTTP client
+     * @param httpContext HTTP Context
+     * @return Remote Update processor
+     */
+    public static UpdateProcessor createRemote(Update update, String remoteEndpoint, Context context, HttpClient client, HttpContext httpContext)
+    {
         return createRemote(new UpdateRequest(update), remoteEndpoint, context, client) ;
     }
         
@@ -328,7 +351,7 @@ public class UpdateExecutionFactory
      */
     public static UpdateProcessor createRemote(UpdateRequest updateRequest, String remoteEndpoint)
     {
-        return createRemote(updateRequest, remoteEndpoint, null, null) ;
+        return createRemote(updateRequest, remoteEndpoint, null, null, null) ;
     }
     
     /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service.
@@ -340,6 +363,18 @@ public class UpdateExecutionFactory
     public static UpdateProcessor createRemote(UpdateRequest updateRequest, String remoteEndpoint, HttpClient client)
     {
         return createRemote(updateRequest, remoteEndpoint, null, client) ;
+    }
+
+    /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service.
+     * @param updateRequest Updates
+     * @param remoteEndpoint Endpoint URL
+     * @param client HTTP client
+     * @param httpContext HTTP Context
+     * @return Remote Update processor
+     */
+    public static UpdateProcessor createRemote(UpdateRequest updateRequest, String remoteEndpoint, HttpClient client, HttpContext httpContext)
+    {
+        return createRemote(updateRequest, remoteEndpoint, null, client, httpContext) ;
     }
 
     /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service.
@@ -362,7 +397,20 @@ public class UpdateExecutionFactory
      */
     public static UpdateProcessor createRemote(UpdateRequest updateRequest, String remoteEndpoint, Context context, HttpClient client)
     {
-        return new UpdateProcessRemote(updateRequest, remoteEndpoint, context, client) ;
+        return new UpdateProcessRemote(updateRequest, remoteEndpoint, context, client, null) ;
+    }
+    
+    /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service.
+     * @param updateRequest Updates
+     * @param remoteEndpoint Endpoint URL
+     * @param context Context
+     * @param client HTTP client
+     * @param httpContext   HTTP Context
+     * @return Remote Update processor
+     */
+    public static UpdateProcessor createRemote(UpdateRequest updateRequest, String remoteEndpoint, Context context, HttpClient client, HttpContext httpContext)
+    {
+        return new UpdateProcessRemote(updateRequest, remoteEndpoint, context, client, httpContext) ;
     }
     
     /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
@@ -372,7 +420,7 @@ public class UpdateExecutionFactory
      */
     public static UpdateProcessor createRemoteForm(Update update, String remoteEndpoint)
     {
-        return createRemoteForm(update, remoteEndpoint, null, null) ;
+        return createRemoteForm(update, remoteEndpoint, null, null, null) ;
     }
     
     /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
@@ -386,6 +434,18 @@ public class UpdateExecutionFactory
         return createRemoteForm(update, remoteEndpoint, null, client) ;
     }
     
+    /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
+     * @param update Updates
+     * @param remoteEndpoint Endpoint URL
+     * @param client HTTP client
+     * @param httpContext   HTTP Context
+     * @return Remote Update processor
+     */
+    public static UpdateProcessor createRemoteForm(Update update, String remoteEndpoint, HttpClient client, HttpContext httpContext)
+    {
+        return createRemoteForm(update, remoteEndpoint, null, client, httpContext) ;
+    }
+
     /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
      * @param update Updates
      * @param remoteEndpoint Endpoint URL
@@ -410,13 +470,24 @@ public class UpdateExecutionFactory
     }
     
     /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
+     * @param update Updates
+     * @param remoteEndpoint Endpoint URL
+     * @param context Context
+     * @param client HTTP client
+     * @param httpContext   HTTP Context
+     * @return Remote Update processor
+     */
+    public static UpdateProcessor createRemoteForm(Update update, String remoteEndpoint, Context context, HttpClient client, HttpContext httpContext) {
+        return createRemoteForm(new UpdateRequest(update), remoteEndpoint, null, client, httpContext) ;
+    }
+    /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
      * @param updateRequest Updates
      * @param remoteEndpoint Endpoint URL
      * @return Remote Update processor
      */
     public static UpdateProcessor createRemoteForm(UpdateRequest updateRequest, String remoteEndpoint)
     {
-        return createRemoteForm(updateRequest, remoteEndpoint, null, null) ;
+        return createRemoteForm(updateRequest, remoteEndpoint, null, null, null) ;
     }
     
     /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
@@ -430,6 +501,18 @@ public class UpdateExecutionFactory
         return createRemoteForm(updateRequest, remoteEndpoint, null, client) ;
     }
     
+    /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
+     * @param updateRequest Updates
+     * @param remoteEndpoint Endpoint URL
+     * @param client HTTP client
+     * @param httpContext   HTTP Context
+     * @return Remote Update processor
+     */
+    public static UpdateProcessor createRemoteForm(UpdateRequest updateRequest, String remoteEndpoint, HttpClient client, HttpContext httpContext)
+    {
+        return createRemoteForm(updateRequest, remoteEndpoint, null, client, httpContext) ;
+    }
+
     /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
      * @param updateRequest Updates
      * @param remoteEndpoint Endpoint URL
@@ -450,6 +533,19 @@ public class UpdateExecutionFactory
      */
     public static UpdateProcessor createRemoteForm(UpdateRequest updateRequest, String remoteEndpoint, Context context, HttpClient client)
     {
-        return new UpdateProcessRemoteForm(updateRequest, remoteEndpoint, context, client) ;
+        return createRemoteForm(updateRequest, remoteEndpoint, context, client, null) ;
+    }
+    
+    /** Create an UpdateProcessor that sends the update request to a remote SPARQL Update service using an HTML form
+     * @param updateRequest Updates
+     * @param remoteEndpoint Endpoint URL
+     * @param context Context
+     * @param client HTTP client
+     * @param httpContext   HTTP Context
+     * @return Remote Update processor
+     */
+    public static UpdateProcessor createRemoteForm(UpdateRequest updateRequest, String remoteEndpoint, Context context, HttpClient client, HttpContext httpContext) 
+    {
+        return new UpdateProcessRemoteForm(updateRequest, remoteEndpoint, context, client, httpContext) ;
     }
 }

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionRemote.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionRemote.java
@@ -51,28 +51,26 @@ public class TestRDFConnectionRemote extends AbstractTestRDFConnection {
         server.start() ;
     }
 
-    @AfterClass
-    public static void afterClass() {
-        server.stop(); 
-    }
-    
     @Before
     public void beforeTest() {
         // Clear server
         Txn.executeWrite(serverdsg, ()->serverdsg.clear()) ;
     }
-    
-//    @After
-//    public void afterTest() {}
-//    }
 
+//  @After
+//  public void afterTest() {}
+    
+    @AfterClass
+    public static void afterClass() {
+        server.stop(); 
+    }
+    
     @Override
     protected boolean supportsAbort() { return false ; }
 
     @Override
     protected RDFConnection connection() {
-        return RDFConnectionFactory.connect("http://localhost:2244/ds") ;
+        return RDFConnectionFactory.connect("http://localhost:2244/ds");
     }
-
 }
 

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConn.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConn.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.rdfconnection;
 
+import java.util.Objects;
+
 /** package-wide utilities etc */
 /*package*/ class RDFConn {
     private static String dftName =  "default" ;
@@ -26,15 +28,44 @@ package org.apache.jena.rdfconnection;
         return name == null || name.equals(dftName) ;
     }
     
-    /*package*/ static String queryStringForGraph(String graphName) {
+    private static String queryStringForGraph(String ch, String graphName) {
         return 
-            (RDFConn.isDefault(graphName) )
-            ? "?default"
-            : "?graph="+graphName ;
+            ch + 
+                (RDFConn.isDefault(graphName)
+                ? "default"
+                : "graph="+graphName) ;
     }
     
     /*package*/ static String urlForGraph(String graphStoreProtocolService, String graphName) {
-        return graphStoreProtocolService + queryStringForGraph(graphName) ;
+        // If query string
+        String ch = "?";
+        if ( graphStoreProtocolService.contains("?") )
+            // Already has a query string, append with "&"  
+            ch = "&";
+        return graphStoreProtocolService + queryStringForGraph(ch, graphName) ;
+    }
+
+    /*package*/ static String formServiceURL(String destination, String srvEndpoint) {
+        Objects.requireNonNull(srvEndpoint, "Service Endpoint");
+        if ( destination == null )
+            return srvEndpoint;
+        // If the srvEndpoint looks like an absolute URL, use as given. 
+        if ( srvEndpoint.startsWith("http:/") || srvEndpoint.startsWith("https:/") )
+            return srvEndpoint;
+        String queryString = null;
+        String dest = destination;
+        if ( destination.contains("?") ) {
+            // query string : remove and append later.
+            int i = destination.indexOf('?');
+            queryString = destination.substring(i);
+            dest = destination.substring(0, i);
+        }
+        if ( dest.endsWith("/") )
+            dest = dest.substring(0, dest.length()-1);
+        dest = dest+"/"+srvEndpoint;
+        if ( queryString != null )
+           dest = dest+queryString; 
+        return dest;
     }
 
 }

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionFactory.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionFactory.java
@@ -55,8 +55,7 @@ public class RDFConnectionFactory {
                                         String updateServiceEndpoint,
                                         String graphStoreProtocolEndpoint) {
         return new RDFConnectionRemote(queryServiceEndpoint, updateServiceEndpoint, graphStoreProtocolEndpoint);
-   }
-
+    }
     
     /** Create a connection to a remote location by URL.
      * This is the URL for the dataset.

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemote.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemote.java
@@ -200,7 +200,13 @@ public class RDFConnectionRemote implements RDFConnection {
         doPutPost(model, null, true);
     }
     
-    private void upload(String graph, String file, boolean replace) {
+    /** Send a file to named graph (or "default" or null for the default graph).
+     * <p>
+     * The Content-Type is inferred from the file extension.
+     * <p>
+     * "Replace" means overwrite existing data, othewise the date is added to the target.
+     */
+    protected void upload(String graph, String file, boolean replace) {
         // if triples
         Lang lang = RDFLanguages.filenameToLang(file);
         if ( RDFLanguages.isQuads(lang) )
@@ -211,7 +217,13 @@ public class RDFConnectionRemote implements RDFConnection {
         doPutPost(url, file, lang, replace);
     }
 
-    private void doPutPost(String url, String file, Lang lang, boolean replace) {
+    /** Send a file to named graph (or "default" or null for the defaultl graph).
+     * <p>
+     * The Content-Type is taken from the given {@code Lang}.
+     * <p>
+     * "Replace" means overwrite existing data, othewise the date is added to the target.
+     */
+    protected void doPutPost(String url, String file, Lang lang, boolean replace) {
         File f = new File(file);
         long length = f.length(); 
         InputStream source = IO.openFile(file);
@@ -224,7 +236,13 @@ public class RDFConnectionRemote implements RDFConnection {
         });
     }
 
-    private void doPutPost(Model model, String name, boolean replace) {
+    /** Send a model to named graph (or "default" or null for the defaultl graph).
+     * <p>
+     * The Content-Type is taken from the given {@code Lang}.
+     * <p>
+     * "Replace" means overwrite existing data, othewise the date is added to the target.
+     */
+    protected void doPutPost(Model model, String name, boolean replace) {
         String url = RDFConn.urlForGraph(svcGraphStore, name);
         exec(()->{
             Graph graph = model.getGraph();
@@ -289,7 +307,13 @@ public class RDFConnectionRemote implements RDFConnection {
         doPutPostDataset(dataset, true); 
     }
 
-    private void doPutPostDataset(String file, boolean replace) {
+    /** Do a PUT or POST to a dataset, sending the contents of the file.
+     * <p>
+     * The Content-Type is inferred from the file extension.
+     * <p>
+     * "Replace" implies PUT, otherwise a POST is used.
+     */
+    protected void doPutPostDataset(String file, boolean replace) {
         Lang lang = RDFLanguages.filenameToLang(file);
         File f = new File(file);
         long length = f.length();
@@ -302,7 +326,12 @@ public class RDFConnectionRemote implements RDFConnection {
         });
     }
 
-    private void doPutPostDataset(Dataset dataset, boolean replace) {
+    /** Do a PUT or POST to a dataset, sending the contents of a daatsets.
+     * The Content-Type is {@code application/n-quads}.
+     * <p>
+     * "Replace" implies PUT, otherwise a POST is used.
+     */
+    protected void doPutPostDataset(Dataset dataset, boolean replace) {
         exec(()->{
             DatasetGraph dsg = dataset.asDatasetGraph();
             if ( replace )

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemote.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemote.java
@@ -50,7 +50,7 @@ import org.apache.jena.update.UpdateRequest;
 import org.apache.jena.web.HttpSC;
 
 /** 
- * Implemntation of the {@link RDFConnection} interface using remote SPARQL operations.  
+ * Implementation of the {@link RDFConnection} interface using remote SPARQL operations.  
  */
 public class RDFConnectionRemote implements RDFConnection {
     private static final String fusekiDftSrvQuery   = "sparql";
@@ -74,7 +74,6 @@ public class RDFConnectionRemote implements RDFConnection {
              fusekiDftSrvGSP);
     }
 
-
     /** Create connection, using URL of the dataset and default service names */
     public RDFConnectionRemote(String destination) {
         this(requireNonNull(destination),
@@ -83,7 +82,6 @@ public class RDFConnectionRemote implements RDFConnection {
              fusekiDftSrvGSP);
     }
 
-    // ??
     /** Create connection, using full URLs for services. Pass a null for "no service endpoint". */
     public RDFConnectionRemote(String sQuery, String sUpdate, String sGSP) {
         this(null, sQuery, sUpdate, sGSP);
@@ -97,9 +95,9 @@ public class RDFConnectionRemote implements RDFConnection {
     /** Create connection, using URL of the dataset and short names for the services */
     public RDFConnectionRemote(HttpClient httpClient, String destination, String sQuery, String sUpdate, String sGSP) {
         this.destination = destination;
-        this.svcQuery = formServiceURL(destination,sQuery);
-        this.svcUpdate = formServiceURL(destination,sUpdate);
-        this.svcGraphStore = formServiceURL(destination,sGSP);
+        this.svcQuery = RDFConn.formServiceURL(destination, sQuery);
+        this.svcUpdate = RDFConn.formServiceURL(destination, sUpdate);
+        this.svcGraphStore = RDFConn.formServiceURL(destination, sGSP);
         this.httpClient = httpClient;
     }
     
@@ -119,25 +117,20 @@ public class RDFConnectionRemote implements RDFConnection {
         this.httpContext = httpContext;
     }
 
-    private static String formServiceURL(String destination, String srvEndpoint) {
-        if ( destination == null )
-            return srvEndpoint;
-        String dest = destination;
-        if ( dest.endsWith("/") )
-            dest = dest.substring(0, dest.length()-1);
-        return dest+"/"+srvEndpoint;
-    }
+    
 
+    // Needs HttpContext
+    
     @Override
     public QueryExecution query(Query query) {
         checkQuery();
-        return exec(()->QueryExecutionFactory.createServiceRequest(svcQuery, query));
+        return exec(()->QueryExecutionFactory.sparqlService(svcQuery, query, this.httpClient, this.httpContext));
     }
 
     @Override
     public void update(UpdateRequest update) {
         checkUpdate();
-        UpdateProcessor proc = UpdateExecutionFactory.createRemote(update, svcUpdate);
+        UpdateProcessor proc = UpdateExecutionFactory.createRemote(update, svcUpdate, this.httpClient, this.httpContext);
         exec(()->proc.execute());
     }
     

--- a/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/TS_RDFConnection.java
+++ b/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/TS_RDFConnection.java
@@ -23,10 +23,11 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses( {
-    // Other tests are in jena-integration-tests
+    // Other tests, especifically for RDFCommectionRemote are in jena-integration-tests
     TestRDFConnectionLocalTxnMem.class
     , TestRDFConnectionLocalMRSW.class
     , TestLocalIsolation.class
+    , TestRDFConn.class
 })
 
 public class TS_RDFConnection {}

--- a/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/TestRDFConn.java
+++ b/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/TestRDFConn.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.rdfconnection;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TestRDFConn {
+    
+    @Test public void service_url_01() {
+        testServiceName(null, "XYZ", "XYZ"); 
+    }
+    
+    @Test public void service_url_02() {
+        testServiceName("http://example/", "XYZ", "http://example/XYZ"); 
+    }
+
+    @Test public void service_url_03() {
+        testServiceName("http://example/abc", "XYZ", "http://example/abc/XYZ"); 
+    }
+
+    @Test public void service_url_04() {
+        testServiceName("http://example/abc/", "XYZ", "http://example/abc/XYZ"); 
+    }
+    
+    @Test public void service_url_05() {
+        testServiceName("http://example/abc?param=value", "XYZ", "http://example/abc/XYZ?param=value"); 
+    }
+
+    @Test public void service_url_06() {
+        testServiceName("http://example/dataset", "http://other/abc/", "http://other/abc/"); 
+    }
+
+    @Test public void service_url_07() {
+        testServiceName("http://example/dataset", "http://example/abc/XYZ?param=value", "http://example/abc/XYZ?param=value"); 
+    }
+    
+    private static void testServiceName(String destination, String service, String expected) {
+        String x = RDFConn.formServiceURL(destination, service);
+        assertEquals(expected, x);
+    }
+    
+    // Assumes service name constructed correctly (see above). 
+    
+    @Test public void gsp_url_01() {
+        testGSP("http://example/", null, "http://example/?default");  
+    }
+
+    @Test public void gsp_url_02() {
+        testGSP("http://example/", "default", "http://example/?default");  
+    }
+
+    @Test public void gsp_url_03() {
+        testGSP("http://example/dataset", null, "http://example/dataset?default");  
+    }
+
+    @Test public void gsp_url_04() {
+        testGSP("http://example/dataset", "default", "http://example/dataset?default");  
+    }
+    
+    @Test public void gsp_url_05() {
+        testGSP("http://example/dataset?param=value", "default", "http://example/dataset?param=value&default");  
+    }
+    
+    @Test public void gsp_url_06() {
+        testGSP("http://example/?param=value", "default", "http://example/?param=value&default");  
+    }
+
+    @Test public void gsp_url_07() {
+        testGSP("http://example/dataset?param=value", "default", "http://example/dataset?param=value&default");  
+    }
+    
+    @Test public void gsp_url_08() {
+        testGSP("http://example/dataset/?param=value", "default", "http://example/dataset/?param=value&default");  
+    }
+
+    @Test public void gsp_url_11() {
+        testGSP("http://example/dataset", "name", "http://example/dataset?graph=name");  
+    }
+
+    @Test public void gsp_url_12() {
+        testGSP("http://example/", "name", "http://example/?graph=name");  
+    }
+    
+    @Test public void gsp_url_13() {
+        testGSP("http://example/dataset/", "name", "http://example/dataset/?graph=name");  
+    }
+
+    @Test public void gsp_url_20() {
+        testGSP("http://example/dataset?param=value", null, "http://example/dataset?param=value&default");  
+    }
+
+    @Test public void gsp_url_21() {
+        testGSP("http://example/?param=value", null, "http://example/?param=value&default");  
+    }
+
+    @Test public void gsp_url_16() {
+        testGSP("http://example/dataset?param=value", "name", "http://example/dataset?param=value&graph=name");  
+    }
+
+    @Test public void gsp_url_17() {
+        testGSP("http://example/?param=value", "name", "http://example/?param=value&graph=name");  
+    }
+
+    private void testGSP(String gsp, String graphName, String expected) {
+        String x = RDFConn.urlForGraph(gsp, graphName);
+        assertEquals(expected, x);
+    }
+    
+}


### PR DESCRIPTION
JENA-1330: pass HttpClient/HttpContext in query and update calls.

JENA-1331: Support additional query string in URLs for services.

Add operations for HttpClient/HttpContext to 
QueryExecutionFactory and UpdateExecutionFactory.

Use HttpContext in HtpQuery, then HttpClientContext.adapt as necessary.

Tests for URL generation.