### PR TITLE
JENA-1742: Fix OSGi imports

### DIFF
--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -261,6 +261,8 @@
               !org.apache.jena.ext.*,
               !org.checkerframework.checker.*,
               !com.google.errorprone.annotations.*,
+              !com.google.appengine.api,
+              !com.google.apphosting.api,
               sun.misc;resolution:=optional,
               *
             </Import-Package>


### PR DESCRIPTION
Add exclusion for google appengine and apphosting packages

Note: with this change, I am able to successfully deploy Jena in Karaf 4.x