### PR TITLE
Algorithms for JENA-1414

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/iterator/Iter.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/iterator/Iter.java
@@ -351,6 +351,22 @@ public class Iter<T> implements Iterator<T> {
         return filter(iter, Objects::nonNull) ;
     }
 
+    /** Step forward up to {@code steps} places.
+     * <br/>Return number of steps taken.
+     * 
+     * @apiNote
+     * The iterator is moved at most {@code steps} places with no overshoot.
+     * The iterator can be used afterwards.
+     */ 
+    public static int step(Iterator<?> iter, int steps) {
+        for ( int i = 0 ; i < steps; i++) {
+            if ( ! iter.hasNext() ) 
+                return i;
+            iter.next();
+        }
+        return steps;
+    }
+
     /** Take the first N elements of an iterator - stop early if too few */
     public static <T> List<T> take(Iterator<T> iter, int N) {
         iter = new IteratorN<>(iter, N) ;

--- a/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIter.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIter.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue ;
 
 import java.util.* ;
 import java.util.function.Predicate;
+import java.util.stream.IntStream;
 
 import org.junit.Test ;
 
@@ -320,6 +321,48 @@ public class TestIter
         List<String> data = Arrays.asList( "11", "AA", "BB", "CC") ;
         assertEquals(-1, Iter.lastIndex(data, filter)) ;
     }
+    
+    
+    private static Iterator<?> iterator(int n) { 
+        return IntStream.range(1, n+1).iterator();
+    }
+
+    @Test public void iteratorStep_1() {
+        Iterator<?> iter = iterator(0); 
+        int x = Iter.step(iter, 0);
+        assertEquals(0,x);
+    }
+    
+    @Test public void iteratorStep_2() {
+        Iterator<?> iter = iterator(0); 
+        int x = Iter.step(iter, 1);
+        assertEquals(0,x);
+    }
+
+    @Test public void iteratorStep_3() {
+        Iterator<?> iter = iterator(5); 
+        int x = Iter.step(iter, 1);
+        assertEquals(1,x);
+    }
+
+    @Test public void iteratorStep_4() {
+        Iterator<?> iter = iterator(5); 
+        int x = Iter.step(iter, 4);
+        assertEquals(4,x);
+    }
+    
+    @Test public void iteratorStep_5() {
+        Iterator<?> iter = iterator(5); 
+        int x = Iter.step(iter, 5);
+        assertEquals(5,x);
+    }
+    
+    @Test public void iteratorStep_6() {
+        Iterator<?> iter = iterator(5); 
+        int x = Iter.step(iter, 6);
+        assertEquals(5,x);
+    }
+
     
     @Test
     public void take_01()

--- a/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIter.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIter.java
@@ -36,30 +36,25 @@ public class TestIter
     List<String> data3 = Arrays.asList(null, "x", null, null, null, "y", "z", null);
  
     @Test
-    public void append_1()
-    {
-        Iterator<String> iter = Iter.append(data1.iterator(), data0.iterator()) ;
-        test(iter, "a") ;
+    public void append_1() {
+        Iterator<String> iter = Iter.append(data1.iterator(), data0.iterator());
+        test(iter, "a");
     }
-        
-        
+       
     @Test
-    public void append_2()
-    {
-        Iterator<String> iter = Iter.append(data0.iterator(), data1.iterator()) ;
-        test(iter, "a") ;
+    public void append_2() {
+        Iterator<String> iter = Iter.append(data0.iterator(), data1.iterator());
+        test(iter, "a");
     }
         
     @Test
-    public void append_3()
-    {
-        Iterator<String> iter = Iter.append(data1.iterator(), data2.iterator()) ;
-        test(iter, "a", "x", "y", "z") ;
+    public void append_3() {
+        Iterator<String> iter = Iter.append(data1.iterator(), data2.iterator());
+        test(iter, "a", "x", "y", "z");
     }
 
     @Test
-    public void append_4()
-    {
+    public void append_4() {
         List<String> L = new ArrayList<>(3);
         L.add("a");
         L.add("b");
@@ -68,28 +63,24 @@ public class TestIter
         R.add("d");
         R.add("e");
         R.add("f");
-        
-        
-        Iterator<String> LR = Iter.append(L.iterator(), R.iterator()) ;
-        
-        while (LR.hasNext())
-        {
+
+        Iterator<String> LR = Iter.append(L.iterator(), R.iterator());
+
+        while (LR.hasNext()) {
             String s = LR.next();
-            
-            if ("c".equals(s))
-            {
+
+            if ( "c".equals(s) ) {
                 LR.hasNext();  // test for JENA-60
                 LR.remove();
             }
         }
-        
+
         assertEquals("ab", Iter.asString(L, ""));
         assertEquals("def", Iter.asString(R, ""));
     }
-    
+
     @Test
-    public void append_5()
-    {
+    public void append_5() {
         List<String> L = new ArrayList<>(3);
         L.add("a");
         L.add("b");
@@ -98,28 +89,24 @@ public class TestIter
         R.add("d");
         R.add("e");
         R.add("f");
-        
-        
-        Iterator<String> LR = Iter.append(L.iterator(), R.iterator()) ;
-        
-        while (LR.hasNext())
-        {
+
+        Iterator<String> LR = Iter.append(L.iterator(), R.iterator());
+
+        while (LR.hasNext()) {
             String s = LR.next();
-            
-            if ("d".equals(s))
-            {
+
+            if ( "d".equals(s) ) {
                 LR.hasNext();  // test for JENA-60
                 LR.remove();
             }
         }
-        
+
         assertEquals("abc", Iter.asString(L, ""));
         assertEquals("ef", Iter.asString(R, ""));
     }
-    
+
     @Test
-    public void append_6()
-    {
+    public void append_6() {
         List<String> L = new ArrayList<>(3);
         L.add("a");
         L.add("b");
@@ -128,272 +115,241 @@ public class TestIter
         R.add("d");
         R.add("e");
         R.add("f");
-        
-        
-        Iterator<String> LR = Iter.append(L.iterator(), R.iterator()) ;
-        
-        while (LR.hasNext())
-        {
-            LR.next() ;
+
+        Iterator<String> LR = Iter.append(L.iterator(), R.iterator());
+
+        while (LR.hasNext()) {
+            LR.next();
         }
-        LR.remove() ;
-        
-        assertEquals("abc", Iter.asString(L, "")) ;
-        assertEquals("de", Iter.asString(R, "")) ;
-    }
-    
-    @Test
-    public void asString_1() 
-    {
-        String x = Iter.asString(data0, "") ;
-        assertEquals("", x) ;
+        LR.remove();
+
+        assertEquals("abc", Iter.asString(L, ""));
+        assertEquals("de", Iter.asString(R, ""));
     }
 
     @Test
-    public void asString_2() 
-    {
-        String x = Iter.asString(data1, "") ;
-        assertEquals("a", x) ;
+    public void asString_1() {
+        String x = Iter.asString(data0, "");
+        assertEquals("", x);
     }
 
     @Test
-    public void asString_3() 
-    {
-        String x = Iter.asString(data1, "/") ;
-        assertEquals("a", x) ;
+    public void asString_2() {
+        String x = Iter.asString(data1, "");
+        assertEquals("a", x);
     }
 
     @Test
-    public void asString_4() 
-    {
-        String x = Iter.asString(data2, "/") ;
-        assertEquals("x/y/z", x) ;
+    public void asString_3() {
+        String x = Iter.asString(data1, "/");
+        assertEquals("a", x);
     }
-    
-    private static void test(Iterator<?> iter, Object... items)
-    {
-        for ( Object x : items )
-        {
-            assertTrue(iter.hasNext()) ;
-            assertEquals(x, iter.next()) ;
+
+    @Test
+    public void asString_4() {
+        String x = Iter.asString(data2, "/");
+        assertEquals("x/y/z", x);
+    }
+
+    private static void test(Iterator<? > iter, Object...items) {
+        for ( Object x : items ) {
+            assertTrue(iter.hasNext());
+            assertEquals(x, iter.next());
         }
-        assertFalse(iter.hasNext()) ;
+        assertFalse(iter.hasNext());
     }
     
-    static Iter.Folder<String, String> f1 = new Iter.Folder<String, String>() {
-                                                 @Override
-                                                public String eval(String acc, String arg)
-                                                 {
-                                                     return acc + arg ;
-                                                 }
-                                             } ;
+    static Iter.Folder<String, String> f1 = (acc, arg)->acc + arg ;
     
     @Test
-    public void fold_01() 
-    {
-        String[] x = { "a", "b", "c" } ;
-        String z = Iter.foldLeft(Arrays.asList(x), f1, "X") ;
-        assertEquals("Xabc", z) ;
-    }
-    
-    @Test
-    public void fold_02() 
-    {
-        String[] x = { "a", "b", "c" } ;
-        String z = Iter.foldRight(Arrays.asList(x), f1, "X") ;
-        assertEquals("Xcba", z) ;
-    }
-    
-    @Test
-    public void fold_03() 
-    {
-        String[] x = {  } ;
-        String z = Iter.foldLeft(Arrays.asList(x), f1, "X") ;
-        assertEquals("X", z) ;
-    }
-    
-    @Test
-    public void fold_04() 
-    {
-        String[] x = { } ;
-        String z = Iter.foldRight(Arrays.asList(x), f1, "X") ;
-        assertEquals("X", z) ;
+    public void fold_01() {
+        String[] x = {"a", "b", "c"};
+        String z = Iter.foldLeft(Arrays.asList(x), f1, "X");
+        assertEquals("Xabc", z);
     }
 
-    
     @Test
-    public void map_01()
-    {
+    public void fold_02() {
+        String[] x = {"a", "b", "c"};
+        String z = Iter.foldRight(Arrays.asList(x), f1, "X");
+        assertEquals("Xcba", z);
+    }
+
+    @Test
+    public void fold_03() {
+        String[] x = {};
+        String z = Iter.foldLeft(Arrays.asList(x), f1, "X");
+        assertEquals("X", z);
+    }
+
+    @Test
+    public void fold_04() {
+        String[] x = {};
+        String z = Iter.foldRight(Arrays.asList(x), f1, "X");
+        assertEquals("X", z);
+    }
+
+    @Test
+    public void map_01() {
         Iterator<String> it = Iter.map(data2.iterator(), item -> item + item);
         test(it, "xx", "yy", "zz");
     }
 	
-    Predicate<String> filter = item -> item.length() == 1;
+    private Predicate<String> filter = item -> item.length() == 1;
    
     @Test
-    public void first_01()
-    {
-        Iter<String> iter = Iter.nullIter() ;
-        assertEquals(null, Iter.first(iter, filter)) ;
+    public void first_01() {
+        Iter<String> iter = Iter.nullIter();
+        assertEquals(null, Iter.first(iter, filter));
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void first_02()
-    {
-        List<String> data = Arrays.asList( "11", "A", "B", "C") ;
-        assertEquals("A", Iter.first(data, filter)) ;
+    public void first_02() {
+        List<String> data = Arrays.asList("11", "A", "B", "C");
+        assertEquals("A", Iter.first(data, filter));
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void first_03()
-    {
-        List<String> data = Arrays.asList( "11", "AA", "BB", "CC") ;
-        assertEquals(null, Iter.first(data, filter)) ;
+    public void first_03() {
+        List<String> data = Arrays.asList("11", "AA", "BB", "CC");
+        assertEquals(null, Iter.first(data, filter));
     }
- 
+
     @Test
-    public void first_04()
-    {
-        Iter<String> iter = Iter.nullIter() ;
-        assertEquals(-1, Iter.firstIndex(iter, filter)) ;
+    public void first_04() {
+        Iter<String> iter = Iter.nullIter();
+        assertEquals(-1, Iter.firstIndex(iter, filter));
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void first_05()
-    {
-        List<String> data = Arrays.asList( "11", "A", "B", "C") ;
-        assertEquals(1, Iter.firstIndex(data, filter)) ;
+    public void first_05() {
+        List<String> data = Arrays.asList("11", "A", "B", "C");
+        assertEquals(1, Iter.firstIndex(data, filter));
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void first_06()
-    {
-        List<String> data = Arrays.asList( "11", "AA", "BB", "CC") ;
-        assertEquals(-1, Iter.firstIndex(data, filter)) ;
+    public void first_06() {
+        List<String> data = Arrays.asList("11", "AA", "BB", "CC");
+        assertEquals(-1, Iter.firstIndex(data, filter));
     }
 
     @Test
-    public void last_01()
-    {
-        Iter<String> iter = Iter.nullIter() ;
-        assertEquals(null, Iter.last(iter, filter)) ;
+    public void last_01() {
+        Iter<String> iter = Iter.nullIter();
+        assertEquals(null, Iter.last(iter, filter));
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void last_02()
-    {
-        List<String> data = Arrays.asList( "11", "A", "B", "C") ;
-        assertEquals("C", Iter.last(data, filter)) ;
+    public void last_02() {
+        List<String> data = Arrays.asList("11", "A", "B", "C");
+        assertEquals("C", Iter.last(data, filter));
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void last_03()
-    {
-        List<String> data = Arrays.asList( "11", "AA", "BB", "CC") ;
-        assertEquals(null, Iter.last(data, filter)) ;
+    public void last_03() {
+        List<String> data = Arrays.asList("11", "AA", "BB", "CC");
+        assertEquals(null, Iter.last(data, filter));
     }
- 
+
     @Test
-    public void last_04()
-    {
-        Iter<String> iter = Iter.nullIter() ;
-        assertEquals(-1, Iter.lastIndex(iter, filter)) ;
+    public void last_04() {
+        Iter<String> iter = Iter.nullIter();
+        assertEquals(-1, Iter.lastIndex(iter, filter));
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void last_05()
-    {
-        List<String> data = Arrays.asList( "11", "A", "B", "C") ;
-        assertEquals(3, Iter.lastIndex(data, filter)) ;
+    public void last_05() {
+        List<String> data = Arrays.asList("11", "A", "B", "C");
+        assertEquals(3, Iter.lastIndex(data, filter));
     }
 
     @SuppressWarnings("deprecation")
     @Test
-    public void last_06()
-    {
-        List<String> data = Arrays.asList( "11", "AA", "BB", "CC") ;
-        assertEquals(-1, Iter.lastIndex(data, filter)) ;
-    }
-    
-    
-    private static Iterator<?> iterator(int n) { 
-        return IntStream.range(1, n+1).iterator();
+    public void last_06() {
+        List<String> data = Arrays.asList("11", "AA", "BB", "CC");
+        assertEquals(-1, Iter.lastIndex(data, filter));
     }
 
-    @Test public void iteratorStep_1() {
-        Iterator<?> iter = iterator(0); 
+    private static Iterator<? > iterator(int n) {
+        return IntStream.range(1, n + 1).iterator();
+    }
+
+    @Test
+    public void iteratorStep_1() {
+        Iterator<? > iter = iterator(0);
         int x = Iter.step(iter, 0);
-        assertEquals(0,x);
-    }
-    
-    @Test public void iteratorStep_2() {
-        Iterator<?> iter = iterator(0); 
-        int x = Iter.step(iter, 1);
-        assertEquals(0,x);
+        assertEquals(0, x);
     }
 
-    @Test public void iteratorStep_3() {
-        Iterator<?> iter = iterator(5); 
+    @Test
+    public void iteratorStep_2() {
+        Iterator<? > iter = iterator(0);
         int x = Iter.step(iter, 1);
-        assertEquals(1,x);
+        assertEquals(0, x);
     }
 
-    @Test public void iteratorStep_4() {
-        Iterator<?> iter = iterator(5); 
+    @Test
+    public void iteratorStep_3() {
+        Iterator<? > iter = iterator(5);
+        int x = Iter.step(iter, 1);
+        assertEquals(1, x);
+    }
+
+    @Test
+    public void iteratorStep_4() {
+        Iterator<? > iter = iterator(5);
         int x = Iter.step(iter, 4);
-        assertEquals(4,x);
+        assertEquals(4, x);
     }
-    
-    @Test public void iteratorStep_5() {
-        Iterator<?> iter = iterator(5); 
+
+    @Test
+    public void iteratorStep_5() {
+        Iterator<? > iter = iterator(5);
         int x = Iter.step(iter, 5);
-        assertEquals(5,x);
+        assertEquals(5, x);
     }
-    
-    @Test public void iteratorStep_6() {
-        Iterator<?> iter = iterator(5); 
+
+    @Test
+    public void iteratorStep_6() {
+        Iterator<? > iter = iterator(5);
         int x = Iter.step(iter, 6);
-        assertEquals(5,x);
-    }
-
-    
-    @Test
-    public void take_01()
-    {
-        List<String> data = Arrays.asList( "1", "A", "B", "CC") ;
-        List<String> data2 = Iter.take(data.iterator(), 2) ;
-        assertEquals(2, data2.size()) ;
-        assertEquals("1", data2.get(0)) ;
-        assertEquals("A", data2.get(1)) ;
-    }
-    
-    @Test
-    public void take_02()
-    {
-        List<String> data = Arrays.asList( "1", "A", "B", "CC") ;
-        List<String> data2 = Iter.take(data.iterator(), 0) ;
-        assertEquals(0, data2.size()) ;
+        assertEquals(5, x);
     }
 
     @Test
-    public void take_03()
-    {
-        List<String> data = Arrays.asList( "1", "A", "B", "CC") ;
-        List<String> data2 = Iter.take(data.iterator(), 10) ;
-        assertEquals(4, data2.size()) ;
-        assertEquals("1", data2.get(0)) ;
-        assertEquals("A", data2.get(1)) ;
-        assertEquals("B", data2.get(2)) ;
-        assertEquals("CC", data2.get(3)) ;
+    public void take_01() {
+        List<String> data = Arrays.asList("1", "A", "B", "CC");
+        List<String> data2 = Iter.take(data.iterator(), 2);
+        assertEquals(2, data2.size());
+        assertEquals("1", data2.get(0));
+        assertEquals("A", data2.get(1));
     }
-    
+
+    @Test
+    public void take_02() {
+        List<String> data = Arrays.asList("1", "A", "B", "CC");
+        List<String> data2 = Iter.take(data.iterator(), 0);
+        assertEquals(0, data2.size());
+    }
+
+    @Test
+    public void take_03() {
+        List<String> data = Arrays.asList("1", "A", "B", "CC");
+        List<String> data2 = Iter.take(data.iterator(), 10);
+        assertEquals(4, data2.size());
+        assertEquals("1", data2.get(0));
+        assertEquals("A", data2.get(1));
+        assertEquals("B", data2.get(2));
+        assertEquals("CC", data2.get(3));
+    }
+
     @Test
     public void take_04() {
         List<String> data = Arrays.asList("a", "b", "b", "c", "c", "d");
@@ -440,57 +396,52 @@ public class TestIter
         Iterator<String> iter = Iter.takeWhile(data.iterator(), item -> true);
         assertFalse(iter.hasNext());
     }
-    
+
     @Test
-    public void filter_01()
-    {
+    public void filter_01() {
         test(Iter.removeNulls(data3.iterator()), "x", "y", "z");
     }
-    
+
     @Test
-    public void filter_02()
-    {
+    public void filter_02() {
         Iterator<String> it = Iter.filter(data3.iterator(), item -> "x".equals(item) || "z".equals(item));
-        
         test(it, "x", "z");
     }
-    
+
     @Test
-    public void filter_03()
-    {
+    public void filter_03() {
         Iterator<String> it = Iter.filter(data3.iterator(), item -> null == item || "x".equals(item));
-        
         test(it, null, "x", null, null, null, null);
     }
-    
-    @Test public void distinct_01() 
-    {
-        List<String> x = Arrays.asList("a", "b", "a") ;
-        Iterator<String> iter = Iter.distinct(x.iterator()) ;
-        test(iter, "a", "b") ;
+
+    @Test
+    public void distinct_01() {
+        List<String> x = Arrays.asList("a", "b", "a");
+        Iterator<String> iter = Iter.distinct(x.iterator());
+        test(iter, "a", "b");
     }
-    
-    @Test public void distinct_02() 
-    {
-        List<String> x = Arrays.asList("a", "b", "a") ;
-        Iterator<String> iter = Iter.distinctAdjacent(x.iterator()) ;
-        test(iter, "a", "b", "a") ;
+
+    @Test
+    public void distinct_02() {
+        List<String> x = Arrays.asList("a", "b", "a");
+        Iterator<String> iter = Iter.distinctAdjacent(x.iterator());
+        test(iter, "a", "b", "a");
     }
-    
-    @Test public void distinct_03() 
-    {
-        List<String> x = Arrays.asList("a", "a", "b", "b", "b", "a", "a") ;
-        Iterator<String> iter = Iter.distinct(x.iterator()) ;
-        test(iter, "a", "b") ;
+
+    @Test
+    public void distinct_03() {
+        List<String> x = Arrays.asList("a", "a", "b", "b", "b", "a", "a");
+        Iterator<String> iter = Iter.distinct(x.iterator());
+        test(iter, "a", "b");
     }
-    
-    @Test public void distinct_04() 
-    {
-        List<String> x = Arrays.asList("a", "a", "b", "b", "b", "a", "a") ;
-        Iterator<String> iter = Iter.distinctAdjacent(x.iterator()) ;
-        test(iter, "a", "b", "a") ;
+
+    @Test
+    public void distinct_04() {
+        List<String> x = Arrays.asList("a", "a", "b", "b", "b", "a", "a");
+        Iterator<String> iter = Iter.distinctAdjacent(x.iterator());
+        test(iter, "a", "b", "a");
     }
-    
+
     private static class AlwaysAcceptFilterStack extends FilterStack<Object> {
         public AlwaysAcceptFilterStack(Predicate<Object> f) {
             super(f);
@@ -508,12 +459,11 @@ public class TestIter
         FilterStack<Object> filterStack = new AlwaysAcceptFilterStack(filter);
         assertTrue(filterStack.test(new Object()));
     }
-    
+
     @Test
     public void testFilterStack_02() {
         Predicate<Object> filter = x -> false;
         FilterStack<Object> filterStack = new AlwaysAcceptFilterStack(filter);
         assertFalse(filterStack.test(new Object()));
     }
-
 }

--- a/jena-core/src/main/java/org/apache/jena/graph/GraphUtil.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/GraphUtil.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.impl.GraphWithPerform;
 import org.apache.jena.util.IteratorCollection;
 import org.apache.jena.util.iterator.ExtendedIterator;
@@ -98,7 +99,7 @@ public class GraphUtil
      * @return an iterator over all the graph's triples
      */
     public static ExtendedIterator<Triple> findAll(Graph g) {
-        return g.find(Triple.ANY) ;
+        return g.find() ;
     }
     
     public static void add(Graph graph, Triple[] triples) {
@@ -185,34 +186,69 @@ public class GraphUtil
             deleteIteratorWorker(graph, it);
     }
     
-    private static int MIN_SRC_SIZE   = 1000 ;
-    private static int DST_SRC_RATIO  = 2 ;
+    private static final int sliceSize = 1000 ;
+
+    /** A safe and cautious remove() function that converts the remove to
+     *  a number of {@link Graph#delete(Triple)} operations. 
+     *  <p>
+     *  To avoid any possible ConcurrentModificationExceptions,
+     *  it finds batches of triples, deletes them and tries again until
+     *  no more triples matching the input can be found. 
+     */
+    public static void remove(Graph g, Node s, Node p, Node o) {
+        // Beware of ConcurrentModificationExceptions.
+        // Delete in batches.
+        // That way, there is no active iterator when a delete
+        // from the indexes happens.
     
-    /** Delete triples in the destination (arg 1) as given in the source (arg 2) */
-    public static void deleteFrom(Graph dstGraph, Graph srcGraph) {
-        boolean events = requireEvents(dstGraph);
-        
-        if ( dstGraph == srcGraph && ! events ) {
-            dstGraph.clear();
-            return;
+        Triple[] array = new Triple[sliceSize] ;
+    
+        while (true) {
+            // Convert/cache s,p,o?
+            // The Node Cache will catch these so don't worry unduely.
+            ExtendedIterator<Triple> iter = g.find(s, p, o) ;
+    
+            // Get a slice
+            int len = 0 ;
+            for ( ; len < sliceSize ; len++ ) {
+                if ( !iter.hasNext() )
+                    break ;
+                array[len] = iter.next() ;
+            }
+    
+            // Delete them.
+            for ( int i = 0 ; i < len ; i++ ) {
+                g.delete(array[i]) ;
+                array[i] = null ;
+            }
+            // Finished?
+            if ( len < sliceSize )
+                break ;
         }
-        
+    }
+
+    /**
+     * Delete triples in {@code srcGraph} from {@code dstGraph}
+     * by looping on {@code srcGraph}.
+     * 
+     */
+    public static void deleteLoopSrc(Graph dstGraph, Graph srcGraph) {
+        deleteIteratorWorker(dstGraph, findAll(srcGraph)) ;
+        dstGraph.getEventManager().notifyDeleteGraph(dstGraph, srcGraph) ;
+    }
+
+    /** 
+     * Delete the triple in {@code srcGraph} from {@code dstGraph}
+     * by checking the contents of {@code dsgGraph} against the {@code srcGraph}.
+     * This involves calling {@code srcGraph.contains}. 
+     * @implNote
+     * {@code dstGraph.size()} is used by this method. 
+     */
+    public static void deleteLoopDst(Graph dstGraph, Graph srcGraph) {
+        // Size the list to avoid reallocation on growth.
         int dstSize = dstGraph.size();
-        int srcSize = srcGraph.size();
-        
-        // Whether to loop on dstGraph or srcGraph.
-        // Loop on src if:
-        // * srcGraph is below the threshold MIN_SRC_SIZE (a "Just Do it" number)
-        // * dstGraph is "much" larger than src where "much" is given by DST_SRC_RATIO
-        boolean loopOnSrc = (srcSize < MIN_SRC_SIZE || dstSize > DST_SRC_RATIO*srcSize) ;
-        
-        if ( loopOnSrc ) {
-            deleteIteratorWorker(dstGraph, findAll(srcGraph)) ;
-            dstGraph.getEventManager().notifyDeleteGraph(dstGraph, srcGraph) ;
-            return;
-        }
-        // Loop on dstGraph, not srcGraph, but need to use srcGraph.contains on this code path.
         List<Triple> toBeDeleted = new ArrayList<>(dstSize);
+        
         Iterator<Triple> iter = findAll(dstGraph);
         for( ; iter.hasNext() ; ) {
            Triple t = iter.next();
@@ -246,43 +282,120 @@ public class GraphUtil
         }
     }
 
-    private static final int sliceSize = 1000 ;
-    /** A safe and cautious remove() function that converts the remove to
-     *  a number of {@link Graph#delete(Triple)} operations. 
+    private static int MIN_SRC_SIZE   = 1000 ;
+    // If source and destination are large, limit the search for the best way round to "deleteFrom" 
+    private static int MAX_SRC_SIZE   = 1000*1000 ;
+    private static int DST_SRC_RATIO  = 2 ;
+
+    /**
+     * Delete triples in the destination (arg 1) as given in the source (arg 2).
+     *
+     * @implNote
+     *  This is designed for the case of {@code dstGraph} being comparable or much larger than
+     *  {@code srcGraph} or {@code srcGraph} having a lot of triples to actually be
+     *  deleted from {@code dstGraph}. This includes teh case of large, persistent {@code dstGraph}.
+     *  <p>  
+     *  It is not designed for a large {@code srcGraph} and large {@code dstGraph} 
+     *  with only a few triples in common to delete from {@code dstGraph}. It is better to
+     *  calculate the difference in some way, and copy into a small graph to use as the {@srcGraph}.  
      *  <p>
-     *  To avoid any possible ConcurrentModificationExceptions,
-     *  it finds batches of triples, deletes them and tries again until
-     *  no more triples matching the input can be found. 
+     *  To force delete by looping on {@code srcGraph}, use {@link #deleteLoopSrc(Graph, Graph)}.
+     *  <p>
+     *  For large {@code srcGraph} and small {@code dstGraph}, use {@link #deleteLoopDst}.
+     *  
+     * See discussion on <a href=""https://github.com/apache/jena/pull/212">jena/pull/212</a>, 
+     * (archived at <a href="https://issues.apache.org/jira/browse/JENA-1284">JENA-1284</a>).
      */
-    public static void remove(Graph g, Node s, Node p, Node o) {
-        // Beware of ConcurrentModificationExceptions.
-        // Delete in batches.
-        // That way, there is no active iterator when a delete
-        // from the indexes happens.
+    public static void deleteFrom(Graph dstGraph, Graph srcGraph) {
+        boolean events = requireEvents(dstGraph);
+        
+        if ( dstGraph == srcGraph && ! events ) {
+            dstGraph.clear();
+            return;
+        }
+        
+        boolean loopOnSrc = decideHowtoExecute(dstGraph, srcGraph);
+        
+        if ( loopOnSrc ) {
+            // Normal path.
+            deleteLoopSrc(dstGraph, srcGraph);
+            return;
+        }
 
-        Triple[] array = new Triple[sliceSize] ;
+        // Loop on dstGraph, not srcGraph, but need to use srcGraph.contains on this code path.
+        deleteLoopDst(dstGraph, srcGraph);
+    }
+    
+    private static final int CMP_GREATER = 1;
+    private static final int CMP_EQUAL   = 0;
+    private static final int CMP_LESS    = -1;
+    
+    /**
+     * Decide whether to loop on dstGraph or srcGraph.
+     * @param dstGraph
+     * @param srcGraph
+     * @return boolean true for "loop on src"
+     */
+    private static boolean decideHowtoExecute(Graph dstGraph, Graph srcGraph) {
+        //return decideHowtoExecuteBySizeSize(dstGraph, srcGraph);
 
-        while (true) {
-            // Convert/cache s,p,o?
-            // The Node Cache will catch these so don't worry unduely.
-            ExtendedIterator<Triple> iter = g.find(s, p, o) ;
+        // Avoid calling dstGraph.size()
+        return decideHowtoExecuteBySizeStep(dstGraph, srcGraph);
+    }
+    
+    /**
+     * Decide using dstGraph.size() and srcGraph.size()
+     */
+    private static boolean decideHowtoExecuteBySizeSize(Graph dstGraph, Graph srcGraph) {
+        // Loop on src if:
+        //     size(src) <= MIN_SRC_SIZE : srcGraph is below the threshold MIN_SRC_SIZE (a "Just Do it" number)
+        //     size(src)*DST_SRC_RATIO <= size(dst)
+        // dstGraph is "much" larger than src where "much" is given by DST_SRC_RATIO
+        //     Assumes dstGraph.size is efficient.
+        
+        int srcSize = srcGraph.size();
+        if ( srcSize <= MIN_SRC_SIZE )
+            return true ;
+        int dstSize = dstGraph.size();
+        
+        boolean loopOnSrc = (srcSize <= MIN_SRC_SIZE || dstSize > DST_SRC_RATIO*srcSize) ;
+        return loopOnSrc;
+    }
 
-            // Get a slice
-            int len = 0 ;
-            for ( ; len < sliceSize ; len++ ) {
-                if ( !iter.hasNext() )
-                    break ;
-                array[len] = iter.next() ;
-            }
+    /**
+     *  Avoid dstGraph.size(). Instead step through {@codedstGraph.find} to compare to {@code srcGraph.size()} 
+     *  
+     */
+    private static boolean decideHowtoExecuteBySizeStep(Graph dstGraph, Graph srcGraph) {
+        // loopOnSrc if:
+        //     size(src) <= MIN_SRC_SIZE
+        //     size(src)*DST_SRC_RATIO <= |find(dst)|
+        int srcSize = srcGraph.size();
+        if ( srcSize <= MIN_SRC_SIZE )
+            return true ;
+        boolean loopOnSrc = (srcSize <= MIN_SRC_SIZE || compareSizeTo(dstGraph, DST_SRC_RATIO*srcSize) == CMP_GREATER) ;
+        return loopOnSrc;
+    }
 
-            // Delete them.
-            for ( int i = 0 ; i < len ; i++ ) {
-                g.delete(array[i]) ;
-                array[i] = null ;
-            }
-            // Finished?
-            if ( len < sliceSize )
-                break ;
+    /** Compare the size of a graph to {@code size}, without calling Graph.size
+     *  by iterating on {@code graph.find()} as necessary.
+     *  <p>
+     *  Return -1 , 0, 1 for the comparison.  
+     */
+    /*package*/ static int compareSizeTo(Graph graph, int size) {
+        ExtendedIterator<Triple> it = graph.find();
+        try {
+            int stepsTake = Iter.step(it, size);
+            if ( stepsTake < size )
+                // Iterator ran out.
+                return CMP_LESS;
+            if ( !it.hasNext())
+                // Finsiehd at the same timne. 
+                return CMP_EQUAL;
+            // Still more to go
+            return CMP_GREATER;
+        } finally {
+            it.close();
         }
     }
 }

--- a/jena-core/src/test/java/org/apache/jena/graph/TestGraphUtil.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/TestGraphUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.graph;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.jena.graph.test.GraphTestBase;
+import org.junit.Test;
+
+// Test for the compare by src.size and step dst case.
+public class TestGraphUtil {
+    private static Graph graph0 = make(0);
+    private static Graph graph1 = make(1);
+    private static Graph graph2 = make(2);
+
+    private static Graph make(int N) {
+        Graph graph = Factory.createGraphMem();
+        for ( int i = 0 ; i < N ; i++ ) {
+            Triple t = GraphTestBase.triple("a P 'x"+i+"'");
+            graph.add(t);
+        }
+        return graph ;
+    }
+    
+    @Test public void compareSizeTo_1() {
+        assertEquals(1, GraphUtil.compareSizeTo(graph2, 0));
+        assertEquals(1, GraphUtil.compareSizeTo(graph2, 1));
+        assertEquals(0, GraphUtil.compareSizeTo(graph2, 2));
+        assertEquals(-1, GraphUtil.compareSizeTo(graph2, 3));
+        assertEquals(-1, GraphUtil.compareSizeTo(graph2, 4));
+    }
+    
+    @Test public void compareSizeTo_2() {
+        assertEquals(1, GraphUtil.compareSizeTo(graph1, 0));
+        assertEquals(0, GraphUtil.compareSizeTo(graph1, 1));
+        assertEquals(-1, GraphUtil.compareSizeTo(graph1, 2));
+    }
+
+    @Test public void compareSizeTo_3() {
+        assertEquals(0, GraphUtil.compareSizeTo(graph0, 0));
+        assertEquals(-1, GraphUtil.compareSizeTo(graph0, 1));
+    }
+}

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestPackage.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestPackage.java
@@ -20,6 +20,7 @@ package org.apache.jena.graph.test;
 
 import junit.framework.JUnit4TestAdapter ;
 import junit.framework.TestSuite ;
+import org.apache.jena.graph.TestGraphUtil;
 
 /**
     Collected test suite for the .graph package.
@@ -55,5 +56,8 @@ public class TestPackage extends TestSuite {
         addTest( TestGraphMatchWithInference.suite());
         addTestSuite( TestGraphEvents.class );
         addTestSuite( TestGraphBaseToString.class );
+        
+        // Has to be in a different package.
+        addTest( new JUnit4TestAdapter(TestGraphUtil.class ) );
     }
 }


### PR DESCRIPTION
This PR rstructures `GraphUtil.deleteFrom` to put the decision on whether to loop on the target (_dst_) graph or the source (_src_) graph.

There are 3 algorithms for discussion:

1. Use the size of the graphs - this is the current Jena 3.5.0 policy
2. Use the size of the _src_ and iterate on the _dst_ to compare sizes
3. Iterator on both _src_ and _dst_ to compare sizes. `Graph.size` is not used at all.

The cost of `Graph.size()` can be small (already known) or large (needs to be calculated to be accurate). The latter is bad for large persistent graphs.

The PR also adds javadoc to explain how to call a specific algorithm (_src_ loop or _dst_ loop).

