### PR TITLE
JENA-1645: Use uri predicate in concrete subject query.

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndex.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndex.java
@@ -51,6 +51,10 @@ public interface TextIndex extends Closeable //, Transactional
     List<TextHit> query(Node property, String qs, String graphURI, String lang) ;
 
     List<TextHit> query(Node property, String qs, String graphURI, String lang, int limit, String highlight) ;
-    
+
+    default List<TextHit> query(String subjectUri, Node property, String qs, String graphURI, String lang, int limit, String highlight){
+        return query(property, qs, graphURI, lang, limit, highlight);
+    }
+
     EntityDefinition getDocDef() ;
 }


### PR DESCRIPTION
Added URI predicate to the Lucene search in case of concrete subject search. 
Method added in TextIndex interface made default with a fallback to the previous implementation.