### PR TITLE
Added dcat:Resource

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/vocabulary/DCAT.java
+++ b/jena-core/src/main/java/org/apache/jena/vocabulary/DCAT.java
@@ -51,6 +51,7 @@ public class DCAT {
 	// Classes added in DCAT version 2
 	public static final Resource DataService = m.createResource(NS + "DataService");
 	public static final Resource Relationship = m.createResource(NS + "Relationship");
+	public static final Resource Resource = m.createResource(NS + "Resource");
 	public static final Resource Role = m.createResource(NS + "Role");
 	
 	// Properties


### PR DESCRIPTION
Double-checked DCAT2 changes with https://w3c.github.io/dxwg/dcat/rdf/dcat.ttl

dcat:Resource is the only missing URI in namespace.

Code: https://github.com/projekt-opal/vocabulary-enhancement/blob/197a19ab369420a6b43961738a5dbe3140417e0b/src/main/java/org/dice_research/opal/vocabulary_enhancement/RdfImporter.java#L26