### PR TITLE
JENA-1764: Fix Automatic-Module-Name metadata

### DIFF
--- a/jena-db/jena-dboe-storage/pom.xml
+++ b/jena-db/jena-dboe-storage/pom.xml
@@ -34,6 +34,10 @@
 
   <description>Triplestore database storage</description>
 
+  <properties>
+    <automatic.module.name>org.apache.jena.dboe.storage</automatic.module.name>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/jena-elephas/jena-elephas-common/pom.xml
+++ b/jena-elephas/jena-elephas-common/pom.xml
@@ -26,6 +26,10 @@
   <name>Apache Jena - Elephas - Common API</name>
   <description>Common code for RDF on Hadoop such as writable types for RDF primitives</description>
 
+  <properties>
+    <automatic.module.name>org.apache.jena.elephas.common</automatic.module.name>
+  </properties>
+
   <!-- Note that versions are managed by parent POMs -->
   <dependencies>
     <!-- Hadoop Dependencies -->

--- a/jena-elephas/jena-elephas-io/pom.xml
+++ b/jena-elephas/jena-elephas-io/pom.xml
@@ -27,6 +27,10 @@
   <name>Apache Jena - Elephas - I/O</name>
   <description>RDF Input/Output formats library for Hadoop</description>
 
+  <properties>
+    <automatic.module.name>org.apache.jena.elephas.io</automatic.module.name>
+  </properties>
+
   <!-- Note that versions are managed by parent POMs -->
   <dependencies>
     <!-- Internal Project Dependencies -->

--- a/jena-elephas/jena-elephas-mapreduce/pom.xml
+++ b/jena-elephas/jena-elephas-mapreduce/pom.xml
@@ -26,6 +26,10 @@
   <name>Apache Jena - Elephas - Map/Reduce</name>
   <description>Contains some basic Map/Reduce implementations for working with RDF on Hadoop</description>
 
+  <properties>
+    <automatic.module.name>org.apache.jena.elephas.mapreduce</automatic.module.name>
+  </properties>
+
   <dependencies>
 		<!-- Internal Project Dependencies -->
     <dependency>

--- a/jena-elephas/jena-elephas-stats/pom.xml
+++ b/jena-elephas/jena-elephas-stats/pom.xml
@@ -26,6 +26,10 @@
   <name>Apache Jena - Elephas - Statistics Demo App</name>
   <description>A demo application that can be run on Hadoop to produce a statistical analysis on arbitrary RDF inputs</description>
 
+  <properties>
+    <automatic.module.name>org.apache.jena.elephas.stats</automatic.module.name>
+  </properties>
+
   <dependencies>
 		<!-- Internal Project Dependencies -->
     <dependency>

--- a/jena-jdbc/jena-jdbc-core/pom.xml
+++ b/jena-jdbc/jena-jdbc-core/pom.xml
@@ -30,6 +30,7 @@
 
 	<properties>
 		<plugin.license.headerPath>${project.parent.basedir}</plugin.license.headerPath>
+		<automatic.module.name>org.apache.jena.jdbc.core</automatic.module.name>
 	</properties>
 
 	<dependencies>

--- a/jena-jdbc/jena-jdbc-driver-bundle/pom.xml
+++ b/jena-jdbc/jena-jdbc-driver-bundle/pom.xml
@@ -30,6 +30,7 @@
 
 	<properties>
 		<plugin.license.headerPath>${project.parent.basedir}</plugin.license.headerPath>
+		<automatic.module.name>org.apache.jena.jdbc.driver.bundle</automatic.module.name>
 		<!-- Note that we actually skip tests in this module because this module 
 			simply bundles up the other modules BUT it contains a JUnit suite primarily 
 			as a convenience for being able to perform code coverage analysis easily 

--- a/jena-jdbc/jena-jdbc-driver-mem/pom.xml
+++ b/jena-jdbc/jena-jdbc-driver-mem/pom.xml
@@ -30,6 +30,7 @@
 
 	<properties>
 		<plugin.license.headerPath>${project.parent.basedir}</plugin.license.headerPath>
+		<automatic.module.name>org.apache.jena.jdbc.driver.mem</automatic.module.name>
 	</properties>
 
 	<dependencies>

--- a/jena-jdbc/jena-jdbc-driver-remote/pom.xml
+++ b/jena-jdbc/jena-jdbc-driver-remote/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <plugin.license.headerPath>${project.parent.basedir}</plugin.license.headerPath>
+    <automatic.module.name>org.apache.jena.jdbc.driver.remote</automatic.module.name>
   </properties>
 
   <dependencies>

--- a/jena-jdbc/jena-jdbc-driver-tdb/pom.xml
+++ b/jena-jdbc/jena-jdbc-driver-tdb/pom.xml
@@ -30,6 +30,7 @@
 
 	<properties>
 		<plugin.license.headerPath>${project.parent.basedir}</plugin.license.headerPath>
+		<automatic.module.name>org.apache.jena.jdbc.driver.tdb</automatic.module.name>
 	</properties>
 
 	<dependencies>

--- a/jena-shacl/pom.xml
+++ b/jena-shacl/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
-    <automatic.module.name>org.apache.jena.tdb</automatic.module.name>
+    <automatic.module.name>org.apache.jena.shacl</automatic.module.name>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
- This adds missing AMN metadata to `jena-dboe-storage` (an empty string is invalid)
- This fixes incorrect AMN for `jena-shacl` (it currently duplicates the tdb module name)
- This also fixes duplicate AMN metadata for the `jena-elephas-*` and `jena-jdbc-*` modules