### PR TITLE
JENA-1340: Handle riot command --base

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
@@ -190,13 +190,23 @@ public class RDFParserRegistry
 
         @Override
         public void read(InputStream in, String baseURI, ContentType ct, StreamRDF output, Context context) {
-            LangRIOT parser = RiotParsers.createParser(in, lang, baseURI, output, parserProfile);
+            // Unnecessary - RDFParser did it and set it in the ParserProfile
+//            if ( baseURI != null ) {
+//                IRIResolver newResolver = IRIResolver.create(baseURI) ;
+//                parserProfile.setIRIResolver(newResolver);
+//            }
+            LangRIOT parser = RiotParsers.createParser(in, lang, output, parserProfile);
             parser.parse() ;
         }
 
         @Override
         public void read(Reader in, String baseURI, ContentType ct, StreamRDF output, Context context) {
-            LangRIOT parser = RiotParsers.createParser(in, lang, baseURI, output, parserProfile);
+            // Unnecessary - RDFParser did it and set it in the ParserProfile
+//          if ( baseURI != null ) {
+//              IRIResolver newResolver = IRIResolver.create(baseURI) ;
+//              parserProfile.setIRIResolver(newResolver);
+//          }
+            LangRIOT parser = RiotParsers.createParser(in, lang, output, parserProfile);
             parser.parse() ;
         }
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/ReaderRIOTCSV.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/ReaderRIOTCSV.java
@@ -43,7 +43,7 @@ public class ReaderRIOTCSV implements ReaderRIOT {
         }
     }
     
-    public static final String CSV_PREFIX = "http://w3c/future-csv-vocab/";
+    public static final String CSV_PREFIX = "http://jena.apache.org/csv/";
 	public static final String CSV_ROW = CSV_PREFIX + "row";
 
 	private InputStream input = null;

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/RiotParsers.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/RiotParsers.java
@@ -48,7 +48,7 @@ public class RiotParsers {
     private RiotParsers() {}
 
     /** InputStream input */
-    public static LangRIOT createParser(InputStream input, Lang lang, String baseIRI, StreamRDF dest, ParserProfile profile) {
+    public static LangRIOT createParser(InputStream input, Lang lang, StreamRDF dest, ParserProfile profile) {
         if ( RDFLanguages.sameLang(RDFJSON, lang) ) {
             Tokenizer tokenizer = new TokenizerJSON(PeekReader.makeUTF8(input));
             return createParserRdfJson(tokenizer, dest, profile);
@@ -67,7 +67,7 @@ public class RiotParsers {
     }
 
     /** Reader input */
-    public static LangRIOT createParser(Reader input, Lang lang, String baseIRI, StreamRDF dest, ParserProfile profile) {
+    public static LangRIOT createParser(Reader input, Lang lang, StreamRDF dest, ParserProfile profile) {
         if ( RDFLanguages.sameLang(RDFJSON, lang) ) {
             Tokenizer tokenizer = new TokenizerJSON(PeekReader.make(input));
             return createParserRdfJson(tokenizer, dest, profile);

--- a/jena-cmds/src/main/java/riotcmd/riot.java
+++ b/jena-cmds/src/main/java/riotcmd/riot.java
@@ -47,11 +47,13 @@ public class riot extends CmdLangParse
         
         if ( contentType != null && ! WebContent.matchContentType(WebContent.ctTextPlain, contentType) )
             return RDFLanguages.contentTypeToLang(contentType) ;
-
-        Lang lang =  RDFLanguages.filenameToLang(filename) ;
-        if ( lang == null )
-            lang = dftLang ;
-        return lang ;
+        
+        if ( filename != null ) {
+            Lang lang =  RDFLanguages.filenameToLang(filename) ;
+            if ( lang != null )
+                return lang;
+        }
+        return dftLang;
     }
 
     @Override


### PR DESCRIPTION
Changed the style to be based on the configuration of an `RDFParserBuilder` so as not to duplicate policies such as file/URI to InputStream and determining syntax.