### PR TITLE
JENA-1643: Use transactional dataset in clear().

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/GraphView.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/GraphView.java
@@ -90,7 +90,7 @@ public class GraphView extends GraphBase implements NamedGraph, Sync
         return (gn == Quad.defaultGraphNodeGenerated) ? null : gn ;
     }
 
-    /** Return the DatasetGraph we are viewing. */
+    /** Return the {@link DatasetGraph} we are viewing. */
     public DatasetGraph getDataset() {
         return dsg ;
     }


### PR DESCRIPTION
The fix is the one line change in method `clear()`.