### PR TITLE
Enable parallel testing for Elephas IO (JENA-1407)

### DIFF
--- a/jena-elephas/jena-elephas-io/pom.xml
+++ b/jena-elephas/jena-elephas-io/pom.xml
@@ -15,7 +15,8 @@
    limitations under the License.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.jena</groupId>
@@ -30,7 +31,7 @@
   <!-- Note that versions are managed by parent POMs -->
   <dependencies>
     <!-- Internal Project Dependencies -->
-    
+
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-elephas-common</artifactId>
@@ -66,8 +67,8 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
-    <build>
+
+  <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -87,15 +88,34 @@
           </links>
         </configuration>
       </plugin>
-      
+
       <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <parallel>classes</parallel>
-            <threadCount>4</threadCount>
-          </configuration>
-        </plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>get-cpu-count</id>
+            <goals>
+              <goal>cpu-count</goal>
+            </goals>
+            <configuration>
+              <cpuCount>system.numCores</cpuCount>
+              <!-- Use 50% of available cores -->
+              <factor>0.5</factor>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <parallel>classes</parallel>
+          <threadCount>${system.numCores}</threadCount>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/jena-elephas/jena-elephas-io/pom.xml
+++ b/jena-elephas/jena-elephas-io/pom.xml
@@ -87,6 +87,15 @@
           </links>
         </configuration>
       </plugin>
+      
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <parallel>classes</parallel>
+            <threadCount>4</threadCount>
+          </configuration>
+        </plugin>
     </plugins>
   </build>
 </project>

--- a/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/turtle/TurtleInputTest.java
+++ b/jena-elephas/jena-elephas-io/src/test/java/org/apache/jena/hadoop/rdf/io/input/turtle/TurtleInputTest.java
@@ -61,7 +61,7 @@ public class TurtleInputTest extends AbstractWholeFileTripleInputFormatTests {
         // Try to reproduce JENA-1075
         
         // Create test data
-        File f = new File("target/prefixes.ttl");
+        File f = folder.newFile("prefixes.ttl");
         try (FileWriter writer = new FileWriter(f)) {
             //@formatter:off
             writer.write(StrUtils.strjoinNL("@prefix : <http://test/ns#> .",


### PR DESCRIPTION
Using parallelism of 4 reduces build time for Elephas IO to
approximately 3-4 minutes in my testing.  Also fixed one test that was
not parallel safe to use the pre-existing temporary folder.

Ran this a ton of times in a tight loop on my system to check that there weren't any transient errors or serial test assumptions encoded in the tests.