### PR TITLE
JENA-1447: Special case datasets

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphBase.java
@@ -21,6 +21,7 @@ package org.apache.jena.sparql.core;
 import java.util.Iterator ;
 import org.apache.jena.atlas.io.IndentedLineBuffer ;
 import org.apache.jena.atlas.iterator.Iter ;
+import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.shared.Lock ;
@@ -147,6 +148,10 @@ abstract public class DatasetGraphBase implements DatasetGraph
         return g == null || g == Node.ANY;
     }
 
+    protected static void unsupportedMethod(Object object, String method) {
+        throw new UnsupportedOperationException(Lib.className(object)+"."+method) ;
+    }
+    
     @Override
     public void clear() {
         deleteAny(Node.ANY, Node.ANY, Node.ANY, Node.ANY);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphSink.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphSink.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.core;
+
+import java.util.Iterator;
+
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.sparql.graph.GraphSink;
+
+
+/** 
+ * An always empty {@link DatasetGraph} that accepts changes but ignores them.
+ * 
+ * @see DatasetGraphZero
+ */
+public class DatasetGraphSink extends DatasetGraphBaseFind {
+
+    public static DatasetGraph create() { return new DatasetGraphSink(); }
+    
+    private Graph dftGraph = GraphSink.instance();
+    
+    public DatasetGraphSink() {}
+    
+    private TransactionalNull txn                       = TransactionalNull.create();
+    @Override public void begin(ReadWrite mode)         { txn.begin(mode); }
+    @Override public void commit()                      { txn.commit(); }
+    @Override public void abort()                       { txn.abort(); }
+    @Override public boolean isInTransaction()          { return txn.isInTransaction(); }
+    @Override public void end()                         { txn.end(); }
+    @Override public boolean supportsTransactions()     { return true; }
+    // Because there are never any changes, abort() means "finish".  
+    @Override public boolean supportsTransactionAbort() { return true; }
+    
+    @Override
+    public Iterator<Node> listGraphNodes() {
+        return Iter.nullIterator();
+    }
+    
+    @Override
+    protected Iterator<Quad> findInDftGraph(Node s, Node p, Node o) {
+        return Iter.nullIterator();
+    }
+    
+    @Override
+    protected Iterator<Quad> findInSpecificNamedGraph(Node g, Node s, Node p, Node o) {
+        return Iter.nullIterator();
+    }
+    
+    @Override
+    protected Iterator<Quad> findInAnyNamedGraphs(Node s, Node p, Node o) {
+        return Iter.nullIterator();
+    }
+    
+    @Override
+    public Graph getDefaultGraph() {
+        return dftGraph;
+    }
+    @Override
+    public Graph getGraph(Node graphNode) {
+        return null;
+    }
+    @Override
+    public void add(Quad quad) { /* ignore */ } 
+    
+    @Override
+    public void delete(Quad quad) { /* ignore */ }
+    
+    @Override
+    public void deleteAny(Node g, Node s, Node p, Node o) { /* ignore */ }
+    
+    @Override
+    public void setDefaultGraph(Graph g) { /* ignore */ }
+
+    @Override
+    public void addGraph(Node graphName, Graph graph) { /* ignore */ }
+
+    @Override
+    public void removeGraph(Node graphName) { /* ignore */ }
+    
+    @Override
+    public void close() {
+        txn.remove();
+        txn = null;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphZero.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphZero.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.core;
+
+import java.util.Iterator;
+
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.sparql.graph.GraphZero;
+
+/** An always empty {@link DatasetGraph}. 
+ * One graph (the default graph) with zero triples.
+ * No changes allowed - this is not a sink.
+ * @see DatasetGraphSink
+ */
+public class DatasetGraphZero extends DatasetGraphBaseFind {
+
+    public static DatasetGraph create() { return new DatasetGraphZero(); }
+    
+    private Graph dftGraph = GraphZero.instance();
+
+    public DatasetGraphZero() {}
+    
+    private TransactionalNull txn                       = TransactionalNull.create();
+    @Override public void begin(ReadWrite mode)         { txn.begin(mode); }
+    @Override public void commit()                      { txn.commit(); }
+    @Override public void abort()                       { txn.abort(); }
+    @Override public boolean isInTransaction()          { return txn.isInTransaction(); }
+    @Override public void end()                         { txn.end(); }
+    @Override public boolean supportsTransactions()     { return true; }
+    // Because there are never any changes, abort() means "finish".  
+    @Override public boolean supportsTransactionAbort() { return true; }
+    
+    @Override
+    public Iterator<Node> listGraphNodes() {
+        return Iter.nullIterator();
+    }
+    
+    @Override
+    protected Iterator<Quad> findInDftGraph(Node s, Node p, Node o) {
+        return Iter.nullIterator();
+    }
+    
+    @Override
+    protected Iterator<Quad> findInSpecificNamedGraph(Node g, Node s, Node p, Node o) {
+        return Iter.nullIterator();
+    }
+    
+    @Override
+    protected Iterator<Quad> findInAnyNamedGraphs(Node s, Node p, Node o) {
+        return Iter.nullIterator();
+    }
+    
+    @Override
+    public Graph getDefaultGraph() {
+        return dftGraph;
+    }
+    
+    @Override
+    public Graph getGraph(Node graphNode) {
+        return null;
+    }
+    
+    @Override
+    public void add(Quad quad) { unsupportedMethod(this, "add") ; } 
+    
+    @Override
+    public void delete(Quad quad) { unsupportedMethod(this, "delete") ; }
+    
+    @Override
+    public void deleteAny(Node g, Node s, Node p, Node o) {
+        throw new UnsupportedOperationException("deleteAny");
+    }
+
+    @Override
+    public void setDefaultGraph(Graph g) {
+        throw new UnsupportedOperationException("setDefaultGraph");
+    }
+
+    @Override
+    public void addGraph(Node graphName, Graph graph) {
+        throw new UnsupportedOperationException("addGraph");
+    }
+
+    @Override
+    public void removeGraph(Node graphName) {
+        throw new UnsupportedOperationException("removeGraph");
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
@@ -26,7 +26,6 @@ import org.apache.jena.graph.impl.GraphPlain ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.sparql.SystemARQ ;
-import org.apache.jena.sparql.util.graph.GraphSink ;
 import org.apache.jena.system.JenaSystem ;
 
 /** Ways to make graphs and models */

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphSink.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphSink.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.graph;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.TransactionHandler;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.graph.impl.GraphBase ;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.util.iterator.ExtendedIterator ;
+import org.apache.jena.util.iterator.NullIterator ;
+
+/** 
+ * Black hole graph - adds and deletes are silently ignored.
+ * @see GraphZero
+ */
+public class GraphSink extends GraphBase
+{
+    private static Graph graph = new GraphSink();
+    public static Graph instance() {
+        return graph;
+    }
+    
+    @Override
+    protected ExtendedIterator<Triple> graphBaseFind(Triple triple)
+    { return NullIterator.instance() ; }
+    
+    @Override
+    public void performAdd( Triple t ) {}
+    
+    @Override
+    public void performDelete( Triple t ) {}
+    
+    @Override
+    protected PrefixMapping createPrefixMapping() { 
+        return new PrefixMappingSink() ;
+    }
+    
+    @Override 
+    public TransactionHandler getTransactionHandler() {
+        return new TransactionHandlerNull(); 
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphZero.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphZero.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.graph;
+
+import org.apache.jena.graph.Capabilities;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.TransactionHandler;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.graph.impl.AllCapabilities;
+import org.apache.jena.graph.impl.GraphBase;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.util.iterator.ExtendedIterator;
+import org.apache.jena.util.iterator.NullIterator;
+
+/** Immutable empty graph.  
+ *  @see GraphSink
+ */
+public class GraphZero extends GraphBase {
+    
+    private static Graph graph = new GraphZero();
+    public static Graph instance() {
+        return graph;
+    }
+
+    private GraphZero() {}
+    
+    @Override
+    protected ExtendedIterator<Triple> graphBaseFind(Triple triplePattern) {
+        return NullIterator.instance();
+    }
+    
+    
+    @Override 
+    public TransactionHandler getTransactionHandler() {
+        return new TransactionHandlerNull(); 
+    }
+    
+    @Override
+    protected PrefixMapping createPrefixMapping() { 
+        return new PrefixMappingZero() ;
+    }
+    
+    // Choice point: AddDeniedException/DeleteDeniedException or UnsupportedOperationException.
+    //
+    // AddDeniedException is more access centric, e.g. permissions, 
+    // and may be different for different callers.
+    //
+    // UnsupportedOperationException is the general java "no" for not available ata ll,
+    // but is different from the Jena core exceptions.
+    @Override
+    public void performAdd( Triple t ) { throw new UnsupportedOperationException("add triple"); }
+    
+    @Override
+    public void performDelete( Triple t ) { throw new UnsupportedOperationException("delete triple"); }
+
+    @Override
+    public Capabilities getCapabilities() {
+        if ( capabilities == null ) {
+            capabilities = new AllCapabilities() {
+                @Override public boolean addAllowed() { return false; }
+                @Override public boolean addAllowed( boolean every ) { return false; } 
+                @Override public boolean deleteAllowed() { return false; }
+                @Override public boolean deleteAllowed( boolean every ) { return false; } 
+            };
+        }
+        return capabilities;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/PrefixMappingSink.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/PrefixMappingSink.java
@@ -16,20 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.util.graph;
+package org.apache.jena.sparql.graph;
 
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.graph.impl.GraphBase ;
-import org.apache.jena.util.iterator.ExtendedIterator ;
-import org.apache.jena.util.iterator.NullIterator ;
+import org.apache.jena.shared.impl.PrefixMappingImpl;
 
-/** Black hole for triples */
-public class GraphSink extends GraphBase
-{
+/** Sink PrefixMapping. Accepts chnages but does not retain state. */ 
+public class PrefixMappingSink extends PrefixMappingImpl {
     @Override
-    protected ExtendedIterator<Triple> graphBaseFind(Triple triple)
-    { return NullIterator.instance() ; }
+    protected void set(String prefix, String uri) { }
+
+    @Override
+    protected String get(String prefix) { return null; }
+
+    @Override
+    protected void remove(String prefix) { }
     
-    @Override
-    public void performAdd( Triple t ) {}
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/PrefixMappingZero.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/PrefixMappingZero.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.graph;
+
+import org.apache.jena.shared.impl.PrefixMappingImpl;
+
+/** Immutable empty PrefixMapping. */
+public class PrefixMappingZero extends PrefixMappingImpl {
+    @Override
+    protected void set(String prefix, String uri) {
+        throw new UnsupportedOperationException("set prefix");
+    }
+
+    @Override
+    protected String get(String prefix) { return null; }
+
+    @Override
+    protected void remove(String prefix) { 
+        throw new UnsupportedOperationException("remove prefix");
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/TransactionHandlerNull.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/TransactionHandlerNull.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.core;
+package org.apache.jena.sparql.graph;
 
-import org.apache.jena.query.ReadWrite;
+import org.apache.jena.graph.TransactionHandler;
+import org.apache.jena.graph.impl.TransactionHandlerBase;
 import org.apache.jena.sparql.JenaTransactionException;
 
-/**
- * A null action {@link Transactional}.
- * Does not protect anything but does track the transaction status.
- * It does provide "abort".   
- */
-public class TransactionalNull implements Transactional {
-    public static TransactionalNull create() { return new TransactionalNull(); }
+/** Implementation of {@link TransactionHandler} that does nothing but track the transction state. */
+public class TransactionHandlerNull extends TransactionHandlerBase {
+ 
+    private ThreadLocal<Boolean> inTransaction = ThreadLocal.withInitial(()->Boolean.FALSE);
     
-    private ThreadLocal<Boolean> inTransaction = ThreadLocal.withInitial(() -> Boolean.FALSE);
-
     @Override
-    public void begin(ReadWrite readWrite) {
+    public boolean transactionsSupported() {
+        return true;
+    }
+    
+    @Override
+    public void begin() {
         if ( inTransaction.get() )
             throw new JenaTransactionException("Already in transaction"); 
         inTransaction.set(true);
@@ -51,21 +52,6 @@ public class TransactionalNull implements Transactional {
             throw new JenaTransactionException("Not in transaction"); 
         inTransaction.set(false);
     }
-
-    @Override
-    public boolean isInTransaction() {
-        return inTransaction.get();
-    }
-
-    @Override
-    public void end() {
-        inTransaction.set(false);
-    }
-
-//    @Override
-//    public boolean promote() {
-//        return true;
-//    }
 
     public void remove() {
         inTransaction.remove();

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/graph/GraphSink.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/graph/GraphSink.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.util.graph;
+
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.graph.impl.GraphBase ;
+import org.apache.jena.util.iterator.ExtendedIterator ;
+import org.apache.jena.util.iterator.NullIterator ;
+
+/** Black hole for triples.
+ * @deprecated [Dec 2017] Use {@link org.apache.jena.sparql.graph.GraphSink}. To be removed.
+ */
+@Deprecated
+public class GraphSink extends GraphBase
+{
+    @Override
+    protected ExtendedIterator<Triple> graphBaseFind(Triple triple)
+    { return NullIterator.instance() ; }
+    
+    @Override
+    public void performAdd( Triple t ) {}
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TS_Core.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TS_Core.java
@@ -42,7 +42,8 @@ import org.junit.runners.Suite ;
     , TestDatasetGraphBaseFindPattern_General.class
     , TestDatasetGraphBaseFindPattern_Mem.class
     
-    , TestSpecialGraphs.class
+    , TestSpecialGraphNames.class
+    , TestSpecials.class
 })
 
 public class TS_Core

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestSpecialGraphNames.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestSpecialGraphNames.java
@@ -18,8 +18,8 @@
 
 package org.apache.jena.sparql.core;
 
-import static org.apache.jena.sparql.core.TestSpecialGraphs.Mode.QUADS ;
-import static org.apache.jena.sparql.core.TestSpecialGraphs.Mode.TRIPLES ;
+import static org.apache.jena.sparql.core.TestSpecialGraphNames.Mode.QUADS ;
+import static org.apache.jena.sparql.core.TestSpecialGraphNames.Mode.TRIPLES ;
 import static org.junit.Assert.assertEquals ;
 
 import java.util.Arrays ;
@@ -43,9 +43,9 @@ import org.junit.runner.RunWith ;
 import org.junit.runners.Parameterized ;
 import org.junit.runners.Parameterized.Parameters ;
 
-/** Test special graphs */
+/** Test special graph names. */
 @RunWith(Parameterized.class)
-public class TestSpecialGraphs {
+public class TestSpecialGraphNames {
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
         Creator<DatasetGraph> datasetGeneralMaker = ()-> DatasetGraphFactory.createGeneral() ; 
@@ -68,7 +68,7 @@ public class TestSpecialGraphs {
                                           ")") ;
     private DatasetGraph dsg ;
     
-    public TestSpecialGraphs(String label, Creator<DatasetGraph> maker) {
+    public TestSpecialGraphNames(String label, Creator<DatasetGraph> maker) {
         this.dsg = BuilderGraph.buildDataset(maker.create(), SSE.parse(x1)) ;
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestSpecials.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestSpecials.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.TransactionHandler;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.shared.JenaException;
+import org.apache.jena.sparql.JenaTransactionException;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.apache.jena.sparql.graph.GraphSink;
+import org.apache.jena.sparql.graph.GraphZero;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.system.Txn;
+import org.junit.Test;
+
+/** Tests for
+ * {@link DatasetGraphZero},
+ * {@link DatasetGraphSink} and
+ * {@link DatasetGraphOne}
+ * and (via their use in datasets):
+ * {@link GraphZero} and
+ * {@link GraphSink}
+*/
+public class TestSpecials {
+    
+    private static Quad quad = SSE.parseQuad("(:g :s :p :o)");
+    private static Triple triple = SSE.parseTriple("(:s :p :o)");
+    private static Node gn = SSE.parseNode(":gn");
+    
+    // -- zero
+    
+    @Test public void zero_basic_1() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        assertFalse(dsg.find().hasNext());
+        assertTrue(dsg.supportsTransactionAbort());
+        assertEquals(0, dsg.getDefaultGraph().size());
+        assertFalse(dsg.getDefaultGraph().getCapabilities().addAllowed());
+    }
+    
+    @Test public void zero_basic_2() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        assertNull(dsg.getGraph(gn));
+    }
+    
+    @Test(expected=UnsupportedOperationException.class)
+    public void zero_add_1() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        dsg.add(quad);
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void zero_add_2() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        dsg.getDefaultGraph().add(triple);
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void zero_add_3() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        dsg.addGraph(gn, GraphFactory.createGraphMem());
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void zero_delete_1() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        dsg.delete(quad);
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void zero_delete_2() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        dsg.getDefaultGraph().delete(triple);
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void zero_delete_3() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        dsg.deleteAny(Node.ANY, Node.ANY, Node.ANY, Node.ANY);
+    }
+
+    @Test public void zero_txn_1() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        Txn.executeRead(dsg, ()->{});
+        Txn.executeWrite(dsg, ()->{});
+    }
+
+    @Test(expected=JenaTransactionException.class)
+    public void zero_txn_2() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        dsg.begin(ReadWrite.READ);
+        dsg.begin(ReadWrite.READ);
+    }
+
+    @Test(expected=JenaTransactionException.class)
+    public void zero_txn_3() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        dsg.commit();
+    }
+    
+    @Test(expected=JenaTransactionException.class)
+    public void zero_txn_4() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        dsg.begin(ReadWrite.WRITE);
+        dsg.commit();
+        dsg.commit();
+    }
+    
+    @Test public void zero_graph_txn_1() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        Graph g = dsg.getDefaultGraph();
+        g.getTransactionHandler().execute(()->{});
+    }
+
+    @Test public void zero_graph_txn_2() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        Graph g = dsg.getDefaultGraph();
+        TransactionHandler h = g.getTransactionHandler();
+        h.begin();
+        h.abort();
+    }
+
+    @Test(expected=JenaException.class)
+    public void zero_graph_txn_3() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        Graph g = dsg.getDefaultGraph();
+        TransactionHandler h = g.getTransactionHandler();
+        h.begin();
+        h.begin();
+    }
+
+    @Test(expected=JenaException.class)
+    public void zero_graph_txn_4() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        Graph g = dsg.getDefaultGraph();
+        TransactionHandler h = g.getTransactionHandler();
+        h.begin();
+        h.commit();
+        h.abort();
+    }
+
+    @Test(expected=JenaException.class)
+    public void zero_graph_txn_5() {
+        DatasetGraph dsg = DatasetGraphZero.create();
+        Graph g = dsg.getDefaultGraph();
+        TransactionHandler h = g.getTransactionHandler();
+        h.commit();
+    }
+    
+    // -- sink
+    
+    @Test public void sink_basic_1() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        assertFalse(dsg.find().hasNext());
+        assertTrue(dsg.supportsTransactionAbort());
+        assertEquals(0, dsg.getDefaultGraph().size());
+        assertTrue(dsg.getDefaultGraph().getCapabilities().addAllowed());
+    }
+    
+    @Test public void sink_basic_2() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        assertNull(dsg.getGraph(gn));
+    }
+    
+    @Test public void sink_add_1() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        dsg.add(quad);
+    }
+
+    @Test public void sink_add_2() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        dsg.getDefaultGraph().add(triple);
+    }
+
+    @Test
+    public void sink_add_3() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        dsg.addGraph(gn, GraphFactory.createGraphMem());
+    }
+
+    @Test public void sink_delete_1() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        dsg.add(quad);
+    }
+
+    @Test public void sink_delete_2() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        dsg.getDefaultGraph().add(triple);
+    }
+    
+    @Test
+    public void sink_delete_3() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        dsg.deleteAny(Node.ANY, Node.ANY, Node.ANY, Node.ANY);
+    }
+
+    @Test public void sink_txn_1() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        Txn.executeRead(dsg, ()->{});
+        Txn.executeWrite(dsg, ()->{});
+    }
+    
+    @Test(expected=JenaTransactionException.class)
+    public void sink_txn_2() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        dsg.begin(ReadWrite.READ);
+        dsg.begin(ReadWrite.READ);
+    }
+
+    @Test(expected=JenaTransactionException.class)
+    public void sink_txn_3() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        dsg.commit();
+    }
+    
+    @Test(expected=JenaTransactionException.class)
+    public void sink_txn_4() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        dsg.begin(ReadWrite.WRITE);
+        dsg.commit();
+        dsg.commit();
+    }
+    
+    @Test public void sink_graph_txn_1() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        Graph g = dsg.getDefaultGraph();
+        g.getTransactionHandler().execute(()->{});
+    }
+
+
+    @Test public void sink_graph_txn_2() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        Graph g = dsg.getDefaultGraph();
+        TransactionHandler h = g.getTransactionHandler();
+        h.begin();
+        h.abort();
+    }
+
+    @Test(expected=JenaException.class)
+    public void sink_graph_txn_3() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        Graph g = dsg.getDefaultGraph();
+        TransactionHandler h = g.getTransactionHandler();
+        h.begin();
+        h.begin();
+    }
+
+    @Test(expected=JenaException.class)
+    public void sink_graph_txn_4() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        Graph g = dsg.getDefaultGraph();
+        TransactionHandler h = g.getTransactionHandler();
+        h.begin();
+        h.commit();
+        h.abort();
+    }
+
+    @Test(expected=JenaException.class)
+    public void sink_graph_txn_5() {
+        DatasetGraph dsg = DatasetGraphSink.create();
+        Graph g = dsg.getDefaultGraph();
+        TransactionHandler h = g.getTransactionHandler();
+        h.commit();
+    }
+}


### PR DESCRIPTION
A collection of datasets and associated graphs and machinery, for one-graph view datasets, empty and sink datasets.

More details on [JENA-1447](https://issues.apache.org/jira/browse/JENA-1447).