### PR TITLE
JENA-1866: Add volatile to make method thread-safe

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
@@ -92,13 +92,11 @@ public abstract class SPARQLQueryProcessor extends ActionService
     *  </ul>
     *  The default implementation calculates this list of parameters once (on first use).
     */
-    private Set<String> acceptedParams_ = null;
+    private volatile Set<String> acceptedParams_ = null;
     protected Collection<String> acceptedParams(HttpAction action) {
         if ( acceptedParams_ == null ) {
             synchronized(this) {
                 if ( acceptedParams_ == null )
-                    // Does not matter about race condition here because the same Set should be
-                    // created on any call to generateAcceptedParams.
                     acceptedParams_ = generateAcceptedParams();
             }
         }


### PR DESCRIPTION
The old documentation said this:
// Does not matter about race condition here because the same Set should be
// created on any call to generateAcceptedParams.
But this does not make the race in any way benign.
Since we are doing racy reads, it is in fact possible that after
any of the `if(acceptedParams_ == null)` evaluates to true
- and replaces acceptedParams_ with a non-null value -
`return acceptedParams_` can still return null!

Other possible ways to solve this problem are detailed [here](https://shipilev.net/blog/2014/safe-public-construction/#_safe_publication).