### PR TITLE
JENA-1891 reversed resultMessage values

### DIFF
--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMaxLengthConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMaxLengthConstraint.java
@@ -45,7 +45,7 @@ public class StrMaxLengthConstraint extends ConstraintTerm {
         String str = NodeFunctions.str(n);
         if ( str.length() <= maxLength )
             return null;
-        String msg = toString()+": String too short: "+str ;
+        String msg = toString()+": String too long: "+str ;
         return new ReportItem(msg,n);
     }
 

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMinLengthConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMinLengthConstraint.java
@@ -45,7 +45,7 @@ public class StrMinLengthConstraint extends ConstraintTerm {
         String str = NodeFunctions.str(n);
         if ( str.length() >= minLength )
             return null;
-        String msg = toString()+": String too long: "+str;
+        String msg = toString()+": String too short: "+str;
         return new ReportItem(msg, n);
     }
 


### PR DESCRIPTION
I had a look at the tests and because of the [optional properties](https://github.com/apache/jena/blob/master/jena-shacl/src/main/java/org/apache/jena/shacl/validation/VR.java#L161) the resultMessage values aren't checked in the validation checks.