### PR TITLE
 JENA-1814: Update to Apache parent POM v22.

### DIFF
--- a/jena-arq/pom.xml
+++ b/jena-arq/pom.xml
@@ -21,8 +21,6 @@
   <artifactId>jena-arq</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - ARQ (SPARQL 1.1 Query Engine)</name>
-  <version>3.14.0-SNAPSHOT</version>
-
   <parent>
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>

--- a/jena-base/pom.xml
+++ b/jena-base/pom.xml
@@ -26,7 +26,6 @@
     <relativePath>..</relativePath>
   </parent>
   <artifactId>jena-base</artifactId>
-  <version>3.14.0-SNAPSHOT</version>
   <name>Apache Jena - Base Common Environment</name>
   <description>
     This module contains non-RDF library code and the common system runtime.

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/StrUtils.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/StrUtils.java
@@ -201,7 +201,7 @@ public class StrUtils //extends StringUtils
     /**
      * Decode a string using marked hex values e.g. %20
      * 
-     * @param str String to decode : characters should be ASCII (<127)
+     * @param str String to decode : characters should be ASCII (&lt;127)
      * @param marker The marker character
      * @return Decoded string (returns input object on no change)
      */

--- a/jena-cmds/pom.xml
+++ b/jena-cmds/pom.xml
@@ -27,8 +27,6 @@
 
   <name>Apache Jena - Command line tools</name>
   <artifactId>jena-cmds</artifactId>
-  <version>3.14.0-SNAPSHOT</version>
-
   <description>Command line tools</description>
 
   <packaging>jar</packaging>

--- a/jena-core/pom.xml
+++ b/jena-core/pom.xml
@@ -22,8 +22,6 @@
   <artifactId>jena-core</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - Core</name>
-  <version>3.14.0-SNAPSHOT</version>
-
   <parent>
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>

--- a/jena-db/jena-dboe-base/pom.xml
+++ b/jena-db/jena-dboe-base/pom.xml
@@ -31,7 +31,7 @@
   </parent> 
 
   <properties>
-    <automatic.module.name>org.apache.jena.dboe</automatic.module.name>
+    <automatic.module.name>org.apache.jena.dboe.base</automatic.module.name>
   </properties>
 
   <dependencies>

--- a/jena-db/jena-dboe-storage/pom.xml
+++ b/jena-db/jena-dboe-storage/pom.xml
@@ -21,11 +21,9 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.apache.jena</groupId>
   <artifactId>jena-dboe-storage</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - DBOE Storage</name>
-  <version>3.14.0-SNAPSHOT</version>
   <parent>
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-db</artifactId>

--- a/jena-db/pom.xml
+++ b/jena-db/pom.xml
@@ -72,46 +72,48 @@
   </dependencies>
 
   <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>test-jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <!-- <phase>package</phase> package is the default -->
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>attach-sources-test</id>
-            <goals>
-              <goal>test-jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <!-- <phase>package</phase> package is the default -->
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>attach-sources-test</id>
+              <goals>
+                <goal>test-jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
   
 </project>

--- a/jena-elephas/jena-elephas-io/pom.xml
+++ b/jena-elephas/jena-elephas-io/pom.xml
@@ -94,8 +94,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-	      <!-- versions 2.20 and 2.20.1 result in test failures -->
-	      <version>2.19.1</version>
         <configuration>
           <parallel>classes</parallel>
           <threadCount>2</threadCount>

--- a/jena-elephas/pom.xml
+++ b/jena-elephas/pom.xml
@@ -17,7 +17,6 @@ limitations under the License.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>jena-elephas</artifactId>
-  <version>3.14.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>

--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -19,7 +19,6 @@
     <artifactId>jena-fuseki-geosparql</artifactId>
     <packaging>jar</packaging>
     <name>Apache Jena - Fuseki with GeoSPARQL Engine </name>
-    <version>3.14.0-SNAPSHOT</version>
 
     <parent>
       <groupId>org.apache.jena</groupId>

--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -19,7 +19,6 @@
   <artifactId>jena-geosparql</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - GeoSPARQL Engine</name>
-  <version>3.14.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.apache.jena</groupId>

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/GeoSPARQLOperations.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/GeoSPARQLOperations.java
@@ -61,7 +61,6 @@ import org.apache.jena.reasoner.ReasonerRegistry;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.util.iterator.ExtendedIterator;
-import org.apache.jena.util.iterator.NiceIterator;
 import org.apache.jena.vocabulary.RDFS;
 import org.opengis.geometry.MismatchedDimensionException;
 import org.opengis.referencing.operation.TransformException;
@@ -1121,12 +1120,11 @@ public class GeoSPARQLOperations {
      */
     public static final int countGeometryLiterals(Model model, String graphName) {
         Set<String> literalStrings = new TreeSet<>();
-        Iterator<Statement> hasSerializationIterator = model.listStatements(null, Geo.HAS_SERIALIZATION_PROP, (RDFNode) null);
-        Iterator<Statement> asWKTIterator = model.listStatements(null, Geo.AS_WKT_PROP, (RDFNode) null);
-        Iterator<Statement> asGMLIterator = model.listStatements(null, Geo.AS_GML_PROP, (RDFNode) null);
+        ExtendedIterator<Statement> hasSerializationIterator = model.listStatements(null, Geo.HAS_SERIALIZATION_PROP, (RDFNode) null);
+        ExtendedIterator<Statement> asWKTIterator = model.listStatements(null, Geo.AS_WKT_PROP, (RDFNode) null);
+        ExtendedIterator<Statement> asGMLIterator = model.listStatements(null, Geo.AS_GML_PROP, (RDFNode) null);
 
-        NiceIterator niceIterator = new NiceIterator();
-        ExtendedIterator<Statement> allIterator = niceIterator.andThen(hasSerializationIterator).andThen(asWKTIterator).andThen(asGMLIterator);
+        ExtendedIterator<Statement> allIterator = hasSerializationIterator.andThen(asWKTIterator).andThen(asGMLIterator);
         int count = 0;
         while (allIterator.hasNext()) {
             Statement st = allIterator.next();

--- a/jena-integration-tests/pom.xml
+++ b/jena-integration-tests/pom.xml
@@ -21,12 +21,9 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.apache.jena</groupId>
   <artifactId>jena-integration-tests</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - Integration Testing</name>
-  <version>3.14.0-SNAPSHOT</version>
-
   <description>Apache Jena - Integration testing and test tools</description>
 
   <parent>

--- a/jena-iri/pom.xml
+++ b/jena-iri/pom.xml
@@ -23,8 +23,7 @@
   <artifactId>jena-iri</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - IRI</name>
-  <version>3.14.0-SNAPSHOT</version>
-    <parent>
+  <parent>
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>3.14.0-SNAPSHOT</version>

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/metadata/JenaMetadata.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/metadata/JenaMetadata.java
@@ -1219,14 +1219,13 @@ public abstract class JenaMetadata implements DatabaseMetaData {
     @Override
     public abstract boolean usesLocalFiles();
 
-    @SuppressWarnings("javadoc")
+    @Override
     public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
             throws SQLException {
         return new MetaResultSet(MetadataSchema.getPsuedoColumnColumns());
     }
 
-    // Java 6/7 compatibility
-    @SuppressWarnings("javadoc")
+    @Override
     public boolean generatedKeyAlwaysReturned() {
         // We don't support returning keys
         return false;

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/JenaResultSet.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/results/JenaResultSet.java
@@ -633,12 +633,12 @@ public abstract class JenaResultSet implements ResultSet {
         throw new SQLFeatureNotSupportedException("Only the single argument form of getObject() is supported");
     }
     
-    @SuppressWarnings("javadoc")
+    @Override
     public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
         throw new SQLFeatureNotSupportedException("Only the single argument form of getObject() is supported");
     }
     
-    @SuppressWarnings("javadoc")
+    @Override
     public <T> T getObject(String columnLabel,  Class<T> type) throws SQLException {
         throw new SQLFeatureNotSupportedException("Only the single argument form of getObject() is supported");
     }

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/JenaStatement.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/JenaStatement.java
@@ -881,17 +881,15 @@ public abstract class JenaStatement implements Statement {
         }
     }
 
-    // Java 6/7 compatibility
-    @SuppressWarnings("javadoc")
+    @Override
     public boolean isCloseOnCompletion() {
         // Statements do not automatically close
         return false;
     }
 
-    @SuppressWarnings("javadoc")
+    @Override
     public void closeOnCompletion() throws SQLException {
-        // We don't support the JDBC 4.1 feature of closing statements
-        // automatically
+        // We don't support the JDBC 4.1 feature of closing statements automatically
         throw new SQLFeatureNotSupportedException();
     }
 }

--- a/jena-jdbc/jena-jdbc-driver-bundle/pom.xml
+++ b/jena-jdbc/jena-jdbc-driver-bundle/pom.xml
@@ -107,7 +107,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.1</version>
 				<configuration>
 					<transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/jena-permissions/pom.xml
+++ b/jena-permissions/pom.xml
@@ -19,9 +19,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.apache.jena</groupId>
   <artifactId>jena-permissions</artifactId>
-  <version>3.14.0-SNAPSHOT</version>
 
   <name>Apache Jena - Security Permissions</name>
   <description>Security Permissions wrapper around Jena RDF implementation.</description>
@@ -226,7 +224,6 @@
     <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-core</artifactId>
-      <version>1.2.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/jena-rdfconnection/pom.xml
+++ b/jena-rdfconnection/pom.xml
@@ -21,12 +21,9 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.apache.jena</groupId>
   <artifactId>jena-rdfconnection</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - RDF Connection</name>
-  <version>3.14.0-SNAPSHOT</version>
-
   <description>RDF Connection</description>
 
   <parent>

--- a/jena-sdb/pom.xml
+++ b/jena-sdb/pom.xml
@@ -21,8 +21,6 @@
   <artifactId>jena-sdb</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - SDB (SQL based triple store)</name>
-  <version>3.14.0-SNAPSHOT</version>
-
   <parent>
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>

--- a/jena-shacl/pom.xml
+++ b/jena-shacl/pom.xml
@@ -21,7 +21,6 @@
   <artifactId>jena-shacl</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - SHACL</name>
-  <version>3.14.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.apache.jena</groupId>

--- a/jena-tdb/pom.xml
+++ b/jena-tdb/pom.xml
@@ -21,7 +21,6 @@
   <artifactId>jena-tdb</artifactId>
   <packaging>jar</packaging>
   <name>Apache Jena - TDB1 (Native Triple Store)</name>
-  <version>3.14.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.apache.jena</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>21</version>
+    <version>22</version>
   </parent>
 
   <licenses>
@@ -819,13 +819,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.8.1</version>
           <configuration>
             <showDeprecation>false</showDeprecation>
             <encoding>UTF-8</encoding>
@@ -840,9 +840,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>2.22.2</version>
           <!-- 
-               Bug: SUREFIRE-1588
+               Bug: SUREFIRE-1588 Fixed at 3.0.0
                https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911925
           -->
           <configuration>
@@ -966,7 +966,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M1</version>
+          <version>3.0.0-M3</version>
           <executions>
             <execution>
               <id>enforce</id>
@@ -1008,7 +1008,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.2.1</version>
         </plugin>
 
         <!--


### PR DESCRIPTION
Also some general tidying to prepare for the 3.14.0 release: 

* Remove unnecessary <groupId> and <version> (Eclipse warnings of duplicates)
* POM fix to jena-db (old style causes a warning with Apache POM v22).
* A few plugin version updates
* Remove some code warnings.
* A javadoc fix.
