### PR TITLE
 JENA-1766: (more) Handle the case of dataset endpoint (service name = "")

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Operation.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Operation.java
@@ -56,22 +56,22 @@ public class Operation {
      * Create an Operation - this operation interns operations so there is only
      * one object for each operation. It is an extensible enum.
      */
-    static public Operation alloc(String iriStr, String shortName, String description) {
+    static public Operation alloc(String iriStr, String name, String description) {
         IRI iri = IRIResolver.parseIRI(iriStr);
         if ( iri.hasViolation(false) )
             Log.warn(Operation.class, "Poor Operation name: "+iriStr+" : Not an IRI");
         if ( iri.isRelative() )
             Log.warn(Operation.class, "Poor Operation name: "+iriStr+" : Relative IRI");
         Node node = NodeFactory.createURI(iriStr);
-        return alloc(node, shortName, description);
+        return alloc(node, name, description);
     }
 
     /**
      * Create an Operation - this operation interns operations so there is only
      * object for each operation. It is an extensible enum.
      */
-    static public Operation alloc(Node op, String shortName, String description) {
-        return mgr.computeIfAbsent(op, (x)->create(x, shortName, description));
+    static public Operation alloc(Node op, String name, String description) {
+        return mgr.computeIfAbsent(op, (x)->create(x, name, description));
     }
 
     /** Create; not registered */

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/js/app/models/dataset.js
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/js/app/models/dataset.js
@@ -103,24 +103,24 @@ define(
       /** Return the first endpoint of the first service that has the given type */
       endpointOfType: function( serviceType ) {
           var service = this.serviceOfType( serviceType );
-	  if ( ! service )
-	      return null;
-	  var x = service["srv.endpoints"];
-	  x = x.filter(function(v){return v!==''});
-	  var ep = _.first(x);
-	  return ep;
-          /* return service && _.first( service["srv.endpoints"] );*/
+          if ( ! service )
+              return null;
+          var x = service["srv.endpoints"];
+          var ep = _.first(x);
+          return ep;
       },
 
       /* Return URL for a service of a given type or null, if no such service */
       endpointURL: function( serviceType ) {
-        var endpoint = this.endpointOfType( serviceType );
-        return endpoint ? this.datasetEndpointURL( endpoint ) : null;
+          var endpoint = this.endpointOfType( serviceType );
+          return endpoint != null  ? this.datasetEndpointURL( endpoint ) : null ;
       },
 
       /** Return the URL for the given endpoint */
       datasetEndpointURL: function( endpoint ) {
-        return sprintf( "%s%s/%s", this.baseURL(), this.name(), endpoint );
+	  return endpoint == ""
+	      ? sprintf( "%s%s", this.baseURL(), this.name() )
+              : sprintf( "%s%s/%s", this.baseURL(), this.name(), endpoint );
       },
 
       /** Return the sparql query URL for this dataset, if it has one, or null */


### PR DESCRIPTION
JENA-1766 corrected a bug but also showed that the case of an endpoint on the dataset itself never works. i.e the interface did not handle "/ds?query=". It didn't show because when using the old configuration happen to put "/ds/sparql" before "/ds" in the list of endpoint options (by chance - the server has a hash map).

This PR fixes this - with the new endpoint configuration (JENA-1731), it is now easier to write a configuration with dataset level query only and it is also now documented how to configure that with:

    fuseki:endpoint  [ fuseki:operation fuseki:query ] ;
