### PR TITLE
JENA-1413: increase Elasticsearch startup timeout to 60 seconds

### DIFF
--- a/jena-text-es/pom.xml
+++ b/jena-text-es/pom.xml
@@ -133,6 +133,7 @@
           <clusterName>elasticsearch</clusterName>
           <transportPort>9500</transportPort>
           <httpPort>9400</httpPort>
+          <timeout>60</timeout>
         </configuration>
         <executions>
           <!--


### PR DESCRIPTION
This attempts to fix intermittent build problems with jena-text-es by increasing the startup timeout.
See https://issues.apache.org/jira/browse/JENA-1413