### PR TITLE
Escape @xerces.internal annotations

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/Constants.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/Constants.java
@@ -23,7 +23,7 @@ import java.util.NoSuchElementException;
 /**
  * Commonly used constants.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @author Andy Clark, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/DTDDVFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/DTDDVFactory.java
@@ -24,7 +24,7 @@ import java.util.Hashtable;
  * store the created datatypes in static data, so that they can be shared by
  * multiple parser instance, and multiple threads.
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/DVFactoryException.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/DVFactoryException.java
@@ -21,7 +21,7 @@ package org.apache.jena.ext.xerces.impl.dv;
  * A runtime exception that's thrown if an error happens when the application
  * tries to get a DV factory instance.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @version $Id: DVFactoryException.java 446751 2006-09-15 21:54:06Z mrglavas $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/DatatypeException.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/DatatypeException.java
@@ -26,7 +26,7 @@ import java.util.ResourceBundle;
  * (as defined in Appendix C of the structure spec), plus an array of arguments,
  * for error message substitution.
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/DatatypeValidator.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/DatatypeValidator.java
@@ -22,7 +22,7 @@ package org.apache.jena.ext.xerces.impl.dv;
  * The interface that a DTD datatype must implement. The implementation of this
  * interface must be thread-safe.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/InvalidDatatypeFacetException.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/InvalidDatatypeFacetException.java
@@ -21,7 +21,7 @@ package org.apache.jena.ext.xerces.impl.dv;
  * Datatype exception for invalid facet. This exception is only used by
  * schema datatypes.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/InvalidDatatypeValueException.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/InvalidDatatypeValueException.java
@@ -20,7 +20,7 @@ package org.apache.jena.ext.xerces.impl.dv;
 /**
  * Datatype exception for invalid values.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/ObjectFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/ObjectFactory.java
@@ -37,7 +37,7 @@ import java.util.Properties;
  * when bundled as part of the JDK.
  * <p>
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @version $Id: ObjectFactory.java 924307 2010-03-17 14:36:05Z mrglavas $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/SchemaDVFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/SchemaDVFactory.java
@@ -32,7 +32,7 @@ import org.apache.jena.ext.xerces.xs.XSObjectList;
  * The implementation should store the built-in datatypes in static data, so
  * that they can be shared by multiple parser instance, and multiple threads.
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/SecuritySupport.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/SecuritySupport.java
@@ -30,7 +30,7 @@ import java.security.PrivilegedExceptionAction;
  * This class is duplicated for each subpackage so keep it in sync.
  * It is package private and therefore is not exposed as part of any API.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  * 
  * @version $Id: SecuritySupport.java 950361 2010-06-02 04:12:35Z mrglavas $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/ValidatedInfo.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/ValidatedInfo.java
@@ -25,7 +25,7 @@ import org.apache.jena.ext.xerces.xs.*;
  * Class to get the information back after content is validated. This info
  * would be filled by validate().
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/ValidationContext.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/ValidationContext.java
@@ -23,7 +23,7 @@ import java.util.Locale;
  * ValidationContext has all the information required for the
  * validation of: id, idref, entity, notation, qname
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  * @version $Id: ValidationContext.java 713638 2008-11-13 04:42:18Z mrglavas $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/XSFacets.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/XSFacets.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.xs.XSObjectList;
 /**
  * The class used to pass all facets to {@link XSSimpleType#applyFacets}.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/XSSimpleType.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/XSSimpleType.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.xs.XSSimpleTypeDefinition;
  * Any simple type (atomic, list or union) will implement this interface.
  * It inherits from <code>XSTypeDecl</code>.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/util/Base64.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/util/Base64.java
@@ -29,7 +29,7 @@ package org.apache.jena.ext.xerces.impl.dv.util;
  * data. You need the data that you will encode/decode
  * already on a byte arrray.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Jeffrey Rodriguez
  * @author Sandy Gao

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/util/ByteListImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/util/ByteListImpl.java
@@ -25,7 +25,7 @@ import org.apache.jena.ext.xerces.xs.datatypes.ByteList;
 /**
  * Implementation of <code>org.apache.xerces.xs.datatypes.ByteList</code>.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  * 
  * @author Ankit Pasricha, IBM
  * 

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/util/HexBin.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/util/HexBin.java
@@ -22,7 +22,7 @@ package org.apache.jena.ext.xerces.impl.dv.util;
  *
  * This class encodes/decodes hexadecimal data
  * 
- * @xerces.internal  
+ * {@literal @xerces.internal}  
  * 
  * @author Jeffrey Rodriguez
  * @version $Id: HexBin.java 446747 2006-09-15 21:46:20Z mrglavas $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/AbstractDateTimeDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/AbstractDateTimeDV.java
@@ -38,7 +38,7 @@ import org.apache.jena.ext.xerces.xs.datatypes.XSDateTime;
  *          decl object can be used to validate two strings at the same time.
  *          -SG
  *          
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Len Berman

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/AnySimpleDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/AnySimpleDV.java
@@ -23,7 +23,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Represent the schema type "anySimpleType"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/AnyURIDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/AnyURIDV.java
@@ -24,7 +24,7 @@ import org.apache.jena.ext.xerces.util.URI;
 /**
  * Represent the schema type "anyURI"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/Base64BinaryDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/Base64BinaryDV.java
@@ -25,7 +25,7 @@ import org.apache.jena.ext.xerces.impl.dv.util.ByteListImpl;
 /**
  * Represent the schema type "base64Binary"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/BaseDVFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/BaseDVFactory.java
@@ -27,7 +27,7 @@ import org.apache.jena.ext.xerces.xs.XSObjectList;
 /**
  * the factory to create/return built-in schema DVs and create user-defined DVs
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/BaseSchemaDVFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/BaseSchemaDVFactory.java
@@ -28,7 +28,7 @@ import org.apache.jena.ext.xerces.xs.XSObjectList;
 /**
  * the base factory to create/return built-in schema DVs and create user-defined DVs
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/BooleanDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/BooleanDV.java
@@ -23,7 +23,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Represent the schema type "boolean"
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DateDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DateDV.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Validator for <date> datatype (W3C Schema datatypes)
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Gopal Sharma, SUN Microsystems Inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DateTimeDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DateTimeDV.java
@@ -28,7 +28,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Validator for &lt;dateTime&gt; datatype (W3C Schema Datatypes)
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Gopal Sharma, SUN Microsystem Inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DayDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DayDV.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Validator for &lt;gDay&gt; datatype (W3C Schema datatypes)
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Gopal Sharma, SUN Microsystem Inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DayTimeDurationDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DayTimeDurationDV.java
@@ -28,7 +28,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Used to validate the <dayTimeDuration> type
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  * 
  * @author Ankit Pasricha, IBM
  * 

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DecimalDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DecimalDV.java
@@ -27,7 +27,7 @@ import org.apache.jena.ext.xerces.xs.datatypes.XSDecimal;
 /**
  * Represent the schema type "decimal"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DoubleDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DoubleDV.java
@@ -24,7 +24,7 @@ import org.apache.jena.ext.xerces.xs.datatypes.XSDouble;
 /**
  * Represent the schema type "double"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DurationDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/DurationDV.java
@@ -29,7 +29,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Validator for &lt;duration&gt; datatype (W3C Schema Datatypes)
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Gopal Sharma, SUN Microsystem Inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/EntityDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/EntityDV.java
@@ -24,7 +24,7 @@ import org.apache.jena.ext.xerces.util.XMLChar;
 /**
  * Represent the schema type "entity"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/ExtendedSchemaDVFactoryImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/ExtendedSchemaDVFactoryImpl.java
@@ -24,7 +24,7 @@ import org.apache.jena.ext.xerces.util.SymbolHash;
  * A special factory to create/return built-in schema DVs and create user-defined DVs
  * that includes anyAtomicType, yearMonthDuration and dayTimeDuration
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Khaled Noaman, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/FloatDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/FloatDV.java
@@ -24,7 +24,7 @@ import org.apache.jena.ext.xerces.xs.datatypes.XSFloat;
 /**
  * Represent the schema type "float"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/FullDVFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/FullDVFactory.java
@@ -25,7 +25,7 @@ import org.apache.jena.ext.xerces.xs.XSConstants;
 /**
  * the factory to create/return built-in schema DVs and create user-defined DVs
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/HexBinaryDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/HexBinaryDV.java
@@ -25,7 +25,7 @@ import org.apache.jena.ext.xerces.impl.dv.util.HexBin;
 /**
  * Represent the schema type "hexBinary"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/IDDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/IDDV.java
@@ -24,7 +24,7 @@ import org.apache.jena.ext.xerces.util.XMLChar;
 /**
  * Represent the schema type "ID"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/IDREFDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/IDREFDV.java
@@ -24,7 +24,7 @@ import org.apache.jena.ext.xerces.util.XMLChar;
 /**
  * Represent the schema type "IDREF"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/IntegerDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/IntegerDV.java
@@ -23,7 +23,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Represent the schema type "integer"
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/ListDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/ListDV.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.xs.datatypes.ObjectList;
 /**
  * Represent the schema list types
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/MonthDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/MonthDV.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Validator for &lt;gMonth&gt; datatype (W3C Schema Datatypes)
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Gopal Sharma, SUN Microsystem Inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/MonthDayDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/MonthDayDV.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Validator for &lt;gMonthDay&gt; datatype (W3C Schema Datatypes)
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Gopal Sharma, SUN Microsystem Inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/QNameDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/QNameDV.java
@@ -29,7 +29,7 @@ public class QNameDV {}
 ///**
 // * Represent the schema type "QName" and "NOTATION"
 // *
-// * @xerces.internal 
+// * {@literal @xerces.internal} 
 // *
 // * @author Neeraj Bajaj, Sun Microsystems, inc.
 // * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/SchemaDVFactoryImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/SchemaDVFactoryImpl.java
@@ -23,7 +23,7 @@ import org.apache.jena.ext.xerces.util.SymbolHash;
 /**
  * the factory to create/return built-in schema 1.0 DVs and create user-defined DVs
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/SchemaDateTimeException.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/SchemaDateTimeException.java
@@ -18,7 +18,7 @@
 package org.apache.jena.ext.xerces.impl.dv.xs;
 
 /**
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *  
  * @version $Id: SchemaDateTimeException.java 446745 2006-09-15 21:43:58Z mrglavas $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/StringDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/StringDV.java
@@ -23,7 +23,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Represent the schema type "string"
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/TimeDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/TimeDV.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Validator for &lt;time&gt; datatype (W3C Schema Datatypes)
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Gopal Sharma, SUN Microsystem Inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/TypeValidator.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/TypeValidator.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
  * type: allowed facets, converting String to actual value, check equality,
  * comparison, etc.
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/UnionDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/UnionDV.java
@@ -23,7 +23,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Represent the schema union types
  * 
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Neeraj Bajaj, Sun Microsystems, inc.
  * @author Sandy Gao, IBM

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/XSSimpleTypeDecl.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/XSSimpleTypeDecl.java
@@ -38,7 +38,7 @@ import org.apache.jena.ext.xerces.xs.datatypes.ObjectList;
 import org.w3c.dom.TypeInfo;
 
 /**
- * @xerces.internal
+ * {@literal @xerces.internal}
  *  
  * @author Sandy Gao, IBM
  * @author Neeraj Bajaj, Sun Microsystems, inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/XSSimpleTypeDelegate.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/XSSimpleTypeDelegate.java
@@ -23,7 +23,7 @@ import org.apache.jena.ext.xerces.xs.*;
 /**
  * Base class for XSSimpleType wrapper implementations.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  * 
  * @version $Id: XSSimpleTypeDelegate.java 1024038 2010-10-18 22:06:35Z sandygao $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/YearDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/YearDV.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Validator for &lt;gYear&gt; datatype (W3C Schema Datatypes)
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Gopal Sharma, SUN Microsystem Inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/YearMonthDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/YearMonthDV.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Validator for &lt;gYearMonth&gt; datatype (W3C Schema Datatypes)
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Elena Litani
  * @author Gopal Sharma, SUN Microsystem Inc.

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/YearMonthDurationDV.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/dv/xs/YearMonthDurationDV.java
@@ -28,7 +28,7 @@ import org.apache.jena.ext.xerces.impl.dv.ValidationContext;
 /**
  * Used to validate the <yearMonthDuration> type
  *
- * @xerces.internal  
+ * {@literal @xerces.internal}  
  * 
  * @author Ankit Pasricha, IBM
  *  

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/validation/ConfigurableValidationState.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/validation/ConfigurableValidationState.java
@@ -21,7 +21,7 @@ package org.apache.jena.ext.xerces.impl.validation;
  * <p>An extension of ValidationState which can be configured to turn 
  * off checking for ID/IDREF errors and unparsed entity errors.</p>
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @author Peter McCracken, IBM
  * @version $Id: ConfigurableValidationState.java 449320 2006-09-23 22:37:56Z mrglavas $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/validation/EntityState.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/validation/EntityState.java
@@ -23,7 +23,7 @@ package org.apache.jena.ext.xerces.impl.validation;
  * by components that store information about entity declarations, as well as by
  * entity validator that will need to validate attributes of type entity.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  * 
  * @author Elena Litani, IBM
  * @version $Id: EntityState.java 446719 2006-09-15 20:32:39Z mrglavas $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/validation/ValidationManager.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/validation/ValidationManager.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
  * other validators present in the pipeline, but should understand
  * that there are others and that some coordination is required.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  * 
  * @author Elena Litani, IBM
  * @version $Id: ValidationManager.java 606491 2007-12-22 21:00:53Z mrglavas $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/validation/ValidationState.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/validation/ValidationState.java
@@ -29,7 +29,7 @@ import org.apache.jena.ext.xerces.xni.NamespaceContext;
  * Implementation of the ValidationContext interface. Used to establish an
  * environment for simple type validation.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @author Elena Litani, IBM
  * @version $Id: ValidationState.java 713638 2008-11-13 04:42:18Z mrglavas $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/BMPattern.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/BMPattern.java
@@ -22,7 +22,7 @@ import java.text.CharacterIterator;
 /**
  * Boyer-Moore searcher.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @version $Id: BMPattern.java 572108 2007-09-02 18:48:31Z mrglavas $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/CaseInsensitiveMap.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/CaseInsensitiveMap.java
@@ -18,7 +18,7 @@
 package org.apache.jena.ext.xerces.impl.xpath.regex;
 
 /**
- * @xerces.internal
+ * {@literal @xerces.internal}
  * 
  * @version $Id: CaseInsensitiveMap.java 834653 2009-11-10 20:32:39Z mrglavas $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/Match.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/Match.java
@@ -22,7 +22,7 @@ import java.text.CharacterIterator;
 /**
  * An instance of this class has ranges captured in matching.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @see RegularExpression#matches(char[], int, int, Match)
  * @see RegularExpression#matches(char[], Match)

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/Op.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/Op.java
@@ -20,7 +20,7 @@ package org.apache.jena.ext.xerces.impl.xpath.regex;
 import java.util.Vector;
 
 /**
- * @xerces.internal
+ * {@literal @xerces.internal}
  * 
  * @version $Id: Op.java 572108 2007-09-02 18:48:31Z mrglavas $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/ParseException.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/ParseException.java
@@ -18,7 +18,7 @@
 package org.apache.jena.ext.xerces.impl.xpath.regex;
 
 /**
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @author TAMURA Kent &lt;kent@trl.ibm.co.jp&gt;
  * @version $Id: ParseException.java 572108 2007-09-02 18:48:31Z mrglavas $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/ParserForXMLSchema.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/ParserForXMLSchema.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 /**
  * A regular expression parser for the XML Schema.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @author TAMURA Kent &lt;kent@trl.ibm.co.jp&gt;
  * @version $Id: ParserForXMLSchema.java 831926 2009-11-02 15:38:53Z knoaman $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/REUtil.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/REUtil.java
@@ -20,7 +20,7 @@ package org.apache.jena.ext.xerces.impl.xpath.regex;
 import java.text.CharacterIterator;
 
 /**
- * @xerces.internal
+ * {@literal @xerces.internal}
  * 
  * @version $Id: REUtil.java 828015 2009-10-21 13:56:13Z knoaman $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/RangeToken.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/RangeToken.java
@@ -20,7 +20,7 @@ package org.apache.jena.ext.xerces.impl.xpath.regex;
 /**
  * This class represents a character class such as [a-z] or a period.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @version $Id: RangeToken.java 965250 2010-07-18 16:04:58Z mrglavas $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/RegexParser.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/RegexParser.java
@@ -25,7 +25,7 @@ import java.util.Vector;
 /**
  * A Regular Expression Parser.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @version $Id: RegexParser.java 1033661 2010-11-10 19:31:44Z knoaman $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/RegularExpression.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/RegularExpression.java
@@ -480,7 +480,7 @@ import org.apache.jena.ext.xerces.util.IntStack;
  *
  * <hr width="50%">
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @author TAMURA Kent &lt;kent@trl.ibm.co.jp&gt;
  * @version $Id: RegularExpression.java 961928 2010-07-08 20:43:46Z knoaman $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/Token.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xpath/regex/Token.java
@@ -23,7 +23,7 @@ import java.util.Vector;
 /**
  * This class represents a node in parse tree.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  *
  * @version $Id: Token.java 831926 2009-11-02 15:38:53Z knoaman $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/SchemaSymbols.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/SchemaSymbols.java
@@ -21,7 +21,7 @@ package org.apache.jena.ext.xerces.impl.xs;
 /**
  * Collection of symbols used to parse a Schema Grammar.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author jeffrey rodriguez
  * @version $Id: SchemaSymbols.java 446734 2006-09-15 20:51:23Z mrglavas $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/XSDeclarationPool.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/XSDeclarationPool.java
@@ -27,7 +27,7 @@ import org.apache.jena.ext.xerces.impl.dv.xs.XSSimpleTypeDecl;
  * declarations to the pool.
  * Note: The cashing mechanism is not implemented yet.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  * 
  * @author Elena Litani, IBM
  * @version $Id: XSDeclarationPool.java 805582 2009-08-18 21:13:20Z sandygao $

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/util/ObjectListImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/util/ObjectListImpl.java
@@ -25,7 +25,7 @@ import org.apache.jena.ext.xerces.xs.datatypes.ObjectList;
 /**
  * Contains a list of Objects.
  * 
- * @xerces.internal
+ * {@literal @xerces.internal}
  * 
  * @version $Id: ObjectListImpl.java 789785 2009-06-30 15:10:26Z knoaman $
  */

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/util/ShortListImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/util/ShortListImpl.java
@@ -25,7 +25,7 @@ import org.apache.jena.ext.xerces.xs.XSException;
 /**
  * Contains a list of shorts.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/util/StringListImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/util/StringListImpl.java
@@ -26,7 +26,7 @@ import org.apache.jena.ext.xerces.xs.StringList;
 /**
  * Contains a list of Strings.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *

--- a/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/util/XSObjectListImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ext/xerces/impl/xs/util/XSObjectListImpl.java
@@ -29,7 +29,7 @@ import org.apache.jena.ext.xerces.xs.XSObjectList;
 /**
  * Contains a list of XSObjects.
  *
- * @xerces.internal 
+ * {@literal @xerces.internal} 
  *
  * @author Sandy Gao, IBM
  *


### PR DESCRIPTION
Replace "@xerces.internal" with "{@literal @xerces.internal}".

This suppresses javadoc warning about unknown javadoc tags.
