### PR TITLE
Clean up test WARN messages

### DIFF
--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionCoordinator.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionCoordinator.java
@@ -301,9 +301,13 @@ public class TransactionCoordinator {
     }
 
     public void shutdown() {
+        shutdown(false);
+    }
+    
+    public void shutdown(boolean silent) {
         if ( coordinatorLock == null )
             return;
-        if ( countActive() > 0 )
+        if ( ! silent && countActive() > 0 )
             FmtLog.warn(SysErr, "Transactions active: W=%d, R=%d", countActiveWriter(), countActiveReaders());
         components.forEach((id, c) -> c.shutdown());
         shutdownHooks.forEach((h)-> h.shutdown());

--- a/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/AbstractTestTxn.java
+++ b/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/AbstractTestTxn.java
@@ -24,9 +24,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.jena.dboe.base.file.Location;
-import org.apache.jena.dboe.transaction.TransInteger;
-import org.apache.jena.dboe.transaction.TransMonitor;
-import org.apache.jena.dboe.transaction.Transactional;
 import org.apache.jena.dboe.transaction.txn.*;
 import org.apache.jena.dboe.transaction.txn.journal.Journal;
 import org.junit.After;
@@ -49,7 +46,8 @@ public abstract class AbstractTestTxn {
     }
 
     @After public void clearup() {
-        txnMgr.shutdown();
+        // Some test that expect exceptions leave active transactions around.
+        txnMgr.shutdown(true);
     }
 
     protected void checkClear() {
@@ -60,4 +58,3 @@ public abstract class AbstractTestTxn {
 
     }
 }
-

--- a/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestThreadingTransactions.java
+++ b/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestThreadingTransactions.java
@@ -42,7 +42,7 @@ public class TestThreadingTransactions {
     }
 
     @After public void after() {
-        transInt.getTxnMgr().shutdown();
+        transInt.getTxnMgr().shutdown(true);
     }
 
     // Read synchronously in a transaction.

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
@@ -18,7 +18,10 @@
 
 package org.apache.jena.fuseki.main;
 
+import org.apache.jena.atlas.logging.LogCtl;
+import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.main.old.TestFusekiTestAuthOld;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -32,4 +35,12 @@ import org.junit.runners.Suite.SuiteClasses;
   , TestFusekiMainCmd.class
   , TestStdSetup.class 
 })
-public class TS_FusekiMain { }
+public class TS_FusekiMain { 
+    @BeforeClass public static void setupForFusekiServer() {
+        LogCtl.setLevel(Fuseki.serverLogName,        "WARN");
+        LogCtl.setLevel(Fuseki.actionLogName,        "WARN");
+        LogCtl.setLevel(Fuseki.requestLogName,       "WARN");
+        LogCtl.setLevel(Fuseki.adminLogName,         "WARN");
+        LogCtl.setLevel("org.eclipse.jetty",         "WARN");
+    }
+}

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/TC_TDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/TC_TDB.java
@@ -59,7 +59,7 @@ import org.junit.runners.Suite ;
     , TS_SolverTDB.class
     , TS_Sys.class
     , TS_Graph.class
-    , TS_Factory.class
+    , TS_TDBFactory.class
     , TS_TDBAssembler.class
     , TS_TransactionTDB.class
     , TS_ObjectFile.class

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/TS_TDBFactory.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/TS_TDBFactory.java
@@ -27,7 +27,7 @@ import org.junit.runners.Suite;
     TestTDBFactory.class
 })
 
-public class TS_Factory
+public class TS_TDBFactory
 {
 
 }

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/TestTDBFactory.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/TestTDBFactory.java
@@ -46,6 +46,7 @@ public class TestTDBFactory extends BaseTest
 
     @After
     public void after() {
+        TDBInternal.reset();
         FileOps.clearDirectory(DIR);
     }
 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestDatasetTDBPersist.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestDatasetTDBPersist.java
@@ -53,8 +53,8 @@ public class TestDatasetTDBPersist extends BaseTest
     
     @Before public void before()
     {   
+        TDBInternal.reset() ;
     	String dirname = ConfigTest.getCleanDir() ;
-    	TDBInternal.reset() ;
 		graphLocation = new GraphLocation(Location.create(dirname)) ;
         graphLocation.createDataset() ;
     }

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestDynamicDatasetTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestDynamicDatasetTDB.java
@@ -21,6 +21,7 @@ package org.apache.jena.tdb.store;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.sparql.core.AbstractTestDynamicDataset ;
 import org.apache.jena.tdb.TDBFactory ;
+import org.apache.jena.tdb.sys.TDBInternal;
 
 public class TestDynamicDatasetTDB extends AbstractTestDynamicDataset
 {
@@ -31,6 +32,8 @@ public class TestDynamicDatasetTDB extends AbstractTestDynamicDataset
     }
     
     @Override
-    protected void releaseDataset(Dataset ds) {}
+    protected void releaseDataset(Dataset ds) {
+        TDBInternal.expel(ds.asDatasetGraph());
+    }
 }
 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestGraphTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestGraphTDB.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.tdb.store;
 
-import org.apache.jena.atlas.logging.Log ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.sparql.graph.AbstractTestGraphAddDelete ;
 import org.apache.jena.tdb.ConfigTest ;
@@ -49,6 +48,7 @@ public class TestGraphTDB extends AbstractTestGraphAddDelete
     @AfterClass public static void afterClass()
     { 
         graphLocation.release() ;
+        TDBInternal.reset() ;
         graphLocation.clearDirectory() ;
         ConfigTest.deleteTestingDirDB() ;
     }
@@ -56,15 +56,8 @@ public class TestGraphTDB extends AbstractTestGraphAddDelete
     static Graph graph = null ;
     @Before public void before()
     { 
-        try {
+        if ( graph != null )
             graph.clear() ;
-        } catch (Exception ex)
-        {
-            Log.warn(this, "before() : "+ex.getMessage(), ex) ;
-            // Problem - reset.
-            beforeClass() ;
-        }
-        
     }
             
     @After public void after()   

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestLoader.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestLoader.java
@@ -35,6 +35,7 @@ import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.TDBLoader ;
 import org.apache.jena.tdb.base.file.Location ;
 import org.apache.jena.tdb.setup.DatasetBuilderStd;
+import org.apache.jena.tdb.sys.TDBInternal;
 import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
@@ -57,6 +58,7 @@ public class TestLoader extends BaseTest {
     static public void afterClass() {
         LogCtl.enable(ARQ.logExecName) ;
         LogCtl.enable(TDB.logLoaderName) ;
+        TDBInternal.reset();
     }
 
     static DatasetGraphTDB fresh() {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestStoreConnectionsMapped.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestStoreConnectionsMapped.java
@@ -20,6 +20,7 @@ package org.apache.jena.tdb.store;
 
 import org.apache.jena.tdb.base.block.FileMode ;
 import org.apache.jena.tdb.sys.SystemTDB ;
+import org.apache.jena.tdb.sys.TDBInternal;
 import org.apache.jena.tdb.sys.TestOps ;
 import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
@@ -39,6 +40,7 @@ public class TestStoreConnectionsMapped extends AbstractStoreConnections
     public static void afterClassFileMode()
     {
         TestOps.setFileMode(mode) ;
+        TDBInternal.reset();
     }
 }
 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransRestart.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransRestart.java
@@ -37,6 +37,7 @@ import org.apache.jena.tdb.setup.DatasetBuilderStd;
 import org.apache.jena.tdb.store.DatasetGraphTDB ;
 import org.apache.jena.tdb.sys.Names ;
 import org.apache.jena.tdb.sys.SystemTDB ;
+import org.apache.jena.tdb.sys.TDBInternal;
 import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
@@ -57,6 +58,7 @@ public class TestTransRestart extends BaseTest {
     private static Quad quad2 = SSE.parseQuad("(_ <foo:bar> rdfs:label 'bar')") ;
     
     @Before public void setup() {
+        TDBInternal.reset();
         path = ConfigTest.getCleanDir() ; 
         location = Location.create (path) ;
         if ( useTransactionsSetup )
@@ -93,6 +95,7 @@ public class TestTransRestart extends BaseTest {
     }
         
     private void cleanup() {
+        TDBInternal.reset();
         if ( FileOps.exists(path)) {
             FileOps.clearDirectory(path) ;
             FileOps.deleteSilent(path) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransactionTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransactionTDB.java
@@ -40,13 +40,13 @@ public class TestTransactionTDB extends AbstractTestTransactionLifecycle
     
     @Before
     public void before() {
-        DIR = ConfigTest.getCleanDir();
         TDBInternal.reset();
+        DIR = ConfigTest.getCleanDir();
     }
 
     @After
     public void after() {
-        
+        TDBInternal.reset();
         FileOps.clearDirectory(DIR);
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue ;
 import java.util.Iterator;
 
 import org.apache.jena.assembler.Assembler ;
-import org.apache.jena.assembler.exceptions.AssemblerException ;
+import org.apache.jena.assembler.exceptions.AssemblerException;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.query.Dataset ;
@@ -37,8 +37,8 @@ import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.tdb.assembler.AssemblerTDB ;
 import org.apache.jena.tdb.sys.TDBInternal;
 import org.apache.jena.vocabulary.RDF ;
-import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test ;
 
 
@@ -55,11 +55,11 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
     private static final Resource customTextDocProducerSpec;
     private static final Resource customDyadicTextDocProducerSpec;
 
-    @Before public void clearBefore() {
+    @BeforeClass public static void clearBefore() {
         TDBInternal.reset();
     }
     
-    @AfterClass public static void clearAfter() {
+    @After public void clearAfter() {
         TDBInternal.reset();
     }
     
@@ -67,6 +67,7 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
     public void testSimpleDatasetAssembler() {
         Dataset dataset = (Dataset) Assembler.general.open(spec1);
         assertTrue(dataset.getContext().get(TextQuery.textIndex) instanceof TextIndexLucene);
+        dataset.close();
     }
 
     @Test(expected = AssemblerException.class)
@@ -101,7 +102,6 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
         dsgText.begin(ReadWrite.WRITE);
         dsgText.add(G, S, P, O);
         dsgText.commit();
-        dataset.close();
     }
 
     static {


### PR DESCRIPTION
This PR cleans warning due to potentially locked or unlocked databases.

These are due to:

- Cleanup not happening at all levels sometimes.
- Deleting disk files before resetting TDB1.
- Tests for error conditions with expected exceptions not cleaning up.
