### PR TITLE
JENA-1653 ensure unique automatic-module-names

### DIFF
--- a/jena-db/jena-dboe-base/pom.xml
+++ b/jena-db/jena-dboe-base/pom.xml
@@ -30,6 +30,10 @@
     <version>3.10.0-SNAPSHOT</version>
   </parent> 
 
+  <properties>
+    <automatic.module.name>org.apache.jena.dboe</automatic.module.name>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/jena-db/jena-dboe-index-test/pom.xml
+++ b/jena-db/jena-dboe-index-test/pom.xml
@@ -30,6 +30,10 @@
     <version>3.10.0-SNAPSHOT</version>
   </parent> 
 
+  <properties>
+    <automatic.module.name>org.apache.jena.dboe.index.test</automatic.module.name>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/jena-db/jena-dboe-index/pom.xml
+++ b/jena-db/jena-dboe-index/pom.xml
@@ -30,6 +30,10 @@
     <version>3.10.0-SNAPSHOT</version>
   </parent> 
 
+  <properties>
+    <automatic.module.name>org.apache.jena.dboe.index</automatic.module.name>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/jena-db/jena-dboe-trans-data/pom.xml
+++ b/jena-db/jena-dboe-trans-data/pom.xml
@@ -29,6 +29,10 @@
     <version>3.10.0-SNAPSHOT</version>
   </parent> 
 
+  <properties>
+    <automatic.module.name>org.apache.jena.dboe.trans.data</automatic.module.name>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/jena-db/jena-dboe-transaction/pom.xml
+++ b/jena-db/jena-dboe-transaction/pom.xml
@@ -29,6 +29,10 @@
     <version>3.10.0-SNAPSHOT</version>
   </parent> 
 
+  <properties>
+    <automatic.module.name>org.apache.jena.dboe.transaction</automatic.module.name>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/jena-db/pom.xml
+++ b/jena-db/pom.xml
@@ -33,13 +33,6 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <properties>
-    <!-- Default module name : override in a specific POM if not part of the "dboe" module.
-         e.g. jena-tdb2.
-    -->
-    <automatic.module.name>org.apache.jena.dboe</automatic.module.name>
-  </properties>
-
   <licenses>
     <license>
       <name>Apache License 2.0</name>


### PR DESCRIPTION
This sets a unique Automatic-Module-Name value for the modules in jena-db.

This also removes the default value in the parent pom to make it less likely that there will be future duplicates.

N.B. I scanned through all of the other artifacts generated by `mvn install -Pdev` and for the modules that advertise an AMN value, there were no other duplicates.