### PR TITLE
Comments cleanup; remove unused functions.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/Transactional.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/Transactional.java
@@ -26,13 +26,13 @@ import org.apache.jena.system.Txn;
 /** Interface that encapsulates the  begin/abort|commit/end operations.
  * <p>The read lifecycle is:
  * <pre> begin(READ) ... end()</pre>
- * <p>{@code commit} and {@code abort} are allowed. 
+ * <p>{@code commit} and {@code abort} are allowed.
  * <p>The write lifecycle is:
  * <pre> begin(WRITE) ... abort() or commit()</pre>
  * <p>{@code end()} is optional but preferred.
  * <p>
  * Helper code is available {@link Txn} so, for example:
- * <pre>Txn.executeRead(dataset, {@literal ()->} { ... sparql query ... });</pre> 
+ * <pre>Txn.executeRead(dataset, {@literal ()->} { ... sparql query ... });</pre>
  * <pre>Txn.executeWrite(dataset, {@literal ()->} { ... sparql update ... });</pre>
  * or use one of <tt>Txn.calculateRead</tt> and <tt>Txn.executeWrite</tt>
  * to return a value for the transaction block.
@@ -59,39 +59,39 @@ import org.apache.jena.system.Txn;
  * </pre>
  */
 
-public interface Transactional 
+public interface Transactional
 {
     /**
      * Start a transaction which is READ mode and which will switch to WRITE if an update
-     * is attempted but only if no intermediate transaction has performed an update. 
+     * is attempted but only if no intermediate transaction has performed an update.
      * <p>
      * See {@link #begin(TxnType)} for more details an options.
      * <p>
      * May not be implemented. See {@link #begin(ReadWrite)} is guaranteed to be provided.
      */
     public default void begin() { begin(TxnType.READ_PROMOTE); }
-    
+
     /**
      * Start a transaction.<br/>
      * READ or WRITE transactions start in that state and do not change for the
      * lifetime of the transaction.
      * <ul>
-     * 
+     *
      * <li>{@code WRITE}: this guarantees a WRITE will complete if {@code commit()} is
      * called. The same as {@code begin(ReadWrite.WRITE)}.
-     * 
+     *
      * <li>{@code READ}: the transaction can not promote to WRITE,ensuring read-only
      * access to the data. The same as {@code begin(ReadWrite.READ)}.
-     * 
+     *
      * <li>{@code READ_PROMOTE}: the transaction will go from "read" to "write" if an
      * update is attempted and if the dataset has not been changed by another write
      * transaction. See also {@link #promote}.
-     * 
+     *
      * <li>{@code READ_COMMITTED_PROMOTE}: Use this with care. The promotion will
      * succeed but changes from other transactions become visible.
-     * 
+     *
      * </ul>
-     * 
+     *
      * Read committed: at the point transaction attempts promotion from "read" to
      * "write", the system checks if the dataset has change since the transaction started
      * (called {@code begin}). If {@code READ_PROMOTE}, the dataset must not have
@@ -101,14 +101,14 @@ public interface Transactional
      * <p>
      * This operation is optional and some implementations may throw
      * a {@link JenaTransactionException} exception for some or all {@link TxnType} values.
-     * <p> 
+     * <p>
      * See {@link #begin(ReadWrite)} for a form that is required of implementations.
      */
     public void begin(TxnType type);
-    
-    /** Start either a READ or WRITE transaction. */ 
+
+    /** Start either a READ or WRITE transaction. */
     public void begin(ReadWrite readWrite) ;
-    
+
     /**
      * Attempt to promote a transaction from "read" to "write" when the transaction
      * started with a "promote" mode ({@code READ_PROMOTE} or
@@ -127,8 +127,8 @@ public interface Transactional
      * transaction is still valid and in "read" mode. Any further calls to
      * {@code promote()} will also return false.
      * <p>
-     * This method throws an exception if there is an attempt to promote a "READ"
-     * transaction.
+     * <p>
+     * This method returns false if there is an attempt to promote a "READ" transaction.
      */
     public default boolean promote() {
         if ( transactionMode() == ReadWrite.WRITE )
@@ -145,18 +145,18 @@ public interface Transactional
         throw new JenaTransactionException("Can't determine promote '"+txnType+"'transaction");
     }
 
-    public enum Promote { ISOLATED, READ_COMMITTED } ; 
-    
+    public enum Promote { ISOLATED, READ_COMMITTED } ;
+
     /**
      * Attempt to promote a transaction from "read" mode to "write" and the transaction. This
      * method allows the form of promotion to be specified. The transaction must not have been started
-     * with {@code READ}, which is read-only. 
+     * with {@code READ}, which is read-only.
      * <p>
      * An argument of {@code READ_PROMOTE} treats the promotion as if the transaction was started
      * with {@code READ_PROMOTE} (any other writer commiting since the transaction started
      * blocks promotion) and {@code READ_COMMITTED_PROMOTE} treats the promotion as if the transaction was started
      * with {@code READ_COMMITTED_PROMOTE} (intemediate writer commits become visible).
-     * <p> 
+     * <p>
      * Returns "true" if the transaction is in write mode after the call. The method
      * always succeeds of the transaction is already "write".
      * <p>
@@ -171,25 +171,25 @@ public interface Transactional
      */
     public boolean promote(Promote mode);
 
-    /** Commit a transaction - finish the transaction and make any changes permanent (if a "write" transaction) */  
+    /** Commit a transaction - finish the transaction and make any changes permanent (if a "write" transaction) */
     public void commit() ;
-    
-    /** Abort a transaction - finish the transaction and undo any changes (if a "write" transaction) */  
+
+    /** Abort a transaction - finish the transaction and undo any changes (if a "write" transaction) */
     public void abort() ;
 
-    /** Finish the transaction - if a write transaction and commit() has not been called, then abort */  
+    /** Finish the transaction - if a write transaction and commit() has not been called, then abort */
     public void end() ;
 
     /** Return the current mode of the transaction - "read" or "write".
-     * If the caller is not in a transaction, this method returns null. 
-     */ 
+     * If the caller is not in a transaction, this method returns null.
+     */
     public ReadWrite transactionMode();
 
-    /** Return the transaction type used in {@code begin(TxnType)}. 
-     * If the caller is not in a transaction, this method returns null. 
-     */ 
+    /** Return the transaction type used in {@code begin(TxnType)}.
+     * If the caller is not in a transaction, this method returns null.
+     */
     public TxnType transactionType();
 
-    /** Say whether inside a transaction. */ 
+    /** Say whether inside a transaction. */
     public boolean isInTransaction() ;
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphFind.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphFind.java
@@ -45,7 +45,11 @@ import org.junit.Test ;
 /** Tests to cover cases of "find" on a dataset graph.
  *  The coverage should be so that it tests all the frameworks
  *  (DatasetGraphBaseFind, DatasetGraphQuad) and the ways they send
- *  find operations to different methods. 
+ *  find operations to different methods.
+ *
+ * @see AbstractDatasetGraphFindPatterns
+ * @see AbstractDatasetGraphTests
+ * @see AbstractTestGraphOverDatasetGraph
  */
 public abstract class AbstractDatasetGraphFind {
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphFindPatterns.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphFindPatterns.java
@@ -34,10 +34,11 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
 /** Tests to cover cases of "find" patterns on a dataset graph
- * and graoph from datasets.
- * @see AbstractDatasetGraphTests
+ * and graph from datasets.
+ *
  * @see AbstractDatasetGraphFind
- * @see AbstractTestGraphOverDataset
+ * @see AbstractDatasetGraphTests
+ * @see AbstractTestGraphOverDatasetGraph
  */
 public abstract class AbstractDatasetGraphFindPatterns {
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphTests.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphTests.java
@@ -35,6 +35,13 @@ import org.apache.jena.sparql.graph.GraphFactory ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
+/** Test basic operations on a DatasetGraph
+ *
+ * @see AbstractDatasetGraphFind
+ * @see AbstractDatasetGraphFindPatterns
+ * @see AbstractDatasetGraphTests
+ * @see AbstractTestGraphOverDatasetGraph
+ */
 public abstract class AbstractDatasetGraphTests
 {
     protected abstract DatasetGraph emptyDataset() ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestDataset.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestDataset.java
@@ -29,6 +29,7 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.junit.Test;
 
+/** Basic testing of the Dataset API */
 public abstract class AbstractTestDataset extends BaseTest
 {
     protected abstract Dataset createDataset();

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestGraphOverDatasetGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestGraphOverDatasetGraph.java
@@ -33,26 +33,29 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public abstract class AbstractTestGraphOverDataset extends BaseTest
+/**
+ * Tests of graphs as views of a DatasetGraph.
+ */
+public abstract class AbstractTestGraphOverDatasetGraph extends BaseTest
 {
     // See also: ARQ/GraphsTests, TestGraphsMem(enable tests?), UnionTransformTests
-    
+
     protected DatasetGraph baseDSG ;
     protected abstract DatasetGraph createBaseDSG() ;
-    
+
     private static Quad q0 = SSE.parseQuad("(_ <s> <p> 0)") ;
     private static Quad q1 = SSE.parseQuad("(<g1> <s> <p> 1)") ;
     private static Quad q2 = SSE.parseQuad("(<g2> <s> <p> 2)") ;    // same triple - different graph
     private static Quad q3 = SSE.parseQuad("(<g3> <s> <p> 2)") ;    // same triple - different graph
-    
+
     private static Node gn1 = SSE.parseNode("<g1>") ;
     private static Node gn2 = SSE.parseNode("<g2>") ;
     private static Node gn3 = SSE.parseNode("<g3>") ;
     private static Node gnNotSuchGraph = SSE.parseNode("<NoSuchGraph>") ;
-    
+
     protected abstract Graph makeNamedGraph(DatasetGraph dsg, Node gn) ;
     protected abstract Graph makeDefaultGraph(DatasetGraph dsg) ;
-    
+
     @Before public void before()
     {
         baseDSG = createBaseDSG() ;
@@ -61,21 +64,21 @@ public abstract class AbstractTestGraphOverDataset extends BaseTest
         baseDSG.add(q2) ;
         baseDSG.add(q3) ;
     }
-    
+
     @Test public void graphDSG_view_1()
     {
         Triple t = makeDefaultGraph(baseDSG).find(null, null, null).next() ;
         assertEquals(SSE.parseTriple("(<s> <p> 0)"), t) ;
         // Check exact iterator.
     }
-    
+
     @Test public void graphDSG_view_2()
     {
         Triple t = makeNamedGraph(baseDSG, gn1).find(null, null, null).next() ;
         assertEquals(SSE.parseTriple("(<s> <p> 1)"), t) ;
         // Check exact iterator.
     }
-    
+
     @Test public void graphDSG_view_3()
     {
         Graph g = makeDefaultGraph(baseDSG) ;
@@ -85,7 +88,7 @@ public abstract class AbstractTestGraphOverDataset extends BaseTest
         assertEquals(2, g.size()) ;
         // Check exact iterator.
     }
-    
+
     // non-existant graph
     @Test public void graphDSG_view_4()
     {
@@ -95,7 +98,7 @@ public abstract class AbstractTestGraphOverDataset extends BaseTest
         assertEquals(0, g.size()) ;
     }
 
-    // This test only works if the underlying dataset implements Quad.unionGraph   
+    // This test only works if the underlying dataset implements Quad.unionGraph
     @Test public void graphDSG_view_union_1()
     {
         Graph g = makeNamedGraph(baseDSG, Quad.unionGraph) ;
@@ -106,13 +109,13 @@ public abstract class AbstractTestGraphOverDataset extends BaseTest
     }
 
     // ---- contains
-    
+
     @Test public void graphDSG_contains_1()
     {
         boolean b = new DatasetGraphViewGraphs(baseDSG).containsGraph(gn1) ;
         assertTrue(b) ;
     }
-    
+
     @Test public void graphDSG_contains_2()
     {
         boolean b = new DatasetGraphViewGraphs(baseDSG).containsGraph(gnNotSuchGraph) ;
@@ -127,21 +130,21 @@ public abstract class AbstractTestGraphOverDataset extends BaseTest
         PrefixMapping pmap = g.getPrefixMapping() ;
         assertNotNull(pmap) ;
     }
-    
+
     @Test public void graphDSG_prefixes_2()
     {
         Graph g = makeNamedGraph(baseDSG, Quad.unionGraph) ;
         PrefixMapping pmap = g.getPrefixMapping() ;
         assertNotNull(pmap) ;
     }
-    
+
     @Test public void graphDSG_prefixes_3()
     {
         Graph g = makeDefaultGraph(baseDSG) ;
         PrefixMapping pmap = g.getPrefixMapping() ;
         assertNotNull(pmap) ;
     }
-    
+
     @Test public void graphDSG_prefixes_4()
     {
         // All graphs exist.
@@ -149,9 +152,9 @@ public abstract class AbstractTestGraphOverDataset extends BaseTest
         PrefixMapping pmap = g.getPrefixMapping() ;
         assertNotNull(pmap) ;
     }
-    
+
     // ---- update
-    
+
     @Test public void graphDGS_update_1()
     {
         Quad q9 = SSE.parseQuad("(<g3> <s> <p> 9)") ;
@@ -160,7 +163,7 @@ public abstract class AbstractTestGraphOverDataset extends BaseTest
         Triple t = SSE.parseTriple("(<s> <p> 9)") ;
         assertTrue(g.contains(t)) ;
     }
-    
+
     @Test public void graphDGS_update_2()
     {
         Triple t = SSE.parseTriple("(<s> <p> 9)") ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetGraphViewGraphs.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetGraphViewGraphs.java
@@ -28,7 +28,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
 /** Directly call the view mechanism */
-public class TestDatasetGraphViewGraphs extends AbstractTestGraphOverDataset
+public class TestDatasetGraphViewGraphs extends AbstractTestGraphOverDatasetGraph
 {
     @Override
     protected DatasetGraph createBaseDSG() { return DatasetGraphFactory.create() ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetGraphsRegular.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetGraphsRegular.java
@@ -25,7 +25,7 @@ import org.apache.jena.sparql.core.DatasetGraphFactory ;
 import org.apache.jena.sparql.graph.GraphOps ;
 
 /** This is the test suite run over a regular DatasetGraph to check compatibility */
-public class TestDatasetGraphsRegular extends AbstractTestGraphOverDataset
+public class TestDatasetGraphsRegular extends AbstractTestGraphOverDatasetGraph
 {
     @Override
     protected DatasetGraph createBaseDSG() { return DatasetGraphFactory.create() ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestGraphOverDatasetMem.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestGraphOverDatasetMem.java
@@ -25,7 +25,7 @@ import org.apache.jena.sparql.core.DatasetGraphFactory ;
 import org.apache.jena.sparql.core.DatasetGraphViewGraphs ;
 
 /** Test using a view-generating dataset */  
-public class TestGraphOverDatasetMem extends AbstractTestGraphOverDataset
+public class TestGraphOverDatasetMem extends AbstractTestGraphOverDatasetGraph
 {
     @Override
     protected DatasetGraph createBaseDSG()

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BufferChannel.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BufferChannel.java
@@ -29,7 +29,7 @@ import org.apache.jena.atlas.lib.Sync ;
  * Interface to storage : a simplified version of FileChannel. Read and write
  * bytes, passed via ByteBuffers, addressed by file location. This interface is
  * not suitable for memory mapped I/O - there is no ability to use slices of a
- * memory mapped file. This interface does not insert size of ByteBuffer - size
+ * memory mapped file. This interface does not insert size of ByteBuffer, the size
  * of ByteBuffer passed to read controls the number of bytes read. Having our
  * own abstraction enables us to implement memory-backed versions.
  * 

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPlusTree.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPlusTree.java
@@ -37,15 +37,14 @@ import org.slf4j.LoggerFactory ;
 
 import org.apache.jena.query.ReadWrite ;
 
-/** 
- * 
+/**
  * B-Tree taken from:
  * <pre>
  * Introduction to Algorithms, Second Edition
  * Chapter 18: B-Trees
- * by Thomas H. Cormen, Charles E. Leiserson, 
- *    Ronald L. Rivest and Clifford Stein 
- * </pre> 
+ * by Thomas H. Cormen, Charles E. Leiserson,
+ *    Ronald L. Rivest and Clifford Stein
+ * </pre>
  * Includes implementation of removal
  * then the B-Tree code converted to a B+Tree,
  * then made MVCC/transactional.
@@ -56,17 +55,17 @@ import org.apache.jena.query.ReadWrite ;
  * Stores "records", which are a key and value (the value may be absent).
  * <li>
  * In this B+Tree implementation, the (key,value) pairs are held in
- * RecordBuffer, which wraps a ByteBuffer that only has records in it.  
+ * RecordBuffer, which wraps a ByteBuffer that only has records in it.
  * BPTreeRecords provides the B+Tree view of a RecordBuffer. All records
  * are in RecordBuffer - the "tree" part is an index for finding the right
  * page. The tree only holds keys, copies from the (key, value) pairs in
- * the RecordBuffers. 
+ * the RecordBuffers.
  * <li>
  * The version above splits nodes on the way down when full,
  * not when needed where a split can bubble up from below.
  * It means it only ever walks down the tree on insert.
  * Similarly, the delete code ensures a node is suitable
- * before decending. 
+ * before descending.
  * </ul>
  */
 
@@ -75,15 +74,15 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
     /*
      * Insertion:
      * There are two styles for handling node splitting.
-     * 
+     *
      * Classically, when a leaf is split, the separating key is inserted into
      * the parent, which may itself be full and so that is split, etc propagting
      * up to the root (splitting the root is the only time the depth of the
      * BTree increases). This involves walking back up the tree.
-     * 
+     *
      * It is more convenient to have a spare slot in a tree node, so that the
      * new key can be inserted, then the keys and child pointers split.
-     * 
+     *
      * Modification: during insertion, splitting is applied to any full node
      * traversed on the way down, resulting in any node passed through having
      * some space for a new key. When splitting starts at a leaf, only the
@@ -91,47 +90,47 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
      * There is no cascade back to the top of the tree (it would have happened on
      * the way down); in other words, splitting is done early. This is insertion
      * in a single downward pass.
-     * 
+     *
      * When compared to the classic approach including the extra slot for
      * convenient inserting, the space useage is approximately the same.
-     * 
-     * Deletion:    
+     *
+     * Deletion:
      * Deletion always occurs at a leaf; if it's an internal node, swap the key
      * with the right-most left key (predecessor) or left-most right key (successor),
      * and delete in the leaf.
-     * 
+     *
      * The classic way is to propagate node merging back up from the leaf.  The
      * book outlines a way that checks that a nod eis delte-suitable (min+1 in size)
-     * on the way down.  This is implemented here; this is one-pass(ish).  
-     * 
+     * on the way down.  This is implemented here; this is one-pass(ish).
+     *
      * Variants:
      * http://en.wikipedia.org/wiki/Btree
-     * 
+     *
      * B+Tree: Tree contains keys, and only the leaves have the values. Used for
      * secondary indexes (external pointers) but also for general on-disk usage
      * because more keys are packed into a level. Can chain the leaves for a
      * sorted-order traversal.
-     * 
+     *
      * B*Tree: Nodes are always 2/3 full. When a node is full, keys are shared adjacent
      * nodes and if all they are all full do 2 nodes get split into 3 nodes.
      * Implementation wise, it is more complicated; can cause more I/O.
-     * 
+     *
      * B#Tree: A B+Tree where the operations try to swap nodes between immediate
      * sibling nodes instead of immediately splitting (like delete, only on insert).
-     */ 
-    
+     */
+
     private static Logger log = LoggerFactory.getLogger(BPlusTree.class) ;
-    
+
     // Root id across transactions
-    // Changes as the tree evolves in write transactions. 
+    // Changes as the tree evolves in write transactions.
     private int rootIdx = -199 ;
     private BPTStateMgr stateManager ;
-    private BPTreeNodeMgr nodeManager ; 
-    private BPTreeRecordsMgr recordsMgr; 
+    private BPTreeNodeMgr nodeManager ;
+    private BPTreeRecordsMgr recordsMgr;
     private final BPlusTreeParams bpTreeParams ;
     private Mode mode = Mode.TRANSACTIONAL ;
-    private BptTxnState nonTxnState = null ; 
-    
+    private BptTxnState nonTxnState = null ;
+
     // Construction is a two stage process
     //    1/ Create the object, uninitialized
     //      (Setup data structures, without referring to any BPlusTree methods)
@@ -146,8 +145,8 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
 
     /*package*/ void init(BPTStateMgr stateManager, BPTreeNodeMgr  nodeManager, BPTreeRecordsMgr recordsMgr) {
         // Second part of creating.
-        // Some of these point to the BPlusTree object so we create te BPlusTree as 
-        // absic structure then initialize fully here.
+        // Some of these point to the BPlusTree object so we create the BPlusTree as
+        // basic structure then initialize fully here.
         this.rootIdx = stateManager.getRoot() ;
         this.stateManager = stateManager ;
         this.nodeManager = nodeManager ;
@@ -175,7 +174,7 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
     private boolean isTransactional() {
         return mode == Mode.TRANSACTIONAL || mode == Mode.TRANSACTIONAL_AUTOCOMMIT ;
     }
-    
+
     private void releaseRootRead(BPTreeNode rootNode) {
         rootNode.release() ;
     }
@@ -192,10 +191,10 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         if ( isTransactional() )
             getDataState().setRoot(newRoot.getId()) ;
         else
-            rootIdx = newRoot.getId() ; 
+            rootIdx = newRoot.getId() ;
     }
 
-//    // Very, very dangerous operation. 
+//    // Very, very dangerous operation.
 //    public void $testForce$(int rootIdx) {
 //        this.rootIdx = rootIdx ;
 //    }
@@ -214,20 +213,20 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
             return null ;
         }
         return nonTxnState ;
-    }  
-    
+    }
+
     /** Get the parameters describing this B+Tree */
-    public BPlusTreeParams getParams()          { return bpTreeParams ; } 
+    public BPlusTreeParams getParams()          { return bpTreeParams ; }
 
     /** Only use for careful manipulation of structures */
-    public BPTStateMgr getStateManager()          { return stateManager ; } 
+    public BPTStateMgr getStateManager()          { return stateManager ; }
 
     /** Only use for careful manipulation of structures */
     public BPTreeNodeMgr getNodeManager()       { return nodeManager ; }
-    
+
     /** Only use for careful manipulation of structures */
     public BPTreeRecordsMgr getRecordsMgr()     { return recordsMgr ; }
-    
+
     @Override
     public RecordFactory getRecordFactory() {
         return bpTreeParams.recordFactory ;
@@ -283,7 +282,7 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         finishUpdateBlkMgr() ;
         return r ;
     }
-    
+
     @Override
     public boolean delete(Record record) {
         return deleteAndReturnOld(record) != null ;
@@ -298,12 +297,12 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         return r ;
     }
 
-    private static Record noMin = null ; 
-    private static Record noMax = null ; 
-    
+    private static Record noMin = null ;
+    private static Record noMax = null ;
+
     @Override
     public Iterator<Record> iterator() {
-        return iterator(noMin, noMax) ; 
+        return iterator(noMin, noMax) ;
     }
 
     @Override
@@ -315,7 +314,7 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         return BPTreeRangeIterator.create(root, fromRec, toRec) ;
         //return iterator(fromRec, toRec, RecordFactory.mapperRecord) ;
     }
-    
+
     /*
     @Override
     public <X> Iterator<X> iterator(Record minRec, Record maxRec, RecordMapper<X> mapper) {
@@ -332,16 +331,16 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
     private static <X> Iterator<X> iterator(BPTreeNode node, Record fromRec, Record toRec, RecordMapper<X> mapper)
     {
         // Look for starting RecordsBufferPage id.
-        int id = BPTreeNode.recordsPageId(node, fromRec) ; 
+        int id = BPTreeNode.recordsPageId(node, fromRec) ;
         if ( id < 0 )
             return Iter.nullIter() ;
         RecordBufferPageMgr pageMgr = node.getBPlusTree().getRecordsMgr().getRecordBufferPageMgr() ;
         // No pages are active at this point.
         return RecordRangeIterator.iterator(id, fromRec, toRec, pageMgr, mapper) ;
     }
- 
+
      */
-    
+
     @Override
     public <X> Iterator<X> iterator(Record minRec, Record maxRec, RecordMapper<X> mapper) {
         startReadBlkMgr() ;
@@ -350,7 +349,7 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         finishReadBlkMgr() ;
         return iterator(root, minRec, maxRec, mapper);
     }
-    
+
     private <X> Iterator<X> iterator(BPTreeNode node, Record minRec, Record maxRec, RecordMapper<X> mapper) {
         int keyLen = recordsMgr.getRecordBufferPageMgr().getRecordFactory().keyLength();
         return BPTreeRangeIteratorMapper.create(node, minRec, maxRec, keyLen, mapper) ;
@@ -386,14 +385,14 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         finishReadBlkMgr() ;
         return b ;
     }
-    
+
     private static int SLICE = 10000 ;
     @Override
     public void clear() {
         Record[] records = new Record[SLICE] ;
         while(true) {
             Iterator<Record> iter = iterator() ;
-            int i = 0 ; 
+            int i = 0 ;
             for ( i = 0 ; i < SLICE ; i++ ) {
                 if ( ! iter.hasNext() )
                     break ;
@@ -408,7 +407,7 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
             }
         }
     }
-    
+
     @Override
     public void sync() {
         if ( nodeManager.getBlockMgr() != null )
@@ -423,7 +422,7 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         recordsMgr.close() ;
         stateManager.close() ;
     }
-    
+
 //    public void closeIterator(Iterator<Record> iter)
 //    {
 //    }
@@ -448,7 +447,7 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         boolean b = BPT.Logging ;
         BPT.Logging = false ;
         try { root.dump() ; }
-        finally { 
+        finally {
             releaseRootRead(root) ;
             BPT.Logging = b ;
             }
@@ -464,19 +463,19 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
     public void nonTransactional() {
         setMode(Mode.MUTABLE) ;
     }
-    
-    private void setMode(Mode newMode) { 
-        
+
+    private void setMode(Mode newMode) {
+
         mode = newMode ;
-        
+
         switch(mode) {
-            case IMMUTABLE : 
-                nonTxnState = new BptTxnState(BPlusTreeParams.RootId, 
+            case IMMUTABLE :
+                nonTxnState = new BptTxnState(BPlusTreeParams.RootId,
                                               nodeManager.allocLimit(),
                                               recordsMgr.allocLimit()) ;
                 break ;
             case IMMUTABLE_ALL:
-                nonTxnState = new BptTxnState(BPlusTreeParams.RootId, 
+                nonTxnState = new BptTxnState(BPlusTreeParams.RootId,
                                               Long.MAX_VALUE,
                                               Long.MAX_VALUE) ;
                 break ;
@@ -495,7 +494,7 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
                 throw new NotImplementedException("TRANSACTIONAL_AUTOCOMMIT not implemented");
         }
     }
-    
+
     @Override
     public void startRecovery() {}
 
@@ -511,7 +510,7 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
     public void finishRecovery() {
         stateManager.sync();
     }
-    
+
     @Override
     public void cleanStart() { }
 
@@ -521,15 +520,15 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
     }
 
     private BptTxnState createState() {
-        return new BptTxnState(rootIdx, 
+        return new BptTxnState(rootIdx,
                                nodeManager.allocLimit(),
                                recordsMgr.allocLimit()) ;
     }
-    
+
     /* The persistent transactional state of a B+Tree is new root and the
      * allocation limits of both block managers.
      */
-    
+
     @Override
     protected BptTxnState _promote(TxnId txnId, BptTxnState oldState) {
         BptTxnState newState = createState();
@@ -540,11 +539,11 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
     protected ByteBuffer _commitPrepare(TxnId txnId, BptTxnState state) {
         nodeManager.getBlockMgr().sync();
         recordsMgr.getBlockMgr().sync();
-        
+
         long nodeLimit = nodeManager.allocLimit() ;
         long recordsLimit = recordsMgr.allocLimit() ;
         // But don't write it yet.
-        stateManager.setState(state.getRoot(), nodeLimit, recordsLimit); 
+        stateManager.setState(state.getRoot(), nodeLimit, recordsLimit);
         return stateManager.getState() ;
     }
 
@@ -566,13 +565,13 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         // Truncate - logically in block manager space.
         nodeManager.resetAlloc(state.boundaryBlocksNode) ;
         recordsMgr.resetAlloc(state.boundaryBlocksRecord) ;
-        stateManager.setState(state.initialroot, state.boundaryBlocksNode, state.boundaryBlocksRecord); 
+        stateManager.setState(state.initialroot, state.boundaryBlocksNode, state.boundaryBlocksRecord);
         stateManager.sync();
     }
 
     @Override
     protected void _complete(TxnId txnId, BptTxnState state) {
-        
+
     }
 
     @Override

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/data/TransBinaryDataFile.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/data/TransBinaryDataFile.java
@@ -29,7 +29,7 @@ import org.apache.jena.dboe.transaction.txn.*;
 import org.apache.jena.query.ReadWrite ;
 
 /** Transactional {@link BinaryDataFile}.
- *  An binary file that is append-only and allows only one writer at a time.
+ *  A binary file that is append-only and allows only one writer at a time.
  *  All readers see the file up to the last commit point at the time 
  *  they started.  The sole writer sees more of the file.
  */

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/data/TransBlob.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/data/TransBlob.java
@@ -36,7 +36,7 @@ import org.apache.jena.query.ReadWrite ;
  */
 public class TransBlob extends TransactionalComponentLifecycle<TransBlob.BlobState> {
 
-    // The last commited state.
+    // The last committed state.
     // Immutable ByteBuffer.
     private final AtomicReference<ByteBuffer> blobRef = new AtomicReference<>() ;
     private final BufferChannel file ;

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/GraphTDB.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/GraphTDB.java
@@ -81,32 +81,6 @@ public class GraphTDB extends GraphView implements Closeable, Sync {
         //super.close() ;
     }
 
-    protected static ExtendedIterator<Triple> graphBaseFindDft(DatasetGraphTDB dataset, Triple triple) {
-        Iterator<Quad> iterQuads = dataset.find(Quad.defaultGraphIRI, triple.getSubject(), triple.getPredicate(), triple.getObject()) ;
-        if ( iterQuads == null )
-            return org.apache.jena.util.iterator.NullIterator.instance() ;
-        // Can't be duplicates - fixed graph node..
-        Iterator<Triple> iterTriples = projectQuadsToTriples(Quad.defaultGraphIRI, iterQuads) ;
-        return WrappedIterator.createNoRemove(iterTriples) ;
-    }
-
-    protected static ExtendedIterator<Triple> graphBaseFindNG(DatasetGraphTDB dataset, Node graphNode, Triple m) {
-        Node gn = graphNode ;
-        // Explicitly named union graph.
-        if ( isUnionGraph(gn) )
-            gn = Node.ANY ;
-
-        Iterator<Quad> iter = dataset.getQuadTable().find(gn, m.getMatchSubject(), m.getMatchPredicate(), m.getMatchObject()) ;
-        if ( iter == null )
-            return org.apache.jena.util.iterator.NullIterator.instance() ;
-
-        Iterator<Triple> iterTriples = projectQuadsToTriples((gn == Node.ANY ? null : gn), iter) ;
-
-        if ( gn == Node.ANY )
-            iterTriples = Iter.distinct(iterTriples) ;
-        return WrappedIterator.createNoRemove(iterTriples) ;
-    }
-
     @Override
     protected ExtendedIterator<Triple> graphUnionFind(Node s, Node p, Node o) {
         Node g = Quad.unionGraph ;
@@ -141,18 +115,6 @@ public class GraphTDB extends GraphView implements Closeable, Sync {
 		return TupleFactory.tuple(item.get(1), item.get(2), item.get(3));
 	};
 	
-	private static Iterator<Triple> projectQuadsToTriples(Node graphNode, Iterator<Quad> iter) {
-	    // Checking.
-        Function<Quad, Triple> f = (q) -> {
-            if ( graphNode != null && !q.getGraph().equals(graphNode) )
-                throw new InternalError("projectQuadsToTriples: Quads from unexpected graph (expected=" + graphNode + ", got=" + q.getGraph() + ")");
-            return q.asTriple();
-        };
-        // Without checking
-        //Function<Quad, Triple> f = (q) -> q.asTriple();
-	    return Iter.map(iter, f);
-	}
-
     @Override
     public void clear() {
         dataset.deleteAny(getGraphName(), Node.ANY, Node.ANY, Node.ANY) ;

--- a/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/graph/TestGraphOverDatasetTDB.java
+++ b/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/graph/TestGraphOverDatasetTDB.java
@@ -21,13 +21,13 @@ package org.apache.jena.tdb2.graph;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.query.ReadWrite ;
-import org.apache.jena.sparql.core.AbstractTestGraphOverDataset ;
+import org.apache.jena.sparql.core.AbstractTestGraphOverDatasetGraph ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.tdb2.junit.TL;
 import org.junit.After ;
 
 /** This is the view-graph test suite run over a TDB DatasetGraph to check compatibility */
-public class TestGraphOverDatasetTDB extends AbstractTestGraphOverDataset
+public class TestGraphOverDatasetTDB extends AbstractTestGraphOverDatasetGraph
 {
     DatasetGraph dsg = null;
     @After public void after2() {

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/index/bplustree/BPlusTree.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/index/bplustree/BPlusTree.java
@@ -38,33 +38,33 @@ import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
 
 /** B-Tree converted to B+Tree
- * 
+ *
  * B-Tree taken from:
  * Introduction to Algorithms, Second Edition
  * Chapter 18: B-Trees
- * by Thomas H. Cormen, Charles E. Leiserson, 
- *    Ronald L. Rivest and Clifford Stein 
- *  
+ * by Thomas H. Cormen, Charles E. Leiserson,
+ *    Ronald L. Rivest and Clifford Stein
+ *
  * Includes implementation of removal.
- * 
+ *
  * Notes:
  * Stores "records", which are a key and value (the value may be null).
- * 
+ *
  * In this B+Tree implementation, the (key,value) pairs are held in
- * RecordBuffer, which wrap a ByteBuffer that only has records in it.  
+ * RecordBuffer, which wrap a ByteBuffer that only has records in it.
  * BPTreeRecords provides the B+Tree view of a RecordBuffer. All records
  * are in RecordBuffer - the "tree" part is an index for finding the right
  * page. The tree only holds keys, copies from the (key, value) pairs in
- * the RecordBuffers. 
+ * the RecordBuffers.
  *
  * Notes:
- * 
+ *
  * The version above splits nodes on the way down when full,
  * not when needed where a split can bubble up from below.
  * It means it only ever walks down the tree on insert.
  * Similarly, the delete code ensures a node is suitable
- * before descending. 
- *    
+ * before descending.
+ *
  * Variations:
  * In this impl, splitRoot leaves the root node in place.
  * The root is always the same block.
@@ -75,15 +75,15 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
     /*
      * Insertion:
      * There are two styles for handling node splitting.
-     * 
+     *
      * Classically, when a leaf is split, the separating key is inserted into
      * the parent, which may itself be full and so that is split, etc propagting
      * up to the root (splitting the root is the only time the depth of the
      * BTree increases). This involves walking back up the tree.
-     * 
+     *
      * It is more convenient to have a spare slot in a tree node, so that the
      * new key can be inserted, then the keys and child pointers split.
-     * 
+     *
      * Modification: during insertion, splitting is applied to any full node
      * traversed on the way down, resulting in any node passed through having
      * some space for a new key. When splitting starts at a leaf, only the
@@ -91,74 +91,74 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
      * There is no cascade back to the top of the tree (it would have happened on
      * the way down); in other words, splitting is done early. This is insertion
      * in a single downward pass.
-     * 
+     *
      * When compared to the classic approach including the extra slot for
      * convenient inserting, the space useage is approximately the same.
-     * 
-     * Deletion:    
+     *
+     * Deletion:
      * Deletion always occurs at a leaf; if it's an internal node, swap the key
      * with the right-most left key (predecessor) or left-most right key (successor),
      * and delete in the leaf.
-     * 
+     *
      * The classic way is to propagate node merging back up from the leaf.  The
      * book outlines a way that checks that a nod eis delte-suitable (min+1 in size)
-     * on the way down.  This is implemented here; this is one-pass(ish).  
-     * 
+     * on the way down.  This is implemented here; this is one-pass(ish).
+     *
      * Variants:
      * http://en.wikipedia.org/wiki/Btree
-     * 
+     *
      * B+Tree: Tree contains keys, and only the leaves have the values. Used for
      * secondary indexes (external pointers) but also for general on-disk usage
      * because more keys are packed into a level. Can chain the leaves for a
      * sorted-order traversal.
-     * 
+     *
      * B*Tree: Nodes are always 2/3 full. When a node is full, keys are shared adjacent
      * nodes and if all they are all full do 2 nodes get split into 3 nodes.
      * Implementation wise, it is more complicated; can cause more I/O.
-     * 
+     *
      * B#Tree: A B+Tree where the operations try to swap nodes between immediate
      * sibling nodes instead of immediately splitting (like delete, only on insert).
-     */ 
-    
+     */
+
     private static Logger log = LoggerFactory.getLogger(BPlusTree.class) ;
-    
+
     private int rootIdx = BPlusTreeParams.RootId ;
     ///*package*/ BPTreeNode root ;
-    private BPTreeNodeMgr nodeManager ; 
-    private BPTreeRecordsMgr recordsMgr; 
+    private BPTreeNodeMgr nodeManager ;
+    private BPTreeRecordsMgr recordsMgr;
     private BPlusTreeParams bpTreeParams ;
-    
+
     /** Create the in-memory structures to correspond to
      * the supplied block managers for the persistent storage.
      * Initialize the persistent storage to the empty B+Tree if it does not exist.
      * This is the normal way to create a B+Tree.
      */
     public static BPlusTree create(BPlusTreeParams params, BlockMgr blkMgrNodes, BlockMgr blkMgrLeaves)
-    { 
+    {
         BPlusTree bpt = attach(params, blkMgrNodes, blkMgrLeaves) ;
         bpt.createIfAbsent() ;
         return bpt ;
     }
-    
+
     /** Create the in-memory structures to correspond to
      *  the supplied block managers for the persistent storage.
      *  Does not initialize the B+Tree - it assumes the block managers
      *  correspond to an existing B+Tree.
      */
     public static BPlusTree attach(BPlusTreeParams params, BlockMgr blkMgrNodes, BlockMgr blkMgrRecords)
-    { 
+    {
         return new BPlusTree(params, blkMgrNodes, blkMgrRecords) ;
     }
 
     /** (Testing mainly) Make an in-memory B+Tree, with copy-in, copy-out block managers */
     public static BPlusTree makeMem(int order, int minRecords, int keyLength, int valueLength)
     { return makeMem(null, order, minRecords, keyLength, valueLength) ; }
-    
+
     /** (Testing mainly) Make an in-memory B+Tree, with copy-in, copy-out block managers */
     public static BPlusTree makeMem(String name, int order, int minRecords, int keyLength, int valueLength)
     {
         BPlusTreeParams params = new BPlusTreeParams(order, keyLength, valueLength) ;
-        
+
         int blkSize ;
         if ( minRecords > 0 )
         {
@@ -168,10 +168,10 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
         }
         else
             blkSize = params.getCalcBlockSize() ;
-        
+
         BlockMgr mgr1 = BlockMgrFactory.createMem(name+"(nodes)", params.getCalcBlockSize()) ;
         BlockMgr mgr2 = BlockMgrFactory.createMem(name+"(records)", blkSize) ;
-        
+
         BPlusTree bpTree = BPlusTree.create(params, mgr1, mgr2) ;
         return bpTree ;
     }
@@ -213,18 +213,18 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
             rootIdx = nodeManager.createEmptyBPT() ;
             if ( rootIdx != 0 )
                 throw new InternalError() ;
-            
+
             if ( CheckingNode )
-            {            
+            {
                 BPTreeNode root = nodeManager.getRead(rootIdx, BPlusTreeParams.RootParent) ;
                 root.checkNodeDeep() ;
                 root.release() ;
             }
-            
-            // Sync created blocks to disk - any caches are now clean. 
+
+            // Sync created blocks to disk - any caches are now clean.
             nodeManager.getBlockMgr().sync() ;
             recordsMgr.getBlockMgr().sync() ;
-            
+
             // Cache : not currently done - root is null
             //setRoot(root) ;
             finishUpdateBlkMgr() ;
@@ -242,14 +242,14 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
     private void releaseRoot(BPTreeNode rootNode)
     {
 //        // [TxTDB:PATCH-UP]
-//        if ( root != null ) 
+//        if ( root != null )
 //        {
 //            root.release() ;
 //            //nodeManager.release(rootNode) ;
 //        }
 //        if ( root != null && rootNode != root )
 //            log.warn("Root is not root!") ;
-        
+
         rootNode.release() ;
     }
 
@@ -259,19 +259,19 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
     }
 
     /** Get the parameters describing this B+Tree */
-    public BPlusTreeParams getParams()     { return bpTreeParams ; } 
+    public BPlusTreeParams getParams()     { return bpTreeParams ; }
 
     /** Only use for careful manipulation of structures */
     public BPTreeNodeMgr getNodeManager()          { return nodeManager ; }
     /** Only use for careful manipulation of structures */
     public BPTreeRecordsMgr getRecordsMgr()     { return recordsMgr ; }
-    
+
     @Override
     public RecordFactory getRecordFactory()
     {
         return bpTreeParams.recordFactory ;
     }
-    
+
     @Override
     public Record find(Record record)
     {
@@ -282,7 +282,7 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
         finishReadBlkMgr() ;
         return v ;
     }
-    
+
     @Override
     public boolean contains(Record record)
     {
@@ -317,7 +317,7 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
     {
         return addAndReturnOld(record) == null ;
     }
-    
+
     /** Add a record into the B+Tree */
     public Record addAndReturnOld(Record record)
     {
@@ -329,11 +329,11 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
         finishUpdateBlkMgr() ;
         return r ;
     }
-    
+
     @Override
     public boolean delete(Record record)
     { return deleteAndReturnOld(record) != null ; }
-    
+
     public Record deleteAndReturnOld(Record record)
     {
         startUpdateBlkMgr() ;
@@ -355,7 +355,7 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
         finishReadBlkMgr() ;
         return iter ;
     }
-    
+
     @Override
     public Iterator<Record> iterator(Record fromRec, Record toRec)
     {
@@ -368,24 +368,24 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
         // Iterator read blocks still get handled.
         return iter ;
     }
-    
-    /** Iterate over a range of fromRec (inclusive) to toRec (exclusive) */ 
+
+    /** Iterate over a range of fromRec (inclusive) to toRec (exclusive) */
     private static Iterator<Record> iterator(BPTreeNode node, Record fromRec, Record toRec)
-    { 
+    {
         // Look for starting RecordsBufferPage id.
-        int id = BPTreeNode.recordsPageId(node, fromRec) ; 
+        int id = BPTreeNode.recordsPageId(node, fromRec) ;
         if ( id < 0 )
             return Iter.nullIter() ;
         RecordBufferPageMgr pageMgr = node.getBPlusTree().getRecordsMgr().getRecordBufferPageMgr() ;
         // No pages are active at this point.
         return RecordRangeIterator.iterator(id, fromRec, toRec, pageMgr) ;
     }
-    
+
     private static Iterator<Record> iterator(BPTreeNode node)
-    { 
-        return iterator(node, null, null) ; 
+    {
+        return iterator(node, null, null) ;
     }
-    
+
     // Internal calls.
     private void startReadBlkMgr()
     {
@@ -404,13 +404,13 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
         nodeManager.startUpdate() ;
         recordsMgr.startUpdate() ;
     }
-    
+
     private void finishUpdateBlkMgr()
     {
         nodeManager.finishUpdate() ;
         recordsMgr.finishUpdate() ;
     }
-    
+
     @Override
     public boolean isEmpty()
     {
@@ -421,14 +421,14 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
         finishReadBlkMgr() ;
         return b ;
     }
-    
+
     private static int SLICE = 10000 ;
     @Override
     public void clear() {
         Record[] records = new Record[SLICE] ;
         while(true) {
             Iterator<Record> iter = iterator() ;
-            int i = 0 ; 
+            int i = 0 ;
             for ( i = 0 ; i < SLICE ; i++ ) {
                 if ( ! iter.hasNext() )
                     break ;
@@ -443,25 +443,25 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
             }
         }
     }
-    
+
     @Override
-    public void sync() 
-    { 
+    public void sync()
+    {
         if ( nodeManager.getBlockMgr() != null )
             nodeManager.getBlockMgr().sync() ;
         if ( recordsMgr.getBlockMgr() != null )
             recordsMgr.getBlockMgr().sync() ;
     }
-    
+
     @Override
     public void close()
-    { 
+    {
         if ( nodeManager.getBlockMgr() != null )
             nodeManager.getBlockMgr().close()   ;
         if ( recordsMgr.getBlockMgr() != null )
             recordsMgr.getBlockMgr().close() ;
     }
-    
+
 //    public void closeIterator(Iterator<Record> iter)
 //    {
 //    }
@@ -472,7 +472,7 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
         Iterator<Record> iter = iterator() ;
         return Iter.count(iter) ;
     }
-    
+
     @Override
     public void check()
     {
@@ -483,7 +483,7 @@ public class BPlusTree implements Iterable<Record>, RangeIndex
     {
         getRoot().dump() ;
     }
-    
+
     public void dump(IndentedWriter out)
     {
         getRoot().dump(out) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/graph/TestGraphOverDatasetTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/graph/TestGraphOverDatasetTDB.java
@@ -20,12 +20,12 @@ package org.apache.jena.tdb.graph;
 
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
-import org.apache.jena.sparql.core.AbstractTestGraphOverDataset ;
+import org.apache.jena.sparql.core.AbstractTestGraphOverDatasetGraph ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.tdb.TDBFactory ;
 
 /** This is the view-graph test suite run over a TDB DatasetGraph to check compatibility */
-public class TestGraphOverDatasetTDB extends AbstractTestGraphOverDataset
+public class TestGraphOverDatasetTDB extends AbstractTestGraphOverDatasetGraph
 {
     @Override
     protected DatasetGraph createBaseDSG() { return TDBFactory.createDatasetGraph() ; }


### PR DESCRIPTION
This PR is clean up that have accumulated on some of my local branches:

- add some javadoc on test classes
- miscellaneous comment typos
- rename a test class
- remove two unused functions in `tdb2/store/GraphTDB` (not needed for TDB2; old from TDB1 fork)
- some automatic whitespace fixes
