### PR TITLE
Allow direct loading of tuples without temporary tables

### DIFF
--- a/jena-sdb/src/main/java/org/apache/jena/sdb/layout2/TupleLoaderDirect.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/layout2/TupleLoaderDirect.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sdb.layout2;
+
+public interface TupleLoaderDirect {
+    String getDirectInsertNodes();
+    String getDirectInsertTuples();
+}

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/layout2/hash/TupleLoaderHashMySQL.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/layout2/hash/TupleLoaderHashMySQL.java
@@ -19,10 +19,11 @@
 package org.apache.jena.sdb.layout2.hash;
 
 import org.apache.jena.sdb.layout2.TableDescNodes ;
+import org.apache.jena.sdb.layout2.TupleLoaderDirect;
 import org.apache.jena.sdb.sql.SDBConnection ;
 import org.apache.jena.sdb.store.TableDesc ;
 
-public class TupleLoaderHashMySQL extends TupleLoaderHashBase {
+public class TupleLoaderHashMySQL extends TupleLoaderHashBase implements TupleLoaderDirect {
 
 	public TupleLoaderHashMySQL(SDBConnection connection, TableDesc tableDesc,
 			int chunkSize) {
@@ -69,6 +70,34 @@ public class TupleLoaderHashMySQL extends TupleLoaderHashBase {
 		}
 		stmt.append("\nFROM ").append(getTupleLoader());
 		
+		return stmt.toString();
+	}
+
+	@Override
+	public String getDirectInsertNodes() {
+		StringBuilder stmt = new StringBuilder();
+
+		stmt.append("INSERT IGNORE INTO Nodes VALUES (");
+		for (int i = 0; i < getNodeColTypes().length; i++) {
+			if (i != 0) stmt.append(" , ");
+			stmt.append("?");
+		}
+		stmt.append(" )");
+
+		return stmt.toString();
+	}
+
+	@Override
+	public String getDirectInsertTuples() {
+		StringBuilder stmt = new StringBuilder();
+
+		stmt.append("INSERT IGNORE INTO ").append(this.getTableName()).append(" VALUES (");
+		for (int i = 0; i < this.getTableWidth(); i++) {
+			if (i != 0) stmt.append(" , ");
+			stmt.append("?");
+		}
+		stmt.append(" )");
+
 		return stmt.toString();
 	}
 }


### PR DESCRIPTION
Add a new interface to the TupleLoader that allows database engines with appropriate query constructs to bypass the use of a temporary table when adding data to the store.

Currently, this has only been implemented for MySQL using a layout2/hash, although in theory it could be possible to do it for other databases - e.g. Postgres 9.5+.

For a MySQL database, this reduces writing times by about 30%, (based on a local 5.7 instance running on an SSD)