### PR TITLE
JENA-1599: Upgrade to jsonld-java 0.12.1

### DIFF
--- a/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
+++ b/apache-jena-osgi/jena-osgi-features/src/main/resources/features.xml
@@ -37,8 +37,6 @@
 		<bundle dependency="true">mvn:commons-codec/commons-codec/${ver.commons-codec}</bundle>
 		<bundle dependency="true">mvn:commons-io/commons-io/${ver.commonsio}</bundle>
 		<bundle dependency="true">mvn:org.apache.thrift/libthrift/${ver.libthrift}</bundle>
-		<!-- Guava 24.1 is required by jsonld-java -->
-		<bundle dependency="true">mvn:com.google.guava/guava/24.1-jre</bundle>
 	</feature>
 
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
          artifacts so the versions must align. Consult jsonld-java's 
          POM for the correct dependency versions 
     -->
-    <ver.jsonldjava>0.12.0</ver.jsonldjava>
-    <ver.jackson>2.9.5</ver.jackson>
+    <ver.jsonldjava>0.12.1</ver.jsonldjava>
+    <ver.jackson>2.9.6</ver.jackson>
 
     <ver.commonsio>2.6</ver.commonsio>
     <ver.commonscli>1.4</ver.commonscli>


### PR DESCRIPTION
This upgrades jsonld-java to the latest version. That version does not require an extra import of Guava in an OSGi environment (Guava is shaded in jsonld-java, but the bundle manifest was incorrect in 0.12.0), so the extra import can be removed from Jena's `feature.xml` file.

Tested in Karaf 4.2.0 and 4.2.1 under JDK8 and JDK10. With JDK10, one will need to also install `javax.annotation-api` in the Karaf console, but that is separate from this issue. 