### PR TITLE
Cleanup code

### DIFF
--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPlusTreeNonTxn.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPlusTreeNonTxn.java
@@ -29,7 +29,6 @@ import org.apache.jena.dboe.base.record.Record;
 import org.apache.jena.dboe.index.test.AbstractTestRangeIndex;
 import org.apache.jena.dboe.sys.SystemIndex;
 import org.apache.jena.dboe.test.RecordLib;
-import org.apache.jena.dboe.trans.bplustree.BPlusTree;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/AuthFilter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/AuthFilter.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.web.HttpSC;
-import org.eclipse.jetty.security.SecurityHandler;
 
 /**
  * Servlet filter that applies a predicate to incoming requests and rejects with with 403
@@ -35,9 +34,8 @@ import org.eclipse.jetty.security.SecurityHandler;
  * filter chain.
  * <p>
  * Either the user from {@link HttpServletRequest#getRemoteUser() getRemoteUser} is null,
- * no authentication, or it has been validated. Failed authentication will have been
- * handled and rejected by the {@link SecurityHandler security handler} before they get to
- * the filter chain.
+ * no authentication, or it has been validated. Failed authentication attempts will have been
+ * handled and rejected by the servlet container before they get to the filter chain.
  */
 public class AuthFilter implements Filter {
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -129,7 +129,7 @@ public class FusekiMain extends CmdARQ {
                 TransactionManager.QueueBatchSize = TransactionManager.QueueBatchSize / 2;
 
             getUsage().startCategory("Fuseki Main");
-            addModule(modDataset);
+            // Control the order!
             add(argMem, "--mem",
                 "Create an in-memory, non-persistent dataset for the server");
             add(argFile, "--file=FILE",
@@ -142,6 +142,9 @@ public class FusekiMain extends CmdARQ {
                 "Create an in-memory, non-persistent dataset using TDB (testing only)");
 //            add(argEmpty, "--empty",
 //                "Run with no datasets and services (validators only)");
+            add(argConfig, "--config=",
+                "Use a configuration file to determine the services");
+            addModule(modDataset);
             add(argEmpty); // Hidden for now.
             add(argPort, "--port",
                 "Listen on this port number");
@@ -151,8 +154,6 @@ public class FusekiMain extends CmdARQ {
                 "Global timeout applied to queries (value in ms) -- format is X[,Y] ");
             add(argUpdate, "--update",
                 "Allow updates (via SPARQL Update and SPARQL HTTP Update)");
-            add(argConfig, "--config=",
-                "Use a configuration file to determine the services");
             add(argGZip, "--gzip=on|off",
                 "Enable GZip compression (HTTP Accept-Encoding) if request header set");
             add(argBase, "--base=DIR",

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/record/RecordLib.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/record/RecordLib.java
@@ -25,8 +25,6 @@ import java.util.List;
 
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.Bytes ;
-import org.apache.jena.tdb.base.record.Record ;
-import org.apache.jena.tdb.base.record.RecordFactory ;
 
 
 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/index/IndexTestLib.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/index/IndexTestLib.java
@@ -40,7 +40,6 @@ import java.util.TreeSet ;
 import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.tdb.base.record.Record ;
 import org.apache.jena.tdb.base.record.RecordLib ;
-import org.apache.jena.tdb.index.Index ;
 
 public class IndexTestLib
 {

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexDB.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexDB.java
@@ -24,7 +24,6 @@ import org.apache.jena.dboe.transaction.txn.ComponentId;
 import org.apache.jena.dboe.transaction.txn.TransactionalComponentBase;
 import org.apache.jena.dboe.transaction.txn.TxnId;
 import org.apache.jena.query.ReadWrite;
-import org.apache.jena.query.text.TextIndex;
 
 /** 
  * Adapter to put Lucene into DBOE transactions.


### PR DESCRIPTION
Various code cleanup.

The "unused imports" originate from Eclipse now reporting things it wasn't reporting. I can't tell whether this is local to my installation (e.g. config bug) or an Eclipse change. 