### PR TITLE
JENA-1430: Read quads for ja:data by filename

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
@@ -20,12 +20,12 @@ package org.apache.jena.sparql.core.assembler;
 
 import static org.apache.jena.assembler.JA.data;
 import static org.apache.jena.query.DatasetFactory.createTxnMem;
-import static org.apache.jena.query.ReadWrite.WRITE;
 import static org.apache.jena.riot.RDFDataMgr.read;
 import static org.apache.jena.sparql.core.assembler.AssemblerUtils.setContext;
 import static org.apache.jena.sparql.core.assembler.DatasetAssemblerVocab.pGraphName;
 import static org.apache.jena.sparql.core.assembler.DatasetAssemblerVocab.pNamedGraph;
 import static org.apache.jena.sparql.util.graph.GraphUtils.getAsStringValue;
+import static org.apache.jena.sparql.util.graph.GraphUtils.multiValueAsString;
 import static org.apache.jena.sparql.util.graph.GraphUtils.multiValueResource;
 
 import org.apache.jena.assembler.Assembler;
@@ -33,6 +33,7 @@ import org.apache.jena.assembler.Mode;
 import org.apache.jena.assembler.assemblers.AssemblerBase;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.system.Txn;
 
 /**
  * An {@link Assembler} that creates in-memory {@link Dataset}s.
@@ -49,25 +50,21 @@ public class InMemDatasetAssembler extends AssemblerBase implements Assembler {
 		final Dataset dataset = createTxnMem();
 		setContext(root, dataset.getContext());
 
-		dataset.begin(WRITE);
-
-		// load data into the default graph
-		if (root.hasProperty(data)) {
-		    multiValueResource(root, data)
-				.forEach(defaultGraphDocument -> read(dataset, defaultGraphDocument.getURI()));
-		}
-
-		// load data into named graphs
-		multiValueResource(root, pNamedGraph).forEach(namedGraphResource -> {
-			final String graphName = getAsStringValue(namedGraphResource, pGraphName);
-			if (namedGraphResource.hasProperty(data)) {
-			    multiValueResource(namedGraphResource, data)
-			        .forEach(namedGraphData -> read(dataset.getNamedModel(graphName), namedGraphData.getURI()));
-			}
+		Txn.executeWrite(dataset, ()->{ 
+    		// Load data into the default graph
+		    // This also loads quads into the dataset.
+    		multiValueAsString(root, data)
+    		    .forEach(dataURI -> read(dataset, dataURI));
+    
+    		// load data into named graphs
+    		multiValueResource(root, pNamedGraph).forEach(namedGraphResource -> {
+    			final String graphName = getAsStringValue(namedGraphResource, pGraphName);
+    			if (namedGraphResource.hasProperty(data)) {
+    			    multiValueAsString(namedGraphResource, data)
+    			        .forEach(namedGraphData -> read(dataset.getNamedModel(graphName), namedGraphData));
+    			}
+    		});
 		});
-
-		dataset.commit();
-		dataset.end();
 		return dataset;
 	}
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/graph/GraphUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/graph/GraphUtils.java
@@ -66,6 +66,24 @@ public class GraphUtils {
         }
         return values ;
     }
+    
+    /** Get a list of the URIs (as strings) and strings
+     *  @see #getAsStringValue
+     */
+    public static List<String> multiValueAsString(Resource r, Property p) {
+        List<RDFNode> nodes = multiValue(r, p) ;
+        List<String> values = new ArrayList<>() ;
+
+        for ( RDFNode n : nodes ) {
+            if ( n.isLiteral() ) {
+                values.add(((Literal)n).getString()) ;
+            }
+            if ( n.isURIResource() ) {
+                values.add(((Resource)n).getURI());
+            }
+        }
+        return values ;
+    }
 
     public static List<RDFNode> multiValue(Resource r, Property p) {
         List<RDFNode> values = new ArrayList<>() ;

--- a/jena-fuseki2/examples/fuseki-in-mem-txn.ttl
+++ b/jena-fuseki2/examples/fuseki-in-mem-txn.ttl
@@ -1,0 +1,24 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+@prefix :        <#> .
+@prefix fuseki:  <http://jena.apache.org/fuseki#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix tdb:     <http://jena.hpl.hp.com/2008/tdb#> .
+
+<#serviceInMemory> rdf:type fuseki:Service;
+    rdfs:label                   "In-memory, trasnactioal dataset.";
+    fuseki:name                  "ds";
+    fuseki:serviceQuery          "query";
+    fuseki:serviceQuery          "sparql";
+    fuseki:serviceUpdate         "update";
+    fuseki:serviceUpload         "upload" ;
+    fuseki:serviceReadGraphStore "data" ;
+    fuseki:serviceReadGraphStore "get" ;
+    fuseki:dataset <#dataset> ;
+.
+
+<#dataset> rdf:type ja:DatasetTxnMem;
+   ja:data <file:data.trig>;
+.


### PR DESCRIPTION
Add support for {{ja:data "filename"}}.

Strings as filenames and URIs as file names resolve different (the JVM cwd and the assembler file location respectively) which can be confusing for filenames.
