### PR TITLE
JENA-1826: use plain RDF/XML in Fuseki RDF responses

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ResponseDataset.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ResponseDataset.java
@@ -37,7 +37,9 @@ import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.riot.RDFWriterRegistry;
 import org.apache.jena.riot.WebContent;
 import org.apache.jena.shared.JenaException;
 import org.apache.jena.web.HttpSC;
@@ -113,6 +115,9 @@ public class ResponseDataset
         Lang lang = RDFLanguages.contentTypeToLang(contentType);
         if ( lang == null )
             ServletOps.errorBadRequest("Can't determine output content type: "+contentType);
+        // Choose the serialization. For RDX/XML use the fast, plain variant.
+        RDFFormat fmt =
+            ( lang == Lang.RDFXML ) ? RDFFormat.RDFXML_PLAIN : RDFWriterRegistry.defaultSerialization(lang);
 
         try {
             ResponseOps.setHttpResponse(action, contentType, charset);
@@ -120,9 +125,9 @@ public class ResponseDataset
             ServletOutputStream out = response.getOutputStream();
             try {
                 if ( RDFLanguages.isQuads(lang) )
-                    RDFDataMgr.write(out, dataset, lang);
+                    RDFDataMgr.write(out, dataset, fmt);
                 else
-                    RDFDataMgr.write(out, dataset.getDefaultModel(), lang);
+                    RDFDataMgr.write(out, dataset.getDefaultModel(), fmt);
                 out.flush();
             } catch (JenaException ex) {
                 // Some RDF/XML data is unwritable. All we can do is pretend it's a bad

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ResponseDataset.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ResponseDataset.java
@@ -115,7 +115,7 @@ public class ResponseDataset
         Lang lang = RDFLanguages.contentTypeToLang(contentType);
         if ( lang == null )
             ServletOps.errorBadRequest("Can't determine output content type: "+contentType);
-        // Choose the serialization. For RDX/XML use the fast, plain variant.
+        // Choose the serialization. For RDF/XML use the fast, plain variant.
         RDFFormat fmt =
             ( lang == Lang.RDFXML ) ? RDFFormat.RDFXML_PLAIN : RDFWriterRegistry.defaultSerialization(lang);
 


### PR DESCRIPTION
The pretty (aka abbreviated) RDF/XML serialization of Fuseki RDF responses (CONSTRUCT and DESCRIBE queries) sometimes takes excessive amounts of time and CPU to generate. This PR makes Fuseki use plain RDF/XML instead, which is faster to generate.

I had to pass a `RDFFormat` instead of `Lang` to `RDFDataMgr.write()` as it allows more fine-grained control over the serialization syntax. The logic was copied from the GSP_R class.

Jira link: https://issues.apache.org/jira/browse/JENA-1826