### PR TITLE
JENA-1644 ParameterizedSparqlString Empty List fix

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -1893,7 +1893,10 @@ public class ParameterizedSparqlString implements PrefixMapping {
                     replacement.append(") ");
                 }
             }
-            replacement.deleteCharAt(replacement.length() - 1);
+
+            if (replacement.length() > 0) {
+                replacement.deleteCharAt(replacement.length() - 1);
+            }
 
             return replacement.toString();
         }

--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -2015,6 +2015,22 @@ public class TestParameterizedSparqlString {
     }
 
     @Test
+    public void test_empty_list() {
+        // Tests two values for same variable.
+        String str = "SELECT * WHERE { VALUES (?o) {?objs} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        List<RDFNode> objs = new ArrayList<>();
+        pss.setValues("objs", objs);
+
+        String exp = "SELECT * WHERE { VALUES (?o) {} ?s ?p ?o }";
+        String res = pss.toString();
+
+        //System.out.println("Exp: " + exp);
+        //System.out.println("Res: " + res);
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
     public void test_set_values_multiple_variables() {
         // Tests two values for same variable.
         String str = "SELECT * WHERE { VALUES (?p ?o) {?vars} ?s ?p ?o }";


### PR DESCRIPTION
ParameterizedSparqlString now accepts an empty list of values rather than throwing a StringIndexOutOfBoundsException.