### PR TITLE
Improve error message trying to use TDB2 location with TDB (JENA-1658)

### DIFF
--- a/jena-tdb/src/main/java/org/apache/jena/tdb/base/file/LocationLock.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/base/file/LocationLock.java
@@ -103,6 +103,11 @@ public class LocationLock {
             // Can read lock owner from the file
             try {
                 String rawLockInfo = IO.readWholeFileAsUTF8(lockFile.getAbsolutePath());
+                if (rawLockInfo.endsWith("\n")) {
+                    // This is most likely down to trying to open a TDB2 database with TDB1
+                    throw new FileException("Unable to check TDB lock owner, the lock file contents appear to be for a TDB2 database.  Please try loading this location as a TDB2 database.");
+                }
+                
                 int owner = Integer.parseInt(rawLockInfo);
                 return owner;
             } catch (IOException e) {


### PR DESCRIPTION
Since the lock files have slightly different formats TDB can detect when a lock file appears to be TDB2 and issue an appropriate error message to suggest users try using TDB2 instead.

This should avoid user confusion as seen in JENA-1658