### PR TITLE
JENA-1411: use posix tar format with maven-assembly-plugin

### DIFF
--- a/apache-jena/pom.xml
+++ b/apache-jena/pom.xml
@@ -185,6 +185,7 @@
             </goals>
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
+              <tarLongFileMode>posix</tarLongFileMode>
               <descriptors>
                 <descriptor>assembly-jena-zip.xml</descriptor>
               </descriptors>

--- a/jena-fuseki1/pom.xml
+++ b/jena-fuseki1/pom.xml
@@ -351,6 +351,7 @@
             <phase>package</phase>
             <goals><goal>single</goal></goals>
             <configuration>
+              <tarLongFileMode>posix</tarLongFileMode>
               <descriptors>
                 <descriptor>assembly-dist.xml</descriptor>
               </descriptors>

--- a/jena-fuseki2/apache-jena-fuseki/pom.xml
+++ b/jena-fuseki2/apache-jena-fuseki/pom.xml
@@ -62,6 +62,7 @@
             <goals><goal>single</goal></goals>
             <configuration>
               <appendAssemblyId>false</appendAssemblyId>
+              <tarLongFileMode>posix</tarLongFileMode>
               <descriptors>
                 <descriptor>assembly-dist.xml</descriptor>
               </descriptors>

--- a/jena-sdb/pom.xml
+++ b/jena-sdb/pom.xml
@@ -189,6 +189,7 @@
             <phase>package</phase>
             <goals><goal>single</goal></goals>
             <configuration>
+              <tarLongFileMode>posix</tarLongFileMode>
               <descriptors>
                 <descriptor>assembly.xml</descriptor>
               </descriptors>


### PR DESCRIPTION
This sets tarLongFileMode=posix for all the tarballs created in the build.

See https://issues.apache.org/jira/browse/JENA-1411