### PR TITLE
JENA-1403: Tidy up regex pattern handling.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_StrReplace.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_StrReplace.java
@@ -32,10 +32,11 @@ public class E_StrReplace extends ExprFunctionN {
         super(symbol, expr1, expr2, expr3, expr4) ;
 
         if ( isString(expr2) && (expr4 == null || isString(expr4)) ) {
-            int flags = 0 ;
+            String flags = null;
             if ( expr4 != null && expr4.isConstant() && expr4.getConstant().isString() )
-                flags = RegexJava.makeMask(expr4.getConstant().getString()) ;
-            pattern = Pattern.compile(expr2.getConstant().getString(), flags) ;
+                flags = expr4.getConstant().getString();
+            String patternStr = expr2.getConstant().getString();
+            pattern = RegexJava.makePattern("REPLACE", patternStr, flags);
         }
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/RegexJava.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/RegexJava.java
@@ -18,66 +18,60 @@
 
 package org.apache.jena.sparql.expr;
 
-import java.util.regex.Matcher ;
-import java.util.regex.Pattern ;
-import java.util.regex.PatternSyntaxException ;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public class RegexJava implements RegexEngine
 {
-    Pattern regexPattern ;
+    private Pattern regexPattern;
 
-    public RegexJava(String pattern, String flags)
-    {
-        regexPattern = makePattern(pattern, flags) ;
+    public RegexJava(String pattern, String flags) {
+        regexPattern = makePattern("Regex", pattern, flags);
     }
-    
+
     @Override
-    public boolean match(String s)
-    {
-        Matcher m = regexPattern.matcher(s) ;
-        return m.find() ;
+    public boolean match(String s) {
+        Matcher m = regexPattern.matcher(s);
+        return m.find();
     }
-    
-    private Pattern makePattern(String patternStr, String flags)
-    {
-        try { 
-            int mask = 0 ;
+
+    public static Pattern makePattern(String label, String patternStr, String flags) {
+        try {
+            int mask = 0;
             if ( flags != null ) {
-                mask = makeMask(flags) ;
+                mask = makeMask(flags);
                 if ( flags.contains("q") )
                     patternStr = Pattern.quote(patternStr);
             }
-            
-            return Pattern.compile(patternStr, mask) ;
-        } 
-        catch (PatternSyntaxException pEx)
-        { throw new ExprEvalException("Regex: Pattern exception: "+pEx) ; }
+            return Pattern.compile(patternStr, mask);
+        }
+        catch (PatternSyntaxException pEx) {
+            throw new ExprEvalException(label+" pattern exception: " + pEx);
+        }
     }
 
-    public static int makeMask(String modifiers)
-    {
+    public static int makeMask(String modifiers) {
         if ( modifiers == null )
-            return 0 ;
-        
-        int newMask = 0 ;
-        for ( int i = 0 ; i < modifiers.length() ; i++ )
-        {
-            switch(modifiers.charAt(i))
-            {
+            return 0;
+
+        int newMask = 0;
+        for ( int i = 0; i < modifiers.length(); i++ ) {
+            switch (modifiers.charAt(i)) {
                 case 'i': 
-                    newMask |= Pattern.UNICODE_CASE ;
+                    newMask |= Pattern.UNICODE_CASE;
                     newMask |= Pattern.CASE_INSENSITIVE;
-                    break ;
-                case 'm': newMask |= Pattern.MULTILINE ;           break ;
-                case 's': newMask |= Pattern.DOTALL ;              break ;
-                //case 'x': newMask |= Pattern.; break ;
-                case 'q': ; break ;
+                    break;
+                case 'm': newMask |= Pattern.MULTILINE;           break;
+                case 's': newMask |= Pattern.DOTALL;              break;
+                // Not suported by Java regex
+                //case 'x': newMask |= Pattern.; break;
+                case 'q':; break;
                 
                 default: 
-                    throw new ExprEvalException("Unsupported flag in regex modifiers: "+modifiers.charAt(i)) ;
+                    throw new ExprEvalException("Unsupported flag in regex modifiers: "+modifiers.charAt(i));
             }
         }
-        return newMask ;
+        return newMask;
     }
-
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -40,6 +40,7 @@ import java.text.NumberFormat ;
 import java.util.*;
 import java.util.regex.Matcher ;
 import java.util.regex.Pattern ;
+import java.util.regex.PatternSyntaxException ;
 
 import javax.xml.datatype.DatatypeConstants ;
 import javax.xml.datatype.DatatypeConstants.Field ;
@@ -471,7 +472,11 @@ public class XSDFuncOp
             String flagsStr = checkAndGetStringLiteral("replace", nvFlags).getLiteralLexicalForm() ;
             flags = RegexJava.makeMask(flagsStr) ;
         }
-        return strReplace(nvStr, Pattern.compile(pat, flags), nvReplacement) ;
+        try {
+            return strReplace(nvStr, Pattern.compile(pat, flags), nvReplacement) ;
+        } catch (PatternSyntaxException ex){
+            throw new ExprEvalException("PatternSyntaxException", ex) ;
+        } 
     }
 
     public static NodeValue strReplace(NodeValue nvStr, Pattern pattern, NodeValue nvReplacement) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -40,7 +40,6 @@ import java.text.NumberFormat ;
 import java.util.*;
 import java.util.regex.Matcher ;
 import java.util.regex.Pattern ;
-import java.util.regex.PatternSyntaxException ;
 
 import javax.xml.datatype.DatatypeConstants ;
 import javax.xml.datatype.DatatypeConstants.Field ;
@@ -58,7 +57,7 @@ import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.rdf.model.impl.Util ;
 import org.apache.jena.sparql.ARQInternalErrorException ;
 import org.apache.jena.sparql.SystemARQ ;
-import org.apache.jena.sparql.expr.* ;
+import org.apache.jena.sparql.expr.*;
 import org.apache.jena.sparql.util.DateTimeStruct ;
 /**
  * Implementation of XQuery/XPath functions and operators.
@@ -466,18 +465,12 @@ public class XSDFuncOp
     }
 
     public static NodeValue strReplace(NodeValue nvStr, NodeValue nvPattern, NodeValue nvReplacement, NodeValue nvFlags) {
-        String pat = checkAndGetStringLiteral("replace", nvPattern).getLiteralLexicalForm() ;
-        int flags = 0 ;
-        if ( nvFlags != null ) {
-            String flagsStr = checkAndGetStringLiteral("replace", nvFlags).getLiteralLexicalForm() ;
-            flags = RegexJava.makeMask(flagsStr) ;
-        }
-        try {
-            return strReplace(nvStr, Pattern.compile(pat, flags), nvReplacement) ;
-        } catch (PatternSyntaxException ex){
-            throw new ExprEvalException("PatternSyntaxException", ex) ;
-        } 
-    }
+        String pat = checkAndGetStringLiteral("replace", nvPattern).getLiteralLexicalForm();
+        String flagsStr = null;
+        if ( nvFlags != null )
+            flagsStr = checkAndGetStringLiteral("replace", nvFlags).getLiteralLexicalForm();
+        return strReplace(nvStr, RegexJava.makePattern("replace", pat, flagsStr), nvReplacement);
+    }    
 
     public static NodeValue strReplace(NodeValue nvStr, Pattern pattern, NodeValue nvReplacement) {
         String n = checkAndGetStringLiteral("replace", nvStr).getLiteralLexicalForm() ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -319,7 +319,24 @@ public class TestFunctions
     @Test public void exprFnReplace06()  { test("fn:replace('abcbd', 'B.', 'Z', 'i')", NodeValue.makeString("aZZ")) ; }
 
     // Bad group
-    @Test public void exprReplace13()  { testEvalException("REPLACE('abc', '.*', '$1')") ; }
+    @Test
+    public void exprReplace13() {
+        testEvalException("REPLACE('abc', '.*', '$1')");
+    }
+    
+    // Bad pattern ; static (parse or build time) compilation.
+    @Test(expected = ExprException.class)
+    public void exprReplace14() {
+        ExprUtils.parse("REPLACE('abc', '^(a){-9}', 'ABC')");
+    }
+    
+    // Bad pattern : dynamic (eval time) exception. 
+    // The pattern for fn:replace is not compiled on build - if that changes, this test will fail.
+    // See exprReplace14.
+    @Test
+    public void exprReplace15() {
+        testEvalException("fn:replace('abc', '^(a){-9}', 'ABC')");
+    }
 
     @Test public void exprBoolean1()    { test("fn:boolean('')", FALSE) ; }
     @Test public void exprBoolean2()    { test("fn:boolean(0)", FALSE) ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
@@ -18,9 +18,6 @@
 
 package org.apache.jena.sparql.expr;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
@@ -857,17 +854,15 @@ public class TestXSDFuncOp extends BaseTest
         assertNotNull(result.asNode()) ;
     }
     
-    @Test public void testStrReplace()
-    {
+    @Test(expected=ExprEvalException.class)
+    public void testStrReplace() {
         //test invalid pattern 
         NodeValue wrong = NodeValue.makeString("^(?:-*[^-]){-9}");
         NodeValue nvStr= NodeValue.makeString("AGIKLAKLMTUARAR");
         NodeValue empty= NodeValue.makeString("");
-        try {
-        	XSDFuncOp.strReplace(nvStr, wrong, empty);
-        	fail("Should have thrown an exception as the regex is not valid.");
-        } catch (ExprEvalException ex) {}        
+        XSDFuncOp.strReplace(nvStr, wrong, empty);
     }
+    
     // All compatible - no timezone.
     private static NodeValue nv_dt = NodeValue.makeNode("2010-03-22T20:31:54.5", XSDDatatype.XSDdateTime) ;
     private static NodeValue nv_d = NodeValue.makeNode("2010-03-22", XSDDatatype.XSDdate) ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
@@ -18,6 +18,9 @@
 
 package org.apache.jena.sparql.expr;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
@@ -854,6 +857,17 @@ public class TestXSDFuncOp extends BaseTest
         assertNotNull(result.asNode()) ;
     }
     
+    @Test public void testStrReplace()
+    {
+        //test invalid pattern 
+        NodeValue wrong = NodeValue.makeString("^(?:-*[^-]){-9}");
+        NodeValue nvStr= NodeValue.makeString("AGIKLAKLMTUARAR");
+        NodeValue empty= NodeValue.makeString("");
+        try {
+        	XSDFuncOp.strReplace(nvStr, wrong, empty);
+        	fail("Should have thrown an exception as the regex is not valid.");
+        } catch (ExprEvalException ex) {}        
+    }
     // All compatible - no timezone.
     private static NodeValue nv_dt = NodeValue.makeNode("2010-03-22T20:31:54.5", XSDDatatype.XSDdateTime) ;
     private static NodeValue nv_d = NodeValue.makeNode("2010-03-22", XSDDatatype.XSDdate) ;


### PR DESCRIPTION
This includes PR#291, and consolidates pattern exceptions into RegexJava.

Full handling with Xerces regexp for "replace" functionality is a lot of work as Xerces has a separate, parallel set of classes; it is only the "x" flag that is missing from Java. JDK regex is likely to be faster. JDK has been the normal setting; Xerces is there for exact spec compliance in REGEX only.

We don't want more Xerces specific dependencies.
