### PR TITLE
JENA-1642: Check has value for header instead of is true

### DIFF
--- a/jena-cmds/src/main/java/jena/schemagen.java
+++ b/jena-cmds/src/main/java/jena/schemagen.java
@@ -1815,7 +1815,7 @@ public class schemagen {
         @Override
         public String getOutputOption() { return getStringValue( OPT.OUTPUT ); }
         @Override
-        public boolean hasHeaderOption() { return isTrue( OPT.HEADER ); }
+        public boolean hasHeaderOption() { return hasValue( OPT.HEADER ); }
         @Override
         public String getHeaderOption() { return getStringValue( OPT.HEADER ); }
         @Override


### PR DESCRIPTION
When using schemagen from the maven plugin the `header` option does not work. `header` is intended to be a template string and when `isTrue` is checked the string is cast to a boolean and the `BadBooleanException` is thrown. I believe we should check for existence here instead of "truthiness"


Also, it appears that the maven tools are no being built as part of the main project. Is that the case?