### PR TITLE
JENA-1501: add systemd unit file for Fuseki

### DIFF
--- a/jena-fuseki2/apache-jena-fuseki/assembly-dist.xml
+++ b/jena-fuseki2/apache-jena-fuseki/assembly-dist.xml
@@ -86,6 +86,7 @@
       <includes>
         <include>log4j.properties</include>
         <include>fuseki</include>
+        <include>fuseki.service</include>
         <include>fuseki-server</include>
         <include>fuseki-backup</include>
         <include>fuseki-server.bat</include>

--- a/jena-fuseki2/apache-jena-fuseki/dist/README
+++ b/jena-fuseki2/apache-jena-fuseki/dist/README
@@ -11,7 +11,8 @@ to run in a webapp conatiner server such as Apache Tomcat, and also a
 self-contained jar, to run as a operation system process.
 
 The script 'fuseki' is an Linux init script to run Fuseki2 as a service.
-Instructions are in comments at the start of the script.
+The file 'fuseki.service' is a systemd unit file to run Fuseki2 as a service.
+Instructions are in comments at the start of the files.
 
 The script 'fuseki-server' is a script to run the server using
 fuseki-server.jar from the command line.  Use 'fuseki-server --help' for

--- a/jena-fuseki2/apache-jena-fuseki/fuseki.service
+++ b/jena-fuseki2/apache-jena-fuseki/fuseki.service
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# =========
+#
+# Fuseki service configuration / unit file for systemd
+#
+# Usage:
+# ------
+#
+# 1. Place this file under /etc/systemd/system/
+# 2. Adjust the paths and other settings below if necessary
+# 3. Activate using: sudo systemctl enable fuseki.service
+
+[Unit]
+Description=Fuseki
+
+[Service]
+# Edit environment variables to match your installation
+Environment=FUSEKI_HOME=/opt/fuseki
+Environment=FUSEKI_BASE=/etc/fuseki
+# Edit the line below to adjust memory size
+Environment=JVM_ARGS=-Xmx2G
+# Edit to match your installation
+ExecStart=/opt/fuseki/fuseki-server
+# Run as user "fuseki" - you will need to create this user first
+User=fuseki
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/jena-fuseki2/apache-jena-fuseki/fuseki.service
+++ b/jena-fuseki2/apache-jena-fuseki/fuseki.service
@@ -22,8 +22,10 @@
 # ------
 #
 # 1. Place this file under /etc/systemd/system/
-# 2. Adjust the paths and other settings below if necessary
-# 3. Activate using: sudo systemctl enable fuseki.service
+# 2. Create a system user called "fuseki" and make sure it has permission
+#    to access the Fuseki configuration and databases
+# 3. Adjust the paths and other settings below if necessary
+# 4. Activate using: sudo systemctl enable fuseki.service
 
 [Unit]
 Description=Fuseki
@@ -32,11 +34,11 @@ Description=Fuseki
 # Edit environment variables to match your installation
 Environment=FUSEKI_HOME=/opt/fuseki
 Environment=FUSEKI_BASE=/etc/fuseki
-# Edit the line below to adjust memory size
+# Edit the line below to adjust the amount of memory allocated to Fuseki
 Environment=JVM_ARGS=-Xmx2G
 # Edit to match your installation
 ExecStart=/opt/fuseki/fuseki-server
-# Run as user "fuseki" - you will need to create this user first
+# Run as user "fuseki"
 User=fuseki
 Restart=on-abort
 


### PR DESCRIPTION
This adds a systemd unit file to the Fuseki2 distribution.

This is the same file that was circulated on the users list (in response to a question by @jneubert), but with reduced default memory setting (2GB), an ASF license header and some hopefully helpful comments about how to set it up.

See https://issues.apache.org/jira/browse/JENA-1501