### PR TITLE
Cleanup of comments and javadoc. Trivial fixes.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ResultSetFormatter.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ResultSetFormatter.java
@@ -281,7 +281,7 @@ public class ResultSetFormatter {
     { output(System.out, resultSet, rFmt) ; }
 
     /** Output a ResultSet in some format.
-     *  To get detailed control over each format, call the appropropiate operation directly. 
+     *  To get detailed control over each format, call the appropriate operation directly. 
      * 
      * @param outStream Output
      * @param resultSet Result set

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/optimizer/reorder/ReorderLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/optimizer/reorder/ReorderLib.java
@@ -68,7 +68,7 @@ public class ReorderLib
     }
 
     /**
-     * Return a ReorderTransformation that performance some basic reordering
+     * Return a ReorderTransformation that performs some basic reordering
      * based on most grounded triples first, but otherwise leaves things
      * in query-written order. 
      */

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/QueryExecUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/QueryExecUtils.java
@@ -138,10 +138,14 @@ public class QueryExecUtils {
 
         if ( outputFormat.equals(ResultsFormat.FMT_RDF_XML) || outputFormat.equals(ResultsFormat.FMT_RDF_N3)
              || outputFormat.equals(ResultsFormat.FMT_RDF_TTL) ) {
+            Lang langx = Lang.TURTLE;
+            if ( outputFormat.equals(ResultsFormat.FMT_RDF_XML) )
+                langx = Lang.RDFXML;
+            
             Model m = RDFOutput.encodeAsModel(results) ;
             m.setNsPrefixes(prologue.getPrefixMapping()) ;
             m.setNsPrefix("rs", ResultSetGraphVocab.getURI()) ;
-            RDFDataMgr.write(System.out, m, Lang.TURTLE) ;
+            RDFDataMgr.write(System.out, m, langx) ;
             done = true ;
         }
 

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/block/Block.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/block/Block.java
@@ -56,7 +56,7 @@ public final class Block
         this.id = id ;
         this.byteBuffer = byteBuffer ;
         // this.blockRef = null ;
-        // Default - writeable, unmodified block.
+        // Default - writable, unmodified block.
         this.readOnly = false ;
         this.modified = false ;
         this.underlyingByteBuffer = null ;

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/block/BlockMgr.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/block/BlockMgr.java
@@ -48,7 +48,7 @@ public interface BlockMgr extends Sync, Closeable /*UnitMgr<Block>*/
     /** Release a block, unmodified or already written. */
     public void release(Block block) ;
 
-    /** Promote to writeable : it's OK to promote an already writeable block */ 
+    /** Promote to writable : it's OK to promote an already writable block */ 
     public Block promote(Block block);
 
     // Bad name?  "endWrite", "put" -- for a mapped block, the changes are made directly, not on the write() */   

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/block/BlockMgrCache.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/block/BlockMgrCache.java
@@ -115,7 +115,7 @@ public class BlockMgrCache extends BlockMgrSync {
 
         // A requested block may be in the other cache.
         // Writable blocks are readable.
-        // readable blocks are not writeable (see below).
+        // readable blocks are not writable (see below).
         if ( writeCache != null )
             // Might still be in the dirty blocks.
             // Leave in write cache

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/page/Page.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/page/Page.java
@@ -38,8 +38,8 @@ public interface Page extends Printable
     
     /**
      * The underlying block for this page has changed (e.g. it's been
-     * promoted and the promotion may have caused the block to change.
+     * promoted and the promotion may have caused the block to change).
      */
-    public abstract void reset(Block block) ;
+    public void reset(Block block) ;
 
 }

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/page/PageBlockMgr.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/page/PageBlockMgr.java
@@ -155,6 +155,7 @@ public class PageBlockMgr<T extends Page> implements Closeable
     public void promoteInPlace(Page page) {
         Block block = page.getBackingBlock() ;
         block.getByteBuffer().rewind() ;
+
         Block block2 = blockMgr.promote(block) ; 
         block2.setReadOnly(false) ;
         if ( block2.getId() != block.getId() )
@@ -171,7 +172,6 @@ public class PageBlockMgr<T extends Page> implements Closeable
         Block block = page.getBackingBlock() ;
         block.getByteBuffer().rewind() ;
         
-        // --- TODO Always new
         Block block2 =  blockMgr.allocate(-1) ;
         block2.getByteBuffer().put(block.getByteBuffer()) ;
         block2.getByteBuffer().rewind() ;
@@ -202,10 +202,10 @@ public class PageBlockMgr<T extends Page> implements Closeable
     /** Signal the completion of an update operation */
     public void finishUpdate()      { blockMgr.endUpdate() ; }
 
-    /** Signal the start of an update operation */
+    /** Signal the start of an read operation */
     public void startRead()         { blockMgr.beginRead() ; }
     
-    /** Signal the completion of an update operation */
+    /** Signal the completion of an read operation */
     public void finishRead()        { blockMgr.endRead() ; }
 
     @Override

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPT.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPT.java
@@ -36,13 +36,16 @@ import org.slf4j.Logger ;
 public final class BPT {
     public static boolean Logging = false ;                  // Turn on/off logging
     
+    /** Enable forces promotion of blocks; otherwise blocks are promoted as needed. */
     public static boolean forcePromoteModes         = false ;
+    /** Whether to duplicate a records block on a promotion call if forcePromoteModes=true */
     public static boolean promoteDuplicateRecords   = false ;
+    /** Whether to duplicate a nodes block on a promotion call if forcePromoteModes=true */
     public static boolean promoteDuplicateNodes     = false ;
 
     // Check within BPTreeNode
     public static boolean CheckingNode = false ;                      
-    // Check on exit of B+Tree modifiying operations
+    // Check on exit of B+Tree modifying operations
     // Not done?
     public static boolean CheckingConcurrency = SystemIndex.Checking ;
 

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPTreeNode.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPTreeNode.java
@@ -52,6 +52,7 @@ public final class BPTreeNode extends BPTreePage
      */
     /*package*/int id ;             // Or block.getId()            
     
+    // Parent is a debugging aid. It records how we go to this BPTreeNode and also whether this is a root.
     private int parent ;
     private int count ;             // Number of records.  Number of pointers is +1
     
@@ -391,7 +392,7 @@ public final class BPTreeNode extends BPTreePage
     public final PtrBuffer getPtrBuffer()        { return ptrs ; }
     
     final void setParent(int parentId)           { this.parent = parentId ; } 
-    public final int getParent()                 { return parent ; }
+    final int getParent()                        { return parent ; }
 
     
     public final void setIsLeaf(boolean isLeaf)  { this.isLeaf = isLeaf ; }
@@ -748,8 +749,8 @@ public final class BPTreeNode extends BPTreePage
 
         if ( page.isMinSize() ) { 
             // Ensure that a node is at least min+1 so a delete can happen.
-            // Can't be the root - we decended in the get().
-            rebalance(path, page, y) ;  // Ignore return - need to refind.
+            // Can't be the root - we descended in the get().
+            rebalance(path, page, y) ;  // Ignore return - need to re-find.
             page.release(); // TODO But rebalance may have freed this?
             // Rebalance may have moved the record due to shuffling.  
             x = findSlot(rec) ;

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPTreeRecords.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPTreeRecords.java
@@ -129,8 +129,6 @@ public final class BPTreeRecords extends BPTreePage {
 
         if ( promoteInPlace ) {
             bprRecordsMgr.promoteInPlace(this) ;
-            // TODO Is this needed?
-            // Is this replicated in BPTreeNode?
             if ( getBackingBlock().isReadOnly() )
                 bprRecordsMgr.getBlockMgr().promote(getBackingBlock()) ;
             return false ;


### PR DESCRIPTION
Remove one "abstract" in an interface.
Correct QueryExecUtils handling of RDF-format result sets.