### PR TITLE
Reformat QueryIterGroup; no test output from TestParameterizedSparqlString

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1685,7 +1685,6 @@ public class ParameterizedSparqlString implements PrefixMapping {
             }
         }
 
-        @SuppressWarnings("unused")
         public boolean isInsideAltLiteral(int start, int stop) {
             Pair<Integer, String> pair = this.findBefore(start);
             if (pair == null)
@@ -1701,7 +1700,6 @@ public class ParameterizedSparqlString implements PrefixMapping {
             }
         }
 
-        @SuppressWarnings("unused")
         public boolean isBetweenLiterals(int start, int stop) {
             Pair<Integer, String> pairBefore = this.findBefore(start);
             if (pairBefore == null)

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -66,7 +66,6 @@ public class TestParameterizedSparqlString {
         return query.asQuery();
     }
 
-    @SuppressWarnings("unused")
     private UpdateRequest testAsUpdate(ParameterizedSparqlString update) {
         return update.asUpdate();
     }
@@ -1649,7 +1648,6 @@ public class TestParameterizedSparqlString {
                 "group by ?comment ?root_name";
         ParameterizedSparqlString queryStr2 = new ParameterizedSparqlString(test2);
         queryStr2.setLiteral("L_name", map.get("L_name"),map.get("LG_name"));
-        System.out.println(queryStr2.toString());
         queryStr2.asQuery();
     }
 


### PR DESCRIPTION
Reformat `QueryIterGroup` prior to work on aggregates.
Remove print out in from `TestParameterizedQueryString`.
Remove a couple info warnings.
