### PR TITLE
JENA-1508 Update OSGi provisioning features

### DIFF
--- a/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
+++ b/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
@@ -35,6 +35,7 @@
 		<bundle>mvn:org.apache.httpcomponents/httpclient-osgi/${ver.httpclient-osgi}</bundle>
 		<bundle>mvn:org.apache.commons/commons-csv/${ver.commonscsv}</bundle>
 		<bundle>mvn:org.apache.commons/commons-lang3/${ver.commonslang3}</bundle>
+		<bundle>mvn:commons-codec/commons-codec/${ver.commons-codec}</bundle>
 		<bundle>mvn:commons-io/commons-io/${ver.commonsio}</bundle>
 		<bundle>mvn:org.apache.thrift/libthrift/${ver.libthrift}</bundle>	
 	</feature>

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -261,7 +261,7 @@
             -->
             <Embed-Transitive>true</Embed-Transitive>
             <!-- Do not embed but import Xerces classes via OSGi -->
-            <Import-Package>org.osgi.framework.*,org.apache.xml.*,org.apache.xerces.*;version="2.11.0",!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
+            <Import-Package>org.osgi.framework.*,org.apache.xml.*,org.apache.xerces.*;version="2.11.0",!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.jena.ext.*,sun.misc;resolution:=optional,com.google.errorprone.annotations.concurrent;resolution:=optional,*</Import-Package>
             <!--
             <Import-Package>org.osgi.framework.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.xerces.*,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
             -->


### PR DESCRIPTION
This marks the `com.google.errorprone.annotations.concurrent` package
as optional. It also adds the (currently missing) `commons-codec` dependency
to the `features.xml` file.