### PR TITLE
Fixing tests on Windows for 3.5.0 RC2

### DIFF
--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/DatabaseOps.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/DatabaseOps.java
@@ -144,7 +144,7 @@ public class DatabaseOps {
         if ( basename.contains("/") || basename.contains("\\") )
             throw new IllegalArgumentException("Basename must not contain a file path separator (\"/\" or \"\\\")");
         
-        String timestamp = DateTimeUtils.nowAsString("yyyy-MM-dd_HH:mm:ss") ;
+        String timestamp = DateTimeUtils.nowAsString("yyyy-MM-dd_HHmmss") ;
         String filename = basename + "_" + timestamp ;
         Path p = dirPath.resolve(filename+"."+ext);
         int x = 0 ;

--- a/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/sys/TestDatabaseOps.java
+++ b/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/sys/TestDatabaseOps.java
@@ -60,7 +60,7 @@ public class TestDatabaseOps
     
     @Before
     public void before() {
-        dir = Location.create(tempFolder.toString());
+        dir = Location.create(tempFolder.getRoot().getAbsolutePath());
         FileUtils.deleteQuietly(IOX.asFile(dir));
         FileOps.ensureDir(dir.getDirectoryPath());
     }


### PR DESCRIPTION
While testing 3.5.0 RC2 on Windows found another test failure. Spent some five minutes looking into this, and turns out it could be fixed by the `TemporaryFolder` rule too.

Previously, I mistakenly used `toString()` on the `TemporaryFolder`, but that prints the wrong data. You need to actually call `getRoot()` (or `newFolder()` if you want a new temp folder).

Fixed that in the previous test as well.

But more importantly, there is a limitation in `jena/tdb2/sys/DatabaseOps.java`, where it uses the timestamp formatted with colons. However, Windows doesn't like colons in file names (see https://support.microsoft.com/en-us/help/289627/how-to-enable-file-name-character-translation).

So I removed the colon characters, and the time is now formatted with `yyyy-MM-dd_HHmmss`, but happy if someone has a better suggestion (feel free to update this PR if you have the rights to do so too).

With these changes, the build is passing on my Windows with `mvn clean test install -Pbootstrap` (and also with the `dev` profile).

Running `mvn clean test install` hangs during ElasticSearch tests. Looks like a test fails, and then the execution simply hangs. Ctrl+C stops the process, but then I have to manually kill the `java` process. Not related to this bug, and not an issue right now I guess.