### PR TITLE
Fix javadoc in OntModel

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/ontology/OntModel.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/OntModel.java
@@ -743,8 +743,8 @@ public interface OntModel
      * the writable sub-model of the ontology model.
      * </p>
      *
-     * @param cls Resource representing the ontology class to which the individual belongs
      * @param uri The URI for the individual, or null for an anonymous individual.
+     * @param cls Resource representing the ontology class to which the individual belongs.
      * @return An Individual resource.
      */
     public Individual createIndividual( String uri, Resource cls );


### PR DESCRIPTION
Fixed order of parameters description as they appear in the corresponding method signature (first `uri`, then `cls`).