### PR TITLE
JENA-1896: Update Google Guava

### DIFF
--- a/jena-shaded-guava/pom.xml
+++ b/jena-shaded-guava/pom.xml
@@ -39,8 +39,11 @@
     org.apache.jena.ext.com.google....
   </description>
 
-  <dependencies>
+  <properties>
+   <automatic.module.name>org.apache.jena.ext.com.google</automatic.module.name>
+  </properties>
 
+  <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -51,17 +54,22 @@
            This is important because Guava itself (at v24 at least) has tools dependencies
            with various licenses.
       -->
-      <version>24.1-jre</version>
+      <version>29.0-jre</version>
       <optional>true</optional>
-      <!-- These make the excluded parts clean for dependency:tree in the module directory -->
+
+      <!-- These are also affected by the artifactSet and filters of the shade plugin. -->
       <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.checkerframework</groupId>
           <artifactId>checker-qual</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.checkerframework</groupId>
-          <artifactId>checker-compat-qual</artifactId>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.errorprone</groupId>
@@ -71,22 +79,10 @@
           <groupId>com.google.j2objc</groupId>
           <artifactId>j2objc-annotations</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-annotations</artifactId>
-        </exclusion>
       </exclusions>
-
     </dependency>
-
   </dependencies>
-  <properties>
-   <automatic.module.name>org.apache.jena.ext.com.google</automatic.module.name>
-  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -111,15 +107,13 @@
           <createSourcesJar>true</createSourcesJar>
           <artifactSet>
             <includes>
-              <artifact>com.google.guava:guava</artifact>
+              <artifact>com.google.guava:*</artifact>
             </includes>
           </artifactSet>
 
           <filters>
             <filter>
-              <!-- Modify the below patterns if a later guava 
-                   contains other packages 
-              -->
+              <!-- Modify the below patterns if a later guava contains other packages -->
               <artifact>com.google.guava:guava</artifact>
               <includes>
                 <include>com/google/common/**</include>
@@ -137,15 +131,9 @@
                depending on Jena.
           -->
           <relocations>
-            <!-- Modify the below patterns if a later guava contains other
-                 packages -->
             <relocation>
-              <pattern>com.google.common</pattern>
-              <shadedPattern>org.apache.jena.ext.com.google.common</shadedPattern>
-            </relocation>
-            <relocation>
-              <pattern>com.google.thirdparty</pattern>
-              <shadedPattern>org.apache.jena.ext.com.google.thirdparty</shadedPattern>
+              <pattern>com.google</pattern>
+              <shadedPattern>org.apache.jena.ext.com.google</shadedPattern>
             </relocation>
           </relocations>
         </configuration>


### PR DESCRIPTION
Update to Guava 29.0-jre.
Clear up the shaded artifact POM a little to reflect the current dependency state of Guava itself.

