### PR TITLE
JENA-1831: Fix SDB transform issue with using UNION in restrincting a query

### DIFF
--- a/jena-sdb/src/main/java/org/apache/jena/sdb/compiler/TransformOptimizeSubqueryFragments.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/compiler/TransformOptimizeSubqueryFragments.java
@@ -169,7 +169,8 @@ public class TransformOptimizeSubqueryFragments extends TransformCopy {
         private Op addStatements(Op dest, Op src, BasicPattern potentialAdditions) {
             // Only needed if destination is a Basic Graph Pattern
             if (OpBGP.isBGP(dest)) {
-                if (src instanceof Op2) {
+                // Only add statements from an Op2 if it is not a Union
+                if (src instanceof Op2 && !(src instanceof OpUnion)) {
                     // Get the left side of an Op2 from src
                     Op opLeft = ((Op2) src).getLeft();
 


### PR DESCRIPTION
Encountered a case using a UNION in a query to select e.g. objects where type is asserted as X, Y or Z (but not A, B, C, etc.)

Pull request prevents the transformer from copying restrictions out of a UNION so that the algebra is correct in this case.

Includes a test for a query that exhibits the problem. All previously existing transformer tests are unmodified and continue to pass, as do all the other unit tests in SDB.

https://issues.apache.org/jira/browse/JENA-1831