### PR TITLE
 [JENA-1524] org.apache.jena.system is split by org.apache.jena.arq and org.apache.jena.core

### DIFF
--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -145,7 +145,7 @@
     </dependency>
     <!--
     NOTE: Also update 
-    src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
+    src/main/resources/META-INF/services/org.apache.jena.sys.JenaSubsystemLifecycle
     to the concatenation of the different Jena modules' JenaSubsystemLifecycle
     (order does not matter). See JENA-1139 for details.
     -->

--- a/apache-jena-osgi/jena-osgi/src/main/java/org/apache/jena/osgi/Activator.java
+++ b/apache-jena-osgi/jena-osgi/src/main/java/org/apache/jena/osgi/Activator.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.osgi;
 
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 

--- a/apache-jena-osgi/jena-osgi/src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
+++ b/apache-jena-osgi/jena-osgi/src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
@@ -1,4 +1,4 @@
-org.apache.jena.system.InitJenaCore
+org.apache.jena.sys.InitJenaCore
 org.apache.jena.riot.system.InitRIOT
 org.apache.jena.sparql.system.InitARQ
 org.apache.jena.tdb.sys.InitTDB

--- a/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
@@ -37,7 +37,7 @@ import org.apache.jena.sparql.pfunction.PropertyFunctionRegistry ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.MappingRegistry ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
 

--- a/jena-arq/src/main/java/org/apache/jena/query/Query.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/Query.java
@@ -40,7 +40,7 @@ import org.apache.jena.sparql.syntax.Element ;
 import org.apache.jena.sparql.syntax.PatternVars ;
 import org.apache.jena.sparql.syntax.Template ;
 import org.apache.jena.sparql.util.FmtUtils ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /** The data structure for a query as presented externally.
  *  There are two ways of creating a query - use the parser to turn

--- a/jena-arq/src/main/java/org/apache/jena/query/ResultSetFormatter.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ResultSetFormatter.java
@@ -45,7 +45,7 @@ import org.apache.jena.sparql.resultset.ResultsFormat;
 import org.apache.jena.sparql.resultset.TextOutput;
 import org.apache.jena.sparql.resultset.XMLOutput;
 import org.apache.jena.sparql.serializer.SerializationContext ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 
 /** ResultSetFormatter - Convenience ways to call the various output formatters.
  *  in various formats.

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
@@ -45,7 +45,7 @@ import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.graph.GraphFactory ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
@@ -25,7 +25,7 @@ import org.apache.jena.riot.system.RiotLib ;
 import org.apache.jena.riot.thrift.WriterDatasetThrift ;
 import org.apache.jena.riot.thrift.WriterGraphThrift ;
 import org.apache.jena.riot.writer.* ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 public class RDFWriterRegistry
 {

--- a/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
@@ -24,7 +24,7 @@ import org.apache.jena.sparql.SystemARQ ;
 import org.apache.jena.sparql.mgt.SystemInfo ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 public class RIOT {
     // Initialization statics must be first in the class to avoid

--- a/jena-arq/src/main/java/org/apache/jena/riot/ResultSetMgr.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/ResultSetMgr.java
@@ -33,7 +33,7 @@ import org.apache.jena.riot.resultset.rw.ResultsWriter;
 import org.apache.jena.sparql.resultset.ResultSetException;
 import org.apache.jena.sparql.resultset.SPARQLResult;
 import org.apache.jena.sparql.util.Context ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 
 /** 
  * Reading and writing of Result Sets.

--- a/jena-arq/src/main/java/org/apache/jena/riot/resultset/rw/ResultsWriter.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/resultset/rw/ResultsWriter.java
@@ -30,7 +30,7 @@ import org.apache.jena.riot.resultset.ResultSetWriter;
 import org.apache.jena.riot.resultset.ResultSetWriterFactory;
 import org.apache.jena.riot.resultset.ResultSetWriterRegistry;
 import org.apache.jena.sparql.util.Context;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 
 public class ResultsWriter {
     static { JenaSystem.init(); }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/InitRIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/InitRIOT.java
@@ -19,7 +19,7 @@
 package org.apache.jena.riot.system;
 
 import org.apache.jena.riot.RIOT ;
-import org.apache.jena.system.JenaSubsystemLifecycle ;
+import org.apache.jena.sys.JenaSubsystemLifecycle ;
 
 /** RIOT initialization. Used by {@code JenaSystem} */
 public class InitRIOT implements JenaSubsystemLifecycle {

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/SerializerRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/SerializerRDF.java
@@ -28,8 +28,8 @@ import org.apache.thrift.protocol.TProtocol;
 public class SerializerRDF {
     
     public static void init() {
-        org.apache.jena.system.Serializer.setNodeSerializer(SNode::new);
-        org.apache.jena.system.Serializer.setTripleSerializer(STriple::new);
+        org.apache.jena.sys.Serializer.setNodeSerializer(SNode::new);
+        org.apache.jena.sys.Serializer.setTripleSerializer(STriple::new);
         org.apache.jena.riot.system.Serializer.setQuadSerializer(SQuad::new);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/Var.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/Var.java
@@ -28,7 +28,7 @@ import org.apache.jena.sparql.ARQConstants ;
 import org.apache.jena.sparql.ARQInternalErrorException ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.expr.ExprVar ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 
 /** A SPARQL variable */
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
@@ -35,7 +35,7 @@ import org.apache.jena.sparql.util.MappingRegistry ;
 import org.apache.jena.sparql.util.Symbol ;
 import org.apache.jena.sparql.util.TypeNotUniqueException ;
 import org.apache.jena.sparql.util.graph.GraphUtils ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.vocabulary.RDFS ;
 import static org.apache.jena.sparql.core.assembler.DatasetAssemblerVocab.*;
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -58,7 +58,7 @@ import org.apache.jena.sparql.graph.NodeConst ;
 import org.apache.jena.sparql.graph.NodeTransform ;
 import org.apache.jena.sparql.serializer.SerializationContext ;
 import org.apache.jena.sparql.util.* ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.vocabulary.RDF ;
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
@@ -26,7 +26,7 @@ import org.apache.jena.graph.impl.GraphPlain ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.sparql.SystemARQ ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /** Ways to make graphs and models */
 public class GraphFactory

--- a/jena-arq/src/main/java/org/apache/jena/sparql/sse/SSE.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/sse/SSE.java
@@ -58,7 +58,7 @@ import org.apache.jena.sparql.sse.writers.WriterOp ;
 import org.apache.jena.sparql.util.FmtUtils ;
 import org.apache.jena.sparql.vocabulary.FOAF ;
 import org.apache.jena.sparql.vocabulary.ListPFunction ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.util.FileUtils ;
 import org.apache.jena.vocabulary.* ;
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/system/InitARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/system/InitARQ.java
@@ -19,7 +19,7 @@
 package org.apache.jena.sparql.system;
 
 import org.apache.jena.query.ARQ ;
-import org.apache.jena.system.JenaSubsystemLifecycle ;
+import org.apache.jena.sys.JenaSubsystemLifecycle ;
 
 /** ARQ initialization. Used by {@code JenaSystem} */
 public class InitARQ implements JenaSubsystemLifecycle {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/ExprUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/ExprUtils.java
@@ -42,7 +42,7 @@ import org.apache.jena.sparql.serializer.SerializationContext ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.apache.jena.sparql.sse.SSEParseException ;
 import org.apache.jena.sparql.sse.builders.ExprBuildException ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 
 /** Misc support for Expr */

--- a/jena-arq/src/main/java/org/apache/jena/system/JenaInit.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/JenaInit.java
@@ -16,27 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.jena.riot ;
+package org.apache.jena.system;
 
-import org.apache.jena.riot.system.IO_JenaReaders ;
-import org.apache.jena.riot.system.IO_JenaWriters ;
-import org.apache.jena.sys.JenaSystem ;
+import org.apache.jena.sys.JenaSystem;
 
-public class IO_Jena
-{
-    static { JenaSystem.init(); }
-    
-//    private static String      riotBase               = "http://jena.apache.org/riot/" ;
-//    private static String      streamManagerSymbolStr = riotBase + "streammanager" ;
-//    public static Symbol       streamManagerSymbol    = Symbol.create(streamManagerSymbolStr) ;
+/**
+ * This is a temporary adapter for implementations to transition to [JENA-1524]
+ */
+public class JenaInit {
 
-    public static void wireIntoJena() {
-       IO_JenaReaders.wireIntoJena() ;
-       IO_JenaWriters.wireIntoJena() ;
+    /**
+     * Initialize Jena.
+     */
+    public static void init() {
+        JenaSystem.init();
     }
 
-    public static void resetJena() {
-        IO_JenaReaders.resetJena() ;
-        IO_JenaWriters.resetJena() ;
+    /** Shutdown subsystems */
+    public static void shutdown() {
+        JenaSystem.shutdown();
     }
+
 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/TS_LangSuite.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TS_LangSuite.java
@@ -20,7 +20,7 @@ package org.apache.jena.riot;
 
 import junit.framework.TestSuite ;
 import org.apache.jena.riot.langsuite.FactoryTestRiot ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.junit.runner.RunWith ;
 import org.junit.runners.AllTests ;
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestSerializable.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestSerializable.java
@@ -31,7 +31,7 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.sse.SSE;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/ARQTestSuite.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/ARQTestSuite.java
@@ -28,7 +28,7 @@ import org.apache.jena.sparql.engine.main.QueryEngineMain ;
 import org.apache.jena.sparql.engine.ref.QueryEngineRef ;
 import org.apache.jena.sparql.expr.E_Function ;
 import org.apache.jena.sparql.expr.NodeValue ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.system.TS_System ;
 import org.apache.jena.web.TS_Web ;
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestOptimizer.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestOptimizer.java
@@ -29,7 +29,7 @@ import org.apache.jena.sparql.core.VarExprList ;
 import org.apache.jena.sparql.expr.ExprVar ;
 import org.apache.jena.sparql.expr.nodevalue.NodeValueInteger ;
 import org.apache.jena.sparql.sse.SSE ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.junit.Test ;
 
 public class TestOptimizer extends AbstractTestTransform

--- a/jena-arq/src/test/java/org/apache/jena/sparql/function/js/TestSPARQL_JS.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/function/js/TestSPARQL_JS.java
@@ -22,7 +22,7 @@ import junit.framework.TestSuite;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.junit.ScriptTestSuiteFactory;
 import org.apache.jena.sparql.util.Context;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.junit.runner.RunWith;
 import org.junit.runners.AllTests;
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/function/library/TestFnFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/function/library/TestFnFunctions.java
@@ -23,7 +23,7 @@ import static org.apache.jena.sparql.function.library.LibTest.test;
 import org.apache.jena.sparql.expr.ExprEvalException ;
 import org.apache.jena.sparql.expr.ExprException ;
 import org.apache.jena.sparql.expr.VariableNotBoundException ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.junit.Test ;
 
 public class TestFnFunctions {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/resultset/TestResultSet.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/resultset/TestResultSet.java
@@ -48,7 +48,7 @@ import org.apache.jena.sparql.sse.builders.BuilderResultSet ;
 import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.apache.jena.sparql.util.ResultSetUtils ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test ;

--- a/jena-base/pom.xml
+++ b/jena-base/pom.xml
@@ -71,8 +71,8 @@
       <groupId>com.jayway.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
-    </dependency>    
-    
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/jena-cmds/src/main/java/arq/cmdline/CmdARQ.java
+++ b/jena-cmds/src/main/java/arq/cmdline/CmdARQ.java
@@ -25,7 +25,7 @@ import org.apache.jena.atlas.lib.Lib ;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.riot.RIOT ;
 import org.apache.jena.sparql.engine.iterator.QueryIteratorBase ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 public abstract class CmdARQ extends CmdGeneral
 {

--- a/jena-cmds/src/main/java/arq/cmdline/ModContext.java
+++ b/jena-cmds/src/main/java/arq/cmdline/ModContext.java
@@ -30,7 +30,7 @@ import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.MappingRegistry ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /** Set Context items */
 public class ModContext extends ModBase

--- a/jena-cmds/src/main/java/arq/qexpr.java
+++ b/jena-cmds/src/main/java/arq/qexpr.java
@@ -42,7 +42,7 @@ import org.apache.jena.sparql.function.FunctionEnv ;
 import org.apache.jena.sparql.sse.WriterSSE ;
 import org.apache.jena.sparql.util.ExprUtils ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /** A program to execute expressions from the command line. */
 

--- a/jena-cmds/src/main/java/jena/rdfcat.java
+++ b/jena-cmds/src/main/java/jena/rdfcat.java
@@ -33,7 +33,7 @@ import java.util.function.BiConsumer;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.rdf.model.impl.RDFWriterFImpl ;
 import org.apache.jena.shared.NoWriterForLangException ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.util.FileManager ;
 import org.apache.jena.util.FileUtils ;
 import org.apache.jena.vocabulary.OWL ;

--- a/jena-cmds/src/main/java/jena/rdfcompare.java
+++ b/jena-cmds/src/main/java/jena/rdfcompare.java
@@ -25,7 +25,7 @@ import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /** A program which read two RDF models and determines if they are the same.
  *

--- a/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
+++ b/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
@@ -49,7 +49,7 @@ import org.apache.jena.riot.tokens.Tokenizer ;
 import org.apache.jena.riot.tokens.TokenizerFactory ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.DatasetGraphFactory ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /** Common framework for running RIOT parsers */
 public abstract class CmdLangParse extends CmdGeneral

--- a/jena-cmds/src/main/java/riotcmd/dumpthrift.java
+++ b/jena-cmds/src/main/java/riotcmd/dumpthrift.java
@@ -24,7 +24,7 @@ import org.apache.jena.atlas.io.IO ;
 import org.apache.jena.atlas.lib.Lib ;
 import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.riot.thrift.BinRDF ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /** Dump an rdf-thrift file to show structure */ 
 public class dumpthrift {

--- a/jena-cmds/src/main/java/tdb/bulkloader2/CmdIndexBuild.java
+++ b/jena-cmds/src/main/java/tdb/bulkloader2/CmdIndexBuild.java
@@ -19,7 +19,7 @@
 package tdb.bulkloader2;
 
 import org.apache.jena.atlas.logging.LogCtl ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.store.bulkloader2.ProcIndexBuild ;
 
 public class CmdIndexBuild {

--- a/jena-cmds/src/main/java/tdb/bulkloader2/CmdIndexCopy.java
+++ b/jena-cmds/src/main/java/tdb/bulkloader2/CmdIndexCopy.java
@@ -19,7 +19,7 @@
 package tdb.bulkloader2;
 
 import org.apache.jena.atlas.logging.LogCtl ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.store.bulkloader2.ProcIndexCopy ;
 
 public class CmdIndexCopy 

--- a/jena-cmds/src/main/java/tdb/bulkloader2/CmdNodeTableBuilder.java
+++ b/jena-cmds/src/main/java/tdb/bulkloader2/CmdNodeTableBuilder.java
@@ -29,7 +29,7 @@ import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.base.file.Location ;
 import org.apache.jena.tdb.setup.DatasetBuilderStd ;
 import org.apache.jena.tdb.store.bulkloader2.ProcNodeTableBuilder ;

--- a/jena-cmds/src/main/java/tdb/bulkloader2/CmdRewriteIndex.java
+++ b/jena-cmds/src/main/java/tdb/bulkloader2/CmdRewriteIndex.java
@@ -21,7 +21,7 @@ package tdb.bulkloader2;
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.atlas.lib.Lib ;
 import org.apache.jena.atlas.logging.LogCtl ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.base.file.Location ;
 import org.apache.jena.tdb.store.bulkloader2.ProcRewriteIndex ;
 import org.apache.jena.tdb.sys.Names ;

--- a/jena-cmds/src/main/java/tdb/cmdline/CmdTDB.java
+++ b/jena-cmds/src/main/java/tdb/cmdline/CmdTDB.java
@@ -25,7 +25,7 @@ import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.base.file.Location ;
 import org.apache.jena.tdb.setup.DatasetBuilderStd ;

--- a/jena-cmds/src/main/java/tdb2/cmdline/CmdTDB.java
+++ b/jena-cmds/src/main/java/tdb2/cmdline/CmdTDB.java
@@ -26,7 +26,7 @@ import org.apache.jena.dboe.base.file.Location;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb2.TDB2;
 import org.apache.jena.tdb2.store.DatasetGraphSwitchable;
 import org.apache.jena.tdb2.sys.TDBInternal;

--- a/jena-cmds/src/test/java/riotcmd/rdflangtest.java
+++ b/jena-cmds/src/test/java/riotcmd/rdflangtest.java
@@ -43,7 +43,7 @@ import org.apache.jena.sparql.junit.SimpleTestRunner ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.apache.jena.sparql.vocabulary.DOAP ;
 import org.apache.jena.sparql.vocabulary.FOAF ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.vocabulary.DC ;
 import org.apache.jena.vocabulary.DCTerms ;
 import org.apache.jena.vocabulary.RDF ;

--- a/jena-core/src/main/java/org/apache/jena/assembler/assemblers/AssemblerBase.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/assemblers/AssemblerBase.java
@@ -23,7 +23,7 @@ import org.apache.jena.assembler.* ;
 import org.apache.jena.assembler.exceptions.* ;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.shared.JenaException ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.vocabulary.RDF ;
 
 public abstract class AssemblerBase implements Assembler

--- a/jena-core/src/main/java/org/apache/jena/graph/Node.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/Node.java
@@ -27,7 +27,7 @@ import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.graph.impl.LiteralLabel ;
 import org.apache.jena.shared.JenaException ;
 import org.apache.jena.shared.PrefixMapping ;
-import org.apache.jena.system.Serializer;
+import org.apache.jena.sys.Serializer;
 
 /**
     A Node has five subtypes: Node_Blank, Node_Anon, Node_URI,  

--- a/jena-core/src/main/java/org/apache/jena/graph/NodeFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/NodeFactory.java
@@ -25,7 +25,7 @@ import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.datatypes.TypeMapper ;
 import org.apache.jena.graph.impl.LiteralLabel ;
 import org.apache.jena.graph.impl.LiteralLabelFactory ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 
 public class NodeFactory {
     

--- a/jena-core/src/main/java/org/apache/jena/graph/Triple.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/Triple.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apache.jena.shared.PrefixMapping ;
-import org.apache.jena.system.Serializer;
+import org.apache.jena.sys.Serializer;
 import org.apache.jena.util.iterator.ExtendedIterator ;
 import org.apache.jena.util.iterator.NullIterator ;
 

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
@@ -37,7 +37,7 @@ import org.apache.jena.reasoner.InfGraph ;
 import org.apache.jena.reasoner.Reasoner ;
 import org.apache.jena.reasoner.ReasonerRegistry ;
 import org.apache.jena.shared.PrefixMapping ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /**
     ModelFactory provides methods for creating standard kinds of Model.

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ModelCom.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ModelCom.java
@@ -37,7 +37,7 @@ import org.apache.jena.graph.impl.LiteralLabelFactory ;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.shared.* ;
 import org.apache.jena.shared.impl.PrefixMappingImpl ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.util.CollectionFactory ;
 import org.apache.jena.util.iterator.* ;
 import org.apache.jena.vocabulary.RDF ;

--- a/jena-core/src/main/java/org/apache/jena/sys/InitJenaCore.java
+++ b/jena-core/src/main/java/org/apache/jena/sys/InitJenaCore.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.system;
+package org.apache.jena.sys;
 
 import org.apache.jena.vocabulary.OWL ;
 import org.apache.jena.vocabulary.RDF ;

--- a/jena-core/src/main/java/org/apache/jena/sys/JenaSubsystemLifecycle.java
+++ b/jena-core/src/main/java/org/apache/jena/sys/JenaSubsystemLifecycle.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.system;
+package org.apache.jena.sys;
 
 /** Lifecycle interface for jena modules and subsystems. */ 
 public interface JenaSubsystemLifecycle {

--- a/jena-core/src/main/java/org/apache/jena/sys/JenaSubsystemRegistry.java
+++ b/jena-core/src/main/java/org/apache/jena/sys/JenaSubsystemRegistry.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.system;
+package org.apache.jena.sys;
 
 import java.util.List ;
 

--- a/jena-core/src/main/java/org/apache/jena/sys/JenaSubsystemRegistryBasic.java
+++ b/jena-core/src/main/java/org/apache/jena/sys/JenaSubsystemRegistryBasic.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.system;
+package org.apache.jena.sys;
 
 import java.util.ArrayList ;
 import java.util.List ;

--- a/jena-core/src/main/java/org/apache/jena/sys/JenaSystem.java
+++ b/jena-core/src/main/java/org/apache/jena/sys/JenaSystem.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.system;
+package org.apache.jena.sys;
 
 import java.util.Collections ;
 import java.util.Comparator ;

--- a/jena-core/src/main/java/org/apache/jena/sys/Serializer.java
+++ b/jena-core/src/main/java/org/apache/jena/sys/Serializer.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.system;
+package org.apache.jena.sys;
 
 import java.io.Serializable;
 import java.util.function.Function;

--- a/jena-core/src/main/java/org/apache/jena/util/FileManager.java
+++ b/jena-core/src/main/java/org/apache/jena/util/FileManager.java
@@ -27,7 +27,7 @@ import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.shared.JenaException ;
 import org.apache.jena.shared.NotFoundException ;
 import org.apache.jena.shared.WrappedIOException ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
 

--- a/jena-core/src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
+++ b/jena-core/src/main/resources/META-INF/services/org.apache.jena.system.JenaSubsystemLifecycle
@@ -1,1 +1,1 @@
-org.apache.jena.system.InitJenaCore
+org.apache.jena.sys.InitJenaCore

--- a/jena-core/src/test/java/org/apache/jena/test/JenaTestBase.java
+++ b/jena-core/src/test/java/org/apache/jena/test/JenaTestBase.java
@@ -24,7 +24,7 @@ import junit.framework.*;
 
 import java.util.*;
 
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.util.CollectionFactory ;
 import org.apache.jena.util.iterator.* ;
 

--- a/jena-csv/src/main/java/org/apache/jena/lang/csv/InitCSV.java
+++ b/jena-csv/src/main/java/org/apache/jena/lang/csv/InitCSV.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.lang.csv;
 
-import org.apache.jena.system.JenaSubsystemLifecycle ;
+import org.apache.jena.sys.JenaSubsystemLifecycle ;
 
 /** ARQ initialization. Used by {@code JenaSystem} */
 public class InitCSV implements JenaSubsystemLifecycle {

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/TDB2.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/TDB2.java
@@ -29,7 +29,7 @@ import org.apache.jena.sparql.mgt.SystemInfo ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.MappingRegistry ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb2.assembler.VocabTDB2;
 import org.apache.jena.tdb2.modify.UpdateEngineTDB;
 import org.apache.jena.tdb2.solver.QueryEngineTDB;

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/TDB2Factory.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/TDB2Factory.java
@@ -23,7 +23,7 @@ import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.DatasetFactory ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.tdb2.assembler.VocabTDB2 ;
 
 /**

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/assembler/DatasetAssemblerTDB.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/assembler/DatasetAssemblerTDB.java
@@ -36,7 +36,7 @@ import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils ;
 import org.apache.jena.sparql.core.assembler.DatasetAssembler ;
 import org.apache.jena.sparql.expr.NodeValue ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb2.DatabaseMgr;
 import org.apache.jena.tdb2.TDB2;
 

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/DatabaseConnection.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/DatabaseConnection.java
@@ -32,7 +32,7 @@ import org.apache.jena.dboe.base.file.Location;
 import org.apache.jena.dboe.base.file.ProcessFileLock;
 import org.apache.jena.dboe.sys.Names;
 import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.tdb2.TDBException;
 import org.apache.jena.tdb2.setup.StoreParams;
 import org.apache.jena.tdb2.store.DatasetGraphSwitchable;

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/InitTDB2.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/InitTDB2.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.tdb2.sys;
 
-import org.apache.jena.system.JenaSubsystemLifecycle ;
+import org.apache.jena.sys.JenaSubsystemLifecycle ;
 import org.apache.jena.tdb2.TDB2;
 
 public class InitTDB2 implements JenaSubsystemLifecycle {

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/SystemTDB.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/SystemTDB.java
@@ -33,7 +33,7 @@ import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderLib ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb2.TDB2;
 import org.apache.jena.tdb2.TDBException;
 import org.apache.jena.tdb2.store.NodeId;

--- a/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/store/TestDatasetTDB.java
+++ b/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/store/TestDatasetTDB.java
@@ -28,7 +28,7 @@ import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.sse.SSE ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.tdb2.TDB2;
 import org.apache.jena.tdb2.junit.TL;
 import org.junit.After ;

--- a/jena-fuseki1/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki1/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -28,7 +28,7 @@ import org.apache.jena.sparql.lib.Metadata ;
 import org.apache.jena.sparql.mgt.SystemInfo ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.MappingRegistry ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.transaction.TransactionManager ;
 import org.slf4j.Logger ;

--- a/jena-fuseki2/jena-fuseki-basic/src/main/java/org/apache/jena/fuseki/cmds/FusekiBasicCmd.java
+++ b/jena-fuseki2/jena-fuseki-basic/src/main/java/org/apache/jena/fuseki/cmds/FusekiBasicCmd.java
@@ -53,7 +53,7 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.Txn;
 import org.apache.jena.tdb.TDB;
 import org.apache.jena.tdb.TDBFactory;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -34,7 +34,7 @@ import org.apache.jena.sparql.lib.Metadata ;
 import org.apache.jena.sparql.mgt.SystemInfo ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.MappingRegistry ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.transaction.TransactionManager ;
 import org.slf4j.Logger ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/cmd/FusekiCmd.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/cmd/FusekiCmd.java
@@ -43,7 +43,7 @@ import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.riot.RDFLanguages ;
 import org.apache.jena.sparql.core.DatasetGraphFactory ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.system.Txn ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.sys.Names ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiServerEnvironmentInit.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiServerEnvironmentInit.java
@@ -22,7 +22,7 @@ import javax.servlet.ServletContextEvent ;
 import javax.servlet.ServletContextListener ;
 
 import org.apache.jena.fuseki.FusekiLogging ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /** Setup the environment and logging.
  *  Runs before the {@link ShiroEnvironmentLoader}.

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/assembler/TestDatasetAssembler.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/assembler/TestDatasetAssembler.java
@@ -36,7 +36,7 @@ import org.apache.jena.sparql.core.DatasetOne;
 import org.apache.jena.sparql.core.TxnDataset2Graph;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sparql.core.assembler.DatasetAssemblerVocab;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.Txn;
 import org.apache.jena.test.txn.TestDataset2Graph;
 import org.junit.BeforeClass;

--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/AbstractJenaDriverTests.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/AbstractJenaDriverTests.java
@@ -32,7 +32,7 @@ import org.apache.jena.jdbc.postprocessing.ResultsEcho ;
 import org.apache.jena.jdbc.postprocessing.ResultsPostProcessor ;
 import org.apache.jena.jdbc.preprocessing.CommandPreProcessor ;
 import org.apache.jena.jdbc.preprocessing.Echo ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.junit.Assert ;
 import org.junit.Assume ;
 import org.junit.Test ;

--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/connections/AbstractJenaConnectionTests.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/connections/AbstractJenaConnectionTests.java
@@ -37,7 +37,7 @@ import org.apache.jena.jdbc.results.metadata.TripleResultsMetadata ;
 import org.apache.jena.jdbc.utils.TestUtils ;
 import org.apache.jena.query.* ;
 import org.apache.jena.sparql.core.Quad ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.update.UpdateFactory ;
 import org.apache.jena.update.UpdateRequest ;
 import org.junit.Assert ;

--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/metadata/results/AbstractDatabaseMetadataTests.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/metadata/results/AbstractDatabaseMetadataTests.java
@@ -25,7 +25,7 @@ import java.sql.SQLException ;
 import java.util.List ;
 
 import org.apache.jena.jdbc.connections.JenaConnection ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.junit.Assert ;
 import org.junit.Test ;
 

--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/results/AbstractResultSetTests.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/results/AbstractResultSetTests.java
@@ -35,7 +35,7 @@ import org.apache.jena.query.DatasetFactory ;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.rdf.model.Statement ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.vocabulary.XSD ;
 import org.junit.* ;
 

--- a/jena-jdbc/jena-jdbc-driver-mem/src/main/java/org/apache/jena/jdbc/mem/MemDriver.java
+++ b/jena-jdbc/jena-jdbc-driver-mem/src/main/java/org/apache/jena/jdbc/mem/MemDriver.java
@@ -30,7 +30,7 @@ import org.apache.jena.jdbc.mem.connections.MemConnection;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.DatasetFactory ;
 import org.apache.jena.riot.RDFDataMgr;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /**
  * <p>

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/RemoteEndpointDriver.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/RemoteEndpointDriver.java
@@ -35,7 +35,7 @@ import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.JenaDriver;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /**
  * <p>

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/AbstractRemoteEndpointResultSetTests.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/AbstractRemoteEndpointResultSetTests.java
@@ -22,7 +22,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.jdbc.results.AbstractResultSetTests;
 import org.apache.jena.riot.web.HttpOp;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 

--- a/jena-jdbc/jena-jdbc-driver-tdb/src/main/java/org/apache/jena/jdbc/tdb/TDBDriver.java
+++ b/jena-jdbc/jena-jdbc-driver-tdb/src/main/java/org/apache/jena/jdbc/tdb/TDBDriver.java
@@ -30,7 +30,7 @@ import org.apache.jena.jdbc.JenaDriver;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.tdb.connections.TDBConnection;
 import org.apache.jena.query.Dataset ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.TDBFactory ;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/Factory.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/Factory.java
@@ -21,7 +21,7 @@ import org.apache.jena.graph.Graph ;
 import org.apache.jena.permissions.graph.SecuredGraph;
 import org.apache.jena.permissions.model.SecuredModel;
 import org.apache.jena.rdf.model.Model ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 /**
  * The factory that can be used to create an instance of a SecuredGraph or a SecuredModel.

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionFactory.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionFactory.java
@@ -19,7 +19,7 @@
 package org.apache.jena.rdfconnection;
 
 import org.apache.jena.query.Dataset;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 
 public class RDFConnectionFactory {
     static { JenaSystem.init(); }

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/SDB.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/SDB.java
@@ -34,7 +34,7 @@ import org.apache.jena.sparql.mgt.SystemInfo ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.MappingRegistry ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.vocabulary.OWL ;
 import org.apache.jena.vocabulary.RDF ;
 import org.apache.jena.vocabulary.RDFS ;

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/SDBFactory.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/SDBFactory.java
@@ -35,7 +35,7 @@ import org.apache.jena.sdb.store.DatasetStore ;
 import org.apache.jena.sdb.store.StoreFactory ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.modify.GraphStoreBasic ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.update.GraphStore ;
 
 /** Various operations to create or connect objects to do with SDB:

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/core/InitSDB.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/core/InitSDB.java
@@ -19,7 +19,7 @@
 package org.apache.jena.sdb.core;
 
 import org.apache.jena.sdb.SDB ;
-import org.apache.jena.system.JenaSubsystemLifecycle ;
+import org.apache.jena.sys.JenaSubsystemLifecycle ;
 
 /** Jena subsystem initialization */
 public class InitSDB implements JenaSubsystemLifecycle {

--- a/jena-spatial/src/main/java/org/apache/jena/query/spatial/InitJenaSpatial.java
+++ b/jena-spatial/src/main/java/org/apache/jena/query/spatial/InitJenaSpatial.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.query.spatial;
 
-import org.apache.jena.system.JenaSubsystemLifecycle ;
+import org.apache.jena.sys.JenaSubsystemLifecycle ;
 
 public class InitJenaSpatial implements JenaSubsystemLifecycle {
     @Override

--- a/jena-spatial/src/main/java/org/apache/jena/query/spatial/SpatialDatasetFactory.java
+++ b/jena-spatial/src/main/java/org/apache/jena/query/spatial/SpatialDatasetFactory.java
@@ -23,7 +23,7 @@ import org.apache.jena.query.DatasetFactory ;
 import org.apache.jena.query.spatial.assembler.SpatialVocab;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.lucene.store.Directory;
 
 public class SpatialDatasetFactory

--- a/jena-spatial/src/main/java/org/apache/jena/query/spatial/SpatialQuery.java
+++ b/jena-spatial/src/main/java/org/apache/jena/query/spatial/SpatialQuery.java
@@ -29,7 +29,7 @@ import org.apache.jena.sparql.pfunction.PropertyFunction ;
 import org.apache.jena.sparql.pfunction.PropertyFunctionFactory ;
 import org.apache.jena.sparql.pfunction.PropertyFunctionRegistry ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 public class SpatialQuery
 {

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/TDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/TDB.java
@@ -40,7 +40,7 @@ import org.apache.jena.sparql.mgt.SystemInfo ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.MappingRegistry ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.assembler.AssemblerTDB ;
 import org.apache.jena.tdb.modify.UpdateEngineTDB ;
 import org.apache.jena.tdb.setup.DatasetBuilderStd ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/TDBFactory.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/TDBFactory.java
@@ -25,7 +25,7 @@ import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.DatasetFactory ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.assembler.VocabTDB ;
 import org.apache.jena.tdb.base.file.Location ;
 import org.apache.jena.tdb.setup.StoreParams ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/assembler/DatasetAssemblerTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/assembler/DatasetAssemblerTDB.java
@@ -34,7 +34,7 @@ import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils ;
 import org.apache.jena.sparql.core.assembler.DatasetAssembler ;
 import org.apache.jena.sparql.expr.NodeValue ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.TDBFactory ;
 import org.apache.jena.tdb.base.file.Location ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/sys/InitTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/sys/InitTDB.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.tdb.sys;
 
-import org.apache.jena.system.JenaSubsystemLifecycle ;
+import org.apache.jena.sys.JenaSubsystemLifecycle ;
 import org.apache.jena.tdb.TDB ;
 
 /** Jena subsystem initialization */

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/sys/SystemTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/sys/SystemTDB.java
@@ -30,7 +30,7 @@ import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderLib ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.TDBException ;
 import org.apache.jena.tdb.base.block.FileMode ;

--- a/jena-text-es/src/main/java/org/apache/jena/query/text/es/InitJenaTextES.java
+++ b/jena-text-es/src/main/java/org/apache/jena/query/text/es/InitJenaTextES.java
@@ -19,7 +19,7 @@
 package org.apache.jena.query.text.es;
 
 import org.apache.jena.query.text.InitJenaText ;
-import org.apache.jena.system.JenaSubsystemLifecycle ;
+import org.apache.jena.sys.JenaSubsystemLifecycle ;
 
 public class InitJenaTextES implements JenaSubsystemLifecycle {
     @Override

--- a/jena-text-es/src/main/java/org/apache/jena/query/text/es/TextES.java
+++ b/jena-text-es/src/main/java/org/apache/jena/query/text/es/TextES.java
@@ -19,7 +19,7 @@
 package org.apache.jena.query.text.es;
 
 import org.apache.jena.query.text.es.assembler.TextAssemblerES;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 
 public class TextES {
     private static volatile boolean initialized = false ;

--- a/jena-text-es/src/main/java/org/apache/jena/query/text/es/TextESDatasetFactory.java
+++ b/jena-text-es/src/main/java/org/apache/jena/query/text/es/TextESDatasetFactory.java
@@ -23,7 +23,7 @@ import org.apache.jena.query.text.EntityDefinition;
 import org.apache.jena.query.text.TextDatasetFactory;
 import org.apache.jena.query.text.TextIndex;
 import org.apache.jena.query.text.TextIndexConfig;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 public class TextESDatasetFactory
 {

--- a/jena-text/src/main/java/org/apache/jena/query/text/InitJenaText.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/InitJenaText.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.query.text;
 
-import org.apache.jena.system.JenaSubsystemLifecycle ;
+import org.apache.jena.sys.JenaSubsystemLifecycle ;
 
 public class InitJenaText implements JenaSubsystemLifecycle {
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextDatasetFactory.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextDatasetFactory.java
@@ -24,7 +24,7 @@ import org.apache.jena.query.text.assembler.TextVocab ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils ;
 import org.apache.jena.sparql.util.Context ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.store.Directory ;
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextQuery.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextQuery.java
@@ -26,7 +26,7 @@ import org.apache.jena.sparql.pfunction.PropertyFunction ;
 import org.apache.jena.sparql.pfunction.PropertyFunctionFactory ;
 import org.apache.jena.sparql.pfunction.PropertyFunctionRegistry ;
 import org.apache.jena.sparql.util.Symbol ;
-import org.apache.jena.system.JenaSystem ;
+import org.apache.jena.sys.JenaSystem ;
 
 public class TextQuery
 {

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestEntityMapAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestEntityMapAssembler.java
@@ -32,7 +32,7 @@ import org.apache.jena.query.text.TextIndexException ;
 import org.apache.jena.query.text.analyzer.ConfigurableAnalyzer ;
 import org.apache.jena.query.text.analyzer.LowerCaseKeywordAnalyzer ;
 import org.apache.jena.rdf.model.* ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.vocabulary.RDF ;
 import org.apache.jena.vocabulary.RDFS ;
 import org.apache.lucene.analysis.core.KeywordAnalyzer ;

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestGenericAnalyzerAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestGenericAnalyzerAssembler.java
@@ -24,7 +24,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.SimpleAnalyzer;

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
@@ -33,7 +33,7 @@ import org.apache.jena.rdf.model.Resource ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.core.QuadAction ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.tdb.assembler.AssemblerTDB ;
 import org.apache.jena.vocabulary.RDF ;
 import org.junit.Test ;

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextIndexLuceneAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextIndexLuceneAssembler.java
@@ -21,7 +21,7 @@ package org.apache.jena.query.text.assembler;
 import org.apache.jena.assembler.Assembler ;
 import org.apache.jena.query.text.TextIndexLucene ;
 import org.apache.jena.rdf.model.Resource ;
-import org.apache.jena.system.JenaSystem;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.vocabulary.RDFS ;
 import org.apache.lucene.analysis.core.KeywordAnalyzer ;
 import org.apache.lucene.store.RAMDirectory ;


### PR DESCRIPTION
per @afs 

> this renames of "jena-core:org.apache.jena.system" as "jena-core:org.apache.jena.sys", and puts an adapter class `JenaInit` in "jena-arq:org.apache.jena.system" that has two functions to call the real init and shutdown. 
> 
> `JenaInit` will be deprecated prior to removal quite quickly (in a very few release cycles).
> 
> This way the impact is lessened: `org.apache.jena.system.Txn` is not repackaged. The adapter class approach does not work for calls from jena-core to jena-arq without reflection.