### PR TITLE
fix JENA-1439  graph queries fail 'lang:xx'

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/TextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextQueryPF.java
@@ -129,7 +129,6 @@ public class TextQueryPF extends PropertyFunctionBase {
 
     private String extractArg(String prefix, List<Node> objArgs) {
         String value = null;
-        int pos = 0;
         for (Node node : objArgs) {
             if (node.isLiteral()) {
                 String arg = node.getLiteral().toString();
@@ -138,10 +137,7 @@ public class TextQueryPF extends PropertyFunctionBase {
                     break;
                 }
             }
-            pos++;
         }
-        if (value != null)
-            objArgs.remove(pos);
 
         return value;
     }


### PR DESCRIPTION
Fixes JENA-1439 graph queries fail to preserve text:query 'lang:xx' arg. TextQueryPF.extractArg(...) removed the arg unnecessarily from the input list, side-effecting the list which was saved in an OpPropFunc for repeated use on graph iterations and thus the argument was only present on the first graph in the iteration