### PR TITLE
JENA-1635 Fix invalid Automatic-Module-Name values

### DIFF
--- a/jena-fuseki2/jena-fuseki-access/pom.xml
+++ b/jena-fuseki2/jena-fuseki-access/pom.xml
@@ -31,7 +31,7 @@
   <packaging>jar</packaging>
   
   <properties>
-    <automatic.module.name>org.apache.jena.jena-fuseki-access</automatic.module.name>
+    <automatic.module.name>org.apache.jena.fuseki2.access</automatic.module.name>
   </properties>
 
   <dependencies>

--- a/jena-fuseki2/jena-fuseki-core/pom.xml
+++ b/jena-fuseki2/jena-fuseki-core/pom.xml
@@ -30,7 +30,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <automatic.module.name>org.apache.jena.jena-fuseki-core</automatic.module.name>
+    <automatic.module.name>org.apache.jena.fuseki2.core</automatic.module.name>
   </properties>
 
   <dependencies>

--- a/jena-fuseki2/jena-fuseki-main/pom.xml
+++ b/jena-fuseki2/jena-fuseki-main/pom.xml
@@ -31,7 +31,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <automatic.module.name>org.apache.jena.jena-fuseki-main</automatic.module.name>
+    <automatic.module.name>org.apache.jena.fuseki2.main</automatic.module.name>
   </properties>
   
   <dependencies> 


### PR DESCRIPTION
The jena-fuseki-access, jena-fuseki-core and jena-fuseki-main modules
have invalid data for Automatic-Module-Name.

This aligns the data from those modules with the existing fuseki2 module.