### PR TITLE
JENA-1384: Canonical literals: lexical form and langTags

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/CanonicalizeLiteral.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/CanonicalizeLiteral.java
@@ -39,6 +39,9 @@ public class CanonicalizeLiteral implements Function<Node, Node>
 
     private CanonicalizeLiteral() {}
     
+    /**
+     * Canonicaize a literal, both lexical form and language tag (RFc canonical). 
+     */
     @Override
     public Node apply(Node node) {
         if ( ! node.isLiteral() )
@@ -73,6 +76,36 @@ public class CanonicalizeLiteral implements Function<Node, Node>
         return n2 ;
     }
     
+    /** Convert the lexical form to a canonical form if one of the known datatypes,
+     * otherwise return the node argument. (same object :: {@code ==})  
+     */
+    public static Node canonicalValue(Node node) {
+        if ( ! node.isLiteral() )
+            return node ;
+        // Fast-track
+        if ( NodeUtils.isLangString(node) )
+            return node;
+        if ( NodeUtils.isSimpleString(node) )
+            return node;
+
+        if ( ! node.getLiteralDatatype().isValid(node.getLiteralLexicalForm()) )
+            // Invalid lexical form for the datatype - do nothing.
+            return node;
+            
+        RDFDatatype dt = node.getLiteralDatatype() ;
+        // Datatype, not rdf:langString (RDF 1.1). 
+        DatatypeHandler handler = dispatch.get(dt) ;
+        if ( handler == null )
+            return node ;
+        Node n2 = handler.handle(node, node.getLiteralLexicalForm(), dt) ;
+        if ( n2 == null )
+            return node ;
+        return n2 ;
+    }
+    
+    /** Convert the language tag of a lexical form to a canonical form if one of the known datatypes,
+     * otherwise return the node argument. (same object; compare by {@code ==})  
+     */
     private static Node canonicalLangtag(String lexicalForm, String langTag) {
         String langTag2 = LangTag.canonical(langTag);
         if ( langTag2.equals(langTag) )

--- a/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/StreamCanonicalLangTag.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/StreamCanonicalLangTag.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.process.normalize;
+
+import java.util.IllformedLocaleException;
+import java.util.Locale;
+import java.util.function.BiFunction;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.riot.process.StreamRDFApplyObject;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.sparql.util.NodeUtils;
+
+/** {@link StreamRDF} that converts language tags to lower case o rto canokcal form (RFC 4646). */
+public class StreamCanonicalLangTag extends StreamRDFApplyObject {
+    /** Return a {@link StreamRDF} that converts language tags to lower case */ 
+    public static StreamRDF toLC(StreamRDF other) {
+        Locale.Builder locBuild = new Locale.Builder();
+        return new StreamCanonicalLangTag(other, locBuild,
+                                          (b,n) -> canonical(locBuild, n, StreamCanonicalLangTag::langTagLC));
+    }
+    
+    /** Return a {@link StreamRDF} that converts language tags to canonical form (RFC 4646, 5646). */ 
+    public static StreamRDF toCanonical(StreamRDF other) {
+        Locale.Builder locBuild = new Locale.Builder();
+        return new StreamCanonicalLangTag(other, locBuild, 
+                                          (b,n) -> canonical(locBuild, n, StreamCanonicalLangTag::langTagCanonical));
+    }
+
+    
+    
+    private StreamCanonicalLangTag(StreamRDF other, Locale.Builder locBuild, BiFunction<Locale.Builder, Node, Node> stringMapper) {
+        super(other, (n)->stringMapper.apply(locBuild, n));
+    }
+    
+    private static Node canonical(Locale.Builder locBuild, Node n, BiFunction<Locale.Builder, String, String> tagMapper ) {
+        // If no change, return the original object; this prevents object churn.
+        if ( ! NodeUtils.hasLang(n) )
+            return n;
+        String langTag = n.getLiteralLanguage();
+        if ( langTag == null || langTag.isEmpty() )
+            return n;
+        String langTag2 = tagMapper.apply(locBuild, langTag);
+        if ( langTag == langTag2 )
+            return n;
+        Node obj2 = NodeFactory.createLiteral(n.getLiteralLexicalForm(), langTag2);
+        return obj2;
+    }
+    
+    // From taken from "xsd4ld" (which has an Apache License).
+    public static String langTagCanonical(Locale.Builder locBuild, String str) {
+        try {
+            // Does not do conversion of language for ISO 639 codes that have changed.
+            return locBuild.setLanguageTag(str).build().toLanguageTag();
+        } catch (IllformedLocaleException ex) {
+            return str;
+        }
+    }
+
+    public static String langTagLC(Locale.Builder locBuild, String str) {
+        return str.toLowerCase(Locale.ROOT);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/StreamCanonicalLiterals.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/process/normalize/StreamCanonicalLiterals.java
@@ -24,7 +24,7 @@ import org.apache.jena.riot.process.StreamRDFApplyObject;
 import org.apache.jena.riot.process.normalize.CanonicalizeLiteral;
 import org.apache.jena.riot.system.StreamRDF;
 
-/** Canoncialize literals (in the object position).
+/** Canonicalize literal lexcial forms (in the object position).
  * Canoncialize literals use the same RDF term (same lexcial form) for a given value.
  * So {@code "+01"^^xsd:integer} is converted to {@code "1"^^xsd:integer}.
  * Language tags are canonicalized for case as well. 
@@ -39,16 +39,7 @@ public class StreamCanonicalLiterals extends StreamRDFApplyObject {
     private static Node canonical(Node n) {
         if ( ! n.isLiteral() )
             return n;
-        // Lang tag - done in CanonicalizeLiteral anyway.
-//        if ( Util.isLangString(n) ) {
-//            String lang = n.getLiteralLanguage();
-//            String lang2 = LangTag.canonical(lang);
-//            if ( lang == lang2 )
-//                return n ;
-//            return NodeFactory.createLiteral(n.getLiteralLexicalForm(), lang2);
-//        }
-        // Include LangTag (but check).
-        Node obj2 = CanonicalizeLiteral.get().apply(n);
+        Node obj2 = CanonicalizeLiteral.canonicalValue(n);
         return obj2;
     }
 }


### PR DESCRIPTION
RDFParser options to handle canonical lexcial form for values ("+0123" becomes "123" for an xsd:integer) and options for handling language tags (to RFC-canonical form; to lowercase).