### PR TITLE
JENA-1329: Define and use QueryIterator.isJoinIdentity.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/TableFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/TableFactory.java
@@ -27,7 +27,6 @@ import org.apache.jena.sparql.algebra.table.TableN ;
 import org.apache.jena.sparql.algebra.table.TableUnit ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.engine.QueryIterator ;
-import org.apache.jena.sparql.engine.iterator.QueryIterRoot ;
 
 public class TableFactory
 {
@@ -45,13 +44,13 @@ public class TableFactory
     
     public static Table create(QueryIterator queryIterator)
     { 
-        if ( queryIterator instanceof QueryIterRoot )
-        {
+        if ( queryIterator.isJoinIdentity() ) {
             queryIterator.close();
             return createUnit() ;
         }
         
-        return new TableN(queryIterator) ; }
+        return new TableN(queryIterator) ;
+    }
 
     public static Table create(Var var, Node value)
     { return new Table1(var, value) ; }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryIterator.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryIterator.java
@@ -35,4 +35,10 @@ public interface QueryIterator extends Closeable, Iterator<Binding>, PrintSerial
      * Cancels the query as soon as is possible for the given iterator
      */
     public void cancel();
+    
+    /*
+     * Indicate whether this iterator is known to be an iterator of the join identity (one row, no columns).
+     * Returns true if definitely a join identity; false for not or don't know.
+     */
+    public default boolean isJoinIdentity() { return false; }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingRoot.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingRoot.java
@@ -19,8 +19,6 @@
 package org.apache.jena.sparql.engine.binding;
 
 /** Special purpose binding for the root of all bindings. */
-
-
 public class BindingRoot extends Binding0
 {
     public static Binding create() { return new BindingRoot() ; } 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterRoot.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterRoot.java
@@ -20,29 +20,33 @@ package org.apache.jena.sparql.engine.iterator;
 
 import org.apache.jena.atlas.io.IndentedWriter ;
 import org.apache.jena.sparql.engine.ExecutionContext ;
+import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.engine.binding.BindingRoot ;
 import org.apache.jena.sparql.serializer.SerializationContext ;
 
+/** The root binding is one-row, no columns making it the join identity.
+ *  It is useful to be able to spot it before having to activate a {@link QueryIterator}.
+ *  Executing with a pre-set binding does not use QueryIterRoot.
+ */
 public class QueryIterRoot extends QueryIterSingleton
 {
-    public static QueryIterRoot create(ExecutionContext execCxt)
+    public static QueryIterator createRoot(ExecutionContext execCxt)
     { return new QueryIterRoot(BindingRoot.create(), execCxt) ; }
     
-    public static QueryIterRoot create(Binding binding, ExecutionContext execCxt)
-    { return new QueryIterRoot(binding, execCxt) ; }
-
-    private QueryIterRoot(Binding binding, ExecutionContext execCxt)
-    {
+    private QueryIterRoot(Binding binding, ExecutionContext execCxt) {
         super(binding, execCxt) ;
     }
 
     @Override
-    public void output(IndentedWriter out, SerializationContext sCxt)
-    {
+    public void output(IndentedWriter out, SerializationContext sCxt) {
         if ( binding instanceof BindingRoot )
             out.print("QueryIterRoot");
         else
+            // Not used
             out.print("QueryIterRoot: "+binding);
     }
+    
+    @Override
+    public boolean isJoinIdentity() { return true; }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/OpExecutor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/OpExecutor.java
@@ -320,9 +320,9 @@ public class OpExecutor
     protected QueryIterator execute(OpTable opTable, QueryIterator input) {
         if (opTable.isJoinIdentity())
             return input ;
-        if (input instanceof QueryIterRoot) {
+        if (input.isJoinIdentity() ) {
             input.close() ;
-            return opTable.getTable().iterator(execCxt) ;
+            return opTable.getTable().iterator(execCxt);
         }
         QueryIterator qIterT = opTable.getTable().iterator(execCxt) ;
         QueryIterator qIter = Join.join(input, qIterT, execCxt) ;
@@ -435,7 +435,7 @@ public class OpExecutor
     }
 
     public static QueryIterator createRootQueryIterator(ExecutionContext execCxt) {
-        return QueryIterRoot.create(execCxt) ;
+        return QueryIterRoot.createRoot(execCxt) ;
     }
 
     protected QueryIterator root() {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/QueryEngineMain.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/QueryEngineMain.java
@@ -27,6 +27,7 @@ import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.engine.* ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.engine.iterator.QueryIterRoot ;
+import org.apache.jena.sparql.engine.iterator.QueryIterSingleton;
 import org.apache.jena.sparql.engine.iterator.QueryIteratorCheck ;
 import org.apache.jena.sparql.engine.iterator.QueryIteratorTiming ;
 import org.apache.jena.sparql.util.Context ;
@@ -49,7 +50,10 @@ public class QueryEngineMain extends QueryEngineBase
     public QueryIterator eval(Op op, DatasetGraph dsg, Binding input, Context context)
     {
         ExecutionContext execCxt = new ExecutionContext(context, dsg.getDefaultGraph(), dsg, QC.getFactory(context)) ;
-        QueryIterator qIter1 = QueryIterRoot.create(input, execCxt) ;
+        QueryIterator qIter1 = 
+            ( input.isEmpty() ) 
+            ? QueryIterRoot.createRoot(execCxt)
+            : QueryIterSingleton.create(input, execCxt);
         QueryIterator qIter = QC.execute(op, qIter1, execCxt) ;
         // Wrap with something to check for closed iterators.
         qIter = QueryIteratorCheck.check(qIter, execCxt) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/StageGeneratorGeneric.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/StageGeneratorGeneric.java
@@ -28,7 +28,6 @@ import org.apache.jena.sparql.engine.QueryIterator ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.engine.iterator.QueryIterBlockTriples ;
 import org.apache.jena.sparql.engine.iterator.QueryIterPeek ;
-import org.apache.jena.sparql.engine.iterator.QueryIterRoot ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderLib ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderProc ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation ;
@@ -63,20 +62,18 @@ public class StageGeneratorGeneric implements StageGenerator {
             return input ;
         
         if ( reorder != null && pattern.size() >= 2 ) {
-            // If pattern size is 0 or one, nothing to do.
+            // If pattern size is 0 or 1, nothing to do.
             BasicPattern bgp2 = pattern ;
 
             // Try to ground the pattern
-            if ( ! ( input instanceof QueryIterRoot ) ) {
+            if ( ! input.isJoinIdentity() ) {
                 QueryIterPeek peek = QueryIterPeek.create(input, execCxt) ;
-                Binding b = peek.peek() ;
-                // And use this one
+                // And now use this one
                 input = peek ;
+                Binding b = peek.peek() ;
                 bgp2 = Substitute.substitute(pattern, b) ;
-                // ---- common
                 ReorderProc reorderProc = reorder.reorderIndexes(bgp2) ;
                 pattern = reorderProc.reorder(pattern) ;
-
             }
         }
         Explain.explain("Reorder/generic", pattern, execCxt.getContext()) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/ref/Eval.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/ref/Eval.java
@@ -159,7 +159,7 @@ public class Eval
             if ( g == null )
                 return new TableEmpty() ;
             ExecutionContext cxt2 = new ExecutionContext(cxt, g) ;
-            QueryIterator qIter = executeBGP(pattern, QueryIterRoot.create(cxt2), cxt2) ;
+            QueryIterator qIter = executeBGP(pattern, QueryIterRoot.createRoot(cxt2), cxt2) ;
             return TableFactory.create(qIter) ;
         }
         else
@@ -180,7 +180,7 @@ public class Eval
                 // Eval the pattern, eval the variable, join.
                 // Pattern may be non-linear in the variable - do a pure execution.  
                 Table t1 = TableFactory.create(gVar, gn) ;
-                QueryIterator qIter = executeBGP(pattern, QueryIterRoot.create(cxt2), cxt2) ;
+                QueryIterator qIter = executeBGP(pattern, QueryIterRoot.createRoot(cxt2), cxt2) ;
                 Table t2 = TableFactory.create(qIter) ;
                 Table t3 = evaluator.join(t1, t2) ;
                 concat.add(t3.iterator(cxt2)) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/ref/EvaluatorSimple.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/ref/EvaluatorSimple.java
@@ -63,7 +63,7 @@ public class EvaluatorSimple implements Evaluator
     @Override
     public Table basicPattern(BasicPattern pattern)
     {
-        QueryIterator qIter = QC.executeDirect(pattern, QueryIterRoot.create(execCxt), execCxt) ;
+        QueryIterator qIter = QC.executeDirect(pattern, QueryIterRoot.createRoot(execCxt), execCxt) ;
         return TableFactory.create(qIter) ;
     }
 
@@ -72,7 +72,7 @@ public class EvaluatorSimple implements Evaluator
     {
         // Shudder - this may well be expensive, but this is the simple evaluator, written for correctness. 
         QueryIterator qIter = new QueryIterPath(triplePath, 
-                                                QueryIterRoot.create(execCxt),
+                                                QueryIterRoot.createRoot(execCxt),
                                                 execCxt) ;
         return TableFactory.create(qIter) ;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/eval/PathEngine.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/eval/PathEngine.java
@@ -210,7 +210,7 @@ abstract public class PathEngine
         PropertyFunction pf = f.create(p.getURI()) ;
         PropFuncArg sv = arg(s, "S") ;
         PropFuncArg ov = arg(o, "O") ;
-        QueryIterator r = QueryIterRoot.create(new ExecutionContext(context, graph, null, null)) ;
+        QueryIterator r = QueryIterRoot.createRoot(new ExecutionContext(context, graph, null, null)) ;
         QueryIterator qIter = pf.exec(r, sv, p, ov, new ExecutionContext(ARQ.getContext(), graph, null, null)) ;
         if ( ! qIter.hasNext() )
             return Iter.nullIterator() ;


### PR DESCRIPTION
Don't test for class `QueryIterRoot`.
Don't use `QueryIterRoot` to hold a binding with set variables.
