### PR TITLE
Clean up use of "assert"

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/checker/CheckerIRI.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/checker/CheckerIRI.java
@@ -45,7 +45,7 @@ public class CheckerIRI implements NodeChecker
         this.handler = handler ;
         this.iriFactory = iriFactory ;
     }
-    
+
     @Override
     public boolean check(Node node, long line, long col)
     { return node.isURI() && checkURI(node, line, col) ; }
@@ -77,23 +77,23 @@ public class CheckerIRI implements NodeChecker
      *  Assumes error handler throws exceptions on errors if needbe
      *  @param iri  IRI to check
      *  @param errorHandler The error handler to call on each warning or error.
-     *   
+     *
      */
     public static void iriViolations(IRI iri, ErrorHandler errorHandler) {
         iriViolations(iri, errorHandler, -1L, -1L) ;
     }
-    
+
     /** Process violations on an IRI
      *  Calls the errorhandler on all errors and warnings (as warning).
      *  Assumes error handler throws exceptions on errors if needbe
      *  @param iri  IRI to check
      *  @param errorHandler The error handler to call on each warning or error.
-     *   
+     *
      */
     public static void iriViolations(IRI iri, ErrorHandler errorHandler, long line, long col) {
         iriViolations(iri, errorHandler, false, true, line, col) ;
     }
-    
+
     /** Process violations on an IRI
      *  Calls the errorhandler on all errors and warnings (as warning).
      *  Assumes error handler throws exceptions on errors if needbe
@@ -118,10 +118,10 @@ public class CheckerIRI implements NodeChecker
 
     /** Process violations on an IRI
      *  Calls the errorhandler on all errors and warnings (as warning).
-     *  Assumes error handler throws exceptions on errors if needbe 
+     *  Assumes error handler throws exceptions on errors if needbe
      */
-    public static void iriViolations(IRI iri, ErrorHandler errorHandler, 
-                                     boolean allowRelativeIRIs, 
+    public static void iriViolations(IRI iri, ErrorHandler errorHandler,
+                                     boolean allowRelativeIRIs,
                                      boolean includeIRIwarnings,
                                      long line, long col) {
         if ( !allowRelativeIRIs && iri.isRelative() )
@@ -156,8 +156,8 @@ public class CheckerIRI implements NodeChecker
                 if ( isError ) {
                     errorSeen = true ;
                     if ( vError == null )
-                                         // Remember first error
-                                         vError = v ;
+                        // Remember first error
+                        vError = v ;
                 } else {
                     warningSeen = true ;
                     if ( vWarning == null )
@@ -170,24 +170,24 @@ public class CheckerIRI implements NodeChecker
                 // Ideally, we might want to output all messages relating to this IRI
                 // then cause the error or continue.
                 // But that's tricky given the current errorhandler architecture.
-                
+
 //                // Put out warnings for all IRI issues - later, exception for errors.
 //                if (v.getViolationCode() == ViolationCodes.REQUIRED_COMPONENT_MISSING &&
 //                    v.getComponent() == IRIComponents.SCHEME)
 //                {
 //                    if (! allowRelativeIRIs )
 //                        handler.error("Relative URIs are not permitted in RDF: <"+iriStr+">", line, col);
-//                } 
+//                }
 //                else
                 {
                     if ( isError )
-                        // IRI errors are warning at the level of parsing - they got through syntax checks.  
+                        // IRI errors are warning at the level of parsing - they got through syntax checks.
                         errorHandler.warning("Bad IRI: "+msg, line, col);
                     else
                         errorHandler.warning("Not advised IRI: "+msg, line, col);
                 }
             }
-            
+
 //            // and report our choosen error.
 //            if ( errorSeen || (warningsAreErrors && warningSeen) )
 //            {

--- a/jena-arq/src/main/java/org/apache/jena/riot/checker/CheckerLiterals.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/checker/CheckerLiterals.java
@@ -32,7 +32,7 @@ public class CheckerLiterals implements NodeChecker {
     // A flag to enable the test suite to read bad data.
     public static boolean WarnOnBadLiterals = true ;
 
-    private ErrorHandler  handler ;
+    private ErrorHandler handler ;
 
     public CheckerLiterals(ErrorHandler handler) {
         this.handler = handler ;
@@ -69,8 +69,7 @@ public class CheckerLiterals implements NodeChecker {
 
         boolean hasLang = lang != null && !lang.equals("") ;
         if ( !hasLang ) {
-            // Datatype check (and RDF 1.0 simpl literals are always well
-            // formed)
+            // Datatype check (and RDF 1.0 simple literals are always well formed)
             if ( datatype != null )
                 return validateByDatatype(lexicalForm, datatype, handler, line, col) ;
             return true ;
@@ -96,10 +95,10 @@ public class CheckerLiterals implements NodeChecker {
         }
         return true ;
     }
-    
+
     // Whitespace.
     // XSD allows whitespace before and after the lexical forms of a literal but not insiode.
-    // Jena handles this correctly. 
+    // Jena handles this correctly.
 
     protected static boolean validateByDatatype(String lexicalForm, RDFDatatype datatype, ErrorHandler handler, long line, long col) {
 //        if ( SysRIOT.StrictXSDLexicialForms )
@@ -129,7 +128,7 @@ public class CheckerLiterals implements NodeChecker {
         }
         return true ;
     }
-    
+
     private static String xsdDatatypeName(RDFDatatype datatype) {
         return "XSD "+SplitIRI.localname(datatype.getURI());
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/IRIResolver.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/IRIResolver.java
@@ -37,7 +37,7 @@ import org.apache.jena.riot.SysRIOT;
 public abstract class IRIResolver
 {
     private static boolean         showExceptions    = true;
-    
+
     private static final boolean   ShowResolverSetup = false;
 
     private static final IRIFactory iriFactoryInst = new IRIFactory();
@@ -56,12 +56,12 @@ public abstract class IRIResolver
             System.out.println("---- Default settings ----");
             printSetting(iriFactoryInst);
         }
-        
+
         // Accept any scheme.
         setErrorWarning(iriFactoryInst, ViolationCodes.UNREGISTERED_IANA_SCHEME, false, false);
-        
+
         // These are a warning from jena-iri motivated by problems in RDF/XML and also internal processing by IRI
-        // (IRI.relativize).  
+        // (IRI.relativize).
         // The IRI is valid and does correct resolve when relative.
         setErrorWarning(iriFactoryInst, ViolationCodes.NON_INITIAL_DOT_SEGMENT, false, false);
 
@@ -69,10 +69,10 @@ public abstract class IRIResolver
         // setErrorWarning(iriFactory, ViolationCodes.LOWERCASE_PREFERRED, false, false);
         // setErrorWarning(iriFactory, ViolationCodes.PERCENT_ENCODING_SHOULD_BE_UPPERCASE, false, false);
         // setErrorWarning(iriFactory, ViolationCodes.SCHEME_PATTERN_MATCH_FAILED, false, false);
-        
+
         // NFC tests are not well understood by general developers and these cause confusion.
         // See JENA-864
-        
+
         // NFC is in RDF 1.1 so do test for that.
         // https://www.w3.org/TR/rdf11-concepts/#section-IRIs
         // Leave switched on as a warning.
@@ -80,29 +80,22 @@ public abstract class IRIResolver
 
         // NFKC is not mentioned in RDF 1.1. Switch off.
         setErrorWarning(iriFactoryInst, ViolationCodes.NOT_NFKC, false, false);
-        
-        // ** Applies to various unicode blocks.
-        // Don't apply these tests.
-        setErrorWarning(iriFactoryInst, ViolationCodes.COMPATIBILITY_CHARACTER, false, false);
 
-        // This causes test failures.
-        // The tests catch warnings and a warning is expected.
-        // testing/RIOT/Lang/TurtleStd/turtle-eval-bad-02.ttl and 03 and TriG
-        //   > as \u003C  and < \u003E 
-        // Default is error=true, warning=false.
-        // Test pass with error=false, warning=true.
-        // setErrorWarning(iriFactory, ViolationCodes.UNWISE_CHARACTER, false, false);
+        // ** Applies to various unicode blocks.
+        setErrorWarning(iriFactoryInst, ViolationCodes.COMPATIBILITY_CHARACTER, false, false);
         setErrorWarning(iriFactoryInst, ViolationCodes.UNDEFINED_UNICODE_CHARACTER, false, false);
+        // The set of legal characters depends on the Java version.
+        // If not set, this causes test failures in Turtle and Trig eval tests.
+        setErrorWarning(iriFactoryInst, ViolationCodes.UNASSIGNED_UNICODE_CHARACTER, false, false);
 
         if ( ShowResolverSetup ) {
             System.out.println("---- After initialization ----");
             printSetting(iriFactoryInst);
         }
-
     }
-    
+
     // ---- Initialization support
-    
+
     /** Set the error/warning state of a violation code.
      * @param factory   IRIFactory
      * @param code      ViolationCodes constant
@@ -113,7 +106,7 @@ public abstract class IRIResolver
         factory.setIsWarning(code, isWarning);
         factory.setIsError(code, isError);
     }
-    
+
     private static void printSetting(IRIFactory factory) {
         PrintStream ps = System.out;
         printErrorWarning(ps, factory, ViolationCodes.UNREGISTERED_IANA_SCHEME);
@@ -122,24 +115,25 @@ public abstract class IRIResolver
         printErrorWarning(ps, factory, ViolationCodes.NOT_NFKC);
         printErrorWarning(ps, factory, ViolationCodes.UNWISE_CHARACTER);
         printErrorWarning(ps, factory, ViolationCodes.UNDEFINED_UNICODE_CHARACTER);
+        printErrorWarning(ps, factory, ViolationCodes.UNASSIGNED_UNICODE_CHARACTER);
         printErrorWarning(ps, factory, ViolationCodes.COMPATIBILITY_CHARACTER);
         printErrorWarning(ps, factory, ViolationCodes.LOWERCASE_PREFERRED);
         printErrorWarning(ps, factory, ViolationCodes.PERCENT_ENCODING_SHOULD_BE_UPPERCASE);
         printErrorWarning(ps, factory, ViolationCodes.SCHEME_PATTERN_MATCH_FAILED);
         ps.println();
     }
-    
+
     private static void printErrorWarning(PrintStream ps, IRIFactory factory, int code) {
         String x = PatternCompiler.errorCodeName(code);
         ps.printf("%-40s : E:%-5s W:%-5s\n", x, factory.isError(code), factory.isWarning(code));
     }
 
     // ---- System-wide IRI Factory.
-    
+
     /** The IRI checker setup, focused on parsing and languages.
-     *  This is a clean version of jena-iri {@link IRIFactory#iriImplementation()} 
+     *  This is a clean version of jena-iri {@link IRIFactory#iriImplementation()}
      *  modified to allow unregistered schemes and allow {@code <file:relative>} IRIs.
-     *  
+     *
      *  @see IRIFactory
      */
     public static IRIFactory iriFactory() {
@@ -147,7 +141,7 @@ public abstract class IRIResolver
     }
 
     // ---- System-wide operations.
-    
+
     /** Check an IRI string (does not resolve it) */
     public static boolean checkIRI(String iriStr) {
         IRI iri = parseIRI(iriStr);
@@ -176,7 +170,7 @@ public abstract class IRIResolver
 
     // The global resolver may be accessed by multiple threads
     // Other resolvers are not thread safe.
-    
+
     private static IRIResolver globalResolver;
 
     /**
@@ -197,7 +191,7 @@ public abstract class IRIResolver
     /**
      * Turn a filename into a well-formed file: URL relative to the working
      * directory.
-     * 
+     *
      * @param filename
      * @return String The filename as an absolute URL
      */
@@ -213,7 +207,7 @@ public abstract class IRIResolver
     /**
      * Resolve a URI against a base. If baseStr is a relative file IRI
      * then it is first resolved against the current working directory.
-     * 
+     *
      * @param relStr
      * @param baseStr
      *            Can be null if relStr is absolute
@@ -227,7 +221,7 @@ public abstract class IRIResolver
 
     /**
      * Resolve a URI against a base.
-     * 
+     *
      * @param relStr
      * @param baseStr
      *            Can be null if relStr is absolute
@@ -243,7 +237,7 @@ public abstract class IRIResolver
      * Resolve a URI against the base for this process. If baseStr is a
      * relative file IRI then it is first resolved against the current
      * working directory. If it is an absolute URI, it is normalized.
-     * 
+     *
      * @param uriStr
      * @return String An absolute URI
      * @throws RiotException
@@ -257,7 +251,7 @@ public abstract class IRIResolver
      * Resolve a URI against a base. If baseStr is a relative file IRI
      * then it is first resolved against the current working directory.
      * If it is an absolute URI, it is normalized.
-     * 
+     *
      * @param uriStr
      * @return String An absolute URI
      */
@@ -316,7 +310,7 @@ public abstract class IRIResolver
 
     /**
      * Choose a base URI based on the current directory
-     * 
+     *
      * @return String Absolute URI
      */
     static public IRI chooseBaseURI() {
@@ -332,7 +326,7 @@ public abstract class IRIResolver
 
     /**
      * The base of this IRIResolver.
-     * 
+     *
      * @return String
      */
     protected abstract IRI getBaseIRI();
@@ -340,7 +334,7 @@ public abstract class IRIResolver
     /**
      * Resolve a relative URI against the base of this IRIResolver
      * or normalize an absolute URI.
-     * 
+     *
      * @param uriStr
      * @return the resolved IRI
      * @throws RiotException
@@ -351,10 +345,10 @@ public abstract class IRIResolver
     }
 
     /**
-     * Create a URI, resolving relative IRIs, 
-     * normalize an absolute URI, 
+     * Create a URI, resolving relative IRIs,
+     * normalize an absolute URI,
      * but do not throw exception on a bad IRI.
-     * 
+     *
      * @param uriStr
      * @return the resolved IRI
      * @throws RiotException
@@ -380,7 +374,7 @@ public abstract class IRIResolver
 
     /**
      * Throw any exceptions resulting from IRI.
-     * 
+     *
      * @param iri
      * @return iri
      */
@@ -396,7 +390,7 @@ public abstract class IRIResolver
     private static final int CacheSize = 1000;
 
     /**
-     * A resolver that does not resolve IRIs against base. 
+     * A resolver that does not resolve IRIs against base.
      * This can generate relative IRIs.
      **/
     static class IRIResolverNoOp extends IRIResolver
@@ -413,7 +407,7 @@ public abstract class IRIResolver
 
         @Override
         public IRI resolveSilent(final String uriStr) {
-            if ( resolvedIRIs == null ) 
+            if ( resolvedIRIs == null )
                 return iriFactory().create(uriStr);
             Callable<IRI> filler = () -> iriFactory().create(uriStr);
             IRI iri = resolvedIRIs.getOrFill(uriStr, filler);
@@ -445,7 +439,7 @@ public abstract class IRIResolver
          * Construct an IRIResolver with base determined by the argument URI. If
          * this is relative, it is relative against the current working
          * directory.
-         * 
+         *
          * @param baseStr
          * @throws RiotException
          *             If resulting base unparsable.
@@ -475,7 +469,7 @@ public abstract class IRIResolver
             else
                 return resolveSilentCache(uriStr);
         }
-        
+
         private IRI resolveSilentNoCache(String uriStr) {
             IRI x = IRIResolver.iriFactory().create(uriStr);
             if ( SysRIOT.AbsURINoNormalization ) {
@@ -492,7 +486,7 @@ public abstract class IRIResolver
             return resolvedIRIs.getOrFill(uriStr, filler);
         }
     }
-    
+
     /** Thread safe wrapper for an IRIResolver */
     static class IRIResolverSync extends IRIResolver
     {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/resultset/RDFInput.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/resultset/RDFInput.java
@@ -21,6 +21,7 @@ package org.apache.jena.sparql.resultset;
 import java.util.ArrayList;
 
 import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.shared.JenaException;
@@ -98,7 +99,7 @@ public class RDFInput extends ResultSetMem {
         Model m = root.getModel();
         // Assume one result set per file.
         for ( int index = 1 ;; index++ ) {
-            Literal ind = m.createTypedLiteral(index);
+            Literal ind = m.createTypedLiteral(index, XSDDatatype.XSDinteger);
             StmtIterator sIter = m.listStatements(null, ResultSetGraphVocab.index, ind);
             if ( !sIter.hasNext() )
                 break;
@@ -171,7 +172,7 @@ public class RDFInput extends ResultSetMem {
      * Turns an RDF model, with properties and classes from the result set
      * vocabulary, into a SPARQL result set. The result set formed is a copy in
      * memory.
-     * 
+     *
      * @param model
      * @return ResultSet
      */

--- a/jena-arq/src/test/java/org/apache/jena/atlas/csv/TestCSVParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/atlas/csv/TestCSVParser.java
@@ -18,14 +18,15 @@
 
 package org.apache.jena.atlas.csv;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.jena.atlas.junit.BaseTest;
 import org.junit.Test;
 
-public class TestCSVParser extends BaseTest
+public class TestCSVParser
 {
     String[] row1 = {} ;
     String[] row2 = { "" } ;

--- a/jena-arq/src/test/java/org/apache/jena/atlas/data/TestThresholdPolicyCount.java
+++ b/jena-arq/src/test/java/org/apache/jena/atlas/data/TestThresholdPolicyCount.java
@@ -18,11 +18,13 @@
 
 package org.apache.jena.atlas.data;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test ;
 
 
-public class TestThresholdPolicyCount extends BaseTest
+public class TestThresholdPolicyCount
 {
     
     @Test

--- a/jena-arq/src/test/java/org/apache/jena/atlas/event/TestEvent.java
+++ b/jena-arq/src/test/java/org/apache/jena/atlas/event/TestEvent.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.atlas.event;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test ;
 
 
-public class TestEvent extends BaseTest
+public class TestEvent
 {
     EventType ev1 = new EventType("1") ;
     EventType ev2 = new EventType("2") ;

--- a/jena-arq/src/test/java/org/apache/jena/atlas/json/TestJsonBuilder.java
+++ b/jena-arq/src/test/java/org/apache/jena/atlas/json/TestJsonBuilder.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.atlas.json;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test ;
 
-public class TestJsonBuilder extends BaseTest{
+public class TestJsonBuilder{
     @Test public void jsonBuild01() {
         JsonValue x = JSON.parseAny("{ }") ;
         JsonBuilder builder = new JsonBuilder() ;
@@ -62,6 +63,8 @@ public class TestJsonBuilder extends BaseTest{
         JsonValue v = builder.build() ;
         assertEquals(x,v) ;
     }
+
+    private void assertEquals(JsonValue x, JsonValue v) {}
 
     @Test public void jsonBuild05() {
         JsonValue x = JSON.parseAny("[ { a: 'B'} , 56]") ;

--- a/jena-arq/src/test/java/org/apache/jena/atlas/json/TestJsonExt.java
+++ b/jena-arq/src/test/java/org/apache/jena/atlas/json/TestJsonExt.java
@@ -20,11 +20,10 @@ package org.apache.jena.atlas.json;
 
 import static org.apache.jena.atlas.json.LibJsonTest.read ;
 import static org.apache.jena.atlas.json.LibJsonTest.writeRead ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
 /** Tests that are of extensions of JSON */ 
-public class TestJsonExt extends BaseTest
+public class TestJsonExt
 {
     // The Jena JSON parser is more liberal than strict JSON to make embedding easier.
     // * Keys do not need quotes

--- a/jena-arq/src/test/java/org/apache/jena/atlas/json/TestJsonWriter.java
+++ b/jena-arq/src/test/java/org/apache/jena/atlas/json/TestJsonWriter.java
@@ -19,10 +19,11 @@
 package org.apache.jena.atlas.json;
 
 import static org.apache.jena.atlas.json.LibJsonTest.writeRead ;
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test ;
 
-public class TestJsonWriter extends BaseTest
+public class TestJsonWriter
 {
     @Test public void js_write_str_1()  { test("foo") ; }
     

--- a/jena-arq/src/test/java/org/apache/jena/atlas/legacy/BaseTest2.java
+++ b/jena-arq/src/test/java/org/apache/jena/atlas/legacy/BaseTest2.java
@@ -26,7 +26,7 @@ import org.apache.jena.atlas.logging.Log ;
 import org.apache.jena.riot.system.ErrorHandler ;
 import org.apache.jena.riot.system.ErrorHandlerFactory ;
 
-public class BaseTest2 extends BaseTest {
+public class BaseTest2 {
     // Should go elsewhere?
     
   private static Deque<ErrorHandler> errorHandlers = new ArrayDeque<>() ;

--- a/jena-arq/src/test/java/org/apache/jena/atlas/web/TestContentNegotiation.java
+++ b/jena-arq/src/test/java/org/apache/jena/atlas/web/TestContentNegotiation.java
@@ -18,10 +18,13 @@
 
 package org.apache.jena.atlas.web;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import org.junit.Test ;
 
-public class TestContentNegotiation extends BaseTest
+public class TestContentNegotiation
 {
     static final String ctFirefox = "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5" ;
     static final String ctIE_6  = "image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, application/x-shockwave-flash, application/vnd.ms-excel, application/msword, */*" ;

--- a/jena-arq/src/test/java/org/apache/jena/common/TestIsoMatcher.java
+++ b/jena-arq/src/test/java/org/apache/jena/common/TestIsoMatcher.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.common;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList ;
 import java.util.Collection;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.apache.jena.atlas.lib.tuple.TupleFactory ;
 import org.apache.jena.graph.Graph ;
@@ -37,7 +38,7 @@ import org.apache.jena.sparql.util.IsoMatcher ;
 import org.apache.jena.sparql.util.NodeUtils;
 import org.junit.Test ;
 
-public class TestIsoMatcher extends BaseTest
+public class TestIsoMatcher
 {
     @Test public void iso_00() { testGraph("",
                                            "",

--- a/jena-arq/src/test/java/org/apache/jena/riot/ErrorHandlerTestLib.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/ErrorHandlerTestLib.java
@@ -23,7 +23,7 @@ import java.util.List ;
 
 import org.apache.jena.riot.system.ErrorHandler ;
 
-/** Error handled to convert anything to an exception */ 
+/** Error handled to convert anything to an exception */
 public class ErrorHandlerTestLib
 {
     public static class ExFatal extends RuntimeException { ExFatal(String msg) { super(msg) ; } }
@@ -35,15 +35,15 @@ public class ErrorHandlerTestLib
     public static class ErrorHandlerEx implements ErrorHandler
     {
         public ErrorHandlerEx() {}
-        
+
         @Override
         public void warning(String message, long line, long col)
         { throw new ExWarning(message) ; }
-    
+
         @Override
         public void error(String message, long line, long col)
         { throw new ExError(message) ; }
-    
+
         @Override
         public void fatal(String message, long line, long col)
         { throw new ExFatal(message) ; }
@@ -53,15 +53,15 @@ public class ErrorHandlerTestLib
     public static class ErrorHandlerMsg implements ErrorHandler
     {
         public List<String> msgs = new ArrayList<>() ;
-    
+
         @Override
         public void warning(String message, long line, long col)
         { msgs.add(message) ; }
-    
+
         @Override
         public void error(String message, long line, long col)
         { msgs.add(message) ; }
-    
+
         @Override
         public void fatal(String message, long line, long col)
         { msgs.add(message) ; throw new ExFatal(message) ; }

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestJenaReaderRIOT.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestJenaReaderRIOT.java
@@ -18,12 +18,13 @@
 
 package org.apache.jena.riot;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.FileInputStream ;
 import java.io.IOException ;
 import java.io.StringReader ;
 import java.nio.file.Paths ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.IRILib ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.atlas.web.TypedInputStream ;
@@ -37,7 +38,7 @@ import org.junit.Test ;
 
 /* Test of integration with Jena via model.read.
  * Also tests triples format reading of RDFDataMgr */
-public class TestJenaReaderRIOT extends BaseTest
+public class TestJenaReaderRIOT
 {
     private static final String directory = "testing/RIOT/Reader" ;
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestLangRIOT.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestLangRIOT.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.riot;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestLangRIOT extends BaseTest
+public class TestLangRIOT
 {
     @BeforeClass public static void beforeClass() { RDFLanguages.init() ; } 
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestReadData.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestReadData.java
@@ -18,11 +18,14 @@
 
 package org.apache.jena.riot;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
 import java.io.FileInputStream ;
 import java.io.IOException ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.DatasetFactory ;
@@ -36,7 +39,7 @@ import org.junit.Test ;
 /* Tests of RDFDataMgr.
  * See also TestJenaReaderRIOT (which covers reading triples formats)
  */
-public class TestReadData extends BaseTest
+public class TestReadData
 {
     private static final String directory = "testing/RIOT/Reader" ;
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestSyntaxDetermination.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestSyntaxDetermination.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.riot;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.web.ContentType ;
 import org.junit.Test ;
 import org.junit.runner.RunWith ;
@@ -29,7 +30,7 @@ import org.junit.runners.Parameterized ;
 import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
-public class TestSyntaxDetermination extends BaseTest {
+public class TestSyntaxDetermination {
     // On experience of test paramterization:
     //   Macro-generating the test items would be better 
     //   because test failures then leave a clickable

--- a/jena-arq/src/test/java/org/apache/jena/riot/adapters/TestFileManager.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/adapters/TestFileManager.java
@@ -18,9 +18,10 @@
 
 package org.apache.jena.riot.adapters;
 
+import static org.junit.Assert.*;
+
 import java.io.InputStream ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.ontology.Individual ;
 import org.apache.jena.ontology.OntModel ;
 import org.apache.jena.ontology.OntModelSpec ;
@@ -36,7 +37,7 @@ import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
 
 @SuppressWarnings("deprecation")
-public class TestFileManager extends BaseTest
+public class TestFileManager
 {
     static Logger log = LoggerFactory.getLogger(TestFileManager.class) ;
     public static final String testingDir = "testing/RIOT/FileManager" ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestBlankNodeAllocator.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestBlankNodeAllocator.java
@@ -18,10 +18,13 @@
 
 package org.apache.jena.riot.lang;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Node ;
 import org.junit.Test ;
 import org.junit.runner.RunWith ;
@@ -29,7 +32,7 @@ import org.junit.runners.Parameterized ;
 import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
-public class TestBlankNodeAllocator extends BaseTest
+public class TestBlankNodeAllocator
 {
     public interface Factory { public BlankNodeAllocator create() ; }
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestIRI.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestIRI.java
@@ -18,7 +18,9 @@
 
 package org.apache.jena.riot.lang;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.graph.Node ;
 import org.apache.jena.iri.IRI ;
 import org.apache.jena.iri.IRIFactory ;
@@ -30,7 +32,7 @@ import org.apache.jena.riot.system.IRIResolver ;
 import org.apache.jena.riot.system.RiotLib ;
 import org.junit.Test ;
 
-public class TestIRI extends BaseTest
+public class TestIRI
 {
     static protected final ErrorHandler handler = new ErrorHandlerTestLib.ErrorHandlerEx() ;
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLabelToNode.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLabelToNode.java
@@ -18,10 +18,13 @@
 
 package org.apache.jena.riot.lang;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.ArrayList ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.riot.system.SyntaxLabels ;
@@ -31,7 +34,7 @@ import org.junit.runners.Parameterized ;
 import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
-public class TestLabelToNode extends BaseTest
+public class TestLabelToNode
 {
     // See also TestNodeAlloc
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLang.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLang.java
@@ -18,10 +18,12 @@
 
 package org.apache.jena.riot.lang;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap ;
 import java.util.Map ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFLanguages ;
 import org.apache.jena.riot.WebContent ;
@@ -31,7 +33,7 @@ import org.apache.jena.util.FileUtils ;
 import org.junit.Assert ;
 import org.junit.Test ;
 
-public class TestLang extends BaseTest
+public class TestLang
 {
     static { JenaSystem.init(); }
     @Test public void registration_01() { testregistration(RDFLanguages.RDFXML) ; }

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangNQuads.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangNQuads.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.riot.lang;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.riot.ErrorHandlerTestLib.ExFatal ;
 import org.apache.jena.riot.Lang ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangNTriples.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangNTriples.java
@@ -18,6 +18,10 @@
 
 package org.apache.jena.riot.lang;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.StringReader ;
 
 import org.apache.jena.atlas.lib.CharSpace ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangNTuples.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangNTuples.java
@@ -21,10 +21,10 @@ package org.apache.jena.riot.lang;
 import static org.apache.jena.riot.system.ErrorHandlerFactory.errorHandlerNoLogging ;
 import static org.apache.jena.riot.system.ErrorHandlerFactory.getDefaultErrorHandler ;
 import static org.apache.jena.riot.system.ErrorHandlerFactory.setDefaultErrorHandler ;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.CharSpace ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.riot.ErrorHandlerTestLib.ErrorHandlerEx;
@@ -41,7 +41,7 @@ import org.junit.BeforeClass ;
 import org.junit.Test ;
 /** Test of syntax by a tuples parser (does not include node validitiy checking) */ 
 
-abstract public class TestLangNTuples extends BaseTest
+abstract public class TestLangNTuples
 {
     // Test streaming interface.
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangRdfJson.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangRdfJson.java
@@ -18,10 +18,12 @@
 
 package org.apache.jena.riot.lang;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream ;
 import java.io.StringReader ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.rdf.model.Model ;
@@ -36,7 +38,7 @@ import org.apache.jena.riot.tokens.Tokenizer ;
 import org.apache.jena.riot.tokens.TokenizerFactory ;
 import org.junit.Test ;
 
-public class TestLangRdfJson extends BaseTest
+public class TestLangRdfJson
 {
 	@Test
 	public void rdfjson_get_jena_reader()

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTrig.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTrig.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.riot.lang;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.riot.ErrorHandlerTestLib ;
 import org.apache.jena.riot.ErrorHandlerTestLib.ExFatal ;
@@ -29,7 +30,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
 /** Test the behaviour of the RIOT reader for TriG.  TriG includes checking of terms */
-public class TestLangTrig extends BaseTest
+public class TestLangTrig
 {
     @Test public void trig_01()     { parse("{}") ; } 
     @Test public void trig_02()     { parse("{}.") ; }

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTurtle.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTurtle.java
@@ -21,10 +21,12 @@ package org.apache.jena.riot.lang;
 import static org.apache.jena.riot.system.ErrorHandlerFactory.errorHandlerNoLogging ;
 import static org.apache.jena.riot.system.ErrorHandlerFactory.getDefaultErrorHandler ;
 import static org.apache.jena.riot.system.ErrorHandlerFactory.setDefaultErrorHandler ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.StringReader ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.rdf.model.Model ;
@@ -42,7 +44,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestLangTurtle extends BaseTest
+public class TestLangTurtle
 {
     @Test public void blankNodes1()
     {

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestNodeAllocator.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestNodeAllocator.java
@@ -18,13 +18,16 @@
 
 package org.apache.jena.riot.lang;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.riot.system.SyntaxLabels ;
 import org.junit.Test ;
 
-public class TestNodeAllocator extends BaseTest
+public class TestNodeAllocator
 {
     static Node gragh1 = NodeFactory.createURI("g1") ;
     static Node gragh2 = NodeFactory.createURI("g2") ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestNodeToLabel.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestNodeToLabel.java
@@ -18,10 +18,13 @@
 
 package org.apache.jena.riot.lang;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.ArrayList ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.riot.out.NodeToLabel ;
@@ -32,7 +35,7 @@ import org.junit.runners.Parameterized ;
 import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
-public class TestNodeToLabel extends BaseTest
+public class TestNodeToLabel
 {
     public interface NodeToLabelFactory { public NodeToLabel create() ; }
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestParserFactory.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestParserFactory.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.riot.lang;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.StringReader ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFParser ;
@@ -34,7 +35,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
 /** System-level testing of the parsers - testing the parser plumbing, not the language details */
-public class TestParserFactory extends BaseTest
+public class TestParserFactory
 {
     @Test public void ntriples_01() 
     {

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestTriXReader.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestTriXReader.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.riot.lang;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.InputStream ;
 import java.util.Arrays ;
 
 import org.apache.jena.atlas.io.IO ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.riot.ReaderRIOT ;
@@ -38,7 +39,7 @@ import org.junit.runners.Parameterized.Parameter ;
 import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
-public class TestTriXReader extends BaseTest {
+public class TestTriXReader {
     
     static String DIR = "testing/RIOT/Lang/TriX" ;
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestTurtleTerms.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestTurtleTerms.java
@@ -18,14 +18,13 @@
 
 package org.apache.jena.riot.lang;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.riot.system.*;
 import org.apache.jena.riot.tokens.Tokenizer ;
 import org.apache.jena.riot.tokens.TokenizerFactory ;
 import org.junit.Test ;
 
-public class TestTurtleTerms extends BaseTest
+public class TestTurtleTerms
 {
 
 	static public final String QUOTE3 = "\"\"\"" ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/langsuite/FactoryTestRiot.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/langsuite/FactoryTestRiot.java
@@ -33,13 +33,13 @@ public class FactoryTestRiot extends TestFactoryManifest
     public static String assumedRootURIex = "http://example/base/" ;
     public static String assumedRootURITurtle = "http://www.w3.org/2013/TurtleTests/" ;
     public static String assumedRootURITriG = "http://www.w3.org/2013/TriGTests/" ;
-    
+
     public static EarlReport report = null ;
-    
+
     public static TestSuite make(String manifest) {
         return make(manifest, null, null);
     }
-    
+
     public static TestSuite make(String manifest, Resource dftTestType, String labelPrefix) {
         return new FactoryTestRiot(dftTestType, labelPrefix).process(manifest);
     }
@@ -52,7 +52,7 @@ public class FactoryTestRiot extends TestFactoryManifest
         this.dftTestType = dftTestType ;
         this.labelPrefix = labelPrefix ;
     }
-    
+
     @Override
     public Test makeTest(Resource manifest, Resource item, String testName, Resource action, Resource result)
     {
@@ -63,49 +63,49 @@ public class FactoryTestRiot extends TestFactoryManifest
                 r = dftTestType ;
             if ( r == null )
                 throw new RiotException("Can't determine the test type") ;
-            
+
             if ( labelPrefix != null )
                 testName = labelPrefix+testName ;
-            
+
             // In Turtle tests, the action directly names the file to process.
             Resource input = action ;
-            Resource output = result ; 
-            
+            Resource output = result ;
+
             if ( r.equals(VocabLangRDF.TestPositiveSyntaxTTL) )
                 return new UnitTestSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.TURTLE, report) ;
-            
+
             if ( r.equals(VocabLangRDF.TestNegativeSyntaxTTL) )
                 return new UnitTestBadSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.TURTLE, report) ;
 
             if ( r.equals(VocabLangRDF.TestPositiveSyntaxTriG) )
                 return new UnitTestSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.TRIG, report) ;
-            
+
             if ( r.equals(VocabLangRDF.TestNegativeSyntaxTriG) )
                 return new UnitTestBadSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.TRIG, report) ;
 
             if ( r.equals(VocabLangRDF.TestPositiveSyntaxNT) )
                 return new UnitTestSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.NTRIPLES, report) ;
-            
+
             if ( r.equals(VocabLangRDF.TestNegativeSyntaxNT) )
                 return new UnitTestBadSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.NTRIPLES, report) ;
 
             if ( r.equals(VocabLangRDF.TestPositiveSyntaxNQ) )
                 return new UnitTestSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.NQUADS, report) ;
-            
+
             if ( r.equals(VocabLangRDF.TestNegativeSyntaxNQ) )
                 return new UnitTestBadSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.NQUADS, report) ;
 
             if ( r.equals(VocabLangRDF.TestPositiveSyntaxRJ) )
                 return new UnitTestSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.RDFJSON, report) ;
-            
+
             if ( r.equals(VocabLangRDF.TestNegativeSyntaxRJ) )
                 return new UnitTestBadSyntax(testName, item.getURI(), input.getURI(), RDFLanguages.RDFJSON, report) ;
-            
+
             if ( r.equals(VocabLangRDF.TestSurpressed ))
                 return new UnitTestSurpressed(testName, item.getURI(), report) ;
 
             // Eval.
-            
+
             if ( r.equals(VocabLangRDF.TestEvalTTL) ) {
                 String base = rebase(input, assumedRootURITurtle) ;
                 return new UnitTestEval(testName, item.getURI(), input.getURI(), result.getURI(), base, RDFLanguages.TURTLE, report) ;
@@ -118,7 +118,7 @@ public class FactoryTestRiot extends TestFactoryManifest
 
             if ( r.equals(VocabLangRDF.TestNegativeEvalTTL) )
                 return new UnitTestBadEval(testName, item.getURI(), input.getURI(), RDFLanguages.TURTLE, report) ;
-            
+
             if ( r.equals(VocabLangRDF.TestNegativeEvalTriG) )
                 return new UnitTestBadEval(testName, item.getURI(), input.getURI(), RDFLanguages.TRIG, report) ;
 
@@ -127,7 +127,7 @@ public class FactoryTestRiot extends TestFactoryManifest
 
             if ( r.equals(VocabLangRDF.TestNegativeEvalNT) )
                 return new UnitTestBadEval(testName, item.getURI(), input.getURI(), RDFLanguages.NTRIPLES, report) ;
-            
+
             if ( r.equals(VocabLangRDF.TestEvalRJ) ) {
                 String base = rebase(input, assumedRootURIex) ;
                 return new UnitTestEval(testName, item.getURI(), input.getURI(), result.getURI(), base, RDFLanguages.RDFJSON, report) ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/langsuite/UnitTestBadSyntax.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/langsuite/UnitTestBadSyntax.java
@@ -43,21 +43,21 @@ public class UnitTestBadSyntax extends LangTestCase
         this.uri = uri ;
         this.lang = lang ;
     }
-    
-    /** An error handler that throw exceptions on warnings and errors */ 
+
+    /** An error handler that throw exceptions on warnings and errors */
     private static ErrorHandler errorHandlerTestStrict = new ErrorHandler()
     {
         /** report a warning  - do not carry on */
         @Override
         public void warning(String message, long line, long col)
-        { 
+        {
             throw new RiotException(fmtMessage(message, line, col)) ;
         }
-        
+
         /** report an error - do not carry on */
         @Override
         public void error(String message, long line, long col)
-        { 
+        {
             throw new RiotException(fmtMessage(message, line, col)) ;
         }
 
@@ -82,12 +82,12 @@ public class UnitTestBadSyntax extends LangTestCase
         else
             run4() ;
     }
-    
+
     private void run3() {
-        Graph graph = GraphFactory.createDefaultGraph(); 
+        Graph graph = GraphFactory.createDefaultGraph();
         try {
             Parse.parse(graph, uri, lang);
-        } 
+        }
         catch (RiotException ex) { return ; }
         catch (RuntimeException ex) {
             ex.printStackTrace(System.err) ;
@@ -95,7 +95,7 @@ public class UnitTestBadSyntax extends LangTestCase
         }
         fail("Bad syntax test succeed in parsing the file") ;
     }
-    
+
     private void run4() {
         DatasetGraph dsg = DatasetGraphFactory.createGeneral() ;
         try {

--- a/jena-arq/src/test/java/org/apache/jena/riot/out/TestNodeFmt.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/out/TestNodeFmt.java
@@ -18,9 +18,11 @@
 
 package org.apache.jena.riot.out;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.JenaRuntime ;
 import org.apache.jena.atlas.io.StringWriterI ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.CharSpace ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.riot.system.PrefixMap ;
@@ -29,7 +31,7 @@ import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.junit.Test ;
 
-public class TestNodeFmt extends BaseTest
+public class TestNodeFmt
 {
     private static String base = "http://example.org/base" ;
     private static PrefixMap prefixMap = PrefixMapFactory.createForOutput() ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/out/TestNodeFmtLib.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/out/TestNodeFmtLib.java
@@ -18,13 +18,14 @@
 
 package org.apache.jena.riot.out;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.graph.Node ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.apache.jena.vocabulary.RDF ;
 import org.junit.Test ;
 
-public class TestNodeFmtLib extends BaseTest
+public class TestNodeFmtLib
 {
     // : is 3A 
     // - is 2D

--- a/jena-arq/src/test/java/org/apache/jena/riot/resultset/TestResultSetIO.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/resultset/TestResultSetIO.java
@@ -22,6 +22,7 @@ import static org.apache.jena.riot.resultset.ResultSetLang.SPARQLResultSetCSV ;
 import static org.apache.jena.riot.resultset.ResultSetLang.SPARQLResultSetJSON ;
 import static org.apache.jena.riot.resultset.ResultSetLang.SPARQLResultSetTSV ;
 import static org.apache.jena.riot.resultset.ResultSetLang.SPARQLResultSetXML ;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
@@ -29,7 +30,6 @@ import java.util.ArrayList ;
 import java.util.Collection ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.ResultSet ;
 import org.apache.jena.query.ResultSetFactory ;
@@ -46,7 +46,7 @@ import org.junit.runners.Parameterized ;
 import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
-public class TestResultSetIO extends BaseTest {
+public class TestResultSetIO {
     @Parameters(name = "{index}: {0}") 
     public static Collection<Object[]> data() { 
         Lang[] langs = { SPARQLResultSetXML

--- a/jena-arq/src/test/java/org/apache/jena/riot/stream/TestLocators.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/stream/TestLocators.java
@@ -18,15 +18,17 @@
 
 package org.apache.jena.riot.stream;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.web.TypedInputStream ;
 import org.apache.jena.riot.WebContent ;
 import org.apache.jena.riot.system.stream.LocatorFile ;
 import org.junit.Test ;
 
-public class TestLocators extends BaseTest 
+public class TestLocators 
 {
     public static final String testingDir = "testing/RIOT/Files/" ;
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/stream/TestStreamManager.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/stream/TestStreamManager.java
@@ -18,10 +18,12 @@
 
 package org.apache.jena.riot.stream;
 
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.File ;
 
 import org.apache.jena.atlas.io.IO ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.web.TypedInputStream ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
@@ -36,7 +38,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestStreamManager extends BaseTest
+public class TestStreamManager
 {
     private static final String directory = "testing/RIOT/StreamManager" ;
     private static final String absDirectory = new File(directory).getAbsolutePath() ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/AbstractTestPrefixMap.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/AbstractTestPrefixMap.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.riot.system;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.*;
+
 import org.apache.jena.iri.IRIFactory ;
 import org.junit.Test ;
 
@@ -26,7 +27,7 @@ import org.junit.Test ;
  * Abstract tests for {@link PrefixMap} implementations
  * 
  */
-public abstract class AbstractTestPrefixMap extends BaseTest {
+public abstract class AbstractTestPrefixMap {
     protected IRIFactory factory = IRIResolver.iriFactory();
 
     /**

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestFormatRegistration.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestFormatRegistration.java
@@ -19,11 +19,14 @@
 
 package org.apache.jena.riot.system;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
-import org.apache.jena.riot.* ;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFWriterRegistry;
 import org.junit.Test ;
 // Test system integration / registration
 import org.junit.runner.RunWith ;
@@ -32,7 +35,7 @@ import org.junit.runners.Parameterized.Parameters ;
 
 
 @RunWith(Parameterized.class)
-public class TestFormatRegistration extends BaseTest
+public class TestFormatRegistration
 {
     @Parameters(name = "{0} -- {1} {2} {3}")
     public static Iterable<Object[]> data() {

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestJsonLDReadWrite.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestJsonLDReadWrite.java
@@ -19,13 +19,13 @@
 package org.apache.jena.riot.system;
 
 import static org.apache.jena.riot.RDFLanguages.JSONLD ;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 import java.util.Iterator ;
 import java.util.Map ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.DatasetFactory ;
 import org.apache.jena.rdf.model.Model ;
@@ -37,7 +37,7 @@ import org.junit.Assert ;
 import org.junit.Test ;
 
 /** tests : JSONLD->RDF ; JSONLD->RDF->JSONLD */
-public class TestJsonLDReadWrite extends BaseTest
+public class TestJsonLDReadWrite
 {
     private static String DIR = "testing/RIOT/jsonld/" ; 
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestLangRegistration.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestLangRegistration.java
@@ -18,10 +18,13 @@
 
 package org.apache.jena.riot.system;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.riot.* ;
 import org.junit.Test ;
 import org.junit.runner.RunWith ;
@@ -30,7 +33,7 @@ import org.junit.runners.Parameterized.Parameters ;
 
 
 @RunWith(Parameterized.class)
-public class TestLangRegistration extends BaseTest
+public class TestLangRegistration
 {
     @Parameters(name = "{0} -- {1} {2} {3}")
     public static Iterable<Object[]> data() {

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestPrefixMapOther.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestPrefixMapOther.java
@@ -18,14 +18,13 @@
 
 package org.apache.jena.riot.system;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
 /**
  * Test the standard {@link PrefixMapStd} implementation
  *
  */
-public class TestPrefixMapOther extends BaseTest
+public class TestPrefixMapOther
 {
     @Test(expected=UnsupportedOperationException.class) 
     public void other_01()

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestStreamRDF.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestStreamRDF.java
@@ -18,14 +18,15 @@
 
 package org.apache.jena.riot.system;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.riot.lang.StreamRDFCounting ;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
-public class TestStreamRDF extends BaseTest {
+public class TestStreamRDF {
     private static Triple triple1 = SSE.parseTriple("(<s> <p> <o>)") ;
     private static Quad quad1 = SSE.parseQuad("(<g> <s> <p> <o>)") ;
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestResultSetThrift.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestResultSetThrift.java
@@ -18,13 +18,14 @@
 
 package org.apache.jena.riot.thrift;
 
+import static org.junit.Assert.assertFalse;
+
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 import java.io.IOException ;
 import java.io.InputStream ;
 
 import org.apache.jena.atlas.io.IO ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.ResultSet ;
 import org.apache.jena.query.ResultSetFactory ;
@@ -35,7 +36,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.apache.jena.sparql.sse.builders.BuilderResultSet ;
 import org.junit.Test ;
 
-public class TestResultSetThrift extends BaseTest {
+public class TestResultSetThrift {
     // Only datatypes that transmitted perfectly. 
     static ResultSetRewindable rs0 = make
         ("(resultset (?x ?y)"

--- a/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestStreamRDFThrift.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestStreamRDFThrift.java
@@ -18,12 +18,15 @@
 
 package org.apache.jena.riot.thrift;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 import java.util.Iterator ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
@@ -42,7 +45,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.apache.jena.sparql.util.IsoMatcher ;
 import org.junit.Test ;
 
-public class TestStreamRDFThrift extends BaseTest {
+public class TestStreamRDFThrift {
 
     private static final String DIR = TS_RDFThrift.TestingDir ;
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestThriftSetup.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestThriftSetup.java
@@ -19,12 +19,14 @@
 package org.apache.jena.riot.thrift;
 
 import static org.apache.jena.riot.RDFLanguages.THRIFT ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.riot.* ;
 import org.junit.Test ;
 
-public class TestThriftSetup extends BaseTest {
+public class TestThriftSetup {
 
     @Test public void setup_01() {
         assertTrue(RDFLanguages.isRegistered(THRIFT)) ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestThriftTerm.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestThriftTerm.java
@@ -18,8 +18,9 @@
 
 package org.apache.jena.riot.thrift;
 
+import static org.junit.Assert.*;
+
 import org.apache.jena.JenaRuntime ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.rdf.model.impl.Util ;
@@ -35,7 +36,7 @@ import org.apache.jena.vocabulary.RDFS ;
 import org.apache.jena.vocabulary.XSD ;
 import org.junit.Test ;
 
-public class TestThriftTerm extends BaseTest {
+public class TestThriftTerm {
     static PrefixMap prefixMap = PrefixMapFactory.create() ;
     static {
         prefixMap.add("rdf",    RDF.getURI()) ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenForNode.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenForNode.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.riot.tokens;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.graph.Node ;
 import org.apache.jena.riot.system.PrefixMap ;
 import org.apache.jena.riot.system.PrefixMapFactory ;
@@ -26,7 +27,7 @@ import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestTokenForNode extends BaseTest 
+public class TestTokenForNode 
 {
     static String base = "http://localhost/" ;
     static PrefixMap prefixMap = PrefixMapFactory.create() ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizer.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizer.java
@@ -18,17 +18,21 @@
 
 package org.apache.jena.riot.tokens ;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream ;
 
 import org.apache.jena.atlas.io.PeekReader ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.riot.RiotException ;
 import org.apache.jena.riot.RiotParseException ;
 import org.apache.jena.sparql.ARQConstants ;
 import org.junit.Test ;
 
-public class TestTokenizer extends BaseTest {
+public class TestTokenizer {
     // WORKERS
     private static Tokenizer tokenizer(String string) {
         return tokenizer(string, false) ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/web/TestLangTag.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/web/TestLangTag.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.riot.web;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.*;
+
 import org.junit.Test ;
 
-public class TestLangTag extends BaseTest
+public class TestLangTag
 {
     @Test public void parse_01() 
     { parseGood("en",                  "en",               "en", null, null, null, null) ; }

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/AbstractWriterTest.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/AbstractWriterTest.java
@@ -18,12 +18,11 @@
 
 package org.apache.jena.riot.writer;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.riot.RDFDataMgr ;
 
-public class AbstractWriterTest extends BaseTest
+public class AbstractWriterTest
 {
     static String DIR = "testing/RIOT/Writer" ;
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestJenaWriters.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestJenaWriters.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.riot.writer;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.io.ByteArrayOutputStream ;
 import java.util.ArrayList ;
 import java.util.List ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestJsonLDWriter.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestJsonLDWriter.java
@@ -17,6 +17,9 @@
  */
 package org.apache.jena.riot.writer;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
@@ -32,7 +35,6 @@ import com.github.jsonldjava.utils.JsonUtils;
 
 import org.apache.jena.atlas.json.JsonObject;
 import org.apache.jena.atlas.json.JsonString;
-import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.JsonLDWriteContext;
@@ -47,7 +49,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
-public class TestJsonLDWriter extends BaseTest {
+public class TestJsonLDWriter {
 
     /**
      * Checks that JSON-LD RDFFormats supposed to be pretty are pretty

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRDFJSON.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRDFJSON.java
@@ -18,12 +18,13 @@
 
 package org.apache.jena.riot.writer;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 
 import org.apache.jena.atlas.json.JSON ;
 import org.apache.jena.atlas.json.JsonObject ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
@@ -35,7 +36,7 @@ import org.apache.jena.sparql.graph.GraphFactory ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
-public class TestRDFJSON extends BaseTest
+public class TestRDFJSON
 {
     @Test public void rdfjson_00()
     {

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRiotWriterDataset.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRiotWriterDataset.java
@@ -18,6 +18,9 @@
 
 package org.apache.jena.riot.writer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 import java.util.Arrays ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRiotWriterGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRiotWriterGraph.java
@@ -18,6 +18,9 @@
 
 package org.apache.jena.riot.writer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 import java.util.Arrays ;
@@ -146,7 +149,6 @@ public class TestRiotWriterGraph extends AbstractWriterTest
         }
         
         assertTrue("Did not round-trip file="+filename+" / format="+format,  b) ; 
-        
     }
 }
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestTriXWriter.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestTriXWriter.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.riot.writer;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 import java.util.Arrays ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.sparql.core.DatasetGraph ;
@@ -35,7 +36,7 @@ import org.junit.runners.Parameterized.Parameter ;
 import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
-public class TestTriXWriter extends BaseTest {
+public class TestTriXWriter {
 
     static String DIR = "testing/RIOT/Lang/TriX" ;
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestWriterRegistration.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestWriterRegistration.java
@@ -18,13 +18,14 @@
 
 package org.apache.jena.riot.writer;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFFormat ;
 import org.apache.jena.riot.RDFWriterRegistry ;
 import org.junit.Test ;
 
-public class TestWriterRegistration extends BaseTest
+public class TestWriterRegistration
 {
     static { RDFWriterRegistry.init(); }
     @Test public void registration_01() { testregistration(Lang.RDFXML) ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestAlgebraTranslate.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestAlgebraTranslate.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.sparql.algebra;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryFactory ;
@@ -27,7 +28,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
 /** Test translation of syntax to algebra - no otpimization */ 
-public class TestAlgebraTranslate extends BaseTest 
+public class TestAlgebraTranslate 
 {    
     @Test public void translate_01() { test("?s ?p ?o", "(bgp (triple ?s ?p ?o))") ; }
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestClassify.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestClassify.java
@@ -18,7 +18,9 @@
 
 package org.apache.jena.sparql.algebra;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryFactory ;
 import org.apache.jena.query.Syntax ;
@@ -28,7 +30,7 @@ import org.apache.jena.sparql.engine.main.JoinClassifier ;
 import org.apache.jena.sparql.engine.main.LeftJoinClassifier ;
 import org.junit.Test ;
 
-public class TestClassify extends BaseTest
+public class TestClassify
 {
     @Test public void testClassify_Join_01() 
 	{ classifyJ("{?s :p :o . { ?s :p :o FILTER(true) } }", true) ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestOpVars.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestOpVars.java
@@ -18,17 +18,18 @@
 
 package org.apache.jena.sparql.algebra;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays ;
 import java.util.Collection ;
 import java.util.HashSet ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
-public class TestOpVars extends BaseTest
+public class TestOpVars
 {
     @Test public void opvars_01() { visible("(bgp (?s :p ?o))", "s", "o") ; }
     @Test public void opvars_02() { visible("(leftjoin (bgp (?s :p ?o)) (bgp (?s1 :p ?o1)) )", "s1", "o1", "s", "o") ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestPattern2Join.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestPattern2Join.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.sparql.algebra;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryFactory ;
@@ -26,7 +27,7 @@ import org.apache.jena.sparql.algebra.optimize.TransformPattern2Join ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
-public class TestPattern2Join extends BaseTest
+public class TestPattern2Join
 {
     
     @Test public void bgp2join_01() { test3("{}", 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestTransformOpExt.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestTransformOpExt.java
@@ -18,10 +18,12 @@
 
 package org.apache.jena.sparql.algebra;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Set;
 
 import org.apache.jena.atlas.io.IndentedWriter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.sparql.algebra.op.OpExt ;
 import org.apache.jena.sparql.algebra.op.OpFilter;
@@ -36,7 +38,7 @@ import org.apache.jena.sparql.util.NodeIsomorphismMap ;
 import org.junit.Test ;
 
 /** Tests for OpExt */ 
-public class TestTransformOpExt extends BaseTest
+public class TestTransformOpExt
 {
     // An OpExt
     static class OpExtTest extends OpExt {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestTransformQuads.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestTransformQuads.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.sparql.algebra;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryFactory ;
@@ -26,7 +27,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
 //Tests for conversion of algebra forms to quad form. 
-public class TestTransformQuads extends BaseTest
+public class TestTransformQuads
 {
     // Simple
     @Test public void quads01() { test ("{ GRAPH ?g { ?s ?p ?o } }", 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestVarFinder.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestVarFinder.java
@@ -18,18 +18,19 @@
 
 package org.apache.jena.sparql.algebra;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays ;
 import java.util.HashSet ;
 import java.util.List ;
 import java.util.Set ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.engine.main.VarFinder ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
-public class TestVarFinder extends BaseTest
+public class TestVarFinder
 {
     @Test public void varfind_01_1() { varfindFixed("(bgp (?s <p> <o>))", "s") ; }
     @Test public void varfind_01_2() { varfindOpt("(bgp (?s <p> <o>))") ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/AbstractTestTransform.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/AbstractTestTransform.java
@@ -18,9 +18,10 @@
 
 package org.apache.jena.sparql.algebra.optimize ;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Objects ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryFactory ;
@@ -31,7 +32,7 @@ import org.apache.jena.sparql.algebra.Transformer ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Assert ;
 
-public abstract class AbstractTestTransform extends BaseTest {
+public abstract class AbstractTestTransform {
 
     public void testOptimize(String input, String... output) {
         Query q = QueryFactory.create(input) ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestOptDistinctReduced.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestOptDistinctReduced.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.sparql.algebra.optimize;
 
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.algebra.Transform ;
 import org.junit.Test ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestOptimizer.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestOptimizer.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.sparql.algebra.optimize;
 
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.algebra.Op ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformFilterPlacement.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformFilterPlacement.java
@@ -20,7 +20,6 @@ package org.apache.jena.sparql.algebra.optimize ;
 
 import java.util.Objects ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.sparql.algebra.Op ;
@@ -40,7 +39,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Assert ;
 import org.junit.Test ;
 
-public class TestTransformFilterPlacement extends BaseTest { //extends AbstractTestTransform {
+public class TestTransformFilterPlacement { //extends AbstractTestTransform {
     
     // ** Filter
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformMergeBGPs.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformMergeBGPs.java
@@ -18,13 +18,14 @@
 
 package org.apache.jena.sparql.algebra.optimize;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.sparql.algebra.Op ;
 import org.apache.jena.sparql.algebra.Transformer ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
-public class TestTransformMergeBGPs extends BaseTest
+public class TestTransformMergeBGPs
 {
     
     String pre = "(prefix ((: <http://example/>))" ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestVarRename.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestVarRename.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.sparql.algebra.optimize;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashSet ;
 import java.util.Set ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryFactory ;
@@ -36,7 +37,7 @@ import org.junit.Rule;
 import org.junit.Test ;
 import org.junit.rules.TestName;
 
-public class TestVarRename extends BaseTest
+public class TestVarRename
 {
     @Rule public TestName name = new TestName();
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestAPI.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestAPI.java
@@ -18,13 +18,14 @@
 
 package org.apache.jena.sparql.api;
 
+import static org.junit.Assert.*;
+
 import java.util.Iterator;
 import java.util.Set ;
 
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.json.JsonArray;
 import org.apache.jena.atlas.json.JsonObject;
-import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
@@ -61,7 +62,7 @@ import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Test;
 
-public class TestAPI extends BaseTest
+public class TestAPI
 {
     private static final String ns = "http://example/ns#" ;
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestQueryExecutionCancel.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestQueryExecutionCancel.java
@@ -18,7 +18,10 @@
 
 package org.apache.jena.sparql.api;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.query.* ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.Property ;
@@ -30,7 +33,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestQueryExecutionCancel extends BaseTest {
+public class TestQueryExecutionCancel {
 
     private static final String ns = "http://example/ns#" ;
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestQueryExecutionTimeout1.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestQueryExecutionTimeout1.java
@@ -19,10 +19,11 @@
 package org.apache.jena.sparql.api ;
 
 import static org.apache.jena.atlas.lib.Lib.sleep ;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.base.Sys ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.query.* ;
@@ -35,7 +36,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestQueryExecutionTimeout1 extends BaseTest
+public class TestQueryExecutionTimeout1
 {
     static Graph                g   = SSE.parseGraph("(graph (<s> <p> <o1>) (<s> <p> <o2>) (<s> <p> <o3>))") ;
     static DatasetGraph         dsg = DatasetGraphFactory.wrap(g) ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestDataset.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestDataset.java
@@ -18,10 +18,14 @@
 
 package org.apache.jena.sparql.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 
 import org.apache.jena.atlas.iterator.Iter;
-import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -30,7 +34,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.junit.Test;
 
 /** Basic testing of the Dataset API */
-public abstract class AbstractTestDataset extends BaseTest
+public abstract class AbstractTestDataset
 {
     protected abstract Dataset createDataset();
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestDynamicDataset.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestDynamicDataset.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.sparql.core;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.query.* ;
 import org.apache.jena.rdf.model.Model ;
@@ -27,7 +28,7 @@ import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public abstract class AbstractTestDynamicDataset extends BaseTest
+public abstract class AbstractTestDynamicDataset
 {
     protected abstract Dataset createDataset() ;
     protected abstract void releaseDataset(Dataset ds) ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestGraphOverDatasetGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractTestGraphOverDatasetGraph.java
@@ -18,10 +18,14 @@
 
 package org.apache.jena.sparql.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Iterator ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -33,7 +37,7 @@ import org.junit.Test ;
 /**
  * Tests of graphs as views of a DatasetGraph.
  */
-public abstract class AbstractTestGraphOverDatasetGraph extends BaseTest
+public abstract class AbstractTestGraphOverDatasetGraph
 {
     // See also: ARQ/GraphsTests, TestGraphsMem(enable tests?), UnionTransformTests
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestContext.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestContext.java
@@ -18,13 +18,16 @@
 
 package org.apache.jena.sparql.core ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.sparql.ARQException ;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.Symbol ;
 import org.junit.Test ;
 
-public class TestContext extends BaseTest {
+public class TestContext {
     static Symbol p1 = Symbol.create("p1") ;
     static Symbol p2 = Symbol.create("p2") ;
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetGraphViewGraphs.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetGraphViewGraphs.java
@@ -18,6 +18,9 @@
 
 package org.apache.jena.sparql.core;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetMonitor.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetMonitor.java
@@ -22,17 +22,18 @@ import static org.apache.jena.sparql.core.QuadAction.ADD ;
 import static org.apache.jena.sparql.core.QuadAction.DELETE ;
 import static org.apache.jena.sparql.core.QuadAction.NO_ADD ;
 import static org.apache.jena.sparql.core.QuadAction.NO_DELETE ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.Pair ;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
-public class TestDatasetMonitor extends BaseTest
+public class TestDatasetMonitor
 {
     static Quad quad1 = SSE.parseQuad("(_ <s> <p> 1)") ;
     static Quad quad2 = SSE.parseQuad("(<g> <s> <p> 2)") ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/binding/TestBindingStreams.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/binding/TestBindingStreams.java
@@ -18,12 +18,14 @@
 
 package org.apache.jena.sparql.engine.binding;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 import java.util.ArrayList ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.legacy.BaseTest2 ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
@@ -44,7 +46,7 @@ import org.junit.BeforeClass ;
 import org.junit.Test ;
 
 
-public class TestBindingStreams extends BaseTest
+public class TestBindingStreams
 {
     @BeforeClass public static void beforeClass()
     { 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/http/TestQueryEngineHTTP.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/http/TestQueryEngineHTTP.java
@@ -18,12 +18,13 @@
 
 package org.apache.jena.sparql.engine.http;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.riot.WebContent ;
 import org.junit.Test ;
 
 /** A few tests of QueryEngineHTTP - mostly it gets tested in Fuseki */
-public class TestQueryEngineHTTP extends BaseTest {
+public class TestQueryEngineHTTP {
     
     // Check the headers contain the standard types. 
     @Test public void selectHeader_01() {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/AbstractTestDistinctReduced.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/AbstractTestDistinctReduced.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.sparql.engine.iterator;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Arrays ;
 import java.util.HashSet ;
@@ -26,7 +28,6 @@ import java.util.Set ;
 import java.util.stream.Collectors ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.engine.QueryIterator ;
@@ -35,7 +36,7 @@ import org.apache.jena.sparql.engine.binding.BindingFactory ;
 import org.apache.jena.sparql.engine.binding.BindingMap ;
 import org.junit.Test ;
 
-public abstract class AbstractTestDistinctReduced extends BaseTest {
+public abstract class AbstractTestDistinctReduced {
     
     static List<String> data1 =     Arrays.asList("0","1","1","3","9","5","6","8","9","0") ;
     static List<String> results1 =  Arrays.asList("0","1",    "3","9","5","6","8"        ) ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/ref/TestTableJoin.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/ref/TestTableJoin.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.sparql.engine.ref;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashSet ;
 import java.util.Set ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.query.ResultSet ;
 import org.apache.jena.query.ResultSetFactory ;
@@ -37,7 +38,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
 /** Tests on tables and the simple nest loop join (TableJoin) used by the reference query engine */ 
-public class TestTableJoin extends BaseTest
+public class TestTableJoin
 {
     Table unit = new TableUnit() ; 
     Table zero = new TableEmpty() ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestCustomAggregates.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestCustomAggregates.java
@@ -18,7 +18,10 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.graph.Graph ;
@@ -36,7 +39,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestCustomAggregates extends BaseTest {
+public class TestCustomAggregates {
     
     public static final String aggIRI = "http://example.test/agg" ;
     public static final String aggIRI2 = "http://example.test/aggUnRegistered" ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExprTransform.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExprTransform.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
-public class TestExprTransform extends BaseTest
+public class TestExprTransform
 {
     ExprTransform et1 = new ExprTransformCopy() 
     {   @Override

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions2.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions2.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.query.QueryParseException ;
 import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp ;
 import org.apache.jena.sparql.util.ExprUtils ;
@@ -29,7 +30,7 @@ import org.junit.Test ;
 * @see TestExprLib
 * @see TestNodeValue
 */
-public class TestExpressions2 extends BaseTest
+public class TestExpressions2
 {
     @Test public void gregorian_eq_01()         { eval("'1999'^^xsd:gYear = '1999'^^xsd:gYear", true) ; }
     @Test public void gregorian_eq_02()         { eval("'1999'^^xsd:gYear != '1999'^^xsd:gYear", false) ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions3.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions3.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp ;
 import org.apache.jena.sparql.sse.Item ;
@@ -34,7 +35,7 @@ import org.junit.Test ;
 * @see TestExprLib
 * @see TestNodeValue
 */
-public class TestExpressions3 extends BaseTest
+public class TestExpressions3
 {
     @Test public void bound_01()       { eval("BOUND(?x)", "(?x 1)", true) ; }
     @Test public void bound_02()       { eval("BOUND(?x)", "(?y 1)", false) ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressionsMath.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressionsMath.java
@@ -20,12 +20,11 @@ package org.apache.jena.sparql.expr;
 
 import static org.apache.jena.sparql.expr.LibTestExpr.* ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.sparql.ARQException ;
 import org.junit.Test ;
 
 /** Expression evaluation involving math: */
-public class TestExpressionsMath extends BaseTest
+public class TestExpressionsMath
 {
     @Test public void pi_01()           { testDouble("math:pi()", "3.1415926", 0.00001) ; }
     @Test(expected=ARQException.class)

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions2.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions2.java
@@ -18,7 +18,9 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.graph.Node ;
 import org.apache.jena.shared.PrefixMapping ;
 import org.apache.jena.sparql.ARQConstants ;
@@ -29,7 +31,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestFunctions2 extends BaseTest
+public class TestFunctions2
 {
     // Some overlap with TestFunctions except those are direct function calls and these are via SPARQL 1.1 syntax.
     // Better too many tests than too few.

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestLeviathanFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestLeviathanFunctions.java
@@ -22,13 +22,12 @@ import static org.apache.jena.sparql.expr.LibTestExpr.test ;
 import static org.apache.jena.sparql.expr.LibTestExpr.testDouble ;
 import static org.apache.jena.sparql.expr.LibTestExpr.testError ;
 
-import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestLeviathanFunctions extends BaseTest {
+public class TestLeviathanFunctions {
 
     private static final double DELTA = 0.0000000001d;
     static boolean warnOnBadLexicalForms = true;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeFunctions.java
@@ -18,8 +18,11 @@
 
 package org.apache.jena.sparql.expr ;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.JenaRuntime ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
@@ -29,7 +32,7 @@ import org.apache.jena.vocabulary.RDF ;
 import org.apache.jena.vocabulary.XSD ;
 import org.junit.Test ;
 
-public class TestNodeFunctions extends BaseTest {
+public class TestNodeFunctions {
     private static final double accuracyExact = 0.0d ;
     private static final double accuracyClose = 0.000001d ;
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
@@ -18,25 +18,16 @@
 
 package org.apache.jena.sparql.expr;
 
+import static org.junit.Assert.*;
+
 import java.math.BigDecimal ;
-import java.util.Calendar ;
-import java.util.Comparator;
-import java.util.GregorianCalendar ;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.TimeZone ;
+import java.util.*;
 
 import org.apache.jena.JenaRuntime ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp ;
@@ -50,7 +41,7 @@ import org.junit.Test ;
  * @see TestExprLib
  * @see TestNodeValue
  */
-public class TestNodeValue extends BaseTest
+public class TestNodeValue
 {
     static final double doubleAccuracy = 0.00000001d ;
     static boolean warningSetting ; 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValueOps.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValueOps.java
@@ -18,12 +18,13 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.logging.Log ;
 import org.apache.jena.sparql.expr.nodevalue.NodeValueOps ;
 import org.junit.Test ;
 
-public class TestNodeValueOps extends BaseTest
+public class TestNodeValueOps
 {
     // ** Addition
     // Numerics

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestOrdering.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestOrdering.java
@@ -18,14 +18,15 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.sparql.util.NodeUtils ;
 import org.junit.Test ;
 
-public class TestOrdering extends BaseTest
+public class TestOrdering
 {
     NodeValue nvInt2 = NodeValue.makeNodeInteger(2) ;
     NodeValue nvInt3 = NodeValue.makeNodeInteger("3") ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestRegex.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestRegex.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.sparql.expr;
 
+import static org.junit.Assert.fail;
+
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.engine.binding.BindingFactory ;
 import org.apache.jena.sparql.util.Symbol;
@@ -33,7 +34,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 @RunWith(Parameterized.class)
-public class TestRegex extends BaseTest
+public class TestRegex
 {
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
@@ -18,9 +18,10 @@
 
 package org.apache.jena.sparql.expr;
 
+import static org.junit.Assert.*;
+
 import java.math.BigDecimal;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
@@ -30,7 +31,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Assert ;
 import org.junit.Test ;
 
-public class TestXSDFuncOp extends BaseTest
+public class TestXSDFuncOp
 {
     private static final double accuracyExact_D = 0.0d ;
     private static final double accuracyExact_F = 0.0d ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/graph/AbstractTestGraphAddDelete.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/graph/AbstractTestGraphAddDelete.java
@@ -18,7 +18,10 @@
 
 package org.apache.jena.sparql.graph;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -26,7 +29,7 @@ import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.junit.Test ;
 
 /** Basic add and delete tests for a graph */
-public abstract class AbstractTestGraphAddDelete extends BaseTest
+public abstract class AbstractTestGraphAddDelete
 {
     // This will become the basis for a general graph test in Jena
     protected static final Node s1 = NodeFactoryExtra.parseNode("<ex:s1>") ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/graph/AbstractTestPrefixMappingView.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/graph/AbstractTestPrefixMappingView.java
@@ -18,12 +18,14 @@
 
 package org.apache.jena.sparql.graph;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import org.apache.jena.shared.PrefixMapping ;
 import org.junit.Test ;
 
 /** Tests for when the prefix mapping,of the graph it comes from, is view */ 
-public abstract class AbstractTestPrefixMappingView extends BaseTest
+public abstract class AbstractTestPrefixMappingView
 {
     static final String defaultPrefixURI  = "" ;
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/graph/GraphsTests.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/graph/GraphsTests.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.sparql.graph;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Iterator ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.query.* ;
@@ -33,7 +34,7 @@ import org.junit.Test ;
 
 /** Test API use of models, including some union graph cases : see also DatasetGraphTests */
 
-public abstract class GraphsTests extends BaseTest
+public abstract class GraphsTests
 {
     // These graphs must exist.
     protected static final String graph1 = "http://example/g1" ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/graph/TestGraphUnionRead.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/graph/TestGraphUnionRead.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.sparql.graph;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
 import java.util.List;
 
 import org.apache.jena.atlas.iterator.Iter;
-import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
@@ -33,7 +34,7 @@ import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.sparql.sse.builders.BuilderGraph;
 import org.junit.Test;
 
-public class TestGraphUnionRead extends BaseTest
+public class TestGraphUnionRead
 {
     private static String dataStr = StrUtils.strjoinNL(
       "(dataset" ,

--- a/jena-arq/src/test/java/org/apache/jena/sparql/graph/TestGraphsDataBag.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/graph/TestGraphsDataBag.java
@@ -18,9 +18,10 @@
 
 package org.apache.jena.sparql.graph;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.data.ThresholdPolicy ;
 import org.apache.jena.atlas.data.ThresholdPolicyFactory ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.query.* ;
@@ -34,7 +35,7 @@ import org.junit.Before ;
 import org.junit.Test ;
 
 /** Tests for DataBag graphs */
-public class TestGraphsDataBag extends BaseTest
+public class TestGraphsDataBag
 {
     protected Graph distinct;
     protected Graph duplicates;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/junit/TestItem.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/junit/TestItem.java
@@ -152,13 +152,13 @@ public class TestItem
             Model m = RDFDataMgr.loadModel(resultFile) ;
             return new SPARQLResult(m) ;
         }
-        
+
         if ( ResultsFormat.isDatasetSyntax(format) ) {
             Dataset d = RDFDataMgr.loadDataset(resultFile) ;
             return new SPARQLResult(d) ;
         }
 
-        // Attempt to handle as a resulset or boolean result.s
+        // Attempt to handle as a resultset or boolean result.s
         SPARQLResult x = ResultSetFactory.result(resultFile) ;
         return x ;
     }
@@ -195,12 +195,12 @@ public class TestItem
             return Syntax.syntaxSPARQL_11;
         if ( filename.endsWith(".ru") )
             return Syntax.syntaxSPARQL_11;
-        
+
         return Syntax.guessFileSyntax(filename);
     }
 
     private String _getName() {
-        
+
         Statement s = testResource.getProperty(TestManifest.name) ;
         String ln = s.getSubject().getLocalName();
         if ( s == null )
@@ -235,7 +235,7 @@ public class TestItem
     /**
      * Get the data file (default graph): maybe unknown if part for the query
      * (FROM)
-     * 
+     *
      * @return List
      */
 
@@ -258,7 +258,7 @@ public class TestItem
 
     /**
      * Get the named graphs : maybe unknown if part for the query (FROM NAMED)
-     * 
+     *
      * @return List
      */
 
@@ -282,7 +282,7 @@ public class TestItem
     /**
      * Get the query file: either it is the action (data in query) or it is
      * specified within the bNode as a query/data pair.
-     * 
+     *
      * @return
      */
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/lang/TestUnescape.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/lang/TestUnescape.java
@@ -18,11 +18,13 @@
 
 package org.apache.jena.sparql.lang;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.apache.jena.query.QueryParseException ;
 import org.junit.Test ;
 
-public class TestUnescape extends BaseTest
+public class TestUnescape
 {
     @Test public void testEsc01() { execTest("x\\uabcd", "x\uabcd") ; }
     @Test public void testEsc02() { execTest("\\uabcdx", "\uabcdx") ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/lang/TestVarScope.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/lang/TestVarScope.java
@@ -18,13 +18,12 @@
 
 package org.apache.jena.sparql.lang;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryException ;
 import org.apache.jena.query.QueryFactory ;
 import org.junit.Test ;
 
-public class TestVarScope extends BaseTest
+public class TestVarScope
 {
     private static void scope(String queryStr)
     {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateBase.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.sparql.modify ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.GraphUtil ;
 import org.apache.jena.graph.Node ;
@@ -28,7 +27,7 @@ import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.graph.GraphFactory ;
 import org.apache.jena.update.UpdateAction ;
 
-public abstract class AbstractTestUpdateBase extends BaseTest {
+public abstract class AbstractTestUpdateBase {
     protected abstract DatasetGraph getEmptyDatasetGraph() ;
 
     protected void defaultGraphData(DatasetGraph gStore, Graph data) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraph.java
@@ -19,6 +19,10 @@
 package org.apache.jena.sparql.modify;
 
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.graph.* ;
 import org.apache.jena.query.ARQ ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraphMgt.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraphMgt.java
@@ -18,6 +18,10 @@
 
 package org.apache.jena.sparql.modify;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.sparql.core.DatasetGraph ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateCompare.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateCompare.java
@@ -18,13 +18,14 @@
 
 package org.apache.jena.sparql.modify;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.update.UpdateFactory ;
 import org.apache.jena.update.UpdateRequest ;
 import org.junit.Test ;
 
-public class TestUpdateCompare extends BaseTest {
+public class TestUpdateCompare {
     @Test public void updateCompare01()     { test("INSERT DATA {}") ; }
     @Test public void updateCompare02()     { test("INSERT DATA {<s> <p> <o>}") ; }
     @Test public void updateCompare03()     { test("INSERT DATA {<s> <p> _:a}", "INSERT DATA {<s> <p> _:b}") ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateOperations.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateOperations.java
@@ -18,10 +18,12 @@
 
 package org.apache.jena.sparql.modify;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import java.util.concurrent.atomic.AtomicLong ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.rdf.model.Model ;
@@ -47,7 +49,7 @@ import org.junit.Test ;
 
 // Most of the testing of SPARQL Update is scripts and uses the SPARQL-WG test suite.
 // Here are a few additional tests
-public class TestUpdateOperations extends BaseTest
+public class TestUpdateOperations
 {
     private static final String DIR = "testing/Update" ;
     private DatasetGraph graphStore() { return DatasetGraphFactory.create() ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateWriter.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateWriter.java
@@ -18,14 +18,15 @@
 
 package org.apache.jena.sparql.modify;
 
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.io.IndentedLineBuffer ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.sparql.modify.request.UpdateWriter ;
 import org.apache.jena.update.UpdateFactory ;
 import org.apache.jena.update.UpdateRequest ;
 import org.junit.Test ;
 
-public class TestUpdateWriter extends BaseTest {
+public class TestUpdateWriter {
     @Test public void updateWrite01()   { test("INSERT DATA {}") ; }
     @Test public void updateWrite02()   { test("PREFIX : <http://example/> INSERT DATA { <s> :p 123 }") ; }
     @Test public void updateWrite03()   { test("PREFIX : <http://example/> INSERT DATA { _:a :p 123 , 456 }") ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPath.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPath.java
@@ -19,13 +19,16 @@
 package org.apache.jena.sparql.path;
 
 import static org.apache.jena.atlas.lib.ListUtils.equalsUnordered ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays ;
 import java.util.Iterator ;
 import java.util.List ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
@@ -49,7 +52,7 @@ import org.apache.jena.sparql.sse.writers.WriterPath ;
 import org.junit.Assert ;
 import org.junit.Test ;
 
-public class TestPath extends BaseTest
+public class TestPath
 {
     static Graph graph1 = GraphFactory.createDefaultGraph() ;
     static Graph graph2 = GraphFactory.createDefaultGraph() ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPath2.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPath2.java
@@ -18,11 +18,13 @@
 
 package org.apache.jena.sparql.path;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.util.ArrayList ;
 import java.util.List ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
@@ -33,7 +35,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestPath2 extends BaseTest
+public class TestPath2
 {
     @BeforeClass static public void beforeClass() {}
     @AfterClass static public void afterClass() {}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPathPF.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPathPF.java
@@ -49,7 +49,7 @@ import org.junit.Test ;
  * (propfunc) by simple property path flattening in the optimizer
  * or by use in complex path expressions.
  */  
-public class TestPathPF extends BaseTest
+public class TestPathPF
 {
     static Graph graph1 = GraphFactory.createDefaultGraph() ;
     static Node elt1 = SSE.parseNode("'elt1'") ;
@@ -157,6 +157,6 @@ public class TestPathPF extends BaseTest
 
     private static void check(Iterator<Node> iter, List<Node> expected) {
         List<Node> x = Iter.toList(iter) ;
-        assertEqualsUnordered(expected,x) ;
+        BaseTest.assertEqualsUnordered(expected,x) ;
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/resultset/TestResultSet.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/resultset/TestResultSet.java
@@ -18,6 +18,10 @@
 
 package org.apache.jena.sparql.resultset;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 import java.io.InputStream;
@@ -25,7 +29,6 @@ import java.util.ArrayList ;
 import java.util.List ;
 import java.util.NoSuchElementException;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
@@ -53,7 +56,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test ;
 
-public class TestResultSet extends BaseTest
+public class TestResultSet
 {
     static { JenaSystem.init(); }
     

--- a/jena-arq/src/test/java/org/apache/jena/sparql/solver/TestReorder.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/solver/TestReorder.java
@@ -21,14 +21,15 @@ package org.apache.jena.sparql.solver;
 import static org.apache.jena.sparql.solver.TestSolverLib.bgp ;
 import static org.apache.jena.sparql.solver.TestSolverLib.matcher ;
 import static org.apache.jena.sparql.solver.TestSolverLib.triple ;
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.sparql.core.BasicPattern ;
 import org.apache.jena.sparql.engine.optimizer.StatsMatcher ;
 import org.apache.jena.sparql.engine.optimizer.reorder.* ;
 import org.junit.Test ;
 
-public class TestReorder extends BaseTest
+public class TestReorder
 {
 
     @Test public void match_01()

--- a/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionLifecycle.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionLifecycle.java
@@ -18,6 +18,10 @@
 
 package org.apache.jena.sparql.transaction;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -25,7 +29,6 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.ReadWrite;
@@ -37,7 +40,7 @@ import org.junit.Test;
 /**
  * Dataset transaction lifecycle. 
  */
-public abstract class AbstractTestTransactionLifecycle extends BaseTest
+public abstract class AbstractTestTransactionLifecycle
 {
     protected abstract Dataset create();
     
@@ -245,7 +248,6 @@ public abstract class AbstractTestTransactionLifecycle extends BaseTest
         assertFalse(b2);
         ds.end();
     }
-
     
     // JENA-1469
     @Test
@@ -260,7 +262,7 @@ public abstract class AbstractTestTransactionLifecycle extends BaseTest
 
     // XXX Refactor the above code.
     
-    // promotion tyope specified
+    // promotion type specified
     private void testPromote(TxnType txnType , Promote promoteMode, boolean succeeds) {
         Dataset ds = create();
         ds.begin(txnType);

--- a/jena-arq/src/test/java/org/apache/jena/sparql/util/TestDifferenceDatasetGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/util/TestDifferenceDatasetGraph.java
@@ -19,6 +19,8 @@
 package org.apache.jena.sparql.util;
 
 import static org.apache.jena.sparql.sse.SSE.parseGraph;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.jena.graph.*;
 import org.apache.jena.sparql.core.DatasetGraph;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/util/TestDyadicDatasetGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/util/TestDyadicDatasetGraph.java
@@ -19,8 +19,11 @@
 package org.apache.jena.sparql.util;
 
 import static org.apache.jena.sparql.core.DatasetGraphFactory.createTxnMem;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.ReadWrite;
@@ -30,7 +33,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphZero;
 import org.junit.Test;
 
-public abstract class TestDyadicDatasetGraph extends BaseTest {
+public abstract class TestDyadicDatasetGraph {
 
     public abstract DatasetGraph testInstance(DatasetGraph left, DatasetGraph right, Context c);
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/util/TestIntersectionDatasetGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/util/TestIntersectionDatasetGraph.java
@@ -19,6 +19,8 @@
 package org.apache.jena.sparql.util;
 
 import static org.apache.jena.sparql.sse.SSE.parseGraph;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.jena.graph.*;
 import org.apache.jena.sparql.core.DatasetGraph;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/util/TestList.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/util/TestList.java
@@ -18,6 +18,11 @@
 
 package org.apache.jena.sparql.util;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.StringReader ;
 import java.util.Arrays ;
 import java.util.Iterator ;
@@ -39,7 +44,7 @@ import org.apache.jena.vocabulary.RDF ;
 import org.junit.Test ;
 
 /** Test the graph-level RDF list support used in SPARQL */
-public class TestList extends BaseTest
+public class TestList
 {
     private GNode emptyList = parse(listStr_1) ; 
     private GNode list4 = parse(listStr_2) ;
@@ -245,7 +250,7 @@ public class TestList extends BaseTest
     
     private static void check(List<Node> z, Node...expected) {
         List<Node> x = Arrays.asList(expected) ;
-        assertEqualsUnordered(x, z);
+        BaseTest.assertEqualsUnordered(x, z);
     }
     
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/util/TestUnionDatasetGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/util/TestUnionDatasetGraph.java
@@ -19,6 +19,8 @@
 package org.apache.jena.sparql.util;
 
 import static org.apache.jena.sparql.sse.SSE.parseGraph;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.jena.graph.*;
 import org.apache.jena.sparql.core.DatasetGraph;

--- a/jena-arq/src/test/java/org/apache/jena/web/AbstractTestDatasetGraphAccessor.java
+++ b/jena-arq/src/test/java/org/apache/jena/web/AbstractTestDatasetGraphAccessor.java
@@ -18,7 +18,10 @@
 
 package org.apache.jena.web;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.GraphUtil ;
 import org.apache.jena.graph.Node ;
@@ -32,7 +35,7 @@ import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
 @SuppressWarnings("deprecation")
-public abstract class AbstractTestDatasetGraphAccessor extends BaseTest
+public abstract class AbstractTestDatasetGraphAccessor
 {
     protected static final String gn1       = "http://graph/1" ;
     protected static final String gn2       = "http://graph/2" ;

--- a/jena-arq/testing/RIOT/Lang/manifest-all.ttl
+++ b/jena-arq/testing/RIOT/Lang/manifest-all.ttl
@@ -17,5 +17,5 @@
         <NTriplesStd/manifest.ttl>
         <NQuadsStd/manifest.ttl>
         <TurtleStd/manifest.ttl>    # W3C test suite
-        <TrigStd/manifest.ttl>   # W3C Test Suite
+        <TrigStd/manifest.ttl>      # W3C Test Suite
 	).

--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
@@ -18,8 +18,12 @@
 
 package org.apache.jena.atlas.logging;
 
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 
+import org.apache.jena.atlas.AtlasException;
 import org.slf4j.Logger;
 
 /**
@@ -35,7 +39,7 @@ public class LogCtl {
     private static final boolean hasLog4j2 = hasClass("org.apache.logging.slf4j.Log4jLoggerFactory");
     private static final boolean hasLog4j1 = hasClass("org.slf4j.impl.Log4jLoggerFactory");
     private static final boolean hasJUL    = hasClass("org.slf4j.impl.JDK14LoggerFactory");
-    // JUL always present but needs slf4j adpater.
+    // JUL always present but needs slf4j adapter.
 
     private static boolean hasClass(String className) {
         try {
@@ -250,7 +254,7 @@ public class LogCtl {
      * when no configuration is setup; output is to stdout.
      * <p>
      * Ideally, initialize the logging provider using the mechanism specific to that provider.
-     * For example, see the <a href="https://logging.apache.org/log4j/2.x/manual/configuration.html">log4j2 configuration documentation</a>.  
+     * For example, see the <a href="https://logging.apache.org/log4j/2.x/manual/configuration.html">log4j2 configuration documentation</a>.
      * <p>
      * To set application logging, choose one of:
      * <ul>
@@ -296,7 +300,7 @@ public class LogCtl {
 
     // ---- log4j2.
 
-    /** The log4j2 configuration file - must be a file or URL, not a classpath java resource */ 
+    /** The log4j2 configuration file - must be a file or URL, not a classpath java resource */
     public static final String log4j2ConfigProperty = "log4j.configurationFile";
 
     private static final String[] log4j2files = {"log4j2.properties", "log4j2.xml"};
@@ -309,18 +313,18 @@ public class LogCtl {
     public static void setLog4j2() {
         if ( ! isSetLog4j2property() ) {
             setLog4j2property();
-            if ( isSetLog4j2property() ) 
+            if ( isSetLog4j2property() )
                 return;
             // Nothing found - built-in default.
             LogCmd.resetLogging(LogCmd.log4j2setup);
         }
     }
 
-    /*package*/ static boolean isSetLog4j2property() {
-        return System.getProperty(log4j2ConfigProperty) != null ;
+    /* package */ static boolean isSetLog4j2property() {
+        return System.getProperty(log4j2ConfigProperty) != null;
     }
-    
-    /** Set log4j, looking for files */ 
+
+    /** Set log4j, looking for files */
     /*package*/ static void setLog4j2property() {
         if ( isSetLog4j2property() )
             return;
@@ -332,10 +336,10 @@ public class LogCtl {
             }
         }
     }
-    
+
     // ---- java.util.logging - because that's always present.
     // Need: org.slf4j:slf4j-jdk14
-    
+
     private static String JUL_PROPERTY      = "java.util.logging.configuration";
     /**
      * Setup java.util.logging if it has not been set before; otherwise do nothing.
@@ -344,5 +348,19 @@ public class LogCtl {
         if ( System.getProperty(JUL_PROPERTY) != null )
             return;
         LogJUL.resetJavaLogging();
+    }
+
+    /**
+     * Setup java.util.logging with the configuration from a file.
+     * @param filename
+     */
+    public static void setJavaLogging(String filename) {
+        try {
+            InputStream details = new FileInputStream(filename);
+            details = new BufferedInputStream(details);
+            LogJUL.readJavaLoggingConfiguration(details);
+        } catch (Exception ex) {
+            throw new AtlasException(ex);
+        }
     }
 }

--- a/jena-base/src/test/java/org/apache/jena/atlas/io/AbstractTestPeekInputStream.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/io/AbstractTestPeekInputStream.java
@@ -18,10 +18,12 @@
 
 package org.apache.jena.atlas.io;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test ;
 
-public abstract class AbstractTestPeekInputStream extends BaseTest
+public abstract class AbstractTestPeekInputStream
 {
     static int INIT_LINE = PeekInputStream.INIT_LINE ;
     static int INIT_COL = PeekInputStream.INIT_COL ;

--- a/jena-base/src/test/java/org/apache/jena/atlas/io/AbstractTestPeekReader.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/io/AbstractTestPeekReader.java
@@ -18,10 +18,12 @@
 
 package org.apache.jena.atlas.io;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test ;
 
-public abstract class AbstractTestPeekReader extends BaseTest
+public abstract class AbstractTestPeekReader
 {
     static int INIT_LINE = PeekReader.INIT_LINE ;
     static int INIT_COL = PeekReader.INIT_COL ;

--- a/jena-base/src/test/java/org/apache/jena/atlas/io/TestBlockUTF8.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/io/TestBlockUTF8.java
@@ -18,6 +18,10 @@
 
 package org.apache.jena.atlas.io;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.ByteArrayOutputStream ;
 import java.io.IOException ;
 import java.io.OutputStreamWriter ;
@@ -29,11 +33,10 @@ import java.nio.charset.Charset ;
 import java.nio.charset.CharsetDecoder ;
 import java.nio.charset.CharsetEncoder ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.Chars ;
 import org.junit.Test ;
 
-public class TestBlockUTF8 extends BaseTest
+public class TestBlockUTF8
 {
     // Need array and non-array versions.
     
@@ -129,7 +132,7 @@ public class TestBlockUTF8 extends BaseTest
         assertEquals(x, str) ;
     }
 
-    // Tesing, but not against what Java would do (it replaces bad chars, we want binary).
+    // Testing, but not against what Java would do (it replaces bad chars, we want binary).
     static void testInOutBinary(String x)
     {
         int N = x.length() ;

--- a/jena-base/src/test/java/org/apache/jena/atlas/io/TestBufferingWriter.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/io/TestBufferingWriter.java
@@ -18,12 +18,13 @@
 
 package org.apache.jena.atlas.io ;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.StringWriter ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestBufferingWriter extends BaseTest {
+public class TestBufferingWriter {
     StringWriter    sw = null ;
     BufferingWriter w  = null ;
 

--- a/jena-base/src/test/java/org/apache/jena/atlas/io/TestInputStreamBuffered.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/io/TestInputStreamBuffered.java
@@ -18,15 +18,16 @@
 
 package org.apache.jena.atlas.io;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.ByteArrayInputStream ;
 import java.io.IOException ;
 import java.io.InputStream ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.Bytes ;
 import org.junit.Test ;
 
-public class TestInputStreamBuffered extends BaseTest
+public class TestInputStreamBuffered
 {
     @Test public void test_01() throws IOException
     {

--- a/jena-base/src/test/java/org/apache/jena/atlas/io/TestPrintUtils.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/io/TestPrintUtils.java
@@ -18,15 +18,16 @@
 
 package org.apache.jena.atlas.io;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.ByteArrayOutputStream ;
 import java.io.IOException ;
 import java.io.OutputStreamWriter ;
 import java.io.Writer ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestPrintUtils extends BaseTest
+public class TestPrintUtils
 {
     @Test public void hex1()
     {

--- a/jena-base/src/test/java/org/apache/jena/atlas/io/TestStreamUTF8.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/io/TestStreamUTF8.java
@@ -18,6 +18,9 @@
 
 package org.apache.jena.atlas.io;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 import java.io.ByteArrayInputStream ;
 import java.io.ByteArrayOutputStream ;
 import java.io.IOException ;
@@ -27,11 +30,10 @@ import java.nio.charset.Charset ;
 import java.nio.charset.CharsetDecoder ;
 import java.nio.charset.CharsetEncoder ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.Chars ;
 import org.junit.Test ;
 
-public class TestStreamUTF8 extends BaseTest
+public class TestStreamUTF8
     {
         static Charset utf8 = Chars.charsetUTF8 ;
         static CharsetDecoder dec = utf8.newDecoder() ;

--- a/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorPeek.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorPeek.java
@@ -18,14 +18,17 @@
 
 package org.apache.jena.atlas.iterator;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.ext.com.google.common.collect.Iterators ;
 import org.junit.Test ;
 
-public class TestIteratorPeek extends BaseTest
+public class TestIteratorPeek
 {
     List<String> data0 = new ArrayList<>() ;
     List<String> data1 = new ArrayList<>() ;

--- a/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorPushback.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorPushback.java
@@ -18,13 +18,15 @@
 
 package org.apache.jena.atlas.iterator;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import java.util.ArrayList ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestIteratorPushback extends BaseTest
+public class TestIteratorPushback
 {
 
     static List<String> data = new ArrayList<>() ;

--- a/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorSlotted.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorSlotted.java
@@ -18,12 +18,16 @@
 
 package org.apache.jena.atlas.iterator;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays ;
 import java.util.Collection ;
 import java.util.Iterator ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 import org.junit.runner.RunWith ;
 import org.junit.runners.Parameterized ;
@@ -31,7 +35,7 @@ import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
 
-public class TestIteratorSlotted extends BaseTest
+public class TestIteratorSlotted
 {
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> implementations() {

--- a/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorWithBuffer.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorWithBuffer.java
@@ -18,13 +18,14 @@
 
 package org.apache.jena.atlas.iterator;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestIteratorWithBuffer extends BaseTest
+public class TestIteratorWithBuffer
 {
 
     @Test public void iterBuffer_01()

--- a/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorWithHistory.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/iterator/TestIteratorWithHistory.java
@@ -18,13 +18,14 @@
 
 package org.apache.jena.atlas.iterator;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestIteratorWithHistory extends BaseTest
+public class TestIteratorWithHistory
 {
     @Test public void iterHistory_01()
     {

--- a/jena-base/src/test/java/org/apache/jena/atlas/junit/BaseTest.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/junit/BaseTest.java
@@ -24,17 +24,17 @@ import java.util.Locale ;
 import org.apache.jena.atlas.lib.ListUtils ;
 import org.junit.Assert ;
 
-public class BaseTest extends Assert {
+public class BaseTest {
     public static void assertEqualsIgnoreCase(String a, String b) {
         a = a.toLowerCase(Locale.ROOT) ;
         b = b.toLowerCase(Locale.ROOT) ;
-        assertEquals(a, b) ;
+        Assert.assertEquals(a, b) ;
     }
 
     public static void assertEqualsIgnoreCase(String msg, String a, String b) {
         a = a.toLowerCase(Locale.ROOT) ;
         b = b.toLowerCase(Locale.ROOT) ;
-        assertEquals(msg, a, b) ;
+        Assert.assertEquals(msg, a, b) ;
     }
 
     public static <T> void assertEqualsUnordered(List<T> list1, List<T> list2) {
@@ -43,7 +43,7 @@ public class BaseTest extends Assert {
     
     public static <T> void assertEqualsUnordered(String msg, List<T> list1, List<T> list2) {
         if ( ! ListUtils.equalsUnordered(list1, list2) )
-            fail(msg(msg, list1, list2)) ;
+            Assert.fail(msg(msg, list1, list2)) ;
     }
     
     private static <T> String msg(String msg, List<T> list1, List<T> list2) {
@@ -51,5 +51,4 @@ public class BaseTest extends Assert {
         x = x +"Expected: " + list1 + " : Actual: " + list2 ;
         return x ;
     }
-
 }

--- a/jena-base/src/test/java/org/apache/jena/atlas/junit/TextListenerDots.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/junit/TextListenerDots.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.atlas.junit;
+
+import java.io.PrintStream ;
+
+import org.junit.internal.TextListener ;
+import org.junit.runner.Description ;
+import org.junit.runner.notification.Failure ;
+
+/** JUnit4 test listener that prints blocks of '.', 'E' , 'F' or 'I' */
+public class TextListenerDots extends TextListener
+{
+    private PrintStream out ;
+    int count = 0 ;
+
+    public TextListenerDots(PrintStream writer)
+    {
+        super(writer) ;
+        this.out = writer ;
+    }
+
+    @Override
+    public void testRunStarted(Description description)
+    {
+        //count = 0 ;
+    }
+
+    @Override
+    public void testStarted(Description description) {
+        newline() ;
+        out.append('.');
+    }
+
+    private void newline()
+    {
+        if ( count != 0 && count%50 == 0 )
+            out.println();
+        count++ ;
+    }
+
+    @Override
+    public void testFailure(Failure failure) {
+        newline() ;
+        out.append('E');
+    }
+
+    @Override
+    public void testIgnored(Description description) {
+        newline() ;
+        out.append('I');
+    }
+
+}

--- a/jena-base/src/test/java/org/apache/jena/atlas/junit/TextListenerLong.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/junit/TextListenerLong.java
@@ -24,46 +24,32 @@ import org.junit.internal.TextListener ;
 import org.junit.runner.Description ;
 import org.junit.runner.notification.Failure ;
 
-public class TextListener2 extends TextListener
+/** JUnit4 test listener that prints one line per test */
+public class TextListenerLong extends TextListener
 {
     private PrintStream out ;
-    int count = 0 ;
 
-    public TextListener2(PrintStream writer)
-    {
+    public TextListenerLong(PrintStream writer) {
         super(writer) ;
         this.out = writer ;
     }
-    
+
     @Override
-    public void testRunStarted(Description description)
-    {
-        //count = 0 ;
-    }
-    
+    public void testRunStarted(Description description) {}
+
     @Override
     public void testStarted(Description description) {
-        newline() ;
-        out.append('.');
-    }
-
-    private void newline()
-    {
-        if ( count != 0 && count%50 == 0 )
-            out.println();
-        count++ ;
+        out.println(description.getDisplayName());
     }
 
     @Override
     public void testFailure(Failure failure) {
-        newline() ;
-        out.append('E');
+        out.println("Error: "+ failure.getMessage());
     }
 
     @Override
     public void testIgnored(Description description) {
-        newline() ;
-        out.append('I');
+        out.println("  Ignored");
     }
-    
+
 }

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestAlarmClock.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestAlarmClock.java
@@ -19,16 +19,16 @@
 package org.apache.jena.atlas.lib ;
 
 import static org.awaitility.Awaitility.await ;
+import static org.junit.Assert.assertEquals;
 import static org.apache.jena.atlas.lib.Lib.sleep ;
 
 import java.util.concurrent.TimeUnit ;
 import static java.util.concurrent.TimeUnit.* ;
 import java.util.concurrent.atomic.AtomicInteger ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestAlarmClock extends BaseTest {
+public class TestAlarmClock {
     /* Issues with MS Windows.
      * 
      * Running some of these tests on windows is unreliable; sometimes they pass,

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestAlg.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestAlg.java
@@ -18,14 +18,15 @@
 
 package org.apache.jena.atlas.lib;
 
+import static org.junit.Assert.assertEquals;
+
 import java.nio.ByteBuffer ;
 import java.nio.ByteOrder ;
 import java.nio.IntBuffer ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestAlg extends BaseTest
+public class TestAlg
 {
     // Linear search is really there to test binary search.
     @Test public void linear1() 

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestBitsInt.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestBitsInt.java
@@ -18,11 +18,13 @@
 
 package org.apache.jena.atlas.lib;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test ;
 
 
-public class TestBitsInt extends BaseTest
+public class TestBitsInt
 {
     @Test public void testMask1()
     {

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestBitsLong.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestBitsLong.java
@@ -18,11 +18,13 @@
 
 package org.apache.jena.atlas.lib;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test ;
 
 
-public class TestBitsLong extends BaseTest
+public class TestBitsLong
 {
     @Test public void testMask1()
     {

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestBytes.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestBytes.java
@@ -18,12 +18,15 @@
 
 package org.apache.jena.atlas.lib;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.nio.ByteBuffer;
 
-import org.apache.jena.atlas.junit.BaseTest;
 import org.junit.Test;
 
-public class TestBytes extends BaseTest
+public class TestBytes
 {
     @Test public void intToBytes1() {
         byte[] b = Bytes.intToBytes(0xF1020304);

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestCache.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestCache.java
@@ -18,12 +18,15 @@
 
 package org.apache.jena.atlas.lib;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays ;
 import java.util.Collection ;
 import java.util.List ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Before ;
 import org.junit.Test ;
 import org.junit.runner.RunWith ;
@@ -31,7 +34,7 @@ import org.junit.runners.Parameterized ;
 import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
-public class TestCache extends BaseTest
+public class TestCache
 {
     // Tests do not apply to cache1.
     private static interface CacheMaker<K,V> { Cache<K,V> make(int size) ; String name() ; } 

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestCache2.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestCache2.java
@@ -18,13 +18,15 @@
 
 package org.apache.jena.atlas.lib;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import java.util.concurrent.Callable ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
 // Non-parameterized tests
-public class TestCache2 extends BaseTest
+public class TestCache2
 {
     // Cache1
     @Test public void cache_10()

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestFileOps.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestFileOps.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.atlas.lib;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.junit.Test ;
 
-public class TestFileOps extends BaseTest
+public class TestFileOps
 {
     /*
      * t("") ;

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestFilenameProcessing.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestFilenameProcessing.java
@@ -18,13 +18,17 @@
 
 package org.apache.jena.atlas.lib;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File ;
 import java.nio.file.Paths ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestFilenameProcessing extends BaseTest
+public class TestFilenameProcessing
 {
     @Test public void encode_1() { encodeComponent("abc", "abc") ; }
     @Test public void encode_2() { encodeComponent("", "") ; }

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestHex.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestHex.java
@@ -19,10 +19,12 @@
 package org.apache.jena.atlas.lib;
 
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import org.junit.Test ;
 
-public class TestHex extends BaseTest
+public class TestHex
 {
     @Test
     public void hex_01() {

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestListUtils.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestListUtils.java
@@ -19,15 +19,15 @@
 package org.apache.jena.atlas.lib;
 
 import static org.apache.jena.atlas.lib.ListUtils.unique ;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList ;
 import java.util.Arrays ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestListUtils extends BaseTest
+public class TestListUtils
 {
     @Test public void list01() 
     {

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestNumberUtils.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestNumberUtils.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.atlas.lib;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test ;
 
-public class TestNumberUtils extends BaseTest
+public class TestNumberUtils
 {
     @Test public void int_format_01() { testInt(1, 1, "1") ; } 
 

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestSetUtils.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestSetUtils.java
@@ -19,15 +19,16 @@
 package org.apache.jena.atlas.lib;
 
 import static org.apache.jena.atlas.lib.ListUtils.asList ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet ;
 import java.util.List ;
 import java.util.Set ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestSetUtils extends BaseTest
+public class TestSetUtils
 {
     @Test public void set01() 
     {

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestStrUtils.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestStrUtils.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.atlas.lib;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.AtlasException;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.Test ;
 
-public class TestStrUtils extends BaseTest
+public class TestStrUtils
 {
     static char marker = '_' ;
     static char esc[] = { ' ' , '_' } ; 

--- a/jena-cmds/src/main/java/arq/cmdline/ModLangParse.java
+++ b/jena-cmds/src/main/java/arq/cmdline/ModLangParse.java
@@ -36,16 +36,16 @@ public class ModLangParse extends ModBase
 
     private ArgDecl argStrict   = new ArgDecl(ArgDecl.NoValue, "strict") ;
     private ArgDecl argValidate = new ArgDecl(ArgDecl.NoValue, "validate") ;
-    
+
     private ArgDecl argSkip     = new ArgDecl(ArgDecl.NoValue, "skip") ;
     private ArgDecl argNoSkip   = new ArgDecl(ArgDecl.NoValue, "noSkip") ;
     private ArgDecl argStop     = new ArgDecl(ArgDecl.NoValue, "stopOnError", "stoponerror", "stop") ;
     private ArgDecl argStopWarn = new ArgDecl(ArgDecl.NoValue, "stopOnWarning", "stoponwarning", "stop-warnings") ;
-    
+
     private ArgDecl argBase     = new ArgDecl(ArgDecl.HasValue, "base") ;
-    
+
     private ArgDecl argRDFS     = new ArgDecl(ArgDecl.HasValue, "rdfs") ;
-    
+
     private ArgDecl argSyntax     = new ArgDecl(ArgDecl.HasValue, "syntax") ;
 
     private  String rdfsVocabFilename   = null ;
@@ -56,12 +56,12 @@ public class ModLangParse extends ModBase
     private boolean skipOnBadTerm       = false ;
     private boolean stopOnBadTerm       = false ;
     private boolean stopOnWarnings      = false ;
-    private boolean bitbucket           = false ; 
+    private boolean bitbucket           = false ;
     private boolean strict              = false ;
     private boolean validate            = false ;
     private boolean outputCount         = false ;
     private Lang lang                   = null ;
-    
+
     @Override
     public void registerWith(CmdGeneral cmdLine) {
         cmdLine.getUsage().startCategory("Parser control") ;
@@ -73,7 +73,7 @@ public class ModLangParse extends ModBase
         cmdLine.add(argValidate,"--validate",       "Same as --sink --check --strict") ;
         cmdLine.add(argCount,   "--count",          "Count triples/quads parsed, not output them") ;
         cmdLine.add(argRDFS,    "--rdfs=file",      "Apply some RDFS inference using the vocabulary in the file") ;
-        
+
         cmdLine.add(argNoCheck, "--nocheck",        "Turn off checking of RDF terms") ;
 //        cmdLine.add(argSkip,    "--noSkip",         "Skip (do not output) triples failing the RDF term tests") ;
 //        cmdLine.add(argNoSkip,  "--skip",           "Include triples failing the RDF term tests (not recommended)") ;
@@ -123,13 +123,13 @@ public class ModLangParse extends ModBase
 
         if ( cmdLine.contains(argStop) )
             stopOnBadTerm = true ;
-        
+
         if ( cmdLine.contains(argStopWarn) )
             stopOnWarnings = true;
 
         if ( cmdLine.contains(argSink) )
             bitbucket = true ;
-        
+
         if ( cmdLine.contains(argCount) ) {
             bitbucket = true ;
             outputCount = true ;
@@ -174,7 +174,7 @@ public class ModLangParse extends ModBase
     public boolean stopOnBadTerm() {
         return stopOnBadTerm ;
     }
-    
+
     public boolean stopOnWarnings() {
         return stopOnWarnings ;
     }

--- a/jena-cmds/src/test/java/arq/qtest.java
+++ b/jena-cmds/src/test/java/arq/qtest.java
@@ -48,9 +48,9 @@ import org.apache.jena.vocabulary.RDF ;
 import org.apache.jena.vocabulary.XSD ;
 
 /** A program to execute query test suites
- * 
+ *
  * <pre>
- * Usage: 
+ * Usage:
  *   [--all]
  *   [--dawg]
  *   <i>testManifest</i>
@@ -66,15 +66,15 @@ public class qtest extends CmdARQ
     protected ArgDecl dataDecl =   new ArgDecl(ArgDecl.HasValue, "data") ;
     protected ArgDecl resultDecl = new ArgDecl(ArgDecl.HasValue, "result") ;
     protected ArgDecl earlDecl =   new ArgDecl(ArgDecl.NoValue, "earl") ;
-    
+
     protected ModEngine modEngine = null ;
-    
+
     protected TestSuite suite = null;
     protected boolean execAllTests = false;
     protected boolean execDAWGTests = false;
     protected String testfile = null;
     protected boolean createEarlReport = false;
-    
+
     public static void main (String... argv)
     {
         try {
@@ -82,53 +82,53 @@ public class qtest extends CmdARQ
         }
         catch (TerminationException ex) { System.exit(ex.getCode()) ; }
     }
-    
+
     public qtest(String[] argv)
     {
         super(argv) ;
-        
+
         modEngine = setModEngine() ;
         addModule(modEngine) ;
-        
+
         getUsage().startCategory("Tests (single query)") ;
         add(queryDecl, "--query", "run the given query") ;
         add(dataDecl, "--data", "data file to be queried") ;
         add(resultDecl, "--result", "file that specifies the expected result") ;
-        
+
         getUsage().startCategory("Tests (built-in tests)") ;
         add(allDecl, "--all", "run all built-in tests") ;
         add(wgDecl, "--dawg", "run working group tests") ;
-        
+
         getUsage().startCategory("Tests (execute test manifest)") ;
         getUsage().addUsage("<manifest>", "run the tests specified in the given manifest") ;
         add(earlDecl, "--earl", "create EARL report") ;
     }
-    
+
     protected ModEngine setModEngine()
     {
         return new ModEngine() ;
     }
-    
+
     @Override
     protected String getCommandName() { return Lib.className(this) ; }
-    
+
     @Override
     protected String getSummary() { return getCommandName()+" [ --data=<file> --query=<query> --result=<results> ] | --all | --dawg | <manifest>" ; }
-    
+
     @Override
     protected void processModulesAndArgs()
     {
         super.processModulesAndArgs() ;
-        
+
         if ( contains(queryDecl) || contains(dataDecl) || contains(resultDecl) )
         {
             if ( ! ( contains(queryDecl) && contains(dataDecl) && contains(resultDecl) ) )
                 throw new CmdException("Must give query, data and result to run a single test") ;
-            
+
             String query = getValue(queryDecl) ;
             String data = getValue(dataDecl) ;
             String result = getValue(resultDecl) ;
-            
+
             suite = ScriptTestSuiteFactory.make(query, data, result) ;
         }
         else if ( contains(allDecl) )
@@ -142,7 +142,7 @@ public class qtest extends CmdARQ
         else
         {
             // OK - running a manifest
-            
+
             if ( ! hasPositional() )
                 throw new CmdException("No manifest file") ;
 
@@ -150,13 +150,13 @@ public class qtest extends CmdARQ
             createEarlReport = contains(earlDecl) ;
         }
     }
-    
+
     @Override
     protected void exec()
     {
         if ( cmdStrictMode )
             ARQ.setStrictMode() ;
-        
+
         if ( suite != null )
             SimpleTestRunner.runAndReport(suite) ;
         else if ( execAllTests )
@@ -166,17 +166,17 @@ public class qtest extends CmdARQ
         else
         {
             // running a manifest
-            
+
             NodeValue.VerboseWarnings = false ;
             E_Function.WarnOnUnknownFunction = false ;
-            
+
             if ( createEarlReport )
                 oneManifestEarl(testfile) ;
             else
                 oneManifest(testfile) ;
         }
     }
-    
+
     static void oneManifest(String testManifest)
     {
         TestSuite suite = ScriptTestSuiteFactory.make(testManifest) ;
@@ -184,73 +184,73 @@ public class qtest extends CmdARQ
         //junit.textui.TestRunner.run(suite) ;
         SimpleTestRunner.runAndReport(suite) ;
     }
-    
+
     static void oneManifestEarl(String testManifest)
     {
         String name =  "ARQ" ;
         String releaseName =  "ARQ" ;
-        String version = "2.9.1" ;
+        String version = "3.16.0" ;
         String homepage = "http://jena.apache.org/" ;
         String systemURI = "http://jena.apache.org/#arq" ;  // Null for bNode.
-        
+
         // Include information later.
         EarlReport report = new EarlReport(systemURI, name, version, homepage) ;
         ScriptTestSuiteFactory.results = report ;
-        
+
         Model model = report.getModel() ;
         model.setNsPrefix("dawg", TestManifest.getURI()) ;
-        
-        // Update the EARL report. 
+
+        // Update the EARL report.
         Resource jena = model.createResource()
                     .addProperty(FOAF.homepage, model.createResource("http://jena.apache.org/")) ;
-        
+
         // ARQ is part fo Jena.
         Resource arq = report.getSystem()
                         .addProperty(DCTerms.isPartOf, jena) ;
-        
-        // Andy wrote the test software (updates the thing being tested as well as they are the same). 
+
+        // Andy wrote the test software (updates the thing being tested as well as they are the same).
         Resource who = model.createResource(FOAF.Person)
                                 .addProperty(FOAF.name, "Andy Seaborne")
-                                .addProperty(FOAF.homepage, 
+                                .addProperty(FOAF.homepage,
                                              model.createResource("http://people.apache.org/~andy")) ;
-        
+
         Resource reporter = report.getReporter() ;
         reporter.addProperty(DC.creator, who) ;
 
-        model.setNsPrefix("doap", DOAP.getURI()) ; 
+        model.setNsPrefix("doap", DOAP.getURI()) ;
         model.setNsPrefix("xsd", XSD.getURI()) ;
-        
+
         // DAWG specific stuff.
         Resource system = report.getSystem() ;
         system.addProperty(RDF.type, DOAP.Project) ;
         system.addProperty(DOAP.name, name) ;
         system.addProperty(DOAP.homepage, homepage) ;
         system.addProperty(DOAP.maintainer, who) ;
-        
+
         Resource release = model.createResource(DOAP.Version) ;
         system.addProperty(DOAP.release, release) ;
-        
+
         Node today_node = NodeFactoryExtra.todayAsDate() ;
         Literal today = model.createTypedLiteral(today_node.getLiteralLexicalForm(), today_node.getLiteralDatatype()) ;
         release.addProperty(DOAP.created, today) ;
         release.addProperty(DOAP.name, releaseName) ;      // Again
-        
+
         TestSuite suite = ScriptTestSuiteFactory.make(testManifest) ;
         SimpleTestRunner.runSilent(suite) ;
-        
+
         ScriptTestSuiteFactory.results.getModel().write(System.out, "TTL") ;
-        
+
     }
-    
+
     static void allTests()
     {
         // This should load all the built in tests.
         // Check to see if expected directories are present or not.
-        
+
         ensureDirExists("testing") ;
         ensureDirExists("testing/ARQ") ;
         ensureDirExists("testing/DAWG") ;
-        
+
         TestSuite ts = ARQTestSuite.suite() ;
         junit.textui.TestRunner.run(ts) ;
         //SimpleTestRunner.runAndReport(ts) ;
@@ -260,7 +260,7 @@ public class qtest extends CmdARQ
     {
         System.err.println("DAWG tests not packaged up yet") ;
     }
-    
+
     static void ensureDirExists(String dirname)
     {
         File f = new File(dirname) ;

--- a/jena-core/src/test/java/org/apache/jena/util/TestModelCollector.java
+++ b/jena-core/src/test/java/org/apache/jena/util/TestModelCollector.java
@@ -19,7 +19,9 @@
 package org.apache.jena.util;
 
 import static java.util.Collections.singleton;
-import static java.util.stream.Collector.Characteristics.*;
+import static java.util.stream.Collector.Characteristics.CONCURRENT;
+import static java.util.stream.Collector.Characteristics.IDENTITY_FINISH;
+import static java.util.stream.Collector.Characteristics.UNORDERED;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Stream.generate;
 import static java.util.stream.Stream.iterate;
@@ -27,27 +29,32 @@ import static org.apache.jena.ext.com.google.common.collect.Lists.newArrayList;
 import static org.apache.jena.graph.NodeFactory.createLiteralByValue;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.apache.jena.rdf.model.ModelFactory.createModelForGraph;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collector.Characteristics;
 import java.util.stream.Stream;
 
-import org.apache.jena.atlas.junit.BaseTest;
+import junit.framework.JUnit4TestAdapter;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.TypeMapper;
 import org.apache.jena.ext.com.google.common.collect.ImmutableSet;
-import org.apache.jena.graph.*;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.graph.impl.CollectionGraph;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.util.ModelCollector.*;
+import org.apache.jena.util.ModelCollector.ConcurrentModelCollector;
+import org.apache.jena.util.ModelCollector.IntersectionModelCollector;
+import org.apache.jena.util.ModelCollector.UnionModelCollector;
 import org.junit.Test;
 
-import junit.framework.JUnit4TestAdapter;
-
-public class TestModelCollector extends BaseTest {
+public class TestModelCollector {
     
     public static junit.framework.Test suite() {
         return new JUnit4TestAdapter(TestModelCollector.class) ;

--- a/jena-db/jena-dboe-storage/src/test/java/org/apache/jena/dboe/storage/prefixes/AbstractTestDatasetPrefixesStorage.java
+++ b/jena-db/jena-dboe-storage/src/test/java/org/apache/jena/dboe/storage/prefixes/AbstractTestDatasetPrefixesStorage.java
@@ -17,16 +17,18 @@
 
 package org.apache.jena.dboe.storage.prefixes;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import java.util.List;
 
 import org.apache.jena.atlas.iterator.Iter;
-import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.dboe.storage.StoragePrefixes;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.junit.Test;
 
-public abstract class AbstractTestDatasetPrefixesStorage extends BaseTest
+public abstract class AbstractTestDatasetPrefixesStorage
 {
     /** Create a fresh PrefixMapping */
     protected abstract StoragePrefixes create();

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/AbstractFusekiTest.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/AbstractFusekiTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.fuseki;
 
-import org.apache.jena.atlas.junit.BaseTest;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -41,7 +40,7 @@ import org.junit.BeforeClass;
  * requirements.
  */
 
-public class AbstractFusekiTest extends BaseTest
+public class AbstractFusekiTest
 {
     @BeforeClass public static void ctlBeforeClass() { ServerCtl.ctlBeforeClass(); }
     @AfterClass  public static void ctlAfterClass()  { ServerCtl.ctlAfterClass(); }

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestAdmin.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestAdmin.java
@@ -27,6 +27,7 @@ import static org.apache.jena.riot.web.HttpOp.execHttpDelete;
 import static org.apache.jena.riot.web.HttpOp.execHttpGet;
 import static org.apache.jena.riot.web.HttpOp.execHttpPost;
 import static org.apache.jena.riot.web.HttpOp.execHttpPostStream;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +42,7 @@ import org.apache.jena.atlas.json.JSON;
 import org.apache.jena.atlas.json.JsonArray;
 import org.apache.jena.atlas.json.JsonObject;
 import org.apache.jena.atlas.json.JsonValue;
+import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.atlas.web.TypedInputStream;
@@ -399,6 +401,8 @@ public class TestAdmin extends AbstractFusekiTest {
         }
     }
 
+    private void assertEqualsIgnoreCase(String contenttypejson, String contentType) {}
+
     private static JsonValue getTask(String taskId) {
         String url = ServerCtl.urlRoot()+"$/tasks/"+taskId;
         return httpGetJson(url);
@@ -406,7 +410,7 @@ public class TestAdmin extends AbstractFusekiTest {
 
     private static JsonValue getDatasetDescription(String dsName) {
         try (TypedInputStream in = execHttpGet(ServerCtl.urlRoot() + "$/" + opDatasets + "/" + dsName)) {
-            assertEqualsIgnoreCase(WebContent.contentTypeJSON, in.getContentType());
+            BaseTest.assertEqualsIgnoreCase(WebContent.contentTypeJSON, in.getContentType());
             JsonValue v = JSON.parse(in);
             return v;
         }
@@ -633,14 +637,14 @@ public class TestAdmin extends AbstractFusekiTest {
 
     private static JsonValue execGetJSON(String url) {
         try ( TypedInputStream in = execHttpGet(url) ) {
-            assertEqualsIgnoreCase(WebContent.contentTypeJSON, in.getContentType());
+            BaseTest.assertEqualsIgnoreCase(WebContent.contentTypeJSON, in.getContentType());
             return JSON.parse(in);
         }
     }
 
     private static JsonValue execPostJSON(String url) {
         try ( TypedInputStream in = execHttpPostStream(url, null, null, null) ) {
-            assertEqualsIgnoreCase(WebContent.contentTypeJSON, in.getContentType());
+            BaseTest.assertEqualsIgnoreCase(WebContent.contentTypeJSON, in.getContentType());
             return JSON.parse(in);
         }
     }

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestAdminAPI.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestAdminAPI.java
@@ -19,6 +19,9 @@
 package org.apache.jena.fuseki;
 
 import static org.apache.jena.riot.web.HttpOp.execHttpGet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestDatasetAccessorHTTP.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestDatasetAccessorHTTP.java
@@ -27,6 +27,9 @@ import static org.apache.jena.fuseki.ServerTest.gn2;
 import static org.apache.jena.fuseki.ServerTest.gn99;
 import static org.apache.jena.fuseki.ServerTest.model1;
 import static org.apache.jena.fuseki.ServerTest.model2;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.fuseki.test.FusekiTest;

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestDatasetOps.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestDatasetOps.java
@@ -19,8 +19,12 @@
 package org.apache.jena.fuseki;
 
 import static org.apache.jena.fuseki.ServerCtl.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.EntityTemplate;
+import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.atlas.web.TypedInputStream;
@@ -113,7 +117,7 @@ public class TestDatasetOps extends AbstractFusekiTest {
 
         // Do manually so the test can validate the expected ContentType
         try (TypedInputStream in = HttpOp.execHttpGet(urlDataset, acceptheader)) {
-            assertEqualsIgnoreCase(contentTypeResponse, in.getContentType());
+            BaseTest.assertEqualsIgnoreCase(contentTypeResponse, in.getContentType());
             Lang lang = RDFLanguages.contentTypeToLang(in.getContentType());
             DatasetGraph dsg = DatasetGraphFactory.create();
             StreamRDF dest = StreamRDFLib.dataset(dsg);

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestFileUpload.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestFileUpload.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.fuseki;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.web.TypedInputStream;
 import org.apache.jena.query.DatasetAccessor;
 import org.apache.jena.query.DatasetAccessorFactory;

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestHttpOp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestHttpOp.java
@@ -25,6 +25,7 @@ import static org.apache.jena.fuseki.ServerCtl.urlRoot;
 import static org.apache.jena.fuseki.test.FusekiTest.execWithHttpException;
 import static org.apache.jena.fuseki.test.FusekiTest.expect404;
 import static org.apache.jena.riot.web.HttpOp.initialDefaultHttpClient;
+import static org.junit.Assert.*;
 
 import org.apache.http.client.HttpClient;
 import org.apache.jena.atlas.lib.IRILib;

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestMetrics.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestMetrics.java
@@ -30,6 +30,7 @@ import static org.apache.commons.lang3.StringUtils.substringAfter;
 import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class TestMetrics extends AbstractFusekiTest {
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestQuery.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestQuery.java
@@ -24,6 +24,9 @@ import static org.apache.jena.fuseki.ServerTest.gn1;
 import static org.apache.jena.fuseki.ServerTest.gn2;
 import static org.apache.jena.fuseki.ServerTest.model1;
 import static org.apache.jena.fuseki.ServerTest.model2;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.*;
 import java.net.HttpURLConnection;

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestSPARQLProtocol.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestSPARQLProtocol.java
@@ -23,6 +23,7 @@ import static org.apache.jena.fuseki.ServerCtl.serviceUpdate;
 import static org.apache.jena.fuseki.ServerTest.gn1;
 import static org.apache.jena.fuseki.ServerTest.model1;
 import static org.apache.jena.fuseki.ServerTest.model2;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.jena.query.*;
 import org.apache.jena.riot.WebContent;

--- a/jena-iri/src/main/java/org/apache/jena/iri/ViolationCodes.java
+++ b/jena-iri/src/main/java/org/apache/jena/iri/ViolationCodes.java
@@ -1,7 +1,7 @@
 
-    
-    
-    
+
+
+
  /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -36,120 +36,120 @@ import org.apache.jena.iri.impl.ViolationCodeInfo.FromAlso;
 import org.apache.jena.iri.impl.Specification;
 import org.apache.jena.iri.impl.SchemeSpecification;
 import org.apache.jena.iri.impl.Force;
- 
+
 /**
  * Detailed description of problems detected.
- * This interface lists the codes returned by 
+ * This interface lists the codes returned by
  * {@link Violation#getViolationCode()}.
  * Note: not all are errors, some merely reflect internal workings.
- 
+
  <p>The violations are evaluated against the following standards:
  </p>
  <dl>
-  
+
       <dt><a name="ref-RDF">[RDF]</a>
-      
+
       </dt>
       <dd><a href="http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref">
-      
+
 Resource Description Framework (RDF):
 Concepts and Abstract Syntax
 
         (section RDF URI References)
       </a>
       </dd>
-      
+
       <dd>
       The SCHEME component is required.<br />
-    
+
              <br/>
              The following are examples of ill-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>#frag</code>&gt;</li>
-    
+
      <li>&lt;<code>//example.org/foo/bar#frag</code>&gt;</li>
-    
+
              </ul>
-             
+
       </dd>
-      
+
       <dt><a name="ref-URI">[URI]</a>
-      
+
       RFC 3986
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3986.html">
       Uniform Resource Identifier (URI): Generic Syntax</a>
       </dd>
-      
+
       <dt><a name="ref-Unicode">[Unicode]</a>
-      
+
       </dt>
       <dd><a href="http://www.unicode.org/">
       Unicode</a>
       </dd>
-      
+
       <dt><a name="ref-IRI">[IRI]</a>
-      
+
       RFC 3987
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3987.html">
       Internationalized Resource Identifiers (IRIs)</a>
       </dd>
-      
+
       <dt><a name="ref-XML">[XML]</a>
-      
+
       </dt>
       <dd><a href="http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid">
       Extensible Markup Language (XML) 1.0 (Third Edition)
         (section system identifier)
       </a>
       </dd>
-      
+
       <dd>
       The FRAGMENT component must be omitted.<br />
-    
+
       </dd>
-      
+
       <dt><a name="ref-XLink">[XLink]</a>
-      
+
       </dt>
       <dd><a href="http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators">
       XML Linking Language (XLink) Version 1.0
         (section Locator Attribute (href))
       </a>
       </dd>
-      
+
       <dt><a name="ref-Schema">[Schema]</a>
-      
+
       </dt>
       <dd><a href="http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI">
       XML Schema Part 2: Datatypes Second Edition
         (section anyURI)
       </a>
       </dd>
-       
+
  </dl>
- 
+
  <p>Scheme specific checks are enabled. The syntax of the following schemes is fully supported:
  </p>
  <dl>
-  
+
       <dt><a name="ref-http">[http]</a>
-      
+
       RFC 2616
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2616.html">
       Hypertext Transfer Protocol -- HTTP/1.1</a>
       </dd>
-      
+
       <dd>
       Pertinent text from the specification includes:
       <br />
       <dl>
-      
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc2616.html#sec-3.2.2">section 3.2.2<a>
@@ -159,70 +159,70 @@ Concepts and Abstract Syntax
      <pre>
 http_URL = "http:" "//" host [ ":" port ] [ abs_path [ "?" query ]]
 </pre>
-    
-           
+
+
       </dd>
-    
+
       </dl>
       </dd>
-      
+
       <dd>
      <br/>
      This scheme requires the use of hostnames conforming to DNS syntax.
      The IDNA compatibile processing of IRIs for this scheme is enabled if this scheme is enabled.
      To disable this behaviour, this scheme has to be disabled using // TODO how to disable scheme
      and DNS compatibile rules have to be disabled using {@link IRIFactory#dnsViolation}.
-    
+
       The default port is 80.<br />
-    
+
       The USER component must be omitted.<br />
-    
+
       The HOST component is required.<br />
-    
+
              <br/>
              The following are examples of well-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>http://www.example.org/foo/bar</code>&gt;</li>
-    
+
              </ul>
-             
+
              <br/>
              The following are examples of ill-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>http://www.example.org:80/foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>http:foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>http://user@www.example.org/foo/bar</code>&gt;</li>
-    
+
              </ul>
-             
+
       </dd>
-      
+
       <dt><a name="ref-https">[https]</a>
-      
+
       RFC 2818
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2818.html">
       Hypertext Transfer Protocol Secure</a>
       </dd>
-      
+
       <dd>
       Pertinent text from the specification includes:
       <br />
       <dl>
-      
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc2818.html#sec-2.4">section 2.4<a>
       </dt>
       <dd>
-HTTP/TLS is differentiated from HTTP URIs by using the 'https' protocol identifier in place of the 'http' protocol identifier. 
-    
+HTTP/TLS is differentiated from HTTP URIs by using the 'https' protocol identifier in place of the 'http' protocol identifier.
+
       </dd>
-    
+
       <dt>
        See <a href="#ref-http">
      [http]</a>, specifically,
@@ -233,50 +233,50 @@ HTTP/TLS is differentiated from HTTP URIs by using the 'https' protocol identifi
      <pre>
 http_URL = "http:" "//" host [ ":" port ] [ abs_path [ "?" query ]]
 </pre>
-    
-           
+
+
       </dd>
-    
+
       </dl>
       </dd>
-      
+
       <dd>
      <br/>
      This scheme requires the use of hostnames conforming to DNS syntax.
      The IDNA compatibile processing of IRIs for this scheme is enabled if this scheme is enabled.
      To disable this behaviour, this scheme has to be disabled using // TODO how to disable scheme
      and DNS compatibile rules have to be disabled using {@link IRIFactory#dnsViolation}.
-    
+
       The default port is 443.<br />
-    
+
       The USER component must be omitted.<br />
-    
+
       The HOST component is required.<br />
-    
+
              <br/>
              The following are examples of well-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>https://www.example.org/foo/bar</code>&gt;</li>
-    
+
              </ul>
-             
+
              <br/>
              The following are examples of ill-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>https://www.example.org:443/foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>https:foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>https://user@www.example.org/foo/bar</code>&gt;</li>
-    
+
              </ul>
-             
+
       </dd>
-      
+
       <dt><a name="ref-ftp">[ftp]</a>
-      
+
       RFC 1738
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.2">
@@ -284,12 +284,12 @@ http_URL = "http:" "//" host [ ":" port ] [ abs_path [ "?" query ]]
         (section 3.2)
       </a>
       </dd>
-      
+
       <dd>
       Pertinent text from the specification includes:
       <br />
       <dl>
-      
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc1738.html#sec-5">section 5<a>
@@ -302,12 +302,12 @@ fpath = fsegment *[ "/" fsegment ]
 fsegment = *[ uchar | "?" | ":" | "@" | "&amp;" | "=" ]
 ftptype = "A" | "I" | "D" | "a" | "i" | "d"
 </pre>
-    
+
 
      <pre>
 login = [ user [ ":" password ] "@" ] hostport
 </pre>
-    
+
 
      <pre>
 safe = "$" | "-" | "_" | "." | "+"
@@ -316,24 +316,24 @@ escape = "%" hex hex
 unreserved = alpha | digit | safe | extra
 uchar = unreserved | escape
 </pre>
-    
+
 
       </dd>
-    
+
       </dl>
       </dd>
-      
+
       <dd>
      <br/>
      This scheme requires the use of hostnames conforming to DNS syntax.
      The IDNA compatibile processing of IRIs for this scheme is enabled if this scheme is enabled.
      To disable this behaviour, this scheme has to be disabled using // TODO how to disable scheme
      and DNS compatibile rules have to be disabled using {@link IRIFactory#dnsViolation}.
-    
+
       The default port is 21.<br />
-    
+
       The HOST component is required.<br />
-    
+
       The PATHQUERY component:
       <ul>
       <li>
@@ -345,31 +345,31 @@ uchar = unreserved | escape
       the scheme specific syntax.
       </li>
       </ul>
-    
+
              <br/>
              The following are examples of well-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>ftp://user@example.org/foo/bar;type=d</code>&gt;</li>
-    
+
              </ul>
-             
+
              <br/>
              The following are examples of ill-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>ftp:///foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>ftp://user@example.org/foo/bar;type=z</code>&gt;</li>
-    
+
      <li>&lt;<code>ftp://user@example.org/foo/b;ar;type=d</code>&gt;</li>
-    
+
              </ul>
-             
+
       </dd>
-      
+
       <dt><a name="ref-news">[news]</a>
-      
+
       RFC 1738
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.6">
@@ -377,12 +377,12 @@ uchar = unreserved | escape
         (section 3.6)
       </a>
       </dd>
-      
+
       <dd>
       Pertinent text from the specification includes:
       <br />
       <dl>
-      
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc1738.html#sec-5">section 5<a>
@@ -395,7 +395,7 @@ grouppart = "*" | group | article
 group = alpha *[ alpha | digit | "-" | "." | "+" | "_" ]
 article = 1*[ uchar | ";" | "/" | "?" | ":" | "&amp;" | "=" ] "@" host
 </pre>
-    
+
 
      <pre>
 safe = "$" | "-" | "_" | "." | "+"
@@ -404,18 +404,18 @@ escape = "%" hex hex
 unreserved = alpha | digit | safe | extra
 uchar = unreserved | escape
 </pre>
-    
+
 
       </dd>
-    
+
       </dl>
       </dd>
-      
+
       <dd>
       The AUTHORITY component must be omitted.<br />
-    
+
       The PATH component is required.<br />
-    
+
       The PATHQUERY component:
       <ul>
       <li>
@@ -427,39 +427,39 @@ uchar = unreserved | escape
       the scheme specific syntax.
       </li>
       </ul>
-    
+
              <br/>
              The following are examples of well-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>news:*</code>&gt;</li>
-    
+
      <li>&lt;<code>news:group.it</code>&gt;</li>
-    
+
      <li>&lt;<code>news:arb?itrary@news.example.org</code>&gt;</li>
-    
+
      <li>&lt;<code>news:arbitrary@news.example.org</code>&gt;</li>
-    
+
              </ul>
-             
+
              <br/>
              The following are examples of ill-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>news:arbitrary@news.exampl\u00E7.org</code>&gt;</li>
-    
+
      <li>&lt;<code>news:arbitr?ary@news.exampl\u00E7.org</code>&gt;</li>
-    
+
      <li>&lt;<code>news:///foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>news://user@example.org/foo</code>&gt;</li>
-    
+
              </ul>
-             
+
       </dd>
-      
+
       <dt><a name="ref-nntp">[nntp]</a>
-      
+
       RFC 1738
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.7">
@@ -467,12 +467,12 @@ uchar = unreserved | escape
         (section 3.7)
       </a>
       </dd>
-      
+
       <dd>
       Pertinent text from the specification includes:
       <br />
       <dl>
-      
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc1738.html#sec-5">section 5<a>
@@ -482,71 +482,71 @@ uchar = unreserved | escape
      <pre>
 nntpurl = "nntp://" hostport "/" group [ "/" digits ]
 </pre>
-    
+
 
      <pre>
 group = alpha *[ alpha | digit | "-" | "." | "+" | "_" ]
 </pre>
-    
+
 
       </dd>
-    
+
       </dl>
       </dd>
-      
+
       <dd>
      <br/>
      This scheme requires the use of hostnames conforming to DNS syntax.
      The IDNA compatibile processing of IRIs for this scheme is enabled if this scheme is enabled.
      To disable this behaviour, this scheme has to be disabled using // TODO how to disable scheme
      and DNS compatibile rules have to be disabled using {@link IRIFactory#dnsViolation}.
-    
+
       The default port is 119.<br />
-    
+
       The QUERY component must be omitted.<br />
-    
+
       The USER component must be omitted.<br />
-    
+
       The HOST component is required.<br />
-    
+
       The PATH component
       is required to match the regular expression: /[a-zA-Z][-a-zA-Z0-9.+_]*(/[0-9]+)?
       <br/>
-    
+
              <br/>
              The following are examples of well-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>nntp://example.org/foo4</code>&gt;</li>
-    
+
      <li>&lt;<code>nntp://example.org/foo/4</code>&gt;</li>
-    
+
              </ul>
-             
+
              <br/>
              The following are examples of ill-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>nntp://user@example.org/foo</code>&gt;</li>
-    
+
      <li>&lt;<code>nntp:/foo</code>&gt;</li>
-    
+
      <li>&lt;<code>nntp:///foo</code>&gt;</li>
-    
+
      <li>&lt;<code>nntp://example.org/foo/4/3</code>&gt;</li>
-    
+
      <li>&lt;<code>nntp://example.org/</code>&gt;</li>
-    
+
      <li>&lt;<code>nntp://example.org/foo/</code>&gt;</li>
-    
+
      <li>&lt;<code>nntp://example.org/*</code>&gt;</li>
-    
+
              </ul>
-             
+
       </dd>
-      
+
       <dt><a name="ref-file">[file]</a>
-      
+
       RFC 1738
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.10">
@@ -554,12 +554,12 @@ group = alpha *[ alpha | digit | "-" | "." | "+" | "_" ]
         (section 3.10)
       </a>
       </dd>
-      
+
       <dd>
       Pertinent text from the specification includes:
       <br />
       <dl>
-      
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc1738.html#sec-5">section 5<a>
@@ -569,13 +569,13 @@ group = alpha *[ alpha | digit | "-" | "." | "+" | "_" ]
      <pre>
 fileurl = "file://" [ host | "localhost" ] "/" fpath
 </pre>
-    
+
 
      <pre>
 fpath = fsegment *[ "/" fsegment ]
 fsegment = *[ uchar | "?" | ":" | "@" | "&amp;" | "=" ]
 </pre>
-    
+
 
      <pre>
 safe = "$" | "-" | "_" | "." | "+"
@@ -584,28 +584,28 @@ escape = "%" hex hex
 unreserved = alpha | digit | safe | extra
 uchar = unreserved | escape
 </pre>
-    
+
 
       </dd>
-    
+
       </dl>
       </dd>
-      
+
       <dd>
      <br/>
      This scheme requires the use of hostnames conforming to DNS syntax.
      The IDNA compatibile processing of IRIs for this scheme is enabled if this scheme is enabled.
      To disable this behaviour, this scheme has to be disabled using // TODO how to disable scheme
      and DNS compatibile rules have to be disabled using {@link IRIFactory#dnsViolation}.
-    
+
       The USER component must be omitted.<br />
-    
+
       The PORT component must be omitted.<br />
-    
+
       The PATH component is required.<br />
-    
+
       The AUTHORITY component is required.<br />
-    
+
       The PATHQUERY component:
       <ul>
       <li>
@@ -617,70 +617,70 @@ uchar = unreserved | escape
       the scheme specific syntax.
       </li>
       </ul>
-    
+
              <br/>
              The following are examples of well-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>file:///foo/b</code>&gt;</li>
-    
+
      <li>&lt;<code>file:///foo/b?ar/yuk</code>&gt;</li>
-    
+
              </ul>
-             
+
              <br/>
              The following are examples of ill-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>file://user@example.org/foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>file://eg:4029/foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>file:/foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>file://example.org</code>&gt;</li>
-    
+
      <li>&lt;<code>file://foo/bar;t</code>&gt;</li>
-    
+
      <li>&lt;<code>file://foo/~jjc</code>&gt;</li>
-    
+
              </ul>
-             
+
       </dd>
-       
+
  </dl>
- 
- 
+
+
  <p>The syntax of the following schemes is partially supported:
  </p>
  <dl>
-  
+
       <dt><a name="ref-mailto">[mailto]</a>
-      
+
       RFC 2368
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2368.html">
       Electronic mail address</a>
       </dd>
-      
+
       <dd>
       The AUTHORITY component must be omitted.<br />
-    
+
       </dd>
-      
+
       <dt><a name="ref-urn">[urn]</a>
-      
+
       RFC 2141
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2141.html">
       Uniform Resource Names</a>
       </dd>
-      
+
       <dd>
       Pertinent text from the specification includes:
       <br />
       <dl>
-      
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc2141.html#sec-2">section 2<a>
@@ -691,10 +691,10 @@ uchar = unreserved | escape
      <pre>
 &lt;URN&gt; ::= "urn:" &lt;NID&gt; ":" &lt;NSS&gt;
 </pre>
-    
+
 
       </dd>
-    
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.1">section 2.1<a>
@@ -708,10 +708,10 @@ uchar = unreserved | escape
 
 &lt;let-num&gt;     ::= &lt;upper&gt; | &lt;lower&gt; | &lt;number&gt;
 </pre>
-    
+
 
       </dd>
-    
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.2">section 2.2<a>
@@ -729,33 +729,33 @@ uchar = unreserved | escape
                   ":" | "=" | "@" | ";" | "$" |
                   "_" | "!" | "*" | "'"
 </pre>
-    
+
 
       </dd>
-    
+
       <dt>
        See
       <a href="http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.3.2">section 2.3.2<a>
       </dt>
       <dd>
-RFC 1630 [2] reserves the characters "/", "?", and "#" for particular purposes. 
-The URN-WG has not yet debated the applicability and precise semantics of those 
-purposes as applied to URNs. Therefore, these characters are RESERVED for future 
-developments. Namespace developers SHOULD NOT use these characters in unencoded form, 
+RFC 1630 [2] reserves the characters "/", "?", and "#" for particular purposes.
+The URN-WG has not yet debated the applicability and precise semantics of those
+purposes as applied to URNs. Therefore, these characters are RESERVED for future
+developments. Namespace developers SHOULD NOT use these characters in unencoded form,
 but rather use the appropriate %-encoding for each character.
 
       </dd>
-    
+
       </dl>
       </dd>
-      
+
       <dd>
       The AUTHORITY component must be omitted.<br />
-    
+
       The QUERY component must be omitted.<br />
-    
+
       The PATH component is required.<br />
-    
+
       The PATH component:
       <ul>
       <li>
@@ -767,448 +767,448 @@ but rather use the appropriate %-encoding for each character.
       the scheme specific syntax.
       </li>
       </ul>
-    <br/>TODO: case of NIS<br/>TODO: 
+    <br/>TODO: case of NIS<br/>TODO:
            registry of URNs, implement something of the NSS with Namespace specific rules.
-           <br/>TODO: 
+           <br/>TODO:
  To avoid confusion with the "urn:" identifier, the NID "urn" is reserved and MUST NOT be used.
- <br/>TODO: e-mail about frags in URNs<br/>TODO: 
-In addition, octet 0 (0 hex) should NEVER be used, in either unencoded or %-encoded form.           
-           
+ <br/>TODO: e-mail about frags in URNs<br/>TODO:
+In addition, octet 0 (0 hex) should NEVER be used, in either unencoded or %-encoded form.
+
              <br/>
              The following are examples of well-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>urn:x-hp:foo\u00E9</code>&gt;</li>
-    
+
      <li>&lt;<code>urn:urn-1:foo</code>&gt;</li>
-    
+
              </ul>
-             
+
              <br/>
              The following are examples of ill-formed IRIs using this scheme:
              <ul>
-             
+
      <li>&lt;<code>urn:x-hp:foo/bar</code>&gt;</li>
-    
+
      <li>&lt;<code>urn:urn:foo</code>&gt;</li>
-    
+
      <li>&lt;<code>urn://foo</code>&gt;</li>
-    
+
      <li>&lt;<code>urn:foo:bar?query</code>&gt;</li>
-    
+
      <li>&lt;<code>urn:foo:ff~</code>&gt;</li>
-    
+
              </ul>
-             
+
       </dd>
-       
+
  </dl>
- 
- 
+
+
  <p>The names of the following registered schemes are known, but they are otherwise unsupported:
  </p>
  <dl>
-  
+
       <dt><a name="ref-telnet">[telnet]</a>
-      
+
       RFC 4248
       </dt>
       <dd><a href="http://www.ietf.org/rfc/rfc4248.txt">
       Reference to interactive sessions</a>
       </dd>
-      
+
       <dt><a name="ref-wais">[wais]</a>
-      
+
       RFC 4156
       </dt>
       <dd><a href="http://www.ietf.org/rfc/rfc4156.txt">
       Wide Area Information Servers</a>
       </dd>
-      
+
       <dt><a name="ref-prospero">[prospero]</a>
-      
+
       RFC 4157
       </dt>
       <dd><a href="http://www.ietf.org/rfc/rfc4157.txt">
       Prospero Directory Service</a>
       </dd>
-      
+
       <dt><a name="ref-gopher">[gopher]</a>
-      
+
       RFC 4266
       </dt>
       <dd><a href="http://www.ietf.org/rfc/rfc4266.txt">
       The gopher URI scheme</a>
       </dd>
-      
+
       <dt><a name="ref-z39.50s">[z39.50s]</a>
-      
+
       RFC 2056
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2056.html">
       Z39.50 Session</a>
       </dd>
-      
+
       <dt><a name="ref-z39.50r">[z39.50r]</a>
-      
+
       RFC 2056
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2056.html">
       Z39.50 Retrieval</a>
       </dd>
-      
+
       <dt><a name="ref-cid">[cid]</a>
-      
+
       RFC 2392
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2392.html">
       content identifier</a>
       </dd>
-      
+
       <dt><a name="ref-mid">[mid]</a>
-      
+
       RFC 2392
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2392.html">
       message identifier</a>
       </dd>
-      
+
       <dt><a name="ref-vemmi">[vemmi]</a>
-      
+
       RFC 2122
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2122.html">
       versatile multimedia interface</a>
       </dd>
-      
+
       <dt><a name="ref-service">[service]</a>
-      
+
       RFC 2609
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2609.html">
       service location</a>
       </dd>
-      
+
       <dt><a name="ref-imap">[imap]</a>
-      
+
       RFC 2192
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2192.html">
       internet message access protocol</a>
       </dd>
-      
+
       <dt><a name="ref-nfs">[nfs]</a>
-      
+
       RFC 2224
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2224.html">
       network file system protocol</a>
       </dd>
-      
+
       <dt><a name="ref-acap">[acap]</a>
-      
+
       RFC 2244
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2244.html">
       application configuration access protocol</a>
       </dd>
-      
+
       <dt><a name="ref-rtsp">[rtsp]</a>
-      
+
       RFC 2326
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2326.html">
       real time streaming protocol</a>
       </dd>
-      
+
       <dt><a name="ref-tip">[tip]</a>
-      
+
       RFC 2371
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2371.html">
       Transaction Internet Protocol</a>
       </dd>
-      
+
       <dt><a name="ref-pop">[pop]</a>
-      
+
       RFC 2384
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2384.html">
       Post Office Protocol v3</a>
       </dd>
-      
+
       <dt><a name="ref-data">[data]</a>
-      
+
       RFC 2397
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2397.html">
       data</a>
       </dd>
-      
+
       <dt><a name="ref-dav">[dav]</a>
-      
+
       RFC 2518
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2518.html">
       dav</a>
       </dd>
-      
+
       <dt><a name="ref-opaquelocktoken">[opaquelocktoken]</a>
-      
+
       RFC 2518
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2518.html">
       opaquelocktoken</a>
       </dd>
-      
+
       <dt><a name="ref-sip">[sip]</a>
-      
+
       RFC 3261
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3261.html">
       session initiation protocol</a>
       </dd>
-      
+
       <dt><a name="ref-sips">[sips]</a>
-      
+
       RFC 3261
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3261.html">
       secure session intitiaion protocol</a>
       </dd>
-      
+
       <dt><a name="ref-tel">[tel]</a>
-      
+
       RFC 2806
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2806.html">
       telephone</a>
       </dd>
-      
+
       <dt><a name="ref-fax">[fax]</a>
-      
+
       RFC 2806
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2806.html">
       fax</a>
       </dd>
-      
+
       <dt><a name="ref-modem">[modem]</a>
-      
+
       RFC 2806
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2806.html">
       modem</a>
       </dd>
-      
+
       <dt><a name="ref-soap.beep">[soap.beep]</a>
-      
+
       RFC 3288
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3288.html">
       soap.beep</a>
       </dd>
-      
+
       <dt><a name="ref-soap.beeps">[soap.beeps]</a>
-      
+
       RFC 3288
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3288.html">
       soap.beeps</a>
       </dd>
-      
+
       <dt><a name="ref-xmlrpc.beep">[xmlrpc.beep]</a>
-      
+
       RFC 3529
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3529.html">
       xmlrpc.beep</a>
       </dd>
-      
+
       <dt><a name="ref-xmlrpc.beeps">[xmlrpc.beeps]</a>
-      
+
       RFC 3529
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3529.html">
       xmlrpc.beeps</a>
       </dd>
-      
+
       <dt><a name="ref-go">[go]</a>
-      
+
       RFC 3368
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3368.html">
       go</a>
       </dd>
-      
+
       <dt><a name="ref-h323">[h323]</a>
-      
+
       RFC 3508
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3508.html">
       H.323</a>
       </dd>
-      
+
       <dt><a name="ref-ipp">[ipp]</a>
-      
+
       RFC 3510
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3510.html">
       Internet Printing Protocol</a>
       </dd>
-      
+
       <dt><a name="ref-tftp">[tftp]</a>
-      
+
       RFC 3617
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3617.html">
       Trivial File Transfer Protocol</a>
       </dd>
-      
+
       <dt><a name="ref-mupdate">[mupdate]</a>
-      
+
       RFC 3656
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3656.html">
       Mailbox Update (MUPDATE) Protocol</a>
       </dd>
-      
+
       <dt><a name="ref-pres">[pres]</a>
-      
+
       RFC 3859
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3859.html">
       Presence</a>
       </dd>
-      
+
       <dt><a name="ref-im">[im]</a>
-      
+
       RFC 3860
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3860.html">
       Instant Messaging</a>
       </dd>
-      
+
       <dt><a name="ref-mtqp">[mtqp]</a>
-      
+
       RFC 3887
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3887.html">
       Message Tracking Query Protocol</a>
       </dd>
-      
+
       <dt><a name="ref-iris.beep">[iris.beep]</a>
-      
+
       RFC 3983
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc3983.html">
       iris.beep</a>
       </dd>
-      
+
       <dt><a name="ref-dict">[dict]</a>
-      
+
       RFC 2229
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2229.html">
       dictionary service protocol</a>
       </dd>
-      
+
       <dt><a name="ref-snmp">[snmp]</a>
-      
+
       RFC 4088
       </dt>
       <dd><a href="http://www.ietf.org/rfc/rfc4088.txt">
       Simple Network Management Protocol</a>
       </dd>
-      
+
       <dt><a name="ref-crid">[crid]</a>
-      
+
       RFC 4078
       </dt>
       <dd><a href="http://www.ietf.org/rfc/rfc4078.txt">
       TV-Anytime Content Reference Identifier</a>
       </dd>
-      
+
       <dt><a name="ref-tag">[tag]</a>
-      
+
       RFC 4151
       </dt>
       <dd><a href="http://www.ietf.org/rfc/rfc4151.txt">
       tag</a>
       </dd>
-      
+
       <dt><a name="ref-afs">[afs]</a>
-      
+
       </dt>
       <dd><a href="http://www.iana.org/assignments/uri-schemes">
       Andrew File System global file names</a>
       </dd>
-      
+
       <dt><a name="ref-tn3270">[tn3270]</a>
-      
+
       </dt>
       <dd><a href="http://www.iana.org/assignments/uri-schemes">
       Interactive 3270 emulation sessions</a>
       </dd>
-      
+
       <dt><a name="ref-mailserver">[mailserver]</a>
-      
+
       </dt>
       <dd><a href="http://www.iana.org/assignments/uri-schemes">
       Access to data available from mail servers</a>
       </dd>
-      
+
       <dt><a name="ref-dns">[dns]</a>
-      
+
       </dt>
       <dd><a href="http://www.iana.org/assignments/uri-schemes">
       Domain Name System</a>
       </dd>
-      
+
       <dt><a name="ref-info">[info]</a>
-      
+
       </dt>
       <dd><a href="http://www.iana.org/assignments/uri-schemes">
       Information Assets with Identifiers in Public Namespaces</a>
       </dd>
-      
+
       <dt><a name="ref-ldap">[ldap]</a>
-      
+
       </dt>
       <dd><a href="http://www.iana.org/assignments/uri-schemes">
       Lightweight Directory Access Protocol</a>
       </dd>
-       
+
  </dl>
- 
+
  <p>Other relevant standards include:
  </p>
  <dl>
-  
+
       <dt><a name="ref-URL_Registratrion">[URL_Registratrion]</a>
-      
+
       RFC 2717
       </dt>
       <dd><a href="http://www.apps.ietf.org/rfc/rfc2717.html">
-      
+
         Registration Procedures for URL
               Scheme Names</a>
       </dd>
-       
+
  </dl>
- 
+
  */
 public interface ViolationCodes {
-   
+
 /**
 This class is not part of the API.
 */
    class Initialize implements IRIComponents, Force {
    static {
-   
+
    Specification spec;
-   
-   
+
+
      spec =
        new Specification(
                 "RDF",
@@ -1217,26 +1217,26 @@ This class is not part of the API.
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref",
                 "Resource Description Framework (RDF): Concepts and Abstract Syntax",
                 "RDF URI References",
-                  
+
                 new String[]{
-                  
+
       "foo/bar",
-    
+
       "#frag",
-    
+
       "//example.org/foo/bar#frag",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
+
         spec.require(
               IRIComponents.SCHEME
         );
-    
+
      spec =
        new Specification(
                 "URI",
@@ -1245,16 +1245,16 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3986.html",
                 "Uniform Resource Identifier (URI): Generic Syntax",
                 "",
-                  
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
+
      spec =
        new Specification(
                 "Unicode",
@@ -1263,16 +1263,16 @@ This class is not part of the API.
                 "http://www.unicode.org/",
                 "Unicode",
                 "",
-                  
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
+
      spec =
        new Specification(
                 "IRI",
@@ -1281,16 +1281,16 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3987.html",
                 "Internationalized Resource Identifiers (IRIs)",
                 "",
-                  
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
+
      spec =
        new Specification(
                 "XML",
@@ -1299,20 +1299,20 @@ This class is not part of the API.
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid",
                 "Extensible Markup Language (XML) 1.0 (Third Edition)",
                 "system identifier",
-                  
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
+
         spec.prohibit(
               IRIComponents.FRAGMENT
         );
-    
+
      spec =
        new Specification(
                 "XLink",
@@ -1321,16 +1321,16 @@ This class is not part of the API.
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators",
                 "XML Linking Language (XLink) Version 1.0",
                 "Locator Attribute (href)",
-                  
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
+
      spec =
        new Specification(
                 "Schema",
@@ -1339,16 +1339,16 @@ This class is not part of the API.
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI",
                 "XML Schema Part 2: Datatypes Second Edition",
                 "anyURI",
-                  
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
+
      spec =
        new Specification(
                 "URL_Registratrion",
@@ -1357,16 +1357,16 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2717.html",
                 "Registration Procedures for URL Scheme Names",
                 "",
-                  
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
+
      spec =
        new SchemeSpecification(
                 "http",
@@ -1374,51 +1374,51 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2616.html",
                 "Hypertext Transfer Protocol -- HTTP/1.1",
                 "",
-                
+
                 new String[]{
-                  
+
       "http://www.example.org:80/foo/bar",
-    
+
       "http:foo/bar",
-    
+
       "http://user@www.example.org/foo/bar",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
       "http://www.example.org/foo/bar",
-    
+
                 }
             );
-            
-            
+
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc2616.html#sec-3.2.2",    
+                "http://www.apps.ietf.org/rfc/rfc2616.html#sec-3.2.2",
                 ""+
   "\n"+
     "http_URL = \"http:\" \"//\" host [ \":\" port ] [ abs_path [ \"?\" query ]]\n"+
-    "",    
+    "",
                 ""+
      "</p><pre>\n"+
     "http_URL = \"http:\" \"//\" host [ \":\" port ] [ abs_path [ \"?\" query ]]\n"+
     "</pre>"+
      "<p>"
         );
-    
+
         spec.setDNS(true);
-    
+
         spec.port(80);
-    
+
         spec.prohibit(
               IRIComponents.USER
         );
-    
+
         spec.require(
               IRIComponents.HOST
         );
-    
+
      spec =
        new SchemeSpecification(
                 "https",
@@ -1426,58 +1426,58 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2818.html",
                 "Hypertext Transfer Protocol Secure",
                 "",
-                
+
                 new String[]{
-                  
+
       "https://www.example.org:443/foo/bar",
-    
+
       "https:foo/bar",
-    
+
       "https://user@www.example.org/foo/bar",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
       "https://www.example.org/foo/bar",
-    
+
                 }
             );
-            
-            
+
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc2818.html#sec-2.4",    
-                "HTTP/TLS is differentiated from HTTP URIs by using the 'https' protocol identifier in place of the 'http' protocol identifier.",    
+                "http://www.apps.ietf.org/rfc/rfc2818.html#sec-2.4",
+                "HTTP/TLS is differentiated from HTTP URIs by using the 'https' protocol identifier in place of the 'http' protocol identifier.",
                 "HTTP/TLS is differentiated from HTTP URIs by using the 'https' protocol identifier in place of the 'http' protocol identifier."
         );
-    
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc2818.html#sec-3.2.2",    
+                "http://www.apps.ietf.org/rfc/rfc2818.html#sec-3.2.2",
                 ""+
   "\n"+
     "http_URL = \"http:\" \"//\" host [ \":\" port ] [ abs_path [ \"?\" query ]]\n"+
-    "",    
+    "",
                 ""+
      "</p><pre>\n"+
     "http_URL = \"http:\" \"//\" host [ \":\" port ] [ abs_path [ \"?\" query ]]\n"+
     "</pre>"+
      "<p>"
         );
-    
+
         spec.setDNS(true);
-    
+
         spec.port(443);
-    
+
         spec.prohibit(
               IRIComponents.USER
         );
-    
+
         spec.require(
               IRIComponents.HOST
         );
-    
+
      spec =
        new SchemeSpecification(
                 "ftp",
@@ -1485,28 +1485,28 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.2",
                 "File Transfer Protocol",
                 "3.2",
-                
+
                 new String[]{
-                  
+
       "ftp:///foo/bar",
-    
+
       "ftp://user@example.org/foo/bar;type=z",
-    
+
       "ftp://user@example.org/foo/b;ar;type=d",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
       "ftp://user@example.org/foo/bar;type=d",
-    
+
                 }
             );
-            
-            
+
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",    
+                "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
   "\n"+
     "ftpurl = \"ftp://\" login [ \"/\" fpath [ \";type=\" ftptype ]]\n"+
@@ -1523,7 +1523,7 @@ This class is not part of the API.
     "escape = \"%\" hex hex\n"+
     "unreserved = alpha | digit | safe | extra\n"+
     "uchar = unreserved | escape\n"+
-    "",    
+    "",
                 ""+
      "</p><pre>\n"+
     "ftpurl = \"ftp://\" login [ \"/\" fpath [ \";type=\" ftptype ]]\n"+
@@ -1545,20 +1545,20 @@ This class is not part of the API.
     "</pre>"+
      "<p>"
         );
-    
+
         spec.setDNS(true);
-    
+
         spec.port(21);
-    
+
         spec.require(
               IRIComponents.HOST
         );
-    
+
         spec.setPattern(PATHQUERY,
                 "[^;~]*(;@{mustLowerCase(type)}=@{shouldLowerCase([aid])}|)" );
-      
+
         spec.setReserved(PATHQUERY,"~;");
-      
+
      spec =
        new SchemeSpecification(
                 "mailto",
@@ -1566,21 +1566,21 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2368.html",
                 "Electronic mail address",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
         spec.prohibit(
               IRIComponents.AUTHORITY
         );
-    
+
      spec =
        new SchemeSpecification(
                 "news",
@@ -1588,36 +1588,36 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.6",
                 "USENET news",
                 "3.6",
-                
+
                 new String[]{
-                  
+
       "news:arbitrary@news.exampl\u00E7.org",
-    
+
       "news:arbitr?ary@news.exampl\u00E7.org",
-    
+
       "news:///foo/bar",
-    
+
       "news://user@example.org/foo",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
       "news:*",
-    
+
       "news:group.it",
-    
+
       "news:arb?itrary@news.example.org",
-    
+
       "news:arbitrary@news.example.org",
-    
+
                 }
             );
-            
-            
+
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",    
+                "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
   "\n"+
     "newsurl = \"news:\" grouppart\n"+
@@ -1631,7 +1631,7 @@ This class is not part of the API.
     "escape = \"%\" hex hex\n"+
     "unreserved = alpha | digit | safe | extra\n"+
     "uchar = unreserved | escape\n"+
-    "",    
+    "",
                 ""+
      "</p><pre>\n"+
     "newsurl = \"news:\" grouppart\n"+
@@ -1649,20 +1649,20 @@ This class is not part of the API.
     "</pre>"+
      "<p>"
         );
-    
+
         spec.prohibit(
               IRIComponents.AUTHORITY
         );
-    
+
         spec.require(
               IRIComponents.PATH
         );
-    
+
         spec.setPattern(PATHQUERY,
                 "[^@]+@@{host}|[*]|[a-zA-Z][-a-zA-Z0-9.+_]*" );
-      
+
         spec.setReserved(PATHQUERY,"~@");
-      
+
      spec =
        new SchemeSpecification(
                 "nntp",
@@ -1670,45 +1670,45 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.7",
                 "USENET news using NNTP access",
                 "3.7",
-                
+
                 new String[]{
-                  
+
       "nntp://user@example.org/foo",
-    
+
       "nntp:/foo",
-    
+
       "nntp:///foo",
-    
+
       "nntp://example.org/foo/4/3",
-    
+
       "nntp://example.org/",
-    
+
       "nntp://example.org/foo/",
-    
+
       "nntp://example.org/*",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
       "nntp://example.org/foo4",
-    
+
       "nntp://example.org/foo/4",
-    
+
                 }
             );
-            
-            
+
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",    
+                "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
   "\n"+
     "nntpurl = \"nntp://\" hostport \"/\" group [ \"/\" digits ]\n"+
     ""+
   "\n"+
     "group = alpha *[ alpha | digit | \"-\" | \".\" | \"+\" | \"_\" ]\n"+
-    "",    
+    "",
                 ""+
      "</p><pre>\n"+
     "nntpurl = \"nntp://\" hostport \"/\" group [ \"/\" digits ]\n"+
@@ -1719,26 +1719,26 @@ This class is not part of the API.
     "</pre>"+
      "<p>"
         );
-    
+
         spec.setDNS(true);
-    
+
         spec.port(119);
-    
+
         spec.prohibit(
               IRIComponents.QUERY
         );
-    
+
         spec.prohibit(
               IRIComponents.USER
         );
-    
+
         spec.require(
               IRIComponents.HOST
         );
-    
+
         spec.setPattern(PATH,
                 "/[a-zA-Z][-a-zA-Z0-9.+_]*(/[0-9]+)?" );
-      
+
      spec =
        new SchemeSpecification(
                 "telnet",
@@ -1746,17 +1746,17 @@ This class is not part of the API.
                 "http://www.ietf.org/rfc/rfc4248.txt",
                 "Reference to interactive sessions",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "wais",
@@ -1764,17 +1764,17 @@ This class is not part of the API.
                 "http://www.ietf.org/rfc/rfc4156.txt",
                 "Wide Area Information Servers",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "file",
@@ -1782,36 +1782,36 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.10",
                 "Host-specific file names",
                 "3.10",
-                
+
                 new String[]{
-                  
+
       "file://user@example.org/foo/bar",
-    
+
       "file://eg:4029/foo/bar",
-    
+
       "file:/foo/bar",
-    
+
       "file://example.org",
-    
+
       "file://foo/bar;t",
-    
+
       "file://foo/~jjc",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
       "file:///foo/b",
-    
+
       "file:///foo/b?ar/yuk",
-    
+
                 }
             );
-            
-            
+
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",    
+                "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
   "\n"+
     "fileurl = \"file://\" [ host | \"localhost\" ] \"/\" fpath\n"+
@@ -1826,7 +1826,7 @@ This class is not part of the API.
     "escape = \"%\" hex hex\n"+
     "unreserved = alpha | digit | safe | extra\n"+
     "uchar = unreserved | escape\n"+
-    "",    
+    "",
                 ""+
      "</p><pre>\n"+
     "fileurl = \"file://\" [ host | \"localhost\" ] \"/\" fpath\n"+
@@ -1846,30 +1846,30 @@ This class is not part of the API.
     "</pre>"+
      "<p>"
         );
-    
+
         spec.setDNS(true);
-    
+
         spec.prohibit(
               IRIComponents.USER
         );
-    
+
         spec.prohibit(
               IRIComponents.PORT
         );
-    
+
         spec.require(
               IRIComponents.PATH
         );
-    
+
         spec.require(
               IRIComponents.AUTHORITY
         );
-    
+
         spec.setPattern(PATHQUERY,
                 "[^;~]*" );
-      
+
         spec.setReserved(PATHQUERY,"~;");
-      
+
      spec =
        new SchemeSpecification(
                 "prospero",
@@ -1877,17 +1877,17 @@ This class is not part of the API.
                 "http://www.ietf.org/rfc/rfc4157.txt",
                 "Prospero Directory Service",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "gopher",
@@ -1895,17 +1895,17 @@ This class is not part of the API.
                 "http://www.ietf.org/rfc/rfc4266.txt",
                 "The gopher URI scheme",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "z39.50s",
@@ -1913,17 +1913,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2056.html",
                 "Z39.50 Session",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "z39.50r",
@@ -1931,17 +1931,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2056.html",
                 "Z39.50 Retrieval",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "cid",
@@ -1949,17 +1949,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2392.html",
                 "content identifier",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "mid",
@@ -1967,17 +1967,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2392.html",
                 "message identifier",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "vemmi",
@@ -1985,17 +1985,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2122.html",
                 "versatile multimedia interface",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "service",
@@ -2003,17 +2003,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2609.html",
                 "service location",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "imap",
@@ -2021,17 +2021,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2192.html",
                 "internet message access protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "nfs",
@@ -2039,17 +2039,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2224.html",
                 "network file system protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "acap",
@@ -2057,17 +2057,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2244.html",
                 "application configuration access protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "rtsp",
@@ -2075,17 +2075,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2326.html",
                 "real time streaming protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "tip",
@@ -2093,17 +2093,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2371.html",
                 "Transaction Internet Protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "pop",
@@ -2111,17 +2111,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2384.html",
                 "Post Office Protocol v3",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "data",
@@ -2129,17 +2129,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2397.html",
                 "data",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "dav",
@@ -2147,17 +2147,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2518.html",
                 "dav",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "opaquelocktoken",
@@ -2165,17 +2165,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2518.html",
                 "opaquelocktoken",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "sip",
@@ -2183,17 +2183,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3261.html",
                 "session initiation protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "sips",
@@ -2201,17 +2201,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3261.html",
                 "secure session intitiaion protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "tel",
@@ -2219,17 +2219,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2806.html",
                 "telephone",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "fax",
@@ -2237,17 +2237,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2806.html",
                 "fax",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "modem",
@@ -2255,17 +2255,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2806.html",
                 "modem",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "soap.beep",
@@ -2273,17 +2273,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3288.html",
                 "soap.beep",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "soap.beeps",
@@ -2291,17 +2291,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3288.html",
                 "soap.beeps",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "xmlrpc.beep",
@@ -2309,17 +2309,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3529.html",
                 "xmlrpc.beep",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "xmlrpc.beeps",
@@ -2327,17 +2327,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3529.html",
                 "xmlrpc.beeps",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "urn",
@@ -2345,48 +2345,48 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2141.html",
                 "Uniform Resource Names",
                 "",
-                
+
                 new String[]{
-                  
+
       "urn:x-hp:foo/bar",
-    
+
       "urn:urn:foo",
-    
+
       "urn://foo",
-    
+
       "urn:foo:bar?query",
-    
+
       "urn:foo:ff~",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
       "urn:x-hp:foo\u00E9",
-    
+
       "urn:urn-1:foo",
-    
+
                 }
             );
-            
-            
+
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2",    
+                "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2",
                 "All URNs have the following syntax (phrases enclosed in quotes are REQUIRED):"+
   "\n"+
     "<URN&gt; ::= \"urn:\" <NID&gt; \":\" <NSS&gt;\n"+
-    "",    
+    "",
                 "All URNs have the following syntax (phrases enclosed in quotes are REQUIRED):"+
      "</p><pre>\n"+
     "&lt;URN&gt; ::= \"urn:\" &lt;NID&gt; \":\" &lt;NSS&gt;\n"+
     "</pre>"+
      "<p>"
         );
-    
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.1",    
+                "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.1",
                 ""+
   "\n"+
     "<NID&gt;         ::= <let-num&gt; [ 1,31<let-num-hyp&gt; ]\n"+
@@ -2394,7 +2394,7 @@ This class is not part of the API.
     "<let-num-hyp&gt; ::= <upper&gt; | <lower&gt; | <number&gt; | \"-\"\n"+
     "\n"+
     "<let-num&gt;     ::= <upper&gt; | <lower&gt; | <number&gt;\n"+
-    "",    
+    "",
                 ""+
      "</p><pre>\n"+
     "&lt;NID&gt;         ::= &lt;let-num&gt; [ 1,31&lt;let-num-hyp&gt; ]\n"+
@@ -2405,10 +2405,10 @@ This class is not part of the API.
     "</pre>"+
      "<p>"
         );
-    
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.2",    
+                "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.2",
                 ""+
   "\n"+
     "<NSS&gt;         ::= 1*<URN chars&gt;\n"+
@@ -2420,7 +2420,7 @@ This class is not part of the API.
     "<other&gt;       ::= \"(\" | \")\" | \"+\" | \",\" | \"-\" | \".\" |\n"+
     "                  \":\" | \"=\" | \"@\" | \";\" | \"$\" |\n"+
     "                  \"_\" | \"!\" | \"*\" | \"'\"\n"+
-    "",    
+    "",
                 ""+
      "</p><pre>\n"+
     "&lt;NSS&gt;         ::= 1*&lt;URN chars&gt;\n"+
@@ -2435,14 +2435,14 @@ This class is not part of the API.
     "</pre>"+
      "<p>"
         );
-    
+
         spec
         .addDefinition(
-                "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.3.2",    
-                "RFC 1630 [2] reserves the characters \"/\", \"?\", and \"#\" for particular purposes. The URN-WG has not yet debated the applicability and precise semantics of those purposes as applied to URNs. Therefore, these characters are RESERVED for future developments. Namespace developers SHOULD NOT use these characters in unencoded form, but rather use the appropriate %-encoding for each character.",    
+                "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.3.2",
+                "RFC 1630 [2] reserves the characters \"/\", \"?\", and \"#\" for particular purposes. The URN-WG has not yet debated the applicability and precise semantics of those purposes as applied to URNs. Therefore, these characters are RESERVED for future developments. Namespace developers SHOULD NOT use these characters in unencoded form, but rather use the appropriate %-encoding for each character.",
                 "RFC 1630 [2] reserves the characters \"/\", \"?\", and \"#\" for particular purposes. The URN-WG has not yet debated the applicability and precise semantics of those purposes as applied to URNs. Therefore, these characters are RESERVED for future developments. Namespace developers SHOULD NOT use these characters in unencoded form, but rather use the appropriate %-encoding for each character."
         );
-    
+
         spec.prohibit(
               IRIComponents.AUTHORITY
         );
@@ -2452,22 +2452,22 @@ This class is not part of the API.
 //        spec.prohibit(
 //              IRIComponents.QUERY
 //        );
-    
+
         spec.require(
               IRIComponents.PATH
         );
-    
+
         spec.setPattern(QUERY, "[+=].*");
-        
+
         spec.setPattern(PATH,
-                // RFC 2141 - 
+                // RFC 2141 -
                 //"(?![uU][rR][nN]:)[a-zA-Z0-9][-a-zA-Z0-9]{1,31}:[^/~]+"
                 // RFC 8141 revision of 2141 - JENA-1647
                 "(?![uU][rR][nN]:)[a-zA-Z0-9][-a-zA-Z0-9]{1,31}:.*"
                 );
-      
+
         spec.setReserved(PATH,"/~");
-      
+
      spec =
        new SchemeSpecification(
                 "go",
@@ -2475,17 +2475,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3368.html",
                 "go",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "h323",
@@ -2493,17 +2493,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3508.html",
                 "H.323",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "ipp",
@@ -2511,17 +2511,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3510.html",
                 "Internet Printing Protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "tftp",
@@ -2529,17 +2529,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3617.html",
                 "Trivial File Transfer Protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "mupdate",
@@ -2547,17 +2547,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3656.html",
                 "Mailbox Update (MUPDATE) Protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "pres",
@@ -2565,17 +2565,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3859.html",
                 "Presence",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "im",
@@ -2583,17 +2583,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3860.html",
                 "Instant Messaging",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "mtqp",
@@ -2601,17 +2601,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3887.html",
                 "Message Tracking Query Protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "iris.beep",
@@ -2619,17 +2619,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc3983.html",
                 "iris.beep",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "dict",
@@ -2637,17 +2637,17 @@ This class is not part of the API.
                 "http://www.apps.ietf.org/rfc/rfc2229.html",
                 "dictionary service protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "snmp",
@@ -2655,17 +2655,17 @@ This class is not part of the API.
                 "http://www.ietf.org/rfc/rfc4088.txt",
                 "Simple Network Management Protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "crid",
@@ -2673,17 +2673,17 @@ This class is not part of the API.
                 "http://www.ietf.org/rfc/rfc4078.txt",
                 "TV-Anytime Content Reference Identifier",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "tag",
@@ -2691,17 +2691,17 @@ This class is not part of the API.
                 "http://www.ietf.org/rfc/rfc4151.txt",
                 "tag",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "afs",
@@ -2709,17 +2709,17 @@ This class is not part of the API.
                 "http://www.iana.org/assignments/uri-schemes",
                 "Andrew File System global file names",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "tn3270",
@@ -2727,17 +2727,17 @@ This class is not part of the API.
                 "http://www.iana.org/assignments/uri-schemes",
                 "Interactive 3270 emulation sessions",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "mailserver",
@@ -2745,17 +2745,17 @@ This class is not part of the API.
                 "http://www.iana.org/assignments/uri-schemes",
                 "Access to data available from mail servers",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "dns",
@@ -2763,17 +2763,17 @@ This class is not part of the API.
                 "http://www.iana.org/assignments/uri-schemes",
                 "Domain Name System",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "info",
@@ -2781,17 +2781,17 @@ This class is not part of the API.
                 "http://www.iana.org/assignments/uri-schemes",
                 "Information Assets with Identifiers in Public Namespaces",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
      spec =
        new SchemeSpecification(
                 "ldap",
@@ -2799,17 +2799,17 @@ This class is not part of the API.
                 "http://www.iana.org/assignments/uri-schemes",
                 "Lightweight Directory Access Protocol",
                 "",
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 }
             );
-            
-            
+
+
             new ViolationCodeInfo(
                 ILLEGAL_CHARACTER,
                 "ILLEGAL_CHARACTER",
@@ -2817,51 +2817,51 @@ This class is not part of the API.
                 "<p>The character violates the grammar rules for URIs/IRIs.</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "URI",
                 "http://www.apps.ietf.org/rfc/rfc3986.html#page-49"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html#sec-2.2"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "ht$tp://example.org/foo",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 PERCENT_ENCODING_SHOULD_BE_UPPERCASE,
                 "PERCENT_ENCODING_SHOULD_BE_UPPERCASE",
@@ -2869,9 +2869,9 @@ This class is not part of the API.
                 "<p>Percent-escape sequences should use uppercase.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-2.1",
                 "URI producers and normalizers should use *uppercase* hexadecimal digits for all percent-encodings.",
@@ -2879,46 +2879,46 @@ This class is not part of the API.
      " <em>uppercase</em> "+
      "hexadecimal digits for all percent-encodings.</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/foo%c3%80",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 SUPERFLUOUS_NON_ASCII_PERCENT_ENCODING,
                 "SUPERFLUOUS_NON_ASCII_PERCENT_ENCODING",
@@ -2926,29 +2926,29 @@ This class is not part of the API.
                 "<p>Percent-escape sequences should not be used unnecessarily.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html#sec-3.2",
                 "URI-to-IRI conversion removes percent-encodings",
                 "<p>URI-to-IRI conversion removes percent-encodings</p>"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/foo%C3%A9r",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 SUPERFLUOUS_ASCII_PERCENT_ENCODING,
                 "SUPERFLUOUS_ASCII_PERCENT_ENCODING",
@@ -2956,54 +2956,54 @@ This class is not part of the API.
                 "<p>Percent-escape sequences should not be used unnecessarily.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-2.3",
                 "For consistency, percent-encoded octets in the ranges of ALPHA (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should not be created by URI producers",
                 "<p>For consistency, percent-encoded octets in the ranges of ALPHA (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should not be created by URI producers</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/foo%5Fb%61r",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 UNWISE_CHARACTER,
                 "UNWISE_CHARACTER",
@@ -3011,42 +3011,42 @@ This class is not part of the API.
                 "<p>The character matches no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, and XML Schema anyURIs.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html#page-13",
                 "Systems accepting IRIs MAY also deal with the printable characters in US-ASCII that are not allowed in URIs, namely \"<\", \"&gt;\", '\"', space, \"{\", \"}\", \"|\", \"\\\", \"^\", and \"`\", in step 2 above. If these characters are found but are not converted, then the conversion SHOULD fail.",
                 "<p>Systems accepting IRIs MAY also deal with the printable characters in US-ASCII that are not allowed in URIs, namely \"&lt;\", \"&gt;\", '\"', space, \"{\", \"}\", \"|\", \"\\\", \"^\", and \"`\", in step 2 above. If these characters are found but are not converted, then the conversion SHOULD fail.</p>"
             ),
-    
+
             new FromAlso(
                 "URI",
                 "http://www.apps.ietf.org/rfc/rfc3986.html#page-49"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/fo|o",
-    
+
       "http://example.org/fo<o",
-    
+
       "http://example.org/fo&gt;o",
-    
+
       "http://example.org/fo\"o",
-    
+
       "http://example.org/fo`o",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 CONTROL_CHARACTER,
                 "CONTROL_CHARACTER",
@@ -3054,9 +3054,9 @@ This class is not part of the API.
                 "<p>Control characters are not allowed in URIs or RDF URI References.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "RDF", 
+                "RDF",
                 -1,
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref",
                 "A URI reference within an RDF graph (an RDF URI reference) is a Unicode string [UNICODE] that: (0)does not contain any control characters ( #x00 - #x1F, #x7F-#x9F) ",
@@ -3066,9 +3066,9 @@ This class is not part of the API.
      "</ul>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html",
                 ""+
@@ -3091,32 +3091,32 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
             new FromAlso(
                 "URI",
                 "http://www.apps.ietf.org/rfc/rfc3986.html"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/fo\u007Fo",
-    
+
       "http://example.org/fo\u0085o",
-    
+
       "http://example.org/fo\u0009o",
-    
+
       "http://example.org/fo\u0001o",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 NON_XML_CHARACTER,
                 "NON_XML_CHARACTER",
@@ -3124,39 +3124,39 @@ This class is not part of the API.
                 "<p>The character is not legal in XML.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "XML", 
+                "XML",
                 -1,
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#NT-Char",
                 "Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]",
                 "<p>Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]</p>"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/foo\u0001",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 DISCOURAGED_XML_CHARACTER,
                 "DISCOURAGED_XML_CHARACTER",
@@ -3164,39 +3164,39 @@ This class is not part of the API.
                 "<p>The character is discouraged in XML documents.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "XML", 
+                "XML",
                 -1,
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#char32",
                 "Document authors are encouraged to avoid \"compatibility characters\", as defined in section 6.8 of [Unicode] (see also D21 in section 3.6 of [Unicode3]). The characters defined in the following ranges are also discouraged. They are either control characters or permanently undefined Unicode characters: [#x7F-#x84], [#x86-#x9F], [#xFDD0-#xFDDF],",
                 "<p>Document authors are encouraged to avoid \"compatibility characters\", as defined in section 6.8 of [Unicode] (see also D21 in section 3.6 of [Unicode3]). The characters defined in the following ranges are also discouraged. They are either control characters or permanently undefined Unicode characters: [#x7F-#x84], [#x86-#x9F], [#xFDD0-#xFDDF],</p>"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/foo\u0080",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 NON_INITIAL_DOT_SEGMENT,
                 "NON_INITIAL_DOT_SEGMENT",
@@ -3204,9 +3204,9 @@ This class is not part of the API.
                 "<p>The path contains a segment /../ not at the beginning of a relative reference, or it contains a /./ These should be removed.</p>",
                 0|Force.minting|Force.security,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-6.2.2.3",
                 "The complete path segments \".\" and \"..\" are intended *only* for use within relative references",
@@ -3214,56 +3214,56 @@ This class is not part of the API.
      " <em>only</em> "+
      "for use within relative references</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/../foo",
-    
+
       "http://example.org/foo/../foo",
-    
+
       "http://example.org/foo/..",
-    
+
       "http://example.org/foo/./foo",
-    
+
       "http://example.org/./foo",
-    
+
       "http://example.org/foo/.",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 EMPTY_SCHEME,
                 "EMPTY_SCHEME",
@@ -3271,9 +3271,9 @@ This class is not part of the API.
                 "<p>The scheme component is empty.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.1",
                 "Scheme names consist of a sequence of characters *beginning with a letter* and followed by any combination of letters, digits, plus (\"+\"), period (\".\"), or hyphen (\"-\").",
@@ -3281,46 +3281,46 @@ This class is not part of the API.
      " <em>beginning with a letter</em> "+
      "and followed by any combination of letters, digits, plus (\"+\"), period (\".\"), or hyphen (\"-\").</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "://example.org/foo",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 SCHEME_MUST_START_WITH_LETTER,
                 "SCHEME_MUST_START_WITH_LETTER",
@@ -3328,9 +3328,9 @@ This class is not part of the API.
                 "<p>The scheme component must start with a letter.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.1",
                 "Scheme names consist of a sequence of characters *beginning with a letter* and followed by any combination of letters, digits, plus (\"+\"), period (\".\"), or hyphen (\"-\").",
@@ -3338,46 +3338,46 @@ This class is not part of the API.
      " <em>beginning with a letter</em> "+
      "and followed by any combination of letters, digits, plus (\"+\"), period (\".\"), or hyphen (\"-\").</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "007://example.org/foo",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 LOWERCASE_PREFERRED,
                 "LOWERCASE_PREFERRED",
@@ -3385,17 +3385,17 @@ This class is not part of the API.
                 "<p>lowercase is preferred in this component</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 SCHEME,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.1",
                 "An implementation should accept uppercase letters as equivalent to lowercase in scheme names (e.g., allow \"HTTP\" as well as \"http\") for the sake of robustness but should only produce lowercase scheme names for consistency.",
                 "<p>An implementation should accept uppercase letters as equivalent to lowercase in scheme names (e.g., allow \"HTTP\" as well as \"http\") for the sake of robustness but should only produce lowercase scheme names for consistency.</p>"
             ),
-    
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 HOST,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "Although host is case-insensitive, producers and normalizers should use *lowercase for registered names* and hexadecimal addresses for the sake of uniformity, while only using uppercase letters for percent-encodings.",
@@ -3403,48 +3403,48 @@ This class is not part of the API.
      " <em>lowercase for registered names</em> "+
      "and hexadecimal addresses for the sake of uniformity, while only using uppercase letters for percent-encodings.</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "HTTP://example.org/foo",
-    
+
       "http://eXamPle.org/foo",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 PORT_SHOULD_NOT_BE_EMPTY,
                 "PORT_SHOULD_NOT_BE_EMPTY",
@@ -3452,9 +3452,9 @@ This class is not part of the API.
                 "<p>The colon introducing an empty port component should be omitted entirely, or a port number should be specified.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "URI producers and normalizers should omit the port component *and its \":\" delimiter* if port is empty",
@@ -3462,46 +3462,46 @@ This class is not part of the API.
      " <em>and its \":\" delimiter</em> "+
      "if port is empty</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org:/foo",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 DEFAULT_PORT_SHOULD_BE_OMITTED,
                 "DEFAULT_PORT_SHOULD_BE_OMITTED",
@@ -3509,9 +3509,9 @@ This class is not part of the API.
                 "<p>If the port is the default one for the scheme it should be omitted.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "URI producers and normalizers should omit the port component and its \":\" delimiter if port is empty or if its value would be the *same as that of the scheme's default.* ",
@@ -3519,46 +3519,46 @@ This class is not part of the API.
      " <em>same as that of the scheme's default.</em> "+
      "</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org:80/foo",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 PORT_SHOULD_NOT_BE_WELL_KNOWN,
                 "PORT_SHOULD_NOT_BE_WELL_KNOWN",
@@ -3566,9 +3566,9 @@ This class is not part of the API.
                 "<p>Ports under 1024 should be accessed using the appropriate scheme name.</p>",
                 0|Force.security,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-7.2",
                 "Applications should prevent dereference of a URI that specifies a TCP port number within the \"well-known port\" range *(0 - 1023)* unless the protocol being used to dereference that URI is compatible with the protocol expected on that well-known port.",
@@ -3576,46 +3576,46 @@ This class is not part of the API.
      " <em>(0 - 1023)</em> "+
      "unless the protocol being used to dereference that URI is compatible with the protocol expected on that well-known port.</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org:180/foo",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 PORT_SHOULD_NOT_START_IN_ZERO,
                 "PORT_SHOULD_NOT_START_IN_ZERO",
@@ -3623,51 +3623,51 @@ This class is not part of the API.
                 "<p>Leading zeros in the port number should be omitted. This is an added feature of this implementation, not mandated by any standard.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "URI",
                 "http://www.apps.ietf.org/rfc/rfc3986.html"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org:08080/foo",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 BIDI_FORMATTING_CHARACTER,
                 "BIDI_FORMATTING_CHARACTER",
@@ -3675,41 +3675,41 @@ This class is not part of the API.
                 "<p>A prohibited bi-directional control character was found.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html#sec-4.1",
                 "IRIs MUST NOT contain bidirectional formatting characters (LRM, RLM, LRE, RLE, LRO, RLO, and PDF).",
                 "<p>IRIs MUST NOT contain bidirectional formatting characters (LRM, RLM, LRE, RLE, LRO, RLO, and PDF).</p>"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/Andr\u202Abar",
-    
+
       "http://example.org/Andr\u202Bbar",
-    
+
       "http://example.org/Andr\u202Cbar",
-    
+
       "http://example.org/Andr\u202Dbar",
-    
+
       "http://example.org/Andr\u202Ebar",
-    
+
       "http://example.org/Andr\u200Ebar",
-    
+
       "http://example.org/Andr\u200Fbar",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 WHITESPACE,
                 "WHITESPACE",
@@ -3717,33 +3717,33 @@ This class is not part of the API.
                 "<p>A single whitespace character. These match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, and XML Schema anyURIs.</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "URI",
                 "http://www.apps.ietf.org/rfc/rfc3986.html"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/ foo",
-    
+
       "file:///Program Files",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 DOUBLE_WHITESPACE,
                 "DOUBLE_WHITESPACE",
@@ -3751,42 +3751,42 @@ This class is not part of the API.
                 "<p>Either two or more consecutive whitespace characters, or leading or trailing whitespace. These match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, but not XML Schema anyURIs.</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "URI",
                 "http://www.apps.ietf.org/rfc/rfc3986.html"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/  foo",
-    
+
       "file:///Program  Files",
-    
+
       "file:///TabBar ",
-    
+
       " rel-with-initial-space",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 NOT_XML_SCHEMA_WHITESPACE,
                 "NOT_XML_SCHEMA_WHITESPACE",
@@ -3794,19 +3794,19 @@ This class is not part of the API.
                 "<p>Whitespace characters match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, and XML system identifiers. However, tab and new line characters, and consecutive space characters cannot occur in XML Schema anyURIs.</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "URI",
                 "http://www.apps.ietf.org/rfc/rfc3986.html"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
        new FromSpec_iri(
-                "Schema", 
+                "Schema",
                 -1,
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#schema",
                 ""+
@@ -3831,106 +3831,106 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "file:///Tab\u0009Bar",
-    
+
       "file:///Tab\nBar",
-    
+
       "file:///Tab\rBar",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 DOUBLE_DASH_IN_REG_NAME,
                 "DOUBLE_DASH_IN_REG_NAME",
                 new String[]{
-                  
+
       "http://foo--bar//",
-    
+
                 },
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 SCHEME_INCLUDES_DASH,
                 "SCHEME_INCLUDES_DASH",
                 new String[]{
-                  
+
       "ht-tp://foo.bar//",
-    
+
       "-http://foo.bar//",
-    
+
       "http-://foo.bar//",
-    
+
                 },
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 NON_URI_CHARACTER,
                 "NON_URI_CHARACTER",
                 new String[]{
-                  
+
       "http://foo-bar//̳a",
-    
+
       "http://foo-b̳ar//",
-    
+
                 },
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 PERCENT_20,
                 "PERCENT_20",
                 new String[]{
-                  
+
       "http://foo-bar//%20a",
-    
+
                 },
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 PERCENT,
                 "PERCENT",
                 new String[]{
-                  
+
       "http://foo-bar//%AAa",
-    
+
                 },
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 IP_V6_OR_FUTURE_ADDRESS_SYNTAX,
                 "IP_V6_OR_FUTURE_ADDRESS_SYNTAX",
@@ -3938,9 +3938,9 @@ This class is not part of the API.
                 "<p>A syntax violation was detected in an IP V6 (or future) address.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 ""+
@@ -3983,50 +3983,50 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://[/",
-    
+
       "ldap://[20015:db8::7]/c=GB?objectClass?one",
-    
+
       "ldap://[2001:db8:::7]/c=GB?objectClass?one",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 IPv6ADDRESS_SHOULD_BE_LOWERCASE,
                 "IPv6ADDRESS_SHOULD_BE_LOWERCASE",
@@ -4034,9 +4034,9 @@ This class is not part of the API.
                 "<p>IP version 6 addresses should use lowercase hexadecimal</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "Although host is case-insensitive, producers and normalizers *should use lowercase* for registered names and *hexadecimal addresses* for the sake of uniformity",
@@ -4046,48 +4046,48 @@ This class is not part of the API.
      " <em>hexadecimal addresses</em> "+
      "for the sake of uniformity</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "ldap://[2001:Db8::7]/c=GB?objectClass?one",
-    
+
       "ldap://[2001:dB8::7]/c=GB?objectClass?one",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 IP_V4_OCTET_RANGE,
                 "IP_V4_OCTET_RANGE",
@@ -4095,9 +4095,9 @@ This class is not part of the API.
                 "<p>A host entry consists of four numbers, but they are not in the range 0-255, or have leading zeros.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "A host identified by an IPv4 literal address is represented in dotted-decimal notation (a sequence of *four decimal numbers* in the range *0 to 255* , separated by \".\"),",
@@ -4107,9 +4107,9 @@ This class is not part of the API.
      " <em>0 to 255</em> "+
      ", separated by \".\"),</p>"
             ),
-    
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 ""+
@@ -4130,52 +4130,52 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "ldap://155.00.55.102/c=GB?objectClass?one",
-    
+
       "ldap://20.256.20.20/c=GB?objectClass?one",
-    
+
       "ldap://20.1000.20.20/c=GB?objectClass?one",
-    
+
       "ldap://20.010.20.20/c=GB?objectClass?one",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 NOT_DNS_NAME,
                 "NOT_DNS_NAME",
@@ -4183,9 +4183,9 @@ This class is not part of the API.
                 "<p>The host component did not meet the restrictions on DNS names.</p>",
                 0|Force.dns,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "URI producers should use names that *conform to the DNS syntax* , even when use of DNS is not immediately apparent, and should limit these names to no more than 255 characters in length.",
@@ -4193,48 +4193,48 @@ This class is not part of the API.
      " <em>conform to the DNS syntax</em> "+
      ", even when use of DNS is not immediately apparent, and should limit these names to no more than 255 characters in length.</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "ldap://foo$/c=GB?objectClass?one",
-    
+
       "http://foo.example.$org/",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 USE_PUNYCODE_NOT_PERCENTS,
                 "USE_PUNYCODE_NOT_PERCENTS",
@@ -4242,54 +4242,54 @@ This class is not part of the API.
                 "<p>The host component used percent encoding, where punycode is preferred.</p>",
                 0|Force.minting|Force.dns,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "URI producers should provide these registered names in the IDNA encoding, rather than a percent-encoding, if they wish to maximize interoperability with legacy URI resolvers.",
                 "<p>URI producers should provide these registered names in the IDNA encoding, rather than a percent-encoding, if they wish to maximize interoperability with legacy URI resolvers.</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "ftp://andr%C3%A9.example.org/",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 ILLEGAL_PERCENT_ENCODING,
                 "ILLEGAL_PERCENT_ENCODING",
@@ -4297,77 +4297,77 @@ This class is not part of the API.
                 "<p>The host component a percent occurred without two following hexadecimal digits.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-2.1",
                 "A percent-encoded octet is encoded as a character triplet, consisting of the percent character \"%\" followed by the two hexadecimal digits representing that octet's numeric value.",
                 "<p>A percent-encoded octet is encoded as a character triplet, consisting of the percent character \"%\" followed by the two hexadecimal digits representing that octet's numeric value.</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "ftp://andr%%A9.example.org/",
-    
+
       "ftp://andr%.example.org/",
-    
+
       "ftp://andre.example.org/%",
-    
+
       "ftp://andre.example.org/%A",
-    
+
       "ftp://andre.example.org/%A?",
-    
+
       "ftp://andre.example.org/%A#",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 ACE_PREFIX,
                 "ACE_PREFIX",
                 new String[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 LONE_SURROGATE,
                 "LONE_SURROGATE",
@@ -4375,21 +4375,21 @@ This class is not part of the API.
                 "<p>A unicode surrogate character that is not of a surrogate pair.</p>",
                 0,
                 new InSpec[]{
-                  
+
                 },
                 new String[]{
-                  
+
       "http:/foo/p\uD800",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 DNS_LABEL_DASH_START_OR_END,
                 "DNS_LABEL_DASH_START_OR_END",
@@ -4397,62 +4397,62 @@ This class is not part of the API.
                 "<p>A DNS name had a - at the beginning or end.</p>",
                 0|Force.dns,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "Such a name consists of a sequence of domain labels separated by \".\", each domain label starting and ending with an alphanumeric character and possibly also containing \"-\" characters.",
                 "<p>Such a name consists of a sequence of domain labels separated by \".\", each domain label starting and ending with an alphanumeric character and possibly also containing \"-\" characters.</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "ldap://-foo/c=GB?objectClass?one",
-    
+
       "http://foo.example.org-/",
-    
+
       "http://foo.example.org--/",
-    
+
       "http://--foo.example.org/",
-    
+
       "http://-fo-o.example.org/",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 BAD_IDN_UNASSIGNED_CHARS,
                 "BAD_IDN_UNASSIGNED_CHARS",
@@ -4460,57 +4460,57 @@ This class is not part of the API.
                 "<p>Characters used in the IRI were unassigned in the version of Unicode known by this system. They may have been assigned since.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "When a non-ASCII registered name represents an internationalized domain name intended for resolution via the DNS, the name must be transformed to the IDNA encoding [RFC3490] prior to name lookup. URI producers should provide these registered names in the IDNA encoding, rather than a percent-encoding, if they wish to maximize interoperability with legacy URI resolvers.",
                 "<p>When a non-ASCII registered name represents an internationalized domain name intended for resolution via the DNS, the name must be transformed to the IDNA encoding [RFC3490] prior to name lookup. URI producers should provide these registered names in the IDNA encoding, rather than a percent-encoding, if they wish to maximize interoperability with legacy URI resolvers.</p>"
             ),
-    
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html#sec-3.1",
                 "Replace the ireg-name part of the IRI by the part converted using the ToASCII operation specified in section 4.1 of [RFC3490] on each dot-separated label, and by using U+002E (FULL STOP) as a label separator, with the flag UseSTD3ASCIIRules set to TRUE, and with the flag AllowUnassigned set to FALSE for creating IRIs and set to TRUE otherwise.",
                 "<p>Replace the ireg-name part of the IRI by the part converted using the ToASCII operation specified in section 4.1 of [RFC3490] on each dot-separated label, and by using U+002E (FULL STOP) as a label separator, with the flag UseSTD3ASCIIRules set to TRUE, and with the flag AllowUnassigned set to FALSE for creating IRIs and set to TRUE otherwise.</p>"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://foo.example\u0221.org/",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 BAD_IDN,
                 "BAD_IDN",
@@ -4518,61 +4518,61 @@ This class is not part of the API.
                 "<p>The Internationalized Domain Name check failed.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2",
                 "When a non-ASCII registered name represents an internationalized domain name intended for resolution via the DNS, the name must be transformed to the IDNA encoding [RFC3490] prior to name lookup. URI producers should provide these registered names in the IDNA encoding, rather than a percent-encoding, if they wish to maximize interoperability with legacy URI resolvers.",
                 "<p>When a non-ASCII registered name represents an internationalized domain name intended for resolution via the DNS, the name must be transformed to the IDNA encoding [RFC3490] prior to name lookup. URI producers should provide these registered names in the IDNA encoding, rather than a percent-encoding, if they wish to maximize interoperability with legacy URI resolvers.</p>"
             ),
-    
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html#sec-3.1",
                 "Replace the ireg-name part of the IRI by the part converted using the ToASCII operation specified in section 4.1 of [RFC3490] on each dot-separated label, and by using U+002E (FULL STOP) as a label separator, with the flag UseSTD3ASCIIRules set to TRUE, and with the flag AllowUnassigned set to FALSE for creating IRIs and set to TRUE otherwise.",
                 "<p>Replace the ireg-name part of the IRI by the part converted using the ToASCII operation specified in section 4.1 of [RFC3490] on each dot-separated label, and by using U+002E (FULL STOP) as a label separator, with the flag UseSTD3ASCIIRules set to TRUE, and with the flag AllowUnassigned set to FALSE for creating IRIs and set to TRUE otherwise.</p>"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://--foo.example.org/",
-    
+
       "http://xn--andr--ep-.example.org/",
-    
+
       "http://xn.example.\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333/",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 HAS_PASSWORD,
                 "HAS_PASSWORD",
@@ -4580,62 +4580,62 @@ This class is not part of the API.
                 "<p>Including passwords in URIs is deprecated.</p>",
                 0|Force.must|Force.security,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.1",
                 "Use of the format \"user:password\" in the userinfo field is deprecated.",
                 "<p>Use of the format \"user:password\" in the userinfo field is deprecated.</p>"
             ),
-    
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.1",
                 "Applications may choose to ignore or reject such data when it is received as part of a reference and should reject the storage of such data in unencrypted form. The passing of authentication information in clear text has proven to be a security risk in almost every case where it has been used.",
                 "<p>Applications may choose to ignore or reject such data when it is received as part of a reference and should reject the storage of such data in unencrypted form. The passing of authentication information in clear text has proven to be a security risk in almost every case where it has been used.</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://user:pass@example.org/",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 DISCOURAGED_IRI_CHARACTER,
                 "DISCOURAGED_IRI_CHARACTER",
@@ -4643,35 +4643,35 @@ This class is not part of the API.
                 "<p>Certain characters are discouraged in IRIs.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html#sec-6.1",
                 "The UCS contains many areas of characters for which there are strong visual look-alikes. Because of the likelihood of transcription errors, these also should be avoided. This includes the full-width equivalents of Latin characters, half-width Katakana characters for Japanese, and many others. It also includes many look-alikes of \"space\", \"delims\", and \"unwise\", characters excluded in [RFC3491].",
                 "<p>The UCS contains many areas of characters for which there are strong visual look-alikes. Because of the likelihood of transcription errors, these also should be avoided. This includes the full-width equivalents of Latin characters, half-width Katakana characters for Japanese, and many others. It also includes many look-alikes of \"space\", \"delims\", and \"unwise\", characters excluded in [RFC3491].</p>"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/\u2000en-quad",
-    
+
       "http://example.org/\u205Fmedium-mathematical-space",
-    
+
       "http://example\uFF95.org/",
-    
+
       "http://example\uFF47.org/",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 BAD_BIDI_SUBCOMPONENT,
                 "BAD_BIDI_SUBCOMPONENT",
@@ -4679,9 +4679,9 @@ This class is not part of the API.
                 "<p>There are restrictions on bidi characters in subcomponents of IRIs</p>",
                 0|Force.should,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html#sec-4.2",
                 " (0)A component SHOULD NOT use both right-to-left and left-to-right characters. (1)A component using right-to-left characters SHOULD start and end with right-to-left characters. ",
@@ -4693,84 +4693,84 @@ This class is not part of the API.
      "</ol>"+
      "<p></p>"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 DNS_LENGTH_LIMIT,
                 "DNS_LENGTH_LIMIT",
                 new String[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 DNS_LABEL_LENGTH_LIMIT,
                 "DNS_LABEL_LENGTH_LIMIT",
                 new String[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 NOT_UTF8_ESCAPE,
                 "NOT_UTF8_ESCAPE",
                 new String[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 NOT_UTF8_ESCAPE_IN_HOST,
                 "NOT_UTF8_ESCAPE_IN_HOST",
                 new String[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 BAD_DOT_IN_IDN,
                 "BAD_DOT_IN_IDN",
                 new String[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 UNREGISTERED_IANA_SCHEME,
                 "UNREGISTERED_IANA_SCHEME",
@@ -4778,25 +4778,25 @@ This class is not part of the API.
                 "<p>The scheme name does not have a \"-\" in it, but is not in the IANA registry. (Last updated from the registry January 2006)</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_other(
-                "URL_Registratrion", 
+                "URL_Registratrion",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc2717.html#sec-",
                 "",
                 "<p></p>"
             ),
-    
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2",
                 "The NAMES of schemes registered in the IETF tree MUST NOT contain the dash (also known as the hyphen and minus sign) character ('-') USASCII value 2Dh. Use of this character can cause confusion with schemes registered in alternative trees (see section 3.3).",
                 "<p>The NAMES of schemes registered in the IETF tree MUST NOT contain the dash (also known as the hyphen and minus sign) character ('-') USASCII value 2Dh. Use of this character can cause confusion with schemes registered in alternative trees (see section 3.3).</p>"
             ),
-    
+
        new FromSpec_iri(
-                "URI", 
+                "URI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.3",
                 "The syntax for alternative trees shall be as follows: each tree will be identified by a unique prefix, which must be established in the same fashion as a URL scheme name in the IETF tree, except that the prefix must be defined by a Standards Track document. Scheme names in the new tree are then constructed by prepending the prefix to an identifier unique to each scheme in that tree, as prescribed by that tree's identifying document:"+
@@ -4809,46 +4809,46 @@ This class is not part of the API.
     "</pre>"+
      "<p>For instance, the \"foo\" tree would allow creation of scheme names of the form: \"foo-blahblah:\" and \"foo-bar:\", where the tree prescribes an arbitrary USASCII string following the tree's unique prefix.</p>"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "foo://example.org/bar",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 UNREGISTERED_NONIETF_SCHEME_TREE,
                 "UNREGISTERED_NONIETF_SCHEME_TREE",
@@ -4856,9 +4856,9 @@ This class is not part of the API.
                 "<p>The scheme name has a \"-\" in it, but it does not start in \"x-\" and the prefix is not known as the prefix of an alternative tree for URI schemes.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_other(
-                "URL_Registratrion", 
+                "URL_Registratrion",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc2717.html#sec-3.3",
                 "The syntax for alternative trees shall be as follows: each tree will be identified by a unique prefix, which must be established in the same fashion as a URL scheme name in the IETF tree, except that the prefix must be defined by a Standards Track document. Scheme names in the new tree are then constructed by prepending the prefix to an identifier unique to each scheme in that tree, as prescribed by that tree's identifying document:"+
@@ -4871,51 +4871,51 @@ This class is not part of the API.
     "</pre>"+
      "<p>For instance, the \"foo\" tree would allow creation of scheme names of the form: \"foo-blahblah:\" and \"foo-bar:\", where the tree prescribes an arbitrary USASCII string following the tree's unique prefix.</p>"
             ),
-    
+
             new FromAlso(
                 "URI",
                 "http://www.apps.ietf.org/rfc/rfc3986.html"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
             new FromAlso(
                 "XLink",
                 "http://www.w3.org/TR/2001/REC-xlink-20010627/#link-locators"
             ),
-    
+
             new FromAlso(
                 "XML",
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid"
             ),
-    
+
             new FromAlso(
                 "RDF",
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref"
             ),
-    
+
             new FromAlso(
                 "Schema",
                 "http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#anyURI"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "foo-bar://example.org/bar",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 NOT_NFC,
                 "NOT_NFC",
@@ -4923,29 +4923,29 @@ This class is not part of the API.
                 "<p>The IRI is not in Unicode Normal Form C.</p>",
                 0|Force.should,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html#sec-5.3.2.2",
                 "To avoid false negatives and problems with transcoding, IRIs SHOULD be created by using NFC.",
                 "<p>To avoid false negatives and problems with transcoding, IRIs SHOULD be created by using NFC.</p>"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/#Andre\u0301",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 NOT_NFKC,
                 "NOT_NFKC",
@@ -4953,29 +4953,29 @@ This class is not part of the API.
                 "<p>The IRI is not in Unicode Normal Form KC.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "IRI", 
+                "IRI",
                 -1,
                 "http://www.apps.ietf.org/rfc/rfc3987.html#sec-7.5",
                 "Although there may be exceptions, newly created resource names should generally be in NFKC",
                 "<p>Although there may be exceptions, newly created resource names should generally be in NFKC</p>"
             ),
-    
+
                 },
                 new String[]{
-                  
+
       "http://example.org/#Andre\u0301",
-    
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 DEPRECATED_UNICODE_CHARACTER,
                 "DEPRECATED_UNICODE_CHARACTER",
@@ -4983,29 +4983,29 @@ This class is not part of the API.
                 "<p>TODO</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "Unicode",
                 "http://www.unicode.org/"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 UNDEFINED_UNICODE_CHARACTER,
                 "UNDEFINED_UNICODE_CHARACTER",
@@ -5013,29 +5013,29 @@ This class is not part of the API.
                 "<p>TODO</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "Unicode",
                 "http://www.unicode.org/"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 PRIVATE_USE_CHARACTER,
                 "PRIVATE_USE_CHARACTER",
@@ -5043,29 +5043,29 @@ This class is not part of the API.
                 "<p>TODO</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "Unicode",
                 "http://www.unicode.org/"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 UNICODE_CONTROL_CHARACTER,
                 "UNICODE_CONTROL_CHARACTER",
@@ -5073,85 +5073,85 @@ This class is not part of the API.
                 "<p>TODO</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "Unicode",
                 "http://www.unicode.org/"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 UNASSIGNED_UNICODE_CHARACTER,
                 "UNASSIGNED_UNICODE_CHARACTER",
-                "The character code is not assigned in the version of Unicode implemented here. Check validity of code, consider updating your copy of icu4j.jar.",
-                "<p>The character code is not assigned in the version of Unicode implemented here. Check validity of code, consider updating your copy of icu4j.jar.</p>",
+                "The character code is not assigned in the version of Unicode implemented here.",
+                "<p>The character code is not assigned in the version of Unicode implemented here.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "Unicode",
                 "http://www.unicode.org/"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 MAYBE_NOT_NFC,
                 "MAYBE_NOT_NFC",
                 new String[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 MAYBE_NOT_NFKC,
                 "MAYBE_NOT_NFKC",
                 new String[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
                 true||
                 false
             );
-    
+
             new ViolationCodeInfo(
                 UNICODE_WHITESPACE,
                 "UNICODE_WHITESPACE",
@@ -5159,29 +5159,29 @@ This class is not part of the API.
                 "<p>TODO</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "Unicode",
                 "http://www.unicode.org/"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 COMPATIBILITY_CHARACTER,
                 "COMPATIBILITY_CHARACTER",
@@ -5189,29 +5189,29 @@ This class is not part of the API.
                 "<p>TODO</p>",
                 0,
                 new InSpec[]{
-                  
+
             new FromAlso(
                 "Unicode",
                 "http://www.unicode.org/"
             ),
-    
+
             new FromAlso(
                 "IRI",
                 "http://www.apps.ietf.org/rfc/rfc3987.html"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 REQUIRED_COMPONENT_MISSING,
                 "REQUIRED_COMPONENT_MISSING",
@@ -5219,9 +5219,9 @@ This class is not part of the API.
                 "<p>A component that is required by the scheme is missing.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "RDF", 
+                "RDF",
                 SCHEME,
                 "http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref",
                 "representing an *absolute URI* with optional fragment identifier",
@@ -5229,21 +5229,21 @@ This class is not part of the API.
      " <em>absolute URI</em> "+
      "with optional fragment identifier</p>"
             ),
-    
+
        new FromSpec_scheme(
-                "http", 
+                "http",
                 HOST,
                 "http://www.apps.ietf.org/rfc/rfc2616.html"
             ),
-    
+
        new FromSpec_scheme(
-                "https", 
+                "https",
                 HOST,
                 "http://www.apps.ietf.org/rfc/rfc2818.html"
             ),
-    
+
        new FromSpec_scheme(
-                "ftp", 
+                "ftp",
                 HOST,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
@@ -5260,9 +5260,9 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "news", 
+                "news",
                 PATH,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
@@ -5281,15 +5281,15 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "nntp", 
+                "nntp",
                 HOST,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.7"
             ),
-    
+
        new FromSpec_scheme(
-                "file", 
+                "file",
                 PATH,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
@@ -5302,9 +5302,9 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "file", 
+                "file",
                 AUTHORITY,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
@@ -5317,9 +5317,9 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "urn", 
+                "urn",
                 PATH,
                 "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2",
                 ""+
@@ -5332,19 +5332,19 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 PROHIBITED_COMPONENT_PRESENT,
                 "PROHIBITED_COMPONENT_PRESENT",
@@ -5352,29 +5352,29 @@ This class is not part of the API.
                 "<p>A component that is prohibited by the scheme is present.</p>",
                 0,
                 new InSpec[]{
-                  
+
        new FromSpec_iri(
-                "XML", 
+                "XML",
                 FRAGMENT,
                 "http://www.w3.org/TR/2004/REC-xml-20040204/#dt-sysid",
                 "TODO",
                 "<p>TODO</p>"
             ),
-    
+
        new FromSpec_scheme(
-                "http", 
+                "http",
                 USER,
                 "http://www.apps.ietf.org/rfc/rfc2616.html"
             ),
-    
+
        new FromSpec_scheme(
-                "https", 
+                "https",
                 USER,
                 "http://www.apps.ietf.org/rfc/rfc2818.html"
             ),
-    
+
        new FromSpec_scheme(
-                "mailto", 
+                "mailto",
                 AUTHORITY,
                 "http://www.apps.ietf.org/rfc/rfc2368.html",
                 ""+
@@ -5397,9 +5397,9 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "news", 
+                "news",
                 AUTHORITY,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
@@ -5418,21 +5418,21 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "nntp", 
+                "nntp",
                 QUERY,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.7"
             ),
-    
+
        new FromSpec_scheme(
-                "nntp", 
+                "nntp",
                 USER,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-3.7"
             ),
-    
+
        new FromSpec_scheme(
-                "file", 
+                "file",
                 USER,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
@@ -5445,9 +5445,9 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "file", 
+                "file",
                 PORT,
                 "http://www.apps.ietf.org/rfc/rfc1738.html#sec-5",
                 ""+
@@ -5460,9 +5460,9 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "urn", 
+                "urn",
                 AUTHORITY,
                 "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2",
                 ""+
@@ -5475,9 +5475,9 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "urn", 
+                "urn",
                 AUTHORITY,
                 "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.1",
                 ""+
@@ -5490,25 +5490,25 @@ This class is not part of the API.
     "</pre>"+
      "<p></p>"
             ),
-    
+
        new FromSpec_scheme(
-                "urn", 
+                "urn",
                 QUERY,
                 "http://www.apps.ietf.org/rfc/rfc2141.html#sec-2.3.2"
             ),
-    
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 SCHEME_REQUIRES_LOWERCASE,
                 "SCHEME_REQUIRES_LOWERCASE",
@@ -5516,19 +5516,19 @@ This class is not part of the API.
                 "<p>Some part of the scheme specific syntax requires lowercase.</p>",
                 0,
                 new InSpec[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 SCHEME_PREFERS_LOWERCASE,
                 "SCHEME_PREFERS_LOWERCASE",
@@ -5536,19 +5536,19 @@ This class is not part of the API.
                 "<p>Some part of the scheme specific syntax prefers lowercase.</p>",
                 0|Force.minting,
                 new InSpec[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 SCHEME_PATTERN_MATCH_FAILED,
                 "SCHEME_PATTERN_MATCH_FAILED",
@@ -5556,275 +5556,275 @@ This class is not part of the API.
                 "<p>The scheme specific syntax rules are violated.</p>",
                 0,
                 new InSpec[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
             new ViolationCodeInfo(
                 QUERY_IN_LEGACY_SCHEME,
                 "QUERY_IN_LEGACY_SCHEME",
                 new String[]{
-                  
+
                 },
                 new String[]{
-                  
+
                 },
-                
+
                 false
             );
-    
+
      }
    }
-   
-   
+
+
 /**
 		    The character violates the grammar rules for URIs/IRIs.
-	    
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a> (see <a href="http://www.apps.ietf.org/rfc/rfc3986.html#page-49">here<a>), <a href="#ref-IRI">[IRI]</a> (see <a href="http://www.apps.ietf.org/rfc/rfc3987.html#sec-2.2">section 2.2<a>), <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>ht$tp://example.org/foo</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int ILLEGAL_CHARACTER = 0;
-        
-    
+
+
 /**
 		   Percent-escape sequences should use uppercase.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-2.1">section 2.1<a>
      </dt>
      <dd>
-     
-             URI producers and normalizers should use 
+
+             URI producers and normalizers should use
      <em>uppercase</em>
-    
+
 	     hexadecimal digits for all percent-encodings.
-            
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/foo%c3%80</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int PERCENT_ENCODING_SHOULD_BE_UPPERCASE = 1;
-        
-    
+
+
 /**
 		   Percent-escape sequences should not be used unnecessarily.
-	    
+
      <p>
      The IRI specification only weakly suggests that
 		    Unicode characters should be used in preference
 		    to percent encodings.
      </p>
-    
+
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html#sec-3.2">section 3.2<a>
      </dt>
      <dd>
-     
+
 			   URI-to-IRI conversion removes percent-encodings
-                  
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the <a href=
           "#ref-IRI">[IRI]</a>
           specification.</p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/foo%C3%A9r</code>&gt;</li>
-    
+
         </ul>
-       
+
          <p>Unimplemented.</p>
-       
+
 */
         int SUPERFLUOUS_NON_ASCII_PERCENT_ENCODING = 2;
-        
-    
+
+
 /**
 		   Percent-escape sequences should not be used unnecessarily.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-2.3">section 2.3<a>
      </dt>
      <dd>
-     
+
 			  For consistency, percent-encoded octets in the
-			  ranges of ALPHA 
+			  ranges of ALPHA
 			  (%41-%5A and %61-%7A), DIGIT (%30-%39), hyphen
 			  (%2D), period (%2E), underscore (%5F), or tilde
 			  (%7E) should not be created by URI producers
-                  
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/foo%5Fb%61r</code>&gt;</li>
-    
+
         </ul>
-       
+
          <p>Unimplemented.</p>
-       
+
 */
         int SUPERFLUOUS_ASCII_PERCENT_ENCODING = 3;
-        
-    
+
+
 /**
 		    The character matches no grammar rules of URIs/IRIs.
 		    These characters are permitted in RDF URI References,
 		    XML system identifiers, and XML Schema anyURIs.
-	    
+
      <p>
      Whitespace is dealt with separately.
      </p>
-    
+
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html#page-13">here<a>
      </dt>
      <dd>
-     
-              Systems accepting IRIs MAY also deal with the printable characters in US-ASCII 
-              that are not allowed in URIs, namely "&lt;", "&gt;", '"', space, "{", "}", "|", "\", 
-              "^", and "`", in step 2 above. If these characters are found but are not converted, 
-              then the conversion SHOULD fail. 
-             
+
+              Systems accepting IRIs MAY also deal with the printable characters in US-ASCII
+              that are not allowed in URIs, namely "&lt;", "&gt;", '"', space, "{", "}", "|", "\",
+              "^", and "`", in step 2 above. If these characters are found but are not converted,
+              then the conversion SHOULD fail.
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-IRI">[IRI]</a>, <a href="#ref-URI">[URI]</a> (see <a href="http://www.apps.ietf.org/rfc/rfc3986.html#page-49">here<a>).
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/fo|o</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/fo&lt;o</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/fo&gt;o</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/fo"o</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/fo`o</code>&gt;</li>
-    
+
         </ul>
-       
+
      @see IRIFactory#allowUnwiseCharacters
      @see #WHITESPACE
      @see #DOUBLE_WHITESPACE
 */
         int UNWISE_CHARACTER = 4;
-        
-    
+
+
 /**
 		    Control characters are not allowed in URIs or RDF URI References.
-	    
+
      <p>This is specified in <a href="#ref-RDF">
      [RDF]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/#section-Graph-URIref">here<a>
      </dt>
      <dd>
-     
+
                A URI reference within an RDF graph (an RDF URI reference) is a Unicode string [UNICODE] that:
 
      <ul>
@@ -5832,26 +5832,26 @@ This class is not part of the API.
      <li>
      does not contain any control characters ( #x00 - #x1F, #x7F-#x9F)
 </li>
-    
+
 </ul>
-    
-               
+
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html">here<a>
      </dt>
      <dd>
-     
+
 
      <pre>
 ucschar = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
@@ -5861,605 +5861,605 @@ ucschar = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
         / %xA0000-AFFFD / %xB0000-BFFFD / %xC0000-CFFFD
         / %xD0000-DFFFD / %xE1000-EFFFD
 </pre>
-    
-             
+
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-RDF">[RDF]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-URI">[URI]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/fo\u007Fo</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/fo\u0085o</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/fo\u0009o</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/fo\u0001o</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int CONTROL_CHARACTER = 5;
-        
-    
+
+
 /**
 		    The character is not legal in XML.
-	    
+
      <p>This is specified in <a href="#ref-XML">
      [XML]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.w3.org/TR/2004/REC-xml-20040204/#NT-Char">here<a>
      </dt>
      <dd>
-      
+
 Char ::=   #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-	            
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/foo\u0001</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int NON_XML_CHARACTER = 6;
-        
-    
+
+
 /**
 		    The character is discouraged in XML documents.
-	    
+
      <p>This is specified in <a href="#ref-XML">
      [XML]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.w3.org/TR/2004/REC-xml-20040204/#char32">here<a>
      </dt>
      <dd>
-      
-Document authors are encouraged to avoid "compatibility characters", as defined in 
-section 6.8 of [Unicode] (see also D21 in section 3.6 of [Unicode3]). The characters 
-defined in the following ranges are also discouraged. They are either control 
-characters or permanently undefined Unicode characters: [#x7F-#x84], [#x86-#x9F], 
+
+Document authors are encouraged to avoid "compatibility characters", as defined in
+section 6.8 of [Unicode] (see also D21 in section 3.6 of [Unicode3]). The characters
+defined in the following ranges are also discouraged. They are either control
+characters or permanently undefined Unicode characters: [#x7F-#x84], [#x86-#x9F],
 [#xFDD0-#xFDDF],
-	            
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/foo\u0080</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int DISCOURAGED_XML_CHARACTER = 7;
-        
-    
+
+
 /**
 		    The path contains a segment /../ not at the beginning
-		    of a relative reference, or it contains a /./ 
+		    of a relative reference, or it contains a /./
 		    These should be removed.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-6.2.2.3">section 6.2.2.3<a>
      </dt>
      <dd>
-     
-		    The complete path segments "." and ".." are intended 
+
+		    The complete path segments "." and ".." are intended
      <em>only</em>
-     for use within relative references 
-            
+     for use within relative references
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
      <p>This violation may indicate security issues, and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#securityViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/../foo</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/foo/../foo</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/foo/..</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/foo/./foo</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/./foo</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/foo/.</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int NON_INITIAL_DOT_SEGMENT = 8;
-        
-    
+
+
 /**
 		    The scheme component is empty.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.1">section 3.1<a>
      </dt>
      <dd>
-      Scheme names consist of a sequence of characters 
-     <em>beginning 
+      Scheme names consist of a sequence of characters
+     <em>beginning
 				    with a letter</em>
-     and followed by any combination of letters, 
-			    digits, plus ("+"), period ("."), or hyphen ("-"). 
+     and followed by any combination of letters,
+			    digits, plus ("+"), period ("."), or hyphen ("-").
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>://example.org/foo</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int EMPTY_SCHEME = 9;
-        
-    
+
+
 /**
 		    The scheme component must start with a letter.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.1">section 3.1<a>
      </dt>
      <dd>
-      Scheme names consist of a sequence of characters 
-     <em>beginning 
+      Scheme names consist of a sequence of characters
+     <em>beginning
 			    with a letter</em>
-     and followed by any combination of letters, 
-			    digits, plus ("+"), period ("."), or hyphen ("-"). 
+     and followed by any combination of letters,
+			    digits, plus ("+"), period ("."), or hyphen ("-").
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>007://example.org/foo</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int SCHEME_MUST_START_WITH_LETTER = 10;
-        
-    
+
+
 /**lowercase is preferred in this component
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        For the SCHEME component:
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.1">section 3.1<a>
      </dt>
      <dd>
-     An implementation should accept uppercase letters as equivalent to lowercase in scheme names (e.g., allow "HTTP" as well as "http") for the sake of robustness but should only produce lowercase scheme names for consistency. 
+     An implementation should accept uppercase letters as equivalent to lowercase in scheme names (e.g., allow "HTTP" as well as "http") for the sake of robustness but should only produce lowercase scheme names for consistency.
      </dd>
-    
+
      <dt>
-     
+
        For the HOST component:
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
-			    Although host is case-insensitive, producers and normalizers should use 
+
+			    Although host is case-insensitive, producers and normalizers should use
      <em>lowercase for registered names</em>
      and hexadecimal addresses for the sake of uniformity, while only using uppercase letters for percent-encodings.
-	            
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>HTTP://example.org/foo</code>&gt;</li>
-    
+
      <li>&lt;<code>http://eXamPle.org/foo</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int LOWERCASE_PREFERRED = 11;
-        
-    
+
+
 /**The colon introducing an empty port component should be omitted entirely,
 	    or a port number should be specified.
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
-			    URI producers and normalizers should omit the port component 
+
+			    URI producers and normalizers should omit the port component
      <em>and its ":" delimiter</em>
-     if port is empty 
-	            
+     if port is empty
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org:/foo</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int PORT_SHOULD_NOT_BE_EMPTY = 12;
-        
-    
+
+
 /**If the port is the default one for the scheme it should be omitted.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
-			    URI producers and normalizers should omit the port component and its ":" delimiter if port is empty  or if its value would be the 
+
+			    URI producers and normalizers should omit the port component and its ":" delimiter if port is empty  or if its value would be the
      <em>same as that of the scheme's default.</em>
-     
-	            
+
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org:80/foo</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int DEFAULT_PORT_SHOULD_BE_OMITTED = 13;
-        
-    
+
+
 /**
 		    Ports under 1024 should be accessed
 		    using the appropriate scheme name.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-7.2">section 7.2<a>
      </dt>
      <dd>
-     
-			    Applications should prevent dereference of a URI that specifies a TCP port number within the "well-known port" range 
+
+			    Applications should prevent dereference of a URI that specifies a TCP port number within the "well-known port" range
      <em>(0 - 1023)</em>
      unless the protocol being used to dereference that URI is compatible with the protocol expected on that well-known port.
-	            
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation may indicate security issues, and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#securityViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org:180/foo</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int PORT_SHOULD_NOT_BE_WELL_KNOWN = 14;
-        
-    
+
+
 /**Leading zeros in the port number should be omitted.
 		    This is an added feature of this implementation,
 			    not mandated by any standard.
-	    
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org:08080/foo</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int PORT_SHOULD_NOT_START_IN_ZERO = 15;
-        
-    
+
+
 /**A prohibited bi-directional control character was found.
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html#sec-4.1">section 4.1<a>
      </dt>
      <dd>
-     
-			     IRIs MUST NOT contain bidirectional formatting characters (LRM, RLM, LRE, RLE, LRO, RLO, and PDF). 
-	     
+
+			     IRIs MUST NOT contain bidirectional formatting characters (LRM, RLM, LRE, RLE, LRO, RLO, and PDF).
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the <a href=
           "#ref-IRI">[IRI]</a>
           specification.</p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/Andr\u202Abar</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/Andr\u202Bbar</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/Andr\u202Cbar</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/Andr\u202Dbar</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/Andr\u202Ebar</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/Andr\u200Ebar</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/Andr\u200Fbar</code>&gt;</li>
-    
+
         </ul>
-       
+
          <p>Unimplemented.</p>
-       
+
 */
         int BIDI_FORMATTING_CHARACTER = 16;
-        
-    
+
+
 /**
 A single whitespace character.
 These match no grammar rules of URIs/IRIs.
 		    These characters are permitted in RDF URI References,
 		    XML system identifiers, and XML Schema anyURIs.
-	    
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/ foo</code>&gt;</li>
-    
+
      <li>&lt;<code>file:///Program Files</code>&gt;</li>
-    
+
         </ul>
-       
+
      @see IRIFactory#allowUnwiseCharacters
      @see #NOT_XML_SCHEMA_WHITESPACE
      @see #UNWISE_CHARACTER
      @see #DOUBLE_WHITESPACE
 */
         int WHITESPACE = 17;
-        
-    
+
+
 /**
 Either two or more consecutive whitespace characters, or leading or trailing whitespace.
 
 These match no grammar rules of URIs/IRIs.
 These characters are permitted in RDF URI References,
 XML system identifiers, but not XML Schema anyURIs.
-	    
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/  foo</code>&gt;</li>
-    
+
      <li>&lt;<code>file:///Program  Files</code>&gt;</li>
-    
+
      <li>&lt;<code>file:///TabBar </code>&gt;</li>
-    
+
      <li>&lt;<code> rel-with-initial-space</code>&gt;</li>
-    
+
         </ul>
-       
+
      @see IRIFactory#allowUnwiseCharacters
      @see #NOT_XML_SCHEMA_WHITESPACE
      @see #UNWISE_CHARACTER
      @see #WHITESPACE
 */
         int DOUBLE_WHITESPACE = 18;
-        
-    
+
+
 /**
-Whitespace characters 
+Whitespace characters
 		    match no grammar rules of URIs/IRIs.
 		    These characters are permitted in RDF URI References,
 	and	    XML system identifiers.
 	However, tab and new line characters, and consecutive space characters
 	cannot occur in XML Schema anyURIs.
-	    
+
      <p>This is specified in <a href="#ref-Schema">
      [Schema]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#schema">here<a>
      </dt>
      <dd>
-     
+
 
      <pre>
 &lt;xs:simpleType name="anyURI" id="anyURI"&gt;
@@ -6470,92 +6470,92 @@ Whitespace characters
     &lt;/xs:restriction&gt;
 &lt;/xs:simpleType&gt;
 </pre>
-    
-  
+
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>file:///Tab\u0009Bar</code>&gt;</li>
-    
+
      <li>&lt;<code>file:///Tab\u000ABar</code>&gt;</li>
-    
+
      <li>&lt;<code>file:///Tab\u000DBar</code>&gt;</li>
-    
+
         </ul>
-       
+
      @see IRIFactory#allowUnwiseCharacters
      @see #DOUBLE_WHITESPACE
      @see #WHITESPACE
 */
         int NOT_XML_SCHEMA_WHITESPACE = 19;
-        
-    
+
+
 /**
-    Internal code. This is not an error or warning condition, 
+    Internal code. This is not an error or warning condition,
     but is used to trigger more expensive processing.
-    
+
 */
         int DOUBLE_DASH_IN_REG_NAME = 20;
-        
-    
+
+
 /**
-    Internal code. This is not an error or warning condition, 
+    Internal code. This is not an error or warning condition,
     but is used to trigger more expensive processing.
-    
+
 */
         int SCHEME_INCLUDES_DASH = 21;
-        
-    
+
+
 /**
-    Internal code. This is not an error or warning condition, 
+    Internal code. This is not an error or warning condition,
     but is used to trigger more expensive processing.
-    
+
 */
         int NON_URI_CHARACTER = 22;
-        
-    
+
+
 /**
-    Internal code. This is not an error or warning condition, 
+    Internal code. This is not an error or warning condition,
     but is used to trigger more expensive processing.
-    
+
 */
         int PERCENT_20 = 23;
-        
-    
+
+
 /**
-    Internal code. This is not an error or warning condition, 
+    Internal code. This is not an error or warning condition,
     but is used to trigger more expensive processing.
-    
+
 */
         int PERCENT = 24;
-        
-    
+
+
 /**
 		    A syntax violation was detected in an IP V6 (or future) address.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
-			    
+
+
      <pre>
 IP-literal  = "[" ( IPv6address / IPvFuture  ) "]"
 IPvFuture   = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
@@ -6571,117 +6571,117 @@ IPv6address =  6( h16 ":" ) ls32
 
 ls32        = ( h16 ":" h16 ) / IPv4address
                   ; least-significant 32 bits of address
-h16         = 1*4HEXDIG 
+h16         = 1*4HEXDIG
 		  ; 16 bits of address represented in hexadecimal
 </pre>
-    
-	            
+
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://[/</code>&gt;</li>
-    
+
      <li>&lt;<code>ldap://[20015:db8::7]/c=GB?objectClass?one</code>&gt;</li>
-    
+
      <li>&lt;<code>ldap://[2001:db8:::7]/c=GB?objectClass?one</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int IP_V6_OR_FUTURE_ADDRESS_SYNTAX = 25;
-        
-    
+
+
 /**
 	IP version 6 addresses should use lowercase hexadecimal
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
-			    Although host is case-insensitive, producers and normalizers 
-			    
+
+			    Although host is case-insensitive, producers and normalizers
+
      <em>should use lowercase</em>
-     for registered names and 
+     for registered names and
      <em>hexadecimal addresses</em>
      for the sake of uniformity
-		    
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>ldap://[2001:Db8::7]/c=GB?objectClass?one</code>&gt;</li>
-    
+
      <li>&lt;<code>ldap://[2001:dB8::7]/c=GB?objectClass?one</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int IPv6ADDRESS_SHOULD_BE_LOWERCASE = 26;
-        
-    
+
+
 /**
 		    A host entry consists of four numbers,
 		    but they are not in the range 0-255, or have leading zeros.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
-			    A host identified by an IPv4 literal address is represented in dotted-decimal notation (a sequence of 
+
+			    A host identified by an IPv4 literal address is represented in dotted-decimal notation (a sequence of
      <em>four decimal numbers</em>
-     in the range 
+     in the range
      <em>0 to 255</em>
     , separated by "."),
-		    
+
      </dd>
-    
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
-			    
+
+
      <pre>
 dec-octet   = DIGIT                 ; 0-9
             / %x31-39 DIGIT         ; 10-99
@@ -6689,939 +6689,938 @@ dec-octet   = DIGIT                 ; 0-9
             / "2" %x30-34 DIGIT     ; 200-249
             / "25" %x30-35          ; 250-255
 </pre>
-    
-		    
+
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>ldap://155.00.55.102/c=GB?objectClass?one</code>&gt;</li>
-    
+
      <li>&lt;<code>ldap://20.256.20.20/c=GB?objectClass?one</code>&gt;</li>
-    
+
      <li>&lt;<code>ldap://20.1000.20.20/c=GB?objectClass?one</code>&gt;</li>
-    
+
      <li>&lt;<code>ldap://20.010.20.20/c=GB?objectClass?one</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int IP_V4_OCTET_RANGE = 27;
-        
-    
+
+
 /**
 		    The host component did not meet the restrictions on DNS names.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
-			    URI producers should use names that 
+
+			    URI producers should use names that
      <em>conform to the DNS syntax</em>
     , even when use of DNS is not immediately apparent, and should limit these names to no more than 255 characters in length.
-		    
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation is relevant for IRIs using DNS as the registry of hostnames.
      The behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#dnsViolation}.
      </p>
-    
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>ldap://foo$/c=GB?objectClass?one</code>&gt;</li>
-    
+
      <li>&lt;<code>http://foo.example.$org/</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int NOT_DNS_NAME = 28;
-        
-    
+
+
 /**
 		    The host component used percent encoding, where punycode is preferred.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
+
 URI producers should provide these registered names in the IDNA encoding, rather than a percent-encoding, if they wish to maximize interoperability with legacy URI resolvers.
-		    
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
      <p>This violation is relevant for IRIs using DNS as the registry of hostnames.
      The behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#dnsViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>ftp://andr%C3%A9.example.org/</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int USE_PUNYCODE_NOT_PERCENTS = 29;
-        
-    
+
+
 /**
 		    The host component a percent occurred without two following hexadecimal digits.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-2.1">section 2.1<a>
      </dt>
      <dd>
-     
-			     A percent-encoded octet is encoded as a character triplet, consisting of the percent character "%" followed by the two hexadecimal digits representing that octet's numeric value. 
-		    
+
+			     A percent-encoded octet is encoded as a character triplet, consisting of the percent character "%" followed by the two hexadecimal digits representing that octet's numeric value.
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>ftp://andr%%A9.example.org/</code>&gt;</li>
-    
+
      <li>&lt;<code>ftp://andr%.example.org/</code>&gt;</li>
-    
+
      <li>&lt;<code>ftp://andre.example.org/%</code>&gt;</li>
-    
+
      <li>&lt;<code>ftp://andre.example.org/%A</code>&gt;</li>
-    
+
      <li>&lt;<code>ftp://andre.example.org/%A?</code>&gt;</li>
-    
+
      <li>&lt;<code>ftp://andre.example.org/%A#</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int ILLEGAL_PERCENT_ENCODING = 30;
-        
-    
+
+
 /**
-    Internal code. This is not an error or warning condition, 
+    Internal code. This is not an error or warning condition,
     but is used to trigger more expensive processing.
-    
+
 */
         int ACE_PREFIX = 31;
-        
-    
+
+
 /**
 		    A unicode surrogate character that is not of a surrogate pair.
-	    
+
          <p>This does not violate any of the supported IRI, URI or scheme specifications.</p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http:/foo/p\uD800</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int LONE_SURROGATE = 32;
-        
-    
+
+
 /**
 		    A DNS name had a - at the beginning or end.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
-			     Such a name consists of a sequence of domain labels separated by ".", each domain label starting and ending with an alphanumeric character and possibly also containing "-" characters. 
-		    
+
+			     Such a name consists of a sequence of domain labels separated by ".", each domain label starting and ending with an alphanumeric character and possibly also containing "-" characters.
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation is relevant for IRIs using DNS as the registry of hostnames.
      The behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#dnsViolation}.
      </p>
-    
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>ldap://-foo/c=GB?objectClass?one</code>&gt;</li>
-    
+
      <li>&lt;<code>http://foo.example.org-/</code>&gt;</li>
-    
+
      <li>&lt;<code>http://foo.example.org--/</code>&gt;</li>
-    
+
      <li>&lt;<code>http://--foo.example.org/</code>&gt;</li>
-    
+
      <li>&lt;<code>http://-fo-o.example.org/</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int DNS_LABEL_DASH_START_OR_END = 33;
-        
-    
+
+
 /**
 		    Characters used in the IRI were unassigned in the version of Unicode known
                     by this system. They may have been assigned since.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
+
 			    When a non-ASCII registered name represents an internationalized domain name intended for resolution via the DNS, the name must be transformed to the IDNA encoding [RFC3490] prior to name lookup.  URI producers should provide these registered names in the IDNA encoding, rather than a percent-encoding, if they wish to maximize interoperability with legacy URI resolvers.
-		    
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html#sec-3.1">section 3.1<a>
      </dt>
      <dd>
-     
+
 			    Replace the ireg-name part of the IRI by the part converted using the ToASCII operation specified in section 4.1 of [RFC3490] on each dot-separated label, and by using U+002E (FULL STOP) as a label separator, with the flag UseSTD3ASCIIRules set to TRUE, and with the flag AllowUnassigned set to FALSE for creating IRIs and set to TRUE otherwise.
-		    
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://foo.example\u0221.org/</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int BAD_IDN_UNASSIGNED_CHARS = 34;
-        
-    
+
+
 /**
 		    The Internationalized Domain Name check failed.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.2">section 3.2.2<a>
      </dt>
      <dd>
-     
+
 			    When a non-ASCII registered name represents an internationalized domain name intended for resolution via the DNS, the name must be transformed to the IDNA encoding [RFC3490] prior to name lookup.  URI producers should provide these registered names in the IDNA encoding, rather than a percent-encoding, if they wish to maximize interoperability with legacy URI resolvers.
-		    
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html#sec-3.1">section 3.1<a>
      </dt>
      <dd>
-     
+
 			    Replace the ireg-name part of the IRI by the part converted using the ToASCII operation specified in section 4.1 of [RFC3490] on each dot-separated label, and by using U+002E (FULL STOP) as a label separator, with the flag UseSTD3ASCIIRules set to TRUE, and with the flag AllowUnassigned set to FALSE for creating IRIs and set to TRUE otherwise.
-		    
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://--foo.example.org/</code>&gt;</li>
-    
+
      <li>&lt;<code>http://xn--andr--ep-.example.org/</code>&gt;</li>
-    
+
      <li>&lt;<code>http://xn.example.\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333\u3333/</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int BAD_IDN = 35;
-        
-    
+
+
 /**
 	Including passwords in URIs is deprecated.
-	    
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.1">section 3.2.1<a>
      </dt>
      <dd>
-     
-Use of the format "user:password" in the userinfo field is deprecated.		    
-	    
+
+Use of the format "user:password" in the userinfo field is deprecated.
+
      </dd>
-    
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2.1">section 3.2.1<a>
      </dt>
      <dd>
-     
+
 Applications may choose to ignore or reject such data when it is received as part of a reference and should reject the storage of such data in unencrypted form. The passing of authentication information in clear text has proven to be a security risk in almost every case where it has been used.
-            
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
      <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-    
+
      <p>This violation may indicate security issues, and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#securityViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://user:pass@example.org/</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int HAS_PASSWORD = 36;
-        
-    
+
+
 /**
 	Certain characters are discouraged in IRIs.
-	    
+
      <p>
      Implementation is very partial. The amount of guidance
 		    as to which characters to discourage is insufficient.
      </p>
-    
+
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html#sec-6.1">section 6.1<a>
      </dt>
      <dd>
-     
+
 The UCS contains many areas of characters for which there are
 strong visual look-alikes. Because of the likelihood of transcription errors, these also should be avoided. This includes the full-width equivalents of Latin characters, half-width Katakana characters for Japanese, and many others. It also includes many look-alikes of "space", "delims", and "unwise", characters excluded in [RFC3491].
-	    
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the <a href=
           "#ref-IRI">[IRI]</a>
           specification.</p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/\u2000en-quad</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example.org/\u205Fmedium-mathematical-space</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example\uFF95.org/</code>&gt;</li>
-    
+
      <li>&lt;<code>http://example\uFF47.org/</code>&gt;</li>
-    
+
         </ul>
-       
+
          <p>Unimplemented.</p>
-       
+
 */
         int DISCOURAGED_IRI_CHARACTER = 37;
-        
-    
+
+
 /**
 	There are restrictions on bidi characters in subcomponents of IRIs
-	    
+
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html#sec-4.2">section 4.2<a>
      </dt>
      <dd>
-     
+
 
      <ol>
-	
+
      <li>
 A component SHOULD NOT use both right-to-left and left-to-right
     characters.
     </li>
-    
-    
+
+
      <li>
 A component using right-to-left characters SHOULD start and end
     with right-to-left characters.
     </li>
     </ol>
-    	    
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the <a href=
           "#ref-IRI">[IRI]</a>
           specification.</p>
-       
+
      <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">SHOULD</a> force.
      By default, this is treated as an error (for the relevant specs), but that behaviour can be modified by
      {@link IRIFactory#shouldViolation}.
      </p>
-    
+
          <p>Unimplemented.</p>
-       
+
 */
         int BAD_BIDI_SUBCOMPONENT = 38;
-        
-    
+
+
 /**
        // TODO complete entry for DNS_LENGTH_LIMIT
 */
         int DNS_LENGTH_LIMIT = 39;
-        
-    
+
+
 /**
        // TODO complete entry for DNS_LABEL_LENGTH_LIMIT
 */
         int DNS_LABEL_LENGTH_LIMIT = 40;
-        
-    
+
+
 /**
        // TODO complete entry for NOT_UTF8_ESCAPE
 */
         int NOT_UTF8_ESCAPE = 41;
-        
-    
+
+
 /**
        // TODO complete entry for NOT_UTF8_ESCAPE_IN_HOST
 */
         int NOT_UTF8_ESCAPE_IN_HOST = 42;
-        
-    
+
+
 /**
        // TODO complete entry for BAD_DOT_IN_IDN
 */
         int BAD_DOT_IN_IDN = 43;
-        
-    
+
+
 /**
       The scheme name does not have a "-" in it, but is not in the IANA registry.
       (Last updated from the registry January 2006)
-      
+
      <p>This is specified in <a href="#ref-URL_Registratrion">
      [URL_Registratrion]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc2717.html#sec-">section <a>
      </dt>
      <dd>
-     
-        
+
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
      <p>This is specified in <a href="#ref-URI">
      [URI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.2">section 3.2<a>
      </dt>
      <dd>
-     
-         The NAMES of schemes registered in the IETF tree MUST NOT contain the dash 
-         (also known as the hyphen and minus sign) character ('-') USASCII value 2Dh. 
-         Use of this character can cause confusion with schemes registered in 
+
+         The NAMES of schemes registered in the IETF tree MUST NOT contain the dash
+         (also known as the hyphen and minus sign) character ('-') USASCII value 2Dh.
+         Use of this character can cause confusion with schemes registered in
          alternative trees (see section 3.3).
-        
+
      </dd>
-    
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3986.html#sec-3.3">section 3.3<a>
      </dt>
      <dd>
-     
+
         The syntax for alternative trees shall be as follows: each tree will be identified by a unique prefix, which must be established in the same fashion as a URL scheme name in the IETF tree, except that the prefix must be defined by a Standards Track document. Scheme names in the new tree are then constructed by prepending the prefix to an identifier unique to each scheme in that tree, as prescribed by that tree's identifying document:
 
      <pre>
       &lt;prefix&gt;'-'&lt;tree-specific identifier&gt;
 </pre>
-    
-For instance, the "foo" tree would allow creation of scheme names of the form: "foo-blahblah:" and "foo-bar:", where the tree prescribes an arbitrary USASCII string following the tree's unique prefix. 
- 
+
+For instance, the "foo" tree would allow creation of scheme names of the form: "foo-blahblah:" and "foo-bar:", where the tree prescribes an arbitrary USASCII string following the tree's unique prefix.
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>foo://example.org/bar</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int UNREGISTERED_IANA_SCHEME = 44;
-        
-    
+
+
 /**
       The scheme name has a "-" in it, but it does not start in "x-"
       and the prefix is not known as the prefix of an alternative tree for
       URI schemes.
-      
+
      <p>
-     
+
       There is no standard provision for "x-" as a prefix for private use schemes.
       This is a feature of this implementation.
       As far as I am aware, no alternative trees have been registered.
-      
+
      </p>
-    
+
      <p>This is specified in <a href="#ref-URL_Registratrion">
      [URL_Registratrion]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc2717.html#sec-3.3">section 3.3<a>
      </dt>
      <dd>
-     
+
         The syntax for alternative trees shall be as follows: each tree will be identified by a unique prefix, which must be established in the same fashion as a URL scheme name in the IETF tree, except that the prefix must be defined by a Standards Track document. Scheme names in the new tree are then constructed by prepending the prefix to an identifier unique to each scheme in that tree, as prescribed by that tree's identifying document:
 
      <pre>
       &lt;prefix&gt;'-'&lt;tree-specific identifier&gt;
 </pre>
-    
-For instance, the "foo" tree would allow creation of scheme names of the form: "foo-blahblah:" and "foo-bar:", where the tree prescribes an arbitrary USASCII string following the tree's unique prefix. 
- 
+
+For instance, the "foo" tree would allow creation of scheme names of the form: "foo-blahblah:" and "foo-bar:", where the tree prescribes an arbitrary USASCII string following the tree's unique prefix.
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the following specifications:
           <a href="#ref-URI">[URI]</a>, <a href="#ref-IRI">[IRI]</a>, <a href="#ref-XLink">[XLink]</a>, <a href="#ref-XML">[XML]</a>, <a href="#ref-RDF">[RDF]</a>, <a href="#ref-Schema">[Schema]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>foo-bar://example.org/bar</code>&gt;</li>
-    
+
         </ul>
-       
+
 */
         int UNREGISTERED_NONIETF_SCHEME_TREE = 45;
-        
-    
+
+
 /**
       The IRI is not in Unicode Normal Form C.
-    
+
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html#sec-5.3.2.2">section 5.3.2.2<a>
      </dt>
      <dd>
-     
-        To avoid false negatives and problems with transcoding, IRIs SHOULD be created by using NFC. 
-        
+
+        To avoid false negatives and problems with transcoding, IRIs SHOULD be created by using NFC.
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the <a href=
           "#ref-IRI">[IRI]</a>
           specification.</p>
-       
+
      <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">SHOULD</a> force.
      By default, this is treated as an error (for the relevant specs), but that behaviour can be modified by
      {@link IRIFactory#shouldViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/#Andre\u0301</code>&gt;</li>
-    
+
         </ul>
-       
+
          <p>Unimplemented.</p>
-       
+
 */
         int NOT_NFC = 46;
-        
-    
+
+
 /**
       The IRI is not in Unicode Normal Form KC.
-    
+
      <p>This is specified in <a href="#ref-IRI">
      [IRI]</a>.</p>
      <dl>
-     
+
      <dt>
-     
+
        see
      <a href="http://www.apps.ietf.org/rfc/rfc3987.html#sec-7.5">section 7.5<a>
      </dt>
      <dd>
-     
+
         Although there may be exceptions, newly created resource names should generally be in NFKC
-        
+
      </dd>
-    
+
      </dl>
-     
-    
+
+
           <p>This violates the <a href=
           "#ref-IRI">[IRI]</a>
           specification.</p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
         <p>The following are examples of IRIs that have this violation:</p>
         <ul>
-       
+
      <li>&lt;<code>http://example.org/#Andre\u0301</code>&gt;</li>
-    
+
         </ul>
-       
+
          <p>Unimplemented.</p>
-       
+
 */
         int NOT_NFKC = 47;
-        
-    
+
+
 /**TODO
           <p>This violates the following specifications:
           <a href="#ref-Unicode">[Unicode]</a>, <a href="#ref-IRI">[IRI]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int DEPRECATED_UNICODE_CHARACTER = 48;
-        
-    
+
+
 /**TODO
           <p>This violates the following specifications:
           <a href="#ref-Unicode">[Unicode]</a>, <a href="#ref-IRI">[IRI]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int UNDEFINED_UNICODE_CHARACTER = 49;
-        
-    
+
+
 /**TODO
           <p>This violates the following specifications:
           <a href="#ref-Unicode">[Unicode]</a>, <a href="#ref-IRI">[IRI]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int PRIVATE_USE_CHARACTER = 50;
-        
-    
+
+
 /**TODO
           <p>This violates the following specifications:
           <a href="#ref-Unicode">[Unicode]</a>, <a href="#ref-IRI">[IRI]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int UNICODE_CONTROL_CHARACTER = 51;
-        
-    
+
+
 /**The character code is not assigned in the version of Unicode implemented here.
       Check validity of code, consider updating your copy of icu4j.jar.
-      
+
           <p>This violates the following specifications:
           <a href="#ref-Unicode">[Unicode]</a>, <a href="#ref-IRI">[IRI]</a>.
           </p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
 */
         int UNASSIGNED_UNICODE_CHARACTER = 52;
-        
-    
+
+
 /**
-    Internal code. This is not an error or warning condition, 
+    Internal code. This is not an error or warning condition,
     but is used to trigger more expensive processing.
-    
+
 */
         int MAYBE_NOT_NFC = 53;
-        
-    
+
+
 /**
-    Internal code. This is not an error or warning condition, 
+    Internal code. This is not an error or warning condition,
     but is used to trigger more expensive processing.
-    
+
 */
         int MAYBE_NOT_NFKC = 54;
-        
-    
+
+
 /**TODO
           <p>This violates the following specifications:
           <a href="#ref-Unicode">[Unicode]</a>, <a href="#ref-IRI">[IRI]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int UNICODE_WHITESPACE = 55;
-        
-    
+
+
 /**TODO
           <p>This violates the following specifications:
           <a href="#ref-Unicode">[Unicode]</a>, <a href="#ref-IRI">[IRI]</a>.
           </p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int COMPATIBILITY_CHARACTER = 56;
-        
-    
+
+
 /**A component that is required by the scheme is missing.
          <p>This does not violate any of the supported IRI, URI or scheme specifications.</p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int REQUIRED_COMPONENT_MISSING = 57;
-        
-    
+
+
 /**A component that is prohibited by the scheme is present.
          <p>This does not violate any of the supported IRI, URI or scheme specifications.</p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int PROHIBITED_COMPONENT_PRESENT = 58;
-        
-    
+
+
 /**Some part of the scheme specific syntax requires lowercase.
          <p>This does not violate any of the supported IRI, URI or scheme specifications.</p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int SCHEME_REQUIRES_LOWERCASE = 59;
-        
-    
+
+
 /**Some part of the scheme specific syntax prefers lowercase.
          <p>This does not violate any of the supported IRI, URI or scheme specifications.</p>
-       
+
      <p>This violation relates to creating your own IRIs, rather than
      accepting and processing other peoples', and the behaviour of a factory
      implementing the relevant specs can be modified by
      {@link IRIFactory#mintingViolation}.
      </p>
-    
+
 */
         int SCHEME_PREFERS_LOWERCASE = 60;
-        
-    
+
+
 /**The scheme specific syntax rules are violated.
          <p>This does not violate any of the supported IRI, URI or scheme specifications.</p>
-       
+
          <p>This violation has <a href="http://www.apps.ietf.org/rfc/rfc2119.html#sec-1">MUST</a> force.</p>
-       
+
 */
         int SCHEME_PATTERN_MATCH_FAILED = 61;
-        
-    
+
+
 /**
        // TODO complete entry for QUERY_IN_LEGACY_SCHEME
 */
         int QUERY_IN_LEGACY_SCHEME = 62;
-        
-    
+
+
 
 }
-    

--- a/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/AbstractTestRDFConnection.java
+++ b/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/AbstractTestRDFConnection.java
@@ -18,10 +18,13 @@
 
 package org.apache.jena.rdfconnection;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.jena.atlas.iterator.Iter;
-import org.apache.jena.atlas.junit.BaseTest;
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
@@ -35,7 +38,7 @@ import org.apache.jena.update.UpdateRequest;
 import org.junit.Assume;
 import org.junit.Test;
 
-public abstract class AbstractTestRDFConnection extends BaseTest {
+public abstract class AbstractTestRDFConnection {
     // Testing data.
     static String DIR = "testing/RDFConnection/";
 

--- a/jena-sdb/src/main/java/org/apache/jena/sdb/shared/Env.java
+++ b/jena-sdb/src/main/java/org/apache/jena/sdb/shared/Env.java
@@ -33,6 +33,7 @@ public class Env
     
     static { initFM() ; }
     
+    @SuppressWarnings("deprecation")
     private static void initFM()
     {
         fileManager = FileManager.create();

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/TestScriptsTDB1.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/TestScriptsTDB1.java
@@ -31,13 +31,13 @@ public class TestScriptsTDB1 extends TestSuite
     static final String ARQ_DIR = "../jena-arq/testing/ARQ";
 
     static public TestSuite suite() { return new TestScriptsTDB1() ; }
-    
+
     private TestScriptsTDB1()
     {
         super("TDB-Scripts") ;
-//        String manifestMain1 = ConfigTest.getTestingDataRoot()+"/manifest.ttl" ;
-//        TestFactoryTDB.make(this, manifestMain1, "TDB-") ;
-        
+        String manifestMain1 = ConfigTest.getTestingDataRoot()+"/manifest.ttl" ;
+        TestFactoryTDB.make(this, manifestMain1, "TDB-") ;
+
         // From ARQ
         String manifestMain2 = ARQ_DIR + "/RDF-Star/SPARQL-Star/manifest.ttl";
         TestFactoryTDB.make(this, manifestMain2, "TDB-");

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/TestTDBFactory.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/TestTDBFactory.java
@@ -18,7 +18,11 @@
 
 package org.apache.jena.tdb;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.Quad ;
@@ -31,7 +35,7 @@ import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public class TestTDBFactory extends BaseTest
+public class TestTDBFactory
 {
     String DIR = ConfigTest.getCleanDir() ;
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/assembler/TestTDBAssembler.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/assembler/TestTDBAssembler.java
@@ -18,9 +18,10 @@
 
 package org.apache.jena.tdb.assembler;
 
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.assembler.JA ;
 import org.apache.jena.assembler.exceptions.AssemblerException ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.query.Dataset ;
@@ -38,7 +39,7 @@ import org.junit.Before ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestTDBAssembler extends BaseTest
+public class TestTDBAssembler
 {
     // Can be slow - explicitly closes the dataset.
     static String dirAssem      = null ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/block/AbstractTestBlockMgr.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/block/AbstractTestBlockMgr.java
@@ -22,12 +22,13 @@ package org.apache.jena.tdb.base.block;
 import java.nio.ByteBuffer ;
 
 import static org.apache.jena.atlas.lib.ByteBufferLib.fill ;
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public abstract class AbstractTestBlockMgr extends BaseTest
+public abstract class AbstractTestBlockMgr
 {
     static final public int BlkSize = 256 ;
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/block/TestBlockMgrTracked.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/block/TestBlockMgrTracked.java
@@ -18,14 +18,15 @@
 
 package org.apache.jena.tdb.base.block;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import java.nio.ByteBuffer ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestBlockMgrTracked extends BaseTest
+public class TestBlockMgrTracked
 {
     // Mainly testing the tracking
 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/buffer/TestPtrBuffer.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/buffer/TestPtrBuffer.java
@@ -18,15 +18,17 @@
 
 package org.apache.jena.tdb.base.buffer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.nio.ByteBuffer;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.tdb.sys.SystemTDB ;
 import org.junit.AfterClass ;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestPtrBuffer extends BaseTest
+public class TestPtrBuffer
 {
     static boolean originalNullOut ; 
     @BeforeClass static public void beforeClass()

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/buffer/TestRecordBuffer.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/buffer/TestRecordBuffer.java
@@ -20,11 +20,12 @@ package org.apache.jena.tdb.base.buffer;
 
 import static org.apache.jena.tdb.base.record.RecordLib.intToRecord ;
 import static org.apache.jena.tdb.base.record.RecordLib.r ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.tdb.base.record.Record ;
 import org.apache.jena.tdb.base.record.RecordFactory ;
 import org.apache.jena.tdb.base.record.RecordLib ;
@@ -33,7 +34,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestRecordBuffer extends BaseTest
+public class TestRecordBuffer
 {
     static RecordFactory recordFactory = new RecordFactory(RecordLib.TestRecordLength, 0) ;
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/file/AbstractTestBlockAccessFixedSize.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/file/AbstractTestBlockAccessFixedSize.java
@@ -19,13 +19,15 @@
 package org.apache.jena.tdb.base.file;
 
 import static org.apache.jena.tdb.base.BufferTestLib.sameValue ;
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.tdb.base.block.Block ;
 import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public abstract class AbstractTestBlockAccessFixedSize extends BaseTest
+public abstract class AbstractTestBlockAccessFixedSize
 {
     // Fixed block tests.
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/file/AbstractTestBlockAccessVarSize.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/file/AbstractTestBlockAccessVarSize.java
@@ -21,6 +21,7 @@ package org.apache.jena.tdb.base.file;
 import org.apache.jena.tdb.base.block.Block ;
 import org.junit.Test ;
 import static org.apache.jena.tdb.base.BufferTestLib.* ;
+import static org.junit.Assert.assertNotSame;
 
 public abstract class AbstractTestBlockAccessVarSize extends AbstractTestBlockAccessFixedSize
 {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/file/AbstractTestChannel.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/file/AbstractTestChannel.java
@@ -18,14 +18,16 @@
 
 package org.apache.jena.tdb.base.file;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.nio.ByteBuffer ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public abstract class AbstractTestChannel extends BaseTest
+public abstract class AbstractTestChannel
 {
     protected abstract BufferChannel open() ;
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/file/TestMetaFile.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/file/TestMetaFile.java
@@ -18,16 +18,20 @@
 
 package org.apache.jena.tdb.base.file;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.tdb.ConfigTest ;
 import org.apache.jena.tdb.sys.Names ;
 import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public class TestMetaFile extends BaseTest
+public class TestMetaFile
 {
     String testfile = null ;
     String testfileMeta = null ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/objectfile/AbstractTestObjectFile.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/objectfile/AbstractTestObjectFile.java
@@ -19,15 +19,18 @@
 package org.apache.jena.tdb.base.objectfile;
 
 import static org.apache.jena.tdb.base.BufferTestLib.sameValue ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.ByteBuffer ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public abstract class AbstractTestObjectFile extends BaseTest
+public abstract class AbstractTestObjectFile
 {
     ObjectFile file ;
 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/objectfile/AbstractTestStringFile.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/objectfile/AbstractTestStringFile.java
@@ -18,12 +18,14 @@
 
 package org.apache.jena.tdb.base.objectfile;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
 import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public abstract class AbstractTestStringFile extends BaseTest
+public abstract class AbstractTestStringFile
 {
     StringFile f = null ;
     
@@ -94,9 +96,8 @@ public abstract class AbstractTestStringFile extends BaseTest
         f.flush() ;
         long id2 = f.write(x2) ;
         // No flush.
-        
+       
         assertNotEquals("Node Ids", id1, id2) ;
-        
         String z = f.read(id2) ;
         
         test(id2, x2) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/objectfile/TestObjectFileBuffering.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/objectfile/TestObjectFileBuffering.java
@@ -20,15 +20,15 @@ package org.apache.jena.tdb.base.objectfile;
 
 import static org.apache.jena.tdb.base.BufferTestLib.sameValue ;
 import static org.apache.jena.tdb.base.objectfile.AbstractTestObjectFile.fill ;
+import static org.junit.Assert.assertNotSame;
 
 import java.nio.ByteBuffer ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.tdb.base.file.BufferChannel ;
 import org.apache.jena.tdb.base.file.BufferChannelMem ;
 import org.junit.Test ;
 
-public class TestObjectFileBuffering extends BaseTest
+public class TestObjectFileBuffering
 {
     protected ObjectFile make(int bufferSize)
     {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/record/TestRecord.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/record/TestRecord.java
@@ -20,10 +20,13 @@ package org.apache.jena.tdb.base.record;
 
 import static org.apache.jena.tdb.base.record.RecordLib.intToRecord ;
 import static org.apache.jena.tdb.base.record.RecordLib.recordToInt ;
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 
-public class TestRecord extends BaseTest
+public class TestRecord
 {
     static final public int RecLen = 4 ;
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/base/recordfile/TestRecordBufferPage.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/base/recordfile/TestRecordBufferPage.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.tdb.base.recordfile;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.tdb.base.block.BlockMgr ;
 import org.apache.jena.tdb.base.block.BlockMgrFactory ;
 import org.apache.jena.tdb.base.buffer.RecordBuffer ;
@@ -31,7 +32,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestRecordBufferPage extends BaseTest
+public class TestRecordBufferPage
 {
     // Testing: records are 2 bytes, 3 records per block.  
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/graph/TestPrefixMappingTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/graph/TestPrefixMappingTDB.java
@@ -18,6 +18,10 @@
 
 package org.apache.jena.tdb.graph;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import java.util.Map ;
 
 import org.apache.jena.atlas.lib.FileOps ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/index/AbstractTestIndex.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/index/AbstractTestIndex.java
@@ -20,13 +20,16 @@ package org.apache.jena.tdb.index;
 
 import static org.apache.jena.tdb.base.record.RecordLib.intToRecord ;
 import static org.apache.jena.tdb.index.IndexTestLib.* ;
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import org.apache.jena.tdb.base.record.Record ;
 import org.apache.jena.tdb.base.record.RecordLib ;
 import org.junit.After;
 import org.junit.Test;
 
-public abstract class AbstractTestIndex extends BaseTest 
+public abstract class AbstractTestIndex 
 {
     Index index = null ;
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/index/AbstractTestRangeIndex.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/index/AbstractTestRangeIndex.java
@@ -24,15 +24,18 @@ import static org.apache.jena.tdb.index.IndexTestLib.add ;
 import static org.apache.jena.tdb.index.IndexTestLib.randTest ;
 import static org.apache.jena.tdb.index.IndexTestLib.testInsert ;
 import static org.apache.jena.tdb.index.IndexTestLib.testInsertDelete ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.tdb.base.record.RecordLib ;
 import org.junit.After ;
 import org.junit.Test ;
 
-public abstract class AbstractTestRangeIndex extends BaseTest {
+public abstract class AbstractTestRangeIndex {
     private RangeIndex rIndex = null ;
 
     @After

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/index/IndexTestLib.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/index/IndexTestLib.java
@@ -29,6 +29,7 @@ import static org.apache.jena.tdb.base.record.RecordLib.intToRecord ;
 import static org.apache.jena.tdb.base.record.RecordLib.r ;
 import static org.apache.jena.tdb.base.record.RecordLib.toIntList ;
 import static org.junit.Assert.assertEquals ;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull ;
 import static org.junit.Assert.fail ;
 
@@ -37,7 +38,6 @@ import java.util.List ;
 import java.util.SortedSet ;
 import java.util.TreeSet ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.tdb.base.record.Record ;
 import org.apache.jena.tdb.base.record.RecordLib ;
 
@@ -160,7 +160,7 @@ public class IndexTestLib
         }
         
         for ( Record r : x )
-            BaseTest.assertFalse(index.contains(r)) ;
+            assertFalse(index.contains(r)) ;
         long size2 = index.size() ;
 
         assertEquals(size1-count, size2) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/index/bplustree/TestBPTreeRecords.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/index/bplustree/TestBPTreeRecords.java
@@ -18,7 +18,11 @@
 
 package org.apache.jena.tdb.index.bplustree;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.tdb.base.block.BlockMgr ;
 import org.apache.jena.tdb.base.block.BlockMgrFactory ;
 import org.apache.jena.tdb.base.buffer.RecordBuffer ;
@@ -34,7 +38,7 @@ import org.junit.Before ;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestBPTreeRecords extends BaseTest
+public class TestBPTreeRecords
 {
     static private boolean oldNullOut ;
     static private boolean oldCheckingNode ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/index/bplustree/TestBPlusTreeRewriter.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/index/bplustree/TestBPlusTreeRewriter.java
@@ -23,7 +23,6 @@ import java.util.Iterator ;
 import java.util.List ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.Bytes ;
 import org.apache.jena.tdb.base.block.BlockMgr ;
 import org.apache.jena.tdb.base.block.BlockMgrFactory ;
@@ -36,7 +35,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestBPlusTreeRewriter extends BaseTest
+public class TestBPlusTreeRewriter
 {
     // See also CmdTestBlusTreeRewriter for randomized testing. 
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/lib/TestColumnMap.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/lib/TestColumnMap.java
@@ -19,12 +19,13 @@
 package org.apache.jena.tdb.lib;
 
 import static org.apache.jena.atlas.lib.tuple.TupleFactory.* ;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.junit.Test ;
 
-public class TestColumnMap extends BaseTest
+public class TestColumnMap
 {
     @Test public void remap1() 
     {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/lib/TestNodeLib.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/lib/TestNodeLib.java
@@ -19,12 +19,14 @@
 package org.apache.jena.tdb.lib;
 
 import static org.apache.jena.tdb.lib.NodeLib.hash ;
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
 import org.apache.jena.graph.Node ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.junit.Test ;
 
-public class TestNodeLib extends BaseTest
+public class TestNodeLib
 {
     // Tests of TDBs NodeLib
     @Test public void hash1() 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/lib/TestStringAbbrev.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/lib/TestStringAbbrev.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.tdb.lib;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
-public class TestStringAbbrev extends BaseTest
+public class TestStringAbbrev
 {
     @Test public void abbrev_01()
     {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/setup/TestStoreParams.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/setup/TestStoreParams.java
@@ -18,14 +18,18 @@
 
 package org.apache.jena.tdb.setup;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.json.JSON ;
 import org.apache.jena.atlas.json.JsonObject ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.tdb.TDBException ;
 import org.apache.jena.tdb.base.block.FileMode ;
 import org.junit.Test ;
 
-public class TestStoreParams extends BaseTest {
+public class TestStoreParams {
 
     @Test public void store_params_01() {
         assertEqualsStoreParams(StoreParams.getDftStoreParams(), StoreParams.getDftStoreParams()) ; 

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/setup/TestStoreParamsChoose.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/setup/TestStoreParamsChoose.java
@@ -18,7 +18,10 @@
 
 package org.apache.jena.tdb.setup;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb.ConfigTest ;
 import org.apache.jena.tdb.base.file.Location ;
@@ -26,7 +29,7 @@ import org.junit.Test ;
 
 //TestParamsCreate
 /** This test suite uses on-disk structures and can be slow */ 
-public class TestStoreParamsChoose extends BaseTest {
+public class TestStoreParamsChoose {
     private String DIR = ConfigTest.getCleanDir() ;
     
     static final StoreParams pApp = StoreParams.builder()

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/setup/TestStoreParamsCreate.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/setup/TestStoreParamsCreate.java
@@ -19,6 +19,7 @@
 package org.apache.jena.tdb.setup;
 
 import static org.apache.jena.tdb.setup.StoreParamsConst.TDB_CONFIG_FILE ;
+import static org.junit.Assert.*;
 
 import java.nio.file.Files ;
 import java.nio.file.Path ;
@@ -26,7 +27,6 @@ import java.nio.file.Paths ;
 
 import org.apache.jena.atlas.json.JSON ;
 import org.apache.jena.atlas.json.JsonObject ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb.ConfigTest ;
 import org.apache.jena.tdb.StoreConnection ;
@@ -39,7 +39,7 @@ import org.junit.Test ;
  * This test suite uses on-disk structures, does a lot of clean/create/sync
  * calls and can be noticeably slow.
  */
-public class TestStoreParamsCreate extends BaseTest {
+public class TestStoreParamsCreate {
     private final String DB_DIR = ConfigTest.getCleanDir() ;
     private final Path db = Paths.get(DB_DIR) ;
     private final Path cfg = Paths.get(DB_DIR, TDB_CONFIG_FILE) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/solver/TestSolverTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/solver/TestSolverTDB.java
@@ -19,11 +19,12 @@
 package org.apache.jena.tdb.solver;
 
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList ;
 import java.util.Iterator ;
 import java.util.List ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -49,7 +50,7 @@ import org.apache.jena.tdb.TDBFactory ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestSolverTDB extends BaseTest
+public class TestSolverTDB
 {
     static String graphData = null ;
     static Graph graph = null ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/solver/TestStats.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/solver/TestStats.java
@@ -18,9 +18,10 @@
 
 package org.apache.jena.tdb.solver;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Iterator ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.sparql.core.Quad ;
@@ -35,7 +36,7 @@ import org.apache.jena.tdb.store.nodetupletable.NodeTupleTable ;
 import org.apache.jena.tdb.sys.TDBInternal ;
 import org.junit.Test ;
 
-public class TestStats extends BaseTest
+public class TestStats
 {
     static DatasetGraphTDB dsg      = TDBInternal.getBaseDatasetGraphTDB(TDBFactory.createDatasetGraph()) ;
     static NodeTupleTable quads     = dsg.getQuadTable().getNodeTupleTable() ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/AbstractStoreConnections.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/AbstractStoreConnections.java
@@ -18,8 +18,11 @@
 
 package org.apache.jena.tdb.store;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.rdf.model.Model ;
@@ -38,7 +41,7 @@ import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public abstract class AbstractStoreConnections extends BaseTest
+public abstract class AbstractStoreConnections
 {
     // Subclass to give direct and mapped versions.
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestConcurrentAccess.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestConcurrentAccess.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.tdb.store;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.util.ConcurrentModificationException ;
 import java.util.Iterator ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.GraphUtil ;
@@ -40,7 +41,7 @@ import org.apache.jena.tdb.TDBFactory ;
 import org.apache.jena.util.iterator.ExtendedIterator ;
 import org.junit.Test ;
 
-public class TestConcurrentAccess extends BaseTest
+public class TestConcurrentAccess
 {
     static String data = StrUtils.strjoinNL(
        "(graph",

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestDatasetTDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestDatasetTDB.java
@@ -18,7 +18,9 @@
 
 package org.apache.jena.tdb.store;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.query.* ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
@@ -33,7 +35,7 @@ import org.apache.jena.tdb.TDBFactory ;
 import org.junit.Test ;
 
 /** Tests of datasets, prefixes, special URIs etc (see also {@link org.apache.jena.sparql.graph.GraphsTests} */
-public class TestDatasetTDB extends BaseTest
+public class TestDatasetTDB
 {
     
     private static Dataset create()

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestDatasetTDBPersist.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestDatasetTDBPersist.java
@@ -18,11 +18,14 @@
 
 package org.apache.jena.tdb.store;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays ;
 import java.util.List ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -39,7 +42,7 @@ import org.junit.Before ;
 import org.junit.Test ;
 
 /** Testing persistence  */ 
-public class TestDatasetTDBPersist extends BaseTest
+public class TestDatasetTDBPersist
 {
     static Node n0 = NodeFactoryExtra.parseNode("<http://example/n0>") ; 
     static Node n1 = NodeFactoryExtra.parseNode("<http://example/n1>") ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestLoader.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestLoader.java
@@ -18,12 +18,15 @@
 
 package org.apache.jena.tdb.store ;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.InputStream ;
 import java.util.List ;
 
 import org.apache.jena.atlas.io.IO ;
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
@@ -41,7 +44,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestLoader extends BaseTest {
+public class TestLoader {
     private static String DIR = null ;
     private static final Node   g   = NodeFactory.createURI("g") ;
     private static final Node   s   = NodeFactory.createURI("s") ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestNodeId.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestNodeId.java
@@ -18,7 +18,11 @@
 
 package org.apache.jena.tdb.store;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
@@ -26,7 +30,7 @@ import org.apache.jena.sparql.expr.NodeValue ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.junit.Test ;
 
-public class TestNodeId extends BaseTest
+public class TestNodeId
 {
 //    @BeforeClass public static void beforeClass() {
 //        // If running just this test suite, then this happenes before SystemTDB initialization.    

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestQuadFilter.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestQuadFilter.java
@@ -18,9 +18,10 @@
 
 package org.apache.jena.tdb.store;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.function.Predicate;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.query.* ;
@@ -34,7 +35,7 @@ import org.junit.AfterClass ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
-public class TestQuadFilter extends BaseTest
+public class TestQuadFilter
 {
     private static String graphToHide = "http://example/g2" ;
     private static Dataset ds = setup() ;  

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestTripleTable.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/TestTripleTable.java
@@ -18,9 +18,13 @@
 
 package org.apache.jena.tdb.store;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Iterator ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -31,7 +35,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test ;
 
-public class TestTripleTable extends BaseTest
+public class TestTripleTable
 {
     private static String levelInfo;  
     private static String levelExec;  

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/Test_SPARQL_TDB.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/Test_SPARQL_TDB.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.tdb.store;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.NodeFactory ;
@@ -37,7 +38,7 @@ import org.junit.Test ;
 /**
  * Test SPARQL
  */
-public class Test_SPARQL_TDB extends BaseTest
+public class Test_SPARQL_TDB
 {
     private static Dataset create() 
     {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/nodetable/AbstractTestNodeTable.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/nodetable/AbstractTestNodeTable.java
@@ -18,14 +18,18 @@
 
 package org.apache.jena.tdb.store.nodetable;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import org.apache.jena.graph.Node ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.apache.jena.tdb.TDBException ;
 import org.apache.jena.tdb.store.NodeId ;
 import org.junit.Test ;
 
-public abstract class AbstractTestNodeTable extends BaseTest
+public abstract class AbstractTestNodeTable
 {
     protected abstract NodeTable createEmptyNodeTable() ;
     

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/nodetable/TestCodec.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/nodetable/TestCodec.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.tdb.store.nodetable;
 
+import static org.junit.Assert.assertEquals;
+
 import java.nio.ByteBuffer ;
 import java.util.Arrays ;
 import java.util.Collection ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.ByteBufferLib ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
@@ -32,7 +33,7 @@ import org.junit.runners.Parameterized ;
 import org.junit.runners.Parameterized.Parameters ;
 
 @RunWith(Parameterized.class)
-public class TestCodec extends BaseTest 
+public class TestCodec 
 {
     static private final String asciiBase             = "abc" ;
     static private final String latinBase             = "Àéíÿ" ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/tupletable/AbstractTestTupleIndex.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/tupletable/AbstractTestTupleIndex.java
@@ -18,18 +18,22 @@
 
 package org.apache.jena.tdb.store.tupletable;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Iterator ;
 import java.util.Set ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.apache.jena.atlas.lib.tuple.TupleFactory ;
 import org.apache.jena.tdb.store.NodeId ;
 import org.junit.Test ;
 
 /** Test TupleIndexes (general) */
-public abstract class AbstractTestTupleIndex extends BaseTest
+public abstract class AbstractTestTupleIndex
 {
     protected static NodeId n1 = new NodeId(1) ;
     protected static NodeId n2 = new NodeId(2) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/tupletable/TestTupleIndexRecordDirect.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/tupletable/TestTupleIndexRecordDirect.java
@@ -18,11 +18,12 @@
 
 package org.apache.jena.tdb.store.tupletable;
 
+import static org.junit.Assert.*;
+
 import java.util.Iterator ;
 import java.util.Set ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.apache.jena.atlas.lib.tuple.TupleFactory ;
 import org.apache.jena.tdb.base.file.FileSet ;
@@ -36,7 +37,7 @@ import org.apache.jena.tdb.store.NodeId ;
 import org.apache.jena.tdb.sys.SystemTDB ;
 import org.junit.Test ;
 
-public class TestTupleIndexRecordDirect extends BaseTest
+public class TestTupleIndexRecordDirect
 {
     static RecordFactory factory = new RecordFactory(3*SystemTDB.SizeOfNodeId, 0) ;
     static NodeId n1 = new NodeId(1) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/store/tupletable/TestTupleTable.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/store/tupletable/TestTupleTable.java
@@ -18,11 +18,13 @@
 
 package org.apache.jena.tdb.store.tupletable;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Iterator;
 import java.util.List;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.apache.jena.atlas.lib.tuple.TupleFactory ;
 import org.apache.jena.tdb.base.record.RecordFactory ;
@@ -31,7 +33,7 @@ import org.apache.jena.tdb.sys.SystemTDB ;
 import org.junit.Test;
 
 
-public class TestTupleTable extends BaseTest
+public class TestTupleTable
 {
     static RecordFactory factory = new RecordFactory(3*SystemTDB.SizeOfNodeId, 0) ;
     static NodeId n1 = new NodeId(1) ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/sys/TestSys.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/sys/TestSys.java
@@ -19,11 +19,12 @@
 package org.apache.jena.tdb.sys;
 
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertNotNull;
+
 import org.apache.jena.tdb.TDB ;
 import org.junit.Test;
 
-public class TestSys extends BaseTest
+public class TestSys
 {
     @Test public void sys1()
     {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTrans.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTrans.java
@@ -18,10 +18,13 @@
 
 package org.apache.jena.tdb.transaction;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.nio.ByteBuffer ;
 import java.util.Iterator ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.Pair ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.ReadWrite ;
@@ -31,7 +34,7 @@ import org.junit.After ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public abstract class AbstractTestObjectFileTrans extends BaseTest
+public abstract class AbstractTestObjectFileTrans
 {
     static long count = 0 ;
     ObjectFile file1 ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTransComplex.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestObjectFileTransComplex.java
@@ -18,10 +18,13 @@
 
 package org.apache.jena.tdb.transaction;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.nio.ByteBuffer ;
 import java.util.Iterator ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.Pair ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.ReadWrite ;
@@ -32,7 +35,7 @@ import org.junit.Before ;
 import org.junit.Test ;
 
 /** Clone of AbstractTestObjectFileTrans that understands 2-file ObjectFileTransComplex */
-public abstract class AbstractTestObjectFileTransComplex extends BaseTest
+public abstract class AbstractTestObjectFileTransComplex
 {
     static long count = 0 ;
     ObjectFile file1 ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestTransSeq.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/AbstractTestTransSeq.java
@@ -19,7 +19,9 @@
 package org.apache.jena.tdb.transaction;
 
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.sparql.JenaTransactionException;
@@ -35,7 +37,7 @@ import org.junit.BeforeClass ;
 import org.junit.Test ;
 
 /** Basic tests and tests of ordering (single thread) */
-public abstract class AbstractTestTransSeq extends BaseTest
+public abstract class AbstractTestTransSeq
 {
     @BeforeClass public static void beforeClassLoggingOff() { LogCtl.disable(SystemTDB.errlog.getName()) ; } 
     @AfterClass public static void afterClassLoggingOn()    { LogCtl.setInfo(SystemTDB.errlog.getName()) ; }

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestJournal.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestJournal.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.tdb.transaction;
 
+import static org.junit.Assert.*;
+
 import java.nio.ByteBuffer ;
 import java.util.Iterator ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.Bytes ;
 import org.apache.jena.tdb.base.block.Block ;
 import org.apache.jena.tdb.base.file.BufferChannel ;
@@ -30,7 +31,7 @@ import org.apache.jena.tdb.sys.FileRef ;
 import org.junit.Before ;
 import org.junit.Test ;
 
-public class TestJournal extends BaseTest
+public class TestJournal
 {
     static {
         FileRef.file("xyz") ;

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransIterator.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransIterator.java
@@ -18,10 +18,12 @@
 
 package org.apache.jena.tdb.transaction;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import java.util.Iterator ;
 
 import org.apache.jena.atlas.iterator.Iter ;
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.tdb.base.record.Record ;
 import org.apache.jena.tdb.base.record.RecordLib ;
 import org.apache.jena.tdb.index.IndexTestLib ;
@@ -29,7 +31,7 @@ import org.apache.jena.tdb.index.RangeIndex ;
 import org.apache.jena.tdb.index.bplustree.BPlusTree ;
 import org.junit.Test ;
 
-public class TestTransIterator extends BaseTest
+public class TestTransIterator
 {
     static BPlusTree build(int order, int[] values)
     {

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransRestart.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransRestart.java
@@ -18,10 +18,12 @@
 
 package org.apache.jena.tdb.transaction ;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.nio.ByteBuffer ;
 import java.util.Iterator ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.atlas.lib.Pair ;
 import org.apache.jena.query.TxnType;
@@ -43,7 +45,7 @@ import org.junit.Before ;
 import org.junit.Test ;
 
 /** Test of re-attaching to a pre-existing database */  
-public class TestTransRestart extends BaseTest {
+public class TestTransRestart {
     static { 
         // Only if run directly, not in test suite.
         if ( false )

--- a/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransactionUnionGraph.java
+++ b/jena-tdb/src/test/java/org/apache/jena/tdb/transaction/TestTransactionUnionGraph.java
@@ -20,8 +20,8 @@ package org.apache.jena.tdb.transaction;
 
 import static org.apache.jena.query.ReadWrite.READ ;
 import static org.apache.jena.query.ReadWrite.WRITE ;
+import static org.junit.Assert.assertEquals;
 
-import org.apache.jena.atlas.junit.BaseTest ;
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.* ;
 import org.apache.jena.sparql.core.Quad ;
@@ -32,7 +32,7 @@ import org.apache.jena.update.* ;
 import org.junit.* ;
 
 /** Tests of transactions and the TDB union graph */
-public class TestTransactionUnionGraph extends BaseTest
+public class TestTransactionUnionGraph
 {
     private Dataset ds ;
     

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestBuildTextDataset.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestBuildTextDataset.java
@@ -18,19 +18,21 @@
 
 package org.apache.jena.query.text ;
 
-import org.apache.jena.atlas.junit.BaseTest ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.* ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.riot.RDFDataMgr ;
 import org.apache.jena.tdb.TDB ;
 import org.apache.jena.vocabulary.RDFS ;
-import org.apache.lucene.store.Directory ;
 import org.apache.lucene.store.ByteBuffersDirectory ;
+import org.apache.lucene.store.Directory ;
 import org.junit.Test ;
 
 /** Test the examples of building a test dataset */
-public class TestBuildTextDataset extends BaseTest
+public class TestBuildTextDataset
 {
     static final String DIR = "testing/TextQuery" ;
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxnTDB1.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxnTDB1.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.query.text;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.List ;


### PR DESCRIPTION
This PR is a precursor for removing the use of JUnit3 TestSuite feature for tests from manifest files and using Junit4 runners.

This PR tidies up the use of Assert.assert, to be static imports, not via inheriting statics. It is so large it is worth pulling up separately so the real changes of conversion are not swamped.

There are some other small clean up changes that got swept up.
