### PR TITLE
Update OSGi imports

### DIFF
--- a/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
+++ b/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
@@ -21,31 +21,24 @@
 	<feature name="jena" version="${project.version}">
 		<bundle>mvn:org.apache.jena/jena-osgi/${project.version}</bundle>
 		<feature version="${project.version}">jena_osgi_dependencies</feature>
-		<!-- This is normally exposed by Apache Karaf via root classloader -->
-		<!--<feature version="2.11.0">xerces</feature>-->
 	</feature>
 
 	<feature name="jena_osgi_dependencies" version="${project.version}">
-		<bundle>mvn:com.github.andrewoma.dexx/collection/${ver.dexxcollection}</bundle>
-		<bundle>mvn:com.github.jsonld-java/jsonld-java/${ver.jsonldjava}</bundle>
-		<bundle>mvn:com.fasterxml.jackson.core/jackson-core/${ver.jackson}</bundle>
-		<bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${ver.jackson}</bundle>
-		<bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${ver.jackson}</bundle>
-		<bundle>mvn:org.apache.httpcomponents/httpcore-osgi/${ver.httpcore-osgi}</bundle>
-		<bundle>mvn:org.apache.httpcomponents/httpclient-osgi/${ver.httpclient-osgi}</bundle>
-		<bundle>mvn:org.apache.commons/commons-compress/${ver.commons-compress}</bundle>
-		<bundle>mvn:org.apache.commons/commons-csv/${ver.commonscsv}</bundle>
-		<bundle>mvn:org.apache.commons/commons-lang3/${ver.commonslang3}</bundle>
-		<bundle>mvn:commons-codec/commons-codec/${ver.commons-codec}</bundle>
-		<bundle>mvn:commons-io/commons-io/${ver.commonsio}</bundle>
-		<bundle>mvn:org.apache.thrift/libthrift/${ver.libthrift}</bundle>
+		<bundle dependency="true">mvn:com.github.andrewoma.dexx/collection/${ver.dexxcollection}</bundle>
+		<bundle dependency="true">mvn:com.github.jsonld-java/jsonld-java/${ver.jsonldjava}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${ver.jackson}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${ver.jackson}</bundle>
+		<bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${ver.jackson}</bundle>
+		<bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${ver.httpcore-osgi}</bundle>
+		<bundle dependency="true">mvn:org.apache.httpcomponents/httpclient-osgi/${ver.httpclient-osgi}</bundle>
+		<bundle dependency="true">mvn:org.apache.commons/commons-compress/${ver.commons-compress}</bundle>
+		<bundle dependency="true">mvn:org.apache.commons/commons-csv/${ver.commonscsv}</bundle>
+		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/${ver.commonslang3}</bundle>
+		<bundle dependency="true">mvn:commons-codec/commons-codec/${ver.commons-codec}</bundle>
+		<bundle dependency="true">mvn:commons-io/commons-io/${ver.commonsio}</bundle>
+		<bundle dependency="true">mvn:org.apache.thrift/libthrift/${ver.libthrift}</bundle>
 		<!-- Guava 24.1 is required by jsonld-java -->
-		<bundle>mvn:com.google.guava/guava/24.1-jre</bundle>
-	</feature>
-
-	<feature name="xerces" version="2.11.0">
-		<bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/2.11.0_1</bundle>
-		<bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/1.2_5</bundle>
+		<bundle dependency="true">mvn:com.google.guava/guava/24.1-jre</bundle>
 	</feature>
 
 </features>

--- a/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
+++ b/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
@@ -33,11 +33,14 @@
 		<bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${ver.jackson}</bundle>
 		<bundle>mvn:org.apache.httpcomponents/httpcore-osgi/${ver.httpcore-osgi}</bundle>
 		<bundle>mvn:org.apache.httpcomponents/httpclient-osgi/${ver.httpclient-osgi}</bundle>
+		<bundle>mvn:org.apache.commons/commons-compress/${ver.commons-compress}</bundle>
 		<bundle>mvn:org.apache.commons/commons-csv/${ver.commonscsv}</bundle>
 		<bundle>mvn:org.apache.commons/commons-lang3/${ver.commonslang3}</bundle>
 		<bundle>mvn:commons-codec/commons-codec/${ver.commons-codec}</bundle>
 		<bundle>mvn:commons-io/commons-io/${ver.commonsio}</bundle>
-		<bundle>mvn:org.apache.thrift/libthrift/${ver.libthrift}</bundle>	
+		<bundle>mvn:org.apache.thrift/libthrift/${ver.libthrift}</bundle>
+		<!-- Guava 24.1 is required by jsonld-java -->
+		<bundle>mvn:com.google.guava/guava/24.1-jre</bundle>
 	</feature>
 
 	<feature name="xerces" version="2.11.0">

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -251,7 +251,19 @@
             <Export-Package>org.apache.jena.*,!org.apache.jena.ext.*</Export-Package>            
             <Embed-Dependency>artifactId=jena*;inline=true</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
-            <Import-Package>org.osgi.framework.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.jena.ext.*,sun.misc;resolution:=optional,com.google.errorprone.annotations.concurrent;resolution:=optional,*</Import-Package>
+            <Import-Package>
+              org.osgi.framework.*,
+              !sun.io,
+              !org.apache.avalon.framework.logger,
+              !com.ibm.uvm.tools,
+              !com.sun.jdmk.comm,
+              !org.apache.log,
+              !org.checkerframework.checker.*,
+              !org.apache.jena.ext.*,
+              sun.misc;resolution:=optional,
+              com.google.errorprone.annotations.*;resolution:=optional,
+              *
+            </Import-Package>
             <!--
             <Import-Package>org.osgi.framework.*,!sun.io,!org.apache.avalon.framework.logger,!com.ibm.uvm.tools,!com.sun.jdmk.comm,!org.apache.log,!org.apache.xml.*,!org.apache.jena.ext.*,sun.misc;resolution:=optional,*</Import-Package>
             -->

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -258,10 +258,10 @@
               !com.ibm.uvm.tools,
               !com.sun.jdmk.comm,
               !org.apache.log,
-              !org.checkerframework.checker.*,
               !org.apache.jena.ext.*,
+              !org.checkerframework.checker.*,
+              !com.google.errorprone.annotations.*,
               sun.misc;resolution:=optional,
-              com.google.errorprone.annotations.*;resolution:=optional,
               *
             </Import-Package>
             <!--


### PR DESCRIPTION
Resolves: JENA-1557

This adds an exclusion for `org.checkerframework.checker.*`, which is now pulled in by `jena-shaded-guava`. This also adds guava (jsonld-java depends on this) and commons-compress to the `features.xml` file.

In addition, this reformats the `Import-Package` definition to make it easier to read (and maintain).

It is worth noting that the Guava version (24.1-jre) is hard-coded in the `features.xml` file. I was reluctant to add a variable for this in the root `pom.xml` file given [the note](https://github.com/apache/jena/blob/master/jena-shaded-guava/pom.xml#L46) in jena-shaded-guava. However, there may be a better way to structure that value so that it is obvious that it is tied to the jsonld-java dependency.