### PR TITLE
JENA-1758: Wait for the thread to complete when finishing bulk loading

### DIFF
--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/loader/main/DataToTuples.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/loader/main/DataToTuples.java
@@ -69,6 +69,8 @@ public class DataToTuples implements BulkStartFinish {
     private final MonitorOutput output;
     private BlockingQueue<DataBlock> input;
 
+    private Thread thread;
+
     public DataToTuples(DatasetGraphTDB dsgtdb,
                         Destination<Tuple<NodeId>> tuples3,
                         Destination<Tuple<NodeId>> tuples4,
@@ -101,11 +103,18 @@ public class DataToTuples implements BulkStartFinish {
 
     @Override
     public void startBulk() {
-        new Thread(()->action()).start();
+        thread = new Thread(()->action());
+        thread.start();
     }
 
     @Override
-    public void finishBulk() { }
+    public void finishBulk() {
+        try {
+            thread.join();
+        } catch (InterruptedException e) {
+            throw new BulkLoaderException("InterruptedException", e);
+        }
+    }
 
     // Triples.
     private void action() {


### PR DESCRIPTION
This prevents the thread from running until after a loading operation has returned, which can cause problems when the dataset is used immediately thereafter.