### PR TITLE
JENA-204: Fix schemagen maven plugin

### DIFF
--- a/jena-maven-tools/pom.xml
+++ b/jena-maven-tools/pom.xml
@@ -123,11 +123,6 @@
           </execution>
         </executions>
         <dependencies>
-          <dependency> <!-- remove when using maven-invoker-plugin 1.10 -->
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-invoker</artifactId>
-            <version>2.2</version>
-          </dependency>
           <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-verifier</artifactId>

--- a/jena-maven-tools/pom.xml
+++ b/jena-maven-tools/pom.xml
@@ -126,7 +126,7 @@
           <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-verifier</artifactId>
-            <version>1.2</version>
+            <version>1.6</version>
             <exclusions>
               <exclusion>
                 <groupId>junit</groupId>

--- a/jena-maven-tools/src/main/java/org/apache/jena/tools/schemagen/Source.java
+++ b/jena-maven-tools/src/main/java/org/apache/jena/tools/schemagen/Source.java
@@ -46,6 +46,9 @@ public class Source {
     @Parameter
     private String input;
 
+    @Parameter(property="lang")
+    private String lang;
+
     @Parameter(property="lang-daml")
     private Boolean langDaml;
 
@@ -157,6 +160,7 @@ public class Source {
     @Parameter(property="no-strict")
     private Boolean noStrict;
 
+
     @SchemagenOption(opt=OPT.CONFIG_FILE)
     public String getConfigFile() {
         return configFile;
@@ -170,6 +174,11 @@ public class Source {
     @SchemagenOption(opt=OPT.INPUT)
     public String getInput() {
         return input;
+    }
+
+    @SchemagenOption(opt=OPT.LANG)
+    public String getLang() {
+        return lang;
     }
 
     @SchemagenOption(opt=OPT.LANG_DAML)
@@ -367,6 +376,10 @@ public class Source {
 
     public void setInput(String input) {
         this.input = input;
+    }
+
+    public void setLang(String lang) {
+        this.lang = lang;
     }
 
     public void setLangDaml(Boolean langDaml) {

--- a/jena-maven-tools/src/test/java/org/apache/jena/tools/schemagen/SourceParameterTest.java
+++ b/jena-maven-tools/src/test/java/org/apache/jena/tools/schemagen/SourceParameterTest.java
@@ -365,6 +365,11 @@ public class SourceParameterTest
                 expected = true;
                 break;
 
+            case LANG:
+                s.setLang( optionName );
+
+                expected = optionName;
+                break;
         }
     }
 


### PR DESCRIPTION
Following up the work on JENA-204, now this one does 2 things:

1) adds the option `lang`, so users can use the following in their configuration

```
	<build>
		<plugins>
			<plugin>
				<groupId>org.apache.jena</groupId>
				<artifactId>jena-maven-tools</artifactId>
				<version>3.10.0-SNAPSHOT</version>
				<executions>
					<execution>
						<id>schemagen</id>
						<goals>
							<goal>translate</goal>
						</goals>
					</execution>
				</executions>
				<configuration>
					<includes>
						<include>src/vocabs/*</include>
					</includes>
					<fileOptions>
						<source>
				          <input>src/vocabs/org.ttl</input>
				          <package-name>org.example.test</package-name>
				          <lang>fr</lang>  <-----------------
				        </source>
					</fileOptions>
				</configuration>
			</plugin>
		</plugins>
	</build>
```

Attaching screenshot of the `Org` ontology from JENA-204 generated in French.

![screenshot from 2018-12-30 17-55-25](https://user-images.githubusercontent.com/304786/50544635-d071f100-0c61-11e9-9377-01aa7d219508.png)

2) interestingly, the build was broken. i.e. `cd`'ing into `jena-maven-tools` and running `mvn clean install` would fail to run the integration tests. After struggling a little bit without luck, decided to look at dependencies.

So I removed one dependency with a comment saying it could be removed after upgrading past a certain version (we were way beyond it), and updating the `org.apache.maven.shared:maven-verifier` to 1.6. Now the build is passing fine, all tests working as expected.
