### PR TITLE
JENA-1761: General option setting for RDFParser and RDFWriter

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
@@ -49,28 +49,59 @@ import org.apache.jena.sys.JenaSystem ;
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
 
-/** <p>General purpose reader framework for RDF (triples and quads) syntaxes.</p>   
- *  <ul>
- *  <li>HTTP Content negotiation</li>
- *  <li>File type hint by the extension</li>
- *  <li>Application language hint</li>
- *  </ul>
+/**
  * <p>
- *  It also provides a way to lookup names in different
- *  locations and to remap URIs to other URIs. 
- *  </p>
- *  <p>
- *  Extensible - a new syntax can be added to the framework. 
- *  </p>
- *  <p>Operations fall into the following categories:</p>
- *  <ul>
- *  <li>{@code read}    -- Read data from a location into a Model, Dataset, etc. The methods in this class treat all types of Model in the same way. For behavior specific to a subtype of Model, use the methods of that specific class.</li>
- *  <li>{@code loadXXX} -- Read data and return an in-memory object holding the data.</li>
- *  <li>{@code parse}   -- Read data and send to an {@link StreamRDF}</li>
- *  <li>{@code open}    -- Open a typed input stream to the location, using any alternative locations</li>
- *  <li>{@code write}   -- Write Model/Dataset etc</li> 
- *  <li>{@code create}  -- Create a reader or writer explicitly</li> 
- *  </ul> 
+ * General purpose reader framework for RDF (triples and quads) syntaxes.
+ * </p>
+ * <ul>
+ * <li>HTTP Content negotiation</li>
+ * <li>File type hint by the extension</li>
+ * <li>Application language hint</li>
+ * </ul>
+ * <p>
+ * It also provides a way to lookup names in different locations and to remap URIs to
+ * other URIs.
+ * </p>
+ * <p>
+ * Extensible - a new syntax can be added to the framework.
+ * </p>
+ * <p>
+ * Operations fall into the following categories:
+ * </p>
+ * <ul>
+ * <li>{@code read} -- Read data from a location into a Model, Dataset, etc. The
+ * methods in this class treat all types of Model in the same way. For behavior
+ * specific to a subtype of Model, use the methods of that specific class.</li>
+ * <li>{@code loadXXX} -- Read data and return an in-memory object holding the
+ * data.</li>
+ * <li>{@code parse} -- Read data and send to an {@link StreamRDF}</li>
+ * <li>{@code open} -- Open a typed input stream to the location, using any
+ * alternative locations</li>
+ * <li>{@code write} -- Write Model/Dataset etc</li>
+ * <li>{@code create} -- Create a reader or writer explicitly</li>
+ * </ul>
+ * <p>
+ * {@code RDFDataMgr} provides single functions for many of the common application
+ * patterns. It is built on top of {@link RDFParser} for reading and
+ * {@link RDFWriter} for output. Each of these classes has an associated builder that
+ * provides complete control over the parsing process. For example, to translate
+ * language tags to lower case on input:
+ * 
+ * <pre>
+ *     RDFParser.create()
+ *         .source("myData.ttl")
+ *         .langTagLowerCase()
+ *         .parse(graph);
+ * </pre>
+ * 
+ * or to have Turtle written with {@code BASE} and {@code PREFIX} rather than
+ * {@code @base} and {@code @prefix} (both are legal Turtle):
+ * <pre>
+ *     RDFWriter.create()
+ *         .set(RIOT.symTurtlePrefixStyle, "rdf11")
+ *         .source(model)
+ *         .output(System.out);
+ * </pre>   
  */
 
 public class RDFDataMgr

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
@@ -511,7 +511,7 @@ public class RDFParserBuilder {
             return this;
         ensureContext();
         this.context.putAll(context);
-        return this; 
+        return this;
     }
     
     /** 
@@ -603,7 +603,8 @@ public class RDFParserBuilder {
         // Build what we can now - some things have to be built in the parser.
         if ( uri == null && path == null && content == null && inputStream == null && javaReader == null )
             throw new RiotException("No source specified");
-        
+        if ( context == null )
+            context = RIOT.getContext().copy();
         // Setup the HTTP client.
         HttpClient client = buildHttpClient();
         FactoryRDF factory$ = buildFactoryRDF();

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
@@ -40,6 +40,7 @@ import org.apache.jena.riot.web.HttpNames;
 import org.apache.jena.riot.web.HttpOp ;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sparql.util.Symbol;
 
 /**
  * An {@link RDFParser} is a process that will generate triples; 
@@ -487,10 +488,43 @@ public class RDFParserBuilder {
 //        return this;
 //    }
     
+    private void ensureContext() {
+        if ( context == null )
+            context = new Context();
+    }
+    
+    /**
+     * Set the context for the parser when built.
+     * 
+     * If a context is already partly set
+     * for this builder, merge the new settings 
+     * into the outstanding context.
+     * 
+     * If the context argument is null, do nothing.
+     * 
+     * @param context
+     * @return this
+     * @see Context
+     */
     public RDFParserBuilder context(Context context) {
-        if ( context != null )
-            context = context.copy();
-        this.context = context;
+        if ( context == null )
+            return this;
+        ensureContext();
+        this.context.putAll(context);
+        return this; 
+    }
+    
+    /** 
+     * Added a setting to the context for the parser when built.
+     * A value of "null" removes a previous setting.
+     * @param symbol
+     * @param value
+     * @return this
+     * @see Context
+     */
+    public RDFParserBuilder set(Symbol symbol, Object value) {
+        ensureContext();
+        context.put(symbol, value);
         return this;
     }
     

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterBuilder.java
@@ -25,6 +25,7 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sparql.util.Symbol;
 
 public class RDFWriterBuilder {
     private DatasetGraph dataset = null;
@@ -97,16 +98,42 @@ public class RDFWriterBuilder {
 //    // Not implemented
 //    public RDFWriterBuilder formatter(NodeFormatter nodeFormatter) { return this; }
 
-    /** Set the context for the writer when built.
-     *  
+    private void ensureContext() {
+        if ( context == null )
+            context = new Context();
+    }
+    
+    /**
+     * Set the context for the writer when built.
+     * 
+     * If a context is already partly set
+     * for this builder, merge the new settings 
+     * into the outstanding context.
+     * 
      * @param context
      * @return this
+     * @see Context
      */
-    public RDFWriterBuilder context(Context context) { 
-        if ( context != null )
-            context = context.copy();
-        this.context = context;
+    public RDFWriterBuilder context(Context context) {
+        if ( context == null )
+            return this;
+        ensureContext();
+        this.context.putAll(context);
         return this; 
+    }
+    
+    /** 
+     * Added a setting to the context for the writer when built.
+     * A value of "null" removes a previous setting.
+     * @param symbol
+     * @param value
+     * @return this
+     * @see Context
+     */
+    public RDFWriterBuilder set(Symbol symbol, Object value) {
+        ensureContext();
+        context.put(symbol, value);
+        return this;
     }
     
     /**

--- a/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
@@ -107,6 +107,8 @@ public class RIOT {
         return ARQ.BUILD_DATE ;
     }
     
+    // ---- Symbols
+    
     /**
      * Symbol to use to pass (in a Context object) the "@context" to be used when reading jsonld
      * (overriding the actual @context in the jsonld)
@@ -114,4 +116,11 @@ public class RIOT {
      * as expected by the JSONLD-java API (a Map) */
     public static final Symbol JSONLD_CONTEXT = Symbol.create("http://jena.apache.org/riot/jsonld#JSONLD_CONTEXT");
 
+    private static String TURTLE_SYMBOL_BASE = "http://jena.apache.org/riot/turtle#";
+    
+    /** 
+     * Printing style. One of "RDF11" or RDF10". Controls {@literal @prefix} vs PREFIX. 
+     * Values causing SPARQL-style keyword output are "sparql","keyword" and "rdf11".
+     */
+    public static final Symbol symTurtlePrefixStyle = SystemARQ.allocSymbol(TURTLE_SYMBOL_BASE, "prefixStyle");
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
@@ -311,8 +311,26 @@ public class RiotLib
     public static boolean strSafeFor(String str, char ch) {
         return str.indexOf(ch) == -1;
     }
+    
+    public static void writeBase(IndentedWriter out, String base, boolean newStyle) {
+        if ( newStyle )
+            writeBaseNewStyle(out, base);
+        else
+            writeBaseOldStyle(out, base);
+    }
 
-    public static void writeBase(IndentedWriter out, String base) {
+    private static void writeBaseNewStyle(IndentedWriter out, String base) {
+        if ( base != null ) {
+            out.print("BASE ");
+            out.pad(PREFIX_IRI);
+            out.print("<");
+            out.print(base);
+            out.print(">");
+            out.println();
+        }
+    }
+
+    private static void writeBaseOldStyle(IndentedWriter out, String base) {
         if ( base != null ) {
             out.print("@base ");
             out.pad(PREFIX_IRI);
@@ -324,7 +342,32 @@ public class RiotLib
         }
     }
 
-    public static void writePrefixes(IndentedWriter out, PrefixMap prefixMap) {
+    /** Write prefixes, using {@code PREFIX} */ 
+    public static void writePrefixes(IndentedWriter out, PrefixMap prefixMap, boolean newStyle) {
+        if ( newStyle )
+            writePrefixesNewStyle(out, prefixMap);
+        else
+            writePrefixesOldStyle(out, prefixMap);
+    }
+    
+    /** Write prefixes, using {@code PREFIX} */ 
+    private static void writePrefixesNewStyle(IndentedWriter out, PrefixMap prefixMap) {
+        if ( prefixMap != null && !prefixMap.isEmpty() ) {
+            for ( Map.Entry<String, String> e : prefixMap.getMappingCopyStr().entrySet() ) {
+                out.print("PREFIX ");
+                out.print(e.getKey());
+                out.print(": ");
+                out.pad(PREFIX_IRI);
+                out.print("<");
+                out.print(e.getValue());
+                out.print(">");
+                out.println();
+            }
+        }
+    }
+
+    /** Write prefixes, using {@code @prefix} */ 
+    public static void writePrefixesOldStyle(IndentedWriter out, PrefixMap prefixMap) {
         if ( prefixMap != null && !prefixMap.isEmpty() ) {
             for ( Map.Entry<String, String> e : prefixMap.getMappingCopyStr().entrySet() ) {
                 out.print("@prefix ");


### PR DESCRIPTION
Two halves or JENA-1761:

"General option setting for RDFParser and RDFWriter" -- the mechanism
"Option to write Turtle with PREFIX and BASE" -- used for Turtle.

The default remains the "@prefix" forms.