### PR TITLE
JENA-1746: TDB2 abort

### DIFF
--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/TransactionalFactory.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/TransactionalFactory.java
@@ -42,7 +42,7 @@ public class TransactionalFactory {
         return createTransactional(coord, elements);
     }
 
-    private static Transactional createTransactional(TransactionCoordinator coord, TransactionalComponent[] elements) {
+    private static Transactional createTransactional(TransactionCoordinator coord, TransactionalComponent... elements) {
         for ( TransactionalComponent tc : elements ) {
             coord.add(tc);
         }

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/ComponentGroup.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/ComponentGroup.java
@@ -18,10 +18,7 @@
 
 package org.apache.jena.dboe.transaction.txn;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -39,6 +36,10 @@ public class ComponentGroup {
         this.group.putAll(group);
     }
 
+    public void addAll(Collection<TransactionalComponent> components) {
+        components.forEach(this::add);
+    }
+    
     public void add(TransactionalComponent component) {
         Objects.requireNonNull(component);
         //Log.info(this, "add("+component.getComponentId()+")");

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionListener.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionListener.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.dboe.transaction.txn;
+
+/** Call backs for the transaction lifecycle. */ 
+public interface TransactionListener {
+    
+    /** A transaction has started; begin has done the setup. */
+    public default void notifyTxnStart(Transaction transaction) { }
+
+    /** Start a call to promote */
+    public default void notifyPromoteStart(Transaction transaction) { }
+    /** Finish a call to promote */
+    public default void notifyPromoteFinish(Transaction transaction) { }
+
+    /** Start prepare during a commit */
+    public default void notifyPrepareStart(Transaction transaction) { }
+    /** Finish prepare during a commit */
+    public default void notifyPrepareFinish(Transaction transaction) { }
+
+    /** Start a commit (prepare has been done) */
+    public default void notifyCommitStart(Transaction transaction) { }
+    /** Finish a commit (prepare has been done) */
+    public default void notifyCommitFinish(Transaction transaction) { }
+
+    /** Start an abort */
+    public default void notifyAbortStart(Transaction transaction) { }
+    /** Start finish an abort */
+    public default void notifyAbortFinish(Transaction transaction) { }
+
+    /** Start an end() */
+    public default void notifyEndStart(Transaction transaction) { }
+    /** Finish an end() */
+    public default void notifyEndFinish(Transaction transaction) { }
+
+    /** Start the complete step. */
+    public default void notifyCompleteStart(Transaction transaction) { }
+    /** Finish the complete step. */
+    public default void notifyCompleteFinish(Transaction transaction) { }
+    
+    /** Transaction has finished. This is called during "complete" */
+    public default void notifyTxnFinish(Transaction transaction) { }
+}

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalComponentBase.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalComponentBase.java
@@ -51,6 +51,9 @@ public class TransactionalComponentBase<X> extends TransactionalComponentLifecyc
     }
 
     @Override
+    protected X _promote(TxnId txnId, X state) { return null; }
+
+    @Override
     protected ByteBuffer _commitPrepare(TxnId txnId, X state) {
         return null;
     }
@@ -69,9 +72,5 @@ public class TransactionalComponentBase<X> extends TransactionalComponentLifecyc
 
     @Override
     protected void _shutdown() {}
-
-    @Override
-    protected X _promote(TxnId txnId, X state) { return null; }
-
 }
 

--- a/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestTxnSwitching.java
+++ b/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestTxnSwitching.java
@@ -40,7 +40,7 @@ public class TestTxnSwitching {
 
     //Transactional transactional = TransactionalFactory.create(jrnl, integer);
     TransactionalBase transactional;
-    TransactionCoordinator txnMgr = new  TransactionCoordinator(jrnl); {
+    TransactionCoordinator txnMgr = new TransactionCoordinator(jrnl); {
         txnMgr.add(integer);
         transactional = new TransactionalBase(txnMgr);
         txnMgr.start();

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/nodetable/ThreadBufferingCache.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/nodetable/ThreadBufferingCache.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.tdb2.store.nodetable;
+
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.atlas.lib.Cache;
+import org.apache.jena.atlas.lib.CacheFactory;
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.tdb2.TDBException;
+
+/**
+ * A cache that buffers changes.
+ * <p>
+ * It has two modes, when active it captures updates and the underlying main cache is
+ * only updated when {@link #flushBuffer} is called. When not active, it passes
+ * updates straight through.
+ * <p>
+ * For access operations, it looks in the buffered cache and the underlying cache as
+ * well ({@code contains} and {@code get} operations but not {@code keys}).
+ * <p>
+ * The algorithm is utilising the fact that KV entries are not deleted once
+ * committed. Abort causes them never to appear.
+ * <p>
+ * This is one thread that is the creator of new node ids. For all other threads, just
+ * call through to the main cache. For the updating thread, any cache changes are
+ * buffered, then pushed into the main cache on commit or discarded on abort.
+ * The buffering is then cleared.
+ */
+public class ThreadBufferingCache<Key,Value> implements Cache<Key,Value> {
+    private final Cache<Key,Value> localCache;
+    private final Cache<Key,Value> baseCache;
+    private final AtomicReference<Thread> bufferingThread = new AtomicReference<>();
+    private Object lock = new Object();
+    private String label;
+    // This turns the feature off. Development only. Do not release with this set "true".
+    private static final boolean BUFFERING = true;
+    
+    public ThreadBufferingCache(String label, Cache<Key,Value> mainCache, int size) {
+        this.localCache = CacheFactory.createCache(size);
+        this.baseCache = mainCache;
+        this.label = label;
+    }
+
+    private boolean buffering() {
+        if ( ! BUFFERING )
+            return false;
+        // Changes are sync'ed and the only way to change this value is via a sync'ed method.
+        if ( bufferingThread == null )
+            return false;
+        Thread currentThread = Thread.currentThread();
+        return bufferingThread.get() == currentThread;
+    }
+
+    // XXX [1746] Can replace by direct use.
+    private Cache<Key, Value> localCache() {
+        return localCache;
+    }
+
+    // ---- Buffer management.
+    // Only one thread can be using the additional caches.
+    
+    public void enableBuffering() {
+        if ( ! BUFFERING )
+            return;
+        Thread thread = Thread.currentThread();
+        boolean b = bufferingThread.compareAndSet(null, thread);
+        if ( !b ) {
+            throw new TDBException(Lib.className(this)+": already buffering");
+        }
+    }
+    
+    /** Write the local cache to the main cache, and reset the local cache. */
+    public void flushBuffer() {
+        if ( ! buffering() )
+            return ;
+        //System.out.println(label+": Flush:1 L: "+localCache().size());
+        //System.out.println(label+": Flush:1 M: "+baseCache.size());
+
+        localCache().keys().forEachRemaining(k->{
+            Value value = localCache().getIfPresent(k);
+            baseCache.put(k, value);
+        });
+        localCache().clear();
+        //System.out.println(label+": Flush:2 L: "+localCache().size());
+        //System.out.println(label+": Flush:2 M: "+baseCache.size());
+        bufferingThread.set(null);
+    }
+
+    /** Drop the local cache. */
+    public void dropBuffer() {
+        if ( ! buffering() )
+            return ;
+        //System.out.println(label+": Drop: L: "+localCache().size());
+        //System.out.println(label+": Drop: M: "+baseCache.size());
+        localCache().clear();
+        bufferingThread.set(null);
+    }
+    
+    public Cache<Key, Value> getBuffer() {
+        return localCache();
+    }
+
+    public Cache<Key, Value> getBaseCache() {
+        return baseCache;
+    }
+
+    // --- getters with call-through
+
+    @Override
+    public boolean containsKey(Key key) {
+        if ( ! buffering() )
+            return baseCache.containsKey(key);
+        return localCache().containsKey(key) || baseCache.containsKey(key);
+    }
+
+    @Override
+    public Value getIfPresent(Key key) {
+        if ( ! buffering() )
+            return baseCache.getIfPresent(key);
+        Value item = localCache().getIfPresent(key);
+        if ( item != null )
+            return item;
+        return baseCache.getIfPresent(key);
+    }
+
+    @Override
+    public Value getOrFill(Key key, Callable<Value> callable) {
+        if ( ! buffering() )
+            return baseCache.getOrFill(key, callable);
+        // Not thread safe but this overlay cache is for single-thread use.
+        Value item = localCache().getIfPresent(key);
+        if ( item != null )
+            return item;
+        item = baseCache.getIfPresent(key);
+        if ( item != null )
+            return item;
+        // Add to cache so new data hence place in localCache.
+        try {
+            item = callable.call();
+            localCache().put(key, item);
+        } catch (Exception ex) {
+            throw new TDBException("Exception filling cache", ex);
+        }
+        return item;
+    }
+
+    // ---- Flush changes, reset.
+
+    
+
+    // ---- Updates to buffering, local cache.
+
+    /** Goes into local cache. */
+    @Override
+    public void put(Key key, Value value) {
+        if ( ! buffering() ) {
+            baseCache.put(key, value);
+            return ;
+        }
+        localCache().put(key, value);
+    }
+
+    @Override
+    public void remove(Key key) {
+        if ( ! buffering() ) {
+            baseCache.remove(key);
+            return ;
+        }
+        localCache().remove(key);
+    }
+
+
+    @Override
+    public Iterator<Key> keys() {
+        if ( ! buffering() )
+            return baseCache.keys();
+        return Iter.concat(localCache().keys(), baseCache.keys());
+    }
+
+    @Override
+    public boolean isEmpty() {
+        if ( ! buffering() )
+            return baseCache.isEmpty();
+        return localCache().isEmpty();
+    }
+
+    /** Clear local cache. */
+    @Override
+    public void clear() {
+        if ( ! buffering() ) {
+            baseCache.clear();
+            return ;
+        }
+        localCache().clear();
+    }
+
+    /** Size of local cache */
+    @Override
+    public long size() {
+        if ( ! buffering() )
+            return baseCache.size();
+        return localCache().size();
+    }
+
+    @Override
+    public void setDropHandler(BiConsumer<Key, Value> dropHandler) {
+        if ( ! buffering() )
+            return ;
+       localCache().setDropHandler(dropHandler);
+    }
+}

--- a/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/TS_Factory.java
+++ b/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/TS_Factory.java
@@ -26,6 +26,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses( {
     TestDatabaseMgr.class
     , TestTDBFactory.class
+    , TestTDB2.class
 
 })
 

--- a/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/TestTDB2.java
+++ b/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/TestTDB2.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.tdb2;
+
+import java.io.ByteArrayOutputStream;
+
+import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.query.TxnType;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.system.Txn;
+import org.apache.jena.tdb2.sys.TDBInternal;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Misc tests for TDB2. */
+public class TestTDB2 {
+    // Safe on MS Windows - different directories for abort1 and abort2.
+    static String DIR1 = "DB_1";
+    static String DIR2 = "DB_2";
+
+    @BeforeClass public static void beforeClass() {
+        FileOps.ensureDir(DIR1);
+        FileOps.ensureDir(DIR2);
+    }
+    
+    @AfterClass public static void afterClass() {
+        try { 
+            FileOps.clearAll(DIR1);
+            FileOps.clearAll(DIR2);
+            FileOps.deleteSilent(DIR1);
+            FileOps.deleteSilent(DIR2);
+        } catch (Exception ex) {}
+    }
+
+    // JENA-1746 : tests abort1 and abort2.
+    // Inlines are not relevant.
+    // Errors that can occur:
+    //   One common term -> no conversion.
+    //   Two common terms -> bad read.
+    // Feature control: ThreadBufferingCache.BUFFERING
+
+    @Test public void abort1() {
+        Quad q1 = SSE.parseQuad("(:g :s :p :o)");
+        // One term different.
+        Quad q2 = SSE.parseQuad("(:g1 :s :p 123)");
+        testAbort(DIR1, q1, q2);
+    }
+    
+    @Test public void abort2() {
+        Quad q1 = SSE.parseQuad("(:g :s :p :o)");
+        // Two terms different.
+        Quad q2 = SSE.parseQuad("(:g1 :s :p1 123)");
+        testAbort(DIR2, q1, q2);
+    }
+        
+    private void testAbort(String DIR, Quad q1, Quad q2) {
+        DatasetGraph dsg = DatabaseMgr.connectDatasetGraph(DIR);
+        
+        // Abort.
+        dsg.begin(TxnType.WRITE);
+        dsg.add(q1);
+        dsg.abort();
+        dsg.end();
+
+        // Add different data.
+        dsg.begin(TxnType.WRITE);
+        dsg.add(q2);
+        dsg.commit();
+        dsg.end();
+
+        output(dsg);
+        TDBInternal.expel(dsg, true);
+        DatasetGraph dsg2 = DatabaseMgr.connectDatasetGraph(DIR);
+        output(dsg2);
+    }
+
+    private static void output(DatasetGraph dsg) {
+        Txn.executeRead(dsg, ()->RDFDataMgr.write(new ByteArrayOutputStream(),  dsg, Lang.NQUADS));
+    }
+}

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Operation.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Operation.java
@@ -84,7 +84,7 @@ public class Operation {
     public static final Operation GSP_R    = alloc(FusekiVocab.opGSP_r.asNode(),  "gsp-r",  "Graph Store Protocol (Read)");
     public static final Operation GSP_RW   = alloc(FusekiVocab.opGSP_rw.asNode(), "gsp-rw", "Graph Store Protocol");
     public static final Operation NoOp     = alloc(FusekiVocab.opNoOp.asNode(),   "no-op",  "No Op");
-    public static final Operation Shacl    = alloc(FusekiVocab.opShacl.asNode(),  "shacl",  "SHACL Validation");
+    public static final Operation Shacl    = alloc(FusekiVocab.opShacl.asNode(),  "SHACL",  "SHACL Validation");
     static {
         // Not everyone will remember "_" vs "-" so ...
         altName(FusekiVocab.opNoOp_alt,   FusekiVocab.opNoOp); 

--- a/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
@@ -96,7 +96,7 @@ public class DatasetGraphText extends DatasetGraphMonitor implements Transaction
             // Does not overlap with the ids used by TDB2.
             byte[] componentID = { 2,4,6,10 } ;
             TransactionalComponent tc = new TextIndexDB(ComponentId.create(null, componentID), textIndex);
-            coord.modify(()->coord.add(tc));
+            coord.modifyConfig(()->coord.add(tc));
             commitAction = delegateCommit;
             abortAction = delegateAbort;
         } else {


### PR DESCRIPTION
Introduces `ThreadBufferingCache` and `TransactionListener`.

Adds a layer of caching for a write transaction so the caches can be aborted.