### PR TITLE
Update javadoc configuration to support jdk11 builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -878,6 +878,8 @@
             </execution>
           </executions>
           <configuration>
+            <!-- Java 11: explicitly define the source as Java8 -->
+            <source>8</source>
             <!-- Java 10
                  <additionalOptions>-html5</additionalOptions>
             -->


### PR DESCRIPTION
This updates the javadoc configuration so that JDK11-based builds will succeed at the javadoc stage. As with the current maven configuration, the Java source is set to be Java8.