### PR TITLE
Refactoring complex methods of classes FBRuleInfGraph and LPRuleStore

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/LPRuleStore.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/LPRuleStore.java
@@ -194,22 +194,20 @@ public class LPRuleStore extends RuleStore {
         }
 
         // Now add the wild card rules into the list for each non-wild predicate)
-        List<RuleClauseCode> wildRules = predicateToCodeMap.get(Node_RuleVariable.WILD);
-        if (wildRules != null) {
-            for ( Map.Entry<Node, List<RuleClauseCode>> entry : predicateToCodeMap.entrySet() )
-            {
-                Node predicate = entry.getKey();
-                List<RuleClauseCode> predicateCode = entry.getValue();
-                if ( predicate != Node_RuleVariable.WILD )
-                {
-                    predicateCode.addAll( wildRules );
-                }
-            }
-        }
-        indexPredicateToCodeMap.put(Node_RuleVariable.WILD, new HashMap<Node, List<RuleClauseCode>>());
+        addWildCardRules();
                 
         // Now built any required two level indices
-        for ( Map.Entry<Node, Map<Node, List<RuleClauseCode>>> entry : indexPredicateToCodeMap.entrySet() )
+        buildTwoLevelIndices();
+        
+        // Now compile all the clauses
+        for ( RuleClauseCode code : allRuleClauseCodes )
+        {
+            code.compile( this );
+        }
+    }
+
+	private void buildTwoLevelIndices() {
+		for ( Map.Entry<Node, Map<Node, List<RuleClauseCode>>> entry : indexPredicateToCodeMap.entrySet() )
         {
             Node predicate = entry.getKey();
             Map<Node, List<RuleClauseCode>> predicateMap = entry.getValue();
@@ -250,13 +248,23 @@ public class LPRuleStore extends RuleStore {
                 predicateCode.addAll( wildRulesForPredicate );
             }
         }
-        
-        // Now compile all the clauses
-        for ( RuleClauseCode code : allRuleClauseCodes )
-        {
-            code.compile( this );
+	}
+
+	private void addWildCardRules() {
+		List<RuleClauseCode> wildRules = predicateToCodeMap.get(Node_RuleVariable.WILD);
+        if (wildRules != null) {
+            for ( Map.Entry<Node, List<RuleClauseCode>> entry : predicateToCodeMap.entrySet() )
+            {
+                Node predicate = entry.getKey();
+                List<RuleClauseCode> predicateCode = entry.getValue();
+                if ( predicate != Node_RuleVariable.WILD )
+                {
+                    predicateCode.addAll( wildRules );
+                }
+            }
         }
-    }
+        indexPredicateToCodeMap.put(Node_RuleVariable.WILD, new HashMap<Node, List<RuleClauseCode>>());
+	}
     
     /**
      * Add/remove a single rule from the store. 


### PR DESCRIPTION
Related to no particular issue. This is a behavior-preserving refactoring.

Summary of this pull request:

•	We are evaluating a research prototype called Bandago that assists in the refactoring of complex methods. Bandago is an Eclipse plugin that automatically identifies and refactors a type of code smell called Brain Method. A Brain Method centralizes the intelligence of a class and manifests itself as a long and complex method that is difficult to understand and maintain We have applied Bandago to 2 complex methods of your project, and we would like to receive feedback.
•	Bandago is very conservative and you should not observe many source code changes (only in the affected class).
•	The source code (after the refactoring) should behave equivalently to the original one.
•	As a sanity check, we have run tests before and after Bandago performed the refactoring(s) on the project. All tests passed.
•	The goal of the refactorings applied is to improve the legibility of the refactored method.
•	In this case, Bandago refactored the method FBRuleInfGraph.prepare extracting fragments of its code into the new methods initializeDeductions, initializeTGCCache, and callPreprocessingHook. Also, the method LPRuleStore.compileAll() was refactored extracting fragments of its code into the new methods addWildCardRules and buildTwoLevelIndices.

Thanks in advance for your help in this evaluation!
