### PR TITLE
Bugfix Tutorial 6: Missing "/" at the end of an URI resulted in a Nul…

### DIFF
--- a/jena-core/src-examples/jena/examples/rdf/Tutorial06.java
+++ b/jena-core/src-examples/jena/examples/rdf/Tutorial06.java
@@ -29,7 +29,7 @@ import java.io.*;
 public class Tutorial06 extends Object {
     
     static final String inputFileName = "vc-db-1.rdf";
-    static final String johnSmithURI = "http://somewhere/JohnSmith";
+    static final String johnSmithURI = "http://somewhere/JohnSmith/";
     
     public static void main (String args[]) {
         // create an empty model


### PR DESCRIPTION
I found a bug in tutorial 6 and propose a fix for it.

Without "/" at the end of the URI of JohnSmith (http://somewhere/JohnSmith/) an exception occurs in line 51 because no resource vcard could be found. The exception was: "Exception in thread "main" java.lang.NullPointerException". Adding the slash at the end fixes the issue because   <rdf:Description rdf:about="http://somewhere/JohnSmith/">