### PR TITLE
JENA-1881: Add being able to read variations of RDF* JSON syntax.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/resultset/rw/JSONResultsKW.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/resultset/rw/JSONResultsKW.java
@@ -31,7 +31,6 @@ public class JSONResultsKW
     public static String kBindings      = "bindings" ;
     public static String kType          = "type" ;
     public static String kUri           = "uri"  ;
-    public static String kObject        = "object" ;
     
     public static String kValue         = "value" ;
     public static String kLiteral       = "literal" ;
@@ -49,6 +48,11 @@ public class JSONResultsKW
     public static String kSubject       = "subject" ;
     public static String kPredicate     = "predicate" ;
     public static String kProperty      = "property" ;
+    public static String kObject        = "object" ;
+    // RDF* Triple terms -alternative keywords
+    public static String kSubjectAlt    = "s" ;
+    public static String kPredicateAlt  = "p" ;
+    public static String kObjectAlt     = "o" ;
 
 }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/resultset/rw/ResultSetReaderJSON.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/resultset/rw/ResultSetReaderJSON.java
@@ -239,19 +239,29 @@ public class ResultSetReaderJSON implements ResultSetReader {
         private static Node parseTripleTerm(JsonObject term, LabelToNode labelMap) {
             if ( term.entrySet().size() != 3 )
                 throw new ResultSetException("Wrong number of object keys for triple term: should be 3, got " + term.entrySet().size());
-            checkContains(term, true, true, kSubject, kObject);
-            checkContainsOneOf(term, kPredicate, kProperty); 
-            JsonObject sTerm = term.get(kSubject).getAsObject(); 
-            JsonObject pTerm = term.get(kPredicate).getAsObject();
-            if ( pTerm == null )
-                pTerm = term.get(kProperty).getAsObject();
-            JsonObject oTerm = term.get(kObject).getAsObject();
+            checkContainsOneOf(term, kSubject, kSubjectAlt);
+            checkContainsOneOf(term, kObject, kObjectAlt);
+            checkContainsOneOf(term, kPredicate, kProperty, kPredicateAlt);
+            
+            JsonObject sTerm = get(term, kSubject, kSubjectAlt); 
+            JsonObject pTerm = get(term, kPredicate, kProperty, kPredicateAlt);
+            JsonObject oTerm = get(term, kObject, kObjectAlt);
             if ( sTerm == null || pTerm == null || oTerm == null )
                 throw new ResultSetException("Bad triple term: "+term);
             Node s = parseOneTerm(sTerm, labelMap);
             Node p = parseOneTerm(pTerm, labelMap);
             Node o = parseOneTerm(oTerm, labelMap);
             return NodeFactory.createTripleNode(s, p, o);
+        }
+        
+        // Get a object from an object - use the first name in the fields list  
+        private static JsonObject get(JsonObject term, String... fields) {
+            for ( String f : fields ) {
+                JsonValue v = term.get(f);
+                if ( v != null )
+                    return v.getAsObject();
+            }
+            return null;
         }
 
         private static String stringOrNull(JsonObject obj, String key) {

--- a/jena-arq/src/main/java/org/apache/jena/riot/resultset/rw/ResultsReader.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/resultset/rw/ResultsReader.java
@@ -31,9 +31,12 @@ import org.apache.jena.riot.resultset.ResultSetReaderRegistry;
 import org.apache.jena.riot.system.stream.StreamManager;
 import org.apache.jena.sparql.resultset.SPARQLResult;
 import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sys.JenaSystem;
 
 public class ResultsReader {
-    
+
+    static { JenaSystem.init(); }
+
     /** Create a {@code ResultsReader.Builder}. */
     public static Builder create() { return new Builder() ; }
     
@@ -103,7 +106,7 @@ public class ResultsReader {
             lang = RDFLanguages.contentTypeToLang(ct);
         }
         if ( lang == null )
-            throw new RiotException("Can't indentify the result set syntax from "+url); 
+            throw new RiotException("Can't identify the result set syntax from "+url); 
         return lang;
     }
     

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphMap.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphMap.java
@@ -71,16 +71,17 @@ public class DatasetGraphMap extends DatasetGraphTriplesQuads
     
     // ----
     private final Transactional txn                     = TransactionalLock.createMRSW() ;
-    @Override public void begin()                       { txn.begin(); }
-    @Override public void begin(TxnType txnType)        { txn.begin(txnType); }
-    @Override public void begin(ReadWrite mode)         { txn.begin(mode); }
-    @Override public boolean promote(Promote txnType)   { return txn.promote(txnType); }
-    @Override public void commit()                      { txn.commit(); }
-    @Override public void abort()                       { txn.abort(); }
-    @Override public boolean isInTransaction()          { return txn.isInTransaction(); }
-    @Override public void end()                         { txn.end(); }
-    @Override public ReadWrite transactionMode()        { return txn.transactionMode(); }
-    @Override public TxnType transactionType()          { return txn.transactionType(); }
+    private final Transactional txn()                   { return txn; }
+    @Override public void begin()                       { txn().begin(); }
+    @Override public void begin(TxnType txnType)        { txn().begin(txnType); }
+    @Override public void begin(ReadWrite mode)         { txn().begin(mode); }
+    @Override public boolean promote(Promote txnType)   { return txn().promote(txnType); }
+    @Override public void commit()                      { txn().commit(); }
+    @Override public void abort()                       { txn().abort(); }
+    @Override public boolean isInTransaction()          { return txn().isInTransaction(); }
+    @Override public void end()                         { txn().end(); }
+    @Override public ReadWrite transactionMode()        { return txn().transactionMode(); }
+    @Override public TxnType transactionType()          { return txn().transactionType(); }
     @Override public boolean supportsTransactions()     { return true; }
     @Override public boolean supportsTransactionAbort() { return false; }
     // ----

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/TransactionalLock.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/TransactionalLock.java
@@ -33,7 +33,7 @@ import org.apache.jena.sparql.JenaTransactionException ;
  *  To use with implementation inheritance, for when you don't inherit:
  *  <pre>
  *      private final Transactional txn                     = TransactionalLock.createMRSW() ;
- *      protected final Transactional txn()                 { return txn; }
+ *      private final Transactional txn()                   { return txn; }
  *      {@literal @}Override public void begin(TxnType txnType)        { txn().begin(txnType) ; }
  *      {@literal @}Override public void begin()                       { txn().begin(); }
  *      {@literal @}Override public void begin(TxnType txnType)        { txn().begin(txnType); }
@@ -52,7 +52,7 @@ import org.apache.jena.sparql.JenaTransactionException ;
 public class TransactionalLock implements Transactional {
 /*
     private final Transactional txn                     = TransactionalLock.createMRSW() ;
-    protected final Transactional txn()                 { return txn; }
+    private final Transactional txn()                   { return txn; }
     @Override public void begin()                       { txn().begin(); }
     @Override public void begin(TxnType txnType)        { txn().begin(txnType); }
     @Override public void begin(ReadWrite mode)         { txn().begin(mode); }
@@ -64,7 +64,6 @@ public class TransactionalLock implements Transactional {
     @Override public TxnType transactionType()          { return txn().transactionType(); }
     @Override public boolean supportsTransactions()     { return true; }
     @Override public boolean supportsTransactionAbort() { return false; }
-
  */
     
     private ThreadLocal<Boolean>   inTransaction = ThreadLocal.withInitial(() -> Boolean.FALSE);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -600,7 +600,6 @@ public class XSDFuncOp
         if ( nv.isInteger() )
             return nv.getInteger().intValue() ;
         if ( nv.isDecimal() )
-            // No decimal round in Java 1.4
             return (int)Math.round(nv.getDecimal().doubleValue()) ;
 
         if ( nv.isFloat() ) {

--- a/jena-arq/src/test/java/org/apache/jena/rdf_star/TestSPARQLStarExtra.java
+++ b/jena-arq/src/test/java/org/apache/jena/rdf_star/TestSPARQLStarExtra.java
@@ -18,19 +18,24 @@
 
 package org.apache.jena.rdf_star;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.ResultSetFormatter;
+import org.apache.jena.riot.resultset.rw.ResultsReader;
+import org.junit.Test;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
-    TestNQuadsStarParse.class,
-    TestNTriplesStarParse.class,
-    TestTrigStarParse.class,
-    TestTurtleStarParse.class,
-    TestSPARQLStarParse.class,
-    TestSPARQLStarExtra.class
+/** 
+ * Odds and ends for SPARQL*. 
+ */
+public class TestSPARQLStarExtra {
 
-    //See also TC_Scripted SPARQL-star/manifest.ttl which run from JUnit3-centric ARQTestSuite 
-})
-public class TS_RDF_Star {
+    private static String FILES = "testing/ARQ/RDF-Star/Other/";
+
+    // RDF4J format JSON results.
+    // It uses "s", "p" and "o" for the RDF term results. 
+    @Test public void parse_alt() {
+        String x = FILES+"alternate-results.srj";
+        ResultSet rs = ResultsReader.create().read(x);
+        ResultSetFormatter.consume(rs);
+    }
 }
+

--- a/jena-arq/src/test/java/org/apache/jena/sparql/TC_Scripted.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/TC_Scripted.java
@@ -40,7 +40,7 @@ public class TC_Scripted extends TestSuite
         
         return ts ;
     }
-    
+
     public TC_Scripted()
     {
         super("Scripted") ;

--- a/jena-arq/testing/ARQ/RDF-Star/Other/alternate-results.srj
+++ b/jena-arq/testing/ARQ/RDF-Star/Other/alternate-results.srj
@@ -1,0 +1,41 @@
+{
+  "head" : {
+    "vars" : [
+      "a",
+      "b",
+      "c"
+    ]
+  },
+  "results" : {
+    "bindings": [
+      { "a" : {
+          "type" : "triple",
+          "value" : {
+            "s" : {
+              "type" : "uri",
+              "value" : "http://example.org/bob"
+            },
+            "p" : {
+              "type" : "uri",
+              "value" : "http://xmlns.com/foaf/0.1/name"
+            },
+            "o" : {
+              "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
+              "type" : "literal",
+              "value" : "23"
+            }
+          }
+        },
+        "b": { 
+          "type": "uri",
+          "value": "http://example.org/certainty"
+        },
+        "c" : {
+          "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+          "type" : "literal",
+          "value" : "0.9"
+        }
+      }
+    ]
+  }
+}

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -314,7 +314,7 @@ public class Fuseki {
 
     /**
      * Test whether a {@link RDFConnectionRemote} connects to a Fuseki server. This
-     * operation can not guaranttee to detech a Fuseki server - for example, it may be
+     * operation can not guaranteed to detech a Fuseki server - for example, it may be
      * behind a reverse proxy that masks the signature.
      */
     public static boolean isFuseki(RDFConnectionRemote connection) {


### PR DESCRIPTION
The JSON result form changes are not defined in RDF* so there are variations.

This PR adds being about to read RDF4J variation of JSON results.

Also some cleanups that got noticed.
