### PR TITLE
JENA-1862: Query.clone is slow

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/Query.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/Query.java
@@ -32,6 +32,7 @@ import org.apache.jena.sparql.core.* ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.expr.Expr ;
 import org.apache.jena.sparql.expr.ExprAggregator ;
+import org.apache.jena.sparql.expr.ExprTransform ;
 import org.apache.jena.sparql.expr.ExprVar ;
 import org.apache.jena.sparql.expr.aggregate.Aggregator ;
 import org.apache.jena.sparql.serializer.QuerySerializerFactory ;
@@ -39,6 +40,7 @@ import org.apache.jena.sparql.serializer.SerializerRegistry ;
 import org.apache.jena.sparql.syntax.Element ;
 import org.apache.jena.sparql.syntax.PatternVars ;
 import org.apache.jena.sparql.syntax.Template ;
+import org.apache.jena.sparql.syntax.syntaxtransform.* ;
 import org.apache.jena.sparql.util.FmtUtils ;
 import org.apache.jena.sys.JenaSystem ;
 
@@ -765,14 +767,15 @@ public class Query extends Prologue implements Cloneable, Printable
     public Object clone() { return cloneQuery() ; }
 
     /**
-     * Makes a copy of this query.  Copies by parsing a query from the serialized form of this query
+     * Makes a copy of this query using the syntax transform machinery.
      * @return Copy of this query
      */
     public Query cloneQuery() {
-        // A little crude.
-        // Must use toString() rather than serialize() because we may not know how to serialize extended syntaxes
-        String qs = this.toString();
-        return QueryFactory.create(qs, getSyntax()) ;
+        ElementTransform eltTransform = new ElementTransformCopyBase(true);
+        ExprTransform exprTransform = new ExprTransformApplyElementTransform(eltTransform, true);
+
+        Query result = QueryTransformOps.transform(this, eltTransform, exprTransform);
+        return result;
     }
 
     // ---- Query canonical syntax

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementData.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementData.java
@@ -33,11 +33,18 @@ import org.apache.jena.sparql.util.NodeUtils ;
 
 public class ElementData extends Element
 {
-    private List<Var> vars = new ArrayList<>() ;
-    private List<Binding> rows = new ArrayList<>() ;
-    
+    private List<Var> vars ;
+    private List<Binding> rows ;
+
     public ElementData()
     {
+        this(new ArrayList<>(), new ArrayList<>()) ;
+    }
+
+    public ElementData(List<Var> vars, List<Binding> rows)
+    {
+        this.vars = vars ;
+        this.rows = rows ;
     }
 
     public Table getTable()
@@ -47,13 +54,13 @@ public class ElementData extends Element
 
     public List<Var> getVars()      { return vars ; }
     public List<Binding> getRows()  { return rows ; }
-    
+
     public void add(Var var)
-    { 
-        if ( ! vars.contains(var) ) 
-            vars.add(var) ; 
+    {
+        if ( ! vars.contains(var) )
+            vars.add(var) ;
     }
-    
+
     public void add(Binding binding)
     {
         Iterator<Var> iter = binding.vars() ;
@@ -65,7 +72,7 @@ public class ElementData extends Element
         }
         rows.add(binding) ;
     }
-    
+
     @Override
     public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
     {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementPathBlock.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementPathBlock.java
@@ -30,25 +30,30 @@ import org.apache.jena.sparql.util.NodeIsomorphismMap ;
 
 public class ElementPathBlock extends Element implements TripleCollectorMark
 {
-    private PathBlock pattern = new PathBlock() ; 
+    private PathBlock pattern = new PathBlock() ;
 
     public ElementPathBlock()
     {  }
-    
+
+    public ElementPathBlock(PathBlock pattern)
+    {
+        this.pattern = pattern;
+    }
+
     public ElementPathBlock(BasicPattern bgp)
-    {  
+    {
         for ( Triple t : bgp.getList() )
             addTriple(t) ;
     }
 
     public boolean isEmpty() { return pattern.isEmpty() ; }
-    
+
     public void addTriple(TriplePath tp)
     { pattern.add(tp) ; }
-    
+
     @Override
     public int mark() { return pattern.size() ; }
-    
+
     @Override
     public void addTriple(Triple t)
     { addTriplePath(new TriplePath(t)) ; }
@@ -64,15 +69,15 @@ public class ElementPathBlock extends Element implements TripleCollectorMark
     @Override
     public void addTriplePath(int index, TriplePath tPath)
     { pattern.add(index, tPath) ; }
-    
+
     public PathBlock getPattern() { return pattern ; }
     public Iterator<TriplePath> patternElts() { return pattern.iterator(); }
-    
+
     @Override
     public int hashCode()
-    { 
+    {
         int calcHashCode = Element.HashBasicGraphPattern ;
-        calcHashCode ^= pattern.hashCode() ; 
+        calcHashCode ^= pattern.hashCode() ;
         return calcHashCode ;
     }
 
@@ -82,7 +87,7 @@ public class ElementPathBlock extends Element implements TripleCollectorMark
         if ( ! ( el2 instanceof ElementPathBlock) )
             return false ;
         ElementPathBlock eg2 = (ElementPathBlock)el2 ;
-        return this.pattern.equiv(eg2.pattern, isoMap) ; 
+        return this.pattern.equiv(eg2.pattern, isoMap) ;
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/ElementTransformCopyBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/ElementTransformCopyBase.java
@@ -22,6 +22,8 @@ import java.util.List ;
 
 import org.apache.jena.graph.Node ;
 import org.apache.jena.query.Query ;
+import org.apache.jena.sparql.core.BasicPattern ;
+import org.apache.jena.sparql.core.PathBlock ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.expr.Expr ;
 import org.apache.jena.sparql.syntax.* ;
@@ -33,45 +35,76 @@ import org.apache.jena.sparql.syntax.* ;
 public class ElementTransformCopyBase implements ElementTransform {
     // Note the use of == as object pointer equality.
 
+    protected boolean alwaysCopy = false ;
+
+    public ElementTransformCopyBase() {
+        this(false);
+    }
+
+    public ElementTransformCopyBase(boolean alwaysCopy) {
+        super();
+        this.alwaysCopy = alwaysCopy;
+    }
+
     @Override
     public Element transform(ElementTriplesBlock el) {
+        if ( alwaysCopy ) {
+            BasicPattern before = el.getPattern();
+            BasicPattern copy = new BasicPattern();
+            before.getList().forEach(copy::add);
+            el = new ElementTriplesBlock(copy);
+        }
+
         return el ;
     }
 
     @Override
     public Element transform(ElementPathBlock el) {
+        if ( alwaysCopy ) {
+            PathBlock before = el.getPattern();
+            PathBlock copy = new PathBlock();
+            before.getList().forEach(copy::add);
+            el = new ElementPathBlock(copy);
+        }
+
         return el ;
     }
 
     @Override
     public Element transform(ElementFilter el, Expr expr2) {
-        if ( el.getExpr() == expr2 )
+        if ( !alwaysCopy && el.getExpr() == expr2 )
             return el ;
         return new ElementFilter(expr2) ;
     }
 
     @Override
     public Element transform(ElementAssign el, Var v, Expr expr2) {
-        if ( el.getVar() == v && el.getExpr() == expr2 )
+        if ( !alwaysCopy && el.getVar() == v && el.getExpr() == expr2 )
             return el ;
         return new ElementAssign(v, expr2) ;
     }
 
     @Override
     public Element transform(ElementBind el, Var v, Expr expr2) {
-        if ( el.getVar() == v && el.getExpr() == expr2 )
+        if ( !alwaysCopy && el.getVar() == v && el.getExpr() == expr2 )
             return el ;
         return new ElementBind(v, expr2) ;
     }
 
     @Override
     public Element transform(ElementData el) {
+         if( alwaysCopy ) {
+             ElementData copy = new ElementData();
+             el.getVars().forEach(copy::add);
+             el.getTable().rows().forEachRemaining(copy::add);
+             el = copy;
+         }
         return el ;
     }
 
     @Override
     public Element transform(ElementUnion el, List<Element> elts) {
-        if ( el.getElements() == elts )
+        if ( !alwaysCopy && el.getElements() == elts )
             return el ;
         ElementUnion el2 = new ElementUnion() ;
         el2.getElements().addAll(elts) ;
@@ -80,14 +113,14 @@ public class ElementTransformCopyBase implements ElementTransform {
 
     @Override
     public Element transform(ElementOptional el, Element elt1) {
-        if ( el.getOptionalElement() == elt1 )
+        if ( !alwaysCopy && el.getOptionalElement() == elt1 )
             return el ;
         return new ElementOptional(elt1) ;
     }
 
     @Override
     public Element transform(ElementGroup el, List<Element> elts) {
-        if ( el.getElements() == elts )
+        if ( !alwaysCopy && el.getElements() == elts )
             return el ;
         ElementGroup el2 = new ElementGroup() ;
         el2.getElements().addAll(elts) ;
@@ -96,49 +129,49 @@ public class ElementTransformCopyBase implements ElementTransform {
 
     @Override
     public Element transform(ElementDataset el, Element elt1) {
-        if ( el.getElement() == elt1 )
+        if ( !alwaysCopy && el.getElement() == elt1 )
             return el ;
         return new ElementDataset(el.getDataset(), elt1) ;
     }
 
     @Override
     public Element transform(ElementNamedGraph el, Node gn, Element elt1) {
-        if ( el.getGraphNameNode() == gn && el.getElement() == elt1 )
+        if ( !alwaysCopy && el.getGraphNameNode() == gn && el.getElement() == elt1 )
             return el ;
         return new ElementNamedGraph(gn, elt1) ;
     }
 
     @Override
     public Element transform(ElementExists el, Element elt1) {
-        if ( el.getElement() == elt1 )
+        if ( !alwaysCopy && el.getElement() == elt1 )
             return el ;
         return new ElementExists(elt1) ;
     }
 
     @Override
     public Element transform(ElementNotExists el, Element elt1) {
-        if ( el.getElement() == elt1 )
+        if ( !alwaysCopy && el.getElement() == elt1 )
             return el ;
         return new ElementNotExists(elt1) ;
     }
 
     @Override
     public Element transform(ElementMinus el, Element elt1) {
-        if ( el.getMinusElement() == elt1 )
+        if ( !alwaysCopy && el.getMinusElement() == elt1 )
             return el ;
         return new ElementMinus(elt1) ;
     }
 
     @Override
     public Element transform(ElementService el, Node service, Element elt1) {
-        if ( el.getServiceNode() == service && el.getElement() == elt1 )
+        if ( !alwaysCopy && el.getServiceNode() == service && el.getElement() == elt1 )
             return el ;
         return new ElementService(service, elt1, el.getSilent()) ;
     }
 
     @Override
     public Element transform(ElementSubQuery el, Query query) {
-        if ( el.getQuery() == query )
+        if ( !alwaysCopy && el.getQuery() == query )
             return el ;
         return new ElementSubQuery(query) ;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/ExprTransformApplyElementTransform.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/ExprTransformApplyElementTransform.java
@@ -30,16 +30,21 @@ import org.apache.jena.sparql.syntax.Element ;
 public class ExprTransformApplyElementTransform extends ExprTransformCopy
 {
     private final ElementTransform transform ;
-    
+
     public ExprTransformApplyElementTransform(ElementTransform transform) {
-        this.transform = transform ; 
+        this(transform, false);
     }
-    
+
+    public ExprTransformApplyElementTransform(ElementTransform transform, boolean alwaysDuplicate) {
+        super(alwaysDuplicate);
+        this.transform = transform ;
+    }
+
     @Override
     public Expr transform(ExprFunctionOp funcOp, ExprList args, Op opArg)
     {
         Element el2 = ElementTransformer.transform(funcOp.getElement(), transform) ;
-        
+
         if ( el2 == funcOp.getElement() )
             return super.transform(funcOp, args, opArg) ;
         if ( funcOp instanceof E_Exists )

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
@@ -20,6 +20,7 @@ package org.apache.jena.sparql.syntax.syntaxtransform;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Query;
@@ -41,7 +42,9 @@ import org.apache.jena.sparql.expr.ExprTransformer;
 import org.apache.jena.sparql.expr.ExprVar;
 import org.apache.jena.sparql.graph.NodeTransform;
 import org.apache.jena.sparql.syntax.Element;
+import org.apache.jena.sparql.syntax.ElementData;
 import org.apache.jena.sparql.syntax.ElementGroup;
+import org.apache.jena.sparql.syntax.ElementSubQuery;
 
 /** Support for transformation of query abstract syntax. */
 public class QueryTransformOps {
@@ -84,13 +87,27 @@ public class QueryTransformOps {
 
         // Explicit null check to prevent warning in ElementTransformer
         Element el2 = el == null ? null : ElementTransformer.transform(el, transform, exprTransform);
-        // Top level is always a group.
-        if (el2 != null && !(el2 instanceof ElementGroup)) {
+        // Top level is always a group or a subquery
+        if (el2 != null && !(el2 instanceof ElementGroup) && !(el2 instanceof ElementSubQuery)) {
             ElementGroup eg = new ElementGroup();
             eg.addElement(el2);
             el2 = eg;
         }
         q2.setQueryPattern(el2);
+
+        // Pass a values data block through the transform by wrapping it as an ElementData
+        if(q2.hasValues()) {
+            ElementData elData = new ElementData(q2.getValuesVariables(), q2.getValuesData());
+            Element rawElData2 = ElementTransformer.transform(elData, transform, exprTransform);
+            if(!(rawElData2 instanceof ElementData)) {
+                throw new ARQException("Can't transform a values data block to a different type other than ElementData. "
+                        + "Transform yeld type " + Objects.toString(rawElData2.getClass()));
+            }
+
+            ElementData elData2 = (ElementData)rawElData2;
+            q2.setValuesDataBlock(elData2.getVars(), elData2.getRows());
+        }
+
         return q2;
     }
 
@@ -280,8 +297,8 @@ public class QueryTransformOps {
 
         // In some (legacy?) cases, describe queries make use of projection instead
         // of result nodes
-		public void copyProjection(Query query) {
-			VarExprList x = query.getProject();
+        public void copyProjection(Query query) {
+            VarExprList x = query.getProject();
             for (Var v : x.getVars()) {
                 Expr expr = x.getExpr(v);
                 if (expr == null)
@@ -289,7 +306,7 @@ public class QueryTransformOps {
                 else
                     newQuery.addResultVar(v, expr);
             }
-		}
+        }
     }
 
     public static Query shallowCopy(Query query) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
@@ -45,14 +45,14 @@ import org.apache.jena.sparql.syntax.ElementGroup;
 
 /** Support for transformation of query abstract syntax. */
 public class QueryTransformOps {
-    /** Transform a query based on a mapping from {@link Var} variable to replacement {@link Node}. */ 
+    /** Transform a query based on a mapping from {@link Var} variable to replacement {@link Node}. */
     public static Query transform(Query query, Map<Var, ? extends Node> substitutions) {
         ElementTransform eltrans = new ElementTransformSubst(substitutions);
         NodeTransform nodeTransform = new NodeTransformSubst(substitutions);
         ExprTransform exprTrans = new ExprTransformNodeElement(nodeTransform, eltrans);
         return transform(query, eltrans, exprTrans);
     }
-    
+
     /**
      * Transform a query based on a mapping from variable name to replacement
      * {@link RDFNode} (a {@link Resource} (or blank node) or a {@link Literal}).
@@ -65,7 +65,7 @@ public class QueryTransformOps {
 
     /** Transform a query using {@link ElementTransform} and {@link ExprTransform}.
      *  It is the responsibility of these transforms to transform to a legal SPARQL query.
-     */ 
+     */
     public static Query transform(Query query, ElementTransform transform, ExprTransform exprTransform) {
         Query q2 = QueryTransformOps.shallowCopy(query);
 
@@ -166,7 +166,7 @@ public class QueryTransformOps {
                 DatasetDescription desc = query.getDatasetDescription();
                 for (String x : desc.getDefaultGraphURIs())
                     newQuery.addGraphURI(x);
-                for (String x : desc.getDefaultGraphURIs())
+                for (String x : desc.getNamedGraphURIs())
                     newQuery.addNamedGraphURI(x);
             }
 

--- a/jena-arq/src/test/java/org/apache/jena/query/TestQueryCloningCornerCases.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestQueryCloningCornerCases.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.query;
+
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.syntax.ElementGroup;
+import org.apache.jena.sparql.syntax.ElementPathBlock;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestQueryCloningCornerCases {
+
+    /**
+     * Tests for the {@link Query} clone method.
+     * Data and path blocks are mutable elements and modifications after a clone
+     * should be possible independently.
+     *
+     */
+    @Test
+    public void testCloneOfDataAndPathBlocks()
+    {
+        String str = "PREFIX eg: <http://www.example.org/> "
+                + "SELECT * { ?s eg:foo/eg:bar ?o } VALUES (?s ?o) { (eg:baz 1) }";
+        Query query = QueryFactory.create(str);
+
+        Query clone = TestQueryCloningEssentials.checkedClone(query);
+
+        ElementPathBlock eltClone = (ElementPathBlock)((ElementGroup)clone.getQueryPattern()).get(0);
+        eltClone.addTriple(new Triple(RDF.Nodes.type, RDF.Nodes.type, RDF.Nodes.Property));
+
+        Assert.assertNotEquals(eltClone, query);
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/query/TestQueryCloningCornerCases.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestQueryCloningCornerCases.java
@@ -17,7 +17,12 @@
  */
 package org.apache.jena.query;
 
+import java.util.concurrent.TimeUnit;
+
+import org.apache.jena.ext.com.google.common.base.Stopwatch;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.engine.binding.BindingFactory;
+import org.apache.jena.sparql.syntax.ElementData;
 import org.apache.jena.sparql.syntax.ElementGroup;
 import org.apache.jena.sparql.syntax.ElementPathBlock;
 import org.apache.jena.vocabulary.RDF;
@@ -25,6 +30,35 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestQueryCloningCornerCases {
+
+	// @Test
+	public void benchmarkQueryClone() {
+		String str = "SELECT * { ?s ?p ?o }";
+		int n = 1000000;
+
+		// Warmup runs
+		Query q = QueryFactory.create(str);
+		for(int i = 0; i < n; ++i) {
+			TestQueryCloningEssentials.slowClone(q);
+			q.cloneQuery();
+		}
+
+		Stopwatch printParseSw = Stopwatch.createStarted();
+		for(int i = 0; i < n; ++i) {
+			TestQueryCloningEssentials.slowClone(q);
+		}
+		printParseSw.stop();
+
+		Stopwatch transformSw = Stopwatch.createStarted();
+		for(int i = 0; i < n; ++i) {
+			q.cloneQuery();
+		}
+		transformSw.stop();
+
+		double qpsPrintParse = n / (double)(printParseSw.elapsed(TimeUnit.MILLISECONDS) * 0.001);
+		double qpsTransform = n / (double)(transformSw.elapsed(TimeUnit.MILLISECONDS) * 0.001);
+		System.out.println("Queries/Second [Print-Parse: " + qpsPrintParse + "], [Transform: " + qpsTransform + "]");
+	}
 
     /**
      * Tests for the {@link Query} clone method.
@@ -35,15 +69,41 @@ public class TestQueryCloningCornerCases {
     @Test
     public void testCloneOfDataAndPathBlocks()
     {
+
+
+        // FIXME Query.valuesDataBlock is not passed through the copy machinery and is thus not copied
+        // Who is responsible for the copy? Wrapping as an ElementData and passing it through the ElementTransform
+        // is not ideal, as the transform is free to yield an element of another - incompatible - type
+        // String str = "PREFIX eg: <http://www.example.org/> "
+        //        + "SELECT * { ?s eg:foo/eg:bar ?o } VALUES (?s ?o) { (eg:baz 1) }";
+
         String str = "PREFIX eg: <http://www.example.org/> "
-                + "SELECT * { ?s eg:foo/eg:bar ?o } VALUES (?s ?o) { (eg:baz 1) }";
+          + "SELECT * { ?s eg:foo/eg:bar ?o VALUES (?s ?o) { (eg:baz 1) } }";
+
         Query query = QueryFactory.create(str);
 
         Query clone = TestQueryCloningEssentials.checkedClone(query);
 
-        ElementPathBlock eltClone = (ElementPathBlock)((ElementGroup)clone.getQueryPattern()).get(0);
-        eltClone.addTriple(new Triple(RDF.Nodes.type, RDF.Nodes.type, RDF.Nodes.Property));
+        // Modification of the query pattern must not change the original query
+        {
+            Query cloneOfClone = clone.cloneQuery();
+	        ElementPathBlock elt = (ElementPathBlock)((ElementGroup)cloneOfClone.getQueryPattern()).get(0);
+	        elt.addTriple(new Triple(RDF.Nodes.type, RDF.Nodes.type, RDF.Nodes.Property));
 
-        Assert.assertNotEquals(eltClone, query);
+	        Assert.assertNotEquals(elt, query);
+        }
+
+        // After modifying the clone of a clone the initial clone must match the original query
+        Assert.assertEquals(query, clone);
+
+        // Modification of the value block must not change the original query
+        {
+            Query cloneOfClone = clone.cloneQuery();
+            ElementData elt = (ElementData)((ElementGroup)cloneOfClone.getQueryPattern()).get(1);
+            elt.getRows().add(BindingFactory.create());
+            Assert.assertNotEquals(query, cloneOfClone);
+        }
+
+        Assert.assertEquals(query, clone);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/query/TestQueryCloningEssentials.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestQueryCloningEssentials.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.query;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TestQueryCloningEssentials {
+
+    public static Query slowClone(Query query) {
+        String qs = query.toString();
+        return QueryFactory.create(qs, query.getSyntax()) ;
+    }
+
+    /**
+     * Assert whether cloning using the old print-parse approach
+     * yields the same result as the one using the syntax transform
+     * machinery
+     *
+     * @param query
+     */
+    public static Query checkedClone(Query query) {
+        Query expected = slowClone(query);
+        Query actual = query.cloneQuery();
+
+        Assert.assertEquals(expected, actual);;
+        return actual;
+    }
+
+    protected Path queryFile;
+    protected Query query;
+
+    public TestQueryCloningEssentials(Path queryFile, Query query) {
+        this.queryFile = queryFile;
+        this.query = query;
+    }
+
+    @Test
+    public void runTest() {
+        checkedClone(query);
+    }
+
+    @Parameters(name = "Query.clone {0}")
+    public static Collection<Object[]> generateTestParams() throws Exception
+    {
+        Path startPath = Paths.get("./testing").toAbsolutePath().normalize();
+        PathMatcher pathMatcher = startPath.getFileSystem().getPathMatcher("glob:**/*.rq");
+
+        List<Object[]> testParams = new ArrayList<>();
+        Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if(pathMatcher.matches(file)) {
+                    String queryStr = Files.lines(file).collect(Collectors.joining("\n"));
+                    try {
+                        Query query = QueryFactory.create(queryStr);
+
+                        testParams.add(new Object[] {file, query});
+                    } catch(Exception e) {
+                        // Silently ignore queries that fail to parse
+                    }
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        return testParams;
+    }
+
+
+}

--- a/jena-arq/src/test/java/org/apache/jena/query/TestQueryCloningEssentials.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestQueryCloningEssentials.java
@@ -76,14 +76,7 @@ public class TestQueryCloningEssentials {
     @Parameters(name = "Query.clone {0}")
     public static Collection<Object[]> generateTestParams() throws Exception
     {
-        List<String> exclusions = Arrays.asList(
-                // QueryTransformOps states: top level element is always an ElementGroup
-                // However, sub-select-02.rq parsed top level's element is a ElementSubQuery
-                "ARQ/SubQuery/sub-select-02.rq",
-                "ARQ/Serialization/syntax-subselect-02.rq",
-                "ARQ/Serialization/syntax-subselect-01.rq",
-                "ARQ/Syntax/Syntax-SPARQL_11/syntax-subquery-01.rq"
-        );
+        List<String> exclusions = Arrays.asList(/* no exclusions as all test cases work */);
 
         Path startPath = Paths.get("./testing").toAbsolutePath().normalize();
         PathMatcher pathMatcher = startPath.getFileSystem().getPathMatcher("glob:**/*.rq");


### PR DESCRIPTION
This PR changes the implementation of Query.clone to make use of the syntax transform machinery.
A parameterized test case runner with 1230 queries is provided in TestQueryCloningEssentials
A test case for inital corner cases is provided in TestQueryCloningCornerCases - the main purpose is to check that modification of elements of a clone do not affect the original query. Note, that  Query.elementDataBlock is not cloned, I'd said this is an issue in QueryTransformOps.
A little commented out by means of "// @ Test" benchmark runner is provided in TestQueryCloningCornerCases as well.