### PR TITLE
Version bumps for 3.5

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/DateTimeUtils.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/DateTimeUtils.java
@@ -89,7 +89,8 @@ public class DateTimeUtils {
     }
 
     private static String calendarToXSDString(Calendar cal, FastDateFormat fmt) {
-        String lex = fmt.format(cal) ;
+        FastDateFormat zonedFmt = FastDateFormat.getInstance(fmt.getPattern(), cal.getTimeZone());
+        String lex = zonedFmt.format(cal) ;
         // lex = lex + calcTimezone(cal) ;
         return lex ;
     }

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestDateTimeUtils.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestDateTimeUtils.java
@@ -31,7 +31,7 @@ public class TestDateTimeUtils {
 	@Test
 	public void testCalendarToXSDDateTimeString_1() {
 		Calendar cal = createCalendar(1984, Calendar.MARCH, 22, 14, 32, 1, 0, "Z") ;
-		assertEquals("1984-03-22T14:32:01+00:00", DateTimeUtils.calendarToXSDDateTimeString(cal));
+		assertEquals("1984-03-22T14:32:01Z", DateTimeUtils.calendarToXSDDateTimeString(cal));
 		cal.setTimeZone(TimeZone.getTimeZone("MST"));
 		assertEquals("1984-03-22T07:32:01-07:00", DateTimeUtils.calendarToXSDDateTimeString(cal));
 	}
@@ -39,7 +39,7 @@ public class TestDateTimeUtils {
     @Test
     public void testCalendarToXSDDateTimeString_2() {
         Calendar cal = createCalendar(1984, Calendar.MARCH, 22, 14, 32, 1, 50, "Z") ;
-        assertEquals("1984-03-22T14:32:01.050+00:00", DateTimeUtils.calendarToXSDDateTimeString(cal));
+        assertEquals("1984-03-22T14:32:01.050Z", DateTimeUtils.calendarToXSDDateTimeString(cal));
         cal.setTimeZone(TimeZone.getTimeZone("MST"));
         assertEquals("1984-03-22T07:32:01.050-07:00", DateTimeUtils.calendarToXSDDateTimeString(cal));
     }
@@ -49,7 +49,7 @@ public class TestDateTimeUtils {
 	public void testCalendarToXSDDateString() {
 		Calendar cal = createCalendar(1984, Calendar.MARCH, 22, 23, 59, 1, 0, "Z");
 		cal.setTimeZone(TimeZone.getTimeZone("Z")) ;
-		assertEquals("1984-03-22+00:00", DateTimeUtils.calendarToXSDDateString(cal));
+		assertEquals("1984-03-22Z", DateTimeUtils.calendarToXSDDateString(cal));
 		cal.setTimeZone(TimeZone.getTimeZone("MST"));
 		assertEquals("1984-03-22-07:00", DateTimeUtils.calendarToXSDDateString(cal));
 	}

--- a/jena-project/pom.xml
+++ b/jena-project/pom.xml
@@ -80,7 +80,7 @@
 
     <ver.elasticsearch>5.2.2</ver.elasticsearch>
     <!-- elasticsearch uses this by reflection -->
-    <ver.log4j2>2.7</ver.log4j2>
+    <ver.log4j2>2.9.1</ver.log4j2>
 
     <ver.spatial4j>0.6</ver.spatial4j>
 

--- a/jena-project/pom.xml
+++ b/jena-project/pom.xml
@@ -92,7 +92,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
-    <ver.contract.tests>0.1.5</ver.contract.tests>
+    <ver.contract.tests>0.1.7</ver.contract.tests>
   </properties>
 
   <profiles>
@@ -642,7 +642,7 @@
                   <pluginExecutionFilter>
                     <groupId>org.xenei</groupId>
                     <artifactId>contract-test-maven-plugin</artifactId>
-                    <versionRange>[0.1.5,)</versionRange>
+                    <versionRange>[${ver.contract.tests},)</versionRange>
                     <goals>
                       <goal>contract-test</goal>
                     </goals>

--- a/jena-project/pom.xml
+++ b/jena-project/pom.xml
@@ -60,11 +60,11 @@
     <ver.jsonldjava>0.11.1</ver.jsonldjava>
     <ver.jackson>2.9.0</ver.jackson>
 
-    <ver.commonsio>2.5</ver.commonsio>
+    <ver.commonsio>2.6</ver.commonsio>
     <ver.commonscli>1.4</ver.commonscli>
     
     <ver.commonslang3>3.4</ver.commonslang3>
-    <ver.commonscsv>1.4</ver.commonscsv>
+    <ver.commonscsv>1.5</ver.commonscsv>
     <ver.dexxcollection>0.7</ver.dexxcollection>
 
     <ver.httpclient>4.5.3</ver.httpclient>
@@ -75,7 +75,7 @@
     <ver.httpcore-osgi>${ver.httpcore}</ver.httpcore-osgi>
     <ver.httpclient-osgi>${ver.httpclient}</ver.httpclient-osgi>
 
-    <ver.commons-codec>1.10</ver.commons-codec>
+    <ver.commons-codec>1.11</ver.commons-codec>
     <ver.lucene>6.4.1</ver.lucene>
 
     <ver.elasticsearch>5.2.2</ver.elasticsearch>

--- a/jena-project/pom.xml
+++ b/jena-project/pom.xml
@@ -1,867 +1,828 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-   Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements.  See the NOTICE file distributed with
-   this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0
-   (the "License"); you may not use this file except in compliance with
-   the License.  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
--->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-
-  <groupId>org.apache.jena</groupId>
-  <artifactId>jena-project</artifactId>
-  <packaging>pom</packaging>
-  <url>http://jena.apache.org/</url>
-  <version>3.5.0-SNAPSHOT</version>
-  <name>Apache Jena - Project</name>
-
-  <parent>
-    <groupId>org.apache</groupId>
-    <artifactId>apache</artifactId>
-    <!-- This version number is also in the top POM -->
-    <version>18</version>
-    <relativePath />
-  </parent>
-
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-  
-  <organization>
-    <name>The Apache Software Foundation</name>
-    <url>http://www.apache.org/</url>
-  </organization>
-
-  <properties>
-    <ver.slf4j>1.7.25</ver.slf4j>
-    <ver.log4j>1.2.17</ver.log4j>
-    <ver.junit>4.12</ver.junit>
-    <ver.xerces>2.11.0</ver.xerces>
-    <ver.libthrift>0.10.0</ver.libthrift>
-
-    <!-- jsonld-java depends on depends on Jackson core
-         artifacts so the versions must align. Consult jsonld-java's 
-         POM for the correct dependency versions 
-    -->
-    <ver.jsonldjava>0.11.1</ver.jsonldjava>
-    <ver.jackson>2.9.0</ver.jackson>
-
-    <ver.commonsio>2.6</ver.commonsio>
-    <ver.commonscli>1.4</ver.commonscli>
-    
-    <ver.commonslang3>3.4</ver.commonslang3>
-    <ver.commonscsv>1.5</ver.commonscsv>
-    <ver.dexxcollection>0.7</ver.dexxcollection>
-
-    <ver.httpclient>4.5.3</ver.httpclient>
-    <ver.httpcore>4.4.6</ver.httpcore>
-    <!-- Normally, these are the same as the above
-         In the case of 4.2.6, there isn't a httpcore-osgi.
-    -->
-    <ver.httpcore-osgi>${ver.httpcore}</ver.httpcore-osgi>
-    <ver.httpclient-osgi>${ver.httpclient}</ver.httpclient-osgi>
-
-    <ver.commons-codec>1.11</ver.commons-codec>
-    <ver.lucene>6.4.1</ver.lucene>
-
-    <ver.elasticsearch>5.2.2</ver.elasticsearch>
-    <!-- elasticsearch uses this by reflection -->
-    <ver.log4j2>2.9.1</ver.log4j2>
-
-    <ver.spatial4j>0.6</ver.spatial4j>
-
-    <ver.mockito>1.9.5</ver.mockito>
-    <ver.awaitility>1.7.0</ver.awaitility>
-
-    <jdk.version>1.8</jdk.version>
-    <targetJdk>${jdk.version}</targetJdk> <!-- MPMD-86 workaround -->
-
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
-    <ver.contract.tests>0.1.7</ver.contract.tests>
-  </properties>
-
-  <profiles>
-    <profile>
-      <!-- Turn of doclint for java8 and later -->
-      <id>doclint-java8-disable</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-      </activation>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <additionalparam>-Xdoclint:none</additionalparam>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
-  <!-- Version management -->
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${ver.junit}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>xerces</groupId>
-        <artifactId>xercesImpl</artifactId>
-        <version>${ver.xerces}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient-cache</artifactId>
-        <version>${ver.httpclient}</version>
-        <exclusions>
-          <!-- Replace with slf4j adapter -->
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${ver.httpclient}</version>
-        <exclusions>
-          <!-- Replace with slf4j adapter -->
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${ver.commons-codec}</version>
-      </dependency>
-      
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>${ver.commonsio}</version>
-      </dependency>
-      
-      <dependency>
-        <groupId>org.apache.thrift</groupId>
-        <artifactId>libthrift</artifactId>
-        <version>${ver.libthrift}</version>
-        <exclusions>
-          <!-- Use whatever version Jena is using -->
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-csv</artifactId>
-        <version>${ver.commonscsv}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${ver.commonslang3}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>commons-fileupload</groupId>
-        <artifactId>commons-fileupload</artifactId>
-        <version>1.3.3</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-collections4</artifactId>
-        <version>4.1</version>
-      </dependency>
-      
-      <!-- supports persistent data structures -->
-      <dependency>
-        <groupId>com.github.andrewoma.dexx</groupId>
-        <artifactId>collection</artifactId>
-        <version>${ver.dexxcollection}</version>
-      </dependency>
-      
-      <dependency>
-        <groupId>com.github.jsonld-java</groupId>
-        <artifactId>jsonld-java</artifactId>
-        <version>${ver.jsonldjava}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-          <!-- Exclude so we use our choice of versions -->
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-cache</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient-osgi</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore-osgi</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      
-      <!-- Lucene dependencies -->
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-core</artifactId>
-        <version>${ver.lucene}</version>
-        <type>jar</type>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-analyzers-common</artifactId>
-        <version>${ver.lucene}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-queryparser</artifactId>
-        <version>${ver.lucene}</version>
-      </dependency>
-
-      <!-- For jena-spatial -->
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-spatial</artifactId>
-        <version>${ver.lucene}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-spatial-extras</artifactId>
-        <version>${ver.lucene}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.locationtech.spatial4j</groupId>
-        <artifactId>spatial4j</artifactId>
-        <version>${ver.spatial4j}</version>
-      </dependency>
-
-      <!-- Elasticsearch dependencies -->
-
-      <dependency>
-        <groupId>org.elasticsearch.client</groupId>
-        <artifactId>transport</artifactId>
-        <version>${ver.elasticsearch}</version>
-      </dependency>
-
-      <!-- Elasticsearch Server
-      <dependency>
-        <groupId>org.elasticsearch</groupId>
-        <artifactId>elasticsearch</artifactId>
-        <version>${ver.elasticsearch}</version>
-      </dependency>
-      -->
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${ver.log4j2}</version>
-      </dependency>
-      
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-to-slf4j</artifactId>
-        <version>${ver.log4j2}</version>
-      </dependency>
-
-      <!-- Logging -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${ver.slf4j}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>${ver.slf4j}</version>
-      </dependency>
-
-      <!-- And intercept any uses of Jakarta Commons Logging 
-           e.g. Apache Common HTTP client. 
-      -->
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>${ver.slf4j}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>${ver.log4j}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>commons-cli</groupId>
-        <artifactId>commons-cli</artifactId>
-        <version>${ver.commonscli}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.xenei</groupId>
-        <artifactId>junit-contracts</artifactId>
-        <version>${ver.contract.tests}</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <artifactId>commons-cli</artifactId>
-            <groupId>commons-cli</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      
-      <dependency>
-        <groupId>org.xenei</groupId>
-        <artifactId>contract-test-maven-plugin</artifactId>
-        <version>${ver.contract.tests}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>${ver.mockito}</version>
-        <scope>test</scope>
-      </dependency>
-      
-      <dependency>
-        <groupId>com.jayway.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <version>${ver.awaitility}</version>
-      </dependency>
-    </dependencies>
-
-  </dependencyManagement>
-
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-  </dependencies>
-
-  <build>
-    <!-- Run the enforcer plugin automatically at compile time -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration combine.self="override">
-              <rules>
-                <requireJavaVersion>
-                  <version>1.8.0</version>
-                </requireJavaVersion>
-                <requirePluginVersions>
-                  <message>Best practice is to always define plugin versions!</message>
-                  <banLatest>true</banLatest>
-                  <banRelease>true</banRelease>
-                </requirePluginVersions>
-                <requireReleaseDeps>
-                  <message>No SNAPSHOT dependencies are allowed!</message>
-                  <onlyWhenRelease>true</onlyWhenRelease>
-                </requireReleaseDeps>
-              </rules>
-              <fail>true</fail>
-              <failFast>true</failFast>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Run the RAT Plugin -->
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <version>0.12</version>
-        <executions>
-          <execution>
-            <id>rat-checks</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <excludeSubProjects>true</excludeSubProjects>
-          <excludes>
-            <exclude>**/hs_err_pid*.log</exclude>
-            <exclude>**/.project</exclude>
-            <exclude>**/.settings/**</exclude>
-            <exclude>**/.classpath</exclude>
-            <exclude>**/README.*</exclude>
-            <exclude>**/META-INF/services/*</exclude>
-            <!--
-                jena-core exclusions
-            -->
-            <exclude>**/src-examples/data/*</exclude>
-            
-            <!--
-                jena-fuseki exclusions
-            -->
-            <exclude>**/dist/ABOUT</exclude>
-            <exclude>**/SEE_FUSEKI2</exclude>
-            <!-- 
-                 Need to exclude JS and CSS since much of it comes from other Apache licensed projects 
-                 e.g. Bootstrap, Qonsole
-                 
-            -->
-            <exclude>**/src/main/webapp/css/*</exclude>
-            <exclude>**/src/main/webapp/fonts/*</exclude>
-            <exclude>**/src/main/webapp/js/**/*</exclude>
-            
-            <!-- General exclusions -->
-            <!-- 
-                 Vocabularies are often just local copies of vocabularies
-                 published by others
-            -->
-            <exclude>**/vocabularies/*</exclude>
-            <exclude>**/Vocabularies/*</exclude>
-
-            <!--
-                Javadoc add-ons files are required to be simple and our javadoc configuration
-                will ensure appropriate license and copyright statements are inserted
-                into generated documentation anyway so no need to put license statements in these
-                files
-            -->
-            <exclude>**/src/main/**/*.html</exclude>
-            <exclude>**/src/**/package-info.java</exclude>
-            
-            <exclude>**/DEPENDENCIES</exclude>
-            
-            <!--
-                Text and Markdown files are typically used only for documentation purposes
-                and license declarations are usually spurious in these files since often they
-                will refer to the LICENSE/NOTICE for users to find the actual licenses
-            -->
-            <exclude>**/*.txt</exclude>
-            <exclude>**/*.md</exclude>
-            
-            <!--
-                META-INF services files can include comments but a license header would be
-                unecessarily clutter so we exclude these
-            -->
-            <exclude>**/META-INF/services/*</exclude>
-            
-            <!--
-                Jena historically has large numbers of small test file
-                with no license headers.  Such small files are not required 
-                to have headers. 
-
-                In addition, there are files with different Licenses
-                (e.g. W3C Software Licence, W3C Test Suite License) as
-                noted in the code tree.
-            -->
-            <exclude>**/src/test/resources/**/*</exclude>
-            <exclude>**/testing/**/*</exclude>
-
-            <exclude>**/log4j.properties</exclude>
-            <exclude>**/log4j-testing.properties</exclude>
-            <exclude>**/derby.log</exclude>
-            <exclude>**/DB/**/*</exclude>
-            <!-- TDB config files JSON - no comments allowed -->
-            <exclude>**/tdb*.cfg</exclude>
-            <!-- Fuseki2 server "run" area -->
-            <exclude>**/run/**/*</exclude>
-            <!-- Cached classpath for commands - autogenerated -->
-            <exclude>**/*.classpath</exclude>
-
-            <!-- Exclude anything created during the build (plugin generated files) ->-->
-            <exclude>**/target/**/*</exclude>
-            <!-- MSHADE-124 -->
-            <exclude>**/dependency-reduced-pom.xml</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-      </plugin>
-    </plugins>
-
-    <!-- Plugin version list: http://maven.apache.org/plugins/index.html -->
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <encoding>UTF-8</encoding>
-            <debug>true</debug>
-            <debuglevel>source,lines,vars</debuglevel>
-            <optimize>true</optimize>
-            <source>${jdk.version}</source>
-            <target>${jdk.version}</target>
-          </configuration>
-        </plugin>
-
-        <!-- Avoid the warnings and errors from m2e -->
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <!-- 
-                       Warning:
-                       "maven-remote-resources-plugin (goal "process") is ignored by m2e." 
-                  -->
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <versionRange>[1.0.0,)</versionRange>
-                    <goals>
-                      <goal>enforce</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                <pluginExecution>
-                  <!-- 
-                       Warning:
-                       "maven-enforcer-plugin (goal "enforce") is ignored by m2e." 
-                  -->
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-remote-resources-plugin</artifactId>
-                    <versionRange>[1.0.0,)</versionRange>
-                    <goals>
-                      <goal>process</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                
-                <pluginExecution>
-                  <!--
-                      Error:
-                      Plugin execution not covered by lifecycle configuration
-                  -->
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.rat</groupId>
-                    <artifactId>apache-rat-plugin</artifactId>
-                    <versionRange>[0.11,)</versionRange>
-                    <goals>
-                      <goal>check</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.xenei</groupId>
-                    <artifactId>contract-test-maven-plugin</artifactId>
-                    <versionRange>[${ver.contract.tests},)</versionRange>
-                    <goals>
-                      <goal>contract-test</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-                
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-jar-plugin</artifactId>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>attach-sources</id>
-              <goals>
-                <goal>jar-no-fork</goal>
-              </goals>
-            </execution>
-            <!-- Only needed in some jars <execution> <id>attach-sources-test</id> 
-                 <goals> <goal>test-jar-no-fork</goal> </goals> </execution> -->
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>attach-javadocs</id>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <version>true</version>
-            <show>public</show>
-            <quiet>true</quiet>
-            <encoding>UTF-8</encoding>
-            <windowtitle>${project.name} ${project.version}</windowtitle>
-            <doctitle>${project.name} ${project.version}</doctitle>
-            <bottom>Licensed under the Apache License, Version 2.0</bottom>
-            <links>
-              <link>http://jena.apache.org/documentation/javadoc/jena/</link>
-              <link>http://jena.apache.org/documentation/javadoc/arq/</link>
-              <link>http://jena.apache.org/documentation/javadoc/tdb/</link>
-              <link>http://jena.apache.org/documentation/javadoc/text/</link>
-              <link>http://jena.apache.org/documentation/javadoc/spatial/</link>
-              <link>http://jena.apache.org/documentation/javadoc/fuseki2/</link>
-              <link>http://jena.apache.org/documentation/javadoc/permissions/</link>
-              <link>http://jena.apache.org/documentation/javadoc/jdbc/</link>
-              <link>http://jena.apache.org/documentation/javadoc/elephas/</link>
-            </links>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <configuration>
-            <encoding>UTF-8</encoding>
-          </configuration>
-        </plugin>
-
-        <!-- Temp fix for remote-resources while waiting for remote-resources >1.5
-             1.6 should fix this - SNAPSHOT already does.
-        -->
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-remote-resources-plugin</artifactId>
-          <version>1.5</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.shared</groupId>
-              <artifactId>maven-filtering</artifactId>
-              <version>1.2</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <configuration>
-            <overWriteReleases>false</overWriteReleases>
-            <overWriteIfNewer>true</overWriteIfNewer>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-eclipse-plugin</artifactId>
-          <version>2.9</version>
-          <configuration>
-            <!-- By default, have separate Eclipse and maven build areas -->
-            <buildOutputDirectory>${project.build.directory}/classes-eclipse</buildOutputDirectory>
-            <downloadSources>true</downloadSources>
-            <downloadJavadocs>false</downloadJavadocs>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>enforce</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <rules>
-              <requirePluginVersions>
-                <message>Best practice is to always define plugin versions!</message>
-                <banLatest>true</banLatest>
-                <banRelease>true</banRelease>
-              </requirePluginVersions>
-              <requireReleaseDeps>
-                <message>No SNAPSHOT dependencies are allowed!</message>
-                <onlyWhenRelease>true</onlyWhenRelease>
-              </requireReleaseDeps>
-              <DependencyConvergence />
-            </rules>
-            <fail>true</fail>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.felix</groupId>
-          <artifactId>maven-bundle-plugin</artifactId>
-          <version>2.5.3</version>
-          <extensions>true</extensions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.3</version>
-        </plugin>
-
-
-      </plugins>
-    </pluginManagement>
-  </build>
-
-  <reporting>
-    <!-- <outputDirectory>${project.build.directory}/site</outputDirectory> -->
-
-    <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.18.1</version>
-        <configuration>
-          <outputDirectory>${project.basedir}/target/surefire-reports-html</outputDirectory>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <instrumentation>
-            <ignores>
-              <ignore>org.slf4j.*</ignore>
-            </ignores>
-          </instrumentation>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.15</version>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jxr-plugin</artifactId>
-        <version>2.5</version>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.4</version>
-        <configuration>
-          <linkXref>true</linkXref>
-          <sourceEncoding>utf-8</sourceEncoding>
-          <minimumTokens>100</minimumTokens>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version>
-      </plugin>
-
-    </plugins>
-
-  </reporting>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	You under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.apache.jena</groupId>
+	<artifactId>jena-project</artifactId>
+	<packaging>pom</packaging>
+	<url>http://jena.apache.org/</url>
+	<version>3.5.0-SNAPSHOT</version>
+	<name>Apache Jena - Project</name>
+
+	<parent>
+		<groupId>org.apache</groupId>
+		<artifactId>apache</artifactId>
+		<!-- This version number is also in the top POM -->
+		<version>18</version>
+		<relativePath />
+	</parent>
+
+	<licenses>
+		<license>
+			<name>The Apache Software License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<organization>
+		<name>The Apache Software Foundation</name>
+		<url>http://www.apache.org/</url>
+	</organization>
+
+	<properties>
+		<ver.slf4j>1.7.25</ver.slf4j>
+		<ver.log4j>1.2.17</ver.log4j>
+		<ver.junit>4.12</ver.junit>
+		<ver.xerces>2.11.0</ver.xerces>
+		<ver.libthrift>0.10.0</ver.libthrift>
+
+		<!-- jsonld-java depends on depends on Jackson core artifacts so the versions 
+			must align. Consult jsonld-java's POM for the correct dependency versions -->
+		<ver.jsonldjava>0.11.1</ver.jsonldjava>
+		<ver.jackson>2.9.0</ver.jackson>
+
+		<ver.commonsio>2.6</ver.commonsio>
+		<ver.commonscli>1.4</ver.commonscli>
+
+		<ver.commonslang3>3.6</ver.commonslang3>
+		<ver.commonscsv>1.5</ver.commonscsv>
+		<ver.dexxcollection>0.7</ver.dexxcollection>
+
+		<ver.httpclient>4.5.3</ver.httpclient>
+		<ver.httpcore>4.4.6</ver.httpcore>
+		<!-- Normally, these are the same as the above In the case of 4.2.6, there 
+			isn't a httpcore-osgi. -->
+		<ver.httpcore-osgi>${ver.httpcore}</ver.httpcore-osgi>
+		<ver.httpclient-osgi>${ver.httpclient}</ver.httpclient-osgi>
+
+		<ver.commons-codec>1.11</ver.commons-codec>
+		<ver.lucene>6.4.1</ver.lucene>
+
+		<ver.elasticsearch>5.2.2</ver.elasticsearch>
+		<!-- elasticsearch uses this by reflection -->
+		<ver.log4j2>2.9.1</ver.log4j2>
+
+		<ver.spatial4j>0.6</ver.spatial4j>
+
+		<ver.mockito>1.9.5</ver.mockito>
+		<ver.awaitility>1.7.0</ver.awaitility>
+
+		<jdk.version>1.8</jdk.version>
+		<targetJdk>${jdk.version}</targetJdk> <!-- MPMD-86 workaround -->
+
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
+		<ver.contract.tests>0.1.7</ver.contract.tests>
+	</properties>
+
+	<profiles>
+		<profile>
+			<!-- Turn of doclint for java8 and later -->
+			<id>doclint-java8-disable</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+	<!-- Version management -->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>${ver.junit}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>xerces</groupId>
+				<artifactId>xercesImpl</artifactId>
+				<version>${ver.xerces}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient-cache</artifactId>
+				<version>${ver.httpclient}</version>
+				<exclusions>
+					<!-- Replace with slf4j adapter -->
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>${ver.httpclient}</version>
+				<exclusions>
+					<!-- Replace with slf4j adapter -->
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+
+			<dependency>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>${ver.commons-codec}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>${ver.commonsio}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.thrift</groupId>
+				<artifactId>libthrift</artifactId>
+				<version>${ver.libthrift}</version>
+				<exclusions>
+					<!-- Use whatever version Jena is using -->
+					<exclusion>
+						<groupId>org.apache.httpcomponents</groupId>
+						<artifactId>httpcore</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.commons</groupId>
+						<artifactId>commons-lang3</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-csv</artifactId>
+				<version>${ver.commonscsv}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>${ver.commonslang3}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>commons-fileupload</groupId>
+				<artifactId>commons-fileupload</artifactId>
+				<version>1.3.3</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-collections4</artifactId>
+				<version>4.1</version>
+			</dependency>
+
+			<!-- supports persistent data structures -->
+			<dependency>
+				<groupId>com.github.andrewoma.dexx</groupId>
+				<artifactId>collection</artifactId>
+				<version>${ver.dexxcollection}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>com.github.jsonld-java</groupId>
+				<artifactId>jsonld-java</artifactId>
+				<version>${ver.jsonldjava}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+					<!-- Exclude so we use our choice of versions -->
+					<exclusion>
+						<groupId>org.apache.httpcomponents</groupId>
+						<artifactId>httpclient-cache</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.httpcomponents</groupId>
+						<artifactId>httpclient</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.httpcomponents</groupId>
+						<artifactId>httpclient-osgi</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.apache.httpcomponents</groupId>
+						<artifactId>httpcore-osgi</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-api</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+
+			<!-- Lucene dependencies -->
+			<dependency>
+				<groupId>org.apache.lucene</groupId>
+				<artifactId>lucene-core</artifactId>
+				<version>${ver.lucene}</version>
+				<type>jar</type>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.lucene</groupId>
+				<artifactId>lucene-analyzers-common</artifactId>
+				<version>${ver.lucene}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.lucene</groupId>
+				<artifactId>lucene-queryparser</artifactId>
+				<version>${ver.lucene}</version>
+			</dependency>
+
+			<!-- For jena-spatial -->
+			<dependency>
+				<groupId>org.apache.lucene</groupId>
+				<artifactId>lucene-spatial</artifactId>
+				<version>${ver.lucene}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.lucene</groupId>
+				<artifactId>lucene-spatial-extras</artifactId>
+				<version>${ver.lucene}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.locationtech.spatial4j</groupId>
+				<artifactId>spatial4j</artifactId>
+				<version>${ver.spatial4j}</version>
+			</dependency>
+
+			<!-- Elasticsearch dependencies -->
+
+			<dependency>
+				<groupId>org.elasticsearch.client</groupId>
+				<artifactId>transport</artifactId>
+				<version>${ver.elasticsearch}</version>
+			</dependency>
+
+			<!-- Elasticsearch Server <dependency> <groupId>org.elasticsearch</groupId> 
+				<artifactId>elasticsearch</artifactId> <version>${ver.elasticsearch}</version> 
+				</dependency> -->
+
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>${ver.log4j2}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-to-slf4j</artifactId>
+				<version>${ver.log4j2}</version>
+			</dependency>
+
+			<!-- Logging -->
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>${ver.slf4j}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-log4j12</artifactId>
+				<version>${ver.slf4j}</version>
+			</dependency>
+
+			<!-- And intercept any uses of Jakarta Commons Logging e.g. Apache Common 
+				HTTP client. -->
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>jcl-over-slf4j</artifactId>
+				<version>${ver.slf4j}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>log4j</groupId>
+				<artifactId>log4j</artifactId>
+				<version>${ver.log4j}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>commons-cli</groupId>
+				<artifactId>commons-cli</artifactId>
+				<version>${ver.commonscli}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.xenei</groupId>
+				<artifactId>junit-contracts</artifactId>
+				<version>${ver.contract.tests}</version>
+				<scope>test</scope>
+				<exclusions>
+					<exclusion>
+						<artifactId>commons-cli</artifactId>
+						<groupId>commons-cli</groupId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+
+			<dependency>
+				<groupId>org.xenei</groupId>
+				<artifactId>contract-test-maven-plugin</artifactId>
+				<version>${ver.contract.tests}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-all</artifactId>
+				<version>${ver.mockito}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.jayway.awaitility</groupId>
+				<artifactId>awaitility</artifactId>
+				<version>${ver.awaitility}</version>
+			</dependency>
+		</dependencies>
+
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+	</dependencies>
+
+	<build>
+		<!-- Run the enforcer plugin automatically at compile time -->
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration combine.self="override">
+							<rules>
+								<requireJavaVersion>
+									<version>1.8.0</version>
+								</requireJavaVersion>
+								<requirePluginVersions>
+									<message>Best practice is to always define plugin versions!</message>
+									<banLatest>true</banLatest>
+									<banRelease>true</banRelease>
+								</requirePluginVersions>
+								<requireReleaseDeps>
+									<message>No SNAPSHOT dependencies are allowed!</message>
+									<onlyWhenRelease>true</onlyWhenRelease>
+								</requireReleaseDeps>
+							</rules>
+							<fail>true</fail>
+							<failFast>true</failFast>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Run the RAT Plugin -->
+			<plugin>
+				<groupId>org.apache.rat</groupId>
+				<artifactId>apache-rat-plugin</artifactId>
+				<version>0.12</version>
+				<executions>
+					<execution>
+						<id>rat-checks</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<excludeSubProjects>true</excludeSubProjects>
+					<excludes>
+						<exclude>**/hs_err_pid*.log</exclude>
+						<exclude>**/.project</exclude>
+						<exclude>**/.settings/**</exclude>
+						<exclude>**/.classpath</exclude>
+						<exclude>**/README.*</exclude>
+						<exclude>**/META-INF/services/*</exclude>
+						<!-- jena-core exclusions -->
+						<exclude>**/src-examples/data/*</exclude>
+
+						<!-- jena-fuseki exclusions -->
+						<exclude>**/dist/ABOUT</exclude>
+						<exclude>**/SEE_FUSEKI2</exclude>
+						<!-- Need to exclude JS and CSS since much of it comes from other Apache 
+							licensed projects e.g. Bootstrap, Qonsole -->
+						<exclude>**/src/main/webapp/css/*</exclude>
+						<exclude>**/src/main/webapp/fonts/*</exclude>
+						<exclude>**/src/main/webapp/js/**/*</exclude>
+
+						<!-- General exclusions -->
+						<!-- Vocabularies are often just local copies of vocabularies published 
+							by others -->
+						<exclude>**/vocabularies/*</exclude>
+						<exclude>**/Vocabularies/*</exclude>
+
+						<!-- Javadoc add-ons files are required to be simple and our javadoc 
+							configuration will ensure appropriate license and copyright statements are 
+							inserted into generated documentation anyway so no need to put license statements 
+							in these files -->
+						<exclude>**/src/main/**/*.html</exclude>
+						<exclude>**/src/**/package-info.java</exclude>
+
+						<exclude>**/DEPENDENCIES</exclude>
+
+						<!-- Text and Markdown files are typically used only for documentation 
+							purposes and license declarations are usually spurious in these files since 
+							often they will refer to the LICENSE/NOTICE for users to find the actual 
+							licenses -->
+						<exclude>**/*.txt</exclude>
+						<exclude>**/*.md</exclude>
+
+						<!-- META-INF services files can include comments but a license header 
+							would be unecessarily clutter so we exclude these -->
+						<exclude>**/META-INF/services/*</exclude>
+
+						<!-- Jena historically has large numbers of small test file with no 
+							license headers. Such small files are not required to have headers. In addition, 
+							there are files with different Licenses (e.g. W3C Software Licence, W3C Test 
+							Suite License) as noted in the code tree. -->
+						<exclude>**/src/test/resources/**/*</exclude>
+						<exclude>**/testing/**/*</exclude>
+
+						<exclude>**/log4j.properties</exclude>
+						<exclude>**/log4j-testing.properties</exclude>
+						<exclude>**/derby.log</exclude>
+						<exclude>**/DB/**/*</exclude>
+						<!-- TDB config files JSON - no comments allowed -->
+						<exclude>**/tdb*.cfg</exclude>
+						<!-- Fuseki2 server "run" area -->
+						<exclude>**/run/**/*</exclude>
+						<!-- Cached classpath for commands - autogenerated -->
+						<exclude>**/*.classpath</exclude>
+
+						<!-- Exclude anything created during the build (plugin generated files) 
+							-> -->
+						<exclude>**/target/**/*</exclude>
+						<!-- MSHADE-124 -->
+						<exclude>**/dependency-reduced-pom.xml</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+
+		<!-- Plugin version list: http://maven.apache.org/plugins/index.html -->
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<configuration>
+						<encoding>UTF-8</encoding>
+						<debug>true</debug>
+						<debuglevel>source,lines,vars</debuglevel>
+						<optimize>true</optimize>
+						<source>${jdk.version}</source>
+						<target>${jdk.version}</target>
+					</configuration>
+				</plugin>
+
+				<!-- Avoid the warnings and errors from m2e -->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<!-- Warning: "maven-remote-resources-plugin (goal "process") is 
+										ignored by m2e." -->
+									<pluginExecutionFilter>
+										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-enforcer-plugin</artifactId>
+										<versionRange>[1.0.0,)</versionRange>
+										<goals>
+											<goal>enforce</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore />
+									</action>
+								</pluginExecution>
+								<pluginExecution>
+									<!-- Warning: "maven-enforcer-plugin (goal "enforce") is ignored 
+										by m2e." -->
+									<pluginExecutionFilter>
+										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-remote-resources-plugin</artifactId>
+										<versionRange>[1.0.0,)</versionRange>
+										<goals>
+											<goal>process</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore />
+									</action>
+								</pluginExecution>
+
+								<pluginExecution>
+									<!-- Error: Plugin execution not covered by lifecycle configuration -->
+									<pluginExecutionFilter>
+										<groupId>org.apache.rat</groupId>
+										<artifactId>apache-rat-plugin</artifactId>
+										<versionRange>[0.11,)</versionRange>
+										<goals>
+											<goal>check</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore />
+									</action>
+								</pluginExecution>
+
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.xenei</groupId>
+										<artifactId>contract-test-maven-plugin</artifactId>
+										<versionRange>[${ver.contract.tests},)</versionRange>
+										<goals>
+											<goal>contract-test</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore />
+									</action>
+								</pluginExecution>
+
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>attach-sources</id>
+							<goals>
+								<goal>jar-no-fork</goal>
+							</goals>
+						</execution>
+						<!-- Only needed in some jars <execution> <id>attach-sources-test</id> 
+							<goals> <goal>test-jar-no-fork</goal> </goals> </execution> -->
+					</executions>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>attach-javadocs</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<version>true</version>
+						<show>public</show>
+						<quiet>true</quiet>
+						<encoding>UTF-8</encoding>
+						<windowtitle>${project.name} ${project.version}</windowtitle>
+						<doctitle>${project.name} ${project.version}</doctitle>
+						<bottom>Licensed under the Apache License, Version 2.0</bottom>
+						<links>
+							<link>http://jena.apache.org/documentation/javadoc/jena/</link>
+							<link>http://jena.apache.org/documentation/javadoc/arq/</link>
+							<link>http://jena.apache.org/documentation/javadoc/tdb/</link>
+							<link>http://jena.apache.org/documentation/javadoc/text/</link>
+							<link>http://jena.apache.org/documentation/javadoc/spatial/</link>
+							<link>http://jena.apache.org/documentation/javadoc/fuseki2/</link>
+							<link>http://jena.apache.org/documentation/javadoc/permissions/</link>
+							<link>http://jena.apache.org/documentation/javadoc/jdbc/</link>
+							<link>http://jena.apache.org/documentation/javadoc/elephas/</link>
+						</links>
+					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<configuration>
+						<encoding>UTF-8</encoding>
+					</configuration>
+				</plugin>
+
+				<!-- Temp fix for remote-resources while waiting for remote-resources 
+					>1.5 1.6 should fix this - SNAPSHOT already does. -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-remote-resources-plugin</artifactId>
+					<version>1.5</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.apache.maven.shared</groupId>
+							<artifactId>maven-filtering</artifactId>
+							<version>1.2</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-dependency-plugin</artifactId>
+					<configuration>
+						<overWriteReleases>false</overWriteReleases>
+						<overWriteIfNewer>true</overWriteIfNewer>
+					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-eclipse-plugin</artifactId>
+					<version>2.9</version>
+					<configuration>
+						<!-- By default, have separate Eclipse and maven build areas -->
+						<buildOutputDirectory>${project.build.directory}/classes-eclipse</buildOutputDirectory>
+						<downloadSources>true</downloadSources>
+						<downloadJavadocs>false</downloadJavadocs>
+					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>enforce</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<rules>
+							<requirePluginVersions>
+								<message>Best practice is to always define plugin versions!</message>
+								<banLatest>true</banLatest>
+								<banRelease>true</banRelease>
+							</requirePluginVersions>
+							<requireReleaseDeps>
+								<message>No SNAPSHOT dependencies are allowed!</message>
+								<onlyWhenRelease>true</onlyWhenRelease>
+							</requireReleaseDeps>
+							<DependencyConvergence />
+						</rules>
+						<fail>true</fail>
+					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<version>2.5.3</version>
+					<extensions>true</extensions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-shade-plugin</artifactId>
+					<version>2.4.3</version>
+				</plugin>
+
+
+			</plugins>
+		</pluginManagement>
+	</build>
+
+	<reporting>
+		<!-- <outputDirectory>${project.build.directory}/site</outputDirectory> -->
+
+		<plugins>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-report-plugin</artifactId>
+				<version>2.18.1</version>
+				<configuration>
+					<outputDirectory>${project.basedir}/target/surefire-reports-html</outputDirectory>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.7</version>
+				<configuration>
+					<instrumentation>
+						<ignores>
+							<ignore>org.slf4j.*</ignore>
+						</ignores>
+					</instrumentation>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.15</version>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jxr-plugin</artifactId>
+				<version>2.5</version>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>3.4</version>
+				<configuration>
+					<linkXref>true</linkXref>
+					<sourceEncoding>utf-8</sourceEncoding>
+					<minimumTokens>100</minimumTokens>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>3.0.1</version>
+			</plugin>
+
+		</plugins>
+
+	</reporting>
 </project>

--- a/jena-project/pom.xml
+++ b/jena-project/pom.xml
@@ -51,7 +51,7 @@
     <ver.log4j>1.2.17</ver.log4j>
     <ver.junit>4.12</ver.junit>
     <ver.xerces>2.11.0</ver.xerces>
-    <ver.libthrift>0.9.3</ver.libthrift>
+    <ver.libthrift>0.10.0</ver.libthrift>
 
     <!-- jsonld-java depends on depends on Jackson core
          artifacts so the versions must align. Consult jsonld-java's 


### PR DESCRIPTION
There are 5 commits here, the first 4 of which are (I think) non-controversial. In the last, to get from Commons Lang 3.4 to 3.5 (and thence to 3.6) I had to change test code.

I think the changes are kosher-- using `Z` instead of `+00:00` is legit according to the [XSD Dataypes spec](https://www.w3.org/TR/xmlschema11-2/#nt-tzFrag). But it might cause some surprises.