### PR TITLE
JENA-204: Language aware schemagen

### DIFF
--- a/jena-cmds/src/main/java/jena/schemagen.java
+++ b/jena-cmds/src/main/java/jena/schemagen.java
@@ -432,7 +432,7 @@ public class schemagen {
     }
 
     /** Add the appropriate indent to a buffer */
-    protected int indentTo( int i, StringBuffer buf ) {
+    protected int indentTo( int i, StringBuilder buf ) {
         int indent = i * m_indentStep;
         for (int j = 0;  j < indent; j++) {
             buf.append( ' ' );
@@ -463,7 +463,7 @@ public class schemagen {
 
     /** Determine the list of imports to include in the file */
     protected String getImports() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append( "import org.apache.jena.rdf.model.*;" );
         buf.append( m_nl );
 
@@ -538,7 +538,7 @@ public class schemagen {
 
     /** Converts to a legal Java identifier; capitalise first char if cap is true */
     protected String asLegalJavaID( String s, boolean cap ) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         int i = 0;
 
         // treat the first character specially - must be able to start a Java ID, may have to up-case
@@ -1159,7 +1159,7 @@ public class schemagen {
 
     /** Answer all of the commentary on the given resource, as a string */
     protected String getComment( Resource r ) {
-        StringBuffer comment = new StringBuffer();
+        StringBuilder comment = new StringBuilder();
 
         // collect any RDFS or DAML comments attached to the node
         for (NodeIterator ni = m_source.listObjectsOfProperty( r, RDFS.comment );  ni.hasNext(); ) {
@@ -1177,7 +1177,7 @@ public class schemagen {
 
     /** Format the comment as Javadoc, and limit the line width */
     protected String formatComment( String comment ) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         buf.append( "/** <p>" );
 
         boolean inSpace = false;
@@ -1330,7 +1330,7 @@ public class schemagen {
 
     /** Answer the local name of resource r mapped to upper case */
     protected String getUCValueName( Resource r ) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         String localName = r.getLocalName();
         char lastChar = 0;
 

--- a/jena-cmds/src/main/java/jena/schemagen.java
+++ b/jena-cmds/src/main/java/jena/schemagen.java
@@ -125,6 +125,9 @@ public class schemagen {
     /** The output stream we write to */
     protected PrintStream m_output;
 
+    /** The language used to retrieve comments */
+    protected String m_lang;
+
     /** Option definitions */
     /** Stack of replacements to apply */
     protected List<Replacement> m_replacements = new ArrayList<>();
@@ -197,6 +200,7 @@ public class schemagen {
         addIncludes();
         determineLanguage();
         selectInput();
+        selectLang();
         selectOutput();
         setGlobalReplacements();
 
@@ -264,6 +268,14 @@ public class schemagen {
         }
         catch (JenaException e) {
             abort( "Failed to read input source " + input, e );
+        }
+    }
+
+    protected void selectLang() {
+        if (m_options.hasLangOption()) {
+            m_lang = m_options.getLangOption();
+        } else {
+            m_lang = null;
         }
     }
 
@@ -405,6 +417,7 @@ public class schemagen {
         System.err.println();
         System.err.println( "Commonly used options include:" );
         System.err.println( "   -i <input> the source document as a file or URL." );
+        System.err.println( "   -l <lang> the desired language to use to retrieve comments." );
         System.err.println( "   -n <name> the name of the created Java class." );
         System.err.println( "   -a <uri> the namespace URI of the source document." );
         System.err.println( "   -o <file> the file to write the generated class into." );
@@ -1165,7 +1178,13 @@ public class schemagen {
         for (NodeIterator ni = m_source.listObjectsOfProperty( r, RDFS.comment );  ni.hasNext(); ) {
             RDFNode n = ni.nextNode();
             if (n instanceof Literal) {
-                comment.append( ((Literal) n).getLexicalForm().trim() );
+                if (m_lang == null || m_lang.trim().equals("")) {
+                    // default behavior, where no language was specified
+                    comment.append( ((Literal) n).getLexicalForm().trim() );
+                } else if (((Literal) n).getLanguage().equals(m_lang)) {
+                    // otherwise only use comment that matches the language given
+                    comment.append( ((Literal) n).getLexicalForm().trim() );
+                }
             }
             else {
                 System.err.println( "Warning: Comment on resource <" + r.getURI() + "> is not a literal: " + n );
@@ -1408,6 +1427,9 @@ public class schemagen {
             /** Nominate the URL of the input document; use <code>-i &lt;URL&gt;</code> on command line;  use <code>sgen:input</code> in config file */
             INPUT,
 
+            /** Specify the language used to retrieve comments */
+            LANG,
+
             /** Specify that the language of the source is DAML+OIL; use <code>--daml</code> on command line;  use <code>sgen:daml</code> in config file */
             LANG_DAML,
 
@@ -1526,6 +1548,7 @@ public class schemagen {
                 {OPT.ROOT,                new OptionDefinition( "-r", "root" ) },
                 {OPT.NO_COMMENTS,         new OptionDefinition( "--nocomments", "noComments" ) },
                 {OPT.INPUT,               new OptionDefinition( "-i", "input" ) },
+                {OPT.LANG,                new OptionDefinition( "-l", "lang" ) },
                 {OPT.LANG_DAML,           new OptionDefinition( "--daml", "daml" ) },
                 {OPT.LANG_OWL,            new OptionDefinition( "--owl", "owl" ) },
                 {OPT.LANG_RDFS,           new OptionDefinition( "--rdfs", "rdfs" ) },
@@ -1572,6 +1595,8 @@ public class schemagen {
         public String getNoCommentsOption();
         public boolean hasInputOption();
         public Resource getInputOption();
+        public boolean hasLangOption();
+        public String getLangOption();
         public boolean hasLangOwlOption();
         public String getLangOwlOption();
         public boolean hasLangRdfsOption();
@@ -1802,6 +1827,10 @@ public class schemagen {
         public boolean hasInputOption() { return hasValue( OPT.INPUT ); }
         @Override
         public Resource getInputOption() { return getResource( OPT.INPUT ); }
+        @Override
+        public boolean hasLangOption() { return hasValue( OPT.LANG ); }
+        @Override
+        public String getLangOption() { return getStringValue( OPT.LANG ); }
         @Override
         public boolean hasLangOwlOption() { return isTrue( OPT.LANG_OWL ); }
         @Override

--- a/jena-cmds/src/test/java/jena/cmd/Test_schemagen.java
+++ b/jena-cmds/src/test/java/jena/cmd/Test_schemagen.java
@@ -304,6 +304,46 @@ public class Test_schemagen
                              new String[] {} );
     }
 
+    /**
+     * A comment in a certain language. But no language specified in schemagen.
+     */
+    @Test
+    public void testComment4() throws Exception {
+        String SOURCE = PREFIX + "ex:A a owl:Class ; rdfs:comment \"comentario\"@pt .";
+        testSchemagenOutput( SOURCE, null,
+                new String[] {"-a", "http://example.com/sg#", "--owl"},
+                new String[] {" */\\*\\* <p>comentario</p> \\*/ *"},
+                new String[] {} );
+    }
+
+    /**
+     * Comments in certain languages. A different language specified in schemagen.
+     */
+    @Test
+    public void testComment5() throws Exception {
+        String SOURCE = PREFIX + "ex:A a owl:Class ; rdfs:comment \"comentario\"@pt ; rdfs:comment \"comment\"@en .";
+        testSchemagenOutput( SOURCE, null,
+                new String[] {"-l", "es", "-a", "http://example.com/sg#", "--owl"},
+                new String[] {},
+                new String[] {" */\\*\\* <p>comment</p> \\*/ *"} );
+        testSchemagenOutput( SOURCE, null,
+                new String[] {"-l", "es", "-a", "http://example.com/sg#", "--owl"},
+                new String[] {},
+                new String[] {" */\\*\\* <p>comentario</p> \\*/ *"} );
+    }
+
+    /**
+     * Comments in certain languages. One of these languages specified in schemagen.
+     */
+    @Test
+    public void testComment6() throws Exception {
+        String SOURCE = PREFIX + "ex:A a owl:Class ; rdfs:comment \"comentario\"@pt ; rdfs:comment \"comment\"@en .";
+        testSchemagenOutput( SOURCE, null,
+                new String[] {"-l", "pt", "-a", "http://example.com/sg#", "--owl"},
+                new String[] {" */\\*\\* <p>comentario</p> \\*/ *"},
+                new String[] {} );
+    }
+
     @Test
     public void testOntClass0() throws Exception {
         String SOURCE = PREFIX + "ex:A a owl:Class .";


### PR DESCRIPTION
From JENA-204, when you use an input such as http://www.w3.org/ns/org#, that contains comments in multiple languages such as:

```
org:basedAt a owl:ObjectProperty, rdf:Property;

    rdfs:label "based At"@en;
    rdfs:label "basé à"@fr;
    rdfs:label "basata a"@it;

    rdfs:domain foaf:Person;
    rdfs:range  org:Site;  

    rdfs:comment """Indicates the site at which a person is based. We do not restrict the possibility that a person is based at multiple sites."""@en;
    rdfs:comment """Indique le site sur lequel une personne est basée. Nous ne limitons pas le nombre de sites sur lesquels une personne peut être basée."""@fr;    
    rdfs:comment """Indica la sede in cui una è stabilita una persona. Non esclude la possibilità che una persona sia allocata su più sedi."""@it;
    rdfs:comment "人が基礎としているサイトを示します。人が複数のサイトを基礎としている可能性を制限しません。"@ja;
    rdfs:isDefinedBy <http://www.w3.org/ns/org> ;
```

`schemagen` simply concatenates the comments for the `basedAt`, without discerning languages.

This pull request adds an option `-l`, `lang`. This option is turned off by default, which means that users have the same behaviour as before (i.e. previous unit tests passing, and no workflow broken anywhere).

But users can also specify a language now. 

```bash
$ schemagen -l en -i http://www.w3.org/ns/org#
/* CVS $Id: $ */
 
import org.apache.jena.rdf.model.*;
 
/**
 * Vocabulary definitions from http://www.w3.org/ns/org# 
 * @author Auto-generated by schemagen on 29 Dec 2018 19:41 
 */
public class Org {
    /** <p>The RDF model that holds the vocabulary terms</p> */
    private static final Model M_MODEL = ModelFactory.createDefaultModel();
    
    /** <p>The namespace of the vocabulary as a string</p> */
    public static final String NS = "http://www.w3.org/ns/org#";
    
    /** <p>The namespace of the vocabulary as a string</p>
     * @return namespace as String
     * @see #NS */
    public static String getURI() {return NS;}
    
    /** <p>The namespace of the vocabulary as a resource</p> */
    public static final Resource NAMESPACE = M_MODEL.createResource( NS );
    
    /** <p>The ontology's owl:versionInfo as a string</p> */
    public static final String VERSION_INFO = "0.8";
    
    /** <p>Indicates the site at which a person is based. We do not restrict the possibility 
     *  that a person is based at multiple sites.</p>
     */
    public static final Property basedAt = M_MODEL.createProperty( "http://www.w3.org/ns/org#basedAt" );
    
    /** <p>Indicates a change event which resulted in a change to this organization. 
     *  Depending on the event the organization may or may not have continued to exist 
     *  after the event. Inverse of `org:originalOrganization`.</p>
     */
    public static final Property changedBy = M_MODEL.createProperty( "http://www.w3.org/ns/org#changedBy" );
    
    /** <p>Indicates a classification for this Organization within some classification 
     *  scheme. Extension vocabularies may wish to specialize this property to have 
     *  a range corresponding to a specific `skos:ConceptScheme`. This property is 
     *  under discussion and may be revised or removed - in many cases organizations 
     *  are best categorized by defining a sub-class hierarchy in an extension vocabulary.</p>
     */
    public static final Property classification = M_MODEL.createProperty( "http://www.w3.org/ns/org#classification" );
    
    /** <p>Indicates a person who is a member of the subject Organization. Inverse of 
     *  `org:memberOf`, see that property for further clarification. Provided for 
     *  compatibility with `foaf:member`.</p>
     */
    public static final Property hasMember = M_MODEL.createProperty( "http://www.w3.org/ns/org#hasMember" );
    
    /** <p>Indicates a membership relationship that the Agent plays. Inverse of `org:member`.</p> */
    public static final Property hasMembership = M_MODEL.createProperty( "http://www.w3.org/ns/org#hasMembership" );
    
    /** <p>Indicates a Post which exists within the Organization.</p> */
    public static final Property hasPost = M_MODEL.createProperty( "http://www.w3.org/ns/org#hasPost" );
    
    /** <p>Indicates a primary site for the Organization, this is the default means by 
     *  which an Organization can be contacted and is not necessarily the formal headquarters.</p>
     */
    public static final Property hasPrimarySite = M_MODEL.createProperty( "http://www.w3.org/ns/org#hasPrimarySite" );
    
    /** <p>Indicates the legally registered site for the organization, in many legal 
     *  jurisdictions there is a requirement that FormalOrganizations such as Companies 
     *  or Charities have such a primary designed site.</p>
     */
    public static final Property hasRegisteredSite = M_MODEL.createProperty( "http://www.w3.org/ns/org#hasRegisteredSite" );
    
    /** <p>Indicates a site at which the Organization has some presence even if only 
     *  indirect (e.g. virtual office or a professional service which is acting as 
     *  the registered address for a company). Inverse of `org:siteOf`.</p>
     */
    public static final Property hasSite = M_MODEL.createProperty( "http://www.w3.org/ns/org#hasSite" );
    
    /** <p>Represents hierarchical containment of Organizations or Organizational Units; 
     *  indicates an organization which is a sub-part or child of this organization. 
     *  Inverse of `org:subOrganizationOf`.</p>
     */
    public static final Property hasSubOrganization = M_MODEL.createProperty( "http://www.w3.org/ns/org#hasSubOrganization" );
    
    /** <p>Indicates a unit which is part of this Organization, e.g. a Department within 
     *  a larger FormalOrganization. Inverse of `org:unitOf`.</p>
     */
    public static final Property hasUnit = M_MODEL.createProperty( "http://www.w3.org/ns/org#hasUnit" );
    
    /** <p>Indicates that a person is the leader or formal head of the Organization. 
     *  This will normally mean that they are the root of the `org:reportsTo` (acyclic) 
     *  graph, though an organization may have more than one head.</p>
     */
    public static final Property headOf = M_MODEL.createProperty( "http://www.w3.org/ns/org#headOf" );
    
    /** <p>Indicates an Agent which holds a Post.</p> */
    public static final Property heldBy = M_MODEL.createProperty( "http://www.w3.org/ns/org#heldBy" );
    
    /** <p>Indicates a Post held by some Agent.</p> */
    public static final Property holds = M_MODEL.createProperty( "http://www.w3.org/ns/org#holds" );
    
    /** <p>Gives an identifier, such as a company registration number, that can be used 
     *  to used to uniquely identify the organization. Many different national and 
     *  international identier schemes are available. The org ontology is neutral 
     *  to which schemes are used. The particular identifier scheme should be indicated 
     *  by the datatype of the identifier value. Using datatypes to distinguish the 
     *  notation scheme used is consistent with recommended best practice for `skos:notation` 
     *  of which this property is a specialization.</p>
     */
    public static final Property identifier = M_MODEL.createProperty( "http://www.w3.org/ns/org#identifier" );
    
    /** <p>Indicates an arbitrary relationship between two organizations. Specializations 
     *  of this can be used to, for example, denote funding or supply chain relationships.</p>
     */
    public static final Property linkedTo = M_MODEL.createProperty( "http://www.w3.org/ns/org#linkedTo" );
    
    /** <p>Gives a location description for a person within the organization, for example 
     *  a _Mail Stop_ for internal posting purposes.</p>
     */
    public static final Property location = M_MODEL.createProperty( "http://www.w3.org/ns/org#location" );
    
    /** <p>Indicates the Person (or other Agent including Organization) involved in the 
     *  Membership relationship. Inverse of `org:hasMembership`</p>
     */
    public static final Property member = M_MODEL.createProperty( "http://www.w3.org/ns/org#member" );
    
    /** <p>Optional property to indicate the interval for which the membership is/was 
     *  valid.</p>
     */
    public static final Property memberDuring = M_MODEL.createProperty( "http://www.w3.org/ns/org#memberDuring" );
    
    /** <p>Indicates that a person is a member of the Organization with no indication 
     *  of the nature of that membership or the role played. Note that the choice 
     *  of property name is not meant to limit the property to only formal membership 
     *  arrangements, it is also indended to cover related concepts such as affilliation 
     *  or other involvement in the organization. Extensions can specialize this relationship 
     *  to indicate particular roles within the organization or more nuanced relationships 
     *  to the organization. Has an optional inverse, `org:hasmember`.</p>
     */
    public static final Property memberOf = M_MODEL.createProperty( "http://www.w3.org/ns/org#memberOf" );
    
    /** <p>Indicates Organization in which the Agent is a member.</p> */
    public static final Property organization = M_MODEL.createProperty( "http://www.w3.org/ns/org#organization" );
    
    /** <p>Indicates one or more organizations that existed before the change event. 
     *  Depending on the event they may or may not have continued to exist after the 
     *  event. Inverse of `org:changedBy`.</p>
     */
    public static final Property originalOrganization = M_MODEL.createProperty( "http://www.w3.org/ns/org#originalOrganization" );
    
    /** <p>Indicates the Organization in which the Post exists.</p> */
    public static final Property postIn = M_MODEL.createProperty( "http://www.w3.org/ns/org#postIn" );
    
    /** <p>Indicates the purpose of this Organization. There can be many purposes at 
     *  different levels of abstraction but the nature of an organization is to have 
     *  a reason for existence and this property is a means to document that reason. 
     *  An Organization may have multiple purposes. It is recommended that the purpose 
     *  be denoted by a controlled term or code list, ideally a `skos:Concept`. However, 
     *  the range is left open to allow for other types of descriptive schemes. It 
     *  is expected that specializations or application profiles of this vocabulary 
     *  will constrain the range of the purpose. Alternative names: _remit_ _responsibility_ 
     *  (esp. if applied to OrganizationalUnits such as Government Departments).</p>
     */
    public static final Property purpose = M_MODEL.createProperty( "http://www.w3.org/ns/org#purpose" );
    
    /** <p>Indicates a salary or other reward associated with the role. Typically this 
     *  will be denoted using an existing representation scheme such as `gr:PriceSpecification` 
     *  but the range is left open to allow applications to specialize it (e.g. to 
     *  remunerationInGBP).</p>
     */
    public static final Property remuneration = M_MODEL.createProperty( "http://www.w3.org/ns/org#remuneration" );
    
    /** <p>Indicates a reporting relationship as might be depicted on an organizational 
     *  chart. The precise semantics of the reporting relationship will vary by organization 
     *  but is intended to encompass both direct supervisory relationships (e.g. carrying 
     *  objective and salary setting authority) and more general reporting or accountability 
     *  relationships (e.g. so called _dotted line_ reporting).</p>
     */
    public static final Property reportsTo = M_MODEL.createProperty( "http://www.w3.org/ns/org#reportsTo" );
    
    /** <p>Indicates an event which resulted in this organization. Inverse of `org:resultingOrganization`.</p> */
    public static final Property resultedFrom = M_MODEL.createProperty( "http://www.w3.org/ns/org#resultedFrom" );
    
    /** <p>Indicates an organization which was created or changed as a result of the 
     *  event. Inverse of `org:resultedFrom`.</p>
     */
    public static final Property resultingOrganization = M_MODEL.createProperty( "http://www.w3.org/ns/org#resultingOrganization" );
    
    /** <p>Indicates the Role that the Agent plays in a Membership relationship with 
     *  an Organization.</p>
     */
    public static final Property role = M_MODEL.createProperty( "http://www.w3.org/ns/org#role" );
    
    /** <p>This is a metalevel property which is used to annotate an `org:Role` instance 
     *  with a sub-property of `org:memberOf` that can be used to directly indicate 
     *  the role for easy of query. The intended semantics is a Membership relation 
     *  involving the Role implies the existence of a direct property relationship 
     *  through an inference rule of the form: `{ [] org:member ?p; org:organization 
     *  ?o; org:role [org:roleProperty ?r] } -&gt; {?p ?r ?o}`.</p>
     */
    public static final Property roleProperty = M_MODEL.createProperty( "http://www.w3.org/ns/org#roleProperty" );
    
    /** <p>Indicates an address for the site in a suitable encoding. Use of vCard (using 
     *  the http://www.w3.org/TR/vcard-rdf/ vocabulary) is encouraged but the range 
     *  is left open to allow other encodings to be used. The address may include 
     *  email, telephone, and geo-location information and is not restricted to a 
     *  physical address.</p>
     */
    public static final Property siteAddress = M_MODEL.createProperty( "http://www.w3.org/ns/org#siteAddress" );
    
    /** <p>Indicates an Organization which has some presence at the given site. This 
     *  is the inverse of `org:hasSite`.</p>
     */
    public static final Property siteOf = M_MODEL.createProperty( "http://www.w3.org/ns/org#siteOf" );
    
    /** <p>Represents hierarchical containment of Organizations or OrganizationalUnits; 
     *  indicates an Organization which contains this Organization. Inverse of `org:hasSubOrganization`.</p>
     */
    public static final Property subOrganizationOf = M_MODEL.createProperty( "http://www.w3.org/ns/org#subOrganizationOf" );
    
    /** <p>The transitive closure of subOrganizationOf, giving a representation of all 
     *  organizations that contain this one. Note that technically this is a super 
     *  property of the transitive closure so it could contain additional assertions 
     *  but such usage is discouraged.</p>
     */
    public static final Property transitiveSubOrganizationOf = M_MODEL.createProperty( "http://www.w3.org/ns/org#transitiveSubOrganizationOf" );
    
    /** <p>Indicates an Organization of which this Unit is a part, e.g. a Department 
     *  within a larger FormalOrganization. This is the inverse of `org:hasUnit`.</p>
     */
    public static final Property unitOf = M_MODEL.createProperty( "http://www.w3.org/ns/org#unitOf" );
    
    /** <p>Represents an event which resulted in a major change to an organization such 
     *  as a merger or complete restructuring. It is intended for situations where 
     *  the resulting organization is sufficient distinct from the original organizations 
     *  that it has a distinct identity and distinct URI. Extension vocabularies should 
     *  define sub-classes of this to denote particular categories of event. The instant 
     *  or interval at which the event occurred should be given by `prov:startAtTime` 
     *  and `prov:endedAtTime`, a description should be given by `dct:description`.</p>
     */
    public static final Resource ChangeEvent = M_MODEL.createResource( "http://www.w3.org/ns/org#ChangeEvent" );
    
    /** <p>An Organization which is recognized in the world at large, in particular in 
     *  legal jurisdictions, with associated rights and responsibilities. Examples 
     *  include a Corporation, Charity, Government or Church. Note that this is a 
     *  super class of `gr:BusinessEntity` and it is recommended to use the GoodRelations 
     *  vocabulary to denote Business classifications such as DUNS or NAICS.</p>
     */
    public static final Resource FormalOrganization = M_MODEL.createResource( "http://www.w3.org/ns/org#FormalOrganization" );
    
    /** <p>Indicates the nature of an Agent's membership of an organization. Represents 
     *  an n-ary relation between an Agent, an Organization and a Role. It is possible 
     *  to directly indicate membership, independent of the specific Role, through 
     *  use of the `org:memberOf` property.</p>
     */
    public static final Resource Membership = M_MODEL.createResource( "http://www.w3.org/ns/org#Membership" );
    
    /** <p>Represents a collection of people organized together into a community or other 
     *  social, commercial or political structure. The group has some common purpose 
     *  or reason for existence which goes beyond the set of people belonging to it 
     *  and can act as an Agent. Organizations are often decomposable into hierarchical 
     *  structures. It is recommended that SKOS lexical labels should be used to label 
     *  the Organization. In particular `skos:prefLabel` for the primary (possibly 
     *  legally recognized name), `skos:altLabel` for alternative names (trading names, 
     *  colloquial names) and `skos:notation` to denote a code from a code list. Alternative 
     *  names: _Collective_ _Body_ _Org_ _Group_</p>
     */
    public static final Resource Organization = M_MODEL.createResource( "http://www.w3.org/ns/org#Organization" );
    
    /** <p>A collaboration between two or more Organizations such as a project. It meets 
     *  the criteria for being an Organization in that it has an identity and defining 
     *  purpose independent of its particular members but is neither a formally recognized 
     *  legal entity nor a sub-unit within some larger organization. Might typically 
     *  have a shorter lifetime than the Organizations within it, but not necessarily. 
     *  All members are `org:Organization`s rather than individuals and those Organizations 
     *  can play particular roles within the venture. Alternative names: _Project_ 
     *  _Venture_ _Endeavour_ _Consortium_ _Endeavour_</p>
     */
    public static final Resource OrganizationalCollaboration = M_MODEL.createResource( "http://www.w3.org/ns/org#OrganizationalCollaboration" );
    
    /** <p>An Organization such as a University Support Unit which is part of some larger 
     *  FormalOrganization and only has full recognition within the context of that 
     *  FormalOrganization, it is not a Legal Entity in its own right. Units can be 
     *  large and complex containing other Units and even FormalOrganizations. Alternative 
     *  names: _OU_ _Unit_ _Department_</p>
     */
    public static final Resource OrganizationalUnit = M_MODEL.createResource( "http://www.w3.org/ns/org#OrganizationalUnit" );
    
    /** <p>A Post represents some position within an organization that exists independently 
     *  of the person or persons filling it. Posts may be used to represent situations 
     *  where a person is a member of an organization ex officio (for example the 
     *  Secretary of State for Scotland is part of UK Cabinet by virtue of being Secretary 
     *  of State for Scotland, not as an individual person). A post can be held by 
     *  multiple people and hence can be treated as a organization in its own right.</p>
     */
    public static final Resource Post = M_MODEL.createResource( "http://www.w3.org/ns/org#Post" );
    
    /** <p>Denotes a role that a Person or other Agent can take in an organization. Instances 
     *  of this class describe the abstract role; to denote a specific instance of 
     *  a person playing that role in a specific organization use an instance of `org:Membership`. 
     *  It is common for roles to be arranged in some taxonomic structure and we use 
     *  SKOS to represent that. The normal SKOS lexical properties should be used 
     *  when labelling the Role. Additional descriptive properties for the Role, such 
     *  as a Salary band, may be added by extension vocabularies.</p>
     */
    public static final Resource Role = M_MODEL.createResource( "http://www.w3.org/ns/org#Role" );
    
    /** <p>An office or other premise at which the organization is located. Many organizations 
     *  are spread across multiple sites and many sites will host multiple locations. 
     *  In most cases a Site will be a physical location. However, we don't exclude 
     *  the possibility of non-physical sites such as a virtual office with an associated 
     *  post box and phone reception service. Extensions may provide subclasses to 
     *  denote particular types of site.</p>
     */
    public static final Resource Site = M_MODEL.createResource( "http://www.w3.org/ns/org#Site" );
    
    /** <p>A role corresponding to the `org:headOf` property</p> */
    public static final Resource Head = M_MODEL.createResource( "http://www.w3.org/ns/org#Head" );
    
}
```

Current unit tests passed with no changes. But added more tests to cover the other possible situations.

One thing that is bothering me, is the name. There are other command line parameters that are quite similar... --daml is used to specify DAML as language of source... which could be confusing perhaps?

If accepted/merged, JENA-204 needs the FixVersion updated.

Cheers
Bruno