### PR TITLE
JENA-1775: Protect against a bad resource name

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocatorClassLoader.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocatorClassLoader.java
@@ -58,7 +58,8 @@ public class LocatorClassLoader  implements Locator
         if ( classLoader == null )
             return null ;
             
-        InputStream in = classLoader.getResourceAsStream(resourceName) ;
+        InputStream in = null;
+        try { in = classLoader.getResourceAsStream(resourceName) ; } catch (Exception ex) {}
         if ( in == null )
         {
             if ( StreamManager.logAllLookups && log.isTraceEnabled() )

--- a/jena-core/src/main/java/org/apache/jena/util/LocatorClassLoader.java
+++ b/jena-core/src/main/java/org/apache/jena/util/LocatorClassLoader.java
@@ -22,8 +22,6 @@ import java.io.InputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
 public class LocatorClassLoader  implements Locator
 {
     static Logger log = LoggerFactory.getLogger(LocatorClassLoader.class) ;
@@ -53,14 +51,8 @@ public class LocatorClassLoader  implements Locator
             return null ;
             
         String fn = filenameOrURI ;
-//        String fn = FileUtils.toFilename(filenameOrURI) ;
-//        if ( fn == null )
-//        {
-//            if ( FileManager.logAllLookups && log.isTraceEnabled() )
-//                log.trace("Not found: "+filenameOrURI) ; 
-//            return null ;
-//        }
-        InputStream in = classLoader.getResourceAsStream(fn) ;
+        InputStream in = null;
+        try { in = classLoader.getResourceAsStream(fn) ; } catch (Exception ex) {}
         if ( in == null )
         {
             if ( FileManager.logAllLookups && log.isTraceEnabled() )


### PR DESCRIPTION
This responds to the report on users@.

The problem is that the Java resource name is illegal (it has a ":" in it). Until Java13, it seems this was accepted without an exception being thrown.

Solution: protect the call and ignore the exception.

Due to maximising legacy (at the time) there are two LocatorClassLoader - the non-riot one gets used if jena-core is used its own but it also gets touched when installing the RIOT StreamManager code.
