### PR TITLE
Add commons-io to jena-base as dependency.

### DIFF
--- a/jena-base/pom.xml
+++ b/jena-base/pom.xml
@@ -46,6 +46,11 @@
     </dependency> 
 
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency> 
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/jena-core/src/main/java/org/apache/jena/util/FileUtils.java
+++ b/jena-core/src/main/java/org/apache/jena/util/FileUtils.java
@@ -22,7 +22,11 @@ import java.io.* ;
 import java.net.URL ;
 import java.nio.charset.Charset ;
 import java.nio.charset.StandardCharsets ;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.jena.JenaRuntime ;
 import org.apache.jena.shared.JenaException ;
 import org.apache.jena.shared.WrappedIOException ;
@@ -374,8 +378,9 @@ public class FileUtils
      */
     
     public static String readWholeFileAsUTF8(String filename) throws IOException {
-        InputStream in = new FileInputStream(filename) ;
-        return readWholeFileAsUTF8(in) ;
+        Path path = Paths.get(filename);
+        byte b[] = Files.readAllBytes(path);
+        return new String(b, utf8);
     }
 
     /** Read a whole stream as UTF-8
@@ -384,33 +389,7 @@ public class FileUtils
      * @return      String
      * @throws IOException
      */
-    public static String readWholeFileAsUTF8(InputStream in) throws IOException
-    {
-        try ( Reader r = new BufferedReader(asUTF8(in),1024) ) {
-            return readWholeFileAsUTF8(r) ;
-        }
+    public static String readWholeFileAsUTF8(InputStream in) throws IOException {
+        return IOUtils.toString(in, utf8);
     }
-    
-    /** Read a whole file as UTF-8
-     * 
-     * @param r
-     * @return String The whole file
-     * @throws IOException
-     */
-    
-    // Private worker as we are trying to force UTF-8. 
-    private static String readWholeFileAsUTF8(Reader r) throws IOException
-    {
-        try ( StringWriter sw = new StringWriter(1024) ) {
-            char buff[] = new char[1024];
-            int l ; 
-            while ((l = r.read(buff))!=-1) {         // .ready does not work with HttpClient streams.
-                if (l <= 0)
-                    break;
-                sw.write(buff, 0, l);
-            }
-            return sw.toString();
-        }
-    }
-
 }

--- a/jena-core/src/test/java/org/apache/jena/test/TestSystemSetup.java
+++ b/jena-core/src/test/java/org/apache/jena/test/TestSystemSetup.java
@@ -18,17 +18,17 @@
 
 package org.apache.jena.test;
 
-import junit.framework.TestCase ;
-import junit.framework.TestSuite ;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.SystemUtils;
-import org.apache.jena.JenaRuntime ;
-import org.apache.jena.vocabulary.RDFS;
-import org.junit.Assert;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+
+import junit.framework.TestCase ;
+import junit.framework.TestSuite ;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.jena.JenaRuntime ;
+import org.apache.jena.util.FileUtils;
+import org.apache.jena.vocabulary.RDFS;
+import org.junit.Assert;
 
 public class TestSystemSetup extends TestCase {
 
@@ -61,8 +61,7 @@ public class TestSystemSetup extends TestCase {
 
         Assert.assertEquals(0, child.waitFor());
         Assert.assertEquals(RDFS.subClassOf.toString()+"\n",
-                IOUtils.toString(child.getInputStream()));
+                            FileUtils.readWholeFileAsUTF8(child.getInputStream()));
     }
-
 }
 

--- a/jena-fuseki2/jena-fuseki-core/pom.xml
+++ b/jena-fuseki2/jena-fuseki-core/pom.xml
@@ -99,15 +99,6 @@
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-text</artifactId>
       <version>3.5.0-SNAPSHOT</version>
-      <exclusions>
-        <!--
-          Get this via commons-fileupload and also via jena-text/sol4j
-        -->
-        <exclusion>
-          <groupId>commons-io</groupId>
-          <artifactId>commons-io</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/jena-project/pom.xml
+++ b/jena-project/pom.xml
@@ -166,6 +166,12 @@
       </dependency>
       
       <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${ver.commonsio}</version>
+      </dependency>
+      
+      <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
         <version>${ver.libthrift}</version>
@@ -197,7 +203,7 @@
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
As a follow-on to JENA-1386 (update jsonld-java), this PR puts commons:commons-io as a dependency of jena-base.  It was being picked up anyway by via jsonld-java so putting into jena-base makes it more easily available.

Use std libraries (JDK, CommonsIO) in (old) `FileUtils`.
