### PR TITLE
JENA-1878: switched API call to prefix.cc from http to https

### DIFF
--- a/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/js/lib/qonsole.js
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/js/lib/qonsole.js
@@ -514,7 +514,7 @@ var qonsole = function() {
         $("#inputURI").val("");
 
         if (prefix) {
-            $.getJSON(sprintf("http://prefix.cc/%s.file.json", prefix),
+            $.getJSON(sprintf("https://prefix.cc/%s.file.json", prefix),
                     function(data) {
                         $("#inputURI").val(data[prefix]);
                     });


### PR DESCRIPTION
This caused a mixed-content error and the call was blocked by the browser (thereby rendering the entire prefix.cc lookup as useless) when Fuseki was run via https.