### PR TITLE
JENA-1074: Provide a union graph for DatasetGraph

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/Dataset.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/Dataset.java
@@ -35,6 +35,9 @@ public interface Dataset extends Transactional
     /** Get the default graph as a Jena Model */
     public Model getDefaultModel() ;
     
+    /** Get the graph which is teh unionof all named graphs as a Jena Model */
+    public Model getUnionModel() ;
+
     /** Set the default graph.  Can be set to null for none. */ 
     public void  setDefaultModel(Model model) ;
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraph.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraph.java
@@ -49,6 +49,13 @@ public interface DatasetGraph extends Transactional, Closeable
     public Graph getGraph(Node graphNode) ;
     
     /**
+     * Return a {@link Graph} that is the union of all named graphs in this dataset. This
+     * union graph is read-only (its prefix mapping in the current JVM may be changed but
+     * that may not persist).
+     */
+    public Graph getUnionGraph();
+    
+    /**
      * Does the DatasetGraph contain a specific named graph? 
      * Whether a dataset contains a graph if there are no triples is
      * not defined - see the specifc implementation. Some datasets are "open" -

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphBase.java
@@ -26,6 +26,7 @@ import org.apache.jena.graph.Node ;
 import org.apache.jena.shared.Lock ;
 import org.apache.jena.shared.LockMRSW ;
 import org.apache.jena.sparql.core.mem.DatasetGraphInMemory ;
+import org.apache.jena.sparql.graph.GraphOps;
 import org.apache.jena.sparql.sse.writers.WriterGraph ;
 import org.apache.jena.sparql.util.Context ;
 
@@ -58,6 +59,15 @@ abstract public class DatasetGraphBase implements DatasetGraph
     
     @Override
     public abstract Graph getDefaultGraph() ;
+    
+    @Override
+    public Graph getUnionGraph() {
+        // Implementations are encouraged to implement an efficent
+        // {@code DatasetGraphBase.findQuadsInUnionGraph} or
+        // {@code findNG(Quad.unionGraph, Node.ANY, Node.ANY, Node.ANY)}
+        // for a distinct iterator (e.g. avoid calling "distinct()" by not creating duplicates).
+        return GraphOps.unionGraph(this);
+    }
 
     @Override
     public abstract Graph getGraph(Node graphNode) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphBaseFind.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphBaseFind.java
@@ -100,19 +100,27 @@ abstract public class DatasetGraphBaseFind extends DatasetGraphBase
      * No duplicates - the union graph is a <em>set</em> of triples.
      * See {@link #findInAnyNamedGraphs}, where there may be duplicates.
      * <p>
-     * Implementations are encouraged to override this method. For example, it
-     * may be possible to avoid "distinct".
+     * Implementations are encouraged to override this method or {@link #findUnionGraphTriples}.
+     * For example, it may be possible to avoid "distinct".
      */
     public Iterator<Quad> findQuadsInUnionGraph(Node s, Node p , Node o) {
         return findUnionGraphTriples(s,p,o).map(t -> new Quad(Quad.unionGraph, t)).iterator() ;
     }
 
+    /** Find matches in the notional union of all named graphs - return as triples.
+     * No duplicates - the union graph is a <em>set</em> of triples.
+     * See {@link #findInAnyNamedGraphs}, where there may be duplicates.
+     * <p>
+     * Implementations are encouraged to override this method. For example, it
+     * may be possible to avoid "distinct".
+     */
     private Stream<Triple> findUnionGraphTriples(Node s, Node p , Node o) {
         return Iter.asStream(findInAnyNamedGraphs(s,p,o)).map(Quad::asTriple).distinct() ;
     }
 
-    /** Find in a specific named graph - {@code g} is a group term (IRI or bNode), not a wild card (or null). */
+    /** Find in a specific named graph - {@code g} is a ground term (IRI or bNode), not a wild card (or null). */
     protected abstract Iterator<Quad> findInSpecificNamedGraph(Node g, Node s, Node p , Node o) ;
+    
     /** Find in any named graph - return quads.
      * If a triple matches in two different graph, return a quad for each.
      * See {@link #findInUnionGraph} for matching without duplicate triples.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphWrapper.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphWrapper.java
@@ -82,6 +82,10 @@ public class DatasetGraphWrapper implements DatasetGraph, Sync
     { return getG().getDefaultGraph(); }
 
     @Override
+    public Graph getUnionGraph()
+    { return getG().getUnionGraph(); }
+
+    @Override
     public Graph getGraph(Node graphNode)
     { return getG().getGraph(graphNode) ; }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetImpl.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetImpl.java
@@ -83,6 +83,11 @@ public class DatasetImpl implements Dataset
     }
 
     @Override
+    public Model getUnionModel() {
+        return ModelFactory.createModelForGraph(dsg.getUnionGraph()) ;
+    }
+
+    @Override
     public Lock getLock() { return dsg.getLock() ; }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphUnionRead.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphUnionRead.java
@@ -80,7 +80,7 @@ public class GraphUnionRead extends GraphBase {
     protected ExtendedIterator<Triple> graphBaseFind(Triple m) {
         IteratorConcat<Triple> iter = new IteratorConcat<>() ;
         forEachGraph((g) -> iter.add(g.find(m))) ;
-        return WrappedIterator.create(Iter.distinct(iter)) ;
+        return WrappedIterator.createNoRemove(Iter.distinct(iter)) ;
     }
     
     /** Execute action for each graph that exists */

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphUnionRead.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphUnionRead.java
@@ -19,6 +19,7 @@
 package org.apache.jena.sparql.graph ;
 
 import java.util.Collection ;
+import java.util.Iterator;
 import java.util.function.Consumer ;
 
 import org.apache.jena.atlas.iterator.Iter ;
@@ -78,6 +79,14 @@ public class GraphUnionRead extends GraphBase {
 
     @Override
     protected ExtendedIterator<Triple> graphBaseFind(Triple m) {
+        if ( graphs == null ) {
+            // This produces unique quads with the same graph node,
+            // hence the triples are distinct. 
+            Iterator<Quad> qIter = dataset.findNG(Quad.unionGraph, Node.ANY, Node.ANY, Node.ANY);
+            Iterator<Triple> tIter = Iter.map(qIter, quad->quad.asTriple());
+            return WrappedIterator.createNoRemove(tIter) ;
+        }
+        // Only certain graphs.
         IteratorConcat<Triple> iter = new IteratorConcat<>() ;
         forEachGraph((g) -> iter.add(g.find(m))) ;
         return WrappedIterator.createNoRemove(Iter.distinct(iter)) ;
@@ -103,7 +112,7 @@ public class GraphUnionRead extends GraphBase {
     
     @Override
     public void performAdd(Triple t) {
-        throw new AddDeniedException("GraphUnionRead::performAdd - read-only graph") ;
+        throw new AddDeniedException("GraphUnionRead::performAdd - Read-only graph") ;
     }
 
     @Override

--- a/jena-core/src/main/java/org/apache/jena/graph/Graph.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/Graph.java
@@ -92,17 +92,25 @@ public interface Graph
 	/** 
         Returns an iterator over all the Triples that match the triple pattern.
    
-        @param m a Triple[Match] encoding the pattern to look for
+        @param m a Triple encoding the pattern to look for
         @return an iterator of all triples in this graph that match m
 	 */
 	ExtendedIterator<Triple> find(Triple m);
 
-
-/** Returns an iterator over Triple.
-	   */
-	ExtendedIterator<Triple> find(Node s,Node p,Node o);
+	/** Returns an iterator over Triples matching a pattern.
+     * 
+     * @return an iterator of all triples in this graph
+	 */
+	ExtendedIterator<Triple> find(Node s, Node p, Node o);
     
-	/**
+    /** Returns an iterator over all Triples in the graph.
+     * Equivalent to {@code find(Node.ANY, Node.ANY, Node.ANY)}
+     * 
+     * @return an iterator of all triples in this graph
+     */
+    default ExtendedIterator<Triple> find() { return find(Node.ANY, Node.ANY, Node.ANY); }
+
+    /**
 	 * Compare this graph with another using the method
 	 * described in 
 	 * <a href="http://www.w3.org/TR/rdf-concepts#section-Graph-syntax">


### PR DESCRIPTION
This PR adds:

`DatasetGraph.getUnionGraph`
`Dataset.getUnionModel`

It also adds a convenience `Graph.find()`.