### PR TITLE
JENA-1408: Quicker -Pdev; simplify profiles.

### DIFF
--- a/jena-project/pom.xml
+++ b/jena-project/pom.xml
@@ -115,6 +115,23 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>dev</id>
+      <build>
+        <plugins>
+          <!-- For -Pdev :: don't create javadoc. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
 
   <!-- Version management -->

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
       -->
       <modules>
         <module>jena-project</module>
-        <!-- <module>jena-shaded-guava</module>   -->
-        <!-- <module>jena-iri</module>            -->
+        <module>jena-shaded-guava</module>
+        <module>jena-iri</module>
         <module>jena-base</module>
         
         <module>jena-core</module>
@@ -105,38 +105,6 @@
       </modules>
     </profile>
 
-    <profile>
-      <!-- Build to get started, up to Fuseki2.
-           Includes modules skipped by "dev".
-           Use this (or a full build) when building locally
-           and there are no SNAPSHOTs in the "snapshots" repository.
-           This profile does a more complete "dev" build,
-           does not assume anything is already built,
-           and does not include the longer running modules.
-      -->
-      <id>bootstrap</id>
-      <modules>
-        <module>jena-project</module>
-        <module>jena-shaded-guava</module>
-        <module>jena-iri</module> 
-        <module>jena-base</module>
-        <module>jena-core</module>
-        <module>jena-arq</module>
-        <module>jena-rdfconnection</module>
-        <module>jena-tdb</module>
-        <module>jena-db</module>
-        <module>apache-jena-libs</module>
-        <module>jena-text</module>
-        <!--<module>jena-text-es</module>-->
-        <module>jena-spatial</module>
-
-        <module>jena-cmds</module>
-        <module>jena-fuseki2</module>
-
-        <module>jena-integration-tests</module>
-      </modules>
-    </profile>
-    
     <profile>
       <!--
           This is the complete profile, it builds everything including slow


### PR DESCRIPTION
This simplifies and speeds up the quick development profile.

* Don't skip jena-iri and jena-shared-guava in -Pdev. Skipping does not always seem to work when there are new Jenkins built snapshots as well. The time difference is small.
* Remove -Pbootstrap because it is now the same as -Pdev
* Don't build javadoc when running -Pdev

(see the JIRA for some timings)
