### PR TITLE
JENA-1656: Make DatasetGraphMonitor transaction-aware.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetChanges.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetChanges.java
@@ -39,4 +39,15 @@ public interface DatasetChanges
     /** Release any resources */
     public void reset() ;
 
+    /** A transaction has begun. */
+    default void begin() {}
+
+    /** The current transaction has been committed. */
+    default void commit() {}
+
+    /** The current transaction has been aborted. */
+    default void abort() {}
+
+    /** The current transaction has been ended. */
+    default void end() {}
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphMonitor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphMonitor.java
@@ -26,6 +26,8 @@ import java.util.List ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.TxnType;
 import org.apache.jena.sparql.SystemARQ ;
 import org.apache.jena.util.iterator.ExtendedIterator ;
 
@@ -198,6 +200,47 @@ public class DatasetGraphMonitor extends DatasetGraphWrapper
     public void sync() {
         SystemARQ.syncObject(monitor) ;
         super.sync() ;
+    }
+
+    @Override
+    public void begin() {
+    	super.begin();
+    	monitor.begin();
+    }
+
+    @Override
+    public void begin(TxnType type)
+    {
+    	super.begin(type);
+    	monitor.begin();
+    }
+
+    @Override
+    public void begin(ReadWrite readWrite)
+    {
+    	super.begin(readWrite);
+    	monitor.begin();
+    }
+
+    @Override
+    public void commit()
+    {
+        super.commit();
+        monitor.commit();
+    }
+
+    @Override
+    public void abort()
+    {
+        super.abort();
+        monitor.abort();
+    }
+
+    @Override
+    public void end()
+    {
+        super.end();
+        monitor.end();
     }
 }
 


### PR DESCRIPTION
This adds transaction information to the DatasetChanges interface (and uses default methods, is that okay?)