### PR TITLE
JENA-1888: Mark log4j2 optional in OSGi bundle

### DIFF
--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -269,6 +269,7 @@
               !com.ibm.uvm.tools,
               !com.sun.jdmk.comm,
               !org.apache.log,
+              !org.apache.logging.*,
               !org.apache.jena.ext.*,
               !org.checkerframework.checker.*,
               !com.google.errorprone.annotations.*,

--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -269,12 +269,12 @@
               !com.ibm.uvm.tools,
               !com.sun.jdmk.comm,
               !org.apache.log,
-              !org.apache.logging.*,
               !org.apache.jena.ext.*,
               !org.checkerframework.checker.*,
               !com.google.errorprone.annotations.*,
               !com.google.appengine.api,
               !com.google.apphosting.api,
+              org.apache.logging.*;resolution:=optional,
               sun.misc;resolution:=optional,
               *
             </Import-Package>


### PR DESCRIPTION
This excludes the log4j2 dependency from the OSGi bundle metadata