### PR TITLE
DCAT vocabulary version 2

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/vocabulary/DCAT.java
+++ b/jena-core/src/main/java/org/apache/jena/vocabulary/DCAT.java
@@ -48,6 +48,11 @@ public class DCAT {
 	public static final Resource Dataset = m.createResource(NS + "Dataset");
 	public static final Resource Distribution = m.createResource(NS + "Distribution");
 	
+	// Classes added in DCAT version 2
+	public static final Resource DataService = m.createResource(NS + "DataService");
+	public static final Resource Relationship = m.createResource(NS + "Relationship");
+	public static final Resource Role = m.createResource(NS + "Role");
+	
 	// Properties
 	public static final Property accessURL = m.createProperty(NS + "accessURL");
 	public static final Property byteSize = m.createProperty(NS + "byteSize");
@@ -61,4 +66,22 @@ public class DCAT {
 	public static final Property record = m.createProperty(NS + "record");
 	public static final Property theme = m.createProperty(NS + "theme");
 	public static final Property themeTaxonomy = m.createProperty(NS + "themeTaxonomy");
+	
+	// Properties added in DCAT version 2
+	public static final Property accessService = m.createProperty(NS + "");
+	public static final Property bbox = m.createProperty(NS + "");
+	public static final Property catalog = m.createProperty(NS + "");
+	public static final Property centroid = m.createProperty(NS + "");
+	public static final Property compressFormat = m.createProperty(NS + "");
+	public static final Property endDate = m.createProperty(NS + "");
+	public static final Property endpointDescription = m.createProperty(NS + "");
+	public static final Property endpointURL = m.createProperty(NS + "");
+	public static final Property hadRole = m.createProperty(NS + "");
+	public static final Property packageFormat = m.createProperty(NS + "");
+	public static final Property qualifiedRelation = m.createProperty(NS + "");
+	public static final Property servesDataset = m.createProperty(NS + "");
+	public static final Property service = m.createProperty(NS + "");
+	public static final Property spatialResolutionInMeters = m.createProperty(NS + "");
+	public static final Property startDate = m.createProperty(NS + "");
+	public static final Property temporalResolution = m.createProperty(NS + "");
 }


### PR DESCRIPTION
The **Data Catalog Vocabulary (DCAT)** [Version 1](https://www.w3.org/TR/2014/REC-vocab-dcat-20140116/) has been extended to [Version 2](https://www.w3.org/TR/2019/PR-vocab-dcat-2-20191119/) on 19 November 2019 as W3C Proposed Recommendation.

In Apache Jena, there is [org.apache.jena.vocabulary.DCAT](https://github.com/apache/jena/blob/d11b5c8ea739068abd1ab53fc1360e536d6ea471/jena-core/src/main/java/org/apache/jena/vocabulary/DCAT.java) containing Resources (classes) and Properties of version 1.

The additions of this pull request were generated based on data from official docs:
https://github.com/projekt-opal/vocabulary-enhancement