### PR TITLE
GeoSPARQL: Malformed geo:lat and geo:lon checks

### DIFF
--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/SpatialIndex.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/SpatialIndex.java
@@ -456,8 +456,8 @@ public class SpatialIndex {
         while (resIt.hasNext()) {
             Resource feature = resIt.nextResource();
 
-            Literal lat = feature.getProperty(SpatialExtension.GEO_LAT_PROP).getLiteral();
-            Literal lon = feature.getProperty(SpatialExtension.GEO_LON_PROP).getLiteral();
+            Literal lat = feature.getRequiredProperty(SpatialExtension.GEO_LAT_PROP).getLiteral();
+            Literal lon = feature.getRequiredProperty(SpatialExtension.GEO_LON_PROP).getLiteral();
 
             Literal latLonPoint = ConvertLatLon.toLiteral(lat.getFloat(), lon.getFloat());
             GeometryWrapper geometryWrapper = GeometryWrapper.extract(latLonPoint);

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/geo/topological/SpatialObjectGeometryLiteralTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/geo/topological/SpatialObjectGeometryLiteralTest.java
@@ -17,14 +17,18 @@
  */
 package org.apache.jena.geosparql.geo.topological;
 
+import org.apache.jena.datatypes.DatatypeFormatException;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import static org.apache.jena.geosparql.geo.topological.QueryRewriteTestData.FEATURE_B;
 import static org.apache.jena.geosparql.geo.topological.QueryRewriteTestData.GEOMETRY_B;
 import static org.apache.jena.geosparql.geo.topological.QueryRewriteTestData.GEO_FEATURE_LITERAL;
 import static org.apache.jena.geosparql.geo.topological.QueryRewriteTestData.GEO_FEATURE_Y;
 import static org.apache.jena.geosparql.geo.topological.QueryRewriteTestData.LITERAL_B;
+import org.apache.jena.geosparql.implementation.vocabulary.SpatialExtension;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.junit.After;
@@ -68,7 +72,6 @@ public class SpatialObjectGeometryLiteralTest {
     @Test
     public void testRetrieve() {
 
-
         Graph graph = MODEL.getGraph();
         Node targetSpatialObject = null;
         SpatialObjectGeometryLiteral instance = SpatialObjectGeometryLiteral.retrieve(graph, targetSpatialObject);
@@ -84,7 +87,6 @@ public class SpatialObjectGeometryLiteralTest {
     @Test
     public void testRetrieveGeometryLiteral_geometry() {
 
-
         Graph graph = MODEL.getGraph();
         Resource targetSpatialObject = GEOMETRY_B;
         SpatialObjectGeometryLiteral expResult = new SpatialObjectGeometryLiteral(GEOMETRY_B.asNode(), LITERAL_B.asNode());
@@ -98,7 +100,6 @@ public class SpatialObjectGeometryLiteralTest {
     @Test
     public void testRetrieveGeometryLiteral_feature() {
 
-
         Resource targetSpatialObject = FEATURE_B;
         SpatialObjectGeometryLiteral expResult = new SpatialObjectGeometryLiteral(FEATURE_B.asNode(), LITERAL_B.asNode());
         SpatialObjectGeometryLiteral result = SpatialObjectGeometryLiteral.retrieve(MODEL.getGraph(), targetSpatialObject.asNode());
@@ -110,7 +111,6 @@ public class SpatialObjectGeometryLiteralTest {
      */
     @Test
     public void testRetrieveGeometryLiteral_missing_property() {
-
 
         Resource targetSpatialObject = ResourceFactory.createResource("http://example.org#GeometryE");
 
@@ -127,7 +127,6 @@ public class SpatialObjectGeometryLiteralTest {
     @Test
     public void testRetrieveGeometryLiteral_not_feature_geometry() {
 
-
         Resource targetSpatialObject = ResourceFactory.createResource("http://example.org#X");
 
         SpatialObjectGeometryLiteral instance = SpatialObjectGeometryLiteral.retrieve(MODEL.getGraph(), targetSpatialObject.asNode());
@@ -143,11 +142,55 @@ public class SpatialObjectGeometryLiteralTest {
     @Test
     public void testRetrieveGeometryLiteral_feature_lat_lon() {
 
-
         Resource targetSpatialObject = GEO_FEATURE_Y;
         SpatialObjectGeometryLiteral expResult = new SpatialObjectGeometryLiteral(GEO_FEATURE_Y.asNode(), GEO_FEATURE_LITERAL.asNode());
         SpatialObjectGeometryLiteral result = SpatialObjectGeometryLiteral.retrieve(MODEL.getGraph(), targetSpatialObject.asNode());
         assertEquals(expResult, result);
     }
 
+    /**
+     * Test of retrieve method, of class SpatialObjectGeometryLiteral for
+     * multiple geo:lat properties.
+     */
+    @Test(expected = DatatypeFormatException.class)
+    public void testRetrieveGeometryLiteral_multiple_lat() {
+
+        Model model = ModelFactory.createDefaultModel();
+        Resource feature = model.createResource("http://example.org#GeoFeatureX");
+        feature.addLiteral(SpatialExtension.GEO_LAT_PROP, ResourceFactory.createTypedLiteral("0.0", XSDDatatype.XSDfloat));
+        feature.addLiteral(SpatialExtension.GEO_LAT_PROP, ResourceFactory.createTypedLiteral("1.0", XSDDatatype.XSDfloat));
+        feature.addLiteral(SpatialExtension.GEO_LON_PROP, ResourceFactory.createTypedLiteral("60.0", XSDDatatype.XSDfloat));
+        SpatialObjectGeometryLiteral.retrieve(model.getGraph(), feature.asNode());
+    }
+
+    /**
+     * Test of retrieve method, of class SpatialObjectGeometryLiteral for
+     * multiple geo:lon properties.
+     */
+    @Test(expected = DatatypeFormatException.class)
+    public void testRetrieveGeometryLiteral_multiple_lon() {
+
+        Model model = ModelFactory.createDefaultModel();
+        Resource feature = model.createResource("http://example.org#GeoFeatureX");
+        feature.addLiteral(SpatialExtension.GEO_LAT_PROP, ResourceFactory.createTypedLiteral("0.0", XSDDatatype.XSDfloat));
+        feature.addLiteral(SpatialExtension.GEO_LON_PROP, ResourceFactory.createTypedLiteral("60.0", XSDDatatype.XSDfloat));
+        feature.addLiteral(SpatialExtension.GEO_LON_PROP, ResourceFactory.createTypedLiteral("70.0", XSDDatatype.XSDfloat));
+        SpatialObjectGeometryLiteral.retrieve(model.getGraph(), feature.asNode());
+    }
+
+    /**
+     * Test of retrieve method, of class SpatialObjectGeometryLiteral for
+     * multiple geo:lat and geo:lon properties.
+     */
+    @Test(expected = DatatypeFormatException.class)
+    public void testRetrieveGeometryLiteral_multiple_lat_lon() {
+
+        Model model = ModelFactory.createDefaultModel();
+        Resource feature = model.createResource("http://example.org#GeoFeatureX");
+        feature.addLiteral(SpatialExtension.GEO_LAT_PROP, ResourceFactory.createTypedLiteral("0.0", XSDDatatype.XSDfloat));
+        feature.addLiteral(SpatialExtension.GEO_LAT_PROP, ResourceFactory.createTypedLiteral("1.0", XSDDatatype.XSDfloat));
+        feature.addLiteral(SpatialExtension.GEO_LON_PROP, ResourceFactory.createTypedLiteral("60.0", XSDDatatype.XSDfloat));
+        feature.addLiteral(SpatialExtension.GEO_LON_PROP, ResourceFactory.createTypedLiteral("70.0", XSDDatatype.XSDfloat));
+        SpatialObjectGeometryLiteral.retrieve(model.getGraph(), feature.asNode());
+    }
 }


### PR DESCRIPTION
GeoSPARQL
- multiple cases of geo:lat or geo:lon now result in an exception and closure of iterators.
- geo:lat and geo:lon made required properties.