### PR TITLE
JENA-1784 CacheSimple doesn't check keys for equality

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheSimple.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheSimple.java
@@ -76,7 +76,7 @@ public class CacheSimple<K,V> implements Cache<K,V>
     private final int index(K key)
     { 
         int x = (key.hashCode()&0x7fffffff) % size ;
-        if ( keys[x] != null )
+        if (key.equals(keys[x]))
             return x ; 
         return -x-1 ;
     }

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/cache/CacheSimpleTest.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/cache/CacheSimpleTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.jena.atlas.lib.cache;
 
+import org.apache.jena.atlas.lib.Cache;
+import org.junit.Test;
+
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.junit.Assert.*;
-
-import org.apache.jena.atlas.lib.Cache;
-import org.junit.Test;
 
 /**
  * Simple test to ensure that {@link CacheSimple} evidences the fixed-size
@@ -43,17 +43,47 @@ public class CacheSimpleTest {
 
 	@Test
 	public void testSameHash() {
-		Object key1 = new Object() {
-			@Override public int hashCode() { return 1; }
-		};
-		Object key2 = new Object() {
-			@Override public int hashCode() { return 1; }
-		};
+        CompoundKey key1 = new CompoundKey(1, 1);
+        CompoundKey key2 = new CompoundKey(1, 2);
 		assertEquals(key1.hashCode(), key2.hashCode());
 		assertNotEquals(key1, key2);
-		Cache<Object, Integer> cache = new CacheSimple<>(10);
+		Cache<CompoundKey, Integer> cache = new CacheSimple<>(10);
 		cache.put(key1, 1);
-		assertTrue("Same key, expected in cache", cache.containsKey(key1));
+		assertTrue("Same key, expected to be in cache", cache.containsKey(key1));
 		assertFalse("Keys with same hash code should not be considered equal", cache.containsKey(key2));
 	}
+
+	@Test
+	public void testKeyEquality() {
+		CompoundKey key1 = new CompoundKey(1, 1);
+		CompoundKey key2 = new CompoundKey(1, 1);
+		assertNotSame(key1, key2);
+		assertEquals(key1, key2);
+		Cache<CompoundKey, Integer> cache = new CacheSimple<>(10);
+		cache.put(key1, 1);
+		assertTrue("Equal key, expected to be found", cache.containsKey(key2));
+	}
+
+	private static final class CompoundKey {
+	    private final int a;
+        private final int b;
+
+        private CompoundKey(int a, int b) {
+            this.a = a;
+            this.b = b;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CompoundKey that = (CompoundKey) o;
+            return a == that.a && b == that.b; // Checks both "a" and "b"
+        }
+
+        @Override
+        public int hashCode() {
+            return a; // Doesn't depend on "b"
+        }
+    }
 }

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/cache/CacheSimpleTest.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/cache/CacheSimpleTest.java
@@ -21,6 +21,7 @@ package org.apache.jena.atlas.lib.cache;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.apache.jena.atlas.lib.Cache;
 import org.junit.Test;
@@ -39,5 +40,13 @@ public class CacheSimpleTest {
 		rangeClosed(1, submittedEntries).boxed().collect(toMap(k -> k, v -> 1))
 				.forEach(testCache::put);
 		assertEquals("Test cache failed to maintain fixed size!", maxSize, testCache.size());
+	}
+
+	@Test
+	public void testSameHash() {
+		Cache<String, Integer> cache = new CacheSimple<>(10);
+		assertEquals("Aa".hashCode(), "BB".hashCode());
+		cache.put("Aa", 1);
+		assertFalse("Keys with same hash code should not be considered equal", cache.containsKey("BB"));
 	}
 }

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/cache/CacheSimpleTest.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/cache/CacheSimpleTest.java
@@ -20,8 +20,7 @@ package org.apache.jena.atlas.lib.cache;
 
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.IntStream.rangeClosed;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 import org.apache.jena.atlas.lib.Cache;
 import org.junit.Test;
@@ -44,9 +43,17 @@ public class CacheSimpleTest {
 
 	@Test
 	public void testSameHash() {
-		Cache<String, Integer> cache = new CacheSimple<>(10);
-		assertEquals("Aa".hashCode(), "BB".hashCode());
-		cache.put("Aa", 1);
-		assertFalse("Keys with same hash code should not be considered equal", cache.containsKey("BB"));
+		Object key1 = new Object() {
+			@Override public int hashCode() { return 1; }
+		};
+		Object key2 = new Object() {
+			@Override public int hashCode() { return 1; }
+		};
+		assertEquals(key1.hashCode(), key2.hashCode());
+		assertNotEquals(key1, key2);
+		Cache<Object, Integer> cache = new CacheSimple<>(10);
+		cache.put(key1, 1);
+		assertTrue("Same key, expected in cache", cache.containsKey(key1));
+		assertFalse("Keys with same hash code should not be considered equal", cache.containsKey(key2));
 	}
 }


### PR DESCRIPTION
Added an explicit check for keys' equality