### PR TITLE
JENA-1741 Invalid Automatic-Module-Name values

### DIFF
--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -38,7 +38,7 @@
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
         <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
         <!-- @@ TODO Need final check @@ -->
-        <automatic.module.name>org.apache.jena.jena-fuseki-geosparql</automatic.module.name>
+        <automatic.module.name>org.apache.jena.fuseki.geosparql</automatic.module.name>
     </properties>
 
     <dependencies>

--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
-    <automatic.module.name>org.apache.jena.jena-geosparql</automatic.module.name>
+    <automatic.module.name>org.apache.jena.geosparql</automatic.module.name>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This adjusts the AMN metadata to valid names (hyphens are not allowed)