### PR TITLE
JENA-1898: Exclude commons-codec from httpcomponents dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -305,6 +309,10 @@
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Details: [JENA-1898](https://issues.apache.org/jira/browse/JENA-1898).