### PR TITLE
Make FileManagerImpl constructors public

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/util/FileManagerImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/util/FileManagerImpl.java
@@ -105,7 +105,7 @@ public class FileManagerImpl implements FileManager
     
     /** Create an uninitialized FileManager */
 
-    protected FileManagerImpl() {}
+    public FileManagerImpl() {}
     
     protected static FileManager makeStd() {
         FileManagerImpl fm = new FileManagerImpl();

--- a/jena-core/src/main/java/org/apache/jena/util/FileManagerImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/util/FileManagerImpl.java
@@ -114,7 +114,7 @@ public class FileManagerImpl implements FileManager
     }
     
     /** Create with the given location mapper */
-    protected FileManagerImpl(LocationMapper _mapper)    { setLocationMapper(_mapper) ; }
+    public FileManagerImpl(LocationMapper _mapper)    { setLocationMapper(_mapper) ; }
 
     @Override
     public FileManager clone() { return clone(this) ; } 


### PR DESCRIPTION
We have an implementation of `LocationMapper` which reads its configuration from file using the `FileManager`. #759 for some reason changed the `FileManagerImpl` constructor visibility to `protected`, where it was `public` before. Therefore our code no longer compiles:
https://github.com/AtomGraph/Web-Client/blob/master/src/main/java/com/atomgraph/client/locator/PrefixMapper.java#L228

This PR restores the `public` visibility of the `FileManagerImpl` constructors.