### PR TITLE
Geosparql schema checks

### DIFF
--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/ModeSRS.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/ModeSRS.java
@@ -31,6 +31,7 @@ import org.apache.jena.geosparql.implementation.vocabulary.SpatialExtension;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
 import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.util.iterator.ExtendedIterator;
 
 /**
  *
@@ -46,8 +47,14 @@ public class ModeSRS {
 
     public void search(Model model) {
 
-        NodeIterator nodeIter = model.listObjectsOfProperty(Geo.HAS_SERIALIZATION_PROP);
+        ExtendedIterator<RDFNode> nodeIter = model.listObjectsOfProperty(Geo.HAS_SERIALIZATION_PROP);
         boolean isGeometryLiteralsFound = nodeIter.hasNext();
+        if (!isGeometryLiteralsFound) {
+            NodeIterator wktNodeIter = model.listObjectsOfProperty(Geo.AS_WKT_PROP);
+            NodeIterator gmlNodeIter = model.listObjectsOfProperty(Geo.AS_GML_PROP);
+            nodeIter = wktNodeIter.andThen(gmlNodeIter);
+        }
+
         while (nodeIter.hasNext()) {
             RDFNode node = nodeIter.next();
             if (node.isLiteral()) {

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/geo/topological/GenericPropertyFunction.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/geo/topological/GenericPropertyFunction.java
@@ -107,13 +107,17 @@ public abstract class GenericPropertyFunction extends PFuncSimple {
 
         Graph graph = execCxt.getActiveGraph();
 
+        //Search for both Features and Geometry in the Graph. Reliant upon consistent usage of SpatialObject (which is base class of Feature and Geometry) if present.
         ExtendedIterator<Triple> subjectTriples;
         if (graph.contains(null, RDF.type.asNode(), Geo.SPATIAL_OBJECT_NODE)) {
             subjectTriples = graph.find(null, RDF.type.asNode(), Geo.SPATIAL_OBJECT_NODE);
+        } else if (graph.contains(null, RDF.type.asNode(), Geo.FEATURE_NODE) || graph.contains(null, RDF.type.asNode(), Geo.GEOMETRY_NODE)) {
+            ExtendedIterator<Triple> featureTriples = graph.find(null, RDF.type.asNode(), Geo.FEATURE_NODE);
+            ExtendedIterator<Triple> geometryTriples = graph.find(null, RDF.type.asNode(), Geo.GEOMETRY_NODE);
+            subjectTriples = featureTriples.andThen(geometryTriples);
         } else {
             //Check for Geo Predicate Features in the Graph if no GeometryLiterals found.
             subjectTriples = graph.find(null, SpatialExtension.GEO_LAT_NODE, null);
-
         }
 
         //Bind all the Spatial Objects or Geo Predicates once as the subject and search for corresponding Objects.
@@ -146,7 +150,7 @@ public abstract class GenericPropertyFunction extends PFuncSimple {
             isSubjectBound = false;
         }
 
-        if (!graph.contains(boundNode, RDF.type.asNode(), Geo.SPATIAL_OBJECT_NODE)) {
+        if (!(graph.contains(boundNode, RDF.type.asNode(), Geo.SPATIAL_OBJECT_NODE) || graph.contains(boundNode, RDF.type.asNode(), Geo.FEATURE_NODE) || graph.contains(boundNode, RDF.type.asNode(), Geo.GEOMETRY_NODE))) {
             if (!graph.contains(boundNode, SpatialExtension.GEO_LAT_NODE, null)) {
                 //Bound node is not a Feature or a Geometry or has Geo predicates so exit.
                 return QueryIterNullIterator.create(execCxt);
@@ -172,10 +176,14 @@ public abstract class GenericPropertyFunction extends PFuncSimple {
         Var unboundVar = Var.alloc(unboundNode.getName());
         QueryIterConcat queryIterConcat = new QueryIterConcat(execCxt);
 
-        //Search for both Features and Geometry in the Graph.
+        //Search for both Features and Geometry in the Graph. Reliant upon consistent usage of SpatialObject (which is base class of Feature and Geometry) if present.
         ExtendedIterator<Triple> spatialTriples;
         if (graph.contains(null, RDF.type.asNode(), Geo.SPATIAL_OBJECT_NODE)) {
             spatialTriples = graph.find(null, RDF.type.asNode(), Geo.SPATIAL_OBJECT_NODE);
+        } else if (graph.contains(null, RDF.type.asNode(), Geo.FEATURE_NODE) || graph.contains(null, RDF.type.asNode(), Geo.GEOMETRY_NODE)) {
+            ExtendedIterator<Triple> featureTriples = graph.find(null, RDF.type.asNode(), Geo.FEATURE_NODE);
+            ExtendedIterator<Triple> geometryTriples = graph.find(null, RDF.type.asNode(), Geo.GEOMETRY_NODE);
+            spatialTriples = featureTriples.andThen(geometryTriples);
         } else {
             //Check for Geo Predicate Features in the Graph if no GeometryLiterals found.
             spatialTriples = graph.find(null, SpatialExtension.GEO_LAT_NODE, null);

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/geo/topological/SpatialObjectGeometryLiteral.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/geo/topological/SpatialObjectGeometryLiteral.java
@@ -114,6 +114,18 @@ public class SpatialObjectGeometryLiteral {
             //Find the Geometry Literal of the Geometry.
             ExtendedIterator<Triple> iter = graph.find(geometry, Geo.HAS_SERIALIZATION_NODE, null);
             Node literalNode = extractObject(iter);
+
+            // If hasSerialization not found then check asWKT.
+            if (literalNode == null) {
+                iter = graph.find(geometry, Geo.AS_WKT_NODE, null);
+                literalNode = extractObject(iter);
+            }
+            // If asWKT not found then check asGML.
+            if (literalNode == null) {
+                iter = graph.find(geometry, Geo.AS_GML_NODE, null);
+                literalNode = extractObject(iter);
+            }
+
             if (literalNode != null) {
                 return new SpatialObjectGeometryLiteral(targetSpatialObject, literalNode);
             }

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/property_functions/GenericSpatialPropertyFunction.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/property_functions/GenericSpatialPropertyFunction.java
@@ -45,6 +45,7 @@ import org.apache.jena.sparql.expr.ExprEvalException;
 import org.apache.jena.sparql.pfunction.PFuncSimpleAndList;
 import org.apache.jena.sparql.pfunction.PropFuncArg;
 import org.apache.jena.sparql.util.FmtUtils;
+import org.apache.jena.util.iterator.ExtendedIterator;
 
 /**
  *
@@ -112,7 +113,16 @@ public abstract class GenericSpatialPropertyFunction extends PFuncSimpleAndList 
                 Iterator<Triple> geometryTriples = graph.find(subject, Geo.HAS_GEOMETRY_NODE, null);
                 while (geometryTriples.hasNext()) {
                     Node geometry = geometryTriples.next().getObject();
-                    spatialTriples.addIterator(graph.find(geometry, Geo.HAS_SERIALIZATION_NODE, null));
+                    ExtendedIterator<Triple> iter = graph.find(geometry, Geo.HAS_SERIALIZATION_NODE, null);
+                    // Check for asWKT
+                    if (!iter.hasNext()) {
+                        iter = graph.find(geometry, Geo.AS_WKT_NODE, null);
+                    }
+                    // Check for asGML
+                    if (!iter.hasNext()) {
+                        iter = graph.find(geometry, Geo.AS_GML_NODE, null);
+                    }
+                    spatialTriples.addIterator(iter);
                 }
             } else {
                 //Check for Geo predicates against the feature when no geometry literals found.

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/configuration/GeoSPARQLOperationsTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/configuration/GeoSPARQLOperationsTest.java
@@ -74,21 +74,25 @@ public class GeoSPARQLOperationsTest {
         Literal wktA = ResourceFactory.createTypedLiteral("POINT(0 1)", WKTDatatype.INSTANCE);
         ORIGINAL_DATA.add(featureA, Geo.HAS_GEOMETRY_PROP, geometryA);
         ORIGINAL_DATA.add(geometryA, Geo.HAS_SERIALIZATION_PROP, wktA);
+        ORIGINAL_DATA.add(geometryA, Geo.AS_WKT_PROP, wktA);
         ORIGINAL_DATASET.setDefaultModel(ORIGINAL_DATA);
 
         Literal gmlA = ResourceFactory.createTypedLiteral("<gml:Point xmlns:gml=\"http://www.opengis.net/ont/gml\" srsName=\"http://www.opengis.net/def/crs/EPSG/0/4326\"><gml:pos>1 0</gml:pos></gml:Point>", GMLDatatype.INSTANCE);
         CONVERTED_DATATYPE_DATA.add(featureA, Geo.HAS_GEOMETRY_PROP, geometryA);
         CONVERTED_DATATYPE_DATA.add(geometryA, Geo.HAS_SERIALIZATION_PROP, gmlA);
+        CONVERTED_DATATYPE_DATA.add(geometryA, Geo.AS_GML_PROP, gmlA);
         CONVERTED_DATATYPE_DATASET.setDefaultModel(CONVERTED_DATATYPE_DATA);
 
         Literal wktWGSA = ResourceFactory.createTypedLiteral("<http://www.opengis.net/def/crs/EPSG/0/4326> POINT(1 0)", WKTDatatype.INSTANCE);
         CONVERTED_SRS_DATA.add(featureA, Geo.HAS_GEOMETRY_PROP, geometryA);
         CONVERTED_SRS_DATA.add(geometryA, Geo.HAS_SERIALIZATION_PROP, wktWGSA);
+        CONVERTED_SRS_DATA.add(geometryA, Geo.AS_WKT_PROP, wktWGSA);
         CONVERTED_SRS_DATASET.setDefaultModel(CONVERTED_SRS_DATA);
 
         Literal gmlWGSA = ResourceFactory.createTypedLiteral("<gml:Point xmlns:gml=\"http://www.opengis.net/ont/gml\" srsName=\"http://www.opengis.net/def/crs/EPSG/0/4326\"><gml:pos>1 0</gml:pos></gml:Point>", GMLDatatype.INSTANCE);
         CONVERTED_SRS_DATATYPE_DATA.add(featureA, Geo.HAS_GEOMETRY_PROP, geometryA);
         CONVERTED_SRS_DATATYPE_DATA.add(geometryA, Geo.HAS_SERIALIZATION_PROP, gmlWGSA);
+        CONVERTED_SRS_DATATYPE_DATA.add(geometryA, Geo.AS_GML_PROP, gmlWGSA);
         CONVERTED_SRS_DATATYPE_DATASET.setDefaultModel(CONVERTED_SRS_DATATYPE_DATA);
 
         Literal latA = ResourceFactory.createTypedLiteral("1.0", XSDDatatype.XSDfloat);


### PR DESCRIPTION
- SpatialObject no longer has to be asserted or inferred for spatial queries to complete. Instead only Feature and Geometry class relations are required.
- hasSerialization no longer has to be asserted or inferred if asGML and asWKT properties are being used.