### PR TITLE
JENA-1654: Use StringBuilder in Literal#asNumber, and remove field variable

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/LiteralImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/LiteralImpl.java
@@ -281,7 +281,6 @@ public class LiteralImpl extends EnhNode implements Literal {
                 message +=" which is not an xsd type.";
             }
             message += " \n";
-            String type = 
             message += "Java representation type is " + (value == null ? "null" : value.getClass().toString());
             throw new DatatypeFormatException(message);
         }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/LiteralImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/LiteralImpl.java
@@ -275,14 +275,14 @@ public class LiteralImpl extends EnhNode implements Literal {
         if (value instanceof Number) {
             return ((Number)value);
         } else {
-            String message = "Error converting typed value to a number. \n";
-            message += "Datatype is: " + getDatatypeURI();
+            StringBuilder message = new StringBuilder("Error converting typed value to a number. \n");
+            message.append("Datatype is: " + getDatatypeURI());
             if ( getDatatypeURI() == null || ! getDatatypeURI().startsWith(XSDDatatype.XSD)) {
-                message +=" which is not an xsd type.";
+                message.append(" which is not an xsd type.");
             }
-            message += " \n";
-            message += "Java representation type is " + (value == null ? "null" : value.getClass().toString());
-            throw new DatatypeFormatException(message);
+            message.append(" \n");
+            message.append("Java representation type is " + (value == null ? "null" : value.getClass().toString()));
+            throw new DatatypeFormatException(message.toString());
         }
     }    
     private byte byteValue( Number n )

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestLiteralImpl.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestLiteralImpl.java
@@ -18,11 +18,16 @@
 
 package org.apache.jena.rdf.model.test;
 
+import org.apache.jena.datatypes.DatatypeFormatException;
 import org.apache.jena.datatypes.TypeMapper ;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.impl.AdhocDatatype ;
 import org.apache.jena.rdf.model.Literal ;
 import org.apache.jena.rdf.model.LiteralRequiredException ;
 import org.apache.jena.rdf.model.Model ;
+import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.test.helpers.ModelHelper ;
 import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
 import org.apache.jena.test.JenaTestBase ;
@@ -96,6 +101,38 @@ public class TestLiteralImpl extends AbstractModelTestBase
 			JenaTestBase.pass();
 		}
 	}
+
+    /**
+     * Test that a literal node can be as'ed into a number
+     */
+    public void testAsNumber()
+    {
+        int number = ModelHelper.literal(model, "17").getInt();
+        assertEquals(17, number);
+    }
+
+    /**
+     * Test that a literal that is not a number cannot be as'ed into a number
+     */
+    public void testCannotAsNonNumber()
+    {
+        try {
+            Node node = NodeFactory.createLiteral("1984", XSDDatatype.XSDgYear);
+            RDFNode rdfNode = model.asRDFNode(node);
+            Literal literal = rdfNode.asLiteral();
+            // XSDDateTime is not a Number, so getInt will fail, instead of returning 1984
+            literal.getInt();
+            fail("Expected DatatypeFormatException");
+        } catch (DatatypeFormatException e) {
+            final String message = e.getMessage();
+            // displays error message
+            assertTrue(message.contains("Error converting typed value to a number"));
+            // displays the datatype URI
+            assertTrue(message.contains("http://www.w3.org/2001/XMLSchema#gYear"));
+            // displays the Java class name (ignoring the package)
+            assertTrue(message.contains("XSDDateTime"));
+        }
+    }
 
 	public void testInModel()
 	{


### PR DESCRIPTION
Was passing through the LiteralImpl class while reading code for another issue, and found the `field` variable that appeared to be not used.

Removed it, and then realized it could do with `StringBuilder` instead of String concatenation... It could also get a new formatting in the source for homogeneity, and delete a deprecated method that has been commented out... but this can be done later, and I thought keeping this smaller/simpler was better.

Two unit tests added. One for the working/happy path, and the other one for when the exception occurs. Tests working fine before and after the patch. Issue created and assigned to 3.10.0.

Cheers
Bruno