### PR TITLE
[JENA-1525] Add <Automatic-Module-Name> to <manifestEntries> for each jar module

### DIFF
--- a/jena-arq/pom.xml
+++ b/jena-arq/pom.xml
@@ -35,6 +35,7 @@
   <properties>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
+    <automatic.module.name>org.apache.jena.arq</automatic.module.name>
   </properties>
 
   <dependencies>
@@ -66,7 +67,7 @@
       <artifactId>jena-shaded-guava</artifactId>
       <version>3.8.0-SNAPSHOT</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
@@ -82,15 +83,15 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-cache</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
     </dependency>
 
-    <!-- 
-         Intercept any uses of Jakarta Commons Logging 
-         e.g. Apache Common HTTP client. 
+    <!--
+         Intercept any uses of Jakarta Commons Logging
+         e.g. Apache Common HTTP client.
     -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -140,10 +141,10 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <includes>
-            <!-- 
-          The test collections TC_General, TC_Riot, TC_Atlas 
-          are development support that collect the relevant 
-          tests for partial testing during development. 
+            <!--
+          The test collections TC_General, TC_Riot, TC_Atlas
+          are development support that collect the relevant
+          tests for partial testing during development.
         -->
             <include>**/TS_*.java</include>
             <include>**/TC_Scripted.java</include>
@@ -177,6 +178,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>
@@ -210,7 +218,6 @@
           <bottom>Licenced under the Apache License, Version 2.0</bottom>
         </configuration>
       </plugin>
-
     </plugins>
   </build>
 

--- a/jena-base/pom.xml
+++ b/jena-base/pom.xml
@@ -32,6 +32,10 @@
     This module contains non-RDF library code and the common system runtime.
   </description>
 
+  <properties>
+    <automatic.module.name>org.apache.jena.base</automatic.module.name>
+  </properties>
+
   <dependencies>
     
     <dependency>
@@ -86,6 +90,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/jena-cmds/pom.xml
+++ b/jena-cmds/pom.xml
@@ -49,7 +49,8 @@
 
   <properties>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
-    <build.time.xsd>${maven.build.timestamp}</build.time.xsd>  
+    <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
+    <automatic.module.name>org.apache.jena.cmds</automatic.module.name>
   </properties>
   
   <dependencies>
@@ -162,6 +163,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/jena-core/pom.xml
+++ b/jena-core/pom.xml
@@ -36,6 +36,7 @@
   <properties>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
+    <automatic.module.name>org.apache.jena.core</automatic.module.name>
   </properties>
 
   <dependencies>
@@ -214,6 +215,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/jena-csv/pom.xml
+++ b/jena-csv/pom.xml
@@ -35,6 +35,7 @@
   <properties>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
+    <automatic.module.name>org.apache.jena.csv</automatic.module.name>
   </properties>
 
   <dependencies>
@@ -93,6 +94,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/jena-db/pom.xml
+++ b/jena-db/pom.xml
@@ -32,7 +32,11 @@
     <version>3.8.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
-  
+
+  <properties>
+    <automatic.module.name>org.apache.jena.db</automatic.module.name>
+  </properties>
+
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -75,6 +79,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/jena-rdfconnection/pom.xml
+++ b/jena-rdfconnection/pom.xml
@@ -43,6 +43,10 @@
     </license>
   </licenses>
 
+  <properties>
+    <automatic.module.name>org.apache.jena.rdfconnection</automatic.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.jena</groupId>
@@ -136,6 +140,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/jena-spatial/pom.xml
+++ b/jena-spatial/pom.xml
@@ -35,6 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
+    <automatic.module.name>org.apache.jena.spatial</automatic.module.name>
   </properties>
 
   <dependencies>
@@ -137,6 +138,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/jena-tdb/pom.xml
+++ b/jena-tdb/pom.xml
@@ -35,6 +35,7 @@
   <properties>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
+    <automatic.module.name>org.apache.jena.tdb</automatic.module.name>
   </properties>
 
   <dependencies>
@@ -129,6 +130,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/jena-text-es/pom.xml
+++ b/jena-text-es/pom.xml
@@ -34,6 +34,7 @@
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
     <es.startup.timeout>90</es.startup.timeout>
+    <automatic.module.name>org.apache.jena.text.es</automatic.module.name>
   </properties>
 
   <dependencies>
@@ -171,6 +172,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/jena-text/pom.xml
+++ b/jena-text/pom.xml
@@ -33,6 +33,7 @@
   <properties>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
+    <automatic.module.name>org.apache.jena.text</automatic.module.name>
   </properties>
 
   <dependencies>
@@ -128,6 +129,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
See comments here: 
https://github.com/apache/jena/pull/399

It is possible that there are more artifacts that might want this.

FYI: This does not include the following top level projects:
apache-jena, apache-jena-libs, apache-jena-osgi, jena-elephas, jena-examples, jena-extras, jena-fuseki1, jena-fuseki, jena-integration-tests, jena-iri, jena-jdbc, jena-maven-tools, jena-permissions, jena-sdb, jena-shaded-guava
