### PR TITLE
JENA-1832: Default max heap size setting

### DIFF
--- a/jena-fuseki2/apache-jena-fuseki/fuseki-server
+++ b/jena-fuseki2/apache-jena-fuseki/fuseki-server
@@ -102,7 +102,7 @@ then
    CP="${CP}:${FUSEKI_BASE}/extra/*" 
 fi
 
-JVM_ARGS=${JVM_ARGS:--Xmx1200M}
+JVM_ARGS=${JVM_ARGS:--Xmx4G}
 
 exec $JAVA $JVM_ARGS -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
 

--- a/jena-fuseki2/apache-jena-fuseki/fuseki.service
+++ b/jena-fuseki2/apache-jena-fuseki/fuseki.service
@@ -35,7 +35,7 @@ Description=Fuseki
 Environment=FUSEKI_HOME=/opt/fuseki
 Environment=FUSEKI_BASE=/etc/fuseki
 # Edit the line below to adjust the amount of memory allocated to Fuseki
-Environment=JVM_ARGS=-Xmx2G
+Environment=JVM_ARGS=-Xmx4G
 # Edit to match your installation
 ExecStart=/opt/fuseki/fuseki-server
 # Run as user "fuseki"


### PR DESCRIPTION
Sets Fuseki server (full server) to 4G, up from 1.2G or 2G.

[JENA-1832](https://issues.apache.org/jira/browse/JENA-1832)
