### PR TITLE
JENA-1542: Integrate Lucene index in transaction lifecycle (TDB1, TDB2).

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/NamedGraphWrapper.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/NamedGraphWrapper.java
@@ -30,15 +30,20 @@ import org.apache.jena.sparql.graph.GraphWrapper ;
 
 public class NamedGraphWrapper extends GraphWrapper implements NamedGraph {
 
-    private final Node graphName ;
+    private final Node graphName;
 
     public NamedGraphWrapper(Node graphName, Graph graph) {
-        super(graph) ;
+        super(graph);
         this.graphName = graphName;
     }
 
     @Override
     public Node getGraphName() {
-        return graphName ;
+        return graphName;
+    }
+    
+    @Override
+    public String toString() {
+        return "NamedGraphWrapper("+graphName+")";
     }
 }

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/TransInteger.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/TransInteger.java
@@ -55,7 +55,12 @@ public class TransInteger extends TransactionalComponentLifecycle<TransInteger.I
     
     /** In-memory, non persistent, transactional integer */
     public TransInteger(long v) {
-        this(null, ComponentId.allocLocal()) ;
+        this(v, ComponentId.allocLocal()) ;
+    }
+
+    /** In-memory, non persistent, transactional integer */
+    public TransInteger(long v, ComponentId componentId) {
+        this(null, componentId) ;
         value.set(v) ;
     }
 

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionCoordinator.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionCoordinator.java
@@ -131,7 +131,7 @@ public class TransactionCoordinator {
      * This must be setup before recovery is attempted. 
      */
     public TransactionCoordinator add(TransactionalComponent elt) {
-        checklAllowModication() ;
+        checklAllowModification() ;
         components.add(elt) ;
         return this ;
     }
@@ -141,7 +141,7 @@ public class TransactionCoordinator {
      * @see #add 
      */
     public TransactionCoordinator remove(TransactionalComponent elt) {
-        checklAllowModication() ;
+        checklAllowModification() ;
         components.remove(elt.getComponentId()) ;
         return this ;
     }
@@ -172,23 +172,23 @@ public class TransactionCoordinator {
      * and hence hooks may not get called.
      */
     public void add(TransactionCoordinator.ShutdownHook hook) {
-        checklAllowModication() ;
+        checklAllowModification() ;
         shutdownHooks.add(hook) ;
     }
 
     /** Remove a shutdown hook */
     public void remove(TransactionCoordinator.ShutdownHook hook) {
-        checklAllowModication() ;
+        checklAllowModification() ;
         shutdownHooks.remove(hook) ;
     }
     
     public void setQuorumGenerator(QuorumGenerator qGen) {
-        checklAllowModication() ;
+        checklAllowModification() ;
         this.quorumGenerator = qGen ;
     }
 
     public void start() {
-        checklAllowModication() ;
+        checklAllowModification() ;
         recovery() ;
         configurable = false ;
     }
@@ -283,7 +283,7 @@ public class TransactionCoordinator {
     }
 
     // Can modifications be made? 
-    private void checklAllowModication() {
+    private void checklAllowModification() {
         if ( ! configurable )
             throw new TransactionException("TransactionCoordinator configuration is locked") ;
     }

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/TDBInternal.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/TDBInternal.java
@@ -38,6 +38,14 @@ import org.apache.jena.tdb2.store.nodetable.NodeTable;
  * 
  */
 public class TDBInternal {
+    
+    /**
+     * Return true if this is a TDB2 backed DatasetGraph. 
+     */
+    public static boolean isTDB2(DatasetGraph dsg) {
+        return ( dsg instanceof DatasetGraphSwitchable );
+    }
+
     /**
      * Return the NodeId for a node. Returns NodeId.NodeDoesNotExist when the node is not
      * found. Returns null when not a TDB-backed dataset.

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/TDBInternal.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/TDBInternal.java
@@ -19,6 +19,7 @@
 package org.apache.jena.tdb2.sys;
 
 import org.apache.jena.dboe.base.file.Location;
+import org.apache.jena.dboe.transaction.txn.TransactionCoordinator;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -113,6 +114,17 @@ public class TDBInternal {
         throw new TDBException("Not a TDB database container");
     }
     
+    /**
+     * Return the {@link TransactionCoordinator} for a TDB2-backed DatasetGraph
+     * or null, if not backed by TDB2.
+     */
+    public static TransactionCoordinator getTransactionCoordinator(DatasetGraph dsg) {
+        DatasetGraphTDB dsgtdb = getDatasetGraphTDB(dsg);
+        if ( dsgtdb == null )
+            return null;
+        return dsgtdb.getTxnSystem().getTxnMgr();
+    }
+
     /**
      * Return the DatasetGraphTDB for a DatasetGraph, or null.
      * Use the {@link DatasetGraphTDB} with care.

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemoteBuilder.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemoteBuilder.java
@@ -289,7 +289,6 @@ public class RDFConnectionRemoteBuilder {
     /** Build an {RDFConnection}. */ 
     public RDFConnection build() {
         requireNonNull(txnLifecycle);
-        requireNonNull(destination);
         
         Function<RDFConnectionRemoteBuilder, RDFConnection> maker = creator ;
         

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/sys/TDBInternal.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/sys/TDBInternal.java
@@ -41,6 +41,13 @@ import org.apache.jena.tdb.transaction.TransactionManager ;
 public class TDBInternal
 {
     /**
+     * Return true if this is a TDB1 backed DatasetGraph. 
+     */
+    public static boolean isTDB1(DatasetGraph dsg) {
+        return ( dsg instanceof DatasetGraphTransaction );
+    }
+
+    /**
      * Return the NodeId for a node. Returns NodeId.NodeDoesNotExist when the
      * node is not found. Returns null when not a TDB-backed dataset.
      */
@@ -169,4 +176,5 @@ public class TDBInternal
                 return false ;
             return true ;
         } ;
+
 }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/BlockMgrJournal.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/BlockMgrJournal.java
@@ -93,11 +93,20 @@ public class BlockMgrJournal implements BlockMgr, TransactionLifecycle
             writeJournalEntry(blk) ;
         this.active = false ;
     }
+    
+    @Override
+    public void committed(Transaction txn)
+    {}
 
     @Override
-    public void commitEnact(Transaction txn)
-    {
+    public void enactCommitted(Transaction txn) {
         // No-op : this is done by playing the master journal.
+    }
+
+    @Override
+    public void clearupCommitted(Transaction txn) {
+        // Persistent state is in the system journal.
+        clear(txn) ;
     }
 
     @Override
@@ -106,13 +115,6 @@ public class BlockMgrJournal implements BlockMgr, TransactionLifecycle
         checkActive() ;
         this.active = false ;
         // Do clearup of in-memory structures in clearup().
-    }
-    
-    @Override
-    public void commitClearup(Transaction txn)
-    {
-        // Persistent state is in the system journal.
-        clear(txn) ;
     }
     
     /** Set, or reset, this BlockMgr.

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/ObjectFileTrans.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/ObjectFileTrans.java
@@ -21,17 +21,21 @@ package org.apache.jena.tdb.transaction;
 import org.apache.jena.tdb.base.objectfile.ObjectFile ;
 import org.apache.jena.tdb.base.objectfile.ObjectFileWrapper ;
 
-/** Add transactionality control to an ObjectFile.
- * ObjectFiles are "append only" so with a single writer environment, 
- * we just need to manage a reset on abort.
- * A crash in a transaction will accumulate some junk in the file.
- * This is now a tradeoff of speed and space.
+/**
+ * Add transactionality control to an ObjectFile. ObjectFiles are "append only" so with a
+ * single writer environment, we just need to manage a reset on abort. A crash in a
+ * transaction will accumulate some junk in the file. This is now a tradeoff of speed and
+ * space.
  * 
- * Speed : append to the original file directly and tolerate junk.
+ * Speed : append to the original file directly and tolerate junk. This class.
  * 
- * Space : use a journal file and write to main file on commit.
+ * Space : use a journal file and write to main file on commit. {@link ObjectFileTransComplex} 
  * 
- * @see ObjectFileTransComplex  
+ * {@link ObjectFileTransComplex} has an auxilliary file that it writes to, then copies to
+ * the main file on "commit". This avoids the possibility of junk from a failed
+ * transaction on a crash but costs extra writes.
+ * 
+ * The normal choice is this class.
  */
 class ObjectFileTrans extends ObjectFileWrapper implements TransactionLifecycle {
     ObjectFileTrans(Transaction txn /*unused*/, ObjectFile other) {
@@ -57,8 +61,11 @@ class ObjectFileTrans extends ObjectFileWrapper implements TransactionLifecycle 
     }
 
     @Override
-    public void commitEnact(Transaction txn) { }
+    public void committed(Transaction txn) { }
 
     @Override
-    public void commitClearup(Transaction txn) {}
+    public void enactCommitted(Transaction txn) { }
+
+    @Override
+    public void clearupCommitted(Transaction txn) {}
 }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
@@ -332,15 +332,6 @@ public class Transaction
         }
     }
     
-//    /** Return the list of items registered for the transaction lifecycle */ 
-//    public List<TransactionLifecycle> lifecycleComponents() {
-//        List<TransactionLifecycle> x = new ArrayList<>() ;
-//        x.addAll(objectFileTrans) ;
-//        x.addAll(blkMgrs) ;
-//        x.addAll(others);
-//        return x ;
-//    }
-    
     // For development and tracking, keep these as separate lists.
     
     /*package*/ void addComponent(ObjectFileTrans oft) {

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/Transaction.java
@@ -21,6 +21,7 @@ import java.io.IOException ;
 import java.util.ArrayList ;
 import java.util.Iterator ;
 import java.util.List ;
+import java.util.function.Consumer;
 
 import org.apache.jena.atlas.logging.Log ;
 import org.apache.jena.query.ReadWrite ;
@@ -43,6 +44,7 @@ public class Transaction
     
     private final List<ObjectFileTrans> objectFileTrans = new ArrayList<>() ;
     private final List<BlockMgrJournal> blkMgrs = new ArrayList<>() ;
+    private final List<TransactionLifecycle> others = new ArrayList<>() ;
     // The dataset this is a transaction over - may be a commited, pending dataset.
     private final DatasetGraphTDB   basedsg ;
     private final long version ;
@@ -147,6 +149,16 @@ public class Transaction
                             SystemTDB.errlog.warn("Exception during 'commit' : transaction status not known (but not a partial commit): ",ex) ;
                         throw new TDBTransactionException("Exception at commit point", ex) ;
                     }
+                    
+                    try {
+                       committed() ;
+                    } catch (RuntimeException ex) {
+                        if ( isIOException(ex) )
+                            SystemTDB.errlog.warn("IOException during 'committed'"+ex.getMessage()) ;
+                        else
+                            SystemTDB.errlog.warn("Exception during 'committed': "+ex.getMessage(), ex) ;
+                        throw new TDBTransactionException("Exception during 'committed' - transaction did commit", ex) ;
+                    }
                     outcome = TxnOutcome.W_COMMITED ;
                     break ;
             }
@@ -173,13 +185,20 @@ public class Transaction
         }
         return false ;
     }
+    
+    /*package*/ void forAllComponents(Consumer<TransactionLifecycle> action) {
+        objectFileTrans.forEach(action);
+        blkMgrs.forEach(action);
+        others.forEach(action);
+    }
 
     private void prepare() {
         state = TxnState.PREPARING ;
-        for ( TransactionLifecycle x : objectFileTrans )
-            x.commitPrepare(this) ;
-        for ( TransactionLifecycle x : blkMgrs )
-            x.commitPrepare(this) ;
+        forAllComponents(x->x.commitPrepare(this));
+    }
+
+    private void committed() {
+        forAllComponents(x->x.committed(this));
     }
 
     public void abort() {
@@ -193,11 +212,7 @@ public class Transaction
                     if ( state != TxnState.ACTIVE )
                         throw new TDBTransactionException("Transaction has already committed or aborted") ;
                     try {
-                        // Clearup.
-                        for ( TransactionLifecycle x : objectFileTrans )
-                            x.abort(this) ;
-                        for ( TransactionLifecycle x : blkMgrs )
-                            x.abort(this) ;
+                        forAllComponents(x->x.abort(this)) ;
                     }
                     catch (RuntimeException ex) {
                         if ( isIOException(ex) )
@@ -317,13 +332,16 @@ public class Transaction
         }
     }
     
-    /** Return the list of items registered for the transaction lifecycle */ 
-    public List<TransactionLifecycle> lifecycleComponents() {
-        List<TransactionLifecycle> x = new ArrayList<>() ;
-        x.addAll(objectFileTrans) ;
-        x.addAll(blkMgrs) ;
-        return x ;
-    }
+//    /** Return the list of items registered for the transaction lifecycle */ 
+//    public List<TransactionLifecycle> lifecycleComponents() {
+//        List<TransactionLifecycle> x = new ArrayList<>() ;
+//        x.addAll(objectFileTrans) ;
+//        x.addAll(blkMgrs) ;
+//        x.addAll(others);
+//        return x ;
+//    }
+    
+    // For development and tracking, keep these as separate lists.
     
     /*package*/ void addComponent(ObjectFileTrans oft) {
         objectFileTrans.add(oft);
@@ -331,6 +349,10 @@ public class Transaction
 
     /*package*/ void addComponent(BlockMgrJournal blkMgr) {
         blkMgrs.add(blkMgr) ;
+    }
+    
+    /*package*/ void addAdditionaComponent(TransactionLifecycle tlc) {
+        others.add(tlc) ;
     }
 
     public DatasetGraphTDB getBaseDataset() {

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionLifecycle.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/TransactionLifecycle.java
@@ -23,22 +23,33 @@ package org.apache.jena.tdb.transaction;
  */ 
 public interface TransactionLifecycle
 {
-    // begin - commitPrepare - commitEnact - clearup
-    // begin - abort - clearup
+    // begin - commitPrepare commit, then later. commitEnact - clearup
+    // begin - abort
     // May be reused via a new call to begin - see impl for if that's possible. 
     
     /** Start an update transaction */  
     public void begin(Transaction txn) ;
     
-    /** End of active phase - will not be making these changes*/
-    public void abort(Transaction txn) ;
+    /** End of active phase - will not be making these changes. */
+    public void abort(Transaction txn);
     
-    /** End of active phase. Make changes safe; do not update the base data. */
-    public void commitPrepare(Transaction txn) ;
+    /**
+     * Prepare to commit; end of active phase. 
+     * Make changes safe; do not update the base data.
+     */
+    public void commitPrepare(Transaction txn);
 
-    /** Update the base data */ 
-    public void commitEnact(Transaction txn) ;
+    /** 
+     *  The commit has happened
+     */
+    public void committed(Transaction txn) ;
+
+    /** Update the base data - called during journal flush. */ 
+    public void enactCommitted(Transaction txn) ;
     
-    /** All done - transaction committed and incorporated in the base dataset - can now tidy up */
-    public void commitClearup(Transaction txn) ;
+    /**
+     * All done - transaction committed and incorporated in the base dataset - can now
+     * tidy up - called during journal flush if commiting.
+     */
+    public void clearupCommitted(Transaction txn) ;
 }

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTrans.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTrans.java
@@ -108,9 +108,9 @@ public abstract class AbstractTestObjectFileTrans extends BaseTest
         file.begin(txn) ; 
         //contains(file2) ;
         file.commitPrepare(txn) ;
-        file.commitEnact(txn) ;
+        file.enactCommitted(txn) ;
         contains(file1, "ABC") ;
-        file.commitClearup(txn) ;
+        file.clearupCommitted(txn) ;
     }
 
     @Test public void objFileTrans_03()
@@ -120,9 +120,9 @@ public abstract class AbstractTestObjectFileTrans extends BaseTest
         file.begin(txn) ; 
         write(file, "X") ;
         file.commitPrepare(txn) ;
-        file.commitEnact(txn) ;
+        file.enactCommitted(txn) ;
         contains(file1, "ABC", "X") ;
-        file.commitClearup(txn) ;
+        file.clearupCommitted(txn) ;
     }
 
     @Test public void objFileTrans_04()
@@ -132,9 +132,9 @@ public abstract class AbstractTestObjectFileTrans extends BaseTest
         file.begin(txn) ; 
         write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
         file.commitPrepare(txn) ;
-        file.commitEnact(txn) ;
+        file.enactCommitted(txn) ;
         contains(file1, "ABC", "ABC", "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
-        file.commitClearup(txn) ;
+        file.clearupCommitted(txn) ;
     }
 
     @Test public void objFileTrans_05()
@@ -145,7 +145,7 @@ public abstract class AbstractTestObjectFileTrans extends BaseTest
         write(file, "ABCDEF") ;
         file.abort(txn) ;
         contains(file1, "ABC") ;
-        file.commitClearup(txn) ;
+        file.clearupCommitted(txn) ;
     }
 
     @Test public void objFileTrans_06()

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTransComplex.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTransComplex.java
@@ -107,9 +107,9 @@ public abstract class AbstractTestObjectFileTransComplex extends BaseTest
         // Test empty. 
         contains(file2) ;
         file.commitPrepare(txn) ;
-        file.commitEnact(txn) ;
+        file.enactCommitted(txn) ;
         contains(file1, "ABC") ;
-        file.commitClearup(txn) ;
+        file.clearupCommitted(txn) ;
     }
 
     @Test public void objFileTrans_03()
@@ -119,9 +119,9 @@ public abstract class AbstractTestObjectFileTransComplex extends BaseTest
         file.begin(txn) ; 
         write(file, "X") ;
         file.commitPrepare(txn) ;
-        file.commitEnact(txn) ;
+        file.enactCommitted(txn) ;
         contains(file1, "ABC", "X") ;
-        file.commitClearup(txn) ;
+        file.clearupCommitted(txn) ;
     }
 
     @Test public void objFileTrans_04()
@@ -131,9 +131,9 @@ public abstract class AbstractTestObjectFileTransComplex extends BaseTest
         file.begin(txn) ; 
         write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
         file.commitPrepare(txn) ;
-        file.commitEnact(txn) ;
+        file.enactCommitted(txn) ;
         contains(file1, "ABC", "ABC", "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
-        file.commitClearup(txn) ;
+        file.clearupCommitted(txn) ;
     }
 
     @Test public void objFileTrans_05()
@@ -144,7 +144,7 @@ public abstract class AbstractTestObjectFileTransComplex extends BaseTest
         write(file, "ABCDEF") ;
         file.abort(txn) ;
         contains(file1, "ABC") ;
-        file.commitClearup(txn) ;
+        file.clearupCommitted(txn) ;
     }
 
     @Test public void objFileTrans_06()

--- a/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
@@ -21,11 +21,18 @@ package org.apache.jena.query.text ;
 import java.util.Iterator ;
 import java.util.List ;
 
+import org.apache.jena.dboe.transaction.txn.ComponentId;
+import org.apache.jena.dboe.transaction.txn.TransactionCoordinator;
+import org.apache.jena.dboe.transaction.txn.TransactionalComponent;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.query.ReadWrite ;
 import org.apache.jena.query.TxnType;
-import org.apache.jena.sparql.core.* ;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphMonitor;
+import org.apache.jena.sparql.core.GraphView;
+import org.apache.jena.sparql.core.Transactional;
+import org.apache.jena.tdb.transaction.TransactionManager;
 import org.apache.lucene.queryparser.classic.QueryParserBase ;
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
@@ -37,25 +44,65 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
     private final Graph         dftGraph ;
     private final boolean       closeIndexOnClose;
     // Lock needed for commit/abort that perform an index operation and a dataset operation
-    // which need it happen without a W thread coming in between them.
-    // JENA-1302.
+    // when the underlying datsetGraph does not coordinate the commit.
     private final Object        txnExitLock = new Object();
     
     // If we are going to implement Transactional, then we are going to have to do as DatasetGraphWithLock and
     // TDB's DatasetGraphTransaction do and track transaction state in a ThreadLocal
     private final ThreadLocal<ReadWrite> readWriteMode = new ThreadLocal<>();
     
-    public DatasetGraphText(DatasetGraph dsg, TextIndex index, TextDocProducer producer)
-    { 
+    private Runnable delegateCommit = ()-> {
+        super.commit();
+    };
+    
+    private Runnable delegateAbort = ()-> {
+        super.abort();
+    };
+    
+    private Runnable nonDelegatedCommit = ()-> {
+        if (readWriteMode.get() == ReadWrite.WRITE)
+            commit_W();
+        else
+            commit_R();
+    };
+    
+    private Runnable nonDelegatedAbort = ()-> {
+        if (readWriteMode.get() == ReadWrite.WRITE)
+            abort_W();
+        else
+            abort_R();
+    };
+
+    private Runnable commitAction = null;
+    private Runnable abortAction = null;
+    
+    public DatasetGraphText(DatasetGraph dsg, TextIndex index, TextDocProducer producer) {
         this(dsg, index, producer, false);
     }
-    
-    public DatasetGraphText(DatasetGraph dsg, TextIndex index, TextDocProducer producer, boolean closeIndexOnClose)
-    {
+
+    public DatasetGraphText(DatasetGraph dsg, TextIndex index, TextDocProducer producer, boolean closeIndexOnClose) {
         super(dsg, producer) ;
         this.textIndex = index ;
         dftGraph = GraphView.createDefaultGraph(this) ;
         this.closeIndexOnClose = closeIndexOnClose;
+        
+        if ( org.apache.jena.tdb.sys.TDBInternal.isTDB1(dsg) ) {
+            TransactionManager txnMgr = org.apache.jena.tdb.sys.TDBInternal.getTransactionManager(dsg);
+            txnMgr.addAdditionComponent(new TextIndexTDB1(textIndex));
+            commitAction = delegateCommit;
+            abortAction = delegateAbort;
+        } else if ( org.apache.jena.tdb2.sys.TDBInternal.isTDB2(dsg) ) {
+            TransactionCoordinator coord = org.apache.jena.tdb2.sys.TDBInternal.getTransactionCoordinator(dsg);
+            // Does not overlap with the ids used by TDB2.
+            byte[] componentID = { 2,4,6,10 } ;
+            TransactionalComponent tc = new TextIndexDB(ComponentId.create(null, componentID), textIndex);
+            coord.modify(()->coord.add(tc));
+            commitAction = delegateCommit;
+            abortAction = delegateAbort;
+        } else {
+            commitAction = nonDelegatedCommit;
+            abortAction = nonDelegatedAbort;
+        }
     }
 
     // ---- Intercept these and force the use of views.
@@ -128,48 +175,27 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
         super.getMonitor().start() ;
     }
     
-    // JENA-1302 :: txnExitLock
-    // We need to 
-    //   textIndex.prepareCommit();
-    //   super.commit();
-    //   textIndex.commit();
-    // without another thread getting in.
-    
-    // Concurrency control most of the time is because we use the transaction
-    // capability of the wrapped dataset but here we need to do an action before
-    // wrapped dataset commit and also an action after.
-    // 
-    // At the point of super.commit, it let in a new writer in begin() which
-    // races to commit before text index commit.
-    //
-    // txnExitLock extends the time of exclusive access.    
-    
-    /**
-     * Perform a 2-phase commit by first calling prepareCommit() on the TextIndex
-     * followed by committing the Transaction object, and then calling commit()
-     * on the TextIndex().
-     * <p> 
-     * If either of the objects fail on either the preparation or actual commit,
-     * it terminates and calls {@link #abort()} on both of them.
-     * <p>
-     * <b>NOTE:</b> it may happen that the TextIndex fails to commit, after the
-     * Transactional has already successfully committed.  A rollback instruction will
-     * still be issued, but depending on the implementation, it may not have any effect.
-     */
     @Override
     public void commit() {
-        if (readWriteMode.get() == ReadWrite.WRITE)
-            commit_W();
-        else
-            commit_R();
+        super.getMonitor().finish() ;
+        commitAction.run();
+        readWriteMode.set(null);
     }
     
     
+    /**
+     * Rollback all changes, discarding any exceptions that occur.
+     */
+    @Override
+    public void abort() {
+        super.getMonitor().finish() ;
+        abortAction.run();
+        readWriteMode.set(null);
+    }
+
     private void commit_R() {
         // No index action needed.
-        super.getMonitor().finish() ;
         super.commit();
-        readWriteMode.set(null);
     }
 
     private void commit_W() {
@@ -185,6 +211,38 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
             
             // Phase 2
             try {
+                // JENA-1302: This needs the exclusive lock for flushing the queue.
+                // TDB1
+                // Thread 1(W) is running, holds the exclusivitylock=R
+                
+                // Thread 2(W) starts, tries to commit
+                //   Takes txnExitLock
+                //   Calls super.commit
+                //     Find an excessive flush queue.
+                //     It tries to TransactionManger.exclusiveFlushQueue
+                //       This needs exclusivitylock=W
+                //       So Thread 2 blocks, waiting for thread 1
+                //       but still holds txnExitLock
+                //
+                // Thread 1 tries to commit. 
+                //   Can't take the txnExitLock because of thread 2.
+                //
+                // ==> Deadlock.
+                // Fix:
+                //   Put index commit into TDB TransactionLifecycle.
+                //   No txnExitLock.
+                
+                // Doing a non-blocking exclusive attempt in TransactionManger.exclusiveFlushQueue
+                // does not help - we are in a situation where the queue is growing and unflushable
+                // which is why we entered emergency measures. Eventually, RAM will run out as well as
+                // the system becoming slow due to Journal layers. 
+                
+                // TDB2
+                //   All work takes place on the W commiting thread.
+                //   There is no pause point so this can't happen.
+                //     txnExitLock isn't needed, the overall TDB2 transaction 
+                //     means W is unique and all work happens without any potential blocking.
+                
                 super.commit();
                 textIndex.commit();
             }
@@ -193,35 +251,19 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
                 abort();
                 throw new TextIndexException(t);
             }
-            readWriteMode.set(null);
         }
     }
 
-    /**
-     * Rollback all changes, discarding any exceptions that occur.
-     */
-    @Override
-    public void abort() {
-        if (readWriteMode.get() == ReadWrite.WRITE)
-            abort_W();
-        else
-            abort_R();
-    }
-    
     private void abort_R() {
-        super.getMonitor().finish() ;
         try { super.abort() ; }
         catch (Throwable t) { log.warn("Exception in abort: " + t.getMessage(), t); }
-        readWriteMode.set(null) ;
     }
     
     private void abort_W() {
         synchronized(txnExitLock) {
-            super.getMonitor().finish() ;
             // Roll back on both objects, discarding any exceptions that occur
             try { super.abort(); } catch (Throwable t) { log.warn("Exception in abort: " + t.getMessage(), t); }
             try { textIndex.rollback(); } catch (Throwable t) { log.warn("Exception in abort: " + t.getMessage(), t); }
-            readWriteMode.set(null) ;
         }
     }
 
@@ -239,7 +281,7 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
         if (readWriteMode.get() == ReadWrite.WRITE) {
             // If we are still in a write transaction at this point, then commit
             // was never called, so rollback the TextIndex and the dataset.
-            abort();
+            abortAction.run();
         }
         super.end() ;
         super.getMonitor().finish() ;

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexDB.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexDB.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text;
+
+import java.nio.ByteBuffer;
+
+import org.apache.jena.dboe.transaction.txn.ComponentId;
+import org.apache.jena.dboe.transaction.txn.TransactionalComponentBase;
+import org.apache.jena.dboe.transaction.txn.TxnId;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.text.TextIndex;
+
+/** 
+ * Adapter to put Lucene into DBOE transactions.
+ */
+public class TextIndexDB extends TransactionalComponentBase<TextIndexDB.TextState> {
+
+    private final TextIndex textIndex;
+
+    public TextIndexDB(ComponentId id, TextIndex textIndex) {
+        super(id);
+        this.textIndex = textIndex;
+    }
+
+    static class TextState {}
+
+    @Override
+    protected TextState _begin(ReadWrite readWrite, TxnId txnId) {
+        // Need to MRSW?
+        return new TextState();
+    }
+    
+//    @Override
+//    protected TextState _promote(TxnId txnId, TextState oldState) {
+//        return null;
+//    }
+//
+    @Override
+    protected ByteBuffer _commitPrepare(TxnId txnId, TextState state) {
+        textIndex.prepareCommit();
+        return null;
+    }
+
+    // Check.
+    @Override
+    protected void _commit(TxnId txnId, TextState state) {
+        textIndex.commit();
+    }
+
+    @Override
+    protected void _commitEnd(TxnId txnId, TextState state) {}
+
+    @Override
+    protected void _abort(TxnId txnId, TextState state) {
+        textIndex.rollback();
+    }
+//
+//    @Override
+//    protected void _complete(TxnId txnId, TextState state) {}
+//
+//    @Override
+//    protected void _shutdown() {}
+    
+}

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexTDB1.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexTDB1.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text;
+
+import org.apache.jena.query.text.TextIndex;
+import org.apache.jena.tdb.transaction.Transaction;
+import org.apache.jena.tdb.transaction.TransactionLifecycle;
+
+/*&
+ * Adapter to put Lucene text indexes into the TDB1 trsnaction system.
+ */
+public class TextIndexTDB1 implements TransactionLifecycle {
+
+    private final TextIndex textIndex;
+
+    public TextIndexTDB1(TextIndex textIndex) {
+        this.textIndex = textIndex;
+    }
+    
+    @Override
+    public void begin(Transaction txn) {
+    }
+
+    @Override
+    public void abort(Transaction txn) {
+        textIndex.rollback();
+    }
+
+    @Override
+    public void commitPrepare(Transaction txn) {
+        textIndex.prepareCommit();
+        textIndex.commit();
+    }
+
+    @Override
+    public void committed(Transaction txn) { }
+
+    @Override
+    public void enactCommitted(Transaction txn) {}
+
+    @Override
+    public void clearupCommitted(Transaction txn) {}
+    
+}

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -28,6 +28,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+
     TestBuildTextDataset.class
     , TestDatasetWithLuceneTextIndex.class
     , TestDatasetWithLuceneMultilingualTextIndex.class
@@ -35,10 +36,15 @@ import org.junit.runners.Suite.SuiteClasses;
     , TestDatasetWithLuceneGraphTextIndex.class
     , TestDatasetWithLuceneTextIndexDeletionSupport.class
     , TestDatasetWithLuceneStoredLiterals.class
+    
+    , TestTextNonTxn.class
+    , TestTextTxn.class
+    , TestTextNonTxnTDB1.class
+    , TestTextTxnTDB.class
+
     , TestEntityMapAssembler.class
     , TestTextDatasetAssembler.class
     , TestTextIndexLuceneAssembler.class
-    , TestTextTDB.class
     , TestDatasetWithSimpleAnalyzer.class
     , TestDatasetWithStandardAnalyzer.class
     , TestDatasetWithKeywordAnalyzer.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxn.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxn.java
@@ -18,28 +18,52 @@
 
 package org.apache.jena.query.text;
 
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
+import org.apache.jena.atlas.lib.Creator;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.* ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.sse.SSE ;
-import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.TDBFactory ;
 import org.apache.jena.vocabulary.RDFS ;
 import org.apache.lucene.store.Directory ;
 import org.apache.lucene.store.RAMDirectory ;
 import org.junit.Test ;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
-public class TestTextTDB extends BaseTest
+/** Test using various dataset implmentations without transactions
+ *  No context-set union graph usage either.
+ */  
+@RunWith(Parameterized.class)
+public class TestTextNonTxn
 {
-    private static Dataset create() {
-        Dataset ds1 = TDBFactory.createDataset() ;
+    @Parameters(name = "{index}: {0}")
+    public static Collection<Object[]>  data() {
+        Creator<Dataset> plainFactory = ()->DatasetFactory.create();
+        Creator<Dataset> timFactory = ()->DatasetFactory.createTxnMem();
+        Creator<Dataset> tdb1Factory = ()->TDBFactory.createDataset();
+        // TDB2 does not work with these, non transactional, tests.
+        return Arrays.asList( new Object[][]{
+            { "Plain", plainFactory , false } ,
+            { "TIM",  timFactory , false } ,
+            { "TDB1", tdb1Factory , true }
+            // TDB2 requires transactions.
+        });
+    }
+    private Dataset create() {
+        Dataset ds1 = factory.create();
         Directory dir = new RAMDirectory() ;
         EntityDefinition eDef = new EntityDefinition("iri", "text");
         eDef.setPrimaryPredicate(RDFS.label);
@@ -47,97 +71,44 @@ public class TestTextTDB extends BaseTest
         Dataset ds = TextDatasetFactory.create(ds1, tidx) ;
         return ds ;
     }
+    
+    private final Creator<Dataset> factory;
+    private final boolean dsFrom;
+    
+    public TestTextNonTxn(String name, Creator<Dataset> factory, Boolean dsFrom) {
+        this.factory = factory;
+        // Does FROM work by pulling graphs from the dataset?
+        this.dsFrom = dsFrom;
+    }
 
-    @Test public void textDB_1() {
-        // Check the union graph stil works  
-        Dataset ds = create() ;
-        ds.getContext().set(TDB.symUnionDefaultGraph, true) ;
-        Quad quad = SSE.parseQuad("(<g> <p> rdfs:label 'foo')") ;
-        ds.asDatasetGraph().add(quad) ;
-        Query q = QueryFactory.create("SELECT * { ?s ?p ?o }") ;
-        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
-        ResultSet rs = qexec.execSelect() ;
-        List<QuerySolution> x = Iter.toList(rs) ;
-        assertEquals(1,x.size());
-    }
-    
-    @Test public void textDB_2() {
-        // Check text query and union graph
-        Dataset ds = create() ;
-        ds.getContext().set(TDB.symUnionDefaultGraph, true) ;
-        Quad quad = SSE.parseQuad("(<g> <s> rdfs:label 'foo')") ;
-        ds.asDatasetGraph().add(quad) ;
-        
-        String qs = StrUtils.strjoinNL("PREFIX text: <http://jena.apache.org/text#>",
-                                       "PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>",
-                                       "SELECT *",
-                                       "{ ?s text:query 'foo' ;",
-                                       "     rdfs:label 'foo'",
-                                       "}"
-                                       ) ;
-        Query q = QueryFactory.create(qs) ;
-        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
-        ResultSet rs = qexec.execSelect() ;
-        List<QuerySolution> x = Iter.toList(rs) ;
-        assertEquals(1,x.size());
-    }
-    
-    @Test public void textDB_3() {
-        Dataset ds = create() ;
-        ds.getContext().set(TDB.symUnionDefaultGraph, true) ;
-        data(ds, 
-             "(<ex:g1> <s1> rdfs:label 'foo')",
-             "(<ex:g2> <s2> rdfs:label 'bar')") ;
-
-        ds.begin(ReadWrite.READ) ;
-        String qs = StrUtils.strjoinNL(
-            "PREFIX text: <http://jena.apache.org/text#>",
-            "PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>",
-            "SELECT *",
-            "{ ?s text:query 'foo' ;",
-            "     rdfs:label 'foo'",
-            "}"
-            ) ;
-        
-        Query q = QueryFactory.create(qs) ;
-        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
-        ResultSet rs = qexec.execSelect() ;
-        List<QuerySolution> x = Iter.toList(rs) ;
-        ds.end() ;
-        assertEquals(1,x.size());
-    }
-    
-    @Test public void textDB_4() {
+    @Test public void textNonTxn_from_named_graph_1() {
+        assumeTrue(dsFrom);
         Dataset ds = create() ;
         data(ds, 
              "(<ex:g1> <s1> rdfs:label 'foo')",
              "(<ex:g1> <s2> rdfs:label 'apple')",
              "(<ex:g2> <s3> rdfs:label 'bar')") ;
-        
-        ds.begin(ReadWrite.READ) ;
         String qs = StrUtils.strjoinNL(
             "PREFIX text:   <http://jena.apache.org/text#>",
             "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
             "SELECT *",
             "FROM <ex:g1>",
-            "{ ?s text:query 'foo' . ?s rdfs:label ?o }"
+            "{  ?s text:query 'foo*' . ?s rdfs:label ?o }"
             ) ;
         Query q = QueryFactory.create(qs) ;
         QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
         ResultSet rs = qexec.execSelect() ;
         List<QuerySolution> x = Iter.toList(rs) ;
-        ds.end() ;
         assertEquals(1,x.size());
     }
 
-    @Test public void textDB_5() {
+    @Test public void textNonTxn_from_union_graph() {
+        assumeTrue(dsFrom);
         Dataset ds = create() ;
         data(ds, 
              "(<ex:g1> <s1> rdfs:label 'foo')",
              "(<ex:g1> <s2> rdfs:label 'apple')",
              "(<ex:g2> <s3> rdfs:label 'food')") ;
-        
-        ds.begin(ReadWrite.READ) ;
         String qs = StrUtils.strjoinNL(
             "PREFIX text:   <http://jena.apache.org/text#>",
             "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
@@ -149,18 +120,15 @@ public class TestTextTDB extends BaseTest
         QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
         ResultSet rs = qexec.execSelect() ;
         List<QuerySolution> x = Iter.toList(rs) ;
-        ds.end() ;
         assertEquals(2,x.size());
     }
 
-    @Test public void textDB_6() {
+    @Test public void textNonTxn_graph_union_graph() {
         Dataset ds = create() ;
         data(ds, 
              "(<ex:g1> <s1> rdfs:label 'foo')",
              "(<ex:g1> <s2> rdfs:label 'apple')",
              "(<ex:g2> <s3> rdfs:label 'food')") ;
-        
-        ds.begin(ReadWrite.READ) ;
         String qs = StrUtils.strjoinNL(
             "PREFIX text:   <http://jena.apache.org/text#>",
             "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
@@ -173,7 +141,6 @@ public class TestTextTDB extends BaseTest
         QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
         ResultSet rs = qexec.execSelect() ;
         List<QuerySolution> x = Iter.toList(rs) ;
-        ds.end() ;
         assertEquals(2,x.size());
     }
     
@@ -186,20 +153,16 @@ public class TestTextTDB extends BaseTest
             "(<ex:g1> <s2> rdf:type <http://example.org/Entity>)",
             "(<ex:g2> <s3> rdfs:label 'food')",
             "(<ex:g2> <s3> rdf:type <http://example.org/Entity>)");
-        
-        ds.begin(ReadWrite.READ) ;
         String qs = StrUtils.strjoinNL(
             "PREFIX text:   <http://jena.apache.org/text#>",
             "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
             "SELECT *",
-            "FROM <ex:g1>",
-            "{ ?s a <http://example.org/Entity> . ?s text:query 'foo' }"
+            "{ GRAPH ?g { ?s a <http://example.org/Entity> . ?s text:query 'foo' } }"
             ) ;
         Query q = QueryFactory.create(qs) ;
         QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
         ResultSet rs = qexec.execSelect() ;
         List<QuerySolution> x = Iter.toList(rs) ;
-        ds.end() ;
         assertEquals(1,x.size());
     }
 
@@ -211,8 +174,6 @@ public class TestTextTDB extends BaseTest
                 "[] a <http://example.org/Entity>; rdfs:label 'foo' ."
             )
         );
-        
-        ds.begin(ReadWrite.READ) ;
         String qs = StrUtils.strjoinNL(
             "PREFIX text:   <http://jena.apache.org/text#>",
             "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
@@ -223,7 +184,6 @@ public class TestTextTDB extends BaseTest
         QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
         ResultSet rs = qexec.execSelect() ;
         List<QuerySolution> x = Iter.toList(rs) ;
-        ds.end() ;
         assertEquals(1,x.size());
     }
 
@@ -235,8 +195,6 @@ public class TestTextTDB extends BaseTest
                 "[] a <http://example.org/Entity>; rdfs:label 'foo' ."
             )
         );
-        
-        ds.begin(ReadWrite.READ) ;
         String qs = StrUtils.strjoinNL(
             "PREFIX text:   <http://jena.apache.org/text#>",
             "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
@@ -247,7 +205,6 @@ public class TestTextTDB extends BaseTest
         QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
         ResultSet rs = qexec.execSelect() ;
         List<QuerySolution> x = Iter.toList(rs) ;
-        ds.end() ;
         assertEquals(1,x.size());
     }
 
@@ -261,12 +218,7 @@ public class TestTextTDB extends BaseTest
     private static void dataTurtle(Dataset ds, String turtle) {
         Model model = ds.getDefaultModel();
         Reader reader = new StringReader(turtle);
-        ds.begin(ReadWrite.WRITE);
         model.read(reader, "", "TURTLE");
-        ds.commit();
     }
-    
-    // With transactions
-    // With FROM and FROM NAMED + TDB
 }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxnTDB1.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxnTDB1.java
@@ -1,0 +1,273 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.List ;
+
+import org.apache.jena.atlas.iterator.Iter ;
+import org.apache.jena.atlas.junit.BaseTest ;
+import org.apache.jena.atlas.lib.StrUtils ;
+import org.apache.jena.query.* ;
+import org.apache.jena.rdf.model.Model ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.tdb.TDB ;
+import org.apache.jena.tdb.TDBFactory ;
+import org.apache.jena.vocabulary.RDFS ;
+import org.apache.lucene.store.Directory ;
+import org.apache.lucene.store.RAMDirectory ;
+import org.junit.Test ;
+
+/** Text dataset tests using TDB1 non-transactionally, including context unionDefaultGraph */
+public class TestTextNonTxnTDB1 extends BaseTest
+{
+    private static Dataset create() {
+        Dataset ds1 = TDBFactory.createDataset() ;
+        Directory dir = new RAMDirectory() ;
+        EntityDefinition eDef = new EntityDefinition("iri", "text");
+        eDef.setPrimaryPredicate(RDFS.label);
+        TextIndex tidx = new TextIndexLucene(dir, new TextIndexConfig(eDef)) ;
+        Dataset ds = TextDatasetFactory.create(ds1, tidx) ;
+        return ds ;
+    }
+
+    @Test public void textTDB1_1() {
+        // Check the union graph stil works  
+        Dataset ds = create() ;
+        ds.getContext().set(TDB.symUnionDefaultGraph, true) ;
+        Quad quad = SSE.parseQuad("(<g> <p> rdfs:label 'foo')") ;
+        ds.asDatasetGraph().add(quad) ;
+        Query q = QueryFactory.create("SELECT * { ?s ?p ?o }") ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        assertEquals(1,x.size());
+    }
+    
+    @Test public void textTDB1_2() {
+        // Check text query and union graph
+        Dataset ds = create() ;
+        ds.getContext().set(TDB.symUnionDefaultGraph, true) ;
+        Quad quad = SSE.parseQuad("(<g> <s> rdfs:label 'foo')") ;
+        ds.asDatasetGraph().add(quad) ;
+        
+        String qs = StrUtils.strjoinNL("PREFIX text: <http://jena.apache.org/text#>",
+                                       "PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>",
+                                       "SELECT *",
+                                       "{ ?s text:query 'foo' ;",
+                                       "     rdfs:label 'foo'",
+                                       "}"
+                                       ) ;
+        Query q = QueryFactory.create(qs) ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        assertEquals(1,x.size());
+    }
+    
+    @Test public void textTDB1_3() {
+        Dataset ds = create() ;
+        ds.getContext().set(TDB.symUnionDefaultGraph, true) ;
+        data(ds, 
+             "(<ex:g1> <s1> rdfs:label 'foo')",
+             "(<ex:g2> <s2> rdfs:label 'bar')") ;
+
+        ds.begin(ReadWrite.READ) ;
+        String qs = StrUtils.strjoinNL(
+            "PREFIX text: <http://jena.apache.org/text#>",
+            "PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>",
+            "SELECT *",
+            "{ ?s text:query 'foo' ;",
+            "     rdfs:label 'foo'",
+            "}"
+            ) ;
+        
+        Query q = QueryFactory.create(qs) ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        ds.end() ;
+        assertEquals(1,x.size());
+    }
+    
+    @Test public void textTDB1_4() {
+        Dataset ds = create() ;
+        data(ds, 
+             "(<ex:g1> <s1> rdfs:label 'foo')",
+             "(<ex:g1> <s2> rdfs:label 'apple')",
+             "(<ex:g2> <s3> rdfs:label 'bar')") ;
+        
+        ds.begin(ReadWrite.READ) ;
+        String qs = StrUtils.strjoinNL(
+            "PREFIX text:   <http://jena.apache.org/text#>",
+            "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+            "SELECT *",
+            "FROM <ex:g1>",
+            "{ ?s text:query 'foo' . ?s rdfs:label ?o }"
+            ) ;
+        Query q = QueryFactory.create(qs) ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        ds.end() ;
+        assertEquals(1,x.size());
+    }
+
+    @Test public void textTDB1_5() {
+        Dataset ds = create() ;
+        data(ds, 
+             "(<ex:g1> <s1> rdfs:label 'foo')",
+             "(<ex:g1> <s2> rdfs:label 'apple')",
+             "(<ex:g2> <s3> rdfs:label 'food')") ;
+        
+        ds.begin(ReadWrite.READ) ;
+        String qs = StrUtils.strjoinNL(
+            "PREFIX text:   <http://jena.apache.org/text#>",
+            "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+            "SELECT *",
+            "FROM <"+Quad.unionGraph+">",
+            "{ ?s text:query 'foo*' . ?s rdfs:label ?o }"
+            ) ;
+        Query q = QueryFactory.create(qs) ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        ds.end() ;
+        assertEquals(2,x.size());
+    }
+
+    @Test public void textTDB1_6() {
+        Dataset ds = create() ;
+        data(ds, 
+             "(<ex:g1> <s1> rdfs:label 'foo')",
+             "(<ex:g1> <s2> rdfs:label 'apple')",
+             "(<ex:g2> <s3> rdfs:label 'food')") ;
+        
+        ds.begin(ReadWrite.READ) ;
+        String qs = StrUtils.strjoinNL(
+            "PREFIX text:   <http://jena.apache.org/text#>",
+            "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+            "SELECT *",
+            "{ GRAPH <"+Quad.unionGraph+">",
+            "    { ?s text:query 'foo*' . ?s rdfs:label ?o }",
+            "}"
+            ) ;
+        Query q = QueryFactory.create(qs) ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        ds.end() ;
+        assertEquals(2,x.size());
+    }
+    
+    @Test public void textTDB1_7_subject_bound_first() {
+        Dataset ds = create() ;
+        data(ds, 
+            "(<ex:g1> <s1> rdfs:label 'foo')",
+            "(<ex:g1> <s1> rdf:type <http://example.org/Entity>)",
+            "(<ex:g1> <s2> rdfs:label 'apple')",
+            "(<ex:g1> <s2> rdf:type <http://example.org/Entity>)",
+            "(<ex:g2> <s3> rdfs:label 'food')",
+            "(<ex:g2> <s3> rdf:type <http://example.org/Entity>)");
+        
+        ds.begin(ReadWrite.READ) ;
+        String qs = StrUtils.strjoinNL(
+            "PREFIX text:   <http://jena.apache.org/text#>",
+            "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+            "SELECT *",
+            "FROM <ex:g1>",
+            "{ ?s a <http://example.org/Entity> . ?s text:query 'foo' }"
+            ) ;
+        Query q = QueryFactory.create(qs) ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        ds.end() ;
+        assertEquals(1,x.size());
+    }
+
+    @Test public void textTDB1_8_bnode_subject() {
+        Dataset ds = create() ;
+        dataTurtle(ds,
+            StrUtils.strjoinNL(
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "[] a <http://example.org/Entity>; rdfs:label 'foo' ."
+            )
+        );
+        
+        ds.begin(ReadWrite.READ) ;
+        String qs = StrUtils.strjoinNL(
+            "PREFIX text:   <http://jena.apache.org/text#>",
+            "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+            "SELECT *",
+            "{ ?s text:query 'foo' . ?s a <http://example.org/Entity> }"
+            ) ;
+        Query q = QueryFactory.create(qs) ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        ds.end() ;
+        assertEquals(1,x.size());
+    }
+
+    @Test public void textTDB1_9_bnode_subject_bound_first() {
+        Dataset ds = create() ;
+        dataTurtle(ds,
+            StrUtils.strjoinNL(
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "[] a <http://example.org/Entity>; rdfs:label 'foo' ."
+            )
+        );
+        
+        ds.begin(ReadWrite.READ) ;
+        String qs = StrUtils.strjoinNL(
+            "PREFIX text:   <http://jena.apache.org/text#>",
+            "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+            "SELECT *",
+            "{ ?s a <http://example.org/Entity> . ?s text:query 'foo' }"
+            ) ;
+        Query q = QueryFactory.create(qs) ;
+        QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+        ResultSet rs = qexec.execSelect() ;
+        List<QuerySolution> x = Iter.toList(rs) ;
+        ds.end() ;
+        assertEquals(1,x.size());
+    }
+
+    private static void data(Dataset ds, String... quadStrs) {
+        for ( String qs : quadStrs ) {
+            Quad quad = SSE.parseQuad(qs) ;
+            ds.asDatasetGraph().add(quad) ;
+        }
+    }
+
+    private static void dataTurtle(Dataset ds, String turtle) {
+        Model model = ds.getDefaultModel();
+        Reader reader = new StringReader(turtle);
+        ds.begin(ReadWrite.WRITE);
+        model.read(reader, "", "TURTLE");
+        ds.commit();
+    }
+    
+    // With transactions
+    // With FROM and FROM NAMED + TDB
+}
+

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextTxn.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextTxn.java
@@ -1,0 +1,341 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List ;
+
+import org.apache.jena.atlas.iterator.Iter ;
+import org.apache.jena.atlas.lib.Creator;
+import org.apache.jena.atlas.lib.StrUtils ;
+import org.apache.jena.query.* ;
+import org.apache.jena.rdf.model.Model ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.system.Txn;
+import org.apache.jena.tdb.TDBFactory ;
+import org.apache.jena.tdb2.TDB2Factory;
+import org.apache.jena.vocabulary.RDFS ;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.store.Directory ;
+import org.apache.lucene.store.RAMDirectory ;
+import org.junit.Test ;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Text dataset tests using datasets transactionally, named unionDefaultGraph.
+ * <p>
+ * Note that in Lucene, writes are not visible to a reader of the {@code Directory}
+ * until committed. A special {@link IndexReader} is needed. See
+ * {@link DirectoryReader#open(IndexWriter)}. jena-text does not currentyl do this.
+ * <p>
+ * When used outside a transaction, writes are "autocommit" (see
+ * {@link TextDocProducerTriples}) and so are visible immediately.
+ * <p>
+ * TDB2 is transactional only. 
+ * <p>Union graph support by context is required for these tests.
+ */
+
+@RunWith(Parameterized.class)
+public class TestTextTxn
+{
+    @Parameters(name = "{index}: {0}")
+    public static Collection<Object[]>  data() {
+        Creator<Dataset> plainFactory = ()->DatasetFactory.create();
+        Creator<Dataset> timFactory = ()->DatasetFactory.createTxnMem();
+        Creator<Dataset> tdb1Factory = ()->TDBFactory.createDataset();
+        Creator<Dataset> tdb2Factory = ()->TDB2Factory.createDataset();
+        return Arrays.asList( new Object[][]{
+            { "Plain", plainFactory, false } ,
+            { "TIM",   timFactory, false } , 
+            { "TDB1", tdb1Factory, true } ,
+            { "TDB2", tdb2Factory, true }
+        });
+    }
+    
+    private final Creator<Dataset> factory;
+    private final Boolean dsFrom;
+
+    public TestTextTxn(String name, Creator<Dataset> factory, Boolean dsFrom) {
+        this.factory = factory;
+        // Does FROM work by pulling graphs from the dataset?
+        this.dsFrom = dsFrom;
+    }
+    
+    private Dataset create() {
+        Dataset ds1 = factory.create();
+        Directory dir = new RAMDirectory() ;
+        EntityDefinition eDef = new EntityDefinition("iri", "text");
+        eDef.setPrimaryPredicate(RDFS.label);
+        TextIndex tidx = new TextIndexLucene(dir, new TextIndexConfig(eDef)) ;
+        Dataset ds = TextDatasetFactory.create(ds1, tidx) ;
+        return ds ;
+    }
+
+    @Test public void textTxn_dftGraph_1() {
+        Dataset ds = create() ;
+        Quad quad = SSE.parseQuad("(_ <p> rdfs:label 'foo')") ;
+        Txn.executeWrite(ds, ()->ds.asDatasetGraph().add(quad));
+        
+        Txn.executeRead(ds, ()->{
+            Query q = QueryFactory.create("SELECT * { ?s ?p ?o }") ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+    
+    @Test public void textTxn_namedGraphplain_1() {
+        Dataset ds = create() ;
+        Quad quad = SSE.parseQuad("(<g> <p> rdfs:label 'foo')") ;
+        Txn.executeWrite(ds, ()->ds.asDatasetGraph().add(quad));
+        
+        Txn.executeRead(ds, ()->{
+            Query q = QueryFactory.create("SELECT * { GRAPH ?g { ?s ?p ?o } }") ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+    
+    @Test public void textTxn_query_1() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            Quad quad = SSE.parseQuad("(_ <s> rdfs:label 'foo')") ;
+            ds.asDatasetGraph().add(quad) ;
+        });
+
+        Txn.executeRead(ds, ()->{
+            String qs = StrUtils.strjoinNL("PREFIX text: <http://jena.apache.org/text#>",
+                "PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ ?s text:query 'foo' ;",
+                "     rdfs:label 'foo'",
+                "}"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+    
+    @Test public void textTxn_query_2() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            data(ds, 
+                "(_ <s1> rdfs:label 'foo')",
+                "(_ <s2> rdfs:label 'bar')") ;
+        });
+        Txn.executeRead(ds, ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text: <http://jena.apache.org/text#>",
+                "PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ ?s text:query 'foo' ;",
+                "     rdfs:label 'foo'",
+                "}"
+                ) ;
+
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+    
+    @Test public void textTxn_from_namedGraph_query_1() {
+        assumeTrue(dsFrom);
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            data(ds, 
+                "(<ex:g1> <s1> rdfs:label 'foo')",
+                "(<ex:g1> <s2> rdfs:label 'apple')",
+                "(<ex:g2> <s3> rdfs:label 'bar')") ;
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "FROM <ex:g1>",
+                "{ ?s text:query 'foo' . ?s rdfs:label ?o }"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+
+    @Test public void textTxn_from_unionGraph() {
+        assumeTrue(dsFrom);
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+        data(ds, 
+             "(<ex:g1> <s1> rdfs:label 'foo')",
+             "(<ex:g1> <s2> rdfs:label 'apple')",
+             "(<ex:g2> <s3> rdfs:label 'food')") ;
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "FROM <"+Quad.unionGraph+">",
+                "{ ?s text:query 'foo*' . ?s rdfs:label ?o }"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+
+            assertEquals(2,x.size());
+        });
+    }
+
+    @Test public void textTxn_graphUnionGraph() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            data(ds, 
+                "(<ex:g1> <s1> rdfs:label 'foo')",
+                "(<ex:g1> <s2> rdfs:label 'apple')",
+                "(<ex:g2> <s3> rdfs:label 'food')") ;
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ GRAPH <"+Quad.unionGraph+">",
+                "    { ?s text:query 'foo*' . ?s rdfs:label ?o }",
+                "}"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(2,x.size());
+        });
+    }
+    
+    @Test public void textTxn_subject_bound_first() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            data(ds, 
+                "(<ex:g1> <s1> rdfs:label 'foo')",
+                "(<ex:g1> <s1> rdf:type <http://example.org/Entity>)",
+                "(<ex:g1> <s2> rdfs:label 'apple')",
+                "(<ex:g1> <s2> rdf:type <http://example.org/Entity>)",
+                "(<ex:g2> <s3> rdfs:label 'food')",
+                "(<ex:g2> <s3> rdf:type <http://example.org/Entity>)");
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ GRAPH ?g { ?s a <http://example.org/Entity> . ?s text:query 'foo' } }"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+
+    @Test public void textTxn_bnode_subject() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            dataTurtle(ds,
+                StrUtils.strjoinNL(
+                    "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                    "[] a <http://example.org/Entity>; rdfs:label 'foo' ."
+                    )
+                );
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ ?s text:query 'foo' . ?s a <http://example.org/Entity> }"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+
+    @Test public void textTxn_bnode_subject_bound_first() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            dataTurtle(ds,
+                StrUtils.strjoinNL(
+                    "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                    "[] a <http://example.org/Entity>; rdfs:label 'foo' ."
+                    )
+                );
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ ?s a <http://example.org/Entity> . ?s text:query 'foo' }"
+                );
+            Query q = QueryFactory.create(qs);
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds);
+            ResultSet rs = qexec.execSelect();
+            List<QuerySolution> x = Iter.toList(rs);
+            assertEquals(1,x.size());
+        });
+    }
+
+    private static void data(Dataset ds, String... quadStrs) {
+        for ( String qs : quadStrs ) {
+            Quad quad = SSE.parseQuad(qs) ;
+            ds.asDatasetGraph().add(quad) ;
+        }
+    }
+
+    private static void dataTurtle(Dataset ds, String turtle) {
+        Model model = ds.getDefaultModel();
+        Reader reader = new StringReader(turtle);
+        model.read(reader, "", "TURTLE");
+    }
+}
+

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextTxnTDB.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextTxnTDB.java
@@ -1,0 +1,329 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List ;
+
+import org.apache.jena.atlas.iterator.Iter ;
+import org.apache.jena.atlas.lib.Creator;
+import org.apache.jena.atlas.lib.StrUtils ;
+import org.apache.jena.query.* ;
+import org.apache.jena.rdf.model.Model ;
+import org.apache.jena.sparql.core.Quad ;
+import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.system.Txn;
+import org.apache.jena.tdb.TDB ;
+import org.apache.jena.tdb.TDBFactory ;
+import org.apache.jena.tdb2.TDB2;
+import org.apache.jena.tdb2.TDB2Factory;
+import org.apache.jena.vocabulary.RDFS ;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.store.Directory ;
+import org.apache.lucene.store.RAMDirectory ;
+import org.junit.Test ;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Text dataset tests using TDB1 and TDB2 transactionally, including context unionDefaultGraph.
+ * <p>
+ * Note that in Lucene, writes are not visible to a reader of the {@code Directory}
+ * until committed. A special {@link IndexReader} is needed. See
+ * {@link DirectoryReader#open(IndexWriter)}. jena-text does not currentyl do this.
+ * <p>
+ * When used outside a transaction, writes are "autocommit" (see
+ * {@link TextDocProducerTriples}) and so are visible immediately.
+ * <p>
+ * TDB2 is transactional only. 
+ * <p>Union graph support by context is required for these tests.
+ */
+
+@RunWith(Parameterized.class)
+public class TestTextTxnTDB
+{
+    @Parameters(name = "{index}: {0}")
+    public static Collection<Object[]>  data() {
+        Creator<Dataset> tdb1Factory = ()->TDBFactory.createDataset();
+        Creator<Dataset> tdb2Factory = ()->TDB2Factory.createDataset();
+        return Arrays.asList( new Object[][]{
+            { "TDB1", tdb1Factory } ,
+            { "TDB2", tdb2Factory }
+        });
+    }
+    
+    private final Creator<Dataset> factory;
+
+    public TestTextTxnTDB(String name, Creator<Dataset> factory) {
+        this.factory = factory;
+    }
+    
+    private Dataset create() {
+        Dataset ds1 = factory.create();
+        Directory dir = new RAMDirectory() ;
+        EntityDefinition eDef = new EntityDefinition("iri", "text");
+        eDef.setPrimaryPredicate(RDFS.label);
+        TextIndex tidx = new TextIndexLucene(dir, new TextIndexConfig(eDef)) ;
+        Dataset ds = TextDatasetFactory.create(ds1, tidx) ;
+        return ds ;
+    }
+
+    @Test public void textTDB_union_1() {
+        // Check the union graph still works  
+        Dataset ds = create() ;
+        ds.getContext().set(TDB.symUnionDefaultGraph, true) ;
+        ds.getContext().set(TDB2.symUnionDefaultGraph, true) ;
+        Quad quad = SSE.parseQuad("(<g> <p> rdfs:label 'foo')") ;
+        Txn.executeWrite(ds, ()->ds.asDatasetGraph().add(quad));
+        
+        Txn.executeRead(ds, ()->{
+            Query q = QueryFactory.create("SELECT * { ?s ?p ?o }") ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+    
+    @Test public void textTDB_union_2() {
+        // Check text query and union graph
+        Dataset ds = create() ;
+        ds.getContext().set(TDB.symUnionDefaultGraph, true) ;
+        ds.getContext().set(TDB2.symUnionDefaultGraph, true) ;
+        Txn.executeWrite(ds, ()->{
+            Quad quad = SSE.parseQuad("(<g> <s> rdfs:label 'foo')") ;
+            ds.asDatasetGraph().add(quad) ;
+        });
+        Txn.executeRead(ds, ()->{
+            String qs = StrUtils.strjoinNL("PREFIX text: <http://jena.apache.org/text#>",
+                "PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ ?s text:query 'foo' ;",
+                "     rdfs:label 'foo'",
+                "}"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+    
+    @Test public void textTDB_3() {
+        Dataset ds = create() ;
+        ds.getContext().set(TDB.symUnionDefaultGraph, true) ;
+        ds.getContext().set(TDB2.symUnionDefaultGraph, true) ;
+        Txn.executeWrite(ds, ()->{
+            data(ds, 
+                "(<ex:g1> <s1> rdfs:label 'foo')",
+                "(<ex:g2> <s2> rdfs:label 'bar')") ;
+        });
+        Txn.executeRead(ds, ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text: <http://jena.apache.org/text#>",
+                "PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ ?s text:query 'foo' ;",
+                "     rdfs:label 'foo'",
+                "}"
+                ) ;
+
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+    
+    @Test public void textTDB_4() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            data(ds, 
+                "(<ex:g1> <s1> rdfs:label 'foo')",
+                "(<ex:g1> <s2> rdfs:label 'apple')",
+                "(<ex:g2> <s3> rdfs:label 'bar')") ;
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "FROM <ex:g1>",
+                "{ ?s text:query 'foo' . ?s rdfs:label ?o }"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+
+    @Test public void textTDB_5() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+        data(ds, 
+             "(<ex:g1> <s1> rdfs:label 'foo')",
+             "(<ex:g1> <s2> rdfs:label 'apple')",
+             "(<ex:g2> <s3> rdfs:label 'food')") ;
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "FROM <"+Quad.unionGraph+">",
+                "{ ?s text:query 'foo*' . ?s rdfs:label ?o }"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+
+            assertEquals(2,x.size());
+        });
+    }
+
+    @Test public void textTDB_6() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            data(ds, 
+                "(<ex:g1> <s1> rdfs:label 'foo')",
+                "(<ex:g1> <s2> rdfs:label 'apple')",
+                "(<ex:g2> <s3> rdfs:label 'food')") ;
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ GRAPH <"+Quad.unionGraph+">",
+                "    { ?s text:query 'foo*' . ?s rdfs:label ?o }",
+                "}"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(2,x.size());
+        });
+    }
+    
+    @Test public void textTDB_7_subject_bound_first() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            data(ds, 
+                "(<ex:g1> <s1> rdfs:label 'foo')",
+                "(<ex:g1> <s1> rdf:type <http://example.org/Entity>)",
+                "(<ex:g1> <s2> rdfs:label 'apple')",
+                "(<ex:g1> <s2> rdf:type <http://example.org/Entity>)",
+                "(<ex:g2> <s3> rdfs:label 'food')",
+                "(<ex:g2> <s3> rdf:type <http://example.org/Entity>)");
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "FROM <ex:g1>",
+                "{ ?s a <http://example.org/Entity> . ?s text:query 'foo' }"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+
+    @Test public void textTDB_8_bnode_subject() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            dataTurtle(ds,
+                StrUtils.strjoinNL(
+                    "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                    "[] a <http://example.org/Entity>; rdfs:label 'foo' ."
+                    )
+                );
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ ?s text:query 'foo' . ?s a <http://example.org/Entity> }"
+                ) ;
+            Query q = QueryFactory.create(qs) ;
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds) ;
+            ResultSet rs = qexec.execSelect() ;
+            List<QuerySolution> x = Iter.toList(rs) ;
+            assertEquals(1,x.size());
+        });
+    }
+
+    @Test public void textTDB_9_bnode_subject_bound_first() {
+        Dataset ds = create() ;
+        Txn.executeWrite(ds, ()->{
+            dataTurtle(ds,
+                StrUtils.strjoinNL(
+                    "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                    "[] a <http://example.org/Entity>; rdfs:label 'foo' ."
+                    )
+                );
+        });
+        Txn.executeRead(ds,  ()->{
+            String qs = StrUtils.strjoinNL(
+                "PREFIX text:   <http://jena.apache.org/text#>",
+                "PREFIX rdfs:   <http://www.w3.org/2000/01/rdf-schema#>",
+                "SELECT *",
+                "{ ?s a <http://example.org/Entity> . ?s text:query 'foo' }"
+                );
+            Query q = QueryFactory.create(qs);
+            QueryExecution qexec = QueryExecutionFactory.create(q, ds);
+            ResultSet rs = qexec.execSelect();
+            List<QuerySolution> x = Iter.toList(rs);
+            assertEquals(1,x.size());
+        });
+    }
+
+    private static void data(Dataset ds, String... quadStrs) {
+        for ( String qs : quadStrs ) {
+            Quad quad = SSE.parseQuad(qs) ;
+            ds.asDatasetGraph().add(quad) ;
+        }
+    }
+
+    private static void dataTurtle(Dataset ds, String turtle) {
+        Model model = ds.getDefaultModel();
+        Reader reader = new StringReader(turtle);
+        model.read(reader, "", "TURTLE");
+    }
+    
+    // With FROM and FROM NAMED + TDB
+}
+


### PR DESCRIPTION
Includes the fix for JENA-1302.

Integrate a lucene text index into the transaction systems for TDB1 and DBOE/TDB2.  This way, the prepare/commit for Lucene happens during database commit and the synchronization dance (JENA-1302) does not happen.

JENA-1302 only effects TDB1, not TDB2. Only TDB1 has a commit queue that can build up under load and need to be flushed, which in turn causes a thread to take the exclusive lock and so cause the JENA-1302 lockup.
Includes the fix for JENA-1302.

Integrate a Lucene text index into the transaction systems for TDB1 and DBOE/TDB2.  This way, the prepare/commit for Lucene happens during database commit and the synchronization dance (JENA-1302) does not happen.

JENA-1302 only effects TDB1, not TDB2 or any other DatasetGraph implementation. Only TDB1 has a commit queue that can build up under load and need to be flushed, which in turn causes a thread to take the exclusive lock and so cause the JENA-1302 lockup.
