### PR TITLE
JENA-1890: Correctly decode URI with multibyte codepoints

### DIFF
--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestStrUtils.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestStrUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.atlas.lib;
 
+import org.apache.jena.atlas.AtlasException;
 import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
@@ -26,18 +27,22 @@ public class TestStrUtils extends BaseTest
     static char marker = '_' ;
     static char esc[] = { ' ' , '_' } ; 
     
-    static void test(String x)
-    {
-        test(x, null) ;
+    static void test(String x) {
+        test(x, null);
     }
-    
-    static void test(String x, String z)
-    {
-        String y = StrUtils.encodeHex(x, marker, esc) ;
+
+    static void test(String x, String z) {
+        String y = StrUtils.encodeHex(x, marker, esc);
         if ( z != null )
-            assertEquals(z, y) ;
-        String x2 = StrUtils.decodeHex(y, marker) ;
-        assertEquals(x, x2) ;
+            assertEquals(z, y);
+        String x2 = StrUtils.decodeHex(y, marker);
+        assertEquals(x, x2);
+    }
+
+    // Decode only.
+    static void testDecode(String input, String expected) {
+        String x2 = StrUtils.decodeHex(input, marker);
+        assertEquals(expected, x2);
     }
     
     @Test public void enc01() { test("abc") ; } 
@@ -52,7 +57,30 @@ public class TestStrUtils extends BaseTest
     
     @Test public void enc06() { test("_5F", "_5F5F" ) ; } 
     
-    @Test public void enc07() { test("_2") ; } 
+    @Test public void enc07() { test("_2") ; }
     
     @Test public void enc08() { test("AB_CD", "AB_5FCD") ; } 
+    
+    // JENA-1890: Multibyte characters before the "_"  
+    // 사용_설명서 (Korean: "User's Guide")
+    
+    @Test public void enc09() { test("\uC0AC\uC6A9_\uC124\uBA85\uC11C"); }
+    // Same string, but using the glyphs for the codepoints, not the \ u value. Same string after Java parsing. 
+    @Test public void enc09a() { test("사용_설명서"); }
+    
+    // The decode code works more generally than the encoder.
+    // This tests the decode of the UTF=-8 byte encoding of 사용_설명서
+    // Note "_5F" which is "_" encoded.  
+    @Test public void enc10() { testDecode("_EC_82_AC_EC_9A_A9_5F_EC_84_A4_EB_AA_85_EC_84_9C", "사용_설명서"); }
+    
+    @Test public void enc11() { testDecode("_41", "A"); }
+    
+    @Test(expected=AtlasException.class) public void enc20() { testDecode("_4", null); }
+
+    @Test(expected=AtlasException.class) public void enc21() { testDecode("_", null); }
+    
+    @Test(expected=AtlasException.class) public void enc22() { testDecode("_X1", null); }
+    
+    @Test(expected=AtlasException.class) public void enc23() { testDecode("_1X", null); }
+
 }

--- a/jena-cmds/src/main/java/tdb/tdbloader.java
+++ b/jena-cmds/src/main/java/tdb/tdbloader.java
@@ -32,6 +32,7 @@ import org.apache.jena.riot.RDFLanguages ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.tdb.TDBLoader ;
 import org.apache.jena.tdb.store.GraphTDB;
+import org.apache.jena.util.FileUtils;
 import tdb.cmdline.CmdTDB ;
 import tdb.cmdline.CmdTDBGraph ;
 
@@ -127,12 +128,15 @@ public class tdbloader extends CmdTDBGraph {
         List<String> problemFiles = 
             ListUtils.toList(
                 urls.stream()
+                .filter(u->FileUtils.isFile(u))
+                // Only check local files.
                 .map(Paths::get)
                 .filter(p-> !Files.exists(p) || !Files.isRegularFile(p /*follow links*/) || !Files.isReadable(p) )
                 .map(Path::toString)
                 );
         if ( ! problemFiles.isEmpty() ) {
-            throw new CmdException("Can't read files : ["+problemFiles+"]"); 
+            String str = String.join(", ", problemFiles);
+            throw new CmdException("Can't read files : "+str); 
         }
     }
     

--- a/jena-cmds/src/main/java/tdb2/tdbloader.java
+++ b/jena-cmds/src/main/java/tdb2/tdbloader.java
@@ -43,6 +43,7 @@ import org.apache.jena.tdb2.loader.LoaderFactory;
 import org.apache.jena.tdb2.loader.base.LoaderOps;
 import org.apache.jena.tdb2.loader.base.MonitorOutput;
 import org.apache.jena.tdb2.loader.main.LoaderPlans;
+import org.apache.jena.util.FileUtils;
 import tdb2.cmdline.CmdTDB;
 import tdb2.cmdline.CmdTDBGraph;
 
@@ -154,12 +155,14 @@ public class tdbloader extends CmdTDBGraph {
         List<String> problemFiles = 
             ListUtils.toList(
                 urls.stream()
+                .filter(u->FileUtils.isFile(u))  // Local files.
                 .map(Paths::get)
                 .filter(p-> !Files.exists(p) || !Files.isRegularFile(p /*follow links*/) || !Files.isReadable(p) )
                 .map(Path::toString)
                 );
         if ( ! problemFiles.isEmpty() ) {
-            throw new CmdException("Can't read files : ["+problemFiles+"]"); 
+            String str = String.join(", ", problemFiles);
+            throw new CmdException("Can't read files : "+str); 
         }
     }
 


### PR DESCRIPTION
Only affects URIs which also have a hex-encoded character (currently, "_", which is the marker character or " ").