### PR TITLE
Fixes for JENA-1841

### DIFF
--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AskBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AskBuilder.java
@@ -264,13 +264,13 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
 	}
 	@Override
 	public AskBuilder addBind(Expr expression, Object var) {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 
 	@Override
 	public AskBuilder addBind(String expression, Object var) throws ParseException {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 
@@ -282,7 +282,7 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
 
 	@Override
 	public AskBuilder addOrderBy(Object orderBy) {
-		getSolutionModifierHandler().addOrderBy(makeVar(orderBy));
+		getSolutionModifierHandler().addOrderBy(Converters.makeVar(orderBy));
 		return this;
 	}
 
@@ -300,13 +300,13 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
 
 	@Override
 	public AskBuilder addOrderBy(Object orderBy, Order order) {
-		getSolutionModifierHandler().addOrderBy(makeVar(orderBy), order);
+		getSolutionModifierHandler().addOrderBy(Converters.makeVar(orderBy), order);
 		return this;
 	}
 
 	@Override
 	public AskBuilder addGroupBy(Object groupBy) {
-		getSolutionModifierHandler().addGroupBy(makeVar(groupBy));
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(groupBy));
 		return this;
 	}
 
@@ -318,13 +318,13 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
 
 	@Override
 	public AskBuilder addGroupBy(Object var, Expr expr) {
-		getSolutionModifierHandler().addGroupBy(makeVar(var), expr);
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(var), expr);
 		return this;
 	}
 
 	@Override
 	public AskBuilder addGroupBy(Object var, String expr) {
-		getSolutionModifierHandler().addGroupBy(makeVar(var), makeExpr(expr));
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(var), makeExpr(expr));
 		return this;
 	}
 
@@ -342,7 +342,7 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
 
 	@Override
 	public AskBuilder addHaving(Object var) throws ParseException {
-		getSolutionModifierHandler().addHaving(makeVar(var));
+		getSolutionModifierHandler().addHaving(Converters.makeVar(var));
 		return this;
 	}
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
@@ -122,7 +122,7 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
 
 	@Override
 	public ConstructBuilder addOrderBy(Object orderBy) {
-		getSolutionModifierHandler().addOrderBy(makeVar(orderBy));
+		getSolutionModifierHandler().addOrderBy(Converters.makeVar(orderBy));
 		return this;
 	}
 
@@ -140,13 +140,13 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
 
 	@Override
 	public ConstructBuilder addOrderBy(Object orderBy, Order order) {
-		getSolutionModifierHandler().addOrderBy(makeVar(orderBy), order);
+		getSolutionModifierHandler().addOrderBy(Converters.makeVar(orderBy), order);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addGroupBy(Object groupBy) {
-		getSolutionModifierHandler().addGroupBy(makeVar(groupBy));
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(groupBy));
 		return this;
 	}
 
@@ -158,13 +158,13 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
 
 	@Override
 	public ConstructBuilder addGroupBy(Object var, Expr expr) {
-		getSolutionModifierHandler().addGroupBy(makeVar(var), expr);
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(var), expr);
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addGroupBy(Object var, String expr) {
-		getSolutionModifierHandler().addGroupBy(makeVar(var), makeExpr(expr));
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(var), makeExpr(expr));
 		return this;
 	}
 
@@ -182,7 +182,7 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
 
 	@Override
 	public ConstructBuilder addHaving(Object var) throws ParseException {
-		getSolutionModifierHandler().addHaving(makeVar(var));
+		getSolutionModifierHandler().addHaving(Converters.makeVar(var));
 		return this;
 	}
 
@@ -357,13 +357,13 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
 
 	@Override
 	public ConstructBuilder addBind(Expr expression, Object var) {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 
 	@Override
 	public ConstructBuilder addBind(String expression, Object var) throws ParseException {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/Converters.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/Converters.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.arq.querybuilder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.jena.datatypes.BaseDatatype;
+import org.apache.jena.datatypes.DatatypeFormatException;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.TypeMapper;
+import org.apache.jena.graph.FrontsNode;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.impl.LiteralLabel;
+import org.apache.jena.graph.impl.LiteralLabelFactory;
+import org.apache.jena.riot.RiotException;
+import org.apache.jena.riot.system.PrefixMapFactory;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.expr.ExprVar;
+import org.apache.jena.sparql.path.P_Link;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.sparql.path.PathParser;
+import org.apache.jena.sparql.util.NodeFactoryExtra;
+
+/**
+ * A collection of static methods to convert from Objects to various
+ * types used in Query and Update construction.
+ */
+public class Converters {
+	
+	private Converters() { 
+		// do not make instance
+	}
+	
+	/**
+	 * Converts any Node_Variable nodes into Var nodes.
+	 * @param n the node to check
+	 * @return the node n or a new Var if n is an instance of Node_Variable
+	 */
+	public static Node checkVar(Node n )
+	{
+		if (n.isVariable())
+		{
+			return Var.alloc( n );
+		}
+		return n;
+	}
+	
+	/**
+	 * Creates a literal from an object.
+	 * If the object type is registered with the TypeMapper the associated literal
+	 * string is returned.  If the object is not registered an IllegalArgumentException
+	 * is thrown.
+	 * @param o the object to convert.
+	 * @return the literal node.
+	 * @throws IllegalArgumentException if object type is not registered.
+	 */
+	public static Node makeLiteral(Object o) {
+		
+		RDFDatatype dt = TypeMapper.getInstance().getTypeByValue( o );
+		if (dt == null) {
+			String msg = "No TypeDef defined for %s. Use TypeMapper.getInstance().register() to "
+					+ "register one or use makeLiteral() method in query builder instance.";
+			throw new IllegalArgumentException( String.format( msg, o.getClass()));
+		} 
+		return NodeFactory.createLiteral(LiteralLabelFactory.createTypedLiteral(o));
+
+	}
+	
+	/**
+	 * Creates a literal from the value and type URI.
+	 * There are several possible outcomes:
+	 * <ul>
+	 * <li>
+	 * If the URI is registered with TypeMapper and the value is the
+	 * proper lexical form for the type, the registered TypeMapper
+	 * is used and calling {@code getLiteralValue()} on the returned node
+	 * will return a proper object.
+	 * </li><li>
+	 * If the URI is unregistered a Datatype is created but not registered
+	 * with the TypeMapper.  The resulting node is properly constructed for 
+	 * used in output serialization, queries, or updates.  Calling 
+	 * {@code getLiteralValue()} on the returned node will throw DatatypeFormatException.
+	 * Note that if {@code JenaParameters.enableEagerLiteralValidation} is true the 
+	 * DatatypeFormatException will be thrown by this method.
+	 * </li><li>
+	 * If the URI is registered but the value is not a proper lexical form
+	 * a DatatypeFormatException will be thrown by this method.
+	 * </li>
+	 * </ul>
+	 * @param value the value for the literal
+	 * @param typeUri the type URI for the literal node.
+	 * @return the literal node.
+	 * @throws DatatypeFormatException on errors noted above
+	 */
+	public static Node makeLiteral(String value, String typeUri) {
+		Object oValue = value;
+		RDFDatatype dt = TypeMapper.getInstance().getTypeByName(typeUri);
+		if (dt == null)
+		{
+			dt = new BaseDatatype(typeUri) {
+
+			@Override
+			public boolean isValidValue(Object valueForm) {
+				return false;
+			}
+			
+			@Override
+			public Object parse(String lexicalForm) throws DatatypeFormatException {
+				RDFDatatype dt = TypeMapper.getInstance().getTypeByName(uri);
+				if (dt == null)
+				{
+					throw new DatatypeFormatException("no registered Datatype for "+uri );
+				}
+				return dt.parse( lexicalForm );
+		    }
+			
+		};
+		} else {
+			oValue = dt.parse( value );
+		}
+		LiteralLabel ll = LiteralLabelFactory.createByValue( oValue, null, dt );
+		return NodeFactory.createLiteral(ll);
+	}
+	
+	/**
+	 * Makes a node from an object while using the associated prefix mapping.
+	 * <ul>
+	 * <li>Will return Node.ANY if object is null.</li>
+	 * <li>Will return the enclosed Node from a FrontsNode</li>
+	 * <li>Will return the object if it is a Node.</li>
+	 * <li>Will call NodeFactoryExtra.parseNode() using the currently defined
+	 * prefixes if the object is a String</li>
+	 * <li>Will call makeLiteral() to create a literal representation if the parseNode() fails or for
+	 * any other object type.</li>
+	 * </ul>
+	 * @param o The object to convert (may be null).
+	 * @param pMapping The prefix mapping to use for prefix resolution.
+	 * @return The Node value.
+	 * @see #makeLiteral(Object)
+	 */
+	public static Node makeNode(Object o, PrefixMapping pMapping) {
+		if (o == null) {
+			return Node.ANY;
+		}
+		if (o instanceof FrontsNode) {
+			return checkVar(((FrontsNode) o).asNode());
+		}
+
+		if (o instanceof Node) {
+			return checkVar( (Node) o );
+		}
+		if (o instanceof String) {
+			try {
+				return checkVar(NodeFactoryExtra.parseNode((String) o, PrefixMapFactory
+						.createForInput(pMapping)));
+			} catch (final RiotException e) {
+				// expected in some cases -- do nothing
+			}
+
+		}
+		return makeLiteral( o );
+	}
+
+	/**
+	 * Creates a Path or Node as appropriate.
+	 * <ul>
+	 * <li>Will return Node.ANY if object is null.</li>
+	 * <li>Will return the object if it is a Path
+	 * <li>Will return the enclosed Node from a FrontsNode</li>
+	 * <li>Will return the object if it is a Node.</li>
+	 * <li>Will call PathParser.parse() using the prefix mapping if the object is a String</li>
+	 * <li>Will call NodeFactoryExtra.parseNode() using the currently defined
+	 * prefixes if the object is a String and the PathParser.parse() fails.</li>
+	 * <li>Will call makeLiteral() to create a literal representation if the parseNode() fails or for
+	 * any other object type.</li>
+	 * </ul>
+	 * @param o the object that should be interpreted as a path or a node.
+	 * @param pMapping the prefix mapping to resolve path or node with
+	 * @return the Path or Node
+	 * @see #makeLiteral(Object) 
+	 */
+	public static Object makeNodeOrPath(Object o, PrefixMapping pMapping)
+	{
+		if (o == null) {
+			return Node.ANY;
+		}
+		if (o instanceof Path)
+		{
+			return o;
+		}
+		if (o instanceof FrontsNode) {
+			return checkVar(((FrontsNode) o).asNode());
+		}
+
+		if (o instanceof Node) {
+			return checkVar((Node)o);
+		}
+		if (o instanceof String) {
+			try {			
+				final Path p = PathParser.parse((String) o, pMapping);
+				if (p instanceof P_Link)
+				{
+					return ((P_Link)p).getNode();
+				}
+				return p;
+			}
+			
+			catch (final Exception e)
+			{
+				// expected in some cases -- do nothing
+			}
+
+		}
+		return makeNode( o, pMapping );		
+	}
+
+	/**
+	 * Makes a Var from an object.
+	 * <ul>
+	 * <li>Will return Var.ANON if object is null.</li>
+	 * <li>Will return null if the object is "*" or Node_RuleVariable.WILD</li>
+	 * <li>Will return the object if it is a Var</li>
+	 * <li>Will return resolve FrontsNode to Node and then resolve to Var</li>
+	 * <li>Will return resolve Node if the Node implements Node_Variable,
+	 * otherwise throws an NotAVariableException (instance of
+	 * ARQInternalErrorException)</li>
+	 * <li>Will return ?x if object is "?x"</li>
+	 * <li>Will return ?x if object is "x"</li>
+	 * <li>Will return the enclosed Var of a ExprVar</li>
+	 * <li>For all other objects will return the "?" prefixed to the toString()
+	 * value.</li>
+	 * </ul>
+	 * 
+	 * @param o
+	 *            The object to convert.
+	 * @return the Var value.
+	 * @throws ARQInternalErrorException
+	 */
+	public static Var makeVar(Object o) throws ARQInternalErrorException {
+		if (o == null) {
+			return Var.ANON;
+		}
+		if (o instanceof Var) {
+			return (Var) o;
+		}
+		Var retval = null;
+		if (o instanceof FrontsNode) {
+			retval = Var.alloc(((FrontsNode) o).asNode());
+		} else if (o instanceof Node) {
+			retval = Var.alloc((Node) o);
+		} else if (o instanceof ExprVar) {
+			retval = Var.alloc((ExprVar) o);
+		} else {
+			retval = Var.alloc(Var.canonical(o.toString()));
+		}
+		if ("*".equals(Var.canonical(retval.toString()))) {
+			return null;
+		}
+		return retval;
+	}
+
+	/**
+	 * A convenience method to quote a string.
+	 * @param q the string to quote.
+	 * 
+	 * Will use single quotes if there are no single quotes in the string or if the 
+	 * double quote is before the single quote in the string.
+	 * 
+	 * Will use double quote otherwise.
+	 * 
+	 * @return the quoted string. 
+	 */
+	public static String quoted(String q) {
+		int qt = q.indexOf('"');
+		int sqt = q.indexOf("'");
+		if (qt == -1) { 
+			qt = Integer.MAX_VALUE;
+		}
+		if (sqt == -1) {
+			sqt = Integer.MAX_VALUE;
+		}
+		
+		if (qt <= sqt)
+		{
+			return String.format( "'%s'", q);
+		}
+		return String.format( "\"%s\"", q);
+	}
+
+	/**
+	 * Creates a collection of nodes from an iterator of Objects.
+	 * @param iter the iterator of objects, may be null or empty.
+	 * @param prefixMapping the PrefixMapping to use when nodes are created.
+	 * @return a Collection of nodes or null if iter is null or empty.
+	 */
+	public static Collection<Node> makeValueNodes( Iterator<?> iter, PrefixMapping prefixMapping )
+	{
+		if (iter == null || !iter.hasNext())
+		{
+			return null;
+		}
+		final List<Node> values = new ArrayList<Node>();
+		while (iter.hasNext())
+		{
+			final Object o = iter.next();
+			// handle null as UNDEF
+			if (o == null)
+			{
+				values.add( null );
+			} else 
+			{
+				values.add( makeNode( o, prefixMapping ));
+			}
+		}
+		return values;
+	}
+
+}

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/DescribeBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/DescribeBuilder.java
@@ -74,19 +74,19 @@ DatasetClause<DescribeBuilder>,
 
 	@Override
 	public DescribeBuilder addVar(Object var) {
-		getSelectHandler().addVar(makeVar(var));
+		getSelectHandler().addVar(Converters.makeVar(var));
 		return this;
 	}
 
 	@Override
 	public DescribeBuilder addVar(Expr expr, Object var) {
-		getSelectHandler().addVar(expr, makeVar(var));
+		getSelectHandler().addVar(expr, Converters.makeVar(var));
 		return this;
 	}
 
 	@Override
 	public DescribeBuilder addVar(String expr, Object var) throws ParseException {
-		getSelectHandler().addVar(expr, makeVar(var));
+		getSelectHandler().addVar(expr, Converters.makeVar(var));
 		return this;
 	}
 
@@ -103,7 +103,7 @@ DatasetClause<DescribeBuilder>,
 
 	@Override
 	public DescribeBuilder addOrderBy(Object orderBy) {
-		getSolutionModifierHandler().addOrderBy(makeVar(orderBy));
+		getSolutionModifierHandler().addOrderBy(Converters.makeVar(orderBy));
 		return this;
 	}
 
@@ -121,13 +121,13 @@ DatasetClause<DescribeBuilder>,
 
 	@Override
 	public DescribeBuilder addOrderBy(Object orderBy, Order order) {
-		getSolutionModifierHandler().addOrderBy(makeVar(orderBy), order);
+		getSolutionModifierHandler().addOrderBy(Converters.makeVar(orderBy), order);
 		return this;
 	}
 
 	@Override
 	public DescribeBuilder addGroupBy(Object groupBy) {
-		getSolutionModifierHandler().addGroupBy(makeVar(groupBy));
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(groupBy));
 		return this;
 	}
 
@@ -139,13 +139,13 @@ DatasetClause<DescribeBuilder>,
 
 	@Override
 	public DescribeBuilder addGroupBy(Object var, Expr expr) {
-		getSolutionModifierHandler().addGroupBy(makeVar(var), expr);
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(var), expr);
 		return this;
 	}
 
 	@Override
 	public DescribeBuilder addGroupBy(Object var, String expr) {
-		getSolutionModifierHandler().addGroupBy(makeVar(var), makeExpr(expr));
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(var), makeExpr(expr));
 		return this;
 	}
 
@@ -163,7 +163,7 @@ DatasetClause<DescribeBuilder>,
 
 	@Override
 	public DescribeBuilder addHaving(Object var) throws ParseException {
-		getSolutionModifierHandler().addHaving(makeVar(var));
+		getSolutionModifierHandler().addHaving(Converters.makeVar(var));
 		return this;
 	}
 
@@ -341,13 +341,13 @@ DatasetClause<DescribeBuilder>,
 
 	@Override
 	public DescribeBuilder addBind(Expr expression, Object var) {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 
 	@Override
 	public DescribeBuilder addBind(String expression, Object var) throws ParseException {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ExprFactory.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ExprFactory.java
@@ -1694,7 +1694,7 @@ public class ExprFactory {
 	 * <li>otherwise create an ExprVar from {AbstractQuerybuilder.makeVar}
 	 * </ul>
 	 * 
-	 * @see AbstractQueryBuilder#makeVar(Object)
+	 * @see Converters#makeVar(Object)
 	 * 
 	 * @param o
 	 *            the object to convert.
@@ -1704,7 +1704,7 @@ public class ExprFactory {
 		if (o instanceof ExprVar) {
 			return (ExprVar) o;
 		}
-		Var v = AbstractQueryBuilder.makeVar(o);
+		Var v = Converters.makeVar(o);
 		return v == null ? null : new ExprVar(v);
 	}
 
@@ -1744,13 +1744,15 @@ public class ExprFactory {
 	/**
 	 * Convenience method to call AbstractQueryBuilder.quote
 	 * 
-	 * @see AbstractQueryBuilder#quote(String)
+	 * @see Converters#quoted(String)
 	 * @param s
 	 *            the string to quote
 	 * @return the quotes string.
+	 * @deprecated use {@link Converters#quoted(String)}
 	 */
+	@Deprecated
 	public final String quote(String s) {
-		return AbstractQueryBuilder.quote(s);
+		return Converters.quoted(s);
 	}
 
 	/**
@@ -1767,7 +1769,7 @@ public class ExprFactory {
 	 * </ul>
 	 * 
 	 * @see #asVar(Object)
-	 * @see AbstractQueryBuilder#makeVar(Object)
+	 * @see Converters#makeVar(Object)
 	 * 
 	 * @param o
 	 *            the object to create the expression from
@@ -1780,7 +1782,7 @@ public class ExprFactory {
 		if (o instanceof Expr) {
 			return (Expr) o;
 		}
-		Node n = AbstractQueryBuilder.makeNode(o, pMap);
+		Node n = Converters.makeNode(o, pMap);
 
 		if (n.isVariable()) {
 			return new ExprVar(Var.alloc(n));

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
@@ -114,19 +114,19 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
 
 	@Override
 	public SelectBuilder addVar(Object var) {
-		getSelectHandler().addVar(makeVar(var));
+		getSelectHandler().addVar(Converters.makeVar(var));
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addVar(String expression, Object var) throws ParseException {
-		getSelectHandler().addVar(expression, makeVar(var));
+		getSelectHandler().addVar(expression, Converters.makeVar(var));
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addVar(Expr expr, Object var) {
-		getSelectHandler().addVar(expr, makeVar(var));
+		getSelectHandler().addVar(expr, Converters.makeVar(var));
 		return this;
 	}
 
@@ -167,7 +167,7 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
 
 	@Override
 	public SelectBuilder addOrderBy(Object orderBy) {
-		getSolutionModifierHandler().addOrderBy(makeVar(orderBy));
+		getSolutionModifierHandler().addOrderBy(Converters.makeVar(orderBy));
 		return this;
 	}
 
@@ -185,13 +185,13 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
 
 	@Override
 	public SelectBuilder addOrderBy(Object orderBy, Order order) {
-		getSolutionModifierHandler().addOrderBy(makeVar(orderBy), order);
+		getSolutionModifierHandler().addOrderBy(Converters.makeVar(orderBy), order);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addGroupBy(Object groupBy) {
-		getSolutionModifierHandler().addGroupBy(makeVar(groupBy));
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(groupBy));
 		return this;
 	}
 
@@ -203,13 +203,13 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
 
 	@Override
 	public SelectBuilder addGroupBy(Object var, Expr expr) {
-		getSolutionModifierHandler().addGroupBy(makeVar(var), expr);
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(var), expr);
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addGroupBy(Object var, String expr) {
-		getSolutionModifierHandler().addGroupBy(makeVar(var), makeExpr(expr));
+		getSolutionModifierHandler().addGroupBy(Converters.makeVar(var), makeExpr(expr));
 		return this;
 	}
 
@@ -232,7 +232,7 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
 
 	@Override
 	public SelectBuilder addHaving(Object var) throws ParseException {
-		getSolutionModifierHandler().addHaving(makeVar(var));
+		getSolutionModifierHandler().addHaving(Converters.makeVar(var));
 		return this;
 	}
 
@@ -456,13 +456,13 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
 
 	@Override
 	public SelectBuilder addBind(Expr expression, Object var) {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 
 	@Override
 	public SelectBuilder addBind(String expression, Object var) throws ParseException {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
@@ -258,7 +258,7 @@ public class UpdateBuilder {
 	 * @return a TriplePath
 	 */
 	public TriplePath makeTriplePath(Object s, Object p, Object o) {
-		final Object po = AbstractQueryBuilder.makeNodeOrPath( p, prefixHandler.getPrefixes() );
+		final Object po = Converters.makeNodeOrPath( p, prefixHandler.getPrefixes() );
 		if (po instanceof Path)
 		{
 			return new TriplePath(makeNode(s), (Path)po, makeNode(o));
@@ -281,7 +281,7 @@ public class UpdateBuilder {
 	 * @return the Node.
 	 */
 	public Node makeNode(Object o) {
-		return AbstractQueryBuilder.makeNode(o, prefixHandler.getPrefixes());
+		return Converters.makeNode(o, prefixHandler.getPrefixes());
 	}
 
 	/**
@@ -289,15 +289,16 @@ public class UpdateBuilder {
 	 * 
 	 * Shorthand for AbstractQueryBuilder.makeVar( o )
 	 * 
-	 * @see AbstractQueryBuilder#makeVar(Object)
+	 * @see Converters#makeVar(Object)
 	 * 
 	 * @param o
 	 *            the object to convert to a var.
 	 * @return the Var.
+	 * @deprecated use {@link Converters#makeVar(Object)}
 	 */
-
+	@Deprecated
 	public Var makeVar(Object o) {
-		return AbstractQueryBuilder.makeVar(o);
+		return Converters.makeVar(o);
 	}
 
 	/**
@@ -305,15 +306,17 @@ public class UpdateBuilder {
 	 * 
 	 * Shorthand for AbstractQueryBuilder.quote( s )
 	 * 
-	 * @see AbstractQueryBuilder#quote(String)
+	 * @see #quoted(String)
 	 * 
-	 * 
+	 * @deprecated Use quoted()
 	 * @param s
 	 *            the string to quote.
 	 * @return the quoted string.
+	 * @deprecated use {@link Converters#quoted(String)}
 	 */
+	@Deprecated
 	public String quote(String s) {
-		return AbstractQueryBuilder.quote(s);
+		return Converters.quoted(s);
 	}
 
 	/**
@@ -393,7 +396,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addInsert(Object g, Triple t) {
-		Quad q = new Quad(AbstractQueryBuilder.makeNode(g, prefixHandler.getPrefixes()), t);
+		Quad q = new Quad(makeNode(g), t);
 		inserts.add(new SingleQuadHolder(q));
 		return this;
 	}
@@ -460,9 +463,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addInsert(Object g, Model model) {
-		inserts.add( new ModelQuadHolder(
-				AbstractQueryBuilder.makeNode(g, prefixHandler.getPrefixes()),
-				model));
+		inserts.add( new ModelQuadHolder( makeNode(g), model));
 		return this;
 	}
 
@@ -474,9 +475,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addInsert(Object g, Collection<Triple> collection) {
-		inserts.add(new CollectionQuadHolder( 
-				AbstractQueryBuilder.makeNode(g, prefixHandler.getPrefixes()),
-				collection ));
+		inserts.add(new CollectionQuadHolder( makeNode(g), collection ));
 		return this;
 	}
 	
@@ -487,9 +486,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addInsert(Object g, Iterator<Triple> iter) {
-		inserts.add(new CollectionQuadHolder( 
-				AbstractQueryBuilder.makeNode(g, prefixHandler.getPrefixes()),
-				iter ));
+		inserts.add(new CollectionQuadHolder( makeNode(g), iter ));
 		return this;
 	}
 	
@@ -522,7 +519,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addInsert(Object graph, AbstractQueryBuilder<?> queryBuilder) {
-		inserts.add(new QBQuadHolder(AbstractQueryBuilder.makeNode(graph, prefixHandler.getPrefixes()), queryBuilder));
+		inserts.add(new QBQuadHolder(makeNode(graph), queryBuilder));
 		return this;
 	}
 
@@ -543,10 +540,10 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addDelete(Object g, Object s, Object p, Object o) {
-		return addDelete(new Quad(AbstractQueryBuilder.makeNode(g, prefixHandler.getPrefixes()),
-				AbstractQueryBuilder.makeNode(s, prefixHandler.getPrefixes()),
-				AbstractQueryBuilder.makeNode(p, prefixHandler.getPrefixes()),
-				AbstractQueryBuilder.makeNode(o, prefixHandler.getPrefixes())));
+		return addDelete(new Quad(makeNode(g),
+				makeNode(s),
+				makeNode(p),
+				makeNode(o)));
 	}
 
 	/**
@@ -587,9 +584,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addDelete(Object s, Object p, Object o) {
-		addDelete(new Triple(AbstractQueryBuilder.makeNode(s, prefixHandler.getPrefixes()),
-				AbstractQueryBuilder.makeNode(p, prefixHandler.getPrefixes()),
-				AbstractQueryBuilder.makeNode(o, prefixHandler.getPrefixes())));
+		addDelete(new Triple(makeNode(s), makeNode(p), makeNode(o)));
 		return this;
 	}
 
@@ -620,7 +615,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addDelete(Object g, Triple t) {
-		Quad q = new Quad(AbstractQueryBuilder.makeNode(g, prefixHandler.getPrefixes()), t);
+		Quad q = new Quad(makeNode(g), t);
 		deletes.add(new SingleQuadHolder(q));
 		return this;
 	}
@@ -677,9 +672,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addDelete(Object g, Model model) {
-		deletes.add( new ModelQuadHolder(
-				AbstractQueryBuilder.makeNode(g, prefixHandler.getPrefixes()),
-				model));
+		deletes.add( new ModelQuadHolder( makeNode(g), model));
 		return this;
 	}
 
@@ -693,9 +686,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addDelete(Object g, Collection<Triple> collection) {
-		deletes.add(new CollectionQuadHolder( 
-				AbstractQueryBuilder.makeNode(g, prefixHandler.getPrefixes()),
-				collection ));
+		deletes.add(new CollectionQuadHolder( makeNode(g), collection ));
 		return this;
 	}
 	
@@ -708,9 +699,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addDelete(Object g, Iterator<Triple> iter) {
-		deletes.add(new CollectionQuadHolder( 
-				AbstractQueryBuilder.makeNode(g, prefixHandler.getPrefixes()),
-				iter ));
+		deletes.add(new CollectionQuadHolder( makeNode(g), iter ));
 		return this;
 	}
 
@@ -744,7 +733,7 @@ public class UpdateBuilder {
 	 * @return this builder for chaining.
 	 */
 	public UpdateBuilder addDelete(Object graph, AbstractQueryBuilder<?> queryBuilder) {
-		deletes.add(new QBQuadHolder(AbstractQueryBuilder.makeNode(graph, prefixHandler.getPrefixes()), queryBuilder));
+		deletes.add(new QBQuadHolder(makeNode(graph), queryBuilder));
 		return this;
 	}
 
@@ -858,10 +847,9 @@ public class UpdateBuilder {
 	 */
 	public void setVar(Object var, Object value) {
 		if (value == null) {
-			setVar(AbstractQueryBuilder.makeVar(var), null);
+			setVar(Converters.makeVar(var), null);
 		} else {
-			setVar(AbstractQueryBuilder.makeVar(var),
-					AbstractQueryBuilder.makeNode(value, prefixHandler.getPrefixes()));
+			setVar(Converters.makeVar(var), makeNode(value));
 		}
 	}
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/WhereBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/WhereBuilder.java
@@ -212,13 +212,13 @@ public class WhereBuilder extends AbstractQueryBuilder<WhereBuilder> implements 
 
 	@Override
 	public WhereBuilder addBind(Expr expression, Object var) {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 
 	@Override
 	public WhereBuilder addBind(String expression, Object var) throws ParseException {
-		getWhereHandler().addBind(expression, makeVar(var));
+		getWhereHandler().addBind(expression, Converters.makeVar(var));
 		return this;
 	}
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/ValuesClause.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/ValuesClause.java
@@ -65,7 +65,7 @@ public interface ValuesClause<T extends AbstractQueryBuilder<T>> {
 	 *            The variable or collection to add.
 	 * @return The builder for chaining.
 	 * @see AbstractQueryBuilder#makeNode(Object)
-	 * @see AbstractQueryBuilder#makeVar(Object)
+	 * @see Converters#makeVar(Object)
 	 */
 	public T addValueVar(Object var);
 	
@@ -85,7 +85,7 @@ public interface ValuesClause<T extends AbstractQueryBuilder<T>> {
 	 * @param values The values for the variable          
 	 * @return The builder for chaining.
 	 * @see AbstractQueryBuilder#makeNode(Object)
-	 * @see AbstractQueryBuilder#makeVar(Object)
+	 * @see Converters#makeVar(Object)
 	 */
 	public T addValueVar(Object var, Object... values);
 	
@@ -113,7 +113,7 @@ public interface ValuesClause<T extends AbstractQueryBuilder<T>> {
 	 *            The data table to add.
 	 * @return The builder for chaining.
 	 * @see AbstractQueryBuilder#makeNode(Object)
-	 * @see AbstractQueryBuilder#makeVar(Object)
+	 * @see Converters#makeVar(Object)
 	 */
 	public <K extends Collection<?>> T addValueVars(Map<?,K> dataTable);
 	

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/WhereClause.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/WhereClause.java
@@ -111,7 +111,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 	 *            The variable or collection to add.
 	 * @return The builder for chaining.
 	 * @see AbstractQueryBuilder#makeNode(Object)
-	 * @see AbstractQueryBuilder#makeVar(Object)
+	 * @see Converters#makeVar(Object)
 	 */
 	public T addWhereValueVar(Object var);
 	
@@ -131,7 +131,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 	 * @param values The values for the variable          
 	 * @return The builder for chaining.
 	 * @see AbstractQueryBuilder#makeNode(Object)
-	 * @see AbstractQueryBuilder#makeVar(Object)
+	 * @see Converters#makeVar(Object)
 	 */
 	public T addWhereValueVar(Object var, Object... values);
 	
@@ -163,7 +163,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 	 *            The data table to add.
 	 * @return The builder for chaining.
 	 * @see AbstractQueryBuilder#makeNode(Object)
-	 * @see AbstractQueryBuilder#makeVar(Object)
+	 * @see Converters#makeVar(Object)
 	 */
 	public <K extends Collection<?>> T addWhereValueVars(Map<?,K> dataTable);
 	

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/WhereHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/WhereHandler.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
+import org.apache.jena.arq.querybuilder.Converters;
 import org.apache.jena.arq.querybuilder.clauses.SelectClause;
 import org.apache.jena.arq.querybuilder.rewriters.BuildElementVisitor;
 import org.apache.jena.arq.querybuilder.rewriters.ElementRewriter;
@@ -483,7 +484,7 @@ public class WhereHandler implements Handler {
 		Node retval = NodeFactory.createBlankNode();
 		Node lastObject = retval;
 		for (int i = 0; i < objs.length; i++) {
-			Node n = AbstractQueryBuilder.makeNode(objs[i], query.getPrefixMapping());
+			Node n = Converters.makeNode(objs[i], query.getPrefixMapping());
 			addWhere(new TriplePath(new Triple(lastObject, RDF.first.asNode(), n)));
 			if (i + 1 < objs.length) {
 				Node nextObject = NodeFactory.createBlankNode();
@@ -526,10 +527,10 @@ public class WhereHandler implements Handler {
 				throw new IllegalArgumentException( "column must have at least one entry.");
 			}
 			Iterator<?> iter = column.iterator();
-			Var v = AbstractQueryBuilder.makeVar( iter.next() );
-			valuesHandler.addValueVar(v, AbstractQueryBuilder.makeValueNodes(iter,prefixMapping));
+			Var v = Converters.makeVar( iter.next() );
+			valuesHandler.addValueVar(v, Converters.makeValueNodes(iter,prefixMapping));
 		} else {
-			valuesHandler.addValueVar(AbstractQueryBuilder.makeVar(var), null );
+			valuesHandler.addValueVar(Converters.makeVar(var), null );
 		}		
 	}
 
@@ -538,10 +539,10 @@ public class WhereHandler implements Handler {
 		Collection<Node> values = null;
 		if (objects != null)
 		{
-			values = AbstractQueryBuilder.makeValueNodes( Arrays.asList(objects).iterator(), prefixMapping);
+			values = Converters.makeValueNodes( Arrays.asList(objects).iterator(), prefixMapping);
 		}
 		
-		valuesHandler.addValueVar(AbstractQueryBuilder.makeVar(var), values );
+		valuesHandler.addValueVar(Converters.makeVar(var), values );
 	}
 	
 	public <K extends Collection<?>> void addValueVars(PrefixMapping prefixMapping, Map<?,K> dataTable) {
@@ -551,19 +552,19 @@ public class WhereHandler implements Handler {
 			Collection<Node> values = null;
 			if (entry.getValue() != null)
 			{
-				values = AbstractQueryBuilder.makeValueNodes( entry.getValue().iterator(), prefixMapping );
+				values = Converters.makeValueNodes( entry.getValue().iterator(), prefixMapping );
 			}
-			hdlr.addValueVar(AbstractQueryBuilder.makeVar(entry.getKey()), values );
+			hdlr.addValueVar(Converters.makeVar(entry.getKey()), values );
 		}
 		valuesHandler.addAll( hdlr );
 	}
 	
 	public void addValueRow(PrefixMapping prefixMapping, Object... values) {
-		valuesHandler.addValueRow( AbstractQueryBuilder.makeValueNodes( Arrays.asList(values).iterator(), prefixMapping));
+		valuesHandler.addValueRow( Converters.makeValueNodes( Arrays.asList(values).iterator(), prefixMapping));
 	}
 
 	public void addValueRow(PrefixMapping prefixMapping, Collection<?> values) {
-		valuesHandler.addValueRow( AbstractQueryBuilder.makeValueNodes( values.iterator(), prefixMapping));
+		valuesHandler.addValueRow( Converters.makeValueNodes( values.iterator(), prefixMapping));
 	}
 	
 	

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/updatebuilder/QuadIteratorBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/updatebuilder/QuadIteratorBuilder.java
@@ -19,7 +19,7 @@ package org.apache.jena.arq.querybuilder.updatebuilder;
 
 import java.util.function.Function;
 
-import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
+import org.apache.jena.arq.querybuilder.Converters;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Query;
@@ -64,9 +64,9 @@ class QuadIteratorBuilder implements ElementVisitor {
 		@Override
 		public Quad apply(Triple triple) {
 			return new Quad( defaultGraph, 
-					AbstractQueryBuilder.checkVar( triple.getSubject()),
-					AbstractQueryBuilder.checkVar( triple.getPredicate()),
-					AbstractQueryBuilder.checkVar( triple.getObject()));
+					Converters.checkVar( triple.getSubject()),
+					Converters.checkVar( triple.getPredicate()),
+					Converters.checkVar( triple.getObject()));
 		}
 	};
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/updatebuilder/SingleQuadHolder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/updatebuilder/SingleQuadHolder.java
@@ -19,7 +19,7 @@ package org.apache.jena.arq.querybuilder.updatebuilder;
 
 import java.util.Map;
 
-import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
+import org.apache.jena.arq.querybuilder.Converters;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.core.Quad;
@@ -44,10 +44,10 @@ public class SingleQuadHolder implements QuadHolder{
 		if (quad.getGraph().isVariable() || quad.getSubject().isVariable() || quad.getPredicate().isVariable() ||
 				quad.getObject().isVariable())
 		{
-			this.quad = new Quad( AbstractQueryBuilder.checkVar( quad.getGraph()),
-					AbstractQueryBuilder.checkVar( quad.getSubject() ),
-					AbstractQueryBuilder.checkVar( quad.getPredicate()),
-					AbstractQueryBuilder.checkVar( quad.getObject()));
+			this.quad = new Quad( Converters.checkVar( quad.getGraph()),
+					Converters.checkVar( quad.getSubject() ),
+					Converters.checkVar( quad.getPredicate()),
+					Converters.checkVar( quad.getObject()));
 		} else {
 			this.quad = quad;
 		}
@@ -63,9 +63,9 @@ public class SingleQuadHolder implements QuadHolder{
 	public SingleQuadHolder( Triple triple )
 	{
 		this.quad = new Quad( Quad.defaultGraphNodeGenerated, 
-				AbstractQueryBuilder.checkVar( triple.getSubject()),
-				AbstractQueryBuilder.checkVar( triple.getPredicate()),
-				AbstractQueryBuilder.checkVar( triple.getObject())				
+				Converters.checkVar( triple.getSubject()),
+				Converters.checkVar( triple.getPredicate()),
+				Converters.checkVar( triple.getObject())				
 				);
 	}
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/updatebuilder/WhereQuadHolder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/updatebuilder/WhereQuadHolder.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
+import org.apache.jena.arq.querybuilder.Converters;
 import org.apache.jena.arq.querybuilder.clauses.SelectClause;
 import org.apache.jena.arq.querybuilder.handlers.WhereHandler;
 import org.apache.jena.arq.querybuilder.rewriters.BuildElementVisitor;
@@ -406,7 +407,7 @@ public class WhereQuadHolder implements QuadHolder {
 		Node retval = NodeFactory.createBlankNode();
 		Node lastObject = retval;
 		for (int i = 0; i < objs.length; i++) {
-			Node n = AbstractQueryBuilder.makeNode(objs[i], prefixHandler.getPrefixes());
+			Node n = Converters.makeNode(objs[i], prefixHandler.getPrefixes());
 			addWhere(new TriplePath(new Triple(lastObject, RDF.first.asNode(), n)));
 			if (i + 1 < objs.length) {
 				Node nextObject = NodeFactory.createBlankNode();

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilderTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilderTest.java
@@ -99,9 +99,19 @@ public class AbstractQueryBuilderTest {
 		n = builder.makeNode("<one>");
 		assertEquals(NodeFactory.createURI("one"), n);
 
-		n = builder.makeNode(builder);
-		LiteralLabel ll = LiteralLabelFactory.createTypedLiteral(builder);
-		assertEquals(NodeFactory.createLiteral(ll), n);
+		try {
+			n = builder.makeNode(builder);
+			fail( "Should have thrown IllegalArgumentException");
+		} catch (IllegalArgumentException expected)
+		{
+			// do nothing
+		}
+		
+		n = builder.makeNode( Integer.valueOf( 5 ));
+		assertTrue( n.isLiteral() );
+		LiteralLabel ll = LiteralLabelFactory.createTypedLiteral( Integer.valueOf(5));
+		assertEquals( NodeFactory.createLiteral(ll), n );
+
 		
 		n = builder.makeNode( NodeFactory.createVariable("foo"));
 		assertTrue( n.isVariable());
@@ -109,45 +119,12 @@ public class AbstractQueryBuilderTest {
 		assertTrue( n instanceof Var );
 
 		n = builder.makeNode( "'text'@en");
+		assertTrue( n.isLiteral() );
 		assertEquals( "text", n.getLiteralLexicalForm());
 		assertEquals( "en", n.getLiteralLanguage());
 	}
 
-	@Test
-	public void testMakeVar() {
-		Var v = AbstractQueryBuilder.makeVar(null);
-		assertEquals(Var.ANON, v);
-
-		v = AbstractQueryBuilder.makeVar("a");
-		assertEquals(Var.alloc("a"), v);
-
-		v = AbstractQueryBuilder.makeVar("?a");
-		assertEquals(Var.alloc("a"), v);
-
-		Node n = NodeFactory.createVariable("foo");
-		v = AbstractQueryBuilder.makeVar(n);
-		assertEquals(Var.alloc("foo"), v);
-
-		NodeFront nf = new NodeFront(n);
-		v = AbstractQueryBuilder.makeVar(nf);
-		assertEquals(Var.alloc("foo"), v);
-
-		v = AbstractQueryBuilder.makeVar(Node_RuleVariable.WILD);
-		assertNull(v);
-
-		ExprVar ev = new ExprVar("bar");
-		v = AbstractQueryBuilder.makeVar(ev);
-		assertEquals(Var.alloc("bar"), v);
-
-		ev = new ExprVar(n);
-		v = AbstractQueryBuilder.makeVar(ev);
-		assertEquals(Var.alloc("foo"), v);
-
-		ev = new ExprVar(Var.ANON);
-		v = AbstractQueryBuilder.makeVar(ev);
-		assertEquals(Var.ANON, v);
-
-	}
+	
 
 	@Test
 	public void testMakeValueNodes()
@@ -160,16 +137,19 @@ public class AbstractQueryBuilderTest {
 		builder.addPrefix("demo", "http://example.com/");
 		list.add( "demo:type" );
 		list.add( "<one>" );
-		list.add( builder );
+		list.add( Integer.valueOf(5) );
 		
 		Collection<Node> result = builder.makeValueNodes(list.iterator());
 		
+		assertEquals( 6, result.size() );
 		assertTrue( result.contains( null ));
 		assertTrue( result.contains( RDF.type.asNode()));
 		assertTrue( result.contains( n2 ));
 		assertTrue( result.contains(NodeFactory.createURI("http://example.com/type") ));
 		assertTrue( result.contains(NodeFactory.createURI("one")));
-
+		LiteralLabel ll = LiteralLabelFactory.createTypedLiteral( Integer.valueOf(5));
+		assertTrue( result.contains(NodeFactory.createLiteral(ll)));
+		
 	}
 	
 }

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/ConvertersTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/ConvertersTest.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.arq.querybuilder;
+
+import static org.junit.Assert.*;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import org.apache.jena.datatypes.BaseDatatype;
+import org.apache.jena.datatypes.DatatypeFormatException;
+import org.apache.jena.datatypes.TypeMapper;
+import org.apache.jena.graph.FrontsNode ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.NodeFactory ;
+import org.apache.jena.graph.impl.LiteralLabel ;
+import org.apache.jena.graph.impl.LiteralLabelFactory ;
+import org.apache.jena.reasoner.rulesys.Node_RuleVariable ;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.sparql.core.Var ;
+import org.apache.jena.sparql.expr.ExprVar ;
+import org.apache.jena.sparql.path.Path;
+import org.apache.jena.vocabulary.RDF ;
+import org.junit.After;
+import org.junit.Test;
+
+public class ConvertersTest {
+	
+	@After
+	public void cleanup() {
+		TypeMapper.reset();
+	}
+	
+
+	@Test 
+	public void checkVarTest() {
+		Node n = Converters.checkVar( Node.ANY );
+		assertFalse( n instanceof Var );
+		n = Converters.checkVar(NodeFactory.createVariable( "myVar"));
+		assertTrue( n instanceof Var );
+	}
+	
+	@Test
+	public void makeLiteralObjectTest() throws MalformedURLException
+	{
+		Node n = Converters.makeLiteral( 5 );
+		assertEquals( "5", n.getLiteralLexicalForm() );
+		assertEquals( Integer.valueOf(5), n.getLiteralValue());
+		assertEquals( "\"5\"^^http://www.w3.org/2001/XMLSchema#int", n.toString( null, true ));
+
+		n = Converters.makeLiteral( "Hello" );
+		assertEquals( "Hello", n.getLiteralLexicalForm() );
+		assertEquals( "Hello", n.getLiteralValue());
+		assertEquals( "\"Hello\"", n.toString( null, true ));
+		
+		URL url = new URL( "http://example.com");
+		n = Converters.makeLiteral( url);
+		assertEquals( "http://example.com", n.getLiteralLexicalForm() );
+		assertEquals( url, n.getLiteralValue());
+		assertEquals( "\"http://example.com\"^^http://www.w3.org/2001/XMLSchema#anyURI", n.toString(null, true));
+		
+		UUID uuid = UUID.randomUUID();
+		try {
+			n = Converters.makeLiteral( uuid );
+			fail( "Should throw exception");
+		}
+		catch (IllegalArgumentException expected) {
+			// do nothing
+		}
+		
+		TypeMapper.getInstance().registerDatatype(new UuidDataType());
+		try {
+			n = Converters.makeLiteral( uuid );
+			assertEquals( uuid.toString(), n.getLiteralLexicalForm() );
+			assertEquals( uuid, n.getLiteralValue());
+			String value = String.format( "\"%s\"^^java:java.util.UUID", uuid);
+			assertEquals( value, n.toString(null, true));
+		}
+		catch (IllegalArgumentException expected) {
+			fail( "Unexpected IllegalArgumentException");
+		}
+		
+		
+	}
+	
+	@Test
+	public void makeLiteralStringStringTest()
+	{
+		Node n = Converters.makeLiteral( "5", "http://www.w3.org/2001/XMLSchema#int" );
+		assertEquals( "5", n.getLiteralLexicalForm() );
+		assertEquals( Integer.valueOf(5), n.getLiteralValue());
+		assertEquals( "\"5\"^^http://www.w3.org/2001/XMLSchema#int", n.toString( null, true ));
+
+		n = Converters.makeLiteral( "one", "some:stuff" );
+		assertEquals( "one", n.getLiteralLexicalForm() );
+		try {
+			n.getLiteralValue();
+			fail( "Should have thrown DatatypeFormatException");
+		}
+		catch (DatatypeFormatException expected) {
+			// do nothing.
+		}
+		assertEquals( "\"one\"^^some:stuff", n.toString(null, true));
+
+		try {
+			Converters.makeLiteral( "NaN", "http://www.w3.org/2001/XMLSchema#int" );
+			fail( "Should have thrown DatatypeFormatException");
+		} catch (DatatypeFormatException expected) {
+			// do nothing.
+		}
+	}
+	
+	@Test
+	public void makeNodeTest() {
+		PrefixMapping pMap = PrefixMapping.Factory.create();
+		pMap.setNsPrefixes(PrefixMapping.Standard );
+		
+		Node n = Converters.makeNode(null, pMap);
+		assertEquals(Node.ANY, n);
+
+		n = Converters.makeNode(RDF.type, pMap);
+		assertEquals(RDF.type.asNode(), n);
+
+		Node n2 = NodeFactory.createBlankNode();
+		n = Converters.makeNode(n2, pMap);
+		assertEquals(n2, n);
+
+		pMap.setNsPrefix("demo", "http://example.com/");
+		n = Converters.makeNode("demo:type", pMap);
+		assertEquals(NodeFactory.createURI("http://example.com/type"), n);
+
+		n = Converters.makeNode("<one>", pMap);
+		assertEquals(NodeFactory.createURI("one"), n);
+
+		UUID uuid = UUID.randomUUID();
+		try {
+			Converters.makeNode( uuid, pMap);
+			fail( "Should have thrown IllegalArgumentException");
+		}
+		catch (IllegalArgumentException expected) {
+			// do nothing
+		}
+		
+		TypeMapper.getInstance().registerDatatype(new UuidDataType());		
+		n = Converters.makeNode( uuid, pMap );
+		LiteralLabel ll = LiteralLabelFactory.createTypedLiteral(uuid);
+		assertEquals(NodeFactory.createLiteral(ll), n);
+		
+		
+		n = Converters.makeNode( NodeFactory.createVariable("foo"), pMap);
+		assertTrue( n.isVariable());
+		assertEquals( "foo", n.getName());
+		assertTrue( n instanceof Var );
+
+		n = Converters.makeNode( "'text'@en", pMap);
+		assertEquals( "text", n.getLiteralLexicalForm());
+		assertEquals( "en", n.getLiteralLanguage());
+	}
+
+	@Test
+	public void makeNodeOrPathTest() {
+		PrefixMapping pMap = PrefixMapping.Factory.create();
+		pMap.setNsPrefixes(PrefixMapping.Standard );
+		
+		Object n = Converters.makeNodeOrPath(null, pMap);
+		assertEquals(Node.ANY, n);
+
+		n = Converters.makeNodeOrPath(RDF.type, pMap);
+		assertEquals(RDF.type.asNode(), n);
+
+		Node n2 = NodeFactory.createBlankNode();
+		n = Converters.makeNodeOrPath(n2, pMap);
+		assertEquals(n2, n);
+
+		pMap.setNsPrefix("demo", "http://example.com/");
+		n = Converters.makeNodeOrPath("demo:type", pMap);
+		assertEquals(NodeFactory.createURI("http://example.com/type"), n);
+
+		n = Converters.makeNodeOrPath("<one>", pMap);
+		assertEquals(NodeFactory.createURI("one"), n);
+
+		UUID uuid = UUID.randomUUID();
+		try {
+			Converters.makeNodeOrPath( uuid, pMap);
+			fail( "Should have thrown IllegalArgumentException");
+		}
+		catch (IllegalArgumentException expected) {
+			// do nothing
+		}
+
+		TypeMapper.getInstance().registerDatatype(new UuidDataType());		
+		n = Converters.makeNodeOrPath( uuid, pMap);
+		LiteralLabel ll = LiteralLabelFactory.createTypedLiteral(uuid);
+		assertEquals(NodeFactory.createLiteral(ll), n);
+		
+		n = Converters.makeNodeOrPath( NodeFactory.createVariable("foo"), pMap);
+		assertTrue( n instanceof Var );
+		Node node = (Node)n;
+		assertTrue( node.isVariable());
+		assertEquals( "foo", node.getName());
+
+		n = Converters.makeNodeOrPath( "'text'@en", pMap);
+		assertTrue( n instanceof Node );
+		node = (Node)n;
+		assertEquals( "text", node.getLiteralLexicalForm());
+		assertEquals( "en", node.getLiteralLanguage());
+		
+		n = Converters.makeNodeOrPath( "<one>/<two>", pMap);
+		assertTrue( n instanceof Path );
+		Path pth = (Path)n;
+		assertEquals( "<one>/<two>", pth.toString() );
+		
+	}
+	
+	@Test
+	public void makeVarTest() {
+		Var v = Converters.makeVar(null);
+		assertEquals(Var.ANON, v);
+
+		v = Converters.makeVar("a");
+		assertEquals(Var.alloc("a"), v);
+
+		v = Converters.makeVar("?a");
+		assertEquals(Var.alloc("a"), v);
+
+		Node n = NodeFactory.createVariable("foo");
+		v = Converters.makeVar(n);
+		assertEquals(Var.alloc("foo"), v);
+
+		NodeFront nf = new NodeFront(n);
+		v = Converters.makeVar(nf);
+		assertEquals(Var.alloc("foo"), v);
+
+		v = Converters.makeVar(Node_RuleVariable.WILD);
+		assertNull(v);
+
+		ExprVar ev = new ExprVar("bar");
+		v = Converters.makeVar(ev);
+		assertEquals(Var.alloc("bar"), v);
+
+		ev = new ExprVar(n);
+		v = Converters.makeVar(ev);
+		assertEquals(Var.alloc("foo"), v);
+
+		ev = new ExprVar(Var.ANON);
+		v = Converters.makeVar(ev);
+		assertEquals(Var.ANON, v);
+
+	}
+
+	@Test
+	public void makeValueNodesTest()
+	{
+		PrefixMapping pMap = PrefixMapping.Factory.create();
+		pMap.setNsPrefixes(PrefixMapping.Standard );
+
+		List<Object> list = new ArrayList<Object>();
+		list.add( null);
+		list.add( RDF.type );
+		Node n2 = NodeFactory.createBlankNode();
+		list.add( n2 );
+		pMap.setNsPrefix("demo", "http://example.com/");
+		list.add( "demo:type" );
+		list.add( "<one>" );
+		list.add( Integer.MAX_VALUE );
+		
+		Collection<Node> result = Converters.makeValueNodes(list.iterator(), pMap);
+		
+		assertTrue( result.contains( null ));
+		assertTrue( result.contains( RDF.type.asNode()));
+		assertTrue( result.contains( n2 ));
+		assertTrue( result.contains(NodeFactory.createURI("http://example.com/type") ));
+		assertTrue( result.contains(NodeFactory.createURI("one")));
+
+	}
+	
+	@Test
+	public void quotedTest() {
+		assertEquals( "'one'", Converters.quoted( "one" ));
+		assertEquals( "\"'one'\"", Converters.quoted( "'one'" ));
+		assertEquals( "'\"one\"'", Converters.quoted( "\"one\"" ));
+		assertEquals( "'\"I am the 'one'\"'", Converters.quoted( "\"I am the 'one'\"" ));
+		assertEquals( "\"'I am the \"one\"'\"", Converters.quoted( "'I am the \"one\"'" ));
+	}
+
+	private class NodeFront implements FrontsNode {
+		Node n;
+
+		NodeFront(Node n) {
+			this.n = n;
+		}
+
+		@Override
+		public Node asNode() {
+			return n;
+		}
+	}
+	
+	private class UuidDataType extends BaseDatatype {
+		
+		public UuidDataType() {
+			super( "java:java.util.UUID");
+		}
+	
+		@Override
+        public Class<?> getJavaClass() {
+            return UUID.class;
+        }
+
+        @Override
+        public Object parse(String lexicalForm) throws DatatypeFormatException {
+            try {
+                return UUID.fromString(lexicalForm);
+            } catch (Throwable th) {
+                throw new DatatypeFormatException();
+            }
+        }
+    };
+	
+}

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/ExprFactoryTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/ExprFactoryTest.java
@@ -682,7 +682,7 @@ public class ExprFactoryTest {
 	
 	@Test
 	public void asListTest() {
-		ExprList lst = factory.asList("?foo", "http://example.com", factory.quote("hello"), 1, 5L, 3.14f, 6.28d, Var.alloc( "bar" ), null, factory.rand() );
+		ExprList lst = factory.asList("?foo", "http://example.com", Converters.quoted("hello"), 1, 5L, 3.14f, 6.28d, Var.alloc( "bar" ), null, factory.rand() );
 		assertEquals( 10, lst.size() );
 		assertEquals( new ExprVar( "foo" ), lst.get(0));
 		//assertEquals( new ExprVar( "foo" ), lst.get(0));


### PR DESCRIPTION
Moved all Node type buiding statics methods to new Converters class.
Deprecated old methods if they were moved to Converters.
Updated classes to call new Converters methods.
Added Converters.makeLiteral( Object ) that throws
IllegalArgumentException if Object class does not have a registered
Datatype.
Added Converters.makeLiteral( String value , String typeUri ) to build
arbitrary literals suitable for query building and serialization output.
Modified Converters.makeNode() to call Converters.makeLiteral() if a
literal is required.