### PR TITLE
Geosparql empty dataset

### DIFF
--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetOperations.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetOperations.java
@@ -23,15 +23,15 @@ import io.github.galbiston.rdf_tables.file.FileReader;
 import java.io.File;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
+import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
+import org.apache.jena.fuseki.geosparql.cli.FileGraphDelimiter;
+import org.apache.jena.fuseki.geosparql.cli.FileGraphFormat;
 import org.apache.jena.geosparql.configuration.GeoSPARQLConfig;
 import org.apache.jena.geosparql.configuration.GeoSPARQLOperations;
 import org.apache.jena.geosparql.implementation.datatype.GMLDatatype;
 import org.apache.jena.geosparql.implementation.datatype.GeometryDatatype;
 import org.apache.jena.geosparql.implementation.datatype.WKTDatatype;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
-import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
-import org.apache.jena.fuseki.geosparql.cli.FileGraphDelimiter;
-import org.apache.jena.fuseki.geosparql.cli.FileGraphFormat;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.ReadWrite;
@@ -92,14 +92,18 @@ public class DatasetOperations {
         }
 
         //Setup Spatial Extension
-        if (argsConfig.getSpatialIndexFile() != null) {
-            File spatialIndexFile = argsConfig.getSpatialIndexFile();
-            GeoSPARQLConfig.setupSpatialIndex(dataset, spatialIndexFile);
-        } else if (argsConfig.isTDBFileSetup()) {
-            File spatialIndexFile = new File(argsConfig.getTdbFile(), SPATIAL_INDEX_FILE);
-            GeoSPARQLConfig.setupSpatialIndex(dataset, spatialIndexFile);
+        if (!dataset.isEmpty()) {
+            if (argsConfig.getSpatialIndexFile() != null) {
+                File spatialIndexFile = argsConfig.getSpatialIndexFile();
+                GeoSPARQLConfig.setupSpatialIndex(dataset, spatialIndexFile);
+            } else if (argsConfig.isTDBFileSetup()) {
+                File spatialIndexFile = new File(argsConfig.getTdbFile(), SPATIAL_INDEX_FILE);
+                GeoSPARQLConfig.setupSpatialIndex(dataset, spatialIndexFile);
+            } else {
+                GeoSPARQLConfig.setupSpatialIndex(dataset);
+            }
         } else {
-            GeoSPARQLConfig.setupSpatialIndex(dataset);
+            LOGGER.warn("Datset empty. Spatial Index not constructed. Server will require restarting after adding data and any updates to build Spatial Index.");
         }
 
         return dataset;

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/EmptyTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/EmptyTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.fuseki.geosparql;
+
+import com.beust.jcommander.JCommander;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
+import org.apache.jena.geosparql.spatial.SpatialIndexException;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.update.UpdateExecutionFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateProcessor;
+import org.apache.jena.update.UpdateRequest;
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ *
+ */
+public class EmptyTest {
+
+    private static GeosparqlServer SERVER;
+
+    public EmptyTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws DatasetException, SpatialIndexException {
+        String[] args = {"-u"};
+
+        ArgsConfig argsConfig = new ArgsConfig();
+        JCommander.newBuilder()
+                .addObject(argsConfig)
+                .build()
+                .parse(args);
+
+        //Setup dataset
+        Dataset dataset = DatasetOperations.setup(argsConfig);
+
+        //Configure server
+        SERVER = new GeosparqlServer(argsConfig.getPort(), argsConfig.getDatsetName(), argsConfig.isLoopbackOnly(), dataset, argsConfig.isUpdateAllowed());
+        SERVER.start();
+
+        //Add data
+        String update = "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n"
+                + "\n"
+                + "INSERT DATA{"
+                + "<http://example.org/Geometry#LineStringA> geo:hasSerialization \"LINESTRING(0 0, 10 10)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>;"
+                + " a geo:Geometry ;"
+                + " a geo:SpatialObject ."
+                + "<http://example.org/Geometry#LineStringB> geo:hasSerialization \"LINESTRING(0 5, 10 5)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>;"
+                + " a geo:Geometry ;"
+                + " a geo:SpatialObject ."
+                + "<http://example.org/Geometry#PointC> geo:hasSerialization \"POINT(5 5)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>;"
+                + " a geo:Geometry ;"
+                + " a geo:SpatialObject ."
+                + "}";
+
+        UpdateRequest updateRequest = UpdateFactory.create(update);
+        UpdateProcessor updateProcessor = UpdateExecutionFactory.createRemote(updateRequest, SERVER.getLocalServiceURL());
+        updateProcessor.execute();
+
+        System.out.println("Server: " + SERVER.getLocalServiceURL());
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        SERVER.shutdown();
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of empty dataset.
+     */
+    @Test
+    public void testEmpty() {
+        String query = "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n"
+                + "\n"
+                + "SELECT ?obj\n"
+                + "WHERE{\n"
+                + "    <http://example.org/Geometry#LineStringA> geo:sfCrosses ?obj .\n"
+                + "}ORDER by ?obj";
+        List<Resource> result = new ArrayList<>();
+        try (QueryExecution qe = QueryExecutionFactory.sparqlService(SERVER.getLocalServiceURL(), query)) {
+            ResultSet rs = qe.execSelect();
+
+            while (rs.hasNext()) {
+                QuerySolution qs = rs.nextSolution();
+                Resource obj = qs.getResource("obj");
+                result.add(obj);
+            }
+
+            //ResultSetFormatter.outputAsTSV(rs);
+        }
+
+        List<Resource> expResult = new ArrayList<>();
+        expResult.add(ResourceFactory.createResource("http://example.org/Geometry#LineStringB"));
+
+        assertEquals(expResult, result);
+    }
+
+}

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/GeoSPARQLConfig.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/GeoSPARQLConfig.java
@@ -245,6 +245,7 @@ public class GeoSPARQLConfig {
      * Setup Spatial Index using Dataset and most frequent SRS URI in Dataset.
      *
      * @param dataset
+     * @throws SpatialIndexException
      */
     public static final void setupSpatialIndex(Dataset dataset) throws SpatialIndexException {
         SpatialIndex.buildSpatialIndex(dataset);
@@ -257,6 +258,7 @@ public class GeoSPARQLConfig {
      *
      * @param dataset
      * @param spatialIndexFile
+     * @throws SpatialIndexException
      */
     public static final void setupSpatialIndex(Dataset dataset, File spatialIndexFile) throws SpatialIndexException {
         SpatialIndex.buildSpatialIndex(dataset, spatialIndexFile);
@@ -269,6 +271,7 @@ public class GeoSPARQLConfig {
      * @param dataset
      * @param srsURI
      * @param spatialIndexFile
+     * @throws SpatialIndexException
      */
     public static final void setupSpatialIndex(Dataset dataset, String srsURI, File spatialIndexFile) throws SpatialIndexException {
         SpatialIndex.buildSpatialIndex(dataset, srsURI, spatialIndexFile);

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/SpatialIndex.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/SpatialIndex.java
@@ -102,6 +102,7 @@ public class SpatialIndex {
      *
      * @param spatialIndexItems
      * @param srsURI
+     * @throws SpatialIndexException
      */
     public SpatialIndex(Collection<SpatialIndexItem> spatialIndexItems, String srsURI) throws SpatialIndexException {
         int indexCapacity = spatialIndexItems.size() < MINIMUM_CAPACITY ? MINIMUM_CAPACITY : spatialIndexItems.size();
@@ -150,6 +151,7 @@ public class SpatialIndex {
      * Items to add to an unbuilt Spatial Index.
      *
      * @param indexItems
+     * @throws SpatialIndexException
      */
     public final void insertItems(Collection<SpatialIndexItem> indexItems) throws SpatialIndexException {
 
@@ -163,6 +165,7 @@ public class SpatialIndex {
      *
      * @param envelope
      * @param item
+     * @throws SpatialIndexException
      */
     public final void insertItem(Envelope envelope, Resource item) throws SpatialIndexException {
         if (!isBuilt) {
@@ -236,6 +239,7 @@ public class SpatialIndex {
      * @param srsURI
      * @param spatialIndexFile
      * @return SpatialIndex constructed.
+     * @throws SpatialIndexException
      */
     public static SpatialIndex buildSpatialIndex(Dataset dataset, String srsURI, File spatialIndexFile) throws SpatialIndexException {
 
@@ -261,6 +265,7 @@ public class SpatialIndex {
      * @param dataset
      * @param spatialIndexFile
      * @return SpatialIndex constructed.
+     * @throws SpatialIndexException
      */
     public static SpatialIndex buildSpatialIndex(Dataset dataset, File spatialIndexFile) throws SpatialIndexException {
         String srsURI = GeoSPARQLOperations.findModeSRS(dataset);
@@ -275,6 +280,7 @@ public class SpatialIndex {
      * @param dataset
      * @param srsURI
      * @return SpatialIndex constructed.
+     * @throws SpatialIndexException
      */
     public static SpatialIndex buildSpatialIndex(Dataset dataset, String srsURI) throws SpatialIndexException {
         LOGGER.info("Building Spatial Index - Started");
@@ -293,6 +299,7 @@ public class SpatialIndex {
      * @param dataset
      * @param srsURI
      * @return SpatialIndexItems found.
+     * @throws SpatialIndexException
      */
     public static Collection<SpatialIndexItem> findSpatialIndexItems(Dataset dataset, String srsURI) throws SpatialIndexException {
         //Default Model
@@ -321,6 +328,7 @@ public class SpatialIndex {
      *
      * @param dataset
      * @return SpatialIndex constructed.
+     * @throws SpatialIndexException
      */
     public static SpatialIndex buildSpatialIndex(Dataset dataset) throws SpatialIndexException {
         String srsURI = GeoSPARQLOperations.findModeSRS(dataset);
@@ -334,6 +342,7 @@ public class SpatialIndex {
      * @param model
      * @param srsURI
      * @return Dataset with default Model and SpatialIndex in Context.
+     * @throws SpatialIndexException
      */
     public static final Dataset wrapModel(Model model, String srsURI) throws SpatialIndexException {
 
@@ -349,6 +358,7 @@ public class SpatialIndex {
      *
      * @param model
      * @return Dataset with default Model and SpatialIndex in Context.
+     * @throws SpatialIndexException
      */
     public static final Dataset wrapModel(Model model) throws SpatialIndexException {
         Dataset dataset = DatasetFactory.createTxnMem();
@@ -365,6 +375,7 @@ public class SpatialIndex {
      * @param model
      * @param srsURI
      * @return Items found in the Model in the SRS URI.
+     * @throws SpatialIndexException
      */
     public static final Collection<SpatialIndexItem> getSpatialIndexItems(Model model, String srsURI) throws SpatialIndexException {
 
@@ -392,6 +403,7 @@ public class SpatialIndex {
      * @param model
      * @param srsURI
      * @return GeometryLiteral items prepared for adding to SpatialIndex.
+     * @throws SpatialIndexException
      */
     private static Collection<SpatialIndexItem> getGeometryLiteralIndexItems(Model model, String srsURI) throws SpatialIndexException {
         List<SpatialIndexItem> items = new ArrayList<>();
@@ -489,6 +501,7 @@ public class SpatialIndex {
      * @param spatialIndexFileURI
      * @param spatialIndexItems
      * @param srsURI
+     * @throws SpatialIndexException
      */
     public static final void save(String spatialIndexFileURI, Collection<SpatialIndexItem> spatialIndexItems, String srsURI) throws SpatialIndexException {
         save(new File(spatialIndexFileURI), spatialIndexItems, srsURI);
@@ -500,6 +513,7 @@ public class SpatialIndex {
      * @param spatialIndexFile
      * @param spatialIndexItems
      * @param srsURI
+     * @throws SpatialIndexException
      */
     public static final void save(File spatialIndexFile, Collection<SpatialIndexItem> spatialIndexItems, String srsURI) throws SpatialIndexException {
 


### PR DESCRIPTION
- running the geosparql-fuseki server with an empty dataset now emits a logging warning rather than an SpatialIndexException.
- JavaDoc tidy up.