### PR TITLE
JENA-1615 - Compaction leaks file descriptors

### DIFF
--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BlockAccessBase.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BlockAccessBase.java
@@ -166,6 +166,7 @@ public abstract class BlockAccessBase implements BlockAccess {
     @Override
     final public void close() {
         _close() ;
+        FileLib.close(file);
         file = null ;
     }
 

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/data/TransBinaryDataFile.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/data/TransBinaryDataFile.java
@@ -217,6 +217,7 @@ public class TransBinaryDataFile extends TransactionalComponentLifecycle<TransBi
 
     @Override
     public void close() {
+        stateMgr.close();
         binFile.close() ;
     }
 


### PR DESCRIPTION
Close file channel when closing a block to release open file descriptors