### PR TITLE
JENA-1812: Switch to Murmur3 for blank node allocation

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/BlankNodeAllocatorFixedSeedHash.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/BlankNodeAllocatorFixedSeedHash.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.riot.lang;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -42,8 +43,7 @@ public class BlankNodeAllocatorFixedSeedHash extends BlankNodeAllocatorHash {
      */
     public BlankNodeAllocatorFixedSeedHash(UUID seed) {
         super();
-        if (seed == null)
-            throw new NullPointerException("seed cannot be null");
+        Objects.requireNonNull(seed, "seed cannot be null");
         this.seed = seed;
         this.reset();
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/BlankNodeAllocatorHash.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/BlankNodeAllocatorHash.java
@@ -135,7 +135,7 @@ public class BlankNodeAllocatorHash implements BlankNodeAllocator {
 
         String hexString;
         if ( true ) {
-            long[] x = MurmurHash3.hash128(input);
+            long[] x = MurmurHash3.hash128x64(input);
             // dev: String xs = String.format("%016x%016x", Long.reverseBytes(x[0]), Long.reverseBytes(x[1]));
             char[] chars = new char[32];
             longAsHexLC(x[0], chars, 0);
@@ -143,8 +143,8 @@ public class BlankNodeAllocatorHash implements BlankNodeAllocator {
             hexString = new String(chars);
         } else {
             // Guava. Several objects created.
-            // Using 104729 makes it agree with Apache Commons Codec value.
-            byte[] bytes = Hashing.murmur3_128(104729).hashBytes(input).asBytes();
+            // Using MurmurHash3.DEFAULT_SEED (which is 104729) makes it agree with Apache Commons Codec value.
+            byte[] bytes = Hashing.murmur3_128(MurmurHash3.DEFAULT_SEED).hashBytes(input).asBytes();
             hexString = Bytes.asHexLC(bytes);
         }
         return NodeFactory.createBlankNode(hexString);

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/Bytes.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/Bytes.java
@@ -326,7 +326,7 @@ public class Bytes
     }
 
     public static String asHex(byte[] bytes, int start, int finish, char[] hexDigits) {
-        StringBuilder sw = new StringBuilder() ;
+        StringBuilder sw = new StringBuilder(bytes.length*2) ;
         for ( int i = start ; i < finish ; i++ ) {
             byte b = bytes[i] ;
             int hi = (b & 0xF0) >> 4 ;
@@ -338,7 +338,7 @@ public class Bytes
         return sw.toString() ;
     }
     
-    /** Return a hex string representing the bytes, zero padded to length of byte array. */
+    /** Return a hex string representing the byte. */
     public static String asHex(byte b)
     {
         return asHexUC(b) ; 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <ver.commonscli>1.4</ver.commonscli>
     <ver.commonslang3>3.9</ver.commonslang3>
     <ver.commonscsv>1.7</ver.commonscsv>
-    <ver.commons-codec>1.13</ver.commons-codec>
+    <ver.commons-codec>1.14</ver.commons-codec>
     <ver.commons-compress>1.19</ver.commons-compress>
 
     <ver.dexxcollection>0.7</ver.dexxcollection>


### PR DESCRIPTION
Use Murmur3-128bit for blank node label allocation. This code is called when a blank node appears in RDF syntax.

This is an alternative to #667 as discussed at [JENA-1812](https://issues.apache.org/jira/browse/JENA-1812) (Security software is being to flag up the use of MD5)

Murmur3-128 retains the length of blank node labels at 32 hex digits while not triggering security scans.

The murmurs implementation is the one from Apache Commons Codec. The differences between it and the Guava implementation are, for this usage, slight. For reference, the Guava version is includes in the source but the compiler does not generate any bytecode.