### PR TITLE
JENA-1367: Improve apf:strSplit corner cases

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/pfunction/library/strSplit.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/pfunction/library/strSplit.java
@@ -39,11 +39,13 @@ import org.apache.jena.sparql.util.IterLib;
 import org.apache.jena.vocabulary.XSD;
 
 /**
- * Property function that requires the subject to be unbound, and the object to
+ * Property function that requires the object to
  * contain a list of two items, the first of which is a string to be split, and
- * the second is a regular expression denoting the split point. The subject
- * variable is bound for each result of the split, and each result has the
- * whitespace trimmed from it.
+ * the second is a regular expression denoting the split point. If the subject
+ * is an unbound variable, it is bound for each result of the split, and each result has the
+ * whitespace trimmed from it. If the subject is not an unbound variable, then
+ * the property function will match if and only if the subject is one of the
+ * split results.
  */
 public class strSplit extends PFuncSimpleAndList
 {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/pfunction/library/strSplit.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/pfunction/library/strSplit.java
@@ -20,20 +20,23 @@ package org.apache.jena.sparql.pfunction.library ;
 
 import java.util.Arrays ;
 import java.util.Iterator ;
+import java.util.List;
 
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
+import org.apache.jena.query.QueryBuildException;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.engine.ExecutionContext ;
 import org.apache.jena.sparql.engine.QueryIterator ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.engine.binding.BindingFactory ;
 import org.apache.jena.sparql.engine.iterator.QueryIterPlainWrapper ;
-import org.apache.jena.sparql.expr.ExprEvalException ;
 import org.apache.jena.sparql.pfunction.PFuncSimpleAndList ;
 import org.apache.jena.sparql.pfunction.PropFuncArg ;
+import org.apache.jena.sparql.util.IterLib;
+import org.apache.jena.vocabulary.XSD;
 
 /**
  * Property function that requires the subject to be unbound, and the object to
@@ -44,27 +47,58 @@ import org.apache.jena.sparql.pfunction.PropFuncArg ;
  */
 public class strSplit extends PFuncSimpleAndList
 {
+    
+    @Override
+    public void build(PropFuncArg argSubject, Node predicate, PropFuncArg argObject, ExecutionContext execCxt) {
+        super.build(argSubject, predicate, argObject, execCxt);
+
+        if (argObject.getArgListSize() != 2)
+            throw new QueryBuildException("Object list must contain exactly two arguments, the string to split and a regular expression") ;
+    }
+
     @Override
     public QueryIterator execEvaluated(final Binding binding, final Node subject, final Node predicate, final PropFuncArg object, final ExecutionContext execCxt)
     {
-        if (!Var.isVar(subject))
-            throw new ExprEvalException("Subject is not a variable (" + subject + ")") ;
 
-        if (object.getArgListSize() != 2)
-            throw new ExprEvalException("Object list must contain exactly two arguments, the string to split and a regular expression") ;
-
+        if (!object.getArg(0).isLiteral() || !object.getArg(1).isLiteral()) {
+            return IterLib.noResults(execCxt);
+        }
+        
         String s = object.getArg(0).getLiteralLexicalForm() ;
         String regex = object.getArg(1).getLiteralLexicalForm() ;
         
-        final Var subjectVar = Var.alloc(subject);
-        
         // StrUtils will also trim whitespace
-        String[] tokens = StrUtils.split(s, regex);
-		Iterator<Binding> it = Iter.map(
-				Arrays.asList(tokens).iterator(),
-				item -> BindingFactory.binding(binding, subjectVar,
-						NodeFactory.createLiteral(item)));
-        return new QueryIterPlainWrapper(it, execCxt);
+        List<String> tokens = Arrays.asList(StrUtils.split(s, regex));
+        
+        if (Var.isVar(subject)) {
+            
+            // Case: Subject is variable. Return all tokens as results.
+            
+            final Var subjectVar = Var.alloc(subject);
+
+            Iterator<Binding> it = Iter.map(
+                    tokens.iterator(),
+                    item -> BindingFactory.binding(binding, subjectVar,
+                            NodeFactory.createLiteral(item)));
+            return new QueryIterPlainWrapper(it, execCxt);
+            
+        } else if (subject.isLiteral() 
+                && XSD.xstring.getURI().equals(subject.getLiteralDatatypeURI()) 
+                && "".equals(subject.getLiteralLanguage())) {
+
+            // Case: Subject is a plain literal.
+            // Return input unchanged if it is one of the tokens, or nothing otherwise
+            
+            if (tokens.contains(subject.getLiteralLexicalForm())) {
+                return IterLib.result(binding, execCxt);
+            } else {
+                return IterLib.noResults(execCxt);
+            }
+            
+        }
+        
+        // Any other case: Return nothing
+        return IterLib.noResults(execCxt);
     }
 
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/pfunction/library/TestStrSplit.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/pfunction/library/TestStrSplit.java
@@ -1,0 +1,140 @@
+package org.apache.jena.sparql.pfunction.library;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.QueryBuildException;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.sparql.core.Var;
+import org.junit.Test;
+
+public class TestStrSplit {
+	private final static String prologue = 
+			"PREFIX apf: <http://jena.apache.org/ARQ/property#>\n";
+	
+	private QueryExecution qe;
+	
+	@Test public void shouldThrowQBEIfSubjectIsList() {
+		assertQueryBuildException("SELECT ?x { (?x) apf:strSplit ('foo' ';') }");
+	}
+
+	@Test public void shouldThrowQBEIfObjectIsNotList() {
+		assertQueryBuildException("SELECT ?x { ?x apf:strSplit 'foo' }");
+	}
+
+	@Test public void shouldThrowQBEIfWrongNumberOfArgsInObjectList() {
+		assertQueryBuildException("SELECT ?x { ?x apf:strSplit () }");
+		assertQueryBuildException("SELECT ?x { ?x apf:strSplit ('foo') }");
+		assertQueryBuildException("SELECT ?x { ?x apf:strSplit ('foo' ';' 'i') }");
+	}
+
+	@Test public void shouldNotErrorOnSimpleQuery() {
+		query("SELECT ?x { ?x apf:strSplit ('foo' ';') }");
+		qe.execSelect();
+		// No exception -- pass 
+	}
+
+	@Test public void literalInputNonMatchingRegex() {
+		query("SELECT ?x { ?x apf:strSplit ('foo' ';') }");
+		assertAllX("foo");
+	}
+	
+	@Test public void emptyStringInputNonMatchingRegex() {
+		query("SELECT ?x { ?x apf:strSplit ('' ';') }");
+		assertAllX("");
+	}
+	
+	@Test public void literalInputMatchingRegex() {
+		query("SELECT ?x { ?x apf:strSplit ('foo;bar' ';') }");
+		assertAllX("foo", "bar");
+	}
+
+	@Test public void boundVariableInput() {
+		query("SELECT ?x { BIND ('foo;bar' AS ?input) ?x apf:strSplit (?input ';') }");
+		assertAllX("foo", "bar");
+	}
+
+	@Test public void unboundVariableInput() {
+		query("SELECT ?x { ?x apf:strSplit (?unbound ';') }");
+		assertNoResults();
+	}
+	
+	@Test public void boundVariableRegex() {
+		query("SELECT ?x { BIND (';' AS ?regex) ?x apf:strSplit ('foo;bar' ?regex) }");
+		assertAllX("foo", "bar");
+	}
+
+	@Test public void badInputNodeShouldHaveNoResults() {
+		query("SELECT ?x { ?x apf:strSplit (<foo> ';') }");
+		assertNoResults();
+		query("SELECT ?x { ?x apf:strSplit (_:foo ';') }");
+		assertNoResults();
+	}
+
+	@Test public void badRegexNodeShouldHaveNoResults() {
+		query("SELECT ?x { ?x apf:strSplit ('foo;bar' ?unbound) }");
+		assertNoResults();
+		query("SELECT ?x { ?x apf:strSplit ('foo;bar' <;>) }");
+		assertNoResults();
+		query("SELECT ?x { ?x apf:strSplit ('foo;bar' _:foo) }");
+		assertNoResults();
+	}
+
+	@Test public void literalSubjectShouldMatchIfInSplitResults() {
+		query("ASK { 'foo' apf:strSplit ('foo;bar' ';') }");
+		assertAsk(true);
+		query("ASK { 'bar' apf:strSplit ('foo;bar' ';') }");
+		assertAsk(true);
+		query("ASK { 'zzz' apf:strSplit ('foo;bar' ';') }");
+		assertAsk(false);
+	}
+
+	private void assertQueryBuildException(String selectQueryString) {
+		try {
+			query(selectQueryString);
+			qe.execSelect();
+			fail("Expected QueryBuildException");
+		} catch (QueryBuildException ex) {
+			// pass
+		}
+	}
+	
+	private void query(String queryString) {
+		qe = QueryExecutionFactory.create(
+				prologue + queryString, 
+				ModelFactory.createDefaultModel());
+	}
+
+	private void assertAllX(String... literalValues) {
+		List<Node> expectedNodes = new ArrayList<>();
+		for (String value: literalValues) {
+			expectedNodes.add(NodeFactory.createLiteral(value));
+		}
+		ResultSet rs = qe.execSelect();
+		List<Node> actualNodes = new ArrayList<>();
+		while (rs.hasNext()) {
+			actualNodes.add(rs.nextBinding().get(Var.alloc("x")));
+		}
+		assertArrayEquals(
+				expectedNodes.toArray(new Node[expectedNodes.size()]),
+				actualNodes.toArray(new Node[actualNodes.size()]));
+	}
+
+	private void assertNoResults() {
+		assertFalse(qe.execSelect().hasNext());
+	}
+	
+	private void assertAsk(boolean expected) {
+		assertEquals(expected, qe.execAsk());
+	}
+}


### PR DESCRIPTION
This is a patch to improve the behaviour of `apf:strSplit` in cases where it is invoked with inputs other than the obvious node types.

The general syntax of the property function is:

    ?parts apf:strSplit (?input ?regex)

The patch changes various cases that previously would have thrown `ExprEvalException` or `NotLiteralException`:

- If `?input` is an unbound variable, return no match
- If `?input` is an IRI or blank node, return no match
- If `?regex` is not a literal, return no match
- If `?parts` is a plain literal that equals one of the tokens of the parts of `?input`, return true (one match, no new variable bindings)
- If `?parts` is anything else but not a variable, return no match
- If the object is a list but does not have two elements, throw `QueryBuildException`

The patch also adds fairly exhaustive tests for the function. The test class may still need to be hooked into the test suite in some way.