### PR TITLE
JENA-1817: Flush NodeTableCache in CommitFinish

### DIFF
--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionCoordinator.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionCoordinator.java
@@ -122,20 +122,15 @@ public class TransactionCoordinator {
         this(Journal.create(location));
     }
 
-    /** Create a TransactionCoordinator, initially with no associated {@link TransactionalComponent}s */
+    /** Create a TransactionCoordinator, initially with no associated {@link TransactionalComponent TransactionalComponents}. */
     public TransactionCoordinator(Journal journal) {
         this(journal, null , new ArrayList<>());
     }
 
-    /** Create a TransactionCoordinator, initially with {@link TransactionalComponent} in the ComponentGroup */
+    /** Create a TransactionCoordinator, initially with {@link TransactionalComponent TransactionalComponents} in the ComponentGroup */
     public TransactionCoordinator(Journal journal, List<TransactionalComponent> components) {
         this(journal, components , new ArrayList<>());
     }
-
-    //    /** Create a TransactionCoordinator, initially with no associated {@link TransactionalComponent}s */
-//    public TransactionCoordinator(Location journalLocation) {
-//        this(Journal.create(journalLocation), new ArrayList<>() , new ArrayList<>());
-//    }
 
     private TransactionCoordinator(Journal journal, List<TransactionalComponent> txnComp, List<ShutdownHook> shutdownHooks) {
         this.journal = journal;
@@ -467,7 +462,7 @@ public class TransactionCoordinator {
     /**
      * Block until no writers are active, optionally blocking or returning if can't at the moment.
      * <p>
-     * Unlike a write transction, there is no associated transaction.
+     * Unlike a write transaction, there is no associated transaction.
      * <p>
      * If it returns true, the application must call {@link #enableWriters} later.
      * @param canBlock
@@ -732,11 +727,6 @@ public class TransactionCoordinator {
     /*package*/ void executeCommit(Transaction transaction, Runnable commit, Runnable finish, Runnable sysabort) {
         notifyCommitStart(transaction);
         if ( transaction.getMode() == ReadWrite.READ ) {
-
-            //[1746]
-            //executeCommitReader();
-            // No commit on components, all "end".
-            // Make abort the same?
             finish.run();
             notifyCommitFinish(transaction);
             return;

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/nodetable/NodeTableCache.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/nodetable/NodeTableCache.java
@@ -326,7 +326,7 @@ public class NodeTableCache implements NodeTable, TransactionListener {
     }
 
     @Override
-    public void notifyCompleteFinish(Transaction transaction) {
+    public void notifyCommitFinish(Transaction transaction) {
         if(transaction.isWriteTxn()) {
             updateCommit();
         }
@@ -363,7 +363,6 @@ public class NodeTableCache implements NodeTable, TransactionListener {
 
     private void updateCommit() {
         writingThread = null;
-        // Write to main caches.
         node2id_Cache.flushBuffer();
         id2node_Cache.flushBuffer();
     }

--- a/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/TestTDB2.java
+++ b/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/TestTDB2.java
@@ -19,8 +19,12 @@
 package org.apache.jena.tdb2;
 
 import java.io.ByteArrayOutputStream;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.atlas.lib.ThreadLib;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
@@ -58,7 +62,6 @@ public class TestTDB2 {
     // Errors that can occur:
     //   One common term -> no conversion.
     //   Two common terms -> bad read.
-    // Feature control: ThreadBufferingCache.BUFFERING
 
     @Test public void abort1() {
         Quad q1 = SSE.parseQuad("(:g :s :p :o)");
@@ -97,5 +100,54 @@ public class TestTDB2 {
 
     private static void output(DatasetGraph dsg) {
         Txn.executeRead(dsg, ()->RDFDataMgr.write(new ByteArrayOutputStream(),  dsg, Lang.NQUADS));
+    }
+    
+    //JENA-1817: Two W txn, where the second queues on entry.  
+    @Test public void multiple_writers() {
+        Quad q1 = SSE.parseQuad("(:g :s :p :o1)");
+        Quad q2 = SSE.parseQuad("(:g :s :p :o2)");
+        DatasetGraph dsg = DatabaseMgr.createDatasetGraph();
+        
+        // Test controls
+        Semaphore sema =  new Semaphore(0);
+        Semaphore semaTestFinished =  new Semaphore(0);
+        
+        // Setup writers.
+        Runnable r1 = ()->{
+            Txn.executeWrite(dsg,  ()->{
+                // Allow thread 2 run and try to enter the W txn 
+                sema.release(1);
+                dsg.add(q1);
+                // Gives thread2 a chance to enter (can't do this by lock).
+                // It is unfortunate that it's a timeout.
+                Lib.sleep(250);
+            });
+            // Finished.
+            semaTestFinished.release(1);
+        };
+        
+        Runnable r2 = ()->{
+            acquire(sema,1);
+            // Thread 1 is now inside its W txn.
+            Txn.executeWrite(dsg, () -> dsg.add(q2));
+            semaTestFinished.release(1);
+        };
+        ThreadLib.async(r2);
+        ThreadLib.async(r1);
+        
+        // Trigger writers. 
+        sema.release(2);
+        // Wait until test threads have finished
+        acquire(semaTestFinished, 2);
+    }
+    
+    private static void acquire(Semaphore semaphore, int permits) {
+        try {
+            boolean b = semaphore.tryAcquire(permits, 1000, TimeUnit.MILLISECONDS);
+            if ( !b )
+                throw new RuntimeException("Test failure - did not get permits in the time allowed");
+        } catch (InterruptedException ex) {
+            ex.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
The relevant change is:
https://github.com/apache/jena/compare/master...afs:jena1817_tdb2_node_cache?expand=1#diff-e27c3f5f1ae576b9ebb6655fb0585cb6L328

[The test](https://github.com/apache/jena/compare/master...afs:jena1817_tdb2_node_cache?expand=1#diff-d0b153bc6d2468facb2de0d2cf244206R104) in involves waiting points.

From experience, this isn't safe long term. On build systems under load, we have seen very long pauses (many seconds) in thread scheduling. Therefore, the test may need to be tweaked or removed. It has done the necessary proof - undo the fix and the test reliably fails.
