### PR TITLE
Bad regular expression patterns should throw ExprEvalException

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -40,6 +40,7 @@ import java.text.NumberFormat ;
 import java.util.*;
 import java.util.regex.Matcher ;
 import java.util.regex.Pattern ;
+import java.util.regex.PatternSyntaxException ;
 
 import javax.xml.datatype.DatatypeConstants ;
 import javax.xml.datatype.DatatypeConstants.Field ;
@@ -471,7 +472,11 @@ public class XSDFuncOp
             String flagsStr = checkAndGetStringLiteral("replace", nvFlags).getLiteralLexicalForm() ;
             flags = RegexJava.makeMask(flagsStr) ;
         }
-        return strReplace(nvStr, Pattern.compile(pat, flags), nvReplacement) ;
+        try {
+            return strReplace(nvStr, Pattern.compile(pat, flags), nvReplacement) ;
+        } catch (PatternSyntaxException ex){
+            throw new ExprEvalException("PatternSyntaxException", ex) ;
+        } 
     }
 
     public static NodeValue strReplace(NodeValue nvStr, Pattern pattern, NodeValue nvReplacement) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
@@ -18,6 +18,9 @@
 
 package org.apache.jena.sparql.expr;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
@@ -854,6 +857,17 @@ public class TestXSDFuncOp extends BaseTest
         assertNotNull(result.asNode()) ;
     }
     
+    @Test public void testStrReplace()
+    {
+        //test invalid pattern 
+        NodeValue wrong = NodeValue.makeString("^(?:-*[^-]){-9}");
+        NodeValue nvStr= NodeValue.makeString("AGIKLAKLMTUARAR");
+        NodeValue empty= NodeValue.makeString("");
+        try {
+        	XSDFuncOp.strReplace(nvStr, wrong, empty);
+        	fail("Should have thrown an exception as the regex is not valid.");
+        } catch (ExprEvalException ex) {}        
+    }
     // All compatible - no timezone.
     private static NodeValue nv_dt = NodeValue.makeNode("2010-03-22T20:31:54.5", XSDDatatype.XSDdateTime) ;
     private static NodeValue nv_d = NodeValue.makeNode("2010-03-22", XSDDatatype.XSDdate) ;


### PR DESCRIPTION
instead of PatternSyntaxException

This is a minimal patch that throws and ExprEvalException when given bad regular expressions in str replace.

Per internal SIB policies I am authorized to make small patches such as this available under the Apache v2 license.