### PR TITLE
JENA-1659: Improve tests for western hemisphere timezones

### DIFF
--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -456,7 +456,7 @@ public class TestFunctions
     
     @Test public void localDateTime_1() { test("afn:nowtz()", nv-> nv.isDateTime()); }
     // Test field defined.
-    @Test public void localDateTime_2() { test("afn:nowtz()", nv-> nv.getDateTime().getTimezone() > -1 ); }
+    @Test public void localDateTime_2() { test("afn:nowtz()", nv-> nv.getDateTime().getTimezone() > -14 * 60 ); }
 
     @Test public void localDateTime_3() { test("afn:nowtz() = NOW()", NodeValue.TRUE); }
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -456,7 +456,7 @@ public class TestFunctions
     
     @Test public void localDateTime_1() { test("afn:nowtz()", nv-> nv.isDateTime()); }
     // Test field defined.
-    @Test public void localDateTime_2() { test("afn:nowtz()", nv-> nv.getDateTime().getTimezone() > -14 * 60 ); }
+    @Test public void localDateTime_2() { test("afn:nowtz()", nv-> nv.getDateTime().getTimezone() >= -14 * 60 ); }
 
     @Test public void localDateTime_3() { test("afn:nowtz() = NOW()", NodeValue.TRUE); }
     


### PR DESCRIPTION
This adjusts the timezone function tests to pass when run in a timezone to the west of GMT.

This is a follow-on to JENA-1659