### PR TITLE
Deprecate low level non-application operations

### DIFF
--- a/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionLifecycle.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionLifecycle.java
@@ -586,7 +586,7 @@ public abstract class AbstractTestTransactionLifecycle extends BaseTest
             Future<Boolean> f1 = executor.submit(callable);
             Future<Boolean> f2 = executor.submit(callable);
             // Wait longer than the cumulative threads sleep
-            assertTrue(f1.get(4, TimeUnit.SECONDS));
+            assertTrue(f1.get(10, TimeUnit.SECONDS));
             assertTrue(f2.get(1, TimeUnit.SECONDS));
         } finally {
             executor.shutdownNow();

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/StoreConnection.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/StoreConnection.java
@@ -228,9 +228,17 @@ public class StoreConnection
         StoreConnection sConn = cache.get(location) ;
         if (sConn != null) 
             return sConn ;
-        DatasetGraphTDB dsg = DatasetBuilderStd.create(location, params) ;
+        DatasetGraphTDB dsg = build(location, params) ;
         sConn = _makeAndCache(dsg) ;
         return sConn ;
+    }
+    
+    /**
+     * Build storage {@link DatasetGraphTDB}.
+     * This operation is the primitive that creates the storage-level DatasetGraphTDB.
+     */
+    private static DatasetGraphTDB build(Location location, StoreParams params) {
+        return DatasetBuilderStd.create(location, params) ;
     }
 
     /** Make a StoreConnection based on any StoreParams at the location or the system defaults. */

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/StoreConnection.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/StoreConnection.java
@@ -129,10 +129,9 @@ public class StoreConnection
     }
 
     /**
-     * Testing operation - do not use the base dataset without knowing how the
-     * transaction system uses it. The base dataset may not reflect the true state
-     * if pending commits are queued.
-     * @see #flush
+     * Internal operation - to get a dataset for application use, call a
+     * {@link TDBFactory} function. Do not use the base dataset without knowing how the
+     * transaction system uses it.
      */
     public DatasetGraphTDB getBaseDataset() {
         checkValid();

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/setup/Build.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/setup/Build.java
@@ -46,9 +46,6 @@ public class Build
     
     public static TupleIndex openTupleIndex(Location location, String indexName, String primary, String indexOrder, int readCacheSize, int writeCacheSize, int dftKeyLength, int dftValueLength)
     {
-        // XXX replace with:
-        // return DatasetBuilderStd.stdBuilder().makeTupleIndex(location, indexName, primary, indexOrder) ;
-        // All this to BuilderDB.
         StoreParamsBuilder spb = StoreParams.builder() ;
         spb.blockReadCacheSize(readCacheSize) ;
         spb.blockWriteCacheSize(writeCacheSize) ;
@@ -68,7 +65,6 @@ public class Build
         return dbBuild.makeNodeTable(location, params) ; 
     }
     
-    //XXX Reorg all calls to NodeTableBuilder to this argument order.
     public static NodeTable makeNodeTable(Location location, 
                                           String indexNode2Id, int node2NodeIdCacheSize,
                                           String indexId2Node, int nodeId2NodeCacheSize,
@@ -80,8 +76,7 @@ public class Build
         return makeNodeTable(location, spb.build()) ; 
     }
     
-    /** Choose the StoreParams.  This is the policy applied when creating or reattaching to a database.
-     *  (extracted and put here to keep the size of DatasetBuildStd  
+    /** Choose the StoreParams.  This is the policy applied when creating or re-attaching to a database.
      * <p>
      * If the location has parameters in a <tt>tdb.cfg</tt> file, use them, as modified by any
      * application-supplied internal parameters.
@@ -107,13 +102,13 @@ public class Build
      * providing some parameters in the {@link TDBFactory} call.
      * <p>
      * This includes changing filenames,  indexing choices and block size. 
-     * Otherwise, the database may be permanetly and irrecovably corrupted.
+     * Otherwise, the database may be permanently and irrevocably corrupted.
      * You have been warned. 
      * 
      * @param location The place where the database is or will be.
      * @param isNew  Whether the database is being created or whether there is an existing database.
      * @param pApp   Application-provide store parameters.
-     * @param pLoc   Store parameters foud at the location.
+     * @param pLoc   Store parameters found at the location.
      * @param pDft   System default store parameters.
      * @return       StoreParams
      * 

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/sys/TDBMaker.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/sys/TDBMaker.java
@@ -18,9 +18,11 @@
 
 package org.apache.jena.tdb.sys;
 
+import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.tdb.StoreConnection ;
+import org.apache.jena.tdb.TDBFactory;
 import org.apache.jena.tdb.base.file.Location ;
-import org.apache.jena.tdb.setup.DatasetBuilderStd ;
+import org.apache.jena.tdb.setup.DatasetBuilderStd;
 import org.apache.jena.tdb.setup.StoreParams ;
 import org.apache.jena.tdb.store.DatasetGraphTDB ;
 import org.apache.jena.tdb.transaction.DatasetGraphTransaction ;
@@ -29,7 +31,7 @@ import org.apache.jena.tdb.transaction.DatasetGraphTransaction ;
 
 public class TDBMaker
 {
-    // ---- Transactional
+    // ---- Transactional dataset maker.
     // This hides details from the top level TDB Factory (e.g. for testing)
 
     /** Create a DatasetGraph that supports transactions */
@@ -50,24 +52,42 @@ public class TDBMaker
         return createDatasetGraphTransaction(Location.mem()) ;
     }
 
+    /**
+     * Release a {@code Location}.
+     * Do not use a {@code Dataset} at this location without
+     * remaking it via {@link TDBFactory}.
+     */
+    public static void releaseLocation(Location location) {
+        StoreConnection.release(location) ;
+    }
+
+    /** 
+     * Reset the making and caching of datasets.
+     * Applications should not use this operation.
+     * All dataset must be rebuild with {@link TDBFactory}
+     * after calling this operation.
+     * Use {@link TDBFactory#release(DatasetGraph)} with care.  
+     * @deprecated
+     */
+    @Deprecated
+    public static void reset() {
+        StoreConnection.reset() ;
+    }
+    
+    // Make a DatasetGraphTransaction
     private static DatasetGraphTransaction _create(Location location) {
         // No need to cache StoreConnection does all that.
         return new DatasetGraphTransaction(location) ;
     }
 
-    public static void releaseLocation(Location location) {
-        StoreConnection.release(location) ;
-    }
-
-    public static void reset() {
-        StoreConnection.reset() ;
-    }
-    
     // ---- Raw non-transactional
-    /** Create a non-transactional TDB dataset graph.
-     * Bypasses StoreConnection caching. 
-     * <b>Use at your own risk.</b> 
+    /** 
+     * Create a non-transactional TDB dataset graph.
+     * <b>Use at your own risk.</b>
+     * <i>This function does not attempt to share databases at the same location.</i> 
+     * @deprecated Use {@link TDBFactory} or {@link StoreConnection}.
      */
+    @Deprecated
     public static DatasetGraphTDB createDatasetGraphTDB(Location loc, StoreParams params)
     { return DatasetBuilderStd.create(loc, params) ; }
 }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/DatasetGraphTransaction.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/transaction/DatasetGraphTransaction.java
@@ -69,7 +69,11 @@ import org.apache.jena.tdb.store.GraphTxnTDB ;
     private boolean                      isClosed      = false;
 
     public DatasetGraphTransaction(Location location) {
-        sConn = StoreConnection.make(location) ;
+        this(StoreConnection.make(location)) ;
+    }
+
+    public DatasetGraphTransaction(StoreConnection sConn) {
+        this.sConn = sConn; 
     }
 
     public Location getLocation() {
@@ -135,7 +139,7 @@ import org.apache.jena.tdb.store.GraphTxnTDB ;
         if ( sConn.haveUsedInTransaction() )
             throw new TDBTransactionException("Not in a transaction") ;
 
-        // Never used in a transaction - return underlying database for old
+        // Never been used in a transaction - return underlying database for old
         // style (non-transactional) usage.
         return sConn.getBaseDataset() ;
     }

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/TestTDBFactory.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/TestTDBFactory.java
@@ -38,74 +38,69 @@ public class TestTDBFactory extends BaseTest
     static Quad quad1 = SSE.parseQuad("(_ <s> <p> 1)") ;
     static Quad quad2 = SSE.parseQuad("(_ <s> <p> 1)") ;
     
-    @Before public void before()
-    {
-        StoreConnection.reset() ;
-        FileOps.clearDirectory(DIR) ; 
-    }
-    
-    @After public void after()
-    {
-        FileOps.clearDirectory(DIR) ; 
-    }
-    
-    @Test public void testTDBFactory1()
-    {
-        TDBMaker.reset() ;
-        DatasetGraph dg1 = TDBFactory.createDatasetGraph(Location.mem("FOO")) ;
-        DatasetGraph dg2 = TDBFactory.createDatasetGraph(Location.mem("FOO")) ;
-        dg1.add(quad1) ;
-        assertTrue(dg2.contains(quad1)) ;
-    }
-    
-    @Test public void testTDBFactory2()
-    {
-        TDBMaker.reset() ;
-        // The unnamed location is unique each time.
-        DatasetGraph dg1 = TDBFactory.createDatasetGraph(Location.mem()) ;
-        DatasetGraph dg2 = TDBFactory.createDatasetGraph(Location.mem()) ;
-        dg1.add(quad1) ;
-        assertFalse(dg2.contains(quad1)) ;
+    @Before
+    public void before() {
+        StoreConnection.reset();
+        FileOps.clearDirectory(DIR);
     }
 
-    @Test public void testTDBMakerTxn1()
-    {
-        TDBMaker.reset() ;
-        DatasetGraph dg1 = TDBMaker.createDatasetGraphTransaction(Location.create(DIR)) ;
-        DatasetGraph dg2 = TDBMaker.createDatasetGraphTransaction(Location.create(DIR)) ;
-        
-        DatasetGraph dgBase1 = ((DatasetGraphTransaction)dg1).getBaseDatasetGraph() ;
-        DatasetGraph dgBase2 = ((DatasetGraphTransaction)dg2).getBaseDatasetGraph() ;
-        
-        assertSame(dgBase1, dgBase2) ;
+    @After
+    public void after() {
+        FileOps.clearDirectory(DIR);
     }
-    
-    @Test public void testTDBMakerTxn2()
-    {
+
+    @Test
+    public void testTDBFactory1() {
+        DatasetGraph dg1 = TDBFactory.createDatasetGraph(Location.mem("FOO"));
+        DatasetGraph dg2 = TDBFactory.createDatasetGraph(Location.mem("FOO"));
+        dg1.add(quad1);
+        assertTrue(dg2.contains(quad1));
+    }
+
+    @Test
+    public void testTDBFactory2() {
+        // The unnamed location is unique each time.
+        DatasetGraph dg1 = TDBFactory.createDatasetGraph(Location.mem());
+        DatasetGraph dg2 = TDBFactory.createDatasetGraph(Location.mem());
+        dg1.add(quad1);
+        assertFalse(dg2.contains(quad1));
+    }
+
+    @Test
+    public void testTDBMakerTxn1() {
+        DatasetGraph dg1 = TDBMaker.createDatasetGraphTransaction(Location.create(DIR));
+        DatasetGraph dg2 = TDBMaker.createDatasetGraphTransaction(Location.create(DIR));
+
+        DatasetGraph dgBase1 = ((DatasetGraphTransaction)dg1).getBaseDatasetGraph();
+        DatasetGraph dgBase2 = ((DatasetGraphTransaction)dg2).getBaseDatasetGraph();
+
+        assertSame(dgBase1, dgBase2);
+    }
+
+    @Test
+    public void testTDBMakerTxn2() {
         // Named memory locations
-        TDBMaker.reset() ;
-        DatasetGraph dg1 = TDBMaker.createDatasetGraphTransaction(Location.mem("FOO")) ;
-        DatasetGraph dg2 = TDBMaker.createDatasetGraphTransaction(Location.mem("FOO")) ;
-        
-        DatasetGraph dgBase1 = ((DatasetGraphTransaction)dg1).getBaseDatasetGraph() ;
-        DatasetGraph dgBase2 = ((DatasetGraphTransaction)dg2).getBaseDatasetGraph() ;
-        
-        assertSame(dgBase1, dgBase2) ;
+        DatasetGraph dg1 = TDBMaker.createDatasetGraphTransaction(Location.mem("FOO"));
+        DatasetGraph dg2 = TDBMaker.createDatasetGraphTransaction(Location.mem("FOO"));
+
+        DatasetGraph dgBase1 = ((DatasetGraphTransaction)dg1).getBaseDatasetGraph();
+        DatasetGraph dgBase2 = ((DatasetGraphTransaction)dg2).getBaseDatasetGraph();
+
+        assertSame(dgBase1, dgBase2);
     }
-    
-    @Test public void testTDBMakerTxn3()
-    {
+
+    @Test
+    public void testTDBMakerTxn3() {
         // Un-named memory locations
-        TDBMaker.reset() ;
-        DatasetGraph dg1 = TDBMaker.createDatasetGraphTransaction(Location.mem()) ;
-        DatasetGraph dg2 = TDBMaker.createDatasetGraphTransaction(Location.mem()) ;
-        
-        DatasetGraph dgBase1 = ((DatasetGraphTransaction)dg1).getBaseDatasetGraph() ;
-        DatasetGraph dgBase2 = ((DatasetGraphTransaction)dg2).getBaseDatasetGraph() ;
-        
-        assertNotSame(dgBase1, dgBase2) ;
+        DatasetGraph dg1 = TDBMaker.createDatasetGraphTransaction(Location.mem());
+        DatasetGraph dg2 = TDBMaker.createDatasetGraphTransaction(Location.mem());
+
+        DatasetGraph dgBase1 = ((DatasetGraphTransaction)dg1).getBaseDatasetGraph();
+        DatasetGraph dgBase2 = ((DatasetGraphTransaction)dg2).getBaseDatasetGraph();
+
+        assertNotSame(dgBase1, dgBase2);
     }
-    
+
     @Test public void testTDBFresh01() {
         boolean b = TDBFactory.inUseLocation(DIR) ;
         assertFalse("Expect false before any creation attempted", b) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestLoader.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestLoader.java
@@ -34,7 +34,7 @@ import org.apache.jena.tdb.ConfigTest ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.TDBLoader ;
 import org.apache.jena.tdb.base.file.Location ;
-import org.apache.jena.tdb.sys.TDBMaker ;
+import org.apache.jena.tdb.setup.DatasetBuilderStd;
 import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
@@ -60,7 +60,7 @@ public class TestLoader extends BaseTest {
     }
 
     static DatasetGraphTDB fresh() {
-        return TDBMaker.createDatasetGraphTDB(Location.mem(), null) ;
+        return DatasetBuilderStd.create(Location.mem()) ;
     }
 
     @Test

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransRestart.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransRestart.java
@@ -33,10 +33,10 @@ import org.apache.jena.tdb.base.block.FileMode ;
 import org.apache.jena.tdb.base.file.FileFactory ;
 import org.apache.jena.tdb.base.file.Location ;
 import org.apache.jena.tdb.base.objectfile.ObjectFile ;
+import org.apache.jena.tdb.setup.DatasetBuilderStd;
 import org.apache.jena.tdb.store.DatasetGraphTDB ;
 import org.apache.jena.tdb.sys.Names ;
 import org.apache.jena.tdb.sys.SystemTDB ;
-import org.apache.jena.tdb.sys.TDBMaker ;
 import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
@@ -70,14 +70,13 @@ public class TestTransRestart extends BaseTest {
         cleanup() ;
     }
     
-    private static DatasetGraphTDB createPlain(Location location) { return TDBMaker.createDatasetGraphTDB(location, null) ; }
+    private static DatasetGraphTDB createPlain(Location location) { return DatasetBuilderStd.create(location) ; }
     
     private void setupPlain() {
         // Make without transactions.
         DatasetGraphTDB dsg = createPlain(location) ;
         dsg.add(quad1) ; 
         dsg.close() ;
-        StoreConnection.release(location) ; 
         return ;
     }
 


### PR DESCRIPTION
TDBMarker.reset and TDBMaker.createDatasetGraphTDB are operations that should not be called by applications. This PR deprecates them. If applications want to tinker with the internal of the system, they should understand the implications by seeing StoreConnection calls.

