### PR TITLE
JENA-1349: Use RDFParser for conneg.

### DIFF
--- a/jena-arq/src-examples/arq/examples/riot/ExRIOT_2.java
+++ b/jena-arq/src-examples/arq/examples/riot/ExRIOT_2.java
@@ -22,7 +22,6 @@ import java.io.FileInputStream ;
 import java.io.IOException ;
 import java.io.InputStream ;
 
-import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.riot.RDFLanguages ;
 import org.apache.jena.riot.RDFParser ;
 import org.apache.jena.riot.system.ErrorHandlerFactory ;
@@ -30,8 +29,6 @@ import org.apache.jena.riot.system.StreamRDF ;
 import org.apache.jena.riot.system.StreamRDFLib ;
 
 /** Example of using RIOT directly.
- * 
- * RDFDataMgr is the general place to read data.
  * 
  * The parsers produce a stream of triples and quads so processing does not need
  * to hold everything in memory at the same time. See also {@code ExRIOT_4}
@@ -43,11 +40,6 @@ public class ExRIOT_2
         // ---- Parse to a Sink.
         StreamRDF noWhere = StreamRDFLib.sinkNull() ;
 
-        // RIOT controls the conversion from bytes to java chars.
-        try (InputStream in = new FileInputStream("data.trig")) {
-            RDFDataMgr.parse(noWhere, in, "http://example/base", RDFLanguages.TRIG) ;
-        }
-        
         // --- Or create a parser and do the parsing with detailed setup.
         String baseURI = "http://example/base" ;
         

--- a/jena-arq/src-examples/arq/examples/riot/ExRIOT_4.java
+++ b/jena-arq/src-examples/arq/examples/riot/ExRIOT_4.java
@@ -22,7 +22,7 @@ import org.apache.jena.atlas.lib.Sink ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.rdf.model.Property ;
-import org.apache.jena.riot.RDFDataMgr ;
+import org.apache.jena.riot.RDFParser ;
 import org.apache.jena.riot.out.SinkTripleOutput ;
 import org.apache.jena.riot.system.StreamRDF ;
 import org.apache.jena.riot.system.StreamRDFBase ;
@@ -41,8 +41,8 @@ public class ExRIOT_4
         Sink<Triple> output = new SinkTripleOutput(System.out, null, SyntaxLabels.createNodeToLabel()) ;
         StreamRDF filtered = new FilterSinkRDF(output, FOAF.name, FOAF.knows) ;
         
-        // Call the parsing process. 
-        RDFDataMgr.parse(filtered, filename) ;
+        // Call the parsing process.
+        RDFParser.source(filename).parse(filtered);
     }
     
     static class FilterSinkRDF extends StreamRDFBase

--- a/jena-arq/src-examples/arq/examples/riot/ExRIOT_6.java
+++ b/jena-arq/src-examples/arq/examples/riot/ExRIOT_6.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ExecutorService ;
 import java.util.concurrent.Executors ;
 
 import org.apache.jena.graph.Triple ;
-import org.apache.jena.riot.RDFDataMgr ;
+import org.apache.jena.riot.RDFParser ;
 import org.apache.jena.riot.lang.PipedRDFIterator ;
 import org.apache.jena.riot.lang.PipedRDFStream ;
 import org.apache.jena.riot.lang.PipedTriplesStream ;
@@ -53,8 +53,7 @@ public class ExRIOT_6 {
 
             @Override
             public void run() {
-                // Call the parsing process.
-                RDFDataMgr.parse(inputStream, filename);
+                RDFParser.source(filename).parse(inputStream);
             }
         };
 

--- a/jena-arq/src-examples/arq/examples/riot/ExRIOT_7.java
+++ b/jena-arq/src-examples/arq/examples/riot/ExRIOT_7.java
@@ -19,7 +19,7 @@
 package arq.examples.riot;
 
 import org.apache.jena.graph.Triple ;
-import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFParser ;
 import org.apache.jena.riot.lang.CollectorStreamBase;
 import org.apache.jena.riot.lang.CollectorStreamTriples;
 
@@ -38,7 +38,7 @@ public class ExRIOT_7 {
         final String filename = "data.ttl";
         
         CollectorStreamTriples inputStream = new CollectorStreamTriples();
-        RDFDataMgr.parse(inputStream, filename);
+        RDFParser.source(filename).parse(inputStream);
 
         for (Triple triple : inputStream.getCollected()) {
         	System.out.println(triple);

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
@@ -218,7 +218,7 @@ public class RDFDataMgr
     public static void read(Graph graph, String uri, String base, Lang hintLang, Context context)
     {
         StreamRDF dest = StreamRDFLib.graph(graph) ;
-        parse(dest, uri, base, hintLang, context) ;
+        parseFromURI(dest, uri, base, hintLang, context) ;
     }
 
     /** Read triples into a Model with bytes from an InputStream.
@@ -265,7 +265,7 @@ public class RDFDataMgr
     public static void read(Graph graph, InputStream in, String base, Lang lang) {
         Objects.requireNonNull(in, "InputStream is null") ;
         StreamRDF dest = StreamRDFLib.graph(graph) ;
-        process(dest, TypedInputStream.wrap(in), base, lang, (Context)null) ;
+        parseFromInputStream(dest, in, base, lang, null) ;
     }
 
     /** Read triples into a model with chars from an Reader.
@@ -295,7 +295,7 @@ public class RDFDataMgr
     @Deprecated
     public static void read(Graph graph, Reader in, String base, Lang lang) {
         StreamRDF dest = StreamRDFLib.graph(graph) ;
-        process(dest, in, base, lang, (Context)null) ;
+        parseFromReader(dest, in, base, lang, null) ;
     }
 
     /** Read triples into a model with chars from a StringReader.
@@ -307,7 +307,7 @@ public class RDFDataMgr
     public static void read(Model model, StringReader in, String base, Lang lang) {
         Graph g = model.getGraph() ;
         StreamRDF dest = StreamRDFLib.graph(g) ;
-        process(dest, in, base, lang, (Context)null) ;
+        parseFromReader(dest, in, base, lang, (Context)null) ;
     }
 
     /** Read triples into a model with chars from a StringReader.
@@ -318,7 +318,7 @@ public class RDFDataMgr
      */
     public static void read(Graph graph, StringReader in, String base, Lang lang) {
         StreamRDF dest = StreamRDFLib.graph(graph) ;
-        process(dest, in, base, lang, (Context)null) ;
+        parseFromReader(dest, in, base, lang, (Context)null) ;
     }
     
     private static Model createModel()                  { return ModelFactory.createDefaultModel() ; } 
@@ -516,7 +516,7 @@ public class RDFDataMgr
     @Deprecated
     public static void read(DatasetGraph dataset, String uri, String base, Lang hintLang, Context context) {
         StreamRDF sink = StreamRDFLib.dataset(dataset) ;
-        parse(sink, uri, base, hintLang, context) ;
+        parseFromURI(sink, uri, base, hintLang, context) ;
     }
 
     /** Read quads or triples into a dataset with bytes from an input stream.
@@ -556,7 +556,7 @@ public class RDFDataMgr
     public static void read(DatasetGraph dataset, InputStream in, String base, Lang lang) {
         Objects.requireNonNull(in, "InputStream is null") ;
         StreamRDF dest = StreamRDFLib.dataset(dataset) ;
-        process(dest, TypedInputStream.wrap(in), base, lang, (Context)null) ;
+        parseFromInputStream(dest, in, base, lang, (Context)null) ;
     }
     
     /** Read quads into a dataset with chars from an Reader.
@@ -586,7 +586,7 @@ public class RDFDataMgr
     @Deprecated
     public static void read(DatasetGraph dataset, Reader in, String base, Lang lang) {
         StreamRDF dest = StreamRDFLib.dataset(dataset) ;
-        process(dest, in, base, lang, (Context)null) ;
+        parseFromReader(dest, in, base, lang, (Context)null) ;
     }
 
     /** Read quads into a dataset with chars from a StringReader.
@@ -611,22 +611,28 @@ public class RDFDataMgr
      */
     public static void read(DatasetGraph dataset, StringReader in, String base, Lang lang) {
         StreamRDF dest = StreamRDFLib.dataset(dataset) ;
-        process(dest, in, base, lang, (Context)null) ;
+        parseFromReader(dest, in, base, lang, (Context)null) ;
     }
 
     /** Read RDF data.
+     * Use {@code RDFParser.source(uri).parse(sink)}
      * @param sink     Destination for the RDF read.
-     * @param uri       URI to read from (includes file: and a plain file name).
+     * @param uri      URI to read from (includes file: and a plain file name).
      */
+    //@deprecated     Use {@code RDFParser.source(uri).parse(sink)}
+    //@Deprecated
     public static void parse(StreamRDF sink, String uri) {
         parse(sink, uri, defaultLang(uri)) ;
     }
 
     /** Read RDF data.
+     * Use {@code RDFParser.source(uri).lang(hintLang).parse(sink)}
      * @param sink      Destination for the RDF read.
      * @param uri       URI to read from (includes file: and a plain file name).
      * @param lang      Hint for the syntax
      */
+    //* @deprecated     Use {@code RDFParser.source(uri).lang(hintLang).parse(sink)}
+    //@Deprecated
     public static void parse(StreamRDF sink, String uri, Lang lang) {
         parse(sink, uri, lang, (Context)null) ;
     }
@@ -636,7 +642,7 @@ public class RDFDataMgr
      * @param uri       URI to read from (includes file: and a plain file name).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
-     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
+     * @deprecated To be removed.  Use {@code RDFParser.source(uri).lang(hintLang).context(context).parse(sink)}
      */
     @Deprecated
     public static void parse(StreamRDF sink, String uri, Lang hintLang, Context context) {
@@ -648,7 +654,9 @@ public class RDFDataMgr
      * @param uri       URI to read from (includes file: and a plain file name).
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
+     * @deprecated To be removed.  Use {@code RDFParser.source(uri).base(base)...}
      */
+    @Deprecated
     public static void parse(StreamRDF sink, String uri, String base, Lang hintLang) {
         parse(sink, uri, base, hintLang, (Context)null) ;
     }
@@ -659,7 +667,7 @@ public class RDFDataMgr
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
-     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
+     * @deprecated     To be removed.  Use {@code RDFParser.source(uri).lang(hintLang).base(base).context(context).parse(sink)}
      */
     @Deprecated
     public static void parse(StreamRDF sink, String uri, String base, Lang hintLang, Context context) {
@@ -669,30 +677,34 @@ public class RDFDataMgr
             base = SysRIOT.chooseBaseIRI(uri) ;
         if ( hintLang == null )
             hintLang = RDFLanguages.filenameToLang(uri) ;
-        try ( TypedInputStream in = open(uri, context) ) { 
-            if ( in == null )
-                throw new RiotNotFoundException("Not found: "+uri) ;
-            process(sink, in, base, hintLang, context) ;
-        }
+        parseFromURI(sink, uri, base, hintLang, context);
     }
 
+    // TODO Deprecate this?
     /** Read RDF data.
+     *  Use {@code RDFParser.source(in).lang(lang).parse(sink)}
      * @param sink      Destination for the RDF read.
      * @param in        Bytes to read.
      * @param lang      Syntax for the stream.
      */
+    //@deprecated     To be removed.  Use {@code RDFParser.source(in).lang(lang).parse(sink)}
+    //@Deprecated
     public static void parse(StreamRDF sink, InputStream in, Lang lang) {
-        parse(sink, in, defaultBase(), lang, (Context)null) ;  
+        parseFromInputStream(sink, in, defaultBase(), lang, (Context)null) ;  
     }
 
+    // TODO Deprecate this?
     /** Read RDF data.
+     * Use {@code RDFParser.source(in).lang(lang).base(base).parse(sink)}
      * @param sink      Destination for the RDF read.
      * @param in        Bytes to read.
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
      */
+    //@deprecated     To be removed.  Use {@code RDFParser.source(in).lang(lang).base(base).parse(sink)}
+    //@Deprecated
     public static void parse(StreamRDF sink, InputStream in, String base, Lang hintLang) {
-        parse(sink, in, base, hintLang, (Context)null) ;  
+        parseFromInputStream(sink, in, base, hintLang, null) ;  
     }
 
     /** Read RDF data.
@@ -701,17 +713,18 @@ public class RDFDataMgr
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
-     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
+     * @deprecated     To be removed.  Use {@code RDFParser.source(in).base(base).lang(hintLang).context(context).parse(sink)}
      */
     @Deprecated
     public static void parse(StreamRDF sink, InputStream in, String base, Lang hintLang, Context context) {
-        process(sink, TypedInputStream.wrap(in), base, hintLang, context) ;
+        parseFromInputStream(sink, in, base, hintLang, context) ;
     }
 
     /** Read RDF data.
      * @param sink      Destination for the RDF read.
      * @param in        StringReader
      * @param lang      Syntax for the stream.
+     * @deprecated     To be removed. Use {@code RDFParser.create().source(in).lang(hintLang)...}
      */
     public static void parse(StreamRDF sink, StringReader in, Lang lang) {
         parse(sink, in, defaultBase(), lang, (Context)null) ;  
@@ -722,6 +735,7 @@ public class RDFDataMgr
      * @param in        Reader
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
+     * @deprecated     To be removed. Use {@code RDFParser.create().source(in).base(base).lang(hintLang).parse(sink)}
      */
     public static void parse(StreamRDF sink, StringReader in, String base, Lang hintLang) {
         parse(sink, in, base, hintLang, (Context)null) ;  
@@ -733,18 +747,18 @@ public class RDFDataMgr
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
-     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
+     * @deprecated     To be removed. Use {@code RDFParser.create().source(in).base(base).lang(hintLang).context(context).pase(sink)}
      */
     @Deprecated
     public static void parse(StreamRDF sink, StringReader in, String base, Lang hintLang, Context context) {
-        process(sink, in, base, hintLang, context) ;
+        parseFromReader(sink, in, base, hintLang, context) ;
     }
 
     /** Read RDF data.
      * @param sink      Destination for the RDF read.
      * @param in        Reader
      * @param lang      Syntax for the stream.
-     * @deprecated     Use an InputStream or a StringReader. 
+     * @deprecated     To be removed. An {@code InputStream} or {@code StringReader} is preferrable. Use {@code RDFParser.create().source(in).lang(hintLang).parse()}
      */
     @Deprecated
     public static void parse(StreamRDF sink, Reader in, Lang lang) {
@@ -756,7 +770,7 @@ public class RDFDataMgr
      * @param in        Reader
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
-     * @deprecated     Use an InputStream or a StringReader. 
+     * @deprecated     To be removed. An {@code InputStream} or {@code StringReader} is preferrable. Use {@code RDFParser.create().source(in).lang(hintLang).context(context).parse(sink)}
      */
     @Deprecated
     public static void parse(StreamRDF sink, Reader in, String base, Lang hintLang) {
@@ -769,17 +783,19 @@ public class RDFDataMgr
      * @param base      Base URI (defaults to uri).
      * @param hintLang  Hint for the syntax
      * @param context   Content object to control reading process.
-     * @deprecated     To be removed.  Use {@code RDFParser.create().context(context)...}
+     * @deprecated     To be removed. An {@code InputStream} or {@code StringReader} is preferrable. Use {@code RDFParser.create().source(in).lang(hintLang).base(base).context(context).parse(sink)}
      */
     @Deprecated
     public static void parse(StreamRDF sink, Reader in, String base, Lang hintLang, Context context) {
-        process(sink, in, base, hintLang, context) ;
+        parseFromReader(sink, in, base, hintLang, context) ;
     }
 
     /** Read RDF data.
      * @param sink      Destination for the RDF read.
-     * @param in        Bytes to read.  This must include the content type.
+     * @param in        Bytes to read. This must include the content type.
+     * @deprecated     To be removed. Use an {@code InputStream} and {@code RDFParser.source(in).lang(hintLang).parse(sink)}
      */
+    @Deprecated
     public static void parse(StreamRDF sink, TypedInputStream in) {
         parse(sink, in, defaultBase()) ;
     }
@@ -789,7 +805,9 @@ public class RDFDataMgr
      * @param sink      Destination for the RDF read.
      * @param in        Bytes to read.
      * @param base      Base URI
+     * @deprecated     To be removed. Use an {@code InputStream} and {@code RDFParser.source(in).base(base).lang(lang).parse(sink)}
      */
+    @Deprecated
     public static void parse(StreamRDF sink, TypedInputStream in, String base) {
         parse(sink, in, base, (Context)null);
     }
@@ -799,13 +817,13 @@ public class RDFDataMgr
      * @param in        Bytes to read.
      * @param base      Base URI
      * @param context   Content object to control reading process.
-     * @deprecated To be removed.  Use {@code RDFParser.create().context(context)...}
+     * @deprecated To be removed. Use {@code RDFParser.source(in).lang(lang).base(base).context(context).parse(sink)}
      */
     @Deprecated
     public static void parse(StreamRDF sink, TypedInputStream in, String base, Context context) {
         Objects.requireNonNull(in, "TypedInputStream is null") ;
         Lang hintLang = RDFLanguages.contentTypeToLang(in.getMediaType()) ;
-        process(sink, in, base, hintLang, context) ;
+        processFromTypedInputStream(sink, in, base, hintLang, context) ;
     }
 
     /** Open a stream to the destination (URI or filename)
@@ -840,19 +858,10 @@ public class RDFDataMgr
         return in ;
     }
     
-    // -----
-    // Readers are algorithms and must be stateless (or they must create a per
-    // run instance of something) because they may be called concurrency from
-    // different threads. The Context Reader object gives the per-run
-    // configuration.
-
-    private static void process(StreamRDF destination, TypedInputStream in, String baseUri, Lang lang, Context context) {
-        Objects.requireNonNull(in, "TypedInputStream is null") ;
-        
-        // If the input stream comes with a content type, use that in preference to the hint (compatibility).
-        if ( in.getContentType() != null )
-            lang = RDFLanguages.contentTypeToLang(in.getMediaType());
-        
+    // ----
+    // The ways to parse from 3 kinds of source: URI, InputStream and Reader. 
+    
+    private static void parseFromInputStream(StreamRDF destination, InputStream in, String baseUri, Lang lang, Context context) {
         RDFParser.create()
             .source(in)
             .base(baseUri)
@@ -861,10 +870,8 @@ public class RDFDataMgr
             .parse(destination);
     }
     
-    // java.io.Readers are NOT preferred.
     @SuppressWarnings("deprecation")
-    private static void process(StreamRDF destination, Reader in, String baseUri, Lang lang, Context context ) {
-        Objects.requireNonNull(in, "Reader is null") ;
+    private static void parseFromReader(StreamRDF destination, Reader in, String baseUri, Lang lang, Context context) {
         RDFParser.create()
             .source(in)
             .base(baseUri)
@@ -873,8 +880,41 @@ public class RDFDataMgr
             .parse(destination);
     }
 
+
+    private static void parseFromURI(StreamRDF destination, String uri, String baseUri, Lang lang, Context context) {
+        RDFParser.create()
+            .source(uri)
+            .base(baseUri)
+            .lang(lang)
+            .context(context)
+            .parse(destination);
+    }
+    
+    // ---- Support for RDFDataMgr.parse from a TypedInputStream only.
+    @Deprecated
+    private static void processFromTypedInputStream(StreamRDF sink, TypedInputStream in, String baseUri, Lang hintLang, Context context) {
+        // If the input stream comes with a content type, use that in preference to the hint (compatibility).
+        // Except for text/plain. 
+        // Do here, which duplicates RDFParser, because "TypedInputStream" gets lost at RDFParser
+        if ( in.getContentType() != null ) {
+            // Special case of text/plain.
+            ContentType ct = WebContent.determineCT(in.getContentType(), hintLang, null);
+            Lang lang2 = RDFLanguages.contentTypeToLang(ct);
+            hintLang = lang2 ;
+        }
+        RDFParser.create()
+            .source(in)
+            .base(baseUri)
+            .lang(hintLang)
+            // We made the decision above.
+            .forceLang(hintLang)
+            .context(context)
+            .parse(sink);
+    }
+    // ---- Support for RDFDataMgr.parse only.
+
     /** 
-     * @deprecated Use {@link RDFParser#create} or {@link #createReader(Lang, ParserProfile)}.
+     * @deprecated Use {@link RDFParser#create}.
      */
     @Deprecated
     public static ReaderRIOT createReader(Lang lang) {
@@ -1248,7 +1288,7 @@ public class RDFDataMgr
         // Otherwise, we have to spin up a thread to deal with it
         PipedRDFIterator<Triple> it = new PipedRDFIterator<>();
         PipedTriplesStream out = new PipedTriplesStream(it);
-        Thread t = new Thread(()->parse(out, input, baseIRI, lang)) ;
+        Thread t = new Thread(()->parseFromInputStream(out, input, baseIRI, lang, null)) ;
         t.start();
         return it;
     }
@@ -1271,7 +1311,7 @@ public class RDFDataMgr
         final PipedRDFIterator<Quad> it = new PipedRDFIterator<>();
         final PipedQuadsStream out = new PipedQuadsStream(it);
 
-        Thread t = new Thread(()->parse(out, input, baseIRI, lang)) ;
+        Thread t = new Thread(()->parseFromInputStream(out, input, baseIRI, lang, null)) ;
         t.start();
         return it;
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
@@ -251,7 +251,8 @@ public class RDFParser {
                 ct = forceLang.getContentType();
                 reader = createReader(r, forceLang);
             } else {
-                // Conneg and hint
+                // No forced language.
+                // Conneg and hint, ignoring text/plain.
                 ct = WebContent.determineCT(input.getContentType(), hintLang, baseUri);
                 if ( ct == null )
                     throw new RiotException("Failed to determine the content type: (URI=" + baseUri + " : stream=" + input.getContentType()+")");

--- a/jena-arq/src/main/java/org/apache/jena/riot/web/HttpResponseLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/web/HttpResponseLib.java
@@ -31,10 +31,7 @@ import org.apache.jena.atlas.io.IO ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.query.ResultSet ;
 import org.apache.jena.query.ResultSetFactory ;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFDataMgr ;
-import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.riot.WebContent ;
+import org.apache.jena.riot.* ;
 import org.apache.jena.riot.system.StreamRDF ;
 import org.apache.jena.riot.system.StreamRDFLib ;
 import org.apache.jena.sparql.graph.GraphFactory ;
@@ -60,7 +57,7 @@ public class HttpResponseLib
                 Lang lang = RDFLanguages.contentTypeToLang(ct) ;
                 StreamRDF dest = StreamRDFLib.graph(g) ; 
                 try(InputStream in = entity.getContent()) {
-                    RDFDataMgr.parse(dest, in, baseIRI, lang) ;
+                    RDFParser.source(in).lang(lang).base(baseIRI).parse(dest);
                 }
                 this.graph = g ; 
             } catch (IOException ex) { IO.exception(ex) ; }

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestParserFactory.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestParserFactory.java
@@ -26,7 +26,7 @@ import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.Pair ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFDataMgr ;
+import org.apache.jena.riot.RDFParser ;
 import org.apache.jena.riot.RIOT;
 import org.apache.jena.riot.system.*;
 import org.apache.jena.riot.tokens.Tokenizer ;
@@ -183,7 +183,7 @@ public class TestParserFactory extends BaseTest
 
     private CatchParserOutput parseCapture(String s, Lang lang) {
         CatchParserOutput sink = new CatchParserOutput() ;
-        RDFDataMgr.parse(sink, new StringReader(s), "http://base/", lang) ;
+        RDFParser.create().source(new StringReader(s)).base("http://base/").lang(lang).parse(sink);
         return sink ;
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestPipedRDFIterators.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestPipedRDFIterators.java
@@ -24,8 +24,8 @@ import java.nio.charset.StandardCharsets ;
 import java.util.concurrent.* ;
 
 import org.apache.jena.graph.Triple ;
-import org.apache.jena.riot.RDFDataMgr ;
-import org.apache.jena.riot.RDFLanguages ;
+import org.apache.jena.riot.Lang ;
+import org.apache.jena.riot.RDFParser ;
 import org.apache.jena.riot.RiotException ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
@@ -396,7 +396,7 @@ public class TestPipedRDFIterators {
                 Charset utf8 = StandardCharsets.UTF_8 ;
                 ByteArrayInputStream input = new ByteArrayInputStream(data.getBytes(utf8));
                 try {
-                    RDFDataMgr.parse(out, input, RDFLanguages.TURTLE);
+                    RDFParser.source(input).lang(Lang.TTL).parse(out);
                 } catch (Throwable t) {
                     // Ignore the error
                 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestTriXBad.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestTriXBad.java
@@ -23,7 +23,7 @@ import java.util.Arrays ;
 
 import org.apache.jena.atlas.io.IO ;
 import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFDataMgr ;
+import org.apache.jena.riot.RDFParser ;
 import org.apache.jena.riot.RiotException ;
 import org.apache.jena.riot.system.ErrorHandler ;
 import org.apache.jena.riot.system.ErrorHandlerFactory ;
@@ -67,7 +67,7 @@ public class TestTriXBad extends Assert /*BaseTest*/ {
             ErrorHandlerFactory.setDefaultErrorHandler(ErrorHandlerFactory.errorHandlerSimple()) ;
             InputStream in = IO.openFile(fInput) ;
             StreamRDF sink = StreamRDFLib.sinkNull() ;
-            RDFDataMgr.parse(sink, in, Lang.TRIX) ;
+            RDFParser.source(in).lang(Lang.TRIX).parse(sink);
         } finally {
             ErrorHandlerFactory.setDefaultErrorHandler(err) ;
         }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
@@ -41,7 +41,10 @@ import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.atlas.web.ContentType ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.fuseki.FusekiLib ;
-import org.apache.jena.fuseki.build.* ;
+import org.apache.jena.fuseki.build.DatasetDescriptionRegistry ;
+import org.apache.jena.fuseki.build.FusekiBuilder ;
+import org.apache.jena.fuseki.build.Template ;
+import org.apache.jena.fuseki.build.TemplateFunctions ;
 import org.apache.jena.fuseki.server.* ;
 import org.apache.jena.fuseki.servlets.* ;
 import org.apache.jena.graph.Node ;
@@ -49,10 +52,7 @@ import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.ReadWrite ;
 import org.apache.jena.rdf.model.* ;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFDataMgr ;
-import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.riot.WebContent ;
+import org.apache.jena.riot.* ;
 import org.apache.jena.riot.system.StreamRDF ;
 import org.apache.jena.riot.system.StreamRDFLib ;
 import org.apache.jena.shared.uuid.JenaUUID ;
@@ -292,7 +292,7 @@ public class ActionDatasets extends ActionContainerItem {
             template = TemplateFunctions.templateFile(Template.templateTDBFN, params, Lang.TTL) ;
         if ( dbType.equalsIgnoreCase(tDatabasetMem))
             template = TemplateFunctions.templateFile(Template.templateMemFN, params, Lang.TTL) ;
-        RDFDataMgr.parse(dest, new StringReader(template), "http://base/", Lang.TTL) ;
+        RDFParser.create().source(new StringReader(template)).base("http://base/").lang(Lang.TTL).parse(dest);
     }
 
     private static void assemblerFromUpload(HttpAction action, StreamRDF dest) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/migrate/GraphLoadUtils.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/migrate/GraphLoadUtils.java
@@ -25,7 +25,7 @@ import org.apache.jena.graph.Factory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
-import org.apache.jena.riot.RDFDataMgr ;
+import org.apache.jena.riot.RDFParser ;
 import org.apache.jena.riot.system.StreamRDF ;
 import org.apache.jena.riot.system.StreamRDFLib ;
 
@@ -68,8 +68,7 @@ public class GraphLoadUtils
         // We need to do this ourselves, not via riot, to use the webStreamManager
         StreamRDF sink = StreamRDFLib.graph(graph) ;
         sink = new StreamRDFLimited(sink, limit) ;
-
         TypedInputStream input = Fuseki.webStreamManager.open(uri) ;
-        RDFDataMgr.parse(sink, input, uri) ;
+        RDFParser.source(input).base(uri).parse(sink);
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/json/DataValidatorJSON.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/json/DataValidatorJSON.java
@@ -59,8 +59,7 @@ public class DataValidatorJSON {
         StreamRDF dest = StreamRDFLib.sinkNull() ;
         
         try {
-            // Set error handler!
-            RDFDataMgr.parse(dest, sr, null, language) ;
+            RDFParser.create().source(sr).lang(language).parse(dest);
         } catch (RiotParseException ex) {
             obj.key(jErrors) ;
 

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestDatasetOps.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestDatasetOps.java
@@ -24,9 +24,7 @@ import org.apache.http.entity.EntityTemplate ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.atlas.web.HttpException ;
 import org.apache.jena.atlas.web.TypedInputStream ;
-import org.apache.jena.riot.RDFDataMgr ;
-import org.apache.jena.riot.RDFFormat ;
-import org.apache.jena.riot.WebContent ;
+import org.apache.jena.riot.* ;
 import org.apache.jena.riot.system.StreamRDF ;
 import org.apache.jena.riot.system.StreamRDFLib ;
 import org.apache.jena.riot.web.HttpOp ;
@@ -119,11 +117,15 @@ public class TestDatasetOps extends AbstractFusekiTest
     private void gsp_x_ct(String urlDataset, String acceptheader, String contentTypeResponse) {
         HttpEntity e = datasetToHttpEntity(data) ;
         HttpOp.execHttpPut(urlDataset(), e);
-        TypedInputStream in = HttpOp.execHttpGet(urlDataset, acceptheader) ;
-        assertEqualsIgnoreCase(contentTypeResponse, in.getContentType()) ;
-        DatasetGraph dsg = DatasetGraphFactory.create() ;
-        StreamRDF dest = StreamRDFLib.dataset(dsg) ;
-        RDFDataMgr.parse(dest, in) ;
+        
+        // Do manually so the test can validate the expected ContentType
+        try ( TypedInputStream in = HttpOp.execHttpGet(urlDataset, acceptheader) ) {
+            assertEqualsIgnoreCase(contentTypeResponse, in.getContentType()) ;
+            Lang lang = RDFLanguages.contentTypeToLang(in.getContentType());
+            DatasetGraph dsg = DatasetGraphFactory.create() ;
+            StreamRDF dest = StreamRDFLib.dataset(dsg) ;
+            RDFParser.source(in).lang(lang).parse(dest);
+        }
     }
 
     @Test 


### PR DESCRIPTION
RDFDataMgr was duplicating the functionality of RDFParser but was not making the same decisions. Use RDFParser execlusively by creating 3 paths in RDFDataMgr, one each for the three cases of reading from a URI, from an InputStream and from a Reader.