### PR TITLE
JENA-1881: Model API changes for RDF*

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterBlockTriplesStar.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterBlockTriplesStar.java
@@ -32,7 +32,6 @@ import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.serializer.SerializationContext;
 
-
 /**
  * Like {@link QueryIterBlockTriples} except it process triple term patterns (RDF*)
  * as well.
@@ -94,7 +93,7 @@ public class QueryIterBlockTriplesStar extends QueryIter1 {
 
     /**
      * Insert the stages necessary for a triple with triple pattern term inside it.
-     * If the triple pattern has am triple term, possibly with variables, introduce
+     * If the triple pattern has a triple term, possibly with variables, introduce
      * an iterator to solve for that, assign the matching triple term to a hidden
      * variable, and put allocated variable in to main triple pattern. Do for subject
      * and object positions, and also any nested triple pattern terms.
@@ -106,9 +105,8 @@ public class QueryIterBlockTriplesStar extends QueryIter1 {
     }
 
     // If we assume the data is correct (in PG mode), no need to test for the triple
-    // of a concrete Node_Triple because we able to // test for it in the triple
+    // of a concrete Node_Triple because we able to test for it in the triple
     // pattern itself.
-    // In SA: not an issue.
     // This should be "false".
     private static final boolean TEST_FOR_CONCRETE_TRIPLE_TERM = false;
 

--- a/jena-core/src/main/java/org/apache/jena/enhanced/EnhNode.java
+++ b/jena-core/src/main/java/org/apache/jena/enhanced/EnhNode.java
@@ -84,10 +84,17 @@ public class EnhNode extends Polymorphic<RDFNode> implements FrontsNode
     }
     
     /**
-        An enhanced node is a resource if it's node is a URI node or a blank node.
+        An enhanced node is a statement resource iff its underlying node is a triple term (RDF*).
+     */
+    public final boolean isStmtResource() {
+        return node.isNodeTriple();
+    }
+
+    /**
+        An enhanced node is a resource if it's node is a URI node, a blank node or a triple term.
     */
     public final boolean isResource() {
-        return node.isURI() || node.isBlank();
+        return node.isURI() || node.isBlank() || node.isNodeTriple();
     }
     
     /**

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/Model.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/Model.java
@@ -190,6 +190,13 @@ public interface Model
 	   @return a new resource linked to this model.
 	*/
 	public Resource createResource( String uri ) ;
+	
+	/**
+	 * Create a resource that represents a statement. This is in support of RDF*.
+	 * @param statement
+	 * @return a new resource linked to this model.
+	 */
+	public Resource createResource( Statement statement ) ;
 
 	/**
         Create a property with a given URI composed from a namespace part and a

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/RDFNode.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/RDFNode.java
@@ -55,10 +55,16 @@ public interface RDFNode extends FrontsNode
     
     /**
         Answer true iff this RDFNode is a URI resource or an anonymous
-        resource (ie is not a literal). Useful for one-off tests: see also 
+        resource or a statement term (ie is not a literal). Useful for one-off tests: see also 
         visitWith() for making literal/anon/URI choices.
     */
     public boolean isResource();
+    
+    /**
+        Answer true iff this RDFNode is a resource representing an RDF* triple term. 
+     */
+    
+    public boolean isStmtResource();
     
     /**
         RDFNodes can be converted to different implementation types. Convert

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/RDFVisitor.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/RDFVisitor.java
@@ -39,6 +39,16 @@ public interface RDFVisitor
     */
     Object visitURI( Resource r, String uri );
     
+    
+    /**
+     * Method to call when visiting a resource with a statement.
+     *   @param r the resource node being visited
+     *   @param uri the statement of that node
+     *   @return value to be returned from the visit
+     */ 
+        
+    default Object visitStmt( Resource r, Statement statement) { return null; }
+    
     /**
         Method to call when visiting a literal RDF node l.
         @param l the RDF Literal node

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/Resource.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/Resource.java
@@ -65,7 +65,7 @@ public interface Resource extends RDFNode {
     public AnonId getId();
     
     /**
-        Override RDFNode.inModel() to produce a staticly-typed Resource
+        Override RDFNode.inModel() to produce a statically-typed Resource
         in the given Model.
     */
     @Override
@@ -77,10 +77,17 @@ public interface Resource extends RDFNode {
     */
     public boolean hasURI( String uri );
 
-    /** Return the URI of the resource, or null if it's a bnode.
-     * @return The URI of the resource, or null if it's a bnode.
+    /** Return the URI of the resource, or null if it's a bnode or statement.
+     * @return The URI of the resource, or null if it's a bnode or statement.
      */
     public String getURI();
+    
+    /**
+     * Return the statement of this resource, or null if it is not an RDF* triple term.
+     * This is not a resource for a reified statement.   
+     * @return The statement of this resource,or null if it is not an RDF* triple term.
+     */
+    public Statement getStmtTerm();
 
     /** Returns the namespace associated with this resource if it is a URI, else return null. 
      * <p> 

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/ResourceFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/ResourceFactory.java
@@ -53,14 +53,14 @@ public class ResourceFactory {
     private ResourceFactory() {
     }
 
-    /** get the current factory object.
+    /** Get the current factory object.
      * 
      *  @return the current factory object
      */
     public static Interface getInstance() {
         return instance;
     }
-    /** set the current factory object.
+    /** Set the current factory object.
      * 
      * @param newInstance the new factory object
      * @return the previous factory object
@@ -71,7 +71,7 @@ public class ResourceFactory {
         return previousInstance;
     }
 
-    /** create a new anonymous resource.
+    /** Create a new anonymous resource.
      * 
      * <p>Uses the current factory object to create a new anonymous resource.</p>
      * 
@@ -81,7 +81,7 @@ public class ResourceFactory {
         return instance.createResource();
     }
 
-    /** create a new resource.
+    /** Create a new resource.
      * 
      * <p>Uses the current factory object to create a new resource.</p>
      * 
@@ -92,9 +92,18 @@ public class ResourceFactory {
         return instance.createResource(uriref);
     }
     
+    /** 
+     * Create a new resource representing an RDF* triple term.
+     * @param statement
+     * @return a new resource 
+     */
+    public static Resource createStmtResource(Statement statement) {
+        return instance.createStmtResource(statement);
+    }
+    
     /**
      * Answer a string (xsd:string) literal.
-     * This is the equivalent of a plain liteal with no language from RDF 1.0
+     * This is the equivalent of a plain literal with no language from RDF 1.0
      * (also called a simple literal in SPARQL)
      * 
      * Using {@link #createStringLiteral} is preferred; "plain literal" is RDF 1.0 terminology.  
@@ -109,7 +118,7 @@ public class ResourceFactory {
     
     /**
      * Answer a string (xsd:string) literal.
-     * This is the equivalent of a plain liteal with no language from RDF 1.0
+     * This is the equivalent of a plain literal with no language from RDF 1.0
      * (also called a simple literal in SPARQL)
      * 
      * @param string
@@ -135,29 +144,25 @@ public class ResourceFactory {
 
     /**
      * Answer a typed literal.
-     * 
-     * @param string
-     *            the string which forms the value of the literal
-     * @param dType
-     *            RDFDatatype of the type literal
+     * @param string the string which forms the value of the literal
+     * @param dType RDFDatatype of the type literal
      * @return a Literal node with that string as value
      */
 
-    public static Literal createTypedLiteral( String string , RDFDatatype dType)
-    {
+    public static Literal createTypedLiteral( String string , RDFDatatype dType) {
         return instance.createTypedLiteral( string , dType);
     }
     
     /**
-    Answer a typed literal.
-    @param value a java Object, the default RDFDatatype for that object will be used
-    @return a Literal node with that value
-    */
+     * Answer a typed literal.
+     * @param value a java Object, the default RDFDatatype for that object will be used
+     * @return a Literal node with that value
+     */
     public static Literal createTypedLiteral( Object value ) {
         return instance.createTypedLiteral(value);
     }
     
-    /** create a new property.
+    /** Create a new property.
      * 
      * <p>Uses the current factory object to create a new resource.</p>
      * 
@@ -168,7 +173,7 @@ public class ResourceFactory {
         return instance.createProperty(uriref);
     }
 
-    /** create a new property.
+    /** Create a new property.
      * 
      * <p>Uses the current factory object to create a new property.</p>
      * 
@@ -180,12 +185,14 @@ public class ResourceFactory {
         return instance.createProperty(namespace, localName);
     }
 
-    /** create a new statement.
+    /** 
+     * Create a new statement.
+     * <p>
      * Uses the current factory object to create a new statement.</p>
      * 
      * @param subject the subject of the new statement
      * @param predicate the predicate of the new statement
-     * @param object the objectof the new statement
+     * @param object the object of the new statement
      * @return a new resource
      */
     public static Statement createStatement(
@@ -195,22 +202,29 @@ public class ResourceFactory {
         return instance.createStatement(subject, predicate, object);
     }
 
-    /** the interface to resource factory objects.
+    /** The interface to resource factory objects.
      */
     public interface Interface {
 
-        /** create a new anonymous resource.
+        /** Create a new anonymous resource.
          * 
          * @return a new anonymous resource
          */
         public Resource createResource();
 
-        /** create a new resource.
+        /** Create a new resource.
          * 
          * @param uriref URIREF of the resource
          * @return a new resource
          */
         public Resource createResource(String uriref);
+        
+        /** Create a new resource representing an RDF* triple term.
+         * 
+         * @param statement
+         * @return a new resource
+         */
+        public Resource createStmtResource(Statement statement);
         
         /**
          * Answer a string (xsd:string) literal.
@@ -230,38 +244,40 @@ public class ResourceFactory {
         }
 
         /**
-        Answer a plain (untyped) literal with no language and the given content.
-        @param string the string which forms the value of the literal
-        @param lang The language tag to be used
-        @return a Literal node with that string as value
+         * Answer a plain (untyped) literal with no language and the given content.
+         * 
+         * @param string the string which forms the value of the literal
+         * @param lang The language tag to be used
+         * @return a Literal node with that string as value
          */
 
         public Literal createLangLiteral( String string , String lang );
 
         /**
-        Answer a typed literal.
-        @param string the string which forms the value of the literal
-        @param datatype RDFDatatype of the type literal
-        @return a Literal node with that string as value
-        */
+         * Answer a typed literal.
+         * 
+         * @param string the string which forms the value of the literal
+         * @param datatype RDFDatatype of the type literal
+         * @return a Literal node with that string as value
+         */
         public Literal createTypedLiteral( String string , RDFDatatype datatype) ;
 
 
         /**
-        Answer a typed literal.
-        @param value a java Object, the default RDFDatatype for that object will be used
-        @return a Literal node with that value
-        */
+         * Answer a typed literal.
+         * @param value a java Object, the default RDFDatatype for that object will be used
+         * @return a Literal node with that value
+         */
         public Literal createTypedLiteral( Object value ) ;
 
-        /** create a new property.
+        /** Create a new property.
          * 
          * @param uriref URIREF of the property
          * @return a new property
          */
         public Property createProperty(String uriref);
 
-        /** create a new property.
+        /** Create a new property.
          * 
          * @param namespace uriref of the namespace
          * @param localName localname of the property
@@ -269,7 +285,7 @@ public class ResourceFactory {
          */
         public Property createProperty(String namespace, String localName);
 
-        /** create a new statement.
+        /** Create a new statement.
          * 
          * @param subject subject of the new statement
          * @param predicate predicate of the new statement
@@ -295,6 +311,11 @@ public class ResourceFactory {
         @Override
         public Resource createResource(String uriref) {
             return new ResourceImpl(uriref);
+        }
+        
+        @Override
+        public Resource createStmtResource(Statement statement) {
+            return new ResourceImpl(statement, null);
         }
         
         @Override
@@ -342,6 +363,5 @@ public class ResourceFactory {
             RDFNode object) {
             return new StatementImpl(subject, predicate, object);
         }
-
     }
 }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ModelCom.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ModelCom.java
@@ -634,6 +634,10 @@ implements Model, PrefixMapping, Lock
     { return new ResourceImpl( id, this ); }
 
     @Override
+    public Resource createResource( Statement statement )
+    { return new ResourceImpl( statement, this ); }
+
+    @Override
     @Deprecated public Resource createResource( String uri, ResourceF f )  
     { return f.createResource( createResource( uri ) ); }
 
@@ -1455,7 +1459,7 @@ implements Model, PrefixMapping, Lock
       { return (Seq) getSeq(uri).addProperty( RDF.type, RDF.Seq ); }
 
       /**
-        Answer a Statement in this Model whcih encodes the given Triple.
+        Answer a Statement in this Model which encodes the given Triple.
         @param t a triple to wrap as a statement
         @return a statement wrapping the triple and in this model
        */

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ResourceImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ResourceImpl.java
@@ -24,6 +24,8 @@ import org.apache.jena.enhanced.EnhNode ;
 import org.apache.jena.enhanced.Implementation ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
+import org.apache.jena.graph.Node_Triple;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.shared.PropertyNotFoundException;
 
@@ -109,6 +111,10 @@ public class ResourceImpl extends EnhNode implements Resource {
         this( NodeFactory.createURI( nameSpace + localName ), m );
     }
 
+    public ResourceImpl(Statement statement, ModelCom m) {
+        this( NodeFactory.createTripleNode(statement.asTriple()), m);
+    }
+
     @Override
     public Object visitWith( RDFVisitor rv )
         { return isAnon() ? rv.visitBlank( this, getId() ) : rv.visitURI( this, getURI() ); }
@@ -135,12 +141,22 @@ public class ResourceImpl extends EnhNode implements Resource {
         { return uri == null ? NodeFactory.createBlankNode() : NodeFactory.createURI( uri ); }
 
     @Override
-    public AnonId getId() 
-        { return new AnonId(asNode().getBlankNodeId()); }
+    public AnonId getId() {
+        return new AnonId(asNode().getBlankNodeId());
+    }
 
     @Override
     public String  getURI() {
-        return isAnon() ? null : node.getURI();
+        return this.isURIResource() ? node.getURI() : null;
+    }
+    
+    @Override
+    public Statement getStmtTerm() {
+        if ( ! isStmtResource() )
+            return null;
+        Triple t =  Node_Triple.triple(node);
+        Statement stmt = StatementImpl.toStatement(t, getModelCom());
+        return stmt; 
     }
 
     @Override

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/StatementImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/StatementImpl.java
@@ -24,7 +24,7 @@ import org.apache.jena.rdf.model.* ;
 
 /** An implementation of Statement.
  */
-public class StatementImpl  extends StatementBase implements Statement {
+public class StatementImpl extends StatementBase implements Statement {
     
     protected Resource subject;
     protected Property predicate;
@@ -40,7 +40,6 @@ public class StatementImpl  extends StatementBase implements Statement {
 		this.object = object.inModel( model );
 		}
     
-    // TODO fix this hack
     protected static ModelCom empty = (ModelCom) ModelFactory.createDefaultModel();
     
 	public StatementImpl(Resource subject, Property predicate, RDFNode object)

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestRDFNodes.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestRDFNodes.java
@@ -157,6 +157,12 @@ public class TestRDFNodes extends AbstractModelTestBase
 				Assert.assertEquals("must have correct field", R.getURI(), uri);
 				return "uri result";
 			}
+
+            @Override
+            public Object visitStmt(Resource r, Statement statement) {
+                history.add("statementTerm");
+                return "statement term result";
+            }
 		};
 		/* */
 		Assert.assertEquals("blank result", S.visitWith(rv));

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestResourceFactory.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestResourceFactory.java
@@ -80,6 +80,11 @@ public class TestResourceFactory extends TestCase
 		}
 
 		@Override
+        public Resource createStmtResource(Statement statement) {
+            return null;
+        }
+
+        @Override
 		public Statement createStatement( final Resource subject,
 				final Property predicate, final RDFNode object )
 		{
@@ -98,7 +103,6 @@ public class TestResourceFactory extends TestCase
 		{
 			return null;
 		}
-
 	}
 
 	static final String uri1 = "http://example.org/example#a1";
@@ -146,6 +150,19 @@ public class TestResourceFactory extends TestCase
 		Assert.assertTrue(r1.getURI().equals(TestResourceFactory.uri1));
 	}
 
+	public void testCreateStmtTerm() {
+	    Resource s = ResourceFactory.createResource();
+	    Property p = ResourceFactory.createProperty(TestResourceFactory.uri2);
+	    Resource o = ResourceFactory.createResource();
+	    Statement stmt = ResourceFactory.createStatement(s, p, o);
+
+	    Resource r = ResourceFactory.createStmtResource(stmt);
+	    Assert.assertTrue(r.isResource());
+	    Assert.assertFalse(r.isURIResource());
+	    Assert.assertFalse(r.isAnon());
+	    Assert.assertTrue(r.isStmtResource());
+	}
+
 	public void testCreateStatement()
 	{
 		final Resource s = ResourceFactory.createResource();
@@ -165,9 +182,7 @@ public class TestResourceFactory extends TestCase
 		Assert.assertTrue(l.getLexicalForm().equals("22"));
 		Assert.assertTrue(l.getLanguage().equals(""));
 		Assert.assertTrue(l.getDatatype() == XSDDatatype.XSDinteger);
-		Assert.assertTrue(l.getDatatypeURI().equals(
-				XSDDatatype.XSDinteger.getURI()));
-
+		Assert.assertTrue(l.getDatatypeURI().equals(XSDDatatype.XSDinteger.getURI()));
 	}
 
 	public void testCreateTypedLiteralObject()

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
@@ -834,6 +834,11 @@ public class SecuredModelImpl extends SecuredItemImpl implements SecuredModel {
 	}
 
 	@Override
+    public Resource createResource(Statement statement) {
+        throw new UnsupportedOperationException("SecuredModel.createResource(Statement)");
+    }
+
+    @Override
 	public SecuredResource createResource(final String uri, final Resource type)
 			throws UpdateDeniedException, AddDeniedException, AuthenticationRequiredException {
 		final Resource r = ResourceFactory.createResource(uri);

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredRDFNodeImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredRDFNodeImpl.java
@@ -178,6 +178,11 @@ public abstract class SecuredRDFNodeImpl extends SecuredItemImpl implements Secu
 		return holder.getBaseItem().isURIResource();
 	}
 
+	@Override
+	public boolean isStmtResource() {
+	    throw new UnsupportedOperationException("SecuredRDFNode.isStmtResource");
+	}
+	
 	/**
 	 * An RDFNode is equal to another enhanced node n iff the underlying nodes
 	 * are equal. We generalise to allow the other object to be any class

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredResourceImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredResourceImpl.java
@@ -580,6 +580,11 @@ public class SecuredResourceImpl extends SecuredRDFNodeImpl implements SecuredRe
 		return holder.getBaseItem().getURI();
 	}
 
+    @Override
+    public Statement getStmtTerm() {
+        throw new UnsupportedOperationException("SecuredResource.getStmtTerm");
+    }
+	
 	/**
 	 * Answer true iff this resource has the value <code>o</code> for property
 	 * <code>p</code>. <code>o</code> is interpreted as a typed literal with the
@@ -923,5 +928,4 @@ public class SecuredResourceImpl extends SecuredRDFNodeImpl implements SecuredRe
 	public Object visitWith(final RDFVisitor rv) {
 		return isAnon() ? rv.visitBlank(this, getId()) : rv.visitURI(this, getURI());
 	}
-
 }

--- a/jena-permissions/src/test/java/org/apache/jena/permissions/model/SecuredRDFNodeTest.java
+++ b/jena-permissions/src/test/java/org/apache/jena/permissions/model/SecuredRDFNodeTest.java
@@ -19,10 +19,8 @@ package org.apache.jena.permissions.model;
 
 import org.apache.jena.permissions.Factory;
 import org.apache.jena.permissions.MockSecurityEvaluator;
-import org.apache.jena.permissions.SecurityEvaluatorParameters;
 import org.apache.jena.permissions.SecurityEvaluator.Action;
-import org.apache.jena.permissions.model.SecuredModel;
-import org.apache.jena.permissions.model.SecuredRDFNode;
+import org.apache.jena.permissions.SecurityEvaluatorParameters;
 import org.apache.jena.permissions.model.impl.SecuredRDFNodeImpl;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.shared.ReadDeniedException;

--- a/jena-permissions/src/test/java/org/apache/jena/permissions/model/SecuredResourceTest.java
+++ b/jena-permissions/src/test/java/org/apache/jena/permissions/model/SecuredResourceTest.java
@@ -28,7 +28,6 @@ import org.apache.jena.permissions.MockSecurityEvaluator;
 import org.apache.jena.permissions.SecurityEvaluator;
 import org.apache.jena.permissions.SecurityEvaluatorParameters;
 import org.apache.jena.permissions.SecurityEvaluator.Action;
-import org.apache.jena.permissions.model.SecuredResource;
 import org.apache.jena.permissions.model.impl.SecuredResourceImpl;
 import org.apache.jena.permissions.model.impl.SecuredStatementIterator;
 import org.apache.jena.rdf.model.Literal;


### PR DESCRIPTION
This PR adds triple term to the mode API by making them a kind of "Resource", along side URI and blank node.

This is the only way to incorporate triple terms without a major change to the type-safe API because they can appear in the subject position.
