### PR TITLE
Fuseki code maintenance.

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IO.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IO.java
@@ -21,6 +21,11 @@ package org.apache.jena.atlas.io;
 import java.io.* ;
 import java.nio.charset.Charset ;
 import java.nio.charset.StandardCharsets ;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.zip.GZIPInputStream ;
 import java.util.zip.GZIPOutputStream ;
 
@@ -363,5 +368,32 @@ public class IO
             IO.exception(e) ;
             return null ;
         }
+    }
+    
+    /** Delete everything from a {@code Path} start point, including the path itself.
+     * This function works on files or directories.
+     * This function does not follow symbolic links.
+     */  
+    public static void deleteAll(Path start) {
+        // Walks down the tree and delete directories on the way backup.
+        try { 
+            Files.walkFileTree(start, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+                    if (e == null) {
+                        Files.delete(dir);
+                        return FileVisitResult.CONTINUE;
+                    } else {
+                        throw e;
+                    }
+                }
+            });
+        }
+        catch (IOException ex) { IO.exception(ex) ; return; }
     }
 }

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/StorageTDB.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/StorageTDB.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.tdb2.store;
 
+import java.util.Objects;
+
 import org.apache.jena.dboe.base.file.Location;
 import org.apache.jena.tdb2.setup.StoreParams;
 
@@ -31,6 +33,13 @@ public class StorageTDB {
     
     public StorageTDB(TripleTable tripleTable, QuadTable quadTable, DatasetPrefixesTDB prefixes, Location location, StoreParams params) {
         super();
+        
+        Objects.requireNonNull(tripleTable);
+        Objects.requireNonNull(quadTable);
+        Objects.requireNonNull(prefixes);
+        Objects.requireNonNull(location);
+        Objects.requireNonNull(params);
+        
         this.tripleTable = tripleTable;
         this.quadTable = quadTable;
         this.prefixes = prefixes;

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/TDBInternal.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/TDBInternal.java
@@ -160,7 +160,7 @@ public class TDBInternal {
         return null;
     }
 
-    /** Stop managing a DatasetGraph. Use with great care (testing only). */
+    /** Stop managing a DatasetGraph. Use with great care. */
     public static synchronized void expel(DatasetGraph dsg) {
         Location locContainer = null;
         Location locStorage = null;
@@ -176,6 +176,23 @@ public class TDBInternal {
         StoreConnection.internalExpel(locStorage, false);
     }
 
+    /** Stop managing a DatasetGraph. Use with great care. */
+    public static synchronized void expel(DatasetGraph dsg, boolean force) {
+        Location locContainer = null;
+        Location locStorage = null;
+        
+        if ( dsg instanceof DatasetGraphSwitchable ) {
+            locContainer = ((DatasetGraphSwitchable)dsg).getLocation();
+            dsg = ((DatasetGraphSwitchable)dsg).getWrapped();
+        }
+        if ( dsg instanceof DatasetGraphTDB )
+            locStorage = ((DatasetGraphTDB)dsg).getLocation();
+        
+        DatabaseConnection.internalExpel(locContainer, force);
+        StoreConnection.internalExpel(locStorage, force);
+    }
+
+    
     /** 
      * Reset the whole TDB system.      
      * Use with great care.

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/TDBInternal.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/TDBInternal.java
@@ -172,7 +172,8 @@ public class TDBInternal {
         if ( dsg instanceof DatasetGraphTDB )
             locStorage = ((DatasetGraphTDB)dsg).getLocation();
         
-        DatabaseConnection.internalExpel(locContainer, false);
+        if ( locContainer != null )
+            DatabaseConnection.internalExpel(locContainer, false);
         StoreConnection.internalExpel(locStorage, false);
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/FusekiLib.java
@@ -71,7 +71,7 @@ public class FusekiLib {
         return ContentType.create(contentTypeHeader) ;
     }
     
-    /** Get the incoming Lang based on Content-Type of an action.
+    /** Get the incoming {@link Lang} based on Content-Type of an action.
      * @param  action
      * @param  dft Default if no "Content-Type:" found. 
      * @return ContentType
@@ -178,8 +178,8 @@ public class FusekiLib {
     }
 
     /**
-     * Test whether a URL identifies a Fuseki server. This operation can not guaranttee to
-     * detech a Fuseki server - for example, it may be behind a reverse proxy that masks
+     * Test whether a URL identifies a Fuseki server. This operation can not guarantee to
+     * detect a Fuseki server - for example, it may be behind a reverse proxy that masks
      * the signature.
      */
     public static boolean isFuseki(String datasetURL) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiBuildLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiBuildLib.java
@@ -36,6 +36,20 @@ public class FusekiBuildLib {
         return query(string, m, null, null) ;
     }
 
+    public static RDFNode queryOne(String string, Model m, String varname) {
+        ResultSet rs = query(string, m) ;
+        return getExactlyOne(rs, varname);
+    }
+    
+    private static RDFNode getExactlyOne(ResultSet rs, String varname) {
+        if ( ! rs.hasNext() )
+            return null;
+        QuerySolution qs = rs.next();
+        if ( rs.hasNext() )
+            return null;
+        return qs.get(varname);
+    }
+
     public static ResultSet query(String string, Dataset ds) {
         return query(string, ds, null, null) ;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiBuilder.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiBuilder.java
@@ -171,7 +171,5 @@ public class FusekiBuilder
             //log.info("  " + operation.name + " = " + dataAccessPoint.getName() + "/" + epName) ;
         }
     }
-
-
 }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
@@ -226,7 +226,7 @@ public class FusekiConfig {
                 Resource g = row.getResource("g") ;
                 Resource rStatus = row.getResource("status") ;
                 //String name = row.getLiteral("name").getLexicalForm() ;
-                DatasetStatus status = DatasetStatus.status(rStatus) ;
+                DataServiceStatus status = DataServiceStatus.status(rStatus) ;
 
                 Model m = ds.getNamedModel(g.getURI()) ;
                 // Rebase the resource of the service description to the containing graph.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPoint.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPoint.java
@@ -31,6 +31,7 @@ public class DataAccessPoint {
     public DataAccessPoint(String name, DataService dataService) {
         this.name = canonical(name) ;
         this.dataService = dataService ;
+        dataService.noteDataAccessPoint(this);
     }
     
     public String getName()     { return name ; }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataService.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataService.java
@@ -18,111 +18,134 @@
 
 package org.apache.jena.fuseki.server;
 
-import static org.apache.jena.fuseki.server.DatasetStatus.CLOSING ;
-import static org.apache.jena.fuseki.server.DatasetStatus.UNINITIALIZED ;
+import static java.lang.String.format;
+import static org.apache.jena.fuseki.server.DataServiceStatus.*;
 
-import java.util.* ;
-import java.util.concurrent.atomic.AtomicBoolean ;
-import java.util.concurrent.atomic.AtomicLong ;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jena.ext.com.google.common.collect.ArrayListMultimap;
 import org.apache.jena.ext.com.google.common.collect.ListMultimap;
-import org.apache.jena.fuseki.DEF ;
-import org.apache.jena.fuseki.Fuseki ;
+import org.apache.jena.fuseki.DEF;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.query.TxnType;
-import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.sparql.core.DatasetGraphFactory ;
-import org.apache.jena.sparql.core.DatasetGraphReadOnly ;
-import org.apache.jena.tdb.StoreConnection ;
-import org.apache.jena.tdb.transaction.DatasetGraphTransaction ;
+import org.apache.jena.query.text.DatasetGraphText;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.core.DatasetGraphReadOnly;
 
 public class DataService { //implements DatasetMXBean {
     public static DataService serviceOnlyDataService() {
-        return dummy ; 
+        return dummy; 
     }
     
-    public static final DataService dummy ;
+    private static final DataService dummy;
     static {
-        DatasetGraph dsg = new DatasetGraphReadOnly(DatasetGraphFactory.create()) ;
-        dummy = new DataService(dsg) ;
-        dummy.addEndpoint(Operation.Query, DEF.ServiceQuery) ;
-        dummy.addEndpoint(Operation.Query, DEF.ServiceQueryAlt) ;
+        DatasetGraph dsg = new DatasetGraphReadOnly(DatasetGraphFactory.create());
+        dummy = new DataService(dsg);
+        dummy.addEndpoint(Operation.Query, DEF.ServiceQuery);
+        dummy.addEndpoint(Operation.Query, DEF.ServiceQueryAlt);
     }
     
-    private DatasetGraph dataset ;
+    private DatasetGraph dataset;
 
-    private ListMultimap<Operation, Endpoint> operations    = ArrayListMultimap.create() ;
-    private Map<String, Endpoint> endpoints                     = new HashMap<>() ;
-    
-    private volatile DatasetStatus state = UNINITIALIZED ;
+    private ListMultimap<Operation, Endpoint> operations  = ArrayListMultimap.create();
+    private Map<String, Endpoint> endpoints               = new HashMap<>();
+
+    /**
+     * Record which {@link DataAccessPoint DataAccessPoints} this {@code DataService} is
+     * associated with. This is mainly for checking and development.
+     * Usually, one {@code DataService} is associated with one {@link DataAccessPoint}.
+     */
+    private List<DataAccessPoint> dataAccessPoints      = new ArrayList<>(1);
+
+    private volatile DataServiceStatus state            = UNINITIALIZED;
 
     // DataService-level counters.
-    private final CounterSet    counters                = new CounterSet() ;
-    private final AtomicLong    requestCounter          = new AtomicLong(0) ;   
-    private final AtomicBoolean offlineInProgress       = new AtomicBoolean(false) ;
-    private final AtomicBoolean acceptingRequests       = new AtomicBoolean(true) ;
+    private final CounterSet    counters                = new CounterSet();
+    private final AtomicBoolean offlineInProgress       = new AtomicBoolean(false);
+    private final AtomicBoolean acceptingRequests       = new AtomicBoolean(true);
 
     /** Create a {@code DataService} for the given dataset. */
     public DataService(DatasetGraph dataset) {
-        this.dataset = dataset ;
-        counters.add(CounterName.Requests) ;
-        counters.add(CounterName.RequestsGood) ;
-        counters.add(CounterName.RequestsBad) ;
+        this.dataset = dataset;
+        counters.add(CounterName.Requests);
+        counters.add(CounterName.RequestsGood);
+        counters.add(CounterName.RequestsBad);
+        // Start ACTIVE. Registration controls visibility. 
+        goActive();
+
     }
 
     /**
      * Create a {@code DataService} that has the same dataset, same operations and
-     * endpoints as another {@code DataService}. Counters are not copied.
+     * endpoints as another {@code DataService}. Counters are not copied, not
+     * DataAccessPoint associations.
      */
-    public DataService(DataService other) {
+    private DataService(int dummy, DataService other) {
         // Copy non-counter state of 'other'.
-        this.dataset = other.dataset ;
-        this.operations = ArrayListMultimap.create(other.operations) ;
-        this.endpoints = new HashMap<>(other.endpoints) ;
+        this.dataset = other.dataset;
+        this.operations = ArrayListMultimap.create(other.operations);
+        this.endpoints = new HashMap<>(other.endpoints);
+        this.state = UNINITIALIZED;
     }
 
+    /*package*/ void noteDataAccessPoint(DataAccessPoint dap) {
+        this.dataAccessPoints.add(dap);
+    }
+    
+    private String label() {
+        StringJoiner sj = new StringJoiner(", ", "[", "]");
+        dataAccessPoints.stream()
+            .map(DataAccessPoint::getName)
+            .filter(x->!x.isEmpty())
+            .forEach(sj::add);
+        return sj.toString();
+    }
     
     public DatasetGraph getDataset() {
-        return dataset ; 
+        return dataset; 
     }
     
     public void addEndpoint(Operation operation, String endpointName) {
-        Endpoint endpoint = new Endpoint(operation, endpointName) ;
-        endpoints.put(endpointName, endpoint) ;
+        Endpoint endpoint = new Endpoint(operation, endpointName);
+        endpoints.put(endpointName, endpoint);
         operations.put(operation, endpoint);
     }
     
     public Endpoint getEndpoint(String endpointName) {
-        return endpoints.get(endpointName) ;
+        return endpoints.get(endpointName);
     }
 
     public List<Endpoint> getEndpoints(Operation operation) {
-        List<Endpoint> x = operations.get(operation) ;
+        List<Endpoint> x = operations.get(operation);
         if ( x == null )
-            x = Collections.emptyList() ;
-        return x ;  
+            x = Collections.emptyList();
+        return x;  
     }
 
     /** Return the operations available here.
      *  @see #getEndpoints(Operation) to get the endpoint list
      */
     public Collection<Operation> getOperations() {
-        return operations.keySet() ;
+        return operations.keySet();
     }
 
     //@Override
-    public boolean allowUpdate()    { return true ; }
+    public boolean allowUpdate()    { return true; }
 
     public void goOffline() {
         offlineInProgress.set(true);
         acceptingRequests.set(false);
-        state = DatasetStatus.OFFLINE;
+        state = OFFLINE;
     }
 
     public void goActive() {
         offlineInProgress.set(false);
         acceptingRequests.set(true);
-        state = DatasetStatus.ACTIVE;
+        state = ACTIVE;
     }
 
     // Due to concurrency, call isAcceptingRequests().
@@ -131,56 +154,79 @@ public class DataService { //implements DatasetMXBean {
 //    }
 
     public boolean isAcceptingRequests() {
-        return acceptingRequests.get() ;
+        return acceptingRequests.get();
     }
     
     //@Override
-    public  CounterSet getCounters() { return counters ; }
+    public  CounterSet getCounters() { return counters; }
     
     //@Override 
     public long getRequests() { 
-        return counters.value(CounterName.Requests) ;
+        return counters.value(CounterName.Requests);
     }
 
     //@Override
     public long getRequestsGood() {
-        return counters.value(CounterName.RequestsGood) ;
+        return counters.value(CounterName.RequestsGood);
     }
     //@Override
     public long getRequestsBad() {
-        return counters.value(CounterName.RequestsBad) ;
+        return counters.value(CounterName.RequestsBad);
     }
 
     /** Counter of active transactions */
-    public AtomicLong   activeTxn           = new AtomicLong(0) ;
+    public AtomicLong   activeTxn           = new AtomicLong(0);
 
     /** Cumulative counter of transactions */
-    public AtomicLong   totalTxn            = new AtomicLong(0) ;
+    public AtomicLong   totalTxn            = new AtomicLong(0);
 
     public void startTxn(TxnType mode) {
+        check(DataServiceStatus.ACTIVE);
         activeTxn.getAndIncrement();
         totalTxn.getAndIncrement();
+    }
+
+    private void check(DataServiceStatus status) {
+        if ( state != status ) {
+            String msg = format("DataService %s: Expected=%s, Actual=%s", label(), status, state);
+            throw new FusekiException(msg);
+        }
     }
 
     public void finishTxn() {
         activeTxn.decrementAndGet();
     }
 
-    private void checkShutdown() {
-        if ( state == CLOSING ) {
-            if ( activeTxn.get() == 0 )
-                shutdown() ;
-        }
+    /** Shutdown and never use again. */
+    public synchronized void shutdown() {
+        if ( state == CLOSING )
+            return;
+        Fuseki.serverLog.info(format("Shutting down data service for %s", endpoints.keySet()));
+        expel(dataset);
+        dataset = null; 
+        state = CLOSED;
     }
-
-    private void shutdown() {
-        Fuseki.serverLog.info("Shutting down dataset") ;
-        dataset.close() ;
-        if ( dataset instanceof DatasetGraphTransaction ) {
-            DatasetGraphTransaction dsgtxn = (DatasetGraphTransaction)dataset ;
-            StoreConnection.release(dsgtxn.getLocation()) ;
+    
+    private void expel(DatasetGraph database) {
+        // Text databases.
+        // Close the in-JVM objects for Lucene index and databases. 
+        if ( database instanceof DatasetGraphText ) {
+            DatasetGraphText dbtext = (DatasetGraphText)database;
+            database = dbtext.getBase();
+            dbtext.getTextIndex().close();
         }
-        dataset = null ; 
+    
+        boolean isTDB1 = org.apache.jena.tdb.sys.TDBInternal.isTDB1(database);
+        boolean isTDB2 = org.apache.jena.tdb2.sys.TDBInternal.isTDB2(database);
+        
+        if ( ( isTDB1 || isTDB2 ) ) {
+            // JENA-1586: Remove database from the process.
+            if ( isTDB1 )
+                org.apache.jena.tdb.sys.TDBInternal.expel(database);
+            if ( isTDB2 )
+                org.apache.jena.tdb2.sys.TDBInternal.expel(database);
+        } else
+            dataset.close();
     }
 }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataServiceStatus.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataServiceStatus.java
@@ -20,12 +20,18 @@ package org.apache.jena.fuseki.server;
 
 import org.apache.jena.rdf.model.Resource ;
 
-public enum DatasetStatus {
-    UNINITIALIZED("Uninitialized"), ACTIVE("Active"), OFFLINE("Offline"), CLOSING("Closing"), CLOSED("Closed") ;
-    public final String name ; 
-    DatasetStatus(String string) { name = string ; }
+public enum DataServiceStatus {
     
-    public static DatasetStatus status(Resource r) {
+    UNINITIALIZED("Uninitialized"),
+    ACTIVE("Active"),
+    OFFLINE("Offline"),
+    CLOSING("Closing"),
+    CLOSED("Closed") ;
+    
+    public final String name ; 
+    DataServiceStatus(String string) { name = string ; }
+    
+    public static DataServiceStatus status(Resource r) {
         if ( FusekiVocab.stateActive.equals(r) )
             return ACTIVE ;
         if ( FusekiVocab.stateOffline.equals(r) )

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiVocab.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiVocab.java
@@ -48,10 +48,10 @@ public class FusekiVocab
     
     // Internal
     
-    private static final String stateNameActive      = DatasetStatus.ACTIVE.name ;
-    private static final String stateNameOffline     = DatasetStatus.OFFLINE.name ;
-    private static final String stateNameClosing     = DatasetStatus.CLOSING.name ;
-    private static final String stateNameClosed      = DatasetStatus.CLOSED.name ;
+    private static final String stateNameActive      = DataServiceStatus.ACTIVE.name ;
+    private static final String stateNameOffline     = DataServiceStatus.OFFLINE.name ;
+    private static final String stateNameClosing     = DataServiceStatus.CLOSING.name ;
+    private static final String stateNameClosed      = DataServiceStatus.CLOSED.name ;
     
     public static final Resource stateActive        = resource(stateNameActive) ;
     public static final Resource stateOffline       = resource(stateNameOffline) ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.fuseki.servlets;
 
-import static org.apache.jena.query.TxnType.*;
+import static org.apache.jena.query.TxnType.READ;
+import static org.apache.jena.query.TxnType.READ_PROMOTE;
 import static org.apache.jena.query.TxnType.WRITE;
 
 import java.util.HashMap ;
@@ -305,10 +306,11 @@ public class HttpAction
                 Log.warn(this, "Exception in forced abort (trying to continue)", ex) ;
             }
         }
-        transactional.end() ;
+        if ( transactional.isInTransaction() )
+            transactional.end() ;
         activeDSG = null ;
     }
-    
+
     public void commit() {
         dataService.finishTxn() ;
         transactional.commit() ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads_RW.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/REST_Quads_RW.java
@@ -109,7 +109,7 @@ public class REST_Quads_RW extends REST_Quads_R {
             action.abort() ;
             ServletOps.errorOccurred(ex.getMessage()) ;
         } finally {
-            action.endWrite() ;
+            action.end() ;
         }
         ServletOps.uploadResponse(action, details) ;
     }
@@ -143,7 +143,7 @@ public class REST_Quads_RW extends REST_Quads_R {
             } catch (Exception ex2) {}
             ServletOps.errorOccurred(ex.getMessage()) ;
         } finally {
-            action.endWrite() ;
+            action.end() ;
         }
         ServletOps.uploadResponse(action, details) ;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_GSP_RW.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_GSP_RW.java
@@ -68,7 +68,7 @@ public class SPARQL_GSP_RW extends SPARQL_GSP_R
             deleteGraph(action) ;
             action.commit() ;
         }
-        finally { action.endWrite() ; }
+        finally { action.end() ; }
         ServletOps.successNoContent(action) ;
     }
 
@@ -143,7 +143,7 @@ public class SPARQL_GSP_RW extends SPARQL_GSP_R
             ServletOps.errorOccurred(ex.getMessage()) ;
             return null ;
         } finally {
-            action.endWrite() ;
+            action.end() ;
         }
     }
     
@@ -188,7 +188,7 @@ public class SPARQL_GSP_RW extends SPARQL_GSP_R
             try { action.abort() ; } catch (Exception ex2) {} 
             ServletOps.errorOccurred(ex.getMessage()) ;
             return null ;            
-        } finally { action.endWrite() ; }
+        } finally { action.end() ; }
     }
     
     /** Delete a graph. This removes the storage choice and looses the setup.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
@@ -249,7 +249,7 @@ public class SPARQL_Update extends SPARQL_Protocol
                 try { action.abort() ; } catch (Exception ex2) {}
                 ServletOps.errorOccurred(ex.getMessage(), ex) ;
             }
-        } finally { action.endWrite(); }
+        } finally { action.end(); }
     }
 
     /* [It is an error to supply the using-graph-uri or using-named-graph-uri parameters

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
@@ -38,18 +38,12 @@ import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.web.HttpSC ;
 
 /**
- * Upload data into a graph within a dataset. This is fuseki:serviceUpload.
+ * Upload data into a graph within a dataset. This is {@code fuseki:serviceUpload}.
  * 
  * It is better to use GSP POST with the body being the content.
  * 
- * This class work with general HTML form file upload wherte  has the name somewhere in the form and that may be
+ * This class works with general HTML form file upload where the name is somewhere in the form and that may be
  * after the data.
- * 
- * With sophisticated use of {@link ServletFileUpload}, it is possible to stream to disk
- * avoid an in-memory copy. The whole form is processed to find the fields before parsing starts
- * and potentially is is several files.
- * 
- * This all makes transactional stream-parsing quite complex and it requires an abort. 
  * 
  * Consider this service useful for small files and use GSP POST for large ones.
  */

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Upload.java
@@ -20,35 +20,39 @@ package org.apache.jena.fuseki.servlets;
 
 import static java.lang.String.format ;
 
-import java.io.InputStream ;
 import java.io.PrintWriter ;
-import java.util.zip.GZIPInputStream ;
 
 import javax.servlet.http.HttpServletRequest ;
 import javax.servlet.http.HttpServletResponse ;
 
-import org.apache.commons.fileupload.FileItemIterator ;
-import org.apache.commons.fileupload.FileItemStream ;
 import org.apache.commons.fileupload.servlet.ServletFileUpload ;
-import org.apache.commons.fileupload.util.Streams ;
-import org.apache.jena.atlas.web.ContentType ;
 import org.apache.jena.fuseki.Fuseki ;
 import org.apache.jena.fuseki.FusekiLib ;
+import org.apache.jena.fuseki.system.Upload;
+import org.apache.jena.fuseki.system.UploadDetailsWithName;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
-import org.apache.jena.iri.IRI ;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.riot.lang.StreamRDFCounting ;
-import org.apache.jena.riot.system.IRIResolver ;
-import org.apache.jena.riot.system.StreamRDF ;
-import org.apache.jena.riot.system.StreamRDFLib ;
 import org.apache.jena.riot.web.HttpNames ;
 import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.sparql.core.DatasetGraphFactory ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.web.HttpSC ;
 
+/**
+ * Upload data into a graph within a dataset. This is fuseki:serviceUpload.
+ * 
+ * It is better to use GSP POST with the body being the content.
+ * 
+ * This class work with general HTML form file upload wherte  has the name somewhere in the form and that may be
+ * after the data.
+ * 
+ * With sophisticated use of {@link ServletFileUpload}, it is possible to stream to disk
+ * avoid an in-memory copy. The whole form is processed to find the fields before parsing starts
+ * and potentially is is several files.
+ * 
+ * This all makes transactional stream-parsing quite complex and it requires an abort. 
+ * 
+ * Consider this service useful for small files and use GSP POST for large ones.
+ */
 public class SPARQL_Upload extends ActionService
 {
     public SPARQL_Upload() {
@@ -120,7 +124,7 @@ public class SPARQL_Upload extends ActionService
      * are caught before inserting any data.
      */
     private static long uploadNonTxn(HttpAction action, String base) {
-        UploadDetails upload = uploadWorker(action, base) ;
+        UploadDetailsWithName upload = Upload.multipartUploadWorker(action, base) ;
         String graphName = upload.graphName ;
         DatasetGraph dataTmp = upload.data ;
         long count = upload.count ;
@@ -153,125 +157,16 @@ public class SPARQL_Upload extends ActionService
             ServletOps.errorOccurred(ex.getMessage()) ;
             return -1 ;
         }
-        finally { action.endWrite() ; }
+        finally { action.end() ; }
     }
 
-     /** Transactional - we'd like data to go straight to the destination, with an abort on parse error.
-      * But file upload with a name means that the name can be after the data
-      * (it is in the Fuseki default pages).
-      * Use Graph Store protocol for bulk uploads.
-      * (It would be possible to process the incoming stream and see the graph name first.)
-      */
-     private static long uploadTxn(HttpAction action, String base) {
-         // We can't do better than the non-transaction approach.
-         return uploadNonTxn(action, base) ;
-     }
-
-     static class UploadDetails {
-         final String graphName  ;
-         final DatasetGraph data ;
-         final long count ;
-         UploadDetails(String gn, DatasetGraph dsg, long parserCount) {
-             this.graphName = gn ;
-             this.data = dsg ;
-             this.count = parserCount ;
-         }
-     }
-
-    /** Process an HTTP file upload of RDF with additional name field for the graph name.
-     *  We can't stream straight into a dataset because the graph name can be after the data.
-     *  @return graph name and count
+    // XXX Improve.  Needs Upload code rework.
+    /** 
+     * Transactional - we'd like better handle the data and go straight to the destination, with an abort on parse error.
+     * Use Graph Store protocol for bulk uploads.
      */
-
-    // ?? Combine with Upload.fileUploadWorker
-    // Difference is the handling of names for graphs.
-    static private UploadDetails uploadWorker(HttpAction action, String base) {
-        DatasetGraph dsgTmp = DatasetGraphFactory.create() ;
-        ServletFileUpload upload = new ServletFileUpload() ;
-        String graphName = null ;
-        boolean isQuads = false ;
-        long count = -1 ;
-
-        String name = null ;
-        ContentType ct = null ;
-        Lang lang = null ;
-
-        try {
-            FileItemIterator iter = upload.getItemIterator(action.request) ;
-            while (iter.hasNext()) {
-                FileItemStream item = iter.next() ;
-                String fieldName = item.getFieldName() ;
-                InputStream stream = item.openStream() ;
-                if ( item.isFormField() ) {
-                    // Graph name.
-                    String value = Streams.asString(stream, "UTF-8") ;
-                    if ( fieldName.equals(HttpNames.paramGraph) ) {
-                        graphName = value ;
-                        if ( graphName != null && !graphName.equals("") && !graphName.equals(HttpNames.valueDefault) ) {
-                            IRI iri = IRIResolver.parseIRI(value) ;
-                            if ( iri.hasViolation(false) )
-                                ServletOps.errorBadRequest("Bad IRI: " + graphName) ;
-                            if ( iri.getScheme() == null )
-                                ServletOps.errorBadRequest("Bad IRI: no IRI scheme name: " + graphName) ;
-                            if ( iri.getScheme().equalsIgnoreCase("http") || iri.getScheme().equalsIgnoreCase("https") ) {
-                                // Redundant??
-                                if ( iri.getRawHost() == null )
-                                    ServletOps.errorBadRequest("Bad IRI: no host name: " + graphName) ;
-                                if ( iri.getRawPath() == null || iri.getRawPath().length() == 0 )
-                                    ServletOps.errorBadRequest("Bad IRI: no path: " + graphName) ;
-                                if ( iri.getRawPath().charAt(0) != '/' )
-                                    ServletOps.errorBadRequest("Bad IRI: Path does not start '/': " + graphName) ;
-                            }
-                        }
-                    } else if ( fieldName.equals(HttpNames.paramDefaultGraphURI) )
-                        graphName = null ;
-                    else
-                        // Add file type?
-                        action.log.info(format("[%d] Upload: Field=%s ignored", action.id, fieldName)) ;
-                } else {
-                    // Process the input stream
-                    name = item.getName() ;
-                    if ( name == null || name.equals("") || name.equals("UNSET FILE NAME") )
-                        ServletOps.errorBadRequest("No name for content - can't determine RDF syntax") ;
-
-                    String contentTypeHeader = item.getContentType() ;
-                    ct = ContentType.create(contentTypeHeader) ;
-
-                    lang = RDFLanguages.contentTypeToLang(ct.getContentType()) ;
-                    if ( lang == null ) {
-                        lang = RDFLanguages.filenameToLang(name) ;
-
-                        // JENA-600 filenameToLang() strips off certain
-                        // extensions such as .gz and
-                        // we need to ensure that if there was a .gz extension
-                        // present we wrap the stream accordingly
-                        if ( name.endsWith(".gz") )
-                            stream = new GZIPInputStream(stream) ;
-                    }
-
-                    if ( lang == null )
-                        // Desperate.
-                        lang = RDFLanguages.RDFXML ;
-
-                    isQuads = RDFLanguages.isQuads(lang) ;
-
-                    action.log.info(format("[%d] Upload: Filename: %s, Content-Type=%s, Charset=%s => %s", action.id, name,
-                                           ct.getContentType(), ct.getCharset(), lang.getName())) ;
-
-                    StreamRDF x = StreamRDFLib.dataset(dsgTmp) ;
-                    StreamRDFCounting dest = StreamRDFLib.count(x) ;
-                    ActionLib.parse(action, dest, stream, lang, base) ;
-                    count = dest.count() ;
-                }
-            }
-
-            if ( graphName == null || graphName.equals("") )
-                graphName = HttpNames.valueDefault ;
-            if ( isQuads )
-                graphName = null ;
-            return new UploadDetails(graphName, dsgTmp, count) ;
-        }
-        catch (ActionErrorException ex) { throw ex ; }
-        catch (Exception ex)            { ServletOps.errorOccurred(ex) ; return null ; }
+    private static long uploadTxn(HttpAction action, String base) {
+        return uploadNonTxn(action, base) ;
     }
+
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServiceRouter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServiceRouter.java
@@ -340,8 +340,6 @@ public abstract class ServiceRouter extends ActionService {
         return null;
     }
 
-    // XXX -------------------
-
     private boolean isReadMethod(HttpServletRequest request) {
         String method = request.getMethod();
         // REST dataset.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/UploadDetailsWithName.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/UploadDetailsWithName.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.system;
+
+import org.apache.jena.sparql.core.DatasetGraph;
+
+public class UploadDetailsWithName {
+     public final String graphName  ;
+     public final DatasetGraph data ;
+     public final long count ;
+     public UploadDetailsWithName(String gn, DatasetGraph dsg, long parserCount) {
+         this.graphName = gn ;
+         this.data = dsg ;
+         this.count = parserCount ;
+     }
+ }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerListener.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerListener.java
@@ -75,7 +75,6 @@ public class FusekiServerListener implements ServletContextListener {
         DataAccessPointRegistry dataAccessPointRegistry = new DataAccessPointRegistry() ;
         DataAccessPointRegistry.set(servletContext, dataAccessPointRegistry);
         
-        
         try {
             FusekiSystem.formatBaseArea() ; 
             if ( ! FusekiSystem.serverInitialized ) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/webapp/FusekiSystem.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/webapp/FusekiSystem.java
@@ -96,7 +96,7 @@ public class FusekiSystem
     /** Directory for system database */
     public static Path        dirSystemDatabase  = null ;
 
-    /** Directory for files uploaded (e.g upload assmbler descriptions); not data uploads. */
+    /** Directory for files uploaded (e.g upload assembler descriptions); not data uploads. */
     public static Path        dirFileArea        = null ;
     
     /** Directory for assembler files */
@@ -185,22 +185,26 @@ public class FusekiSystem
             try {
                 Files.copy(src.resolve(fn), dstFile, StandardCopyOption.COPY_ATTRIBUTES) ;
             } catch (IOException e) {
-                IO.exception("Failed to copy file "+src, e);
+                IO.exception("Failed to copy file "+src.resolve(fn), e);
                 e.printStackTrace();
             }
         } else {
-            try {
-                // Get from the file from area "org/apache/jena/fuseki/server"  (our package)
-                URL url = FusekiSystem.class.getResource(fn) ;
-                if ( url == null )
-                    throw new FusekiConfigException("Failed to find resource '"+fn+"'") ; 
-                InputStream in = url.openStream() ;
-                Files.copy(in, dstFile) ;
-            }
-            catch (IOException e) {
-                IO.exception("Failed to copy file from resource: "+src, e);
-                e.printStackTrace();
-            }
+            copyFileFromResource(fn, dstFile);
+        }
+    }
+    
+    public static void copyFileFromResource(String fn, Path dstFile) {
+        try {
+            // Get from the file from area "org/apache/jena/fuseki/server"  (our package)
+            URL url = FusekiSystem.class.getResource(fn) ;
+            if ( url == null )
+                throw new FusekiConfigException("Failed to find resource '"+fn+"'") ; 
+            InputStream in = url.openStream() ;
+            Files.copy(in, dstFile) ;
+        }
+        catch (IOException e) {
+            IO.exception("Failed to copy file from resource: "+fn, e);
+            e.printStackTrace();
         }
     }
 
@@ -221,7 +225,8 @@ public class FusekiSystem
     private static void enable(DataAccessPointRegistry registry, List<DataAccessPoint> datapoints) {
         for ( DataAccessPoint dap : datapoints ) {
             Fuseki.configLog.info("Register: "+dap.getName()) ;
-            registry.register(dap.getName(), dap); 
+            dap.getDataService().goActive();
+            registry.register(dap.getName(), dap);
         }
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/webapp/WEB-INF/web.xml
+++ b/jena-fuseki2/jena-fuseki-core/src/main/webapp/WEB-INF/web.xml
@@ -257,11 +257,6 @@
   </servlet-mapping>
 
   <servlet-mapping>
-    <servlet-name>ActionStats</servlet-name>
-    <url-pattern>/$/stats/*</url-pattern>
-  </servlet-mapping>
-
-  <servlet-mapping>
     <servlet-name>ActionLogs</servlet-name>
     <url-pattern>/$/logs</url-pattern>
   </servlet-mapping>

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/ServerCtl.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/ServerCtl.java
@@ -22,6 +22,7 @@ import static org.apache.jena.fuseki.ServerCtl.ServerScope.CLASS ;
 import static org.apache.jena.fuseki.ServerCtl.ServerScope.SUITE ;
 import static org.apache.jena.fuseki.ServerCtl.ServerScope.TEST ;
 
+import java.nio.file.Path;
 import java.nio.file.Paths ;
 import java.util.concurrent.atomic.AtomicInteger ;
 
@@ -226,7 +227,25 @@ public class ServerCtl {
         FileOps.ensureDir(TS_Fuseki.FusekiTestHome);
         FileOps.ensureDir(TS_Fuseki.FusekiTestBase) ;
         FusekiEnv.FUSEKI_BASE = Paths.get(TS_Fuseki.FusekiTestBase).toAbsolutePath() ;
+        // Must have shiro.ini.
+        // This fakes the state after FusekiSystem initialization
+        // in the case of starting in the same location. FusekiSystem has statics.
+        // Fuseki-full is designed to be the only server, not restartable.
+        // Here, we want to reset for testing.
+        emptyDirectory(FusekiSystem.dirSystemDatabase);
+        emptyDirectory(FusekiSystem.dirBackups);
+        emptyDirectory(FusekiSystem.dirLogs);
+        emptyDirectory(FusekiSystem.dirConfiguration);
+        emptyDirectory(FusekiSystem.dirDatabases);
+        
         setupServer(port(), null, datasetPath(), updateable) ;
+    }
+    
+    private static void emptyDirectory(Path directory) {
+        if ( directory == null )
+            // Server will create.
+            return; 
+        FileOps.clearAll(directory.toString());
     }
     
     public static void setupServer(int port, String authConfigFile, String datasetPath, boolean updateable) {

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TS_Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TS_Fuseki.java
@@ -41,6 +41,7 @@ import org.junit.runners.Suite ;
     , TestDatasetOps.class
     , TestFileUpload.class
     , TestAdmin.class
+    , TestAdminAPI.class
     , TestServerReadOnly.class
     , TestBuilder.class
 })

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestAdmin.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestAdmin.java
@@ -349,7 +349,6 @@ public class TestAdmin extends AbstractFusekiTest {
                 result = JSON.parseAny(in) ;
             }
         }
-        
     }
 
     private static String execSleepTask(String name, int millis) {

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestAdminAPI.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TestAdminAPI.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.http.HttpEntity ;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.jena.fuseki.webapp.FusekiSystem;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.rdfconnection.RDFConnection;
+import org.apache.jena.rdfconnection.RDFConnectionFactory;
+import org.apache.jena.riot.web.HttpOp ;
+import org.apache.jena.sparql.engine.http.Params;
+import org.junit.Test ;
+
+/** More tests of the admin functionality
+ * See also TestAdmin.
+ */
+public class TestAdminAPI extends AbstractFusekiTest {
+
+    @Test public void add_delete_api_1() throws Exception {
+        testAddDelete("db_mem", "mem", false);
+    }
+    
+    @Test public void add_delete_api_2() throws Exception {
+        testAddDelete("db_tdb", "tdb", true);
+    }
+
+    @Test public void add_delete_api_3() throws Exception {
+        testAddDelete("db_tdb2", "tdb2", true);
+    }
+
+    private static void testAddDelete(String dbName, String dbType, boolean hasFiles) {
+        String URL = ServerCtl.urlRoot()+dbName;
+        String admin = ServerCtl.urlRoot()+"$/";
+        HttpEntity e = createFormEntity(dbName, "tdb");
+        
+        HttpOp.execHttpPost(admin+"datasets", e); 
+
+        RDFConnection conn = RDFConnectionFactory.connect(URL);
+        conn.update("INSERT DATA { <x:s> <x:p> 123 }");
+        int x1 = count(conn);
+        assertEquals(1, x1);
+        
+        Path pathDB = FusekiSystem.dirDatabases.resolve(dbName);
+            
+        if ( hasFiles )
+            assertTrue(Files.exists(pathDB));
+
+        HttpOp.execHttpDelete(admin+"datasets/"+dbName);
+        
+        //if ( hasFiles )
+            assertFalse(Files.exists(pathDB));
+        
+        // Recreate : no contents.
+        HttpOp.execHttpPost(admin+"datasets", e);
+        int x2 = count(conn);
+        assertEquals(0, x2);
+        if ( hasFiles )
+            assertTrue(Files.exists(pathDB));
+    }
+                              
+                              
+                              
+    static int count(RDFConnection conn) {
+        try ( QueryExecution qExec = conn.query("SELECT (count(*) AS ?C) { ?s ?p ?o }")) {
+            return qExec.execSelect().next().getLiteral("C").getInt();
+        }
+    }
+    
+    static HttpEntity createFormEntity(String dbName, String dbType) {
+        List <? extends NameValuePair> parameters = 
+            Arrays.asList(
+                new Params.Pair("dbName", dbName),
+                new Params.Pair("dbType", dbType));
+        UrlEncodedFormEntity e = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        return e;
+    }
+}
+

--- a/jena-fuseki2/jena-fuseki-embedded/src/main/java/org/apache/jena/fuseki/embedded/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-embedded/src/main/java/org/apache/jena/fuseki/embedded/FusekiServer.java
@@ -396,6 +396,10 @@ public class FusekiServer {
             // Clone to isolate from any future changes. 
             ServiceDispatchRegistry.set(cxt, new ServiceDispatchRegistry(serviceDispatch));
             DataAccessPointRegistry.set(cxt, new DataAccessPointRegistry(dataAccessPoints));
+
+            // Start services.
+            DataAccessPointRegistry.get(cxt).forEach((name, dap)->dap.getDataService().goActive());
+            
             setMimeTypes(handler);
             servlets(handler);
             

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/sys/TDBInternal.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/sys/TDBInternal.java
@@ -25,6 +25,7 @@ import org.apache.jena.atlas.lib.Lib ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.system.Txn;
 import org.apache.jena.tdb.StoreConnection ;
 import org.apache.jena.tdb.TDBException ;
 import org.apache.jena.tdb.base.file.Location ;
@@ -146,6 +147,15 @@ public class TDBInternal
         if ( dsg instanceof DatasetGraphTransaction )
             return ((DatasetGraphTransaction)dsg).getStoreConnection() ;
         throw new TDBException("Not a suitable TDB-backed DatasetGraph: " + Lib.classShortName(dsg.getClass())) ;
+    }
+    
+    /** Stop managing a DatasetGraph. Use with great care. */
+    public static synchronized void expel(DatasetGraph dsg) {
+        DatasetGraphTDB dsgtdb = Txn.calculate(dsg, ()->getDatasetGraphTDB(dsg));
+        if ( dsgtdb == null )
+            return;
+        StoreConnection.expel(dsgtdb.getLocation(), false);
+        // No longer valid.
     }
     
     /** Look at a directory and see if it is a new area */


### PR DESCRIPTION
This follows on from PR #458 so it shows the commits for that PR in the comparison to Jena master.

It is the 3 individual commits after "Delete databases and expel from JVM".

It is a number of internal tidy-ups and updates of internal operations following from the new Jena transaction TxnType. For uploading, there are comments about file upload and moving the multitarget upload code to the `Upload` library.