### PR TITLE
SDB Transform - improve performance of OPTIONAL, MINUS

### DIFF
--- a/jena-sdb/src/main/java/org/apache/jena/sdb/SDB.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/SDB.java
@@ -68,6 +68,8 @@ public class SDB
     // See also SDBConstants.jdbcFetchSizeOff
     
     public static final Symbol annotateGeneratedSQL     = SDBConstants.allocSymbol("annotateGeneratedSQL") ;
+
+    public static final Symbol optimizeSubqueryFragments = SDBConstants.allocSymbol("optimizeSubqueryFragments") ;
     // ----------------------------------
     
     // Global context is the ARQ context.

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/compiler/TransformOptimizeSubqueryFragments.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/compiler/TransformOptimizeSubqueryFragments.java
@@ -56,7 +56,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
     /**
      * Static method to run the transformer (needs to keep track of visited nodes)
-     * @param op The algebra to rewrite
      */
     public static Op transform(Op op) {
         final Deque<Op> stack = new ArrayDeque<>();
@@ -71,11 +70,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
     /**
      * Run transformation on joins
-     *
-     * @param opJoin
-     * @param opLeft
-     * @param opRight
-     * @return
      */
     @Override
     public Op transform(OpJoin opJoin, Op opLeft, Op opRight) {
@@ -85,11 +79,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
     /**
      * Run transformation on leftjoins
-     *
-     * @param opLeftJoin
-     * @param opLeft
-     * @param opRight
-     * @return
      */
     @Override
     public Op transform(OpLeftJoin opLeftJoin, Op opLeft, Op opRight) {
@@ -99,11 +88,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
     /**
      * Run transformation on minus
-     *
-     * @param opMinus
-     * @param opLeft
-     * @param opRight
-     * @return
      */
     @Override
     public Op transform(OpMinus opMinus, Op opLeft, Op opRight) {
@@ -113,11 +97,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
     /**
      * Run transformation on unions
-     *
-     * @param opUnion
-     * @param opLeft
-     * @param opRight
-     * @return
      */
     @Override
     public Op transform(OpUnion opUnion, Op opLeft, Op opRight) {
@@ -155,7 +134,7 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
                 }
             }
 
-            // If we have previous operations in the tracket
+            // If we have previous operations in the tracker
             if (needToProcess()) {
                 // Iterate through the tracker
                 Iterator<Op> iter = tracker.iterator();
@@ -173,8 +152,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
         /**
          * Determine if there are entries in the tracker that need to be processed
-         *
-         * @return
          */
         private boolean needToProcess() {
             // If the current op is in the tracker
@@ -295,9 +272,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
         /**
          * Add a triple to the pattern if not already present
-         *
-         * @param pattern
-         * @param triple
          */
         private void addToPatternIfNotPresent(BasicPattern pattern, Triple triple) {
             if (pattern != null) {
@@ -309,10 +283,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
         /**
          * Can we recurse the left side of the root op
-         *
-         * @param current
-         * @param root
-         * @return
          */
         private boolean shouldRecurseLeft(Op current, Op root) {
             // If the operation is a join, leftjoin or minus
@@ -331,9 +301,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
         /**
          * Can we recurse the right side of the op
-         *
-         * @param op
-         * @return
          */
         private boolean shouldRecurseRight(Op2 op) {
             // If the operator is a join
@@ -350,10 +317,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
         /**
          * Test whether the triple is currently in the basic pattern
-         *
-         * @param bp
-         * @param t
-         * @return
          */
         private boolean isInPattern(BasicPattern bp, Triple t) {
             for (Triple bpt : bp) {
@@ -367,9 +330,6 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
 
         /**
          * Extract any variable names that are subjects in the basic pattern
-         *
-         * @param bp
-         * @return
          */
         private Set<String> getVariableNames(BasicPattern bp) {
             final Set<String> names = new HashSet<>();

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/compiler/TransformOptimizeSubqueryFragments.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/compiler/TransformOptimizeSubqueryFragments.java
@@ -1,0 +1,352 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sdb.compiler;
+
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpVisitor;
+import org.apache.jena.sparql.algebra.OpVisitorBase;
+import org.apache.jena.sparql.algebra.TransformCopy;
+import org.apache.jena.sparql.algebra.Transformer;
+import org.apache.jena.sparql.algebra.op.Op2;
+import org.apache.jena.sparql.algebra.op.OpBGP;
+import org.apache.jena.sparql.algebra.op.OpJoin;
+import org.apache.jena.sparql.algebra.op.OpLeftJoin;
+import org.apache.jena.sparql.algebra.op.OpMinus;
+import org.apache.jena.sparql.algebra.op.OpTable;
+import org.apache.jena.sparql.core.BasicPattern;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * For large datasets, the performance of the OPTIONAL joins in SQL can suffer, as the subqueries
+ * generate large views which are expensive to join.
+ *
+ * This optimizer transforms the algebra to insert the restrictions from outside of the optional subquery,
+ * reducing the amount of data that has to be joined.
+ */
+public class TransformOptimizeSubqueryFragments extends TransformCopy {
+    private Deque<Op> tracker;
+
+    /**
+     * Static method to run the transformer (needs to keep track of visited nodes)
+     * @param op The algebra to rewrite
+     */
+    public static Op transform(Op op) {
+        final Deque<Op> stack = new ArrayDeque<>();
+        OpVisitor before = new Pusher(stack);
+        OpVisitor after = new Popper(stack);
+        return Transformer.transform(new TransformOptimizeSubqueryFragments(stack), op, before, after);
+    }
+
+    private TransformOptimizeSubqueryFragments(Deque<Op> tracker) {
+        this.tracker = tracker;
+    }
+
+    /**
+     * Run transformation on joins
+     *
+     * @param opJoin
+     * @param opLeft
+     * @param opRight
+     * @return
+     */
+    @Override
+    public Op transform(OpJoin opJoin, Op opLeft, Op opRight) {
+        OpTransformer transformer = new OpTransformer(opJoin, opLeft, opRight);
+        return super.transform(opJoin, transformer.opLeft, transformer.opRight);
+    }
+
+    /**
+     * Run transformation on leftjoins
+     *
+     * @param opLeftJoin
+     * @param opLeft
+     * @param opRight
+     * @return
+     */
+    @Override
+    public Op transform(OpLeftJoin opLeftJoin, Op opLeft, Op opRight) {
+        OpTransformer transformer = new OpTransformer(opLeftJoin, opLeft, opRight);
+        return super.transform(opLeftJoin, transformer.opLeft, transformer.opRight);
+    }
+
+    /**
+     * Run transformation on minus
+     *
+     * @param opMinus
+     * @param opLeft
+     * @param opRight
+     * @return
+     */
+    @Override
+    public Op transform(OpMinus opMinus, Op opLeft, Op opRight) {
+        OpTransformer transformer = new OpTransformer(opMinus, opLeft, opRight);
+        return super.transform(opMinus, transformer.opLeft, transformer.opRight);
+    }
+
+    /**
+     * Helper class to perform the transformation, as it is used for OpJoin, OpLeftJoin and OpMinus
+     */
+    private class OpTransformer {
+        private Op opCurrent;
+        private Op opLeft;
+        private Op opRight;
+
+        OpTransformer(Op opCurrent, Op opLeft, Op opRight) {
+            // Store the parameters
+            this.opCurrent = opCurrent;
+            this.opLeft = opLeft;
+            this.opRight = opRight;
+
+            // Run the transformation
+            transform();
+        }
+
+        private void transform() {
+            // Add statements from left to right, unless left is table op
+            if (!(opLeft instanceof OpTable)) {
+                opRight = addStatements(opRight, opLeft);
+            }
+
+            // If we have previous operations in the tracket
+            if (tracker.size() > 1) {
+                // Iterate through the tracker
+                Iterator<Op> iter = tracker.iterator();
+                while (iter.hasNext()) {
+                    Op op = iter.next();
+                    // As long as the operation is not the one being transformed
+                    if (op != opCurrent) {
+                        // Copy statements from previous operations into the subpatterns
+                        opLeft = addStatements(opLeft, op);
+                        opRight = addStatements(opRight, op);
+                    }
+                }
+            }
+        }
+
+        // Add statements from src innto dest
+        private Op addStatements(Op dest, Op src) {
+            // Only needed if destination is a Basic Graph Pattern
+            if (OpBGP.isBGP(dest)) {
+                if (src instanceof Op2) {
+                    // Get the left side of an Op2 from src
+                    Op opLeft = ((Op2)src).getLeft();
+
+                    // If the left side is a Basic Graph Pattern
+                    if (OpBGP.isBGP(opLeft)) {
+                        // Copy statements from the Basic Graph Pattern to the destination
+                        dest = addStatements(dest, opLeft);
+                    } else {
+                        // Not a Basic Graph Pattern
+                        // Determine if we should copy statements from the right hand side
+                        if (shouldRecurseRight((Op2)src)) {
+                            // Add statements from the right hand side of the op to the destination
+                            dest = addStatements(dest, ((Op2)src).getRight());
+                        }
+
+                        // Determine if we should copy statements from the left hand side
+                        if (shouldRecurseLeft(dest, src)) {
+                            // Add statements from the left hand side of the op to the destination
+                            dest = addStatements(dest, opLeft);
+                        }
+                    }
+                } else if (OpBGP.isBGP(src)) {
+                    // If the source is a Basic Graph Pattern we need to copy matching statements into the destination
+                    BasicPattern destP = new BasicPattern( ((OpBGP)dest).getPattern() );
+                    BasicPattern srcP  = ((OpBGP)src).getPattern();
+
+                    int initialCount = destP.size();
+                    int loopCount;
+                    do {
+                        // Record the current size of the destination pattern
+                        loopCount = destP.size();
+
+                        // Get any variable names that are subjects in the destination
+                        Set<String> names = getSubjectVariableNames(destP);
+
+                        // Iterate through all of the statements in the source BGP
+                        for (Triple srcT : srcP) {
+                            if (srcT.getSubject().isVariable() && names.contains(srcT.getSubject().getName())) {
+                                // If the subject in the source is a variable
+                                // and the name is in the list of destination variables
+                                if (srcT.getObject().isVariable()) {
+                                    // And the object in the source is a variable
+                                    // Check that the name binds to the destination
+                                    if (names.contains(srcT.getObject().getName())) {
+                                        // Add the triple to the destination if it is not already present
+                                        if (!isInPattern(destP, srcT)) {
+                                            destP.add(srcT);
+                                        }
+                                    }
+                                } else {
+                                    // The object is a literal or resource
+                                    // So add the triple to the destination if it is not already present
+                                    if (!isInPattern(destP, srcT)) {
+                                        destP.add(srcT);
+                                    }
+                                }
+                            } else if (srcT.getObject().isVariable() && names.contains(srcT.getObject().getName())) {
+                                // If the object is a variable, and the name is in the list of destination variables
+                                if (!isInPattern(destP, srcT)) {
+                                    destP.add(srcT);
+                                }
+                            }
+                        }
+
+                        // Loop if we have added any statements
+                    } while (loopCount < destP.size());
+
+                    // Only create a new OpBGP if we have added statements
+                    if (initialCount < destP.size()) {
+                        return new OpBGP(destP);
+                    }
+                }
+            }
+
+            // Return the destination
+            return dest;
+        }
+
+        /**
+         * Can we recurse the left side of the root op
+         *
+         * @param current
+         * @param root
+         * @return
+         */
+        private boolean shouldRecurseLeft(Op current, Op root) {
+            // If the operation is a join, leftjoin or minus
+            // We need to parse the Op if the the current operator is not immediately to the left or right of the root
+            if (root instanceof OpJoin) {
+                return current != ((OpJoin)root).getLeft() && current != ((OpJoin)root).getRight();
+            } else if (root instanceof OpLeftJoin) {
+                return current != ((OpLeftJoin)root).getLeft() && current != ((OpLeftJoin)root).getRight();
+            } else if (root instanceof OpMinus) {
+                return current != ((OpMinus)root).getLeft() && current != ((OpMinus)root).getRight();
+            }
+
+            // Not an operator that we are considering, so return false
+            return false;
+        }
+
+        /**
+         * Can we recurse the right side of the op
+         *
+         * @param op
+         * @return
+         */
+        private boolean shouldRecurseRight(Op2 op) {
+            // If the operator is a join
+            if (op instanceof OpJoin) {
+                // If the left side is an op2, and the left side of it is NOT an OpTable
+                if (op.getLeft() instanceof Op2) {
+                    return ((Op2) op.getLeft()).getLeft() instanceof OpTable;
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * Test whether the triple is currently in the basic pattern
+         *
+         * @param bp
+         * @param t
+         * @return
+         */
+        private boolean isInPattern(BasicPattern bp, Triple t) {
+            for (Triple bpt : bp) {
+                if (bpt.matches(t)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /**
+         * Extract any variable names that are subjects in the basic pattern
+         *
+         * @param bp
+         * @return
+         */
+        private Set<String> getSubjectVariableNames(BasicPattern bp) {
+            final Set<String> names = new HashSet<>();
+
+            for (Triple triple : bp) {
+                if (triple.getSubject().isVariable()) {
+                    names.add(triple.getSubject().getName());
+                }
+            }
+
+            return names;
+        }
+    }
+
+    private static class Pusher extends OpVisitorBase {
+        Deque<Op> stack ;
+
+        Pusher(Deque<Op> stack) {
+            this.stack = stack;
+        }
+
+        @Override
+        public void visit(OpLeftJoin opLeftJoin) {
+            stack.push(opLeftJoin);
+        }
+
+        @Override
+        public void visit(OpJoin opJoin) {
+            stack.push(opJoin);
+        }
+
+        @Override
+        public void visit(OpMinus opMinus) {
+            stack.push(opMinus);
+        }
+    }
+
+    private static class Popper extends OpVisitorBase {
+        Deque<Op> stack ;
+
+        Popper(Deque<Op> stack) {
+            this.stack = stack;
+        }
+
+        @Override
+        public void visit(OpLeftJoin opLeftJoin) {
+            stack.pop();
+        }
+
+        @Override
+        public void visit(OpJoin opJoin) {
+            stack.pop();
+        }
+
+        @Override
+        public void visit(OpMinus opMinus) {
+            stack.pop();
+        }
+    }
+}

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/engine/QueryEngineSDB.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/engine/QueryEngineSDB.java
@@ -25,6 +25,7 @@ import org.apache.jena.sdb.SDBException ;
 import org.apache.jena.sdb.Store ;
 import org.apache.jena.sdb.compiler.OpSQL ;
 import org.apache.jena.sdb.compiler.SDBCompile ;
+import org.apache.jena.sdb.compiler.TransformOptimizeSubqueryFragments;
 import org.apache.jena.sdb.core.SDBRequest ;
 import org.apache.jena.sdb.store.DatasetGraphSDB ;
 import org.apache.jena.sparql.ARQConstants ;
@@ -97,7 +98,12 @@ public class QueryEngineSDB extends QueryEngineBase
         // e.g. don't place filters
         // Op op = Algebra.optimize(originalOp, context) ;
         Op op = originalOp ;
-        
+
+        // Rewrite algebra to improve OPTIONAL and MINUS performance
+        if (context.isTrueOrUndef(SDB.optimizeSubqueryFragments)) {
+            op = TransformOptimizeSubqueryFragments.transform(op);
+        }
+
         // Do property functions.
         op = Transformer.transform(new TransformPropertyFunction(context), op) ;
         op = Transformer.transform(new TransformFilterEquality(), op) ;

--- a/jena-sdb/src/test/java/org/apache/jena/sdb/test/SDBTestMisc.java
+++ b/jena-sdb/src/test/java/org/apache/jena/sdb/test/SDBTestMisc.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.sdb.test;
 
+import org.apache.jena.sdb.test.compiler.TestTransformOptimizeSubqueryFragments;
 import org.apache.jena.sdb.test.misc.* ;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -30,7 +31,8 @@ import org.junit.runners.Suite;
     TestExprMatch.class,
     TestRegex.class,
     TestPrefixMappingSDB.class,
-    TestRegistry.class
+    TestRegistry.class,
+    TestTransformOptimizeSubqueryFragments.class
 } )
 
 public class SDBTestMisc

--- a/jena-sdb/src/test/java/org/apache/jena/sdb/test/compiler/TestTransformOptimizeSubqueryFragments.java
+++ b/jena-sdb/src/test/java/org/apache/jena/sdb/test/compiler/TestTransformOptimizeSubqueryFragments.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sdb.test.compiler;
+
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.sdb.compiler.TransformOptimizeSubqueryFragments;
+import org.apache.jena.sparql.algebra.Algebra;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.sse.SSE;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTransformOptimizeSubqueryFragments {
+    @Test
+    public void testSimpleOptional() {
+        testTransform(
+                // SPARQL to Test
+                "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n" +
+                "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
+                "        \n" +
+                "        SELECT ?sublect ?label\n" +
+                "        WHERE {\n" +
+                "            ?subject a  foaf:Person.\n" +
+                "            OPTIONAL {\n" +
+                "                ?subject rdfs:label ?label .\n" +
+                "            }\n" +
+                "        } \n",
+
+                // Target Op
+                "(project (?sublect ?label)\n" +
+                "  (leftjoin\n" +
+                "    (bgp (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>))\n" +
+                "    (bgp\n" +
+                "      (triple ?subject <http://www.w3.org/2000/01/rdf-schema#label> ?label)\n" +
+                "      (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>)\n" +
+                "    )))\n"
+        );
+    }
+
+    @Test
+    public void testSimpleMinus() {
+        testTransform(
+                // SPARQL to Test
+                "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n" +
+                        "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
+                        "        \n" +
+                        "        SELECT ?sublect ?label\n" +
+                        "        WHERE {\n" +
+                        "            ?subject a  foaf:Person.\n" +
+                        "            MINUS {\n" +
+                        "                ?subject rdfs:label ?label .\n" +
+                        "            }\n" +
+                        "        } \n",
+
+                // Target Op
+                "(project (?sublect ?label)\n" +
+                        "  (minus\n" +
+                        "    (bgp (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>))\n" +
+                        "    (bgp\n" +
+                        "      (triple ?subject <http://www.w3.org/2000/01/rdf-schema#label> ?label)\n" +
+                        "      (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>)\n" +
+                        "    )))\n"
+        );
+    }
+
+    @Test
+    public void testOptionalNotBound() {
+        testTransform(
+                // SPARQL to Test
+                "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n" +
+                        "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
+                        "        \n" +
+                        "        SELECT ?sublect ?label\n" +
+                        "        WHERE {\n" +
+                        "            ?subject a  foaf:Person.\n" +
+                        "            OPTIONAL {\n" +
+                        "                ?unbound rdfs:label ?label .\n" +
+                        "            }\n" +
+                        "        } \n",
+
+                // Target Op
+                "(project (?sublect ?label)\n" +
+                        "  (leftjoin\n" +
+                        "    (bgp (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>))\n" +
+                        "    (bgp (triple ?unbound <http://www.w3.org/2000/01/rdf-schema#label> ?label))))\n"
+        );
+    }
+
+    @Test
+    public void testUnion() {
+        testTransform(
+                // SPARQL to Test
+                "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n" +
+                        "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
+                        "        \n" +
+                        "        SELECT ?sublect ?label\n" +
+                        "        WHERE {\n" +
+                        "            ?subject a  foaf:Person.\n" +
+                        "            {\n" +
+                        "                ?subject rdfs:label ?label .\n" +
+                        "            } UNION {\n" +
+                        "                ?subject <http://example.com/hasVcard> ?vcard .\n" +
+                        "                ?vcard rdfs:label ?label .\n" +
+                        "            }\n" +
+                        "        } \n",
+
+                // Target Op
+                "(project (?sublect ?label)\n" +
+                        "  (join\n" +
+                        "    (bgp (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>))\n" +
+                        "    (union\n" +
+                        "      (bgp\n" +
+                        "        (triple ?subject <http://www.w3.org/2000/01/rdf-schema#label> ?label)\n" +
+                        "        (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>)\n" +
+                        "      )\n" +
+                        "      (bgp\n" +
+                        "        (triple ?subject <http://example.com/hasVcard> ?vcard)\n" +
+                        "        (triple ?vcard <http://www.w3.org/2000/01/rdf-schema#label> ?label)\n" +
+                        "        (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>)\n" +
+                        "      ))))\n"
+        );
+    }
+
+
+    @Test
+    public void testUnionWithOptional() {
+        testTransform(
+                // SPARQL to Test
+                "PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n" +
+                        "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
+                        "        \n" +
+                        "        SELECT ?sublect ?label\n" +
+                        "        WHERE {\n" +
+                        "            ?subject a  foaf:Person.\n" +
+                        "            {\n" +
+                        "                ?subject rdfs:label ?label .\n" +
+                        "            } UNION {\n" +
+                        "                ?subject <http://example.com/hasVcard> ?vcard .\n" +
+                        "                OPTIONAL {\n" +
+                        "                   ?vcard rdfs:label ?label .\n" +
+                        "                }\n" +
+                        "            }\n" +
+                        "        } \n",
+
+                // Target Op
+                "(project (?sublect ?label)\n" +
+                        "  (join\n" +
+                        "    (bgp (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>))\n" +
+                        "    (union\n" +
+                        "      (bgp\n" +
+                        "        (triple ?subject <http://www.w3.org/2000/01/rdf-schema#label> ?label)\n" +
+                        "        (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>)\n" +
+                        "      )\n" +
+                        "      (leftjoin\n" +
+                        "        (bgp\n" +
+                        "          (triple ?subject <http://example.com/hasVcard> ?vcard)\n" +
+                        "          (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>)\n" +
+                        "        )\n" +
+                        "        (bgp\n" +
+                        "          (triple ?vcard <http://www.w3.org/2000/01/rdf-schema#label> ?label)\n" +
+                        "          (triple ?subject <http://example.com/hasVcard> ?vcard)\n" +
+                        "          (triple ?subject <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person>)\n" +
+                        "        )))))\n"
+        );
+    }
+
+    private void testTransform(String sparql, String targetOp) {
+        // Generate Op
+        Op op = Algebra.compile(QueryFactory.create(sparql));
+
+        // Transofrm to optimize subquery
+        op = TransformOptimizeSubqueryFragments.transform(op);
+
+        // Parse target Op structure and compate
+        Op target = SSE.parseOp(targetOp);
+        Assert.assertTrue(target.equalTo(op, null));
+    }
+}


### PR DESCRIPTION
Algebra transformation that finds applicable restrictions that bind to e.g. OPTIONAL subqueries, and adds those restrictions into the subquery.

This reduces the amount of data that the subquery returns, and in so doing reduces that amount of data that is considered when joining to the outer query, improving performance.

e.g. Queries with multiple OPTIONALs that would take over 400msecs to execute in SQL, are transformed into ones that take 1msec.

(This is on a local MySQL containing approx 500,000 quads, and 100,000 nodes)

Currently, this is enabled by default (all unit tests still pass, not encountered any queries that fail), but there is an option to disable it in the context (optimizeSubqueryFragments = false).
