### PR TITLE
JENA-1578

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1829,9 +1829,8 @@ public class ParameterizedSparqlString implements PrefixMapping {
         if (varIndex > -1) {
             String subCmd = command.substring(0, varIndex).toLowerCase(); //Truncate the command at the varName. Lowercase to search both types of values.
             int valuesIndex = subCmd.lastIndexOf(VALUES_KEYWORD);
-            int bracesIndex = subCmd.lastIndexOf("{");
-            String vars = command.substring(valuesIndex + VALUES_KEYWORD.length(), bracesIndex);
-            isNeeded = vars.contains("(");
+            int parenthesisIndex = subCmd.indexOf("(", valuesIndex + VALUES_KEYWORD.length());
+            isNeeded = parenthesisIndex > -1;
         } else {
             isNeeded = false;
         }

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1741,10 +1741,13 @@ public class ParameterizedSparqlString implements PrefixMapping {
     }
     
     /**
-     * Assign a varName with a multiple items.<br>
+     * Assign a VALUES varName with a multiple items.<br>
      * Can be used to assign multiple values to a single variable or single
      * value to multiple variables (if using a List) in the SPARQL query.<br>
-     * See setGroupedValues to assign multiple values to multiple variables.
+     * See setGroupedValues to assign multiple values to multiple variables.<br>
+     * Using "var" with list(prop_A, obj_A) on query "VALUES ?p ?o {?var}" would
+     * produce "VALUES ?p ?o {prop_A obj_A}".
+     *
      *
      * @param varName
      * @param items
@@ -1755,7 +1758,9 @@ public class ParameterizedSparqlString implements PrefixMapping {
     }
 
     /**
-     * Assign a varName with a single item.<br>
+     * Assign a VALUES varName with a single item.<br>
+     * Using "var" with Literal obj_A on query "VALUES ?o {?var}" would produce
+     * "VALUES ?o {obj_A}".
      *
      * @param varName
      * @param item
@@ -1766,7 +1771,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
 
     /**
      * **
-     * Sets a map of varNames and their items.<br>
+     * Sets a map of VALUES varNames and their items.<br>
      * Can be used to assign multiple values to a single variable or single
      * value to multiple variables (if using a List) in the SPARQL query.<br>
      * See setGroupedValues to assign multiple values to multiple variables.
@@ -1778,7 +1783,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
     }
 
     /**
-     * Allocate multiple lists of variables to a single varName.<br>
+     * Allocate multiple lists of variables to a single VALUES varName.<br>
      * Using "vars" with list(list(prop_A, obj_A), list(prop_B, obj_B)) on query
      * "VALUES (?p ?o) {?vars}" would produce "VALUES (?p ?o) {(prop_A obj_A)
      * (prop_B obj_B)}".

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1902,7 +1902,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
                 replacement.append("(");
 
                 for (RDFNode item : group) {
-                    String insert = createInsert(item);
+                    String insert = FmtUtils.stringForNode(item.asNode(), (PrefixMapping) null);
                     replacement.append(insert);
                     replacement.append(" ");
                 }
@@ -1922,7 +1922,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
                 if (isParenthesisNeeded) {
                     replacement.append("(");
                 }
-                String insert = createInsert(item);
+                String insert = FmtUtils.stringForNode(item.asNode(), (PrefixMapping) null);
                 replacement.append(insert);
                 if (isParenthesisNeeded) {
                     replacement.append(")");
@@ -1952,24 +1952,6 @@ public class ParameterizedSparqlString implements PrefixMapping {
             return target;
         }
 
-        /**
-         * Insert the SPARQL representation of the RDF node.
-         *
-         * @param item
-         * @return
-         */
-        private String createInsert(RDFNode item) {
-            String insert;
-            if (item.isLiteral()) {
-                Literal lit = item.asLiteral();
-                insert = "\"" + lit.getLexicalForm() + "\"^^" + lit.getDatatypeURI();
-            } else if (item.isResource()) {
-                insert = "<" + item.asResource().getURI() + ">";
-            } else {
-                insert = item.asResource().getId().getLabelString();
-            }
-            return insert;
-        }
     }
     
 }

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1744,18 +1744,18 @@ public class ParameterizedSparqlString implements PrefixMapping {
     }
     
     /**
-     * Assign a VALUES varName with a multiple items.<br>
+     * Assign a VALUES valueName with a multiple items.<br>
      * Can be used to assign multiple values to a single variable or single
      * value to multiple variables (if using a List) in the SPARQL query.<br>
      * See setRowValues to assign multiple values to multiple variables.<br>
-     * Using "var" with list(prop_A, obj_A) on query "VALUES (?p ?o) {?var}"
-     * would produce "VALUES (?p ?o) {(prop_A obj_A)}".
+     * Using "valueName" with list(prop_A, obj_A) on query "VALUES (?p ?o)
+     * {?valueName}"     * would produce "VALUES (?p ?o) {(prop_A obj_A)}".
      *
      *
-     * @param varName
+     * @param valueName
      * @param items
      */
-    public void setValues(String varName, Collection<? extends RDFNode> items) {
+    public void setValues(String valueName, Collection<? extends RDFNode> items) {
         items.forEach(item -> validateParameterValue(item.asNode()));
 
         //Ensure that a list is used for the items.
@@ -1765,24 +1765,24 @@ public class ParameterizedSparqlString implements PrefixMapping {
         } else {
             rowItems.add(new ArrayList<>(items));
         }
-        this.valuesReplacements.put(varName, new ValueReplacement(varName, rowItems));
+        this.valuesReplacements.put(valueName, new ValueReplacement(valueName, rowItems));
     }
 
     /**
-     * Assign a VALUES varName with a single item.<br>
-     * Using "var" with Literal obj_A on query "VALUES ?o {?var}" would produce
-     * "VALUES ?o {obj_A}".
+     * Assign a VALUES valueName with a single item.<br>
+     * Using "valueName" with Literal obj_A on query "VALUES ?o {?valueName}"
+     * would produce     * "VALUES ?o {obj_A}".
      *
-     * @param varName
+     * @param valueName
      * @param item
      */
-    public void setValues(String varName, RDFNode item) {
-        setValues(varName, Arrays.asList(item));
+    public void setValues(String valueName, RDFNode item) {
+        setValues(valueName, Arrays.asList(item));
     }
 
     /**
      * **
-     * Sets a map of VALUES varNames and their items.<br>
+     * Sets a map of VALUES valueNames and their items.<br>
      * Can be used to assign multiple values to a single variable or single
      * value to multiple variables (if using a List) in the SPARQL query.<br>
      * See setRowValues to assign multiple values to multiple variables.
@@ -1794,17 +1794,17 @@ public class ParameterizedSparqlString implements PrefixMapping {
     }
 
     /**
-     * Allocate multiple lists of variables to a single VALUES varName.<br>
-     * Using "vars" with list(list(prop_A, obj_A), list(prop_B, obj_B)) on query
-     * "VALUES (?p ?o) {?vars}" would produce "VALUES (?p ?o) {(prop_A obj_A)
-     * (prop_B obj_B)}".
+     * Allocate multiple lists of variables to a single VALUES valueName.<br>
+     * Using "valuesName" with list(list(prop_A, obj_A), list(prop_B, obj_B)) on
+     * query "VALUES (?p ?o) {?valuesName}" would produce "VALUES (?p ?o)
+     * {(prop_A obj_A)     * (prop_B obj_B)}".
      *
-     * @param varName
+     * @param valueName
      * @param rowItems
      */
-    public void setRowValues(String varName, Collection<List<? extends RDFNode>> rowItems) {
+    public void setRowValues(String valueName, Collection<List<? extends RDFNode>> rowItems) {
         rowItems.forEach(collection -> collection.forEach(item -> validateParameterValue(item.asNode())));
-        this.valuesReplacements.put(varName, new ValueReplacement(varName, rowItems));
+        this.valuesReplacements.put(valueName, new ValueReplacement(valueName, rowItems));
     }
 
     private String applyValues(String command, SerializationContext context) {
@@ -1817,12 +1817,12 @@ public class ParameterizedSparqlString implements PrefixMapping {
 
     private static final String VALUES_KEYWORD = "values";
 
-    protected static String[] extractTargetVars(String command, String varName) {
+    protected static String[] extractTargetVars(String command, String valueName) {
         String[] targetVars = new String[]{};
 
-        int varIndex = command.indexOf(varName);
-        if (varIndex > -1) {
-            String subCmd = command.substring(0, varIndex).toLowerCase(); //Truncate the command at the varName. Lowercase to search both types of values.
+        int valueIndex = command.indexOf(valueName);
+        if (valueIndex > -1) {
+            String subCmd = command.substring(0, valueIndex).toLowerCase(); //Truncate the command at the valueName. Lowercase to search both cases of VALUES keyword.
             int valuesIndex = subCmd.lastIndexOf(VALUES_KEYWORD);
             int openBracesIndex = subCmd.lastIndexOf("{");
             int closeBracesIndex = subCmd.lastIndexOf("}");
@@ -1840,11 +1840,11 @@ public class ParameterizedSparqlString implements PrefixMapping {
      */
     private class ValueReplacement {
 
-        private final String varName;
+        private final String valueName;
         private final Collection<List<? extends RDFNode>> rowItems;
 
-        public ValueReplacement(String varName, Collection<List<? extends RDFNode>> rowItems) {
-            this.varName = varName;
+        public ValueReplacement(String valueName, Collection<List<? extends RDFNode>> rowItems) {
+            this.valueName = valueName;
             this.rowItems = rowItems;
         }
 
@@ -1854,7 +1854,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
                 return command;
             }
 
-            String[] targetVars = extractTargetVars(command, varName);
+            String[] targetVars = extractTargetVars(command, valueName);
             if (targetVars.length == 0) {
                 //VALUES keyword has not been found or there is another issue so do not modify the command.
                 return command;
@@ -1899,18 +1899,18 @@ public class ParameterizedSparqlString implements PrefixMapping {
         }
 
         /**
-         * Tidy up varName if doesn't start with a ? or $.
+         * Tidy up valueName if doesn't start with a ? or $.
          *
-         * @param varName
+         * @param valueName
          * @return
          */
         private String createTarget() {
             String target;
 
-            if (varName.startsWith("?") || varName.startsWith("$")) {
-                target = varName;
+            if (valueName.startsWith("?") || valueName.startsWith("$")) {
+                target = valueName;
             } else {
-                target = "[?$]" + varName;
+                target = "[?$]" + valueName;
             }
             return target;
         }

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1159,14 +1159,15 @@ public class ParameterizedSparqlString implements PrefixMapping {
     }
 
     /**
-     * Clears the value for a variable parameter so the given variable will not
-     * have a value injected
+     * Clears the value for a variable or values parameter so the given variable
+     * will not     * have a value injected
      * 
      * @param var
      *            Variable
      */
     public void clearParam(String var) {
         this.params.remove(var);
+        this.valuesReplacements.remove(var);
     }
 
     /**
@@ -1180,10 +1181,11 @@ public class ParameterizedSparqlString implements PrefixMapping {
     }
 
     /**
-     * Clears all values for both variable and positional parameters
+     * Clears all values for variable, values and positional parameters
      */
     public void clearParams() {
         this.params.clear();
+        this.valuesReplacements.clear();
         this.positionalParams.clear();
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -32,7 +32,6 @@ import java.util.Map.Entry;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.apache.jena.atlas.lib.Pair;
 import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.graph.Node ;
@@ -1793,10 +1792,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
      * @param valuesItems
      */
     public void setValues(Map<String, Collection<? extends RDFNode>> valuesItems) {
-        for (String varName : valuesItems.keySet()) {
-            Collection<? extends RDFNode> items = valuesItems.get(varName);
-            setValues(varName, items);
-        }
+        valuesItems.forEach(this::setValues);
     }
 
     /**
@@ -1806,10 +1802,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
      * @param isParenthesisNeeded
      */
     public void setValues(Map<String, Collection<? extends RDFNode>> valuesItems, Boolean isParenthesisNeeded) {
-        for (String varName : valuesItems.keySet()) {
-            Collection<? extends RDFNode> items = valuesItems.get(varName);
-            setValues(varName, items, isParenthesisNeeded);
-        }
+        valuesItems.forEach((varName, items) -> setValues(varName, items, isParenthesisNeeded));
     }
 
     /**

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1749,6 +1749,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
      * @param isParenthesisNeeded
      */
     public void setValues(String varName, Collection<? extends RDFNode> items, boolean isParenthesisNeeded) {
+        items.forEach(item -> validateParameterValue(item.asNode()));
         this.valuesReplacements.put(varName, new ValueReplacement(varName, items, isParenthesisNeeded));
     }
 
@@ -1837,6 +1838,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
      * @param items
      */
     public void setGroupedValues(String varName, Collection<List<? extends RDFNode>> items) {
+        items.forEach(collection -> collection.forEach(item -> validateParameterValue(item.asNode())));
         this.valuesReplacements.put(varName, new ValueReplacement(varName, items));
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1826,7 +1826,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
             int closeBracesIndex = subCmd.lastIndexOf("}");
             if (valuesIndex > -1 && valuesIndex < openBracesIndex && closeBracesIndex < valuesIndex) { //Ensure that VALUES keyword is found, open braces index is located after the VALUES and any close braces is located before the VALUES.
                 String vars = command.substring(valuesIndex + VALUES_KEYWORD.length(), openBracesIndex);
-                targetVars = vars.replaceAll("[(?)]", "").trim().split(" ");
+                targetVars = vars.replaceAll("[(?$)]", "").trim().split(" ");
             }
         }
         return targetVars;
@@ -1861,13 +1861,12 @@ public class ParameterizedSparqlString implements PrefixMapping {
             validateValuesSafeToInject(command, targetVars);
 
             String target = createTarget();
-            StringBuilder replacement = buildReplacement(targetVars.length);
+            String replacement = buildReplacement(targetVars.length);
 
-            return command.replace(target, replacement);
+            return command.replaceAll(target, replacement);
         }
 
-
-        private StringBuilder buildReplacement(int targetVarCount) {
+        private String buildReplacement(int targetVarCount) {
 
             StringBuilder replacement = new StringBuilder("");
 
@@ -1894,7 +1893,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
             }
             replacement.deleteCharAt(replacement.length() - 1);
 
-            return replacement;
+            return replacement.toString();
         }
 
         /**
@@ -1909,7 +1908,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
             if (varName.startsWith("?") || varName.startsWith("$")) {
                 target = varName;
             } else {
-                target = "?" + varName;
+                target = "[?$]" + varName;
             }
             return target;
         }

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1334,7 +1334,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
         }
 
         // Inject Values Parameters
-        command = applyValues(command);
+        command = applyValues(command, context);
         
         // Then inject Positional Parameters
         // To do this we need to find the ? we will replace
@@ -1807,10 +1807,10 @@ public class ParameterizedSparqlString implements PrefixMapping {
         this.valuesReplacements.put(varName, new ValueReplacement(varName, rowItems));
     }
 
-    private String applyValues(String command) {
+    private String applyValues(String command, SerializationContext context) {
 
         for (ValueReplacement valueReplacement : valuesReplacements.values()) {
-            command = valueReplacement.apply(command);
+            command = valueReplacement.apply(command, context);
         }
         return command;
     }
@@ -1848,7 +1848,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
             this.rowItems = rowItems;
         }
 
-        public String apply(String command) {
+        public String apply(String command, SerializationContext context) {
 
             if (rowItems.isEmpty()) {
                 return command;
@@ -1863,29 +1863,29 @@ public class ParameterizedSparqlString implements PrefixMapping {
             validateValuesSafeToInject(command, targetVars);
 
             String target = createTarget();
-            String replacement = buildReplacement(targetVars.length);
+            String replacement = buildReplacement(targetVars.length, context);
 
             return command.replaceAll(target, replacement);
         }
 
-        private String buildReplacement(int targetVarCount) {
+        private String buildReplacement(int targetVarCount, SerializationContext context) {
 
             StringBuilder replacement = new StringBuilder("");
 
             if (targetVarCount == 1) {
                 for (List<? extends RDFNode> row : rowItems) {
                     for (RDFNode item : row) {
-                    replacement.append("(");
-                    String insert = FmtUtils.stringForNode(item.asNode(), (PrefixMapping) null);
-                    replacement.append(insert);
-                    replacement.append(") ");
+                        replacement.append("(");
+                        String insert = stringForNode(item.asNode(), context);
+                        replacement.append(insert);
+                        replacement.append(") ");
                     }
                 }
             } else {
                 for (List<? extends RDFNode> row : rowItems) {
                     replacement.append("(");
                     for (RDFNode item : row) {
-                        String insert = FmtUtils.stringForNode(item.asNode(), (PrefixMapping) null);
+                        String insert = stringForNode(item.asNode(), context);
                         replacement.append(insert);
                         replacement.append(" ");
                     }

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -1942,6 +1942,62 @@ public class TestParameterizedSparqlString {
     }
 
     @Test
+    public void test_set_values_item2() {
+        // Tests a single value being added using '$' variable syntax - always adding parenthesis.
+        String str = "SELECT * WHERE { VALUES $o {$objs} $s $p $o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        pss.setValues("objs", ResourceFactory.createPlainLiteral("test"));
+
+        String exp = "SELECT * WHERE { VALUES $o {(\"test\")} $s $p $o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_item_missing_values() {
+        // VALUES keyword missing so query is unchanged.
+        String str = "SELECT * WHERE { ?o {?objs} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        pss.setValues("objs", ResourceFactory.createPlainLiteral("test"));
+
+        String exp = "SELECT * WHERE { ?o {?objs} ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_item_missing_braces() {
+        // Braces missing so query is unchanged.
+        String str = "SELECT * WHERE { VALUES ?o ?objs ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        pss.setValues("objs", ResourceFactory.createPlainLiteral("test"));
+
+        String exp = "SELECT * WHERE { VALUES ?o ?objs ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_item_missing_varName() {
+        // varName missing ('props' instead of 'objs') so query is unchanged.
+        String str = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        pss.setValues("props", ResourceFactory.createPlainLiteral("test"));
+
+        String exp = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
     public void test_set_values_items_parenthesis() {
         // Tests two values for same variable.
         String str = "SELECT * WHERE { VALUES (?o) {?objs} ?s ?p ?o }";

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -2058,4 +2058,16 @@ public class TestParameterizedSparqlString {
         //System.out.println("Res: " + res);
         Assert.assertEquals(exp, res);
     }
+
+    @Test(expected = ARQException.class)
+    public void test_set_values_uri_injection() {
+        // This injection is prevented by forbidding the > character in URIs
+        String str = "PREFIX : <http://example/>\nSELECT * WHERE { VALUES ?obj {?objVar} <s> <p> ?obj . }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        pss.setValues(str, ResourceFactory.createResource("<http://example.org/obj_A>"));
+
+        pss.asQuery();
+        Assert.fail("Attempt to do SPARQL injection should result in an exception");
+    }
+
 }

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -2070,4 +2070,43 @@ public class TestParameterizedSparqlString {
         Assert.fail("Attempt to do SPARQL injection should result in an exception");
     }
 
+    @Test
+    public void test_extract_target_vars() {
+        // Identifies the vars in the VALUES clause according to the substituting varName.
+        String cmd = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
+        String varName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String[] exp = new String[]{"o"};
+
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertArrayEquals(exp, res);
+    }
+
+    @Test
+    public void test_extract_two_target_vars() {
+        // Identifies the vars in the VALUES clause according to the substituting varName.
+        String cmd = "SELECT * WHERE { VALUES(?p ?o){?vars} ?s ?p ?o }";
+        String varName = "vars";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String[] exp = new String[]{"p", "o"};
+
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertArrayEquals(exp, res);
+    }
+
+    @Test
+    public void test_extract_multiple_target_vars() {
+        // Identifies the vars in the VALUES clause according to the substituting varName.
+        String cmd = "SELECT * WHERE { VALUES ?p {?props} VALUES ?o {?objs} ?s ?p ?o }";
+        String varName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String[] exp = new String[]{"o"};
+
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertArrayEquals(exp, res);
+    }
+
 }

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -1992,8 +1992,8 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { VALUES ?p {(<http://example.org/prop_A>) (<http://example.org/prop_B>)} VALUES ?o {(\"obj_A\") (\"obj_B\")} ?s ?p ?o }";
         String res = pss.toString();
-        System.out.println("Exp: " + exp);
-        System.out.println("Res: " + res);
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
         Assert.assertEquals(exp, res);
     }
 
@@ -2042,8 +2042,8 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
         String[] exp = new String[]{"o"};
 
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+        //System.out.println("Exp: " + String.join(",", exp));
+        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2055,8 +2055,8 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
         String[] exp = new String[]{"p", "o"};
 
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+        ///System.out.println("Exp: " + String.join(",", exp));
+        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2068,8 +2068,86 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
         String[] exp = new String[]{"o"};
 
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+        //System.out.println("Exp: " + String.join(",", exp));
+        //System.out.println("Res: " + String.join(",", res));
+        Assert.assertArrayEquals(exp, res);
+    }
+
+    @Test
+    public void test_extract_target_vars_missing_target() {
+        // Missing target variable name so should return empty array.
+        String cmd = "SELECT * WHERE { VALUES ?o {} ?s ?p ?o }";
+        String varName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String[] exp = new String[]{};
+
+        //System.out.println("Exp: " + String.join(",", exp));
+        //System.out.println("Res: " + String.join(",", res));
+        Assert.assertArrayEquals(exp, res);
+    }
+
+    @Test
+    public void test_extract_target_vars_missing_brace() {
+        // Missing brace so should return empty array.
+        String cmd = "SELECT * WHERE { VALUES ?o ?objs} ?s ?p ?o }";
+        String varName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String[] exp = new String[]{};
+
+        //System.out.println("Exp: " + String.join(",", exp));
+        //System.out.println("Res: " + String.join(",", res));
+        Assert.assertArrayEquals(exp, res);
+    }
+
+    @Test
+    public void test_extract_multiple_target_vars_missing_brace() {
+        // Missing brace so should return empty array.
+        String cmd = "SELECT * WHERE { VALUES ?p {?props} VALUES ?o ?objs} ?s ?p ?o }";
+        String varName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String[] exp = new String[]{};
+
+        //System.out.println("Exp: " + String.join(",", exp));
+        //System.out.println("Res: " + String.join(",", res));
+        Assert.assertArrayEquals(exp, res);
+    }
+
+    @Test
+    public void test_extract_target_vars_missing_values() {
+        // Missing VALUES keyword so should return empty array.
+        String cmd = "SELECT * WHERE { ?o {?objs} ?s ?p ?o }";
+        String varName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String[] exp = new String[]{};
+
+        //System.out.println("Exp: " + String.join(",", exp));
+        //System.out.println("Res: " + String.join(",", res));
+        Assert.assertArrayEquals(exp, res);
+    }
+
+    @Test
+    public void test_extract_multiple_target_vars_missing_values() {
+        // Missing VALUES keyword so should return empty array.
+        String cmd = "SELECT * WHERE { VALUES ?p {?props} ?o {?objs} ?s ?p ?o }";
+        String varName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String[] exp = new String[]{};
+
+        //System.out.println("Exp: " + String.join(",", exp));
+        //System.out.println("Res: " + String.join(",", res));
+        Assert.assertArrayEquals(exp, res);
+    }
+
+    @Test
+    public void test_extract_multiple_target_vars_no_braces() {
+        // Missing braces and VALUES keyword so should return empty array.
+        String cmd = "SELECT * WHERE { VALUES ?p ?props ?o ?objs ?s ?p ?o }";
+        String varName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String[] exp = new String[]{};
+
+        //System.out.println("Exp: " + String.join(",", exp));
+        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -18,9 +18,11 @@
 
 package org.apache.jena.query;
 
+import java.util.ArrayList;
 import java.util.Calendar ;
 import java.util.HashMap;
 import java.util.Iterator ;
+import java.util.List;
 import java.util.TimeZone ;
 
 import org.apache.jena.datatypes.TypeMapper ;
@@ -1924,5 +1926,137 @@ public class TestParameterizedSparqlString {
         pss.setLiteral("o", "has $9 sign");
 
         pss.toString();
+    }
+    
+    @Test
+    public void test_set_values_item() {
+        // Tests a single value being added.
+        String str = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        pss.setValues("objs", ResourceFactory.createPlainLiteral("test"));
+
+        String exp = "SELECT * WHERE { VALUES ?o {\"test\"^^http://www.w3.org/2001/XMLSchema#string} ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_item_parenthesis() {
+        // Tests a single value with parenthesis.
+        String str = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        pss.setValues("objs", ResourceFactory.createPlainLiteral("test"), true);
+
+        String exp = "SELECT * WHERE { VALUES ?o {(\"test\"^^http://www.w3.org/2001/XMLSchema#string)} ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_items() {
+        // Tests two values for same variable.
+        String str = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        List<RDFNode> objs = new ArrayList<>();
+        objs.add(ResourceFactory.createPlainLiteral("obj_A"));
+        objs.add(ResourceFactory.createPlainLiteral("obj_B"));
+        pss.setValues("objs", objs);
+
+        String exp = "SELECT * WHERE { VALUES ?o {\"obj_A\"^^http://www.w3.org/2001/XMLSchema#string \"obj_B\"^^http://www.w3.org/2001/XMLSchema#string} ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_items_parenthesis() {
+        // Tests two values for same variable.
+        String str = "SELECT * WHERE { VALUES (?o) {?objs} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        List<RDFNode> objs = new ArrayList<>();
+        objs.add(ResourceFactory.createPlainLiteral("obj_A"));
+        objs.add(ResourceFactory.createPlainLiteral("obj_B"));
+        pss.setValues("objs", objs, true);
+
+        String exp = "SELECT * WHERE { VALUES (?o) {(\"obj_A\"^^http://www.w3.org/2001/XMLSchema#string) (\"obj_B\"^^http://www.w3.org/2001/XMLSchema#string)} ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_multi_var() {
+        // Tests two variables.
+        String str = "SELECT * WHERE { VALUES ?p {?props} VALUES ?o {?objs} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        List<RDFNode> objs = new ArrayList<>();
+        objs.add(ResourceFactory.createPlainLiteral("obj_A"));
+        objs.add(ResourceFactory.createPlainLiteral("obj_B"));
+        pss.setValues("objs", objs);
+
+        List<RDFNode> props = new ArrayList<>();
+        props.add(ResourceFactory.createProperty("http://example.org/prop_A"));
+        props.add(ResourceFactory.createProperty("http://example.org/prop_B"));
+        pss.setValues("props", props);
+
+        String exp = "SELECT * WHERE { VALUES ?p {<http://example.org/prop_A> <http://example.org/prop_B>} VALUES ?o {\"obj_A\"^^http://www.w3.org/2001/XMLSchema#string \"obj_B\"^^http://www.w3.org/2001/XMLSchema#string} ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_multi_var_parenthesis() {
+        // Tests two variables with parenthesis for one.
+        String str = "SELECT * WHERE { VALUES (?p) {?props} VALUES ?o {?objs} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        List<RDFNode> objs = new ArrayList<>();
+        objs.add(ResourceFactory.createPlainLiteral("obj_A"));
+        objs.add(ResourceFactory.createPlainLiteral("obj_B"));
+        pss.setValues("objs", objs);
+
+        List<RDFNode> props = new ArrayList<>();
+        props.add(ResourceFactory.createProperty("http://example.org/prop_A"));
+        props.add(ResourceFactory.createProperty("http://example.org/prop_B"));
+        pss.setValues("props", props, true);
+
+        String exp = "SELECT * WHERE { VALUES (?p) {(<http://example.org/prop_A>) (<http://example.org/prop_B>)} VALUES ?o {\"obj_A\"^^http://www.w3.org/2001/XMLSchema#string \"obj_B\"^^http://www.w3.org/2001/XMLSchema#string} ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_grouped_var() {
+        // Tests two variables with parenthesis for one.
+        String str = "SELECT * WHERE { VALUES (?p ?o) {?vars} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+
+        List<List<? extends RDFNode>> vars = new ArrayList<>();
+        List<RDFNode> objsA = new ArrayList<>();
+        objsA.add(ResourceFactory.createProperty("http://example.org/prop_A"));
+        objsA.add(ResourceFactory.createPlainLiteral("obj_A"));
+        vars.add(objsA);
+
+        List<RDFNode> objsB = new ArrayList<>();
+        objsB.add(ResourceFactory.createProperty("http://example.org/prop_B"));
+        objsB.add(ResourceFactory.createPlainLiteral("obj_B"));
+        vars.add(objsB);
+
+        pss.setGroupedValues("vars", vars);
+
+        String exp = "SELECT * WHERE { VALUES (?p ?o) {(<http://example.org/prop_A> \"obj_A\"^^http://www.w3.org/2001/XMLSchema#string) (<http://example.org/prop_B> \"obj_B\"^^http://www.w3.org/2001/XMLSchema#string)} ?s ?p ?o }";
+        String res = pss.toString();
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -1976,6 +1976,23 @@ public class TestParameterizedSparqlString {
     }
 
     @Test
+    public void test_set_values_multiple_variables_parenthesis() {
+        // Tests two values for same variable.
+        String str = "SELECT * WHERE { VALUES (?p ?o) {?vars} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        List<RDFNode> vars = new ArrayList<>();
+        vars.add(ResourceFactory.createProperty("http://example.org/prop_A"));
+        vars.add(ResourceFactory.createPlainLiteral("obj_A"));
+        pss.setValues("vars", vars);
+
+        String exp = "SELECT * WHERE { VALUES (?p ?o) {(<http://example.org/prop_A> \"obj_A\")} ?s ?p ?o }";
+        String res = pss.toString();
+        System.out.println("Exp: " + exp);
+        System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
     public void test_set_values_multi_var() {
         // Tests two variables.
         String str = "SELECT * WHERE { VALUES ?p {?props} VALUES ?o {?objs} ?s ?p ?o }";

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -2015,7 +2015,7 @@ public class TestParameterizedSparqlString {
     }
 
     @Test
-    public void test_set_values_multiple_variables_parenthesis() {
+    public void test_set_values_multiple_variables() {
         // Tests two values for same variable.
         String str = "SELECT * WHERE { VALUES (?p ?o) {?vars} ?s ?p ?o }";
         ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
@@ -2029,6 +2029,34 @@ public class TestParameterizedSparqlString {
         //System.out.println("Exp: " + exp);
         //System.out.println("Res: " + res);
         Assert.assertEquals(exp, res);
+    }
+
+    @Test(expected = ARQException.class)
+    public void test_set_values_multiple_variables_too_few() {
+        // Test of one value for two variables.
+        String str = "SELECT * WHERE { VALUES (?p ?o) {?vars} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        List<RDFNode> vars = new ArrayList<>();
+        vars.add(ResourceFactory.createProperty("http://example.org/prop_A"));
+        pss.setValues("vars", vars);
+
+        pss.toString();
+        Assert.fail("Attempt to insert incorrect number of values.");
+    }
+
+    @Test(expected = ARQException.class)
+    public void test_set_values_multiple_variables_too_many() {
+        // Test of three values for two variables.
+        String str = "SELECT * WHERE { VALUES (?p ?o) {?vars} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        List<RDFNode> vars = new ArrayList<>();
+        vars.add(ResourceFactory.createProperty("http://example.org/prop_A"));
+        vars.add(ResourceFactory.createPlainLiteral("obj_A"));
+        vars.add(ResourceFactory.createPlainLiteral("obj_A"));
+        pss.setValues("vars", vars);
+
+        pss.toString();
+        Assert.fail("Attempt to insert incorrect number of values.");
     }
 
     @Test
@@ -2086,7 +2114,7 @@ public class TestParameterizedSparqlString {
         ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
         pss.setValues(str, ResourceFactory.createResource("<http://example.org/obj_A>"));
 
-        pss.asQuery();
+        pss.toString();
         Assert.fail("Attempt to do SPARQL injection should result in an exception");
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -1929,29 +1929,12 @@ public class TestParameterizedSparqlString {
     
     @Test
     public void test_set_values_item() {
-        // Tests a single value being added.
+        // Tests a single value being added - always adding parenthesis.
         String str = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
         ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
         pss.setValues("objs", ResourceFactory.createPlainLiteral("test"));
 
-        String exp = "SELECT * WHERE { VALUES ?o {\"test\"} ?s ?p ?o }";
-        String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
-        Assert.assertEquals(exp, res);
-    }
-
-    @Test
-    public void test_set_values_items() {
-        // Tests two values for same variable.
-        String str = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
-        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
-        List<RDFNode> objs = new ArrayList<>();
-        objs.add(ResourceFactory.createPlainLiteral("obj_A"));
-        objs.add(ResourceFactory.createPlainLiteral("obj_B"));
-        pss.setValues("objs", objs);
-
-        String exp = "SELECT * WHERE { VALUES ?o {\"obj_A\" \"obj_B\"} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES ?o {(\"test\")} ?s ?p ?o }";
         String res = pss.toString();
         //System.out.println("Exp: " + exp);
         //System.out.println("Res: " + res);
@@ -1987,14 +1970,14 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { VALUES (?p ?o) {(<http://example.org/prop_A> \"obj_A\")} ?s ?p ?o }";
         String res = pss.toString();
-        System.out.println("Exp: " + exp);
-        System.out.println("Res: " + res);
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
         Assert.assertEquals(exp, res);
     }
 
     @Test
     public void test_set_values_multi_var() {
-        // Tests two variables.
+        // Tests two variables - always adding parenthesis.
         String str = "SELECT * WHERE { VALUES ?p {?props} VALUES ?o {?objs} ?s ?p ?o }";
         ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
         List<RDFNode> objs = new ArrayList<>();
@@ -2007,32 +1990,10 @@ public class TestParameterizedSparqlString {
         props.add(ResourceFactory.createProperty("http://example.org/prop_B"));
         pss.setValues("props", props);
 
-        String exp = "SELECT * WHERE { VALUES ?p {<http://example.org/prop_A> <http://example.org/prop_B>} VALUES ?o {\"obj_A\" \"obj_B\"} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES ?p {(<http://example.org/prop_A>) (<http://example.org/prop_B>)} VALUES ?o {(\"obj_A\") (\"obj_B\")} ?s ?p ?o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
-        Assert.assertEquals(exp, res);
-    }
-
-    @Test
-    public void test_set_values_multi_var_parenthesis() {
-        // Tests two variables with parenthesis for one.
-        String str = "SELECT * WHERE { VALUES (?p) {?props} VALUES ?o {?objs} ?s ?p ?o }";
-        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
-        List<RDFNode> objs = new ArrayList<>();
-        objs.add(ResourceFactory.createPlainLiteral("obj_A"));
-        objs.add(ResourceFactory.createPlainLiteral("obj_B"));
-        pss.setValues("objs", objs);
-
-        List<RDFNode> props = new ArrayList<>();
-        props.add(ResourceFactory.createProperty("http://example.org/prop_A"));
-        props.add(ResourceFactory.createProperty("http://example.org/prop_B"));
-        pss.setValues("props", props);
-
-        String exp = "SELECT * WHERE { VALUES (?p) {(<http://example.org/prop_A>) (<http://example.org/prop_B>)} VALUES ?o {\"obj_A\" \"obj_B\"} ?s ?p ?o }";
-        String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+        System.out.println("Exp: " + exp);
+        System.out.println("Res: " + res);
         Assert.assertEquals(exp, res);
     }
 
@@ -2053,7 +2014,7 @@ public class TestParameterizedSparqlString {
         objsB.add(ResourceFactory.createPlainLiteral("obj_B"));
         vars.add(objsB);
 
-        pss.setGroupedValues("vars", vars);
+        pss.setRowValues("vars", vars);
 
         String exp = "SELECT * WHERE { VALUES (?p ?o) {(<http://example.org/prop_A> \"obj_A\") (<http://example.org/prop_B> \"obj_B\")} ?s ?p ?o }";
         String res = pss.toString();

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -1942,20 +1942,6 @@ public class TestParameterizedSparqlString {
     }
 
     @Test
-    public void test_set_values_item_parenthesis() {
-        // Tests a single value with parenthesis.
-        String str = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
-        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
-        pss.setValues("objs", ResourceFactory.createPlainLiteral("test"), true);
-
-        String exp = "SELECT * WHERE { VALUES ?o {(\"test\")} ?s ?p ?o }";
-        String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
-        Assert.assertEquals(exp, res);
-    }
-
-    @Test
     public void test_set_values_items() {
         // Tests two values for same variable.
         String str = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
@@ -1980,7 +1966,7 @@ public class TestParameterizedSparqlString {
         List<RDFNode> objs = new ArrayList<>();
         objs.add(ResourceFactory.createPlainLiteral("obj_A"));
         objs.add(ResourceFactory.createPlainLiteral("obj_B"));
-        pss.setValues("objs", objs, true);
+        pss.setValues("objs", objs);
 
         String exp = "SELECT * WHERE { VALUES (?o) {(\"obj_A\") (\"obj_B\")} ?s ?p ?o }";
         String res = pss.toString();
@@ -2024,7 +2010,7 @@ public class TestParameterizedSparqlString {
         List<RDFNode> props = new ArrayList<>();
         props.add(ResourceFactory.createProperty("http://example.org/prop_A"));
         props.add(ResourceFactory.createProperty("http://example.org/prop_B"));
-        pss.setValues("props", props, true);
+        pss.setValues("props", props);
 
         String exp = "SELECT * WHERE { VALUES (?p) {(<http://example.org/prop_A>) (<http://example.org/prop_B>)} VALUES ?o {\"obj_A\" \"obj_B\"} ?s ?p ?o }";
         String res = pss.toString();

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -24,8 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator ;
 import java.util.List;
 import java.util.TimeZone ;
-
-import org.apache.jena.datatypes.TypeMapper ;
+import org.apache.jena.datatypes.TypeMapper;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.rdf.model.* ;
@@ -1935,7 +1934,7 @@ public class TestParameterizedSparqlString {
         ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
         pss.setValues("objs", ResourceFactory.createPlainLiteral("test"));
 
-        String exp = "SELECT * WHERE { VALUES ?o {\"test\"^^http://www.w3.org/2001/XMLSchema#string} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES ?o {\"test\"} ?s ?p ?o }";
         String res = pss.toString();
         //System.out.println("Exp: " + exp);
         //System.out.println("Res: " + res);
@@ -1949,7 +1948,7 @@ public class TestParameterizedSparqlString {
         ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
         pss.setValues("objs", ResourceFactory.createPlainLiteral("test"), true);
 
-        String exp = "SELECT * WHERE { VALUES ?o {(\"test\"^^http://www.w3.org/2001/XMLSchema#string)} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES ?o {(\"test\")} ?s ?p ?o }";
         String res = pss.toString();
         //System.out.println("Exp: " + exp);
         //System.out.println("Res: " + res);
@@ -1966,7 +1965,7 @@ public class TestParameterizedSparqlString {
         objs.add(ResourceFactory.createPlainLiteral("obj_B"));
         pss.setValues("objs", objs);
 
-        String exp = "SELECT * WHERE { VALUES ?o {\"obj_A\"^^http://www.w3.org/2001/XMLSchema#string \"obj_B\"^^http://www.w3.org/2001/XMLSchema#string} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES ?o {\"obj_A\" \"obj_B\"} ?s ?p ?o }";
         String res = pss.toString();
         //System.out.println("Exp: " + exp);
         //System.out.println("Res: " + res);
@@ -1983,7 +1982,7 @@ public class TestParameterizedSparqlString {
         objs.add(ResourceFactory.createPlainLiteral("obj_B"));
         pss.setValues("objs", objs, true);
 
-        String exp = "SELECT * WHERE { VALUES (?o) {(\"obj_A\"^^http://www.w3.org/2001/XMLSchema#string) (\"obj_B\"^^http://www.w3.org/2001/XMLSchema#string)} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES (?o) {(\"obj_A\") (\"obj_B\")} ?s ?p ?o }";
         String res = pss.toString();
         //System.out.println("Exp: " + exp);
         //System.out.println("Res: " + res);
@@ -2005,7 +2004,7 @@ public class TestParameterizedSparqlString {
         props.add(ResourceFactory.createProperty("http://example.org/prop_B"));
         pss.setValues("props", props);
 
-        String exp = "SELECT * WHERE { VALUES ?p {<http://example.org/prop_A> <http://example.org/prop_B>} VALUES ?o {\"obj_A\"^^http://www.w3.org/2001/XMLSchema#string \"obj_B\"^^http://www.w3.org/2001/XMLSchema#string} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES ?p {<http://example.org/prop_A> <http://example.org/prop_B>} VALUES ?o {\"obj_A\" \"obj_B\"} ?s ?p ?o }";
         String res = pss.toString();
         //System.out.println("Exp: " + exp);
         //System.out.println("Res: " + res);
@@ -2027,7 +2026,7 @@ public class TestParameterizedSparqlString {
         props.add(ResourceFactory.createProperty("http://example.org/prop_B"));
         pss.setValues("props", props, true);
 
-        String exp = "SELECT * WHERE { VALUES (?p) {(<http://example.org/prop_A>) (<http://example.org/prop_B>)} VALUES ?o {\"obj_A\"^^http://www.w3.org/2001/XMLSchema#string \"obj_B\"^^http://www.w3.org/2001/XMLSchema#string} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES (?p) {(<http://example.org/prop_A>) (<http://example.org/prop_B>)} VALUES ?o {\"obj_A\" \"obj_B\"} ?s ?p ?o }";
         String res = pss.toString();
         //System.out.println("Exp: " + exp);
         //System.out.println("Res: " + res);
@@ -2053,7 +2052,7 @@ public class TestParameterizedSparqlString {
 
         pss.setGroupedValues("vars", vars);
 
-        String exp = "SELECT * WHERE { VALUES (?p ?o) {(<http://example.org/prop_A> \"obj_A\"^^http://www.w3.org/2001/XMLSchema#string) (<http://example.org/prop_B> \"obj_B\"^^http://www.w3.org/2001/XMLSchema#string)} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES (?p ?o) {(<http://example.org/prop_A> \"obj_A\") (<http://example.org/prop_B> \"obj_B\")} ?s ?p ?o }";
         String res = pss.toString();
         //System.out.println("Exp: " + exp);
         //System.out.println("Res: " + res);

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -1984,8 +1984,8 @@ public class TestParameterizedSparqlString {
     }
 
     @Test
-    public void test_set_values_item_missing_varName() {
-        // varName missing ('props' instead of 'objs') so query is unchanged.
+    public void test_set_values_item_missing_valueName() {
+        // valueName missing ('props' instead of 'objs') so query is unchanged.
         String str = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
         ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
         pss.setValues("props", ResourceFactory.createPlainLiteral("test"));
@@ -2092,10 +2092,10 @@ public class TestParameterizedSparqlString {
 
     @Test
     public void test_extract_target_vars() {
-        // Identifies the vars in the VALUES clause according to the substituting varName.
+        // Identifies the vars in the VALUES clause according to the substituting valueName.
         String cmd = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
-        String varName = "objs";
-        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String valueName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{"o"};
 
         //System.out.println("Exp: " + String.join(",", exp));
@@ -2105,10 +2105,10 @@ public class TestParameterizedSparqlString {
 
     @Test
     public void test_extract_two_target_vars() {
-        // Identifies the vars in the VALUES clause according to the substituting varName.
-        String cmd = "SELECT * WHERE { VALUES(?p ?o){?vars} ?s ?p ?o }";
-        String varName = "vars";
-        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        // Identifies the vars in the VALUES clause according to the substituting valueName.
+        String cmd = "SELECT * WHERE { VALUES(?p ?o){?valuesName} ?s ?p ?o }";
+        String valueName = "valuesName";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{"p", "o"};
 
         ///System.out.println("Exp: " + String.join(",", exp));
@@ -2118,10 +2118,10 @@ public class TestParameterizedSparqlString {
 
     @Test
     public void test_extract_multiple_target_vars() {
-        // Identifies the vars in the VALUES clause according to the substituting varName.
+        // Identifies the vars in the VALUES clause according to the substituting valueName.
         String cmd = "SELECT * WHERE { VALUES ?p {?props} VALUES ?o {?objs} ?s ?p ?o }";
-        String varName = "objs";
-        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String valueName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{"o"};
 
         //System.out.println("Exp: " + String.join(",", exp));
@@ -2133,8 +2133,8 @@ public class TestParameterizedSparqlString {
     public void test_extract_target_vars_missing_target() {
         // Missing target variable name so should return empty array.
         String cmd = "SELECT * WHERE { VALUES ?o {} ?s ?p ?o }";
-        String varName = "objs";
-        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String valueName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
         //System.out.println("Exp: " + String.join(",", exp));
@@ -2146,8 +2146,8 @@ public class TestParameterizedSparqlString {
     public void test_extract_target_vars_missing_brace() {
         // Missing brace so should return empty array.
         String cmd = "SELECT * WHERE { VALUES ?o ?objs} ?s ?p ?o }";
-        String varName = "objs";
-        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String valueName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
         //System.out.println("Exp: " + String.join(",", exp));
@@ -2159,8 +2159,8 @@ public class TestParameterizedSparqlString {
     public void test_extract_multiple_target_vars_missing_brace() {
         // Missing brace so should return empty array.
         String cmd = "SELECT * WHERE { VALUES ?p {?props} VALUES ?o ?objs} ?s ?p ?o }";
-        String varName = "objs";
-        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String valueName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
         //System.out.println("Exp: " + String.join(",", exp));
@@ -2172,8 +2172,8 @@ public class TestParameterizedSparqlString {
     public void test_extract_target_vars_missing_values() {
         // Missing VALUES keyword so should return empty array.
         String cmd = "SELECT * WHERE { ?o {?objs} ?s ?p ?o }";
-        String varName = "objs";
-        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String valueName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
         //System.out.println("Exp: " + String.join(",", exp));
@@ -2185,8 +2185,8 @@ public class TestParameterizedSparqlString {
     public void test_extract_multiple_target_vars_missing_values() {
         // Missing VALUES keyword so should return empty array.
         String cmd = "SELECT * WHERE { VALUES ?p {?props} ?o {?objs} ?s ?p ?o }";
-        String varName = "objs";
-        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String valueName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
         //System.out.println("Exp: " + String.join(",", exp));
@@ -2198,8 +2198,8 @@ public class TestParameterizedSparqlString {
     public void test_extract_multiple_target_vars_no_braces() {
         // Missing braces and VALUES keyword so should return empty array.
         String cmd = "SELECT * WHERE { VALUES ?p ?props ?o ?objs ?s ?p ?o }";
-        String varName = "objs";
-        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, varName);
+        String valueName = "objs";
+        String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
         //System.out.println("Exp: " + String.join(",", exp));


### PR DESCRIPTION
- Subclass ValueReplacement and methods added to allow substitution of varNames with collections of RDFNodes. This is used in SPARQL queries to provide inline data with the VALUES keyword.
- Supports multiple values for a single variable, sets of values for multiple variables and multiple sets of values for multiple values.
- Optional inclusion of parenthesis for the first two cases.
- Tests included for use cases.