### PR TITLE
JENA-1731: Fuseki service configuration

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecution.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecution.java
@@ -26,23 +26,26 @@ import org.apache.jena.atlas.json.JsonObject;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.util.Context;
 
 /** A interface for a single execution of a query. */
 public interface QueryExecution extends AutoCloseable 
 {
+    public static QueryExecutionBuilder create() { return QueryExecutionBuilder.create(); }
+    
     /** Set the initial association of variables and values.
      * May not be supported by all QueryExecution implementations.
      * @param binding
      */
     public void setInitialBinding(QuerySolution binding) ;
 
-//    /** Set a table of initial associations of variables and values.
-//     * May not be supported by all QueryExecution implementations.
-//     * @param binding
-//     */
-//    public void setInitialBindings(ResultSet table) ;
-    
+    /** Set the initial association of variables and values.
+     * May not be supported by all QueryExecution implementations.
+     * @param binding
+     */
+    void setInitialBinding(Binding binding);
+
     /**
      * The dataset against which the query will execute.
      * May be null, implying it is expected that the query itself

--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionBuilder.java
@@ -66,10 +66,19 @@ public class QueryExecutionBuilder {
         Objects.requireNonNull(query, "Query for QueryExecution");
 
         query.setResultVars();
-        if ( context == null )
-            context = ARQ.getContext();
+        Context cxt;
+        
+        if ( context == null ) {
+            // Default is to take the global context, the copy it and merge in the dataset context.
+            // If a context is specified by context(Context), use that as given.
+            // The query context is modified to insert the current time.
+            cxt = ARQ.getContext();
+            cxt = Context.setupContextForDataset(cxt, dataset) ;
+        } else {
+            // Isolate to snapshot it and to allow it to be  modified.
+            cxt = context.copy();
+        }
 
-        Context cxt = Context.setupContextForDataset(context, dataset) ;
         QueryEngineFactory f = QueryEngineRegistry.get().find(query, dataset, cxt);
         if ( f == null ) {
             Log.warn(QueryExecutionBuilder.class, "Failed to find a QueryEngineFactory");

--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query;
+
+import java.util.Objects;
+
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.engine.QueryEngineFactory;
+import org.apache.jena.sparql.engine.QueryEngineRegistry;
+import org.apache.jena.sparql.engine.QueryExecutionBase;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.util.Context;
+
+/** Query Execution builder. */
+public class QueryExecutionBuilder {
+
+    private DatasetGraph dataset = null;
+    private Query        query   = null;
+    private Context      context = null;
+    private Binding      binding = null;    
+
+    public static QueryExecutionBuilder create() {
+        return new QueryExecutionBuilder();
+    }
+
+    private QueryExecutionBuilder() {}
+
+    public QueryExecutionBuilder query(Query query) {
+        this.query = query;
+        return this;
+    }
+
+    public QueryExecutionBuilder dataset(DatasetGraph dsg) {
+        this.dataset = dsg;
+        return this;
+    }
+
+    public QueryExecutionBuilder context(Context context) {
+        this.context = context;
+        return this;
+    }
+
+    public QueryExecutionBuilder initialBinding(Binding binding) {
+        this.binding = binding;
+        return this;
+    }
+
+    public QueryExecution build() {
+        Objects.requireNonNull(query, "Query for QueryExecution");
+
+        query.setResultVars();
+        if ( context == null )
+            context = ARQ.getContext();
+
+        Context cxt = Context.setupContextForDataset(context, dataset) ;
+        QueryEngineFactory f = QueryEngineRegistry.get().find(query, dataset, cxt);
+        if ( f == null ) {
+            Log.warn(QueryExecutionBuilder.class, "Failed to find a QueryEngineFactory");
+            return null;
+        }
+
+        // QueryExecutionBase set up the final context, merging in the dataset context and setting the current time.
+        QueryExecution qExec = new QueryExecutionBase(query, dataset, cxt, f);
+        if ( binding != null )
+            qExec.setInitialBinding(binding);
+        return qExec;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
@@ -22,16 +22,15 @@ import java.util.Objects;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.protocol.HttpContext;
-import org.apache.jena.atlas.logging.Log ;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.impl.WrappedGraph;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.GraphView;
 import org.apache.jena.sparql.engine.Plan ;
 import org.apache.jena.sparql.engine.QueryEngineFactory ;
 import org.apache.jena.sparql.engine.QueryEngineRegistry ;
-import org.apache.jena.sparql.engine.QueryExecutionBase ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.engine.binding.BindingRoot ;
 import org.apache.jena.sparql.engine.http.QueryEngineHTTP ;
@@ -107,6 +106,7 @@ public class QueryExecutionFactory
         Objects.requireNonNull(datasetGraph, "DatasetGraph is null") ;
         return make(query, datasetGraph) ;
     }
+    
     /** Create a QueryExecution to execute over the Dataset.
      * 
      * @param queryStr     Query string
@@ -570,7 +570,7 @@ public class QueryExecutionFactory
             context = new Context(ARQ.getContext()) ;
         if ( input == null )
             input = BindingRoot.create() ; 
-        QueryEngineFactory f = findFactory(query, dataset, context) ;
+        QueryEngineFactory f = QueryEngineRegistry.get().find(query, dataset, context);
         if ( f == null )
             return null ;
         return f.create(query, dataset, input, context) ;
@@ -586,12 +586,13 @@ public class QueryExecutionFactory
     }
     
     static protected QueryExecution make(Query query) {
-        return make(query, (Dataset)null) ;
+        return QueryExecution.create().query(query).build();
     }
 
-    protected  static QueryExecution make(Query query, Model model) { 
-        Dataset dataset = DatasetFactory.wrap(model);
-        Graph g = unwrap(model.getGraph());
+    protected  static QueryExecution make(Query query, Model model) {
+        Graph graph = model.getGraph();
+        DatasetGraph dataset = DatasetGraphFactory.wrap(graph);
+        Graph g = unwrap(graph);
         if ( g instanceof GraphView ) {
             GraphView gv = (GraphView)g;
             // Copy context of the storage dataset to the wrapper dataset. 
@@ -611,33 +612,13 @@ public class QueryExecutionFactory
     }
 
     protected static QueryExecution make(Query query, Dataset dataset)
-    { return make(query, dataset, null, null) ; }
+    { return make(query, dataset.asDatasetGraph()); }
 
     protected static QueryExecution make(Query query, DatasetGraph datasetGraph)
-    { return make(query, null, datasetGraph, null) ; }
+    { return QueryExecution.create().query(query).dataset(datasetGraph).build(); }
 
-    // Both Dataset and DatasetGraph for full backwards compatibility 
-    protected static QueryExecution make(Query query, Dataset dataset, DatasetGraph dsg, Context context) {
-        if ( dsg == null && dataset != null )
-            dsg = dataset.asDatasetGraph();
-        query.setResultVars() ;
-        if ( context == null )
-            context = ARQ.getContext() ;  // .copy done in QueryExecutionBase -> Context.setupContext.
-        QueryEngineFactory f = findFactory(query, dsg, context) ;
-        if ( f == null ) {
-            Log.warn(QueryExecutionFactory.class, "Failed to find a QueryEngineFactory") ;
-            return null ;
-        }
-        return new QueryExecutionBase(query, dataset, dsg, context, f) ;
-    }
-
-    static private QueryEngineFactory findFactory(Query query, DatasetGraph dataset, Context context) {
-        return QueryEngineRegistry.get().find(query, dataset, context) ;
-    }
-
-    static private void checkNotNull(Object obj, String msg) {
-        if ( obj == null )
-            throw new IllegalArgumentException(msg) ;
+    static private <X> void checkNotNull(X obj, String msg) {
+        Objects.requireNonNull(obj, msg);
     }
     
     static private void checkArg(Model model)

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
@@ -150,6 +150,8 @@ public class AssemblerUtils
      */
     public static void setContext(Resource r, Context context)
     {
+        if ( ! r.hasProperty(JA.context ) )
+            return ;
         String qs = "PREFIX ja: <"+JA.getURI()+">\nSELECT * { ?x ja:context [ ja:cxtName ?name ; ja:cxtValue ?value ] }" ;
         QuerySolutionMap qsm = new QuerySolutionMap() ;
         qsm.add("x", r) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
@@ -138,7 +138,27 @@ public class AssemblerUtils
         return Assembler.general.open(root) ;
     }
     
-    /** Look for and set context declarations. 
+    /** Look for and build context declarations. 
+     * e.g.
+     * <pre>
+     * root ... ;
+     *   ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "10000" ] ;
+     *   ...
+     * </pre>
+     * Short name forms of context parameters can be used.  
+     * Setting as string "undef" will remove the context setting.
+     * Returns null when there is no {@link JA#context} on the resource.
+     */
+    public static Context parseContext(Resource r)
+    {
+        if ( ! r.hasProperty(JA.context ) )
+            return null;
+        Context context = new Context();
+        mergeContext(r, context);
+        return context;
+    }
+        
+    /** Look for and merge in context declarations. 
      * e.g.
      * <pre>
      * root ... ;
@@ -148,10 +168,7 @@ public class AssemblerUtils
      * Short name forms of context parameters can be used.  
      * Setting as string "undef" will remove the context setting.
      */
-    public static void setContext(Resource r, Context context)
-    {
-        if ( ! r.hasProperty(JA.context ) )
-            return ;
+    public static void mergeContext(Resource r, Context context) {
         String qs = "PREFIX ja: <"+JA.getURI()+">\nSELECT * { ?x ja:context [ ja:cxtName ?name ; ja:cxtValue ?value ] }" ;
         QuerySolutionMap qsm = new QuerySolutionMap() ;
         qsm.add("x", r) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetAssembler.java
@@ -79,7 +79,7 @@ public class DatasetAssembler extends AssemblerBase implements Assembler {
             Model m = a.openModel(g);
             ds.addNamedModel(gName, m);
         }
-        AssemblerUtils.setContext(root, ds.getContext()) ;
+        AssemblerUtils.mergeContext(root, ds.getContext()) ;
         return ds ;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetNullAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetNullAssembler.java
@@ -53,7 +53,7 @@ public class DatasetNullAssembler extends AssemblerBase {
         else
             throw new InternalErrorException();
         Dataset ds = DatasetFactory.wrap(dsg);
-        AssemblerUtils.setContext(root, ds.getContext());
+        AssemblerUtils.mergeContext(root, ds.getContext());
         return ds;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetOneAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetOneAssembler.java
@@ -76,7 +76,7 @@ public class DatasetOneAssembler extends AssemblerBase {
             String x = DatasetAssemblerVocab.tDatasetOne.getLocalName();
             throw new AssemblerException(root, "A "+x+" dataset can only hold a default graph, and no named graphs");
         }
-        AssemblerUtils.setContext(root, ds.getContext());
+        AssemblerUtils.mergeContext(root, ds.getContext());
         return ds;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
@@ -21,7 +21,7 @@ package org.apache.jena.sparql.core.assembler;
 import static org.apache.jena.assembler.JA.data;
 import static org.apache.jena.query.DatasetFactory.createTxnMem;
 import static org.apache.jena.riot.RDFDataMgr.read;
-import static org.apache.jena.sparql.core.assembler.AssemblerUtils.setContext;
+import static org.apache.jena.sparql.core.assembler.AssemblerUtils.mergeContext;
 import static org.apache.jena.sparql.core.assembler.DatasetAssemblerVocab.pGraphName;
 import static org.apache.jena.sparql.core.assembler.DatasetAssemblerVocab.pNamedGraph;
 import static org.apache.jena.sparql.util.graph.GraphUtils.getAsStringValue;
@@ -51,7 +51,7 @@ public class InMemDatasetAssembler extends AssemblerBase implements Assembler {
         if ( ! root.hasProperty( RDF.type, DatasetAssemblerVocab.tDatasetTxnMem ) )
             checkType(root, DatasetAssemblerVocab.tMemoryDataset);
         final Dataset dataset = createTxnMem();
-        setContext(root, dataset.getContext());
+        mergeContext(root, dataset.getContext());
 
         Txn.executeWrite(dataset, ()->{ 
             // Load data into the default graph

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryEngineBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryEngineBase.java
@@ -90,7 +90,8 @@ public abstract class QueryEngineBase implements OpEval, Closeable
         // Ensure context setup - usually done in QueryExecutionBase
         // so it can be changed after initialization.
         if ( context == null )
-            context = Context.setupContextExec(context, dataset) ;
+            context = Context.setupContextForDataset(context, dataset) ;
+        Context.setCurrentDateTime(context) ;
         this.query = null ;
         setOp(op) ;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryEngineHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryEngineHTTP.java
@@ -46,6 +46,7 @@ import org.apache.jena.riot.resultset.ResultSetReaderRegistry;
 import org.apache.jena.sparql.ARQException ;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.engine.ResultSetCheckCondition ;
+import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.graph.GraphFactory ;
 import org.apache.jena.sparql.resultset.ResultSetException;
 import org.apache.jena.sparql.util.Context ;
@@ -242,11 +243,11 @@ public class QueryEngineHTTP implements QueryExecution {
                 "Initial bindings not supported for remote queries, consider using a ParameterizedSparqlString to prepare a query for remote execution");
     }
 
-    public void setInitialBindings(ResultSet table) {
+    @Override
+    public void setInitialBinding(Binding binding) {
         throw new UnsupportedOperationException(
                 "Initial bindings not supported for remote queries, consider using a ParameterizedSparqlString to prepare a query for remote execution");
     }
-
     /**
      * @param defaultGraphURIs
      *            The defaultGraphURIs to set.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/context.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/context.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.function.library;
+
+import java.util.List;
+
+import org.apache.jena.atlas.lib.InternalErrorException;
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.expr.ExprEvalException;
+import org.apache.jena.sparql.expr.ExprList;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.function.FunctionBase;
+import org.apache.jena.sparql.function.FunctionEnv;
+import org.apache.jena.sparql.util.Symbol;
+
+/**
+ * Function that returns the value of a context setting.
+ */
+public class context extends FunctionBase {
+    // This function exists more for testing comnetxt get setup correctly than anything else.
+    public context() {}
+
+    @Override
+    public void checkBuild(String uri, ExprList args) {
+        if ( args.size() != 1 )
+            throw new ExprEvalException("Wrong number of arguments");
+    }
+
+    @Override
+    protected NodeValue exec(List<NodeValue> args, FunctionEnv env) {
+        NodeValue v = args.get(0);
+        if ( ! v.isString() )
+            throw new ExprEvalException("Not a string: function afn:context("+v+")");
+        Symbol symbol = Symbol.create(v.getString());
+        return get(symbol, env);
+    }
+
+    public static NodeValue get(Symbol symbol, FunctionEnv env) {
+        Object obj = env.getContext().get(symbol);
+        if ( obj == null )
+            return NodeValue.nvEmptyString;
+        if ( obj instanceof String )
+            return NodeValue.makeString((String)obj);
+        
+        if ( !(obj instanceof Node) )
+            throw new ExprEvalException("Not a Node: " + Lib.className(obj));
+        Node n = (Node)obj;
+        NodeValue nv = NodeValue.makeNode(n);
+        return nv;
+    }
+
+    @Override
+    public NodeValue exec(List<NodeValue> args) {
+        throw new InternalErrorException("afn:context.exec(args) called");
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessRemoteBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessRemoteBase.java
@@ -75,7 +75,7 @@ public abstract class UpdateProcessRemoteBase implements UpdateProcessor {
 
         this.request = request;
         this.endpoint = endpoint;
-        this.context = Context.setupContextExec(context, null);
+        this.context = Context.setupContextForDataset(context, null);
 
         // Apply service configuration if applicable
         UpdateProcessRemoteBase.applyServiceConfig(endpoint, this);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorBase.java
@@ -45,7 +45,8 @@ public class UpdateProcessorBase implements UpdateProcessor
         this.request = request ;
         this.datasetGraph = datasetGraph ;
         this.inputBinding = inputBinding;
-        this.context = Context.setupContextExec(context, datasetGraph) ;
+        this.context = context;
+        Context.setCurrentDateTime(this.context) ;
         this.factory = factory ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorStreamingBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorStreamingBase.java
@@ -36,7 +36,8 @@ public class UpdateProcessorStreamingBase implements UpdateProcessorStreaming
     public UpdateProcessorStreamingBase(DatasetGraph datasetGraph, Binding inputBinding, Context context, UpdateEngineFactory factory)
     {
         this.datasetGraph = datasetGraph ;
-        this.context = Context.setupContextExec(context, datasetGraph) ;
+        this.context = context;
+        Context.setCurrentDateTime(this.context) ;
         proc = factory.create(datasetGraph, inputBinding, context) ;
     }
     

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/Context.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/Context.java
@@ -349,30 +349,21 @@ public class Context {
         return x ;
     }
 
-    /** Setup a context using another context and a dataset.
-     *  This adds the current time.
-     */
-    public static Context setupContextExec(Context globalContext, DatasetGraph dataset) {
-        if ( globalContext == null )
-            globalContext = ARQ.getContext();
+    /** Setup a context using another context and a dataset.*/
+    public static Context setupContextForDataset(Context globalContext, DatasetGraph dataset) {
         // Copy per-dataset settings.
         Context dsgCxt = ( dataset != null && dataset.getContext() != null ) 
             ? dataset.getContext()
             : null;
         
         Context context = mergeCopy(globalContext, dsgCxt); 
-
-        context.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime()) ;
-
-        // Allocators.
-        // context.set(ARQConstants.sysVarAllocNamed, new VarAlloc(ARQConstants.allocVarMarkerExec)) ;
-        // context.set(ARQConstants.sysVarAllocAnon, new VarAlloc(ARQConstants.allocVarAnonMarkerExec)) ;
-        // Add VarAlloc for variables and bNodes (this is not the parse name).
-        // More added later e.g. query (if there is a query), algebra form (in setOp)
-
         return context;
     }
 
+    public static void setCurrentDateTime(Context context) {
+        context.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime()) ;
+    }
+    
     /** Merge an outer (global) and local context to produce a new context
      * The new context is always a separate copy.  
      */
@@ -381,7 +372,6 @@ public class Context {
             contextGlobal = ARQ.getContext();
         Context context = contextGlobal.copy();
         if ( contextLocal != null )
-            // Copy per-dataset settings.
             context.putAll(contextLocal);
         return context ;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/Context.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/Context.java
@@ -364,8 +364,9 @@ public class Context {
         context.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime()) ;
     }
     
-    /** Merge an outer (global) and local context to produce a new context
-     * The new context is always a separate copy.  
+    /** Merge an outer (defaults to the system global context)
+     *  and local context to produce a new context
+     *  The new context is always a separate copy.  
      */
     public static Context mergeCopy(Context contextGlobal, Context contextLocal) {
         if ( contextGlobal == null )

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/Symbol.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/Symbol.java
@@ -18,46 +18,55 @@
 
 package org.apache.jena.sparql.util;
 
+import java.util.Objects;
+
 /** A way to write constants */
 
-public class Symbol
-{
-    protected final static String nilSymbolName = "nil" ;
-    protected String symbol ;
+public class Symbol {
+    protected final static String nilSymbolName = "nil";
     
-    static public Symbol create(String symbolStr) { return new Symbol(symbolStr) ; }
-    static public Symbol create(Symbol other) { return new Symbol(other) ; }
-    
-    protected Symbol(String symbol)
-    { 
+    protected String symbol;
+
+    static public Symbol create(String symbolStr) {
+        return new Symbol(symbolStr);
+    }
+
+    static public Symbol create(Symbol other) {
+        return new Symbol(other);
+    }
+
+    protected Symbol(String symbol) {
         if ( symbol == null )
-            symbol = nilSymbolName ;
-        else
-            symbol = symbol.intern();
-        this.symbol = symbol ;
+            symbol = nilSymbolName;
+        this.symbol = symbol;
     }
 
-    protected Symbol(Symbol other)  { this.symbol = other.symbol ; }
-    
-    @Override
-    public int hashCode() { return symbol.hashCode() ; } 
-    
-    //public boolean isCompatibleWith(Symbol other) { return equals(other) ; }
-    
-    @Override
-    public boolean equals(Object other)
-    {
-        if ( this == other ) return true ;
-
-        if ( ! ( other instanceof Symbol ) )
-            return false ;
-
-        Symbol otherSymbol = (Symbol)other ;
-        return this.symbol == otherSymbol.symbol ; // String interning.
-        //return this.symbol.equals(otherSymbol.symbol) ;
+    protected Symbol(Symbol other) {
+        this.symbol = other.symbol;
     }
 
-    public String getSymbol() { return symbol ; }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
     @Override
-    public String toString()  { return "symbol:"+symbol ; }
+    public String toString() {
+        return "symbol:" + symbol;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(symbol);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj )
+            return true;
+        if ( !(obj instanceof Symbol) )
+            return false;
+        Symbol other = (Symbol)obj;
+        return Objects.equals(symbol, other.symbol);
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/system/Txn.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/Txn.java
@@ -87,7 +87,7 @@ public class Txn {
         }
     }
 
-    /** Execute and return a value in a transaction with the given {@link TxnType trasnaction type}. */
+    /** Execute and return a value in a transaction with the given {@link TxnType transaction type}. */
     public static <T extends Transactional, X> X calc(T txn, TxnType txnType, Supplier<X> r) {
         boolean b = txn.isInTransaction() ;
         if ( b )

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionFactory.java
@@ -20,7 +20,6 @@ package org.apache.jena.update;
 
 import org.apache.http.client.HttpClient;
 import org.apache.http.protocol.HttpContext;
-import org.apache.jena.query.ARQ ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.QuerySolution ;
 import org.apache.jena.sparql.core.DatasetGraph ;
@@ -245,34 +244,26 @@ public class UpdateExecutionFactory
     // Everything comes through one of these two make methods
     private static UpdateProcessor make(UpdateRequest updateRequest, DatasetGraph datasetGraph, Binding inputBinding, Context context)
     {
-        if ( context == null )
-        {
-            context = ARQ.getContext().copy();
-            context.putAll(datasetGraph.getContext()) ;
-        }
+        Context cxt = Context.setupContextForDataset(context, datasetGraph) ;
         
-        UpdateEngineFactory f = UpdateEngineRegistry.get().find(datasetGraph, context) ;
+        UpdateEngineFactory f = UpdateEngineRegistry.get().find(datasetGraph, cxt) ;
         if ( f == null )
             return null ;
         
-        UpdateProcessorBase uProc = new UpdateProcessorBase(updateRequest, datasetGraph, inputBinding, context, f) ;
+        UpdateProcessorBase uProc = new UpdateProcessorBase(updateRequest, datasetGraph, inputBinding, cxt, f) ;
         return uProc ;
     }
     
     // Everything comes through one of these two make methods
     private static UpdateProcessorStreaming makeStreaming(DatasetGraph datasetGraph, Binding inputBinding, Context context)
     {
-        if ( context == null )
-        {
-            context = ARQ.getContext().copy();
-            context.putAll(datasetGraph.getContext()) ;
-        }
+        Context cxt = Context.setupContextForDataset(context, datasetGraph) ;
         
-        UpdateEngineFactory f = UpdateEngineRegistry.get().find(datasetGraph, context) ;
+        UpdateEngineFactory f = UpdateEngineRegistry.get().find(datasetGraph, cxt) ;
         if ( f == null )
             return null ;
         
-        UpdateProcessorStreamingBase uProc = new UpdateProcessorStreamingBase(datasetGraph, inputBinding, context, f) ;
+        UpdateProcessorStreamingBase uProc = new UpdateProcessorStreamingBase(datasetGraph, inputBinding, cxt, f) ;
         return uProc;
     }
     

--- a/jena-core/src/main/java/org/apache/jena/assembler/JA.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/JA.java
@@ -82,7 +82,13 @@ public class JA
     public static final Property data = property( "data" );
 
     public static final Property content = property( "content" );
+    
+    public static final Property context = property( "context" );
 
+    public static final Property cxtName = property( "cxtName" );
+
+    public static final Property cxtValue = property( "cxtValue" );
+    
     public static final Resource ExternalContent = resource( "ExternalContent" );
 
     public static final Property externalContent = property( "externalContent" );

--- a/jena-core/src/main/java/org/apache/jena/sys/JenaSubsystemLifecycle.java
+++ b/jena-core/src/main/java/org/apache/jena/sys/JenaSubsystemLifecycle.java
@@ -18,15 +18,15 @@
 
 package org.apache.jena.sys;
 
-/** Lifecycle interface for jena modules and subsystems. */ 
+/** Lifecycle interface for jena modules and subsystems. */
 public interface JenaSubsystemLifecycle {
-    
-    /** start - a module should be ready to operate when this returns */  
+
+    /** start - a module should be ready to operate when this returns. */
     public void start() ;
-    
-    /** stop - a module should have preformed any shutdown operations by the time this returns */   
+
+    /** stop - a module should have performed any shutdown operations by the time this returns. */
     public void stop() ;
-    
+
     /** Provide a marker as to the level to order initialization, 10,20,30,... 
      * See {@link JenaSystem} for details.
      */

--- a/jena-core/src/main/java/org/apache/jena/sys/JenaSystem.java
+++ b/jena-core/src/main/java/org/apache/jena/sys/JenaSystem.java
@@ -28,14 +28,15 @@ import java.util.function.Consumer ;
  * All initialization should be concurrent and thread-safe.  In particular,
  * some subsystems need initialization in some sort of order (e.g. ARQ before TDB).
  * <p>
- * This is achieved by "levels": levels less than 100 are considered "jena system levels" 
- * and are reserved. 
+ * This is achieved by "levels": levels less than 100 are considered "Jena system levels" 
+ * and are reserved.
  * <ul>
  * <li>0 - reserved
  * <li>10 - jena-core
  * <li>20 - RIOT
  * <li>30 - ARQ
  * <li>40 - TDB
+ * <li>100-500 - Fuseki initialization, including customizations
  * <li>9999 - other
  * </ul>
  * See also the <a href="http://jena.apache.org/documentation/notes/system-initialization.html">notes on Jena initialization</a>.

--- a/jena-core/src/main/java/org/apache/jena/util/SplitIRI.java
+++ b/jena-core/src/main/java/org/apache/jena/util/SplitIRI.java
@@ -72,7 +72,7 @@ public class SplitIRI
         return namespace(string) ;
     }
 
-    /** Calculate a localname - enforce legal Turle
+    /** Calculate a localname - enforce legal Turtle
      * escape PN_LOCAL_ESC, check for final '.'
      * Use with {@link #namespaceTTL}
      */

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/assembler/DatasetAssemblerTDB.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/assembler/DatasetAssemblerTDB.java
@@ -73,7 +73,7 @@ public class DatasetAssemblerTDB extends DatasetAssembler
             //ja:context [ ja:cxtName "arq:queryTimeout";  ja:cxtValue "10000" ] ;
             tdb:unionGraph true; # or "true"
         */
-        AssemblerUtils.setContext(root, dsg.getContext());
+        AssemblerUtils.mergeContext(root, dsg.getContext());
         return DatasetFactory.wrap(dsg);
     }
 

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/EnvTDB.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/EnvTDB.java
@@ -45,15 +45,10 @@ public class EnvTDB
                 String keyStr = (String)key;
                 if ( keyStr.startsWith(prefix) )
                     keyStr = SystemTDB.symbolNamespace+keyStr.substring(prefix.length());
-
-
                 if ( ! keyStr.startsWith(SystemTDB.symbolNamespace) )
                     continue;
-
                 Object value = properties.get(key);
-
                 Symbol symbol = Symbol.create(keyStr);
-
                 context.set(symbol, value);
             }
         }

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/AccessCtl_Deny.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/AccessCtl_Deny.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.access;
+
+import org.apache.jena.atlas.lib.InternalErrorException;
+import org.apache.jena.fuseki.servlets.ActionService;
+import org.apache.jena.fuseki.servlets.HttpAction;
+import org.apache.jena.fuseki.servlets.ServletOps;
+
+/**
+ * An {@link ActionService} that rejects requests.
+ */
+public class AccessCtl_Deny extends ActionService {
+
+    private final String label;
+
+    public AccessCtl_Deny(String label) {
+        this.label = label;
+    }
+
+    @Override
+    public void validate(HttpAction action) {
+        if ( label == null )
+            ServletOps.errorBadRequest("Not supported");
+        ServletOps.errorBadRequest(label+" : not supported");
+    }
+
+    @Override
+    public void execute(HttpAction action) {
+        throw new InternalErrorException("AccessCtl_DenyUpdate: "+ "didn't reject request");
+    }
+}

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/DataAccessCtl.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/DataAccessCtl.java
@@ -89,7 +89,7 @@ public class DataAccessCtl {
             DatasetGraphAccessControl dsgx = (DatasetGraphAccessControl)dsgBase;
             if ( reg == dsgx.getAuthService() )
                 return dsgx;
-            throw new IllegalArgumentException("DatasetGraph is alerady wrapped on a DatasetGraphAccessControl with a different AuthorizationService");
+            throw new IllegalArgumentException("DatasetGraph is already wrapped on a DatasetGraphAccessControl with a different AuthorizationService");
         }
 
         DatasetGraphAccessControl dsg1 = new DatasetGraphAccessControl(dsgBase, reg);

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiExt.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiExt.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.build;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.jena.fuseki.server.Operation;
+import org.apache.jena.fuseki.server.OperationRegistry;
+import org.apache.jena.fuseki.servlets.ActionService;
+
+/** Operations to extend Fuseki with external code. */ 
+public class FusekiExt {
+
+    // Additional operations provided by extension, added via Jena init / typically ServiceLoader
+    static Map<String, Operation> extraOperationServicesRead;
+    static Map<String, Operation> extraOperationServicesWrite;
+
+    /** 
+     * Add a new operation, which will be included in a default configuration.
+     * The operation must have been added with {@link #registerOperation} first.
+     */
+    public static void addDefaultEndpoint(Operation op, String serviceName) {
+        // Include in both sets.
+        addDefaultEndpoint(op, serviceName, false);
+        addDefaultEndpoint(op, serviceName, true);
+    }
+
+    /**
+     * Add a new operation, which will be included in a default configuration,
+     * depending on whether it is for general inclusion or for inclusion for update
+     * only configuration.
+     * The operation must have been added with {@link #registerOperation} first.
+     */
+    public static void addDefaultEndpoint(Operation op, String serviceName, boolean forUpdate) {
+        // Due to class loading and ServiceLoader interaction, it is not reliable to
+        // set extraOperationServices as it is declared.
+        if ( extraOperationServicesRead == null )
+            extraOperationServicesRead = new HashMap<>();
+        if ( extraOperationServicesWrite == null )
+            extraOperationServicesWrite = new HashMap<>();
+        
+        if ( forUpdate )
+            extraOperationServicesWrite.put(serviceName, op);
+        else
+            extraOperationServicesRead.put(serviceName, op);
+    }
+
+    /** Make a new operation available. */
+    public static void registerOperation(Operation op, ActionService handler) {
+        OperationRegistry.get().register(op, null, handler);
+    }
+
+//    /**
+//     * Make a new operation available. The {@link EndpointFactory} is called with the
+//     * endpoint description when an endpoint with the operation is created.
+//     */
+//    public static void registerOperation(Operation op, EndpointFactory endpointFactory) {
+//        OperationRegistry.get().register(op, null, endpointFactory);
+//    }
+}

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/ActionServiceFactory.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/ActionServiceFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.server;
+
+import org.apache.jena.fuseki.servlets.ActionProcessor;
+import org.apache.jena.fuseki.servlets.ActionService;
+import org.apache.jena.rdf.model.Resource;
+
+/**
+ * Factory for creating the {@link ActionProcessor} for an endpoint. Each endpoint -
+ * a service name for a dataset has an associated {@link ActionProcessor} to handle
+ * the request. This created when the configuration file is read or the server built
+ * programmatically.
+ * 
+ * {@link ActionService} is a common super class of request handlers, includes counters
+ * for operations and has a validate-execute lifecycle.   
+ * 
+ * @see ActionService
+ */
+@FunctionalInterface 
+public interface ActionServiceFactory {
+    /**
+     * Create an {@linkService} (which can be shared with endpoints), given the description 
+     * which is a link into the server configuration graph.
+     */
+    public ActionService newActionService(Operation operation, Resource endpoint);  
+}

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/CounterName.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/CounterName.java
@@ -27,7 +27,7 @@ public class CounterName {
     static public CounterName register(String name, String hierarchicalName) {
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(hierarchicalName, "hierarchicalName");
-        return mgr.register(name, (n)->new CounterName(name, hierarchicalName));
+        return mgr.alloc(name, (n)->new CounterName(name, hierarchicalName));
     }
 
     // The "name" is used as a JSON key string.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPoint.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPoint.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.fuseki.server;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.jena.fuseki.servlets.HttpAction;
@@ -32,6 +33,8 @@ public class DataAccessPoint {
     private AtomicLong requests = new AtomicLong(0);
 
     public DataAccessPoint(String name, DataService dataService) {
+        Objects.requireNonNull(name, "DataAccessPoint name");
+        Objects.requireNonNull(dataService, "DataService");
         this.name = canonical(name);
         this.dataService = dataService;
         dataService.noteDataAccessPoint(this);

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPoint.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPoint.java
@@ -42,14 +42,19 @@ public class DataAccessPoint {
 
     public String getName()     { return name; }
 
+    /** Canonical name (path) for a dataset.
+     * This always starts with "/".
+     * It is the name within the Fuseki server, no servlet context path. 
+     */
     public static String canonical(String datasetPath) {
         if ( datasetPath == null )
             return datasetPath;
         if ( datasetPath.equals("/") )
-            datasetPath = "";
-        else
-            if ( !datasetPath.startsWith("/") )
-                datasetPath = "/" + datasetPath;
+            return datasetPath;
+        if ( datasetPath.equals("") )
+            return "/";
+        if ( !datasetPath.startsWith("/") )
+            datasetPath = "/" + datasetPath;
         if ( datasetPath.endsWith("/") )
             datasetPath = datasetPath.substring(0, datasetPath.length() - 1);
         return datasetPath;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPointRegistry.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPointRegistry.java
@@ -53,6 +53,12 @@ public class DataAccessPointRegistry extends Registry<String, DataAccessPoint>
             new FusekiRequestsMetrics( accessPt ).bindTo( meterRegistry );
         }
     }
+
+    @Override
+    public DataAccessPoint get(String key) {
+        return super.get(key);
+    }
+
     // Debugging
     public void print(String string) {
         System.out.flush();

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataService.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataService.java
@@ -104,7 +104,7 @@ public class DataService {
     }
 
     public void addEndpoint(Operation operation, String endpointName, AuthPolicy authPolicy) {
-        Endpoint endpoint = new Endpoint(operation, endpointName, authPolicy);
+        Endpoint endpoint = Endpoint.create(operation, endpointName, authPolicy);
         addEndpoint(endpoint);
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Endpoint.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Endpoint.java
@@ -20,8 +20,9 @@ package org.apache.jena.fuseki.server;
 
 import java.util.Objects;
 
-import org.apache.jena.atlas.lib.InternalErrorException;
 import org.apache.jena.fuseki.auth.AuthPolicy;
+import org.apache.jena.fuseki.servlets.ActionProcessor;
+import org.apache.jena.sparql.util.Context;
 
 /*
  * An {@code Endpoint} is an instance of an {@link Operation} within a {@link DataService} and has counters.
@@ -29,22 +30,37 @@ import org.apache.jena.fuseki.auth.AuthPolicy;
  */
 public class Endpoint implements Counters {
 
-    public final Operation   operation;
-    public final String      endpointName;
-    private final AuthPolicy authPolicy;
+    /** The endpoint name used for a dataset-level endpoint. */  
+    public static final String    DatasetEP = "";  
+    
+    private final Operation       operation;
+    private       ActionProcessor processor = null;
+    private final String          endpointName;
+    private final AuthPolicy      authPolicy;
+    private final Context         context;
     // Endpoint-level counters.
-    private final CounterSet counters = new CounterSet();
+    private final CounterSet      counters = new CounterSet();
 
+    public static EndpointBuilder create() { return EndpointBuilder.create(); }
+    
     public Endpoint(Operation operation, String endpointName, AuthPolicy requestAuth) {
+        this(operation, endpointName, requestAuth, null, new Context());
+    }
+    
+    public Endpoint(Operation operation, String endpointName, AuthPolicy requestAuth, ActionProcessor processor, Context context) {
         this.operation = Objects.requireNonNull(operation, "operation");
-        if ( operation == null )
-            throw new InternalErrorException("operation is null");
-        this.endpointName = endpointName;
+        // Canonicalise to "" for dataset-level operations.
+        this.endpointName = endpointName==null? DatasetEP : endpointName;
         this.authPolicy = requestAuth;
+        this.context = context;
+        this.processor = processor;
+        
         // Standard counters - there may be others
         counters.add(CounterName.Requests);
         counters.add(CounterName.RequestsGood);
         counters.add(CounterName.RequestsBad);
+        // Default. Better to explicitly set later.
+        //processor = OperationRegistry.get().findHandler(operation);
     }
 
     @Override
@@ -56,16 +72,28 @@ public class Endpoint implements Counters {
         return operation;
     }
 
-    public boolean isType(Operation operation) {
-        return operation.equals(operation);
+    public ActionProcessor getProcessor() {
+        return processor;
     }
 
+    /** Directly replace the {@link ActionProcessor}.
+     * This allows an endpoint to be created, and then latest have the ActionProcessor set,
+     * such as applying a default (normal case) or a security version injected.
+     */  
+    public void setProcessor(ActionProcessor proc) {
+        processor = proc;
+    }
+    
+    public Context getContext() {
+        return context;
+    }
+    
     public boolean isUnnamed() {
         return endpointName == null || endpointName.isEmpty();
     }
 
     public String getName() {
-        return isUnnamed() ? "" : endpointName;
+        return isUnnamed() ? DatasetEP : endpointName;
     }
 
     public AuthPolicy getAuthPolicy() {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Endpoint.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Endpoint.java
@@ -43,11 +43,13 @@ public class Endpoint implements Counters {
 
     public static EndpointBuilder create() { return EndpointBuilder.create(); }
     
-    public Endpoint(Operation operation, String endpointName, AuthPolicy requestAuth) {
-        this(operation, endpointName, requestAuth, null, new Context());
+    /** Build an endpoint */
+    public static Endpoint create(Operation operation, String endpointName, AuthPolicy requestAuth) {
+        // Common case.
+        return EndpointBuilder.create().operation(operation).endpointName(endpointName).authPolicy(requestAuth).build(); 
     }
     
-    public Endpoint(Operation operation, String endpointName, AuthPolicy requestAuth, ActionProcessor processor, Context context) {
+    /*package*/ Endpoint(Operation operation, String endpointName, AuthPolicy requestAuth, ActionProcessor processor, Context context) {
         this.operation = Objects.requireNonNull(operation, "operation");
         // Canonicalise to "" for dataset-level operations.
         this.endpointName = endpointName==null? DatasetEP : endpointName;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/EndpointBuilder.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/EndpointBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.server;
+
+import java.util.Objects;
+
+import org.apache.jena.fuseki.auth.AuthPolicy;
+import org.apache.jena.fuseki.servlets.ActionProcessor;
+import org.apache.jena.sparql.util.Context;
+
+/** {@link Endpoint} builder */
+public class EndpointBuilder {
+
+    private Context         context      = null;
+    private Operation       operation    = null;
+    private String          endpointName = null;
+    private AuthPolicy      authPolicy   = null;
+    private ActionProcessor processor    = null;
+
+    public static EndpointBuilder create() { return new EndpointBuilder(); }
+
+    private EndpointBuilder() { }
+
+    public EndpointBuilder operation(Operation operation) {
+        this.operation = operation;
+        return this;
+    }
+
+    public EndpointBuilder endpointName(String endpointName) {
+        this.endpointName = endpointName;
+        return this;
+    }
+
+    public EndpointBuilder context(Context context) {
+        this.context = context;
+        return this;
+    }
+
+    public EndpointBuilder authPolicy(AuthPolicy authPolicy) {
+        this.authPolicy = authPolicy;
+        return this;
+    }
+
+    public EndpointBuilder processor(ActionProcessor processor) {
+        this.processor = processor;
+        return this;
+    }
+
+    public Context context() { return context; }
+
+    public Operation operation() { return operation; }
+
+    public String endpointName() { return endpointName; }
+
+    public AuthPolicy authPolicy() { return authPolicy; }
+
+    public ActionProcessor processor() { return processor; }
+
+    public Endpoint build() {
+        Objects.requireNonNull(operation, "Operation for Endpoint");
+        return new Endpoint(operation, endpointName, authPolicy, processor, context);
+    }
+}

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/EndpointFactoryRegistry.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/EndpointFactoryRegistry.java
@@ -18,26 +18,9 @@
 
 package org.apache.jena.fuseki.server;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-
 /**
- * Management of intern'ed names {@code T} that can be used as keys. {@link #alloc}
- * creates an intern'ed {@code T}; if the object with the same name has already been
- * created, return the original. There is only ever one object for a given name.
- * <p>
- * {@code T ==} can be used to test of name match, though providing
- * {@code .hashCode} and {@code .equals} is preferred.
+ * 
  */
-public class NameMgr<T> {
-    private final Map<String, T> registered = new ConcurrentHashMap<>();
-    
-    public NameMgr() { }
-    
-    /** register, creating an object if necessary */
-    public T alloc(String name, Function<String, T> maker) {
-        return registered.computeIfAbsent(name, maker);
-    }
+public class EndpointFactoryRegistry {
 
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/EndpointSet.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/EndpointSet.java
@@ -25,7 +25,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
 import org.apache.jena.atlas.logging.Log;
-import org.apache.jena.fuseki.servlets.Dispatcher;
 import org.apache.jena.fuseki.servlets.HttpAction;
 
 /** Collection of endpoints for a dispatch point.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiVocab.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiVocab.java
@@ -52,7 +52,6 @@ public class FusekiVocab
     public static final Property pUnionDefaultGraph         = property("unionDefaultGraph");
     public static final Property pAllowTimeoutOverride      = property("allowTimeoutOverride");
     public static final Property pMaximumTimeoutOverride    = property("maximumTimeoutOverride");
-    
 
     // Server endpoints.
     public static final Property pServerPing        = property("pingEP");
@@ -67,13 +66,17 @@ public class FusekiVocab
     public static final Property pServiceReadWriteQuadsEP       = property("serviceReadWriteQuads");
     public static final Property pServiceReadQuadsEP            = property("serviceReadQuads");
 
-    // Operation names : the standard SPARQL operations. 
+    // Operation names : the standard operations. 
+    // "alt" names are the same but using "-" not "_".
     public static final Resource opQuery       = resource("query");
     public static final Resource opUpdate      = resource("update");
     public static final Resource opUpload      = resource("upload");
-    public static final Resource opGSP_r       = resource("gsp_r");
-    public static final Resource opGSP_rw      = resource("gsp_rw");
-    
+    public static final Resource opGSP_r       = resource("gsp-r");
+    public static final Resource opGSP_r_alt   = resource("gsp_r");
+    public static final Resource opGSP_rw      = resource("gsp-rw");
+    public static final Resource opGSP_rw_alt  = resource("gsp_rw");
+    public static final Resource opNoOp        = resource("no_op");
+    public static final Resource opNoOp_alt    = resource("no-op");
     
     // Internal
     private static final String stateNameActive     = DataServiceStatus.ACTIVE.name;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiVocab.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiVocab.java
@@ -20,7 +20,10 @@ package org.apache.jena.fuseki.server;
 
 import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.iri.IRI;
-import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.system.IRIResolver;
 
 public class FusekiVocab
@@ -33,17 +36,29 @@ public class FusekiVocab
     public static final Resource fusekiService      = resource("Service");
 
     public static final Property pServices          = property("services");
-    public static final Property pServiceName       = property("name");
 
-    public static final Property pAllowedUsers      = property("allowedUsers");
-    public static final Property pPasswordFile      = property("passwd");
-    public static final Property pRealm             = property("realm");
-    public static final Property pAuth              = property("auth");
+    // Endpoint description.
+    public static final Property pServiceName               = property("name");
+    public static final Property pEndpointName              = property("name");
+    public static final Property pPasswordFile              = property("passwd");
+    public static final Property pRealm                     = property("realm");
+    public static final Property pAuth                      = property("auth");
+    public static final Property pEndpoint                  = property("endpoint");
+    public static final Property pOperation                 = property("operation");
+    public static final Property pAllowedUsers              = property("allowedUsers");
+    public static final Property pTimeout                   = property("timeout");
+    public static final Property pImplementation            = property("implementation");
+    public static final Property pQueryLimit                = property("queryLimit");
+    public static final Property pUnionDefaultGraph         = property("unionDefaultGraph");
+    public static final Property pAllowTimeoutOverride      = property("allowTimeoutOverride");
+    public static final Property pMaximumTimeoutOverride    = property("maximumTimeoutOverride");
+    
 
     // Server endpoints.
     public static final Property pServerPing        = property("pingEP");
     public static final Property pServerStats       = property("statsEP");
 
+    // Endpoint description - old style.
     public static final Property pServiceQueryEP                = property("serviceQuery");
     public static final Property pServiceUpdateEP               = property("serviceUpdate");
     public static final Property pServiceUploadEP               = property("serviceUpload");
@@ -52,11 +67,15 @@ public class FusekiVocab
     public static final Property pServiceReadWriteQuadsEP       = property("serviceReadWriteQuads");
     public static final Property pServiceReadQuadsEP            = property("serviceReadQuads");
 
-    public static final Property pAllowTimeoutOverride          = property("allowTimeoutOverride");
-    public static final Property pMaximumTimeoutOverride        = property("maximumTimeoutOverride");
-
+    // Operation names : the standard SPARQL operations. 
+    public static final Resource opQuery       = resource("query");
+    public static final Resource opUpdate      = resource("update");
+    public static final Resource opUpload      = resource("upload");
+    public static final Resource opGSP_r       = resource("gsp_r");
+    public static final Resource opGSP_rw      = resource("gsp_rw");
+    
+    
     // Internal
-
     private static final String stateNameActive     = DataServiceStatus.ACTIVE.name;
     private static final String stateNameOffline    = DataServiceStatus.OFFLINE.name;
     private static final String stateNameClosing    = DataServiceStatus.CLOSING.name;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Operation.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Operation.java
@@ -27,6 +27,7 @@ import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.iri.IRI;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.system.IRIResolver;
 
 /**
@@ -52,7 +53,7 @@ public class Operation {
     
     /**
      * Create an Operation - this operation interns operations so there is only
-     * object for each operation. It is an extensible enum.
+     * one object for each operation. It is an extensible enum.
      */
     static public Operation alloc(String iriStr, String shortName, String description) {
         IRI iri = IRIResolver.parseIRI(iriStr);
@@ -82,7 +83,15 @@ public class Operation {
     public static final Operation Upload   = alloc(FusekiVocab.opUpload.asNode(), "upload", "File Upload");
     public static final Operation GSP_R    = alloc(FusekiVocab.opGSP_r.asNode(),  "gsp-r",  "Graph Store Protocol (Read)");
     public static final Operation GSP_RW   = alloc(FusekiVocab.opGSP_rw.asNode(), "gsp-rw", "Graph Store Protocol");
-
+    public static final Operation NoOp     = alloc(FusekiVocab.opNoOp.asNode(),   "no-op",  "No Op");
+    
+    static {
+        // Not everyone will remember "_" vs "-" so ...
+        altName(FusekiVocab.opNoOp_alt,   FusekiVocab.opNoOp); 
+        altName(FusekiVocab.opGSP_r_alt,  FusekiVocab.opGSP_r);
+        altName(FusekiVocab.opGSP_rw_alt, FusekiVocab.opGSP_rw);
+    }
+    
     private final Node id;
     private final String name;
     private final String description;
@@ -126,6 +135,15 @@ public class Operation {
     @Override
     public String toString() {
         return name;
+    }
+
+    private static void altName(Resource altName, Resource properName) {
+        altName(altName.asNode(), properName.asNode());
+    }
+
+    private static void altName(Node altName, Node properName) {
+        Operation op = mgr.get(properName);
+        mgr.put(altName, op);
     }
 }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Operation.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Operation.java
@@ -18,7 +18,16 @@
 
 package org.apache.jena.fuseki.server;
 
-import org.apache.jena.fuseki.servlets.OperationRegistry;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.jena.atlas.lib.IRILib;
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.iri.IRI;
+import org.apache.jena.riot.system.IRIResolver;
 
 /**
  * Operations are symbol to look up in the {@link OperationRegistry#operationToHandler} map. The name
@@ -27,32 +36,67 @@ import org.apache.jena.fuseki.servlets.OperationRegistry;
  */
 public class Operation {
 
-    /** Create/intern. */
-    static private NameMgr<Operation> mgr = new NameMgr<>();
-    static public Operation register(String name, String description) {
-        return mgr.register(name, (x)->create(x, description));
-    }
+    private static String NS = FusekiVocab.NS;
+    
+    /** Create/intern. Maps short name to operation. */
+    static private Map<Node, Operation> mgr = new HashMap<>();
 
+    static public Operation get(Node node) { return mgr.get(node); }
+    
+    /** @deprecated Use {@link #alloc(Node, String, String)}. */
+    @Deprecated
+    static public Operation register(String shortName, String description) {
+        String x = IRILib.encodeUriPath(shortName); 
+        return alloc("http://migration/"+x, shortName, description);
+    }
+    
+    /**
+     * Create an Operation - this operation interns operations so there is only
+     * object for each operation. It is an extensible enum.
+     */
+    static public Operation alloc(String iriStr, String shortName, String description) {
+        IRI iri = IRIResolver.parseIRI(iriStr);
+        if ( iri.hasViolation(false) )
+            Log.warn(Operation.class, "Poor Operation name: "+iriStr+" : Not an IRI");
+        if ( iri.isRelative() )
+            Log.warn(Operation.class, "Poor Operation name: "+iriStr+" : Relative IRI");
+        Node node = NodeFactory.createURI(iriStr);
+        return alloc(node, shortName, description);
+    }
+    
+    /**
+     * Create an Operation - this operation interns operations so there is only
+     * object for each operation. It is an extensible enum.
+     */
+    static public Operation alloc(Node op, String shortName, String description) {
+        return mgr.computeIfAbsent(op, (x)->create(x, shortName, description));
+    }
+    
     /** Create; not registered */
-    static private Operation create(String name, String description) {
-        return new Operation(name, description);
+    static private Operation create(Node id, String shortName, String description) {
+        return new Operation(id, shortName, description);
     }
 
-    public static final Operation Query          = register("Query", "SPARQL Query");
-    public static final Operation Update         = register("Update", "SPARQL Update");
-    public static final Operation Upload         = register("Upload", "File Upload");
-    public static final Operation Patch          = register("Patch", "RDF Patch");
-    public static final Operation GSP_R          = register("GSP_R", "Graph Store Protocol (Read)");
-    public static final Operation GSP_RW         = register("GSP_RW", "Graph Store Protocol");
+    public static final Operation Query    = alloc(FusekiVocab.opQuery.asNode(),  "query",  "SPARQL Query");
+    public static final Operation Update   = alloc(FusekiVocab.opUpdate.asNode(), "update", "SPARQL Update");
+    public static final Operation Upload   = alloc(FusekiVocab.opUpload.asNode(), "upload", "File Upload");
+    public static final Operation GSP_R    = alloc(FusekiVocab.opGSP_r.asNode(),  "gsp-r",  "Graph Store Protocol (Read)");
+    public static final Operation GSP_RW   = alloc(FusekiVocab.opGSP_rw.asNode(), "gsp-rw", "Graph Store Protocol");
 
-    private final String description;
+    private final Node id;
     private final String name;
-
-    private Operation(String name, String description) {
+    private final String description;
+    
+    private Operation(Node fullName, String name, String description) {
+        this.id = fullName;
         this.name = name;
         this.description = description;
     }
 
+    public Node getId() {
+        return id;
+    }
+    
     public String getName() {
         return name;
     }
@@ -63,30 +107,20 @@ public class Operation {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        return result;
+        return Objects.hash(id);
     }
 
     // Could be this == obj
     // because we intern'ed the object
-
+    
     @Override
     public boolean equals(Object obj) {
         if ( this == obj )
             return true;
-        if ( obj == null )
-            return false;
-        if ( getClass() != obj.getClass() )
+        if ( !(obj instanceof Operation) )
             return false;
         Operation other = (Operation)obj;
-        if ( name == null ) {
-            if ( other.name != null )
-                return false;
-        } else if ( !name.equals(other.name) )
-            return false;
-        return true;
+        return Objects.equals(id, other.id);
     }
 
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/OperationRegistry.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/OperationRegistry.java
@@ -46,6 +46,8 @@ public class OperationRegistry {
     private static final ActionService uploadServlet   = new SPARQL_Upload();
     private static final ActionService gspServlet_R    = new GSP_R();
     private static final ActionService gspServlet_RW   = new GSP_RW();
+    private static final ActionService noOperation     = new NoOpActionService();
+    
     
     /** The server-wide standard configuration. */
     private static final OperationRegistry stdConfig   = stdConfig();
@@ -59,11 +61,12 @@ public class OperationRegistry {
 
     private static OperationRegistry stdConfig() {
         OperationRegistry stdOpReg = new OperationRegistry();
-        stdOpReg.register(Operation.Query, WebContent.contentTypeSPARQLQuery, queryServlet);
-        stdOpReg.register(Operation.Update, WebContent.contentTypeSPARQLUpdate, updateServlet);
-        stdOpReg.register(Operation.Upload,   null, uploadServlet);
-        stdOpReg.register(Operation.GSP_R,    null, gspServlet_R);
-        stdOpReg.register(Operation.GSP_RW,   null, gspServlet_RW);
+        stdOpReg.register(Operation.Query,   WebContent.contentTypeSPARQLQuery, queryServlet);
+        stdOpReg.register(Operation.Update,  WebContent.contentTypeSPARQLUpdate, updateServlet);
+        stdOpReg.register(Operation.Upload,  null, uploadServlet);
+        stdOpReg.register(Operation.GSP_R,   null, gspServlet_R);
+        stdOpReg.register(Operation.GSP_RW,  null, gspServlet_RW);
+        stdOpReg.register(Operation.NoOp,    null, noOperation);
         return stdOpReg;
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionBase.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionBase.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.fuseki.servlets;
 
+import org.apache.jena.fuseki.server.Dispatcher;
+
 /**
  * Base of all implementations of service {@link HttpAction}. This class provides the
  * two steps execution of "validate" and "perform". 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionLib.java
@@ -54,7 +54,7 @@ public class ActionLib {
      */
     public static String mapRequestToDataset(HttpAction action) {
          String uri = action.getActionURI();
-         return mapActionRequestToDataset(uri);
+         return mapRequestToDataset(uri);
      }
 
     /** Map request to uri in the registry.
@@ -64,7 +64,7 @@ public class ActionLib {
      *  The URI must be the action URI (no contact path)
      */
 
-    public static String mapActionRequestToDataset(String uri) {
+    public static String mapRequestToDataset(String uri) {
         // Chop off trailing part - the service selector
         // e.g. /dataset/sparql => /dataset
         int i = uri.lastIndexOf('/');
@@ -79,7 +79,7 @@ public class ActionLib {
     }
 
     /** Calculate the operation, given action and data access point */
-    public static String mapRequestToOperation(HttpAction action, DataAccessPoint dsRef) {
+    public static String mapRequestToEndpointName(HttpAction action, DataAccessPoint dsRef) {
         if ( dsRef == null )
             return "";
         String uri = action.getActionURI();

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionProcessor.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionProcessor.java
@@ -41,12 +41,17 @@ public interface ActionProcessor {
         }
     }
 
-    public default void execHead(HttpAction action)     { ServletOps.errorMethodNotAllowed(METHOD_HEAD); }
-    public default void execGet(HttpAction action)      { ServletOps.errorMethodNotAllowed(METHOD_GET); }
-    public default void execPost(HttpAction action)     { ServletOps.errorMethodNotAllowed(METHOD_POST); }
-    public default void execPatch(HttpAction action)    { ServletOps.errorMethodNotAllowed(METHOD_PATCH); }
-    public default void execPut(HttpAction action)      { ServletOps.errorMethodNotAllowed(METHOD_PUT); }
-    public default void execDelete(HttpAction action)   { ServletOps.errorMethodNotAllowed(METHOD_DELETE); }
-    public default void execOptions(HttpAction action)  { ServletOps.errorMethodNotAllowed(METHOD_OPTIONS); }
-    public default void execTrace(HttpAction action)    { ServletOps.errorMethodNotAllowed(METHOD_TRACE); }
+    public default void execHead(HttpAction action)     { execAny(METHOD_HEAD,    action); }
+    public default void execGet(HttpAction action)      { execAny(METHOD_GET,     action); }
+    public default void execPost(HttpAction action)     { execAny(METHOD_POST,    action); }
+    public default void execPatch(HttpAction action)    { execAny(METHOD_PATCH,   action); }
+    public default void execPut(HttpAction action)      { execAny(METHOD_PUT,     action); }
+    public default void execDelete(HttpAction action)   { execAny(METHOD_DELETE,  action); }
+    public default void execOptions(HttpAction action)  { execAny(METHOD_OPTIONS, action); }
+    public default void execTrace(HttpAction action)    { execAny(METHOD_TRACE,   action); }
+    
+    // Override this for all HTTP verbs.
+    public default void execAny(String methodName, HttpAction action) {
+        ServletOps.errorMethodNotAllowed(methodName);
+    }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionREST.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionREST.java
@@ -162,11 +162,5 @@ public abstract class ActionREST extends ActionService
   // If not final in ActionBase
   //@Override public void process(HttpAction action)      { executeLifecycle(action); }
 
-  @Override public void execHead(HttpAction action)     { executeLifecycle(action); }
-  @Override public void execGet(HttpAction action)      { executeLifecycle(action); }
-  @Override public void execPost(HttpAction action)     { executeLifecycle(action); }
-  @Override public void execPatch(HttpAction action)    { executeLifecycle(action); }
-  @Override public void execPut(HttpAction action)      { executeLifecycle(action); }
-  @Override public void execDelete(HttpAction action)   { executeLifecycle(action); }
-  @Override public void execOptions(HttpAction action)  { executeLifecycle(action); }
+  @Override public void execAny(String methodName, HttpAction action)     { executeLifecycle(action); }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.server.Dispatcher;
 import org.slf4j.Logger;
 
 /** Look at all requests and see if they match a registered dataset name;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSPLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSPLib.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.servlets;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class GSPLib {
+
+    /** Check whether there is exactly one HTTP header value */
+    public static boolean hasExactlyOneValue(HttpAction action, String name) {
+        String[] values = action.request.getParameterValues(name);
+        if ( values == null )
+            return false;
+        if ( values.length == 0 )
+            return false;
+        if ( values.length > 1 )
+            return false;
+        return true;
+    }
+
+    /** Get one value where there may be several HTTP header values.
+     * Multiple values causes an exception.
+     * No value returns null.
+     */
+    public static String getOneOnly(HttpServletRequest request, String name) {
+        String[] values = request.getParameterValues(name);
+        if ( values == null )
+            return null;
+        if ( values.length == 0 )
+            return null;
+        if ( values.length > 1 )
+            ServletOps.errorBadRequest("Multiple occurrences of '" + name + "'");
+        return values[0];
+    }
+}

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSP_Base.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSP_Base.java
@@ -32,6 +32,8 @@ import org.apache.jena.sparql.core.DatasetGraph;
 
 public abstract class GSP_Base extends ActionREST {
 
+    protected GSP_Base() {}
+    
     @Override
     public void validate(HttpAction action) {
         if ( isQuads(action) )
@@ -91,8 +93,8 @@ public abstract class GSP_Base extends ActionREST {
 //        if ( ! dsg.isInTransaction() )
 //            ServletOps.errorOccurred("Internal error : No transaction");
 
-        boolean dftGraph = getOneOnly(action.request, HttpNames.paramGraphDefault) != null;
-        String uri = getOneOnly(action.request, HttpNames.paramGraph);
+        boolean dftGraph = GSPLib.getOneOnly(action.request, HttpNames.paramGraphDefault) != null;
+        String uri = GSPLib.getOneOnly(action.request, HttpNames.paramGraph);
 
         if ( !dftGraph && uri == null ) {
             // No params - direct naming.
@@ -136,29 +138,5 @@ public abstract class GSP_Base extends ActionREST {
     private static GSPTarget namedTarget(DatasetGraph dsg, String graphName) {
         Node gn = NodeFactory.createURI(graphName);
         return GSPTarget.createNamed(dsg, graphName, gn);
-    }
-
-    // XXX --> SPARQLProtocol
-    protected static boolean hasExactlyOneValue(HttpAction action, String name) {
-        String[] values = action.request.getParameterValues(name);
-        if ( values == null )
-            return false;
-        if ( values.length == 0 )
-            return false;
-        if ( values.length > 1 )
-            return false;
-        return true;
-    }
-
-    // XXX To a library. 
-    protected static String getOneOnly(HttpServletRequest request, String name) {
-        String[] values = request.getParameterValues(name);
-        if ( values == null )
-            return null;
-        if ( values.length == 0 )
-            return null;
-        if ( values.length > 1 )
-            ServletOps.errorBadRequest("Multiple occurrences of '" + name + "'");
-        return values[0];
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSP_R.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSP_R.java
@@ -33,6 +33,9 @@ import org.apache.jena.shared.JenaException;
 import org.apache.jena.sparql.core.DatasetGraph;
 
 public class GSP_R extends GSP_Base {
+    
+    public GSP_R() {}
+    
     @Override
     protected void doGet(HttpAction action) {
         if ( isQuads(action) )
@@ -41,7 +44,6 @@ public class GSP_R extends GSP_Base {
             execGetGSP(action);
     }
 
-    // XXX Generalize and combine by generalizing target.
     protected void execGetQuads(HttpAction action) {
         MediaType mediaType = ActionLib.contentNegotationQuads(action);
         ServletOutputStream output;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSP_RW.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSP_RW.java
@@ -43,7 +43,8 @@ import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.web.HttpSC;
 
 public class GSP_RW extends GSP_R {
-    // XXX Convert to GSPLib. 
+    
+    public GSP_RW() {}
     
     @Override
     protected void doOptions(HttpAction action) {
@@ -139,14 +140,14 @@ public class GSP_RW extends GSP_R {
     }
 
     /** Test whether the operation has exactly one GSP parameter and no other parameters. */ 
-    public static boolean hasGSPParamsStrict(HttpAction action) {
+    public static boolean xasGSPParamsStrict(HttpAction action) {
         if ( action.request.getQueryString() == null )
             return false;
         Map<String, String[]> params = action.request.getParameterMap();
         if ( params.size() != 1 )
             return false;
-        boolean hasParamGraphDefault = hasExactlyOneValue(action, HttpNames.paramGraphDefault);
-        boolean hasParamGraph = hasExactlyOneValue(action, HttpNames.paramGraph);
+        boolean hasParamGraphDefault = GSPLib.hasExactlyOneValue(action, HttpNames.paramGraphDefault);
+        boolean hasParamGraph = GSPLib.hasExactlyOneValue(action, HttpNames.paramGraph);
         // Java XOR
         return hasParamGraph ^ hasParamGraphDefault;
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
@@ -258,6 +258,8 @@ public class HttpAction
      * @param endpoint {@link Endpoint}
      */
     public void setEndpoint(Endpoint endpoint) {
+        if ( endpoint != null )
+            this.context = Context.mergeCopy(getContext(), endpoint.getContext());
         this.endpoint = endpoint;
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/NoOpActionService.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/NoOpActionService.java
@@ -16,25 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.jena.fuseki.main;
+package org.apache.jena.fuseki.servlets;
 
-import org.apache.jena.fuseki.main.access.TS_SecurityFuseki;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+/** An {@link ActionService} that denies service. 
+ *  Used to turn things off.
+ */ 
+public class NoOpActionService extends ActionService {
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
-  TS_FusekiMain.class,
-  TS_SecurityFuseki.class
-})
-public class TC_FusekiMain {
-    @BeforeClass public static void setupForFusekiServer() {
-        // controlled by src/test/resources/log4j.properties.
-//        LogCtl.setLevel(Fuseki.serverLogName,        "WARN");
-//        LogCtl.setLevel(Fuseki.actionLogName,        "WARN");
-//        LogCtl.setLevel(Fuseki.requestLogName,       "WARN");
-//        LogCtl.setLevel(Fuseki.adminLogName,         "WARN");
-//        LogCtl.setLevel("org.eclipse.jetty",         "WARN");
+    @Override
+    public void validate(HttpAction action) {
+        ServletOps.errorBadRequest(action.getActionURI());
     }
+
+    @Override
+    public void execute(HttpAction action) {
+        ServletOps.errorBadRequest(action.getActionURI());
+    }
+    
+    @Override public void execAny(String methodName, HttpAction action)     { executeLifecycle(action); }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
@@ -49,7 +49,6 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Prologue;
 import org.apache.jena.sparql.engine.EngineLib;
 import org.apache.jena.sparql.resultset.SPARQLResult;
-import org.apache.jena.sparql.util.Context;
 import org.apache.jena.web.HttpSC;
 
 /**
@@ -304,16 +303,7 @@ public abstract class SPARQLQueryProcessor extends ActionService
      * @return QueryExecution
      */
     protected QueryExecution createQueryExecution(HttpAction action, Query query, DatasetGraph dataset) {
-        QueryExecution queryExecution = QueryExecutionFactory.create(query, dataset);
-        // The QueryExecution already has the global and dataset context already.
-        // We just need to overlay the endpoint details.
-        // The action has a merged context but QueryExecutionFactory does it's own thing.
-        // Revisit for QueryExecutionBuilder
-        if ( action.getEndpoint() != null ) {
-            Context cxt = action.getEndpoint().getContext();
-            queryExecution.getContext().putAll(cxt);
-        }
-        return queryExecution;
+        return QueryExecution.create().query(query).dataset(dataset).context(action.getContext()).build();
     }
 
     /** Perform the {@link QueryExecution} once.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryGeneral.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryGeneral.java
@@ -54,9 +54,15 @@ public class SPARQL_QueryGeneral extends ServletAction {
 
         public SPARQL_QueryProc() { super(); }
 
-        static private DataService dSrv = new DataService(new DatasetGraphZero());
-        static private DataAccessPoint dap = new DataAccessPoint(null, dSrv);
+        static private DataService dSrv = emptyDataService();
+        static private DataAccessPoint dap = new DataAccessPoint("SPARQL General", dSrv);
 
+        static DataService emptyDataService() {
+            DataService dSrv = new DataService(new DatasetGraphZero());
+            dSrv.goActive();
+            return dSrv;
+        } 
+        
         @Override
         public void executeLifecycle(HttpAction action) {
             action.setRequest(dap, dSrv);

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
@@ -94,7 +94,8 @@ public class FusekiLib {
 
         // Block updates (can just not register these operations).
         builder.registerOperation(Operation.Update, WebContent.contentTypeSPARQLUpdate, new AccessCtl_Deny("Update"));
-        builder.registerOperation(Operation.GSP_RW, new AccessCtl_AllowGET(new GSP_RW(), "GSP Write", determineUser));
+        builder.registerOperation(Operation.GSP_RW, new AccessCtl_AllowGET(new GSP_RW(), "GSP Write"));
+        builder.registerOperation(Operation.GSP_RW, new AccessCtl_GSP_R(determineUser));
         return builder;
     }
 
@@ -126,7 +127,7 @@ public class FusekiLib {
        if ( Operation.GSP_R.equals(op) )
            return new AccessCtl_GSP_R(determineUser);
        if ( Operation.GSP_RW.equals(op) )
-           return new AccessCtl_AllowGET(new GSP_RW(), "GSP Read-only", determineUser);
+           return new AccessCtl_GSP_R(determineUser);
        return new AccessCtl_Deny("Not supported for graph level access control: "+op.getDescription());
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -740,7 +740,11 @@ public class FusekiServer {
             if ( ! dataAccessPoints.isRegistered(name) )
                 throw new FusekiConfigException("Dataset not registered: "+datasetName);
             DataAccessPoint dap = dataAccessPoints.get(name);
-            Endpoint endpoint = new Endpoint(operation, endpointName, authPolicy);
+            Endpoint endpoint = Endpoint.create()
+                .operation(operation)
+                .endpointName(endpointName)
+                .authPolicy(authPolicy)
+                .build();
             dap.getDataService().addEndpoint(endpoint);
         }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -33,7 +33,7 @@ import org.apache.jena.atlas.web.AuthScheme;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiConfigException;
 import org.apache.jena.fuseki.FusekiException;
-import org.apache.jena.fuseki.access.DataAccessCtl;
+import org.apache.jena.fuseki.access.*;
 import org.apache.jena.fuseki.auth.Auth;
 import org.apache.jena.fuseki.auth.AuthPolicy;
 import org.apache.jena.fuseki.build.FusekiConfig;
@@ -92,8 +92,8 @@ import org.slf4j.Logger;
  * <pre>
  *    FusekiServer.make(1234, "/ds", dsg).start();
  * </pre>
- *
  */
+
 public class FusekiServer {
     static { JenaSystem.init(); }
     
@@ -232,9 +232,9 @@ public class FusekiServer {
 
     /** FusekiServer.Builder */
     public static class Builder {
-        private final DataAccessPointRegistry  dataAccessPoints   = new DataAccessPointRegistry(
-                MetricsProviderRegistry.get().getMeterRegistry());
-        private final OperationRegistry  serviceDispatch;
+        private final DataAccessPointRegistry  dataAccessPoints = 
+            new DataAccessPointRegistry( MetricsProviderRegistry.get().getMeterRegistry() );
+        private final OperationRegistry  operationRegistry;
         // Default values.
         private int                      serverPort         = 3330;
         private int                      serverHttpsPort    = -1;
@@ -266,13 +266,14 @@ public class FusekiServer {
         private Map<String, Object>      servletAttr        = new HashMap<>();
         // Builder with standard operation-action mapping.
         Builder() {
-            this.serviceDispatch = new OperationRegistry(true);
+            this.operationRegistry = OperationRegistry.createStd();
         }
 
         // Builder with provided operation-action mapping.
-        Builder(OperationRegistry  serviceDispatch) {
+        Builder(OperationRegistry  operationRegistry) {
             // Isolate.
-            this.serviceDispatch = new OperationRegistry(serviceDispatch);
+            this.operationRegistry = OperationRegistry.createEmpty();
+            OperationRegistry.copyConfig(operationRegistry, this.operationRegistry);
         }
 
         /** Set the port to run on.
@@ -676,9 +677,9 @@ public class FusekiServer {
         public Builder registerOperation(Operation operation, String contentType, ActionService handler) {
             Objects.requireNonNull(operation, "operation");
             if ( handler == null )
-                serviceDispatch.unregister(operation);
+                operationRegistry.unregister(operation);
             else
-                serviceDispatch.register(operation, contentType, handler);
+                operationRegistry.register(operation, contentType, handler);
             return this;
         }
 
@@ -690,7 +691,7 @@ public class FusekiServer {
         public Builder addEndpoint(String datasetName, String endpointName, Operation operation) {
             return addEndpoint(datasetName, endpointName, operation, null);
         }
-        
+
         /**
          * Create an endpoint as a service of the dataset (i.e. {@code /dataset/endpointName}).
          * The operation must already be registered with the builder.
@@ -703,7 +704,7 @@ public class FusekiServer {
             serviceEndpointOperation(datasetName, endpointName, operation, authPolicy);
             return this;
         }
-            
+
         /**
          * Create an endpoint on the dataset i.e. {@code /dataset/} for an operation that has other query parameters
          * or a Content-Type that distinguishes it.  
@@ -714,10 +715,12 @@ public class FusekiServer {
             addOperation(datasetName, operation, null);
             return this;
         }
-        
+
         /**
          * Create an endpoint on the dataset i.e. {@code /dataset/} for an operation that has other query parameters
-         * or a Content-Type that distinguishes it.  
+         * or a Content-Type that distinguishes it.  Use {@link #addEndpoint(String, String, Operation)} when
+         * the functionality is invoked by presence of a name in the URL after the dataset name.  
+         * 
          * The operation must already be registered with the builder.
          * @see #registerOperation(Operation, ActionService)
          */
@@ -731,13 +734,14 @@ public class FusekiServer {
         private void serviceEndpointOperation(String datasetName, String endpointName, Operation operation, AuthPolicy authPolicy) {
             String name = DataAccessPoint.canonical(datasetName);
 
-            if ( ! serviceDispatch.isRegistered(operation) )
+            if ( ! operationRegistry.isRegistered(operation) )
                 throw new FusekiConfigException("Operation not registered: "+operation.getName());
 
             if ( ! dataAccessPoints.isRegistered(name) )
                 throw new FusekiConfigException("Dataset not registered: "+datasetName);
             DataAccessPoint dap = dataAccessPoints.get(name);
-            FusekiConfig.addServiceEP(dap.getDataService(), operation, endpointName, authPolicy);
+            Endpoint endpoint = new Endpoint(operation, endpointName, authPolicy);
+            dap.getDataService().addEndpoint(endpoint);
         }
 
         /**
@@ -776,7 +780,7 @@ public class FusekiServer {
 
         // These booleans are only for validation.
         // They do not affect the build() step. 
-        
+
         // Triggers some checking.
         private boolean hasAuthenticationHandler = false;
         
@@ -864,18 +868,23 @@ public class FusekiServer {
 
             // Clone to isolate from any future changes (reusing the builder).
             DataAccessPointRegistry dapRegistry = new DataAccessPointRegistry(dataAccessPoints);
-            OperationRegistry svcRegistry = new OperationRegistry(serviceDispatch);
-
-            OperationRegistry.set(cxt, svcRegistry);
+            OperationRegistry operationReg = new OperationRegistry(operationRegistry);
+            OperationRegistry.set(cxt, operationReg);
             DataAccessPointRegistry.set(cxt, dapRegistry);
             JettyLib.setMimeTypes(handler);
             servletsAndFilters(handler);
             buildAccessControl(handler);
-
-            if ( hasDataAccessControl ) {
-                // Consider making this "always" and changing the standard operation bindings.
-                FusekiLib.modifyForAccessCtl(svcRegistry, DataAccessCtl.requestUserServlet);
-            }
+            
+            dapRegistry.forEach((name, dap) -> {
+                // Custom processors (endpoint specific,fuseki:implementation) will have already
+                // been set; all others need setting from the OperationRegistry in scope. 
+                dap.getDataService().setEndpointProcessors(operationReg);
+                dap.getDataService().forEachEndpoint(ep->{
+                    // Override for graph-level access control. 
+                    if ( DataAccessCtl.isAccessControlled(dap.getDataService().getDataset()) )
+                        FusekiLib.modifyForAccessCtl(ep, DataAccessCtl.requestUserServlet);
+                });
+            });
 
             // Start services.
             dapRegistry.forEach((name, dap)->dap.getDataService().goActive());
@@ -901,9 +910,8 @@ public class FusekiServer {
                                 JettyLib.addPathConstraint(csh, DataAccessPoint.canonical(name)+"/*");
                             }
                             else {
-                                // TODO Rethink/check.
                                 // Need to to a pass to find the "right" set to install.
-                                dap.getDataService().getEndpoints().forEach(ep->{
+                                dap.getDataService().forEachEndpoint(ep->{
                                     // repeats.
                                     if ( ! authAny(ep.getAuthPolicy()) ) {
                                         // Unnamed - applies to the dataset. Yuk.  

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -32,8 +32,8 @@ import org.apache.jena.atlas.lib.Pair;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.metrics.MetricsProviderRegistry;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
+import org.apache.jena.fuseki.server.OperationRegistry;
 import org.apache.jena.fuseki.servlets.ActionBase;
-import org.apache.jena.fuseki.servlets.OperationRegistry;
 import org.apache.jena.riot.web.HttpNames;
 import org.apache.jena.web.HttpSC;
 import org.eclipse.jetty.http.HttpMethod;
@@ -305,7 +305,7 @@ public class JettyServer {
             // plain Jetty server, e.g. to use Fuseki logging.
             try {
                 Fuseki.setVerbose(cxt, verbose);
-                OperationRegistry.set(cxt, new OperationRegistry(false));
+                OperationRegistry.set(cxt, OperationRegistry.createEmpty());
                 DataAccessPointRegistry.set(cxt, new DataAccessPointRegistry(MetricsProviderRegistry.get().getMeterRegistry()));
             } catch (NoClassDefFoundError err) {
                 LOG.info("Fuseki classes not found");

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -566,9 +566,10 @@ public class FusekiMain extends CmdARQ {
                 dSrv.getOperations().forEach((op)->{
                     dSrv.getEndpoints(op).forEach(ep-> {
                         String x = ep.getName();
-                        if ( x.isEmpty() )
-                            x = "quads";
-                        endpoints.add(x);
+                        x = "\""+x+"\"";
+                        String opName = ep.getOperation().getName();
+                        String str = x+"=>"+opName;
+                        endpoints.add(str);
                     });
                 });
             });

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestConfigFile.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestConfigFile.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.main;
+
+import static org.apache.jena.fuseki.test.FusekiTest.expect400;
+import static org.apache.jena.fuseki.test.FusekiTest.expect404;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.atlas.lib.StrUtils;
+import org.apache.jena.atlas.web.WebLib;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.rdfconnection.RDFConnection;
+import org.apache.jena.rdfconnection.RDFConnectionFactory;
+import org.apache.jena.rdfconnection.RDFConnectionRemote;
+import org.apache.jena.rdfconnection.RDFConnectionRemoteBuilder;
+import org.apache.jena.sparql.core.Var;
+import org.junit.Test;
+
+/** Test server configuration by configuration file */ 
+public class TestConfigFile {
+
+    private static final String DIR = "testing/Config/";
+    
+    private static final String PREFIXES = StrUtils.strjoinNL
+        ("PREFIX afn: <http://jena.apache.org/ARQ/function#>" 
+        ,"PREFIX fuseki: <http://jena.apache.org/fuseki#>"
+        ,"PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>"
+        ,"PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"
+        , ""
+        );
+    
+    private static RDFConnection namedServices(String baseURL) {
+        return RDFConnectionRemote.create()
+            .destination(baseURL)
+            .queryEndpoint("sparql")
+            .updateEndpoint("update")
+            .gspEndpoint("data")
+            .build();
+    }
+    
+    @Test public void basic () {
+        int port = WebLib.choosePort(); 
+        FusekiServer server = server(port, "basic.ttl");
+        server.start();
+        try ( RDFConnection conn = RDFConnectionFactory.connect("http://localhost:"+port+"/ds") ) {
+            assertCxtValueNotNull (conn, "CONTEXT:SERVER");
+            assertCxtValue        (conn, "CONTEXT:SERVER", "server");
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test public void context() {
+        int port = WebLib.choosePort(); 
+        FusekiServer server = server(port, "context.ttl");
+        server.start();
+        try {
+            try ( RDFConnection conn = RDFConnectionFactory.connect("http://localhost:"+port+"/ds-server") ) {
+                assertCxtValue     (conn, "CONTEXT:SERVER",   "server");
+                assertCxtValueNull (conn, "CONTEXT:DATASET");
+                assertCxtValueNull (conn, "CONTEXT:ENDPOINT");
+                assertCxtValue     (conn, "CONTEXT:ABC",      "server-abc");
+            }
+            try ( RDFConnection conn = RDFConnectionFactory.connect("http://localhost:"+port+"/ds-dataset") ) {
+                assertCxtValue     (conn, "CONTEXT:SERVER",   "server");
+                assertCxtValue     (conn, "CONTEXT:DATASET",  "dataset");
+                assertCxtValueNull (conn, "CONTEXT:ENDPOINT");
+                assertCxtValue     (conn, "CONTEXT:ABC",      "dataset-abc");
+            }
+            try ( RDFConnection conn = RDFConnectionFactory.connect("http://localhost:"+port+"/ds-endpoint") ) {
+                assertCxtValue     (conn, "CONTEXT:SERVER",   "server");
+                assertCxtValue     (conn, "CONTEXT:DATASET",  "dataset");
+                assertCxtValue     (conn, "CONTEXT:ENDPOINT", "endpoint");
+                assertCxtValue     (conn, "CONTEXT:ABC",      "endpoint-abc");
+            }
+        } finally { server.stop(); }
+    }
+
+    @Test public void stdServicesNamed () {
+        int port = WebLib.choosePort(); 
+        FusekiServer server = server(port, "std-named.ttl");
+        String serverURL = "http://localhost:"+port+"/ds-named";
+        server.start();
+        try {
+            try ( RDFConnection conn = namedServices(serverURL) ) {
+                // Try each operation. The test is whether the operations can be called.
+                conn.update("INSERT DATA { <x:s> <x:p> 123 }");
+                conn.queryAsk("ASK{}");
+                Graph g = conn.fetch().getGraph();
+                assertEquals(1, g.size());
+            }
+            
+            // These should not work because there is a blocking dataset service (no-op).
+            try ( RDFConnection conn =  RDFConnectionFactory.connect(serverURL) ) {
+                expect400(()->conn.update("INSERT DATA { <x:s> <x:p> 123 }"));
+                expect400(()->conn.queryAsk("ASK{}"));
+                expect400(()->conn.fetch());
+            }
+            // Does not cover file upload which is UI-only for HTML file upload.
+        } finally {
+            server.stop();
+        }
+    }
+    
+    @Test public void stdServicesDirect () {
+        int port = WebLib.choosePort(); 
+        FusekiServer server = server(port, "std-dataset.ttl");
+        String serverURL = "http://localhost:"+port+"/ds-direct";
+        server.start();
+        try {
+            try ( RDFConnection conn =  RDFConnectionFactory.connect(serverURL) ) {
+                conn.update("INSERT DATA { <x:s> <x:p> 123 }");
+                conn.queryAsk("ASK{}");
+                Graph g = conn.fetch().getGraph();
+                assertEquals(1, g.size());
+            }
+            
+            // No named endpoints.
+            try ( RDFConnection conn = namedServices(serverURL) ) {
+                expect404(()->conn.update("INSERT DATA { <x:s> <x:p> 123 }"));
+                expect404(()->conn.queryAsk("ASK{}"));
+                expect404(()->conn.fetch());
+            }
+            
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test public void stdServicesNoConfig() {
+        int port = WebLib.choosePort(); 
+        FusekiServer server = server(port, "std-empty.ttl");
+        String serverURL = "http://localhost:"+port+"/ds-no-ep";
+        
+        server.start();
+        try {
+            try ( RDFConnection conn =  RDFConnectionFactory.connect(serverURL) ) {
+                // 400 if on the dataset
+                expect400(()->conn.queryAsk("ASK{}"));
+            }
+            RDFConnectionRemoteBuilder builder = RDFConnectionRemote.create()
+                .destination(serverURL)
+                .queryEndpoint("sparql")
+                .updateEndpoint("update")
+                .gspEndpoint("data");
+            try ( RDFConnection conn = builder.build() ) {
+                // 404 if on an absent named service
+                expect404(()->conn.queryAsk("ASK{}"));
+            }
+        } finally {
+            server.stop();
+        }
+    }
+    
+    @Test public void stdServicesGeneral() {
+        int port = WebLib.choosePort(); 
+        FusekiServer server = server(port, "std-general.ttl");
+        String serverURL = "http://localhost:"+port+"/ds";
+        
+        server.start();
+        try {
+            // Either style.
+            
+            try ( RDFConnection conn =  RDFConnectionFactory.connect(serverURL) ) {
+                conn.update("INSERT DATA { <x:s> <x:p> 123 }");
+                conn.queryAsk("ASK{}");
+                Graph g = conn.fetch().getGraph();
+                assertEquals(1, g.size());
+            }
+            RDFConnectionRemoteBuilder builder = RDFConnectionRemote.create()
+                .destination(serverURL)
+                .queryEndpoint("sparql")
+                .updateEndpoint("update")
+                .gspEndpoint("data");
+            try ( RDFConnection conn = builder.build() ) {
+                conn.update("INSERT DATA { <x:s> <x:p> 123 }");
+                conn.queryAsk("ASK{}");
+                Graph g = conn.fetch().getGraph();
+                assertEquals(1, g.size());
+            }
+            
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static String NL = "\n";
+    
+    @Test public void unionGraph1() {
+        unionGraph("tdb1-endpoints.ttl","/ds-tdb1");
+    }
+    
+    @Test public void unionGraph2() {
+        unionGraph("tdb2-endpoints.ttl","/ds-tdb2");
+    }
+    
+    @Test public void setupOpsSameName() {
+        int port = WebLib.choosePort(); 
+        FusekiServer server = server(port, "setup1.ttl");
+        String serverURL = "http://localhost:"+port+"/ds";
+        server.start();
+        try {
+            try ( RDFConnection conn =  RDFConnectionFactory.connect(serverURL+"/sparql") ) {
+                conn.update("INSERT DATA { <x:s> <x:p> 1,2,3 }");
+                int x = countDftGraph(conn);
+                assertEquals(3, x);
+            }
+        } finally {
+            server.stop();
+        }
+    }
+    
+    @Test public void setupRootDataset() {
+        int port = WebLib.choosePort(); 
+        FusekiServer server = server(port, "setup2.ttl");
+        String serverURL = "http://localhost:"+port+"/";
+        server.start();
+        try {
+            try ( RDFConnection conn =  RDFConnectionFactory.connect(serverURL) ) {
+                conn.update("INSERT DATA { <x:s> <x:p> 1,2,3,4 }");
+                int x = countDftGraph(conn);
+                assertEquals(4, x);
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    private void unionGraph(String fnConfig, String dbName) {
+        int port = WebLib.choosePort(); 
+        FusekiServer server = server(port, fnConfig);
+        String serverURL = "http://localhost:"+port+dbName;
+        server.start();
+        
+        try {
+            try ( RDFConnection conn =  RDFConnectionFactory.connect(serverURL) ) {
+                conn.update("INSERT DATA {"+NL+
+                    "<x:s> <x:p> 'dft'"+NL+
+                    "GRAPH <x:g1> { <x:s> <x:p> 'g1' }"+NL+
+                    "GRAPH <x:g2> { <x:s> <x:p> 'g2' }"+NL+
+                    " }");
+                int x = countDftGraph(conn);
+                assertEquals(1, x);
+            }
+            // Query union endpoint.
+            RDFConnectionRemoteBuilder builder = RDFConnectionRemote.create()
+                .destination(serverURL)
+                .queryEndpoint("sparql-union");
+            try ( RDFConnection conn = builder.build() ) {
+                int x = countDftGraph(conn);
+                assertEquals(2, x);
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    private static int countDftGraph(RDFConnection conn) {
+        try ( QueryExecution qExec = conn.query("SELECT (count(*) AS ?C) { ?s ?p ?o }") ) {
+            Object obj = qExec.execSelect().nextBinding().get(Var.alloc("C")).getIndexingValue();
+            int x = ((Number)obj).intValue();
+            return x;
+        }
+    }
+    
+    
+    
+    private static void assertCxtValue(RDFConnection conn, String contextSymbol, String value) {
+        String actual = 
+            conn.query(PREFIXES+"SELECT ?V { BIND(afn:context('"+contextSymbol+"') AS ?V) }")
+            .execSelect()
+            .nextBinding().get(Var.alloc("V"))
+            .getLiteralLexicalForm();
+        assertEquals(value, actual);
+    }
+    
+    private static void assertCxtValueNotNull(RDFConnection conn, String contextSymbol) {
+        boolean b = conn.queryAsk(PREFIXES+"ASK { FILTER (afn:context('"+contextSymbol+"') != '' ) }");
+        assertTrue(contextSymbol, b);
+    }
+
+    private static void assertCxtValueNull(RDFConnection conn, String contextSymbol) {
+        boolean b = conn.queryAsk(PREFIXES+"ASK { FILTER (afn:context('"+contextSymbol+"') = '' ) }");
+        assertTrue("Not null: "+contextSymbol, b);
+    }
+    private static void assertQueryTrue(RDFConnection conn, String qs) {
+        boolean b = conn.queryAsk(PREFIXES+qs);
+        assertTrue(qs, b);
+    }
+
+    private static void assertQueryFalse(RDFConnection conn, String qs) {
+        boolean b = conn.queryAsk(PREFIXES+qs);
+        assertFalse(qs, b);
+    }
+
+    private FusekiServer server(int port, String configFile) {
+        FusekiServer server = FusekiServer.create()
+            .parseConfigFile(DIR+configFile)
+            .port(port)
+            .build();
+        return server;
+    }    
+}

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestEmbeddedFuseki.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestEmbeddedFuseki.java
@@ -123,9 +123,9 @@ public class TestEmbeddedFuseki {
         });
 
         DataService dataService = new DataService(dsg);
-        dataService.addEndpointNoName(Operation.GSP_RW);
-        dataService.addEndpointNoName(Operation.Query);
-        dataService.addEndpointNoName(Operation.Update);
+        dataService.addEndpoint(Operation.GSP_RW);
+        dataService.addEndpoint(Operation.Query);
+        dataService.addEndpoint(Operation.Update);
         int port = WebLib.choosePort();
 
         FusekiServer server = FusekiServer.create()

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiCustomOperation.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiCustomOperation.java
@@ -32,6 +32,7 @@ import org.apache.jena.atlas.web.TypedInputStream;
 import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.FusekiConfigException;
 import org.apache.jena.fuseki.build.FusekiConfig;
+import org.apache.jena.fuseki.build.FusekiExt;
 import org.apache.jena.fuseki.server.DataService;
 import org.apache.jena.fuseki.server.Operation;
 import org.apache.jena.fuseki.servlets.ActionService;
@@ -48,7 +49,7 @@ import org.junit.Test;
 
 /** Test for adding a new operation */
 public class TestFusekiCustomOperation {
-    private static final Operation newOp = Operation.register("Special", "Custom operation");
+    private static final Operation newOp = Operation.alloc("http://example/special", "special", "Custom operation");
     private static final String contentType = "application/special";
     private static final String endpointName = "special";
 
@@ -94,6 +95,7 @@ public class TestFusekiCustomOperation {
         DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
         DataService dataService = new DataService(dsg);
         FusekiConfig.populateStdServices(dataService, true);
+        FusekiExt.registerOperation(newOp, customHandler);
         FusekiConfig.addServiceEP(dataService, newOp, endpointName);
 
         FusekiServer server =

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiCustomOperation.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiCustomOperation.java
@@ -89,7 +89,7 @@ public class TestFusekiCustomOperation {
     private final String url = "http://localhost:"+port;
 
     @Test
-    public void cfg_dataservice() {
+    public void cfg_dataservice_named() {
         // Create a DataService and add the endpoint -> operation association.
         // This still needs the server to have the operation registered.
         DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
@@ -104,11 +104,31 @@ public class TestFusekiCustomOperation {
                 .registerOperation(newOp, contentType, customHandler)
                 .add("/ds", dataService)
                 .build();
-        testServer(server, true, true);
+        testServer(server, url, endpointName, true);
     }
 
     @Test
-    public void cfg_builder_CT() {
+    public void cfg_dataservice_unnamed() {
+        // Create a DataService and add the endpoint -> operation association.
+        // This still needs the server to have the operation registered.
+        DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
+        DataService dataService = new DataService(dsg);
+        FusekiConfig.populateStdServices(dataService, true);
+        FusekiExt.registerOperation(newOp, customHandler);
+        FusekiConfig.addServiceEP(dataService, newOp, null);
+
+        FusekiServer server =
+            FusekiServer.create()
+                .port(port)
+                .registerOperation(newOp, contentType, customHandler)
+                .add("/ds", dataService)
+                .build();
+        // No endpoint name dispatch - content-type required.
+        testServer(server, url, null, true);
+    }
+
+    @Test
+    public void cfg_builder_CT_named() {
         FusekiServer server =
             FusekiServer.create()
                 .port(port)
@@ -116,7 +136,19 @@ public class TestFusekiCustomOperation {
                 .add("/ds", DatasetGraphFactory.createTxnMem(), true)
                 .addEndpoint("/ds", endpointName, newOp)
                 .build();
-        testServer(server, true, true);
+        testServer(server, url, endpointName, true);
+    }
+
+    @Test
+    public void cfg_builder_CT_noName() {
+        FusekiServer server =
+            FusekiServer.create()
+                .port(port)
+                .registerOperation(newOp, contentType, customHandler)
+                .add("/ds", DatasetGraphFactory.createTxnMem(), true)
+                .addEndpoint("/ds", "", newOp)
+                .build();
+        testServer(server, url, null, true);
     }
 
     @Test
@@ -128,7 +160,7 @@ public class TestFusekiCustomOperation {
                 .add("/ds", DatasetGraphFactory.createTxnMem(), true)
                 .addEndpoint("/ds", endpointName, newOp)
                 .build();
-        testServer(server, true, false);
+        testServer(server, url, endpointName, false);
     }
 
     @Test(expected=FusekiConfigException.class)
@@ -151,7 +183,7 @@ public class TestFusekiCustomOperation {
         //.build();
     }
 
-    public void cfg_bad_ct_not_enabkled_here() {
+    public void cfg_bad_ct_not_enabled_here() {
         FusekiServer server = FusekiServer.create()
             .port(port)
             .registerOperation(newOp, "app/special", customHandler)
@@ -159,11 +191,11 @@ public class TestFusekiCustomOperation {
             // Unregistered.
             .addEndpoint("/ds", endpointName, newOp)
             .build();
-        testServer(server, false, false);
+        testServer(server, url, null, false);
     }
 
 
-    private void testServer(FusekiServer server, boolean withEndpoint, boolean withContentType) {
+    private static void testServer(FusekiServer server, String url, String epName, boolean withContentType) {
         try {
             server.start();
             // Try query (no extension required)
@@ -173,16 +205,21 @@ public class TestFusekiCustomOperation {
                 }
             }
 
-            if ( withEndpoint ) {
-                // Service endpoint name : GET
-                String s1 = HttpOp.execHttpGetString(url+"/ds/"+endpointName);
+            if ( epName != null ) {
+                if ( ! epName.isEmpty() ) {
+                    // Service endpoint name : GET
+                    String svcCall = url+"/ds/"+epName;
 
-                // Service endpoint name : POST
-                try ( TypedInputStream stream = HttpOp.execHttpPostStream(url+"/ds/"+endpointName, "ignored", "", "text/plain") ) {
-                    String x = IOUtils.toString(stream, StandardCharsets.UTF_8);
-                    assertNotNull(x);
-                } catch (IOException ex) {
-                    IO.exception(ex);
+                    String s1 = HttpOp.execHttpGetString(svcCall);
+
+                    // Service endpoint name : POST
+                    try ( TypedInputStream stream = HttpOp.execHttpPostStream(svcCall, "ignored", "", "text/plain") ) {
+                        assertNotNull(stream);
+                        String x = IOUtils.toString(stream, StandardCharsets.UTF_8);
+                        assertNotNull(x);
+                    } catch (IOException ex) {
+                        IO.exception(ex);
+                    }
                 }
             } else {
                 // No endpoint so we expect a 404.
@@ -198,6 +235,7 @@ public class TestFusekiCustomOperation {
             if ( withContentType ) {
                 // Content-type
                 try ( TypedInputStream stream = HttpOp.execHttpPostStream(url+"/ds", contentType, "", "text/plain") ) {
+                    assertNotNull(stream);
                     String x = IOUtils.toString(stream, StandardCharsets.UTF_8);
                     assertNotNull(x);
                 } catch (IOException ex) {

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestFusekiSecurityAssembler.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestFusekiSecurityAssembler.java
@@ -106,7 +106,8 @@ public abstract class AbstractTestFusekiSecurityAssembler {
             .parseConfigFile(assembler)
             .build();
         // Special way to get the servlet remote user (the authorized principle).
-        FusekiLib.modifyForAccessCtl(server, (a)->user.get());
+        //FusekiLib.modifyForAccessCtl(server, (a)->user.get());
+        FusekiLib.modifyForAccessCtl(server.getDataAccessPointRegistry(), (a)->user.get());
         server.start();
 
         if ( sharedDatabase ) {

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthConfig.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthConfig.java
@@ -41,14 +41,12 @@ public class TestServiceDataAuthConfig extends AbstractTestServiceDatasetAuth {
     }        
         
     public static FusekiServer build(int port, AuthPolicy policy) { 
-
         AuthPolicy policy12 = Auth.policyAllowSpecific("user1", "user2");
         AuthPolicy policy13 = Auth.policyAllowSpecific("user1", "user3");
-        
         DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
         DataService dSrv = new DataService(dsg);
-        dSrv.addEndpoint(new Endpoint(Operation.Query, null, policy12));
-        dSrv.addEndpoint(new Endpoint(Operation.Update, null, policy13));
+        dSrv.addEndpoint(Endpoint.create(Operation.Query, null, policy12));
+        dSrv.addEndpoint(Endpoint.create(Operation.Update, null, policy13));
         FusekiServer server = FusekiServer.create()
             //.verbose(true)
             .port(port)

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthConfig.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthConfig.java
@@ -23,6 +23,7 @@ import org.apache.jena.fuseki.auth.Auth;
 import org.apache.jena.fuseki.auth.AuthPolicy;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.server.DataService;
+import org.apache.jena.fuseki.server.Endpoint;
 import org.apache.jena.fuseki.server.Operation;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
@@ -46,8 +47,8 @@ public class TestServiceDataAuthConfig extends AbstractTestServiceDatasetAuth {
         
         DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
         DataService dSrv = new DataService(dsg);
-        dSrv.addEndpointNoName(Operation.Query, policy12);
-        dSrv.addEndpointNoName(Operation.Update, policy13);
+        dSrv.addEndpoint(new Endpoint(Operation.Query, null, policy12));
+        dSrv.addEndpoint(new Endpoint(Operation.Update, null, policy13));
         FusekiServer server = FusekiServer.create()
             //.verbose(true)
             .port(port)

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExtendFuseki_AddService_1.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExtendFuseki_AddService_1.java
@@ -90,7 +90,7 @@ public class ExtendFuseki_AddService_1 {
         // run is found by looking up the operation in a per-server table that gives the server-specific
         // implementation as an ActionService.
 
-        Operation myOperation = Operation.register("Special", "Custom operation");
+        Operation myOperation = Operation.alloc("http://example/special1", "special1", "Custom operation");
 
         // Service endpoint name.
         // This can be different for different datasets even in the same server.

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExtendFuseki_AddService_2.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExtendFuseki_AddService_2.java
@@ -54,7 +54,7 @@ public class ExtendFuseki_AddService_2 {
     public static void main(String ...args) {
         // Register a new operation
 
-        Operation myOperation = Operation.register("Special", "Custom operation");
+        Operation myOperation = Operation.alloc("http://example/special2", "special2", "Custom operation");
 
         // Service endpoint names.
 

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExtendFuseki_AddService_3.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExtendFuseki_AddService_3.java
@@ -53,7 +53,7 @@ public class ExtendFuseki_AddService_3 {
         // run is found by looking up the operation in a per-server table that gives the server-specific
         // implementation as an ActionService.
 
-        Operation myOperation = Operation.register("Special", "Custom operation");
+        Operation myOperation = Operation.alloc("http://example/special3", "special3", "Custom operation");
 
         // Service endpoint name.
         // This can be different for different datasets even in the same server.

--- a/jena-fuseki2/jena-fuseki-main/src/test/resources/log4j.properties
+++ b/jena-fuseki2/jena-fuseki-main/src/test/resources/log4j.properties
@@ -23,11 +23,11 @@ log4j.logger.org.eclipse.jetty=WARN
 log4j.logger.org.apache.shiro=WARN
 
 # Fuseki System logs.
-log4j.logger.org.apache.jena.fuseki.Server=INFO
-log4j.logger.org.apache.jena.fuseki.Fuseki=INFO
-log4j.logger.org.apache.jena.fuseki.Admin=INFO
-log4j.logger.org.apache.jena.fuseki.Validate=INFO
-log4j.logger.org.apache.jena.fuseki.Config=INFO
+log4j.logger.org.apache.jena.fuseki.Server=WARN
+log4j.logger.org.apache.jena.fuseki.Fuseki=WARN
+log4j.logger.org.apache.jena.fuseki.Admin=WARN
+log4j.logger.org.apache.jena.fuseki.Validate=WARN
+log4j.logger.org.apache.jena.fuseki.Config=WARN
 
 # NCSA Request log.
 log4j.additivity.org.apache.jena.fuseki.Request=false

--- a/jena-fuseki2/jena-fuseki-main/testing/Access/empty-passwd
+++ b/jena-fuseki2/jena-fuseki-main/testing/Access/empty-passwd
@@ -1,0 +1,1 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/basic.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/basic.ttl
@@ -1,0 +1,24 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+[] rdf:type fuseki:Server ;
+   ja:context [ ja:cxtName "CONTEXT:SERVER" ; ja:cxtValue "server" ];
+   ## fuseki:services ( <#service1> )
+.
+
+<#service1> rdf:type fuseki:Service ;
+    fuseki:name         "ds" ;
+    fuseki:endpoint     [
+       fuseki:operation  fuseki:query;
+       fuseki:name       "" ;
+    ] ;
+    fuseki:dataset      <#emptyDataset> ;
+    .
+
+<#emptyDataset> rdf:type ja:RDFDataset .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/context.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/context.ttl
@@ -1,0 +1,47 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+[] rdf:type fuseki:Server ;
+   ja:context [ ja:cxtName "CONTEXT:SERVER" ; ja:cxtValue "server" ] ;
+   ja:context [ ja:cxtName "CONTEXT:ABC"    ; ja:cxtValue "server-abc" ] ;
+.
+
+<#service1> rdf:type fuseki:Service ;
+    fuseki:name         "ds-server" ;
+    fuseki:endpoint     [
+       fuseki:operation  fuseki:query;
+       fuseki:name       "" ;
+    ] ;
+    fuseki:dataset      [  rdf:type ja:RDFDataset ]
+    .
+
+<#service2> rdf:type fuseki:Service ;
+    fuseki:name         "ds-dataset" ;
+    fuseki:endpoint     [
+       fuseki:operation  fuseki:query;
+       fuseki:name       "" ;
+    ] ;
+    fuseki:dataset      <#datasetCxt>
+    .
+    
+<#service3> rdf:type fuseki:Service ;
+    fuseki:name         "ds-endpoint" ;
+    fuseki:endpoint     [
+       fuseki:operation  fuseki:query;
+       fuseki:name       "" ;
+       ja:context [ ja:cxtName "CONTEXT:ENDPOINT" ; ja:cxtValue "endpoint" ] ;
+       ja:context [ ja:cxtName "CONTEXT:ABC"      ; ja:cxtValue "endpoint-abc" ] ;
+    ] ;
+    fuseki:dataset      <#datasetCxt>
+    .
+
+<#datasetCxt> rdf:type ja:RDFDataset ;
+    ja:context [ ja:cxtName "CONTEXT:DATASET" ; ja:cxtValue "dataset" ] ;
+    ja:context [ ja:cxtName "CONTEXT:ABC"     ; ja:cxtValue "dataset-abc" ] ;
+    .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/setup1.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/setup1.ttl
@@ -1,0 +1,27 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+[] rdf:type fuseki:Server .
+
+<#service> rdf:type fuseki:Service ;
+    fuseki:name         "ds" ;
+    ## Same endpoint name, different operations available.
+    fuseki:endpoint     [
+       fuseki:operation  fuseki:query;
+       fuseki:name       "sparql" ;
+    ] ;
+    fuseki:endpoint     [
+       fuseki:operation  fuseki:update;
+       fuseki:name       "sparql" ;
+    ] ;
+
+    fuseki:dataset      <#emptyDataset> ;
+    .
+
+<#emptyDataset> rdf:type ja:RDFDataset .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/setup2.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/setup2.ttl
@@ -1,0 +1,29 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+[] rdf:type fuseki:Server .
+
+<#service> rdf:type fuseki:Service ;
+    ## or "/"
+    fuseki:name         "" ;
+    ## Same endpoint name, different operations available.
+    fuseki:endpoint     [
+       fuseki:operation  fuseki:query;
+       ## Named service and root daatset not supported.
+       #fuseki:name       "sparql" ;
+    ] ;
+    fuseki:endpoint     [
+       fuseki:operation  fuseki:update;
+       #fuseki:name       "sparql" ;
+    ] ;
+
+    fuseki:dataset      <#emptyDataset> ;
+    .
+
+<#emptyDataset> rdf:type ja:RDFDataset .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/std-dataset.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/std-dataset.ttl
@@ -1,0 +1,25 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+[] rdf:type fuseki:Server .
+
+<#service1> rdf:type fuseki:Service ;
+    fuseki:name         "ds-direct" ;
+    ## fuseki:name "" is optional.
+
+    fuseki:endpoint [ fuseki:operation fuseki:query; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update;] ;
+    
+    fuseki:endpoint [ fuseki:operation fuseki:gsp_r;  fuseki:name "" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp_rw; fuseki:name "" ] ;
+    
+    fuseki:dataset      <#emptyDataset> ;
+    .
+
+<#emptyDataset> rdf:type ja:RDFDataset .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/std-empty.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/std-empty.ttl
@@ -1,0 +1,18 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+[] rdf:type fuseki:Server .
+
+<#service1> rdf:type fuseki:Service ;
+    fuseki:name         "ds-no-ep" ;
+    ## No endpoints.
+    fuseki:dataset      <#emptyDataset> ;
+    .
+
+<#emptyDataset> rdf:type ja:RDFDataset .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/std-general.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/std-general.ttl
@@ -1,0 +1,24 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+[] rdf:type fuseki:Server .
+
+<#service1> rdf:type fuseki:Service ;
+    fuseki:name         "ds" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query;  fuseki:name "sparql"  ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:query;  fuseki:name "query"   ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update; fuseki:name "update"  ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp_r;  fuseki:name "get"     ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp_rw; fuseki:name "data"    ] ;
+
+    ## No blocked on endpoint "".
+    fuseki:dataset      <#emptyDataset> ;
+    .
+
+<#emptyDataset> rdf:type ja:RDFDataset .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/std-named.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/std-named.ttl
@@ -1,0 +1,28 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+[] rdf:type fuseki:Server .
+
+<#service1> rdf:type fuseki:Service ;
+    fuseki:name         "ds-named" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query;  fuseki:name "sparql"  ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:query;  fuseki:name "query"   ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update; fuseki:name "update"  ] ;
+    ## fuseki:endpoint [ fuseki:operation fuseki:upload; fuseki:name "upload"  ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp_r;  fuseki:name "get"     ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp_rw; fuseki:name "data"    ] ;
+
+    ## Any explicit dataset level operation means that
+    ## trying as named service does not happen.
+    fuseki:endpoint [ fuseki:operation fuseki:no_op ] ;
+    
+    fuseki:dataset      <#emptyDataset> ;
+    .
+
+<#emptyDataset> rdf:type ja:RDFDataset .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/tdb1-endpoints.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/tdb1-endpoints.ttl
@@ -1,0 +1,28 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX tdb:     <http://jena.hpl.hp.com/2008/tdb#>
+
+[] rdf:type fuseki:Server .
+
+<#service1> rdf:type fuseki:Service ;
+    fuseki:name         "ds-tdb1" ;
+    fuseki:endpoint [
+        fuseki:operation fuseki:query ;
+        fuseki:name "sparql-union" ;
+        ja:context [ ja:cxtName "tdb:unionDefaultGraph" ; ja:cxtValue true ] ;
+    ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:query; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update; ] ;
+    fuseki:dataset <#tdbDataset>
+    .
+
+<#tdbDataset> rdf:type tdb:DatasetTDB ;
+    tdb:location "--mem--" ;
+    .
+ 

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/tdb2-endpoints.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/tdb2-endpoints.ttl
@@ -1,0 +1,29 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
+
+[] rdf:type fuseki:Server .
+
+<#service1> rdf:type fuseki:Service ;
+    fuseki:name         "ds-tdb2" ;
+    fuseki:endpoint [
+        fuseki:operation fuseki:query ;
+        fuseki:name "sparql-union" ;
+        ## TDB2 responds to TDB1 symbols for unionDefaultGraph.
+        ## In context naming, tdb: is built-in
+        ja:context [ ja:cxtName "tdb1:unionDefaultGraph" ; ja:cxtValue true ] ;
+    ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:query; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update; ] ;
+    fuseki:dataset <#tdbDataset>
+    .
+
+<#tdbDataset> rdf:type tdb2:DatasetTDB ;
+    tdb2:location "--mem--" ;
+    .

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
@@ -173,7 +173,7 @@ public class JettyFusekiWebapp {
     public static WebAppContext createWebApp(String contextPath) {
         FusekiEnv.setEnvironment();
         WebAppContext webapp = new WebAppContext();
-        webapp.getServletContext().getContextHandler().setMaxFormContentSize(10 * 1000 * 1000);
+        webapp.getServletContext().getContextHandler().setMaxFormContentSize(20 * 1000 * 1000);
 
         // Hunt for the webapp for the standalone jar (or development system).
         // Note that Path FUSEKI_HOME is not initialized until the webapp starts

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
@@ -232,6 +232,7 @@ public class ActionDatasets extends ActionContainerItem {
 
             // Need to be in Resource space at this point.
             DataAccessPoint dataAccessPoint = FusekiConfig.buildDataAccessPoint(subject, registry);
+            dataAccessPoint.getDataService().setEndpointProcessors(action.getOperationRegistry());
             dataAccessPoint.getDataService().goActive();
             if ( ! datasetPath.equals(dataAccessPoint.getName()) )
                 FmtLog.warn(action.log, "Inconsistent names: datasetPath = %s; DataAccessPoint name = %s", datasetPath, dataAccessPoint);

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiWebapp.java
@@ -29,12 +29,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import jena.cmd.CmdException;
 import org.apache.jena.atlas.io.IO;
@@ -46,11 +41,7 @@ import org.apache.jena.fuseki.build.DatasetDescriptionMap;
 import org.apache.jena.fuseki.build.FusekiConfig;
 import org.apache.jena.fuseki.mgt.Template;
 import org.apache.jena.fuseki.mgt.TemplateFunctions;
-import org.apache.jena.fuseki.server.DataAccessPoint;
-import org.apache.jena.fuseki.server.DataAccessPointRegistry;
-import org.apache.jena.fuseki.server.DataService;
-import org.apache.jena.fuseki.server.FusekiInitialConfig;
-import org.apache.jena.fuseki.server.FusekiVocab;
+import org.apache.jena.fuseki.server.*;
 import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.fuseki.servlets.ServletOps;
 import org.apache.jena.rdf.model.*;
@@ -230,16 +221,7 @@ public class FusekiWebapp
         datapoints.addAll(directoryDBs);
         datapoints.addAll(systemDBs);
 
-        // Having found them, set them all running.
-        enable(registry, datapoints);
-    }
-
-    private static void enable(DataAccessPointRegistry registry, List<DataAccessPoint> datapoints) {
-        for ( DataAccessPoint dap : datapoints ) {
-            Fuseki.configLog.info("Register: "+dap.getName());
-            dap.getDataService().goActive();
-            registry.register(dap);
-        }
+        datapoints.forEach(registry::register);
     }
 
     private static List<DataAccessPoint> initServerConfiguration(FusekiInitialConfig params) {

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemote.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemote.java
@@ -301,7 +301,7 @@ public class RDFConnectionRemote implements RDFConnection {
      * <p>
      * The Content-Type is taken from the given {@code Lang}.
      * <p>
-     * "Replace" means overwrite existing data, othewise the date is added to the target.
+     * "Replace" means overwrite existing data, otherwise the date is added to the target.
      */
     protected void doPutPost(String url, String file, Lang lang, boolean replace) {
         File f = new File(file);

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/assembler/DatasetStoreAssembler.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/assembler/DatasetStoreAssembler.java
@@ -37,7 +37,7 @@ public class DatasetStoreAssembler extends AssemblerBase implements Assembler
     {
         StoreDesc desc = openStore(a, root, mode) ;
         Dataset ds = SDBFactory.connectDataset(desc) ;
-        AssemblerUtils.setContext(root, ds.getContext());
+        AssemblerUtils.mergeContext(root, ds.getContext());
         return ds ;
     }
     

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/TDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/TDB.java
@@ -252,7 +252,8 @@ public class TDB {
             ReaderRIOTRDFXML.RiotUniformCompatibility = true ;
             EnvTDB.processGlobalSystemProperties() ;
             
-            MappingRegistry.addPrefixMapping(SystemTDB.tdbSymbolPrefix, SystemTDB.symbolNamespace) ;
+            MappingRegistry.addPrefixMapping(SystemTDB.tdbSymbolPrefix,  SystemTDB.symbolNamespace) ;
+            MappingRegistry.addPrefixMapping(SystemTDB.tdbSymbolPrefix1, SystemTDB.symbolNamespace) ;
             AssemblerTDB.init() ;
             QueryEngineTDB.register() ;
             UpdateEngineTDB.register() ;

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/assembler/DatasetAssemblerTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/assembler/DatasetAssemblerTDB.java
@@ -71,7 +71,7 @@ public class DatasetAssemblerTDB extends DatasetAssembler
             //ja:context [ ja:cxtName "arq:queryTimeout" ;  ja:cxtValue "10000" ] ;
             tdb:unionGraph true ; # or "true"
         */
-        AssemblerUtils.setContext(root, dsg.getContext());
+        AssemblerUtils.mergeContext(root, dsg.getContext());
         return DatasetFactory.wrap(dsg) ; 
     }
     

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/sys/EnvTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/sys/EnvTDB.java
@@ -45,15 +45,10 @@ public class EnvTDB
                 String keyStr = (String)key ;
                 if ( keyStr.startsWith(prefix) )
                     keyStr = SystemTDB.symbolNamespace+keyStr.substring(prefix.length()) ;
-                
-                
                 if ( ! keyStr.startsWith(SystemTDB.symbolNamespace) )
                     continue ;
-                
                 Object value = properties.get(key) ;
-                
                 Symbol symbol = Symbol.create(keyStr) ;
-                
                 context.set(symbol, value) ;
             }
         }

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/sys/SystemTDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/sys/SystemTDB.java
@@ -104,7 +104,10 @@ public class SystemTDB
 
     /** Root of TDB-defined parameter short names */  
     public static final String tdbSymbolPrefix      = "tdb" ;
-    
+
+    /** Root of TDB-defined parameter short names, alternate name */  
+    public static final String tdbSymbolPrefix1     = "tdb1" ;
+
     /** Root of any TDB-defined Java system properties */   
     public static final String tdbPropertyRoot      = "org.apache.jena.tdb" ;
 


### PR DESCRIPTION
Documentation draft: https://gist.github.com/afs/1d4c6584723b72c5e7b892057029a8f4

This became a major refactoring and clean-up of the Fuseki dispatch and service code. The code was significantly hardwired to the fixed set of standard services so because it needing changing anyway, this PR reworks the code to be general, to rename things to a consistent new naming and general clearup. The old quads/GSP split has gone - quad operations are now an extension of the GSP operations.

Includes JENA-1743 (QueryExecutionBuilder) and renaming a Context operation ("set" becomes merge") which touches lots of files in jena-arq.
