### PR TITLE
JENA-1904: The "defaultGraph" parameter is ignored here, so the sparqlService(…

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
@@ -490,7 +490,7 @@ public class QueryExecutionFactory
      * @return QueryExecution
      */ 
     static public QueryExecution sparqlService(String service, Query query, String defaultGraph, HttpClient client) {
-       return sparqlService(service, query, client, null);
+       return sparqlService(service, query, defaultGraph, client, null);
     }
     
     /** Create a QueryExecution that will access a SPARQL service over HTTP


### PR DESCRIPTION
…String service, Query query, String defaultGraph) method not filter the subGraph. This change fix the problem calling the other method.