### PR TITLE
JENA-1590: fix if statement in RDFWriter#output

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFWriter.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFWriter.java
@@ -139,7 +139,7 @@ public class RDFWriter {
             if ( ct == null )
                 throw new RiotException("Lang and RDFformat unset and can't determine syntax from '"+filename+"'");
             Lang lang = RDFLanguages.contentTypeToLang(ct);
-            if ( ct == null )
+            if ( lang == null )
                 throw new RiotException("No syntax registered for '"+ct.getContentType()+"'"); 
             fmt = RDFWriterRegistry.defaultSerialization(lang);
         }


### PR DESCRIPTION
Eclipse alerted for some Dead code in this class, and after having a look, I thought we actually had to check the `lang` in the second `if`, not `ct`?

Very hard to write a unit test, as the map backing the languages registry will pretty much always return a language, once you have the content type (I think).