### PR TITLE
JENA-1924: Test for ucschar in tokenizer.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/atlas/json/io/parser/TokenizerJSON.java
+++ b/jena-arq/src/main/java/org/apache/jena/atlas/json/io/parser/TokenizerJSON.java
@@ -105,7 +105,7 @@ public class TokenizerJSON implements Tokenizer
     public void remove()
     { throw new UnsupportedOperationException() ; }
 
-    // ---- Machinary
+    // ---- Machinery
     
     // ""-string, ''-string, *X, 
     // various single characters . , : ; 

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
@@ -375,11 +375,10 @@ public class RDFParser {
         }
         
         TypedInputStream in;
+        // Need more control than LocatorURL provides to get the Accept header in and the HttpCLient.
+        // So map now.
         urlStr = streamManager.mapURI(urlStr);
         if ( urlStr.startsWith("http://") || urlStr.startsWith("https://") ) {
-            // Need more control than LocatorURL provides. We could use it for the
-            // httpClient == null case.
-            //  
             // HttpOp.execHttpGet(,acceptHeader,) overrides the HttpClient default setting.
             // 
             // If there is an explicitly set HttpClient use that as given, and do not override
@@ -388,8 +387,9 @@ public class RDFParser {
             String acceptHeader = 
                 ( httpClient == null ) ? WebContent.defaultRDFAcceptHeader : null; 
             in = HttpOp.execHttpGet(urlStr, acceptHeader, httpClient, null);
-        } else { 
-            in = streamManager.open(urlStr);
+        } else {
+            // Already mapped.
+            in = streamManager.openNoMapOrNull(urlStr);
         }
         if ( in == null )
             throw new RiotNotFoundException("Not found: "+urlStr);

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/RiotParsers.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/RiotParsers.java
@@ -53,8 +53,7 @@ public class RiotParsers {
             Tokenizer tokenizer = new TokenizerJSON(PeekReader.makeUTF8(input));
             return createParserRdfJson(tokenizer, dest, profile);
         }
-
-        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input);
+        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input, profile.getErrorHandler());
         if ( RDFLanguages.sameLang(TURTLE, lang) || RDFLanguages.sameLang(N3,  lang) ) 
             return createParserTurtle(tokenizer, dest, profile);
         if ( RDFLanguages.sameLang(NTRIPLES, lang) )
@@ -74,7 +73,7 @@ public class RiotParsers {
         }
 
         @SuppressWarnings("deprecation")
-        Tokenizer tokenizer = TokenizerFactory.makeTokenizer(input);
+        Tokenizer tokenizer = TokenizerFactory.makeTokenizer(input, profile.getErrorHandler());
         if ( RDFLanguages.sameLang(TURTLE, lang) || RDFLanguages.sameLang(N3,  lang) ) 
             return createParserTurtle(tokenizer, dest, profile);
         if ( RDFLanguages.sameLang(NTRIPLES, lang) )
@@ -121,7 +120,7 @@ public class RiotParsers {
     /** Create an iterator for parsing N-Triples. */
     public static Iterator<Triple> createIteratorNTriples(InputStream input, StreamRDF dest, ParserProfile profile) {
         // LangNTriples supports iterator use.
-        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input);
+        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input, profile.getErrorHandler());
         return createParserNTriples(tokenizer, null, profile);
     }
 
@@ -133,7 +132,7 @@ public class RiotParsers {
     /** Create an iterator for parsing N-Quads. */
     public static Iterator<Quad> createIteratorNQuads(InputStream input, StreamRDF dest, ParserProfile profile) {
         // LangNQuads supports iterator use.
-        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input);
+        Tokenizer tokenizer = TokenizerFactory.makeTokenizerUTF8(input, profile.getErrorHandler());
         return createParserNQuads(tokenizer, null,  profile);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ErrorHandlerFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ErrorHandlerFactory.java
@@ -72,8 +72,13 @@ public class ErrorHandlerFactory
      * An error handler that throws a {@link RiotParseException}, hence it
      * exposes the details of errors.
      */
-    public static ErrorHandler errorHandlerDetailed()         { return new ErrorHandlerRiotParseException() ; }
+    public static ErrorHandler errorHandlerDetailed()           { return new ErrorHandlerRiotParseErrors() ; }
 
+    /**
+     * An error handler that throws exceptions in all cases.
+     */
+    public static ErrorHandler errorHandlerExceptions()        { return new ErrorHandlerRiotParseException() ; }
+    
     private static ErrorHandler defaultErrorHandler = errorHandlerStd ;
     /** Get the current default error handler */
     public static ErrorHandler getDefaultErrorHandler() { return defaultErrorHandler ; }
@@ -130,8 +135,9 @@ public class ErrorHandlerFactory
 
         /** report a warning */
         @Override
-        public void warning(String message, long line, long col)
-        { logWarning(message, line, col) ; }
+        public void warning(String message, long line, long col) {
+            logWarning(message, line, col);
+        }
 
         /** report an error */
         @Override
@@ -304,8 +310,10 @@ public class ErrorHandlerFactory
     }
 
     /** An error handler that throws a RiotParseException, hence it exposes the details of errors. */
-    private static class ErrorHandlerRiotParseException implements ErrorHandler {
-        public ErrorHandlerRiotParseException() {}
+    private static class ErrorHandlerRiotParseErrors implements ErrorHandler {
+
+        public ErrorHandlerRiotParseErrors() {}
+
         @Override public void warning(String message, long line, long col) { }
 
         @Override public void error(String message, long line, long col) {
@@ -316,5 +324,22 @@ public class ErrorHandlerFactory
             throw new RiotParseException(message, line, col);
         }
     }
+    
+    /** An error handler that throws a RiotParseException in all cases. */
+    private static class ErrorHandlerRiotParseException implements ErrorHandler {
+        
+        public ErrorHandlerRiotParseException() {}
+        
+        @Override public void warning(String message, long line, long col) {
+            throw new RiotParseException(message, line, col);
+        }
 
+        @Override public void error(String message, long line, long col) {
+            throw new RiotParseException(message, line, col);
+        }
+
+        @Override public void fatal(String message, long line, long col) {
+            throw new RiotParseException(message, line, col);
+        }
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotChars.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotChars.java
@@ -141,7 +141,8 @@ Notes: PN_CHARS_BASE has a hole above #xD800 -- these are the  surrogate pairs
 
     private static boolean r(int ch, int a, int b) { return ( ch >= a && ch <= b ); }
 
-    public static boolean range(int ch, char a, char b) {
+    /** Test whether a codepoint is a given range (both ends inclusive)*/
+    public static boolean range(int ch, int a, int b) {
         return (ch >= a && ch <= b);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocationMapper.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocationMapper.java
@@ -68,6 +68,10 @@ public class LocationMapper
         this.altPrefixes.putAll(lmap2.altPrefixes) ;
     }
 
+    public boolean containsMapping(String uri) {
+        return altMapping(uri, null) != null;
+    }
+
     public String altMapping(String uri) {
         return altMapping(uri, uri) ;
     }
@@ -82,6 +86,8 @@ public class LocationMapper
      * @return The alternative location chosen
      */
     public String altMapping(String uri, String otherwise) {
+        if ( altLocations.isEmpty() && altPrefixes.isEmpty() )
+            return otherwise;
         if ( altLocations.containsKey(uri) )
             return altLocations.get(uri) ;
         String newStart = null ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/stream/StreamManager.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/stream/StreamManager.java
@@ -132,6 +132,11 @@ public class StreamManager {
         return openNoMapOrNull(uri) ;
     }
 
+    /** Test whether a mapping exists */
+    public boolean hasMapping(String filenameOrURI) {
+        return mapper.containsMapping(filenameOrURI);
+    }
+
     /** Apply the mapping of a filename or URI */
     public String mapURI(String filenameOrURI) {
         if ( mapper == null )

--- a/jena-arq/src/main/java/org/apache/jena/riot/tokens/ErrorHandlerTokenizer.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/tokens/ErrorHandlerTokenizer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.tokens;
+
+import org.apache.jena.riot.RiotParseException;
+import org.apache.jena.riot.system.ErrorHandler;
+
+public class ErrorHandlerTokenizer implements ErrorHandler {
+    @Override public void warning(String message, long line, long col) {
+        // Warning/continue.
+        //ErrorHandlerFactory.errorHandlerStd.warning(message, line, col);
+        throw new RiotParseException(message, line, col);
+    }
+
+    @Override public void error(String message, long line, long col) {
+        throw new RiotParseException(message, line, col);
+    }
+
+    @Override public void fatal(String message, long line, long col) {
+        throw new RiotParseException(message, line, col);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/tokens/Token.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/tokens/Token.java
@@ -26,7 +26,6 @@ import java.util.ArrayList ;
 import java.util.List ;
 import java.util.Objects ;
 
-import org.apache.jena.atlas.io.PeekReader ;
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.Pair ;
 import org.apache.jena.datatypes.RDFDatatype ;
@@ -105,8 +104,7 @@ public final class Token
 
     static Token create(String s)
     {
-        PeekReader pr = PeekReader.readString(s) ;
-        TokenizerText tt = new TokenizerText(pr) ;
+        Tokenizer tt = TokenizerText.create().fromString(s).build();
         if ( ! tt.hasNext() )
             throw new RiotException("No token") ;
         Token t = tt.next() ;
@@ -117,8 +115,7 @@ public final class Token
 
     static Iter<Token> createN(String s)
     {
-        PeekReader pr = PeekReader.readString(s) ;
-        TokenizerText tt = new TokenizerText(pr) ;
+        Tokenizer tt = TokenizerText.create().fromString(s).build();
         List<Token> x = new ArrayList<>() ;
         while(tt.hasNext())
             x.add(tt.next()) ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizeTextBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizeTextBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.tokens;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+import org.apache.jena.atlas.io.PeekReader;
+import org.apache.jena.atlas.lib.InternalErrorException;
+import org.apache.jena.riot.system.ErrorHandler;
+import org.apache.jena.riot.system.ErrorHandlerFactory;
+
+/** Builder for TokenizeText */
+public class TokenizeTextBuilder {
+    
+    // One of these.
+    private PeekReader   peekReader   = null;
+    private InputStream  input        = null;
+    private Reader       reader       = null;
+    private String       string       = null;
+    
+    private boolean      lineMode     = false;
+    private boolean      utf8         = true;
+    private ErrorHandler errorHandler = null;
+
+    TokenizeTextBuilder() {}
+
+    private void clearInput() {
+        this.peekReader = null;
+        this.input = null;
+        this.reader = null;
+        this.string = null;
+    }
+
+    public TokenizeTextBuilder source(InputStream input) {
+        clearInput();
+        this.input = input;
+        return this;
+    }
+
+    public TokenizeTextBuilder source(Reader reader) {
+        clearInput();
+        this.reader = reader;
+        return this;
+    }
+
+    public TokenizeTextBuilder source(PeekReader peekReader) {
+        clearInput();
+        this.peekReader = peekReader;
+        return this;
+    }
+
+    public TokenizeTextBuilder fromString(String string) {
+        clearInput();
+        this.string = string;
+        return this;
+    }
+
+    public TokenizeTextBuilder lineMode(boolean lineMode) {
+        this.lineMode = lineMode;
+        return this;
+    }
+
+    public TokenizeTextBuilder asciiOnly(boolean asciiOnly) {
+        this.utf8 = !asciiOnly;
+        return this;
+    }
+
+    public TokenizeTextBuilder errorHandler(ErrorHandler errorHandler) {
+        this.errorHandler = errorHandler;
+        return this;
+    }
+
+    private static int countNulls(Object ... objs) {
+        int x = 0;
+        for ( Object obj : objs )
+            if ( obj == null )
+                x++;
+        return x;
+    }
+
+    private static int countNotNulls(Object ... objs) {
+        int x = 0;
+        for ( Object obj : objs )
+            if ( obj != null )
+                x++;
+        return x;
+    }
+
+    public Tokenizer build() {
+        ErrorHandler errHandler = (errorHandler != null) ? errorHandler : ErrorHandlerFactory.errorHandlerExceptions();
+        int x = countNotNulls(peekReader, input, reader, string);
+        if ( x > 1 )
+            throw new InternalErrorException("Too many data sources");
+        PeekReader pr;
+        if ( input != null ) {
+            pr = utf8 ? PeekReader.makeUTF8(input) : PeekReader.makeASCII(input);
+        } else if ( string != null ) {
+            pr = PeekReader.readString(string);
+        } else if ( reader != null ) {
+            pr = PeekReader.make(reader);
+        } else if ( peekReader != null ) {
+            pr = peekReader;
+        } else {
+            throw new IllegalStateException("No data source");
+        }
+
+        return TokenizerText.internal(pr, lineMode, errHandler);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizerFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizerFactory.java
@@ -16,55 +16,62 @@
  * limitations under the License.
  */
 
-package org.apache.jena.riot.tokens ;
+package org.apache.jena.riot.tokens;
 
-import java.io.ByteArrayInputStream ;
-import java.io.InputStream ;
-import java.io.Reader ;
-import java.io.StringReader ;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
 
-import org.apache.jena.atlas.io.PeekReader ;
-import org.apache.jena.atlas.lib.StrUtils ;
+import org.apache.jena.riot.system.ErrorHandler;
 
 public class TokenizerFactory {
-    
+
+    private static ErrorHandler dftErrorHandler = null;
+
     /** Discouraged - be careful about character sets */
     @Deprecated
     public static Tokenizer makeTokenizer(Reader reader) {
-        PeekReader peekReader = PeekReader.make(reader) ;
-        Tokenizer tokenizer = new TokenizerText(peekReader) ;
-        return tokenizer ;
+        return TokenizerText.create().source(reader).build();
+    }
+
+    /** Discouraged - be careful about character sets */
+    @Deprecated
+    public static Tokenizer makeTokenizer(Reader reader, ErrorHandler errorHandler) {
+        return TokenizerText.create().source(reader).errorHandler(errorHandler).build();
     }
 
     /** Safe use of a StringReader */
     public static Tokenizer makeTokenizer(StringReader reader) {
-        PeekReader peekReader = PeekReader.make(reader) ;
-        Tokenizer tokenizer = new TokenizerText(peekReader) ;
-        return tokenizer ;
+        return TokenizerText.create().source(reader).build();
+    }
+
+    /** Safe use of a StringReader */
+    public static Tokenizer makeTokenizer(StringReader reader, ErrorHandler errorHandler) {
+        return TokenizerText.create().source(reader).errorHandler(errorHandler).build();
     }
 
     public static Tokenizer makeTokenizerUTF8(InputStream in) {
+        return makeTokenizerUTF8(in, dftErrorHandler);
+    }
+
+    public static Tokenizer makeTokenizerUTF8(InputStream input, ErrorHandler errorHandler) {
         // BOM will be removed
-        PeekReader peekReader = PeekReader.makeUTF8(in) ;
-        Tokenizer tokenizer = new TokenizerText(peekReader) ;
-        return tokenizer ;
+        return TokenizerText.create().source(input).errorHandler(errorHandler).build();
     }
 
-    public static Tokenizer makeTokenizerASCII(InputStream in) {
-        PeekReader peekReader = PeekReader.makeASCII(in) ;
-        Tokenizer tokenizer = new TokenizerText(peekReader) ;
-        return tokenizer ;
+    public static Tokenizer makeTokenizerASCII(InputStream input) {
+        return TokenizerText.create().source(input).asciiOnly(true).build();
     }
 
-    public static Tokenizer makeTokenizerASCII(String string) {
-        byte b[] = StrUtils.asUTF8bytes(string) ;
-        ByteArrayInputStream in = new ByteArrayInputStream(b) ;
-        return makeTokenizerASCII(in) ;
+    public static Tokenizer makeTokenizerASCII(InputStream input, ErrorHandler errorHandler) {
+        return TokenizerText.create().source(input).asciiOnly(true).errorHandler(errorHandler).build();
     }
 
     public static Tokenizer makeTokenizerString(String str) {
-        PeekReader peekReader = PeekReader.readString(str) ;
-        Tokenizer tokenizer = new TokenizerText(peekReader) ;
-        return tokenizer ;
+        return TokenizerText.create().fromString(str).build();
+    }
+
+    public static Tokenizer makeTokenizerString(String str, ErrorHandler errorHandler) {
+        return TokenizerText.create().fromString(str).errorHandler(errorHandler).build();
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/AbstractTestLangNTuples.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/AbstractTestLangNTuples.java
@@ -131,7 +131,7 @@ abstract public class AbstractTestLangNTuples
     }
 
     // Bad terms - but accepted by default.
-    @Test(expected = ExFatal.class)
+    @Test(expected = ExError.class)
     public void tuple_bad_10() {
         parseCount("<x> <p> <bad uri> .");
     }

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTrig.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTrig.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.riot.ErrorHandlerTestLib ;
-import org.apache.jena.riot.ErrorHandlerTestLib.ExFatal ;
+import org.apache.jena.riot.ErrorHandlerTestLib.ExError;
 import org.apache.jena.riot.ErrorHandlerTestLib.ExWarning ;
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.sparql.core.DatasetGraph ;
@@ -67,13 +67,13 @@ public class TestLangTrig
     // Also need to check that the RiotExpection is called in normal use. 
     
     // Bad terms.
-    @Test (expected=ExFatal.class)
+    @Test (expected=ExError.class)
     public void trig_20()     { parse("@prefix ex:  <bad iri> .", "{ ex:s ex:p 123 }") ; }
     
-    @Test (expected=ExFatal.class)
+    @Test (expected=ExError.class)
     public void trig_21()     { parse("@prefix ex:  <http://example/> .", "{ ex:s <http://example/broken p> 123 }") ; }
     
-    @Test (expected=ExFatal.class)
+    @Test (expected=ExError.class)
     public void trig_22()     { parse("{ <x> <p> 'number'^^<bad uri> }") ; }
 
     @Test (expected=ExWarning.class)

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTurtle.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTurtle.java
@@ -33,6 +33,7 @@ import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Property ;
 import org.apache.jena.rdf.model.Resource ;
+import org.apache.jena.riot.ErrorHandlerTestLib.ExError;
 import org.apache.jena.riot.ErrorHandlerTestLib.ExFatal ;
 import org.apache.jena.riot.ErrorHandlerTestLib.ExWarning ;
 import org.apache.jena.riot.Lang ;
@@ -157,7 +158,7 @@ public class TestLangTurtle
     @Test(expected=ExFatal.class)
     public void errorBadDatatype()          { parse("<p> <p> 'q'^^.") ; }
     
-    @Test(expected=ExFatal.class)
+    @Test(expected=ExError.class)
     public void errorBadURI_1()
     { parse("<http://example/a b> <http://example/p> 123 .") ; }
 
@@ -171,10 +172,10 @@ public class TestLangTurtle
     { parse("<http://example/a%Aab> <http://example/p> 123 .") ; }
 
     // Bad URIs
-    @Test (expected=ExFatal.class)
+    @Test (expected=ExError.class)
     public void errorBadURI_4()     { parse("@prefix ex:  <bad iri> .  ex:s ex:p 123 ") ; }
     
-    @Test (expected=ExFatal.class)
+    @Test (expected=ExError.class)
     public void errorBadURI_5()     { parse("<x> <p> 'number'^^<bad uri> ") ; }
     
     @Test (expected=ExFatal.class)

--- a/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizer.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizer.java
@@ -33,14 +33,14 @@ import org.apache.jena.sparql.ARQConstants ;
 import org.junit.Test ;
 
 public class TestTokenizer {
-    // WORKERS
+
     private static Tokenizer tokenizer(String string) {
         return tokenizer(string, false) ;
     }
 
     private static Tokenizer tokenizer(String string, boolean lineMode) {
         PeekReader r = PeekReader.readString(string) ;
-        Tokenizer tokenizer = new TokenizerText(r, lineMode) ;
+        Tokenizer tokenizer = TokenizerText.create().source(r).lineMode(lineMode).build();
         return tokenizer ;
     }
 
@@ -1109,7 +1109,7 @@ public class TestTokenizer {
 
     @Test
     public void token_rdf_star_1() {
-        Tokenizer tokenizer = tokenizer("<<>>", true) ;
+        Tokenizer tokenizer = tokenizer("<<>>") ;
         testNextToken(tokenizer, TokenType.LT2) ;
         testNextToken(tokenizer, TokenType.GT2) ;
         assertFalse(tokenizer.hasNext()) ;
@@ -1117,7 +1117,7 @@ public class TestTokenizer {
 
     @Test
     public void token_rdf_star_2() {
-        Tokenizer tokenizer = tokenizer("<< >>", true) ;
+        Tokenizer tokenizer = tokenizer("<< >>") ;
         testNextToken(tokenizer, TokenType.LT2) ;
         testNextToken(tokenizer, TokenType.GT2) ;
         assertFalse(tokenizer.hasNext()) ;
@@ -1125,7 +1125,7 @@ public class TestTokenizer {
 
     @Test
     public void token_rdf_star_3() {
-        Tokenizer tokenizer = tokenizer("<<:s x:p 123>> :q ", true) ;
+        Tokenizer tokenizer = tokenizer("<<:s x:p 123>> :q ") ;
         testNextToken(tokenizer, TokenType.LT2) ;
         testNextToken(tokenizer, TokenType.PREFIXED_NAME, "", "s") ;
         testNextToken(tokenizer, TokenType.PREFIXED_NAME, "x", "p") ;
@@ -1137,7 +1137,7 @@ public class TestTokenizer {
 
     @Test
     public void token_rdf_star_4() {
-        Tokenizer tokenizer = tokenizer("<<<>>>", true) ;
+        Tokenizer tokenizer = tokenizer("<<<>>>") ;
         testNextToken(tokenizer, TokenType.LT2) ;
         Token t = testNextToken(tokenizer, TokenType.IRI) ;
         assertEquals("", t.getImage());

--- a/jena-arq/testing/RIOT/Lang/Changes
+++ b/jena-arq/testing/RIOT/Lang/Changes
@@ -1,0 +1,15 @@
+Tests localName_with_nfc_PN_CHARS_BASE_character_boundaries
+in Turtle and Trig contain IRIs with the character \U000E01EF
+in the result nt/nq files.
+
+That character is illegal in IRIs, even if allowed by syntax.
+So it causes a failure whn reading the test.
+
+It is not in RFC 3987 - the block E0000-E0FFF is excluded.
+
+   ucschar        = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
+                  / %x10000-1FFFD / %x20000-2FFFD / %x30000-3FFFD
+                  / %x40000-4FFFD / %x50000-5FFFD / %x60000-6FFFD
+                  / %x70000-7FFFD / %x80000-8FFFD / %x90000-9FFFD
+                  / %xA0000-AFFFD / %xB0000-BFFFD / %xC0000-CFFFD
+                  / %xD0000-DFFFD / %xE1000-EFFFD

--- a/jena-arq/testing/RIOT/Lang/TrigStd/manifest.ttl
+++ b/jena-arq/testing/RIOT/Lang/TrigStd/manifest.ttl
@@ -53,7 +53,10 @@
     <#underscore_in_localName>
     <#localname_with_COLON>
     <#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries>
-    <#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries>
+
+    ## Contains \U000E01EF in the result which is not legal in a IRI.
+    ##   <#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries>
+
     <#localName_with_nfc_PN_CHARS_BASE_character_boundaries>
     <#localName_with_leading_underscore>
     <#localName_with_leading_digit>

--- a/jena-arq/testing/RIOT/Lang/TurtleStd/manifest.ttl
+++ b/jena-arq/testing/RIOT/Lang/TurtleStd/manifest.ttl
@@ -41,7 +41,10 @@
     <#underscore_in_localName>
     <#localname_with_COLON>
     <#localName_with_assigned_nfc_bmp_PN_CHARS_BASE_character_boundaries>
-    <#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries>
+
+    ## Contains \U000E01EF in the result which is not legal in a IRI.
+    ##   <#localName_with_assigned_nfc_PN_CHARS_BASE_character_boundaries>
+
     <#localName_with_nfc_PN_CHARS_BASE_character_boundaries>
     <#localName_with_leading_underscore>
     <#localName_with_leading_digit>

--- a/jena-core/src/main/java/org/apache/jena/util/FileManagerImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/util/FileManagerImpl.java
@@ -114,7 +114,10 @@ public class FileManagerImpl implements FileManager
     }
     
     /** Create with the given location mapper */
-    protected FileManagerImpl(LocationMapper _mapper)    { setLocationMapper(_mapper) ; }
+    protected FileManagerImpl(LocationMapper _mapper) {
+        this();
+        setLocationMapper(_mapper);
+    }
 
     @Override
     public FileManager clone() { return clone(this) ; } 

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/sys/Sys.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/sys/Sys.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 /** Low level environment */
 public class Sys
 {
-    static final Logger log = LoggerFactory.getLogger("Sys");
+    static final Logger log = LoggerFactory.getLogger("org.apache.jena.dboe.Sys");
 
     /** System log - use for general messages (a few) and warnings.
      *  Generally, do not log events unless you want every user to see them every time.
@@ -39,9 +39,9 @@ public class Sys
      */
 
     /** General system log */
-    public static final Logger syslog = LoggerFactory.getLogger("System");
+    public static final Logger syslog = LoggerFactory.getLogger("org.apache.jena.dboe.System");
     /** Send warnings and error */
-    public static final Logger errlog = LoggerFactory.getLogger("System");
+    public static final Logger errlog = LoggerFactory.getLogger("org.apache.jena.dboe.System");
 
     /** Size, in bytes, of a Java long */
     public static final int SizeOfLong              = Long.BYTES; // Long.SIZE/Byte.SIZE ;

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/SystemTDB.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/SystemTDB.java
@@ -135,7 +135,7 @@ public class SystemTDB
         propertyFileName = x;
     }
 
-    public static final boolean is64bitSystem = determineIf64Bit();
+    public static final boolean is64bitSystem = Sys.is64bitSystem;
 
     private static Properties properties = readPropertiesFile();
 
@@ -312,40 +312,6 @@ public class SystemTDB
             IO.exception(ex);
         }
         return p;
-    }
-
-    // --------
-
-    public static final boolean isWindows = determineIfWindows();	// Memory mapped files behave differently.
-
-    //Or look in File.listRoots.
-    //Alternative method:
-    //  http://stackoverflow.com/questions/1293533/name-of-the-operating-system-in-java-not-os-name
-
-    private static boolean determineIfWindows() {
-    	String s = System.getProperty("os.name");
-    	if ( s == null )
-    		return false;
-    	return s.startsWith("Windows ");
-	}
-
-    private static boolean determineIf64Bit() {
-        String s = System.getProperty("sun.arch.data.model");
-        if ( s != null ) {
-            boolean b = s.equals("64");
-            TDB2.logInfo.debug("System architecture: " + (b ? "64 bit" : "32 bit"));
-            return b;
-        }
-        // Not a SUN VM
-        s = System.getProperty("java.vm.info");
-        if ( s == null ) {
-            log.warn("Can't determine the data model");
-            return false;
-        }
-        log.debug("Can't determine the data model from 'sun.arch.data.model' - using java.vm.info");
-        boolean b = s.contains("64");
-        TDB2.logInfo.debug("System architecture: (from java.vm.info) " + (b ? "64 bit" : "32 bit"));
-        return b;
     }
 
     // ---- File mode

--- a/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/ConfigTest.java
+++ b/jena-db/jena-tdb2/src/test/java/org/apache/jena/tdb2/ConfigTest.java
@@ -19,7 +19,7 @@
 package org.apache.jena.tdb2;
 
 import org.apache.jena.atlas.lib.FileOps;
-import org.apache.jena.tdb2.sys.SystemTDB;
+import org.apache.jena.base.Sys;
 
 public class ConfigTest
 {
@@ -27,7 +27,7 @@ public class ConfigTest
     // Place under target
     private static final String testingDir = "target/tdb-testing";
     private static final String testingDirDB = "target/tdb-testing/DB";
-    static boolean nonDeleteableMMapFiles = SystemTDB.isWindows;
+    static boolean nonDeleteableMMapFiles = Sys.isWindows;
 
     static boolean initialized = false;
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestAdminAPI.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestAdminAPI.java
@@ -34,6 +34,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.atlas.web.TypedInputStream;
+import org.apache.jena.base.Sys;
 import org.apache.jena.fuseki.webapp.FusekiWebapp;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.rdfconnection.RDFConnection;
@@ -61,7 +62,7 @@ public class TestAdminAPI extends AbstractFusekiTest {
 
     @Test public void add_delete_api_3() throws Exception {
         // Deleted mmap files on Windows does not go away until the JVM exits.
-        if ( org.apache.jena.tdb2.sys.SystemTDB.isWindows )
+        if ( Sys.isWindows )
             return;
         testAddDelete("db_tdb2", "tdb2", true);
     }

--- a/jena-iri/src/main/java/org/apache/jena/iri/impl/Parser.java
+++ b/jena-iri/src/main/java/org/apache/jena/iri/impl/Parser.java
@@ -18,14 +18,10 @@
 
 package org.apache.jena.iri.impl;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.LineNumberReader;
-import java.io.Reader;
 import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
+import java.io.*;
 import java.net.IDN;
 
 import org.apache.jena.iri.* ;
@@ -227,15 +223,27 @@ public class Parser implements IRIComponents, ViolationCodes {
         }
     }
 
+    static public void devParse(String uriStr) throws IOException {
+        LineNumberReader in = new LineNumberReader(new StringReader(uriStr));
+        devParse(in);
+    }
+    
     static public void main(String args[]) throws IOException {
-        LineNumberReader in = new LineNumberReader(new InputStreamReader(
-                System.in));
+        LineNumberReader in = new LineNumberReader(new InputStreamReader(System.in));
+        devParse(in);
+    }
+    
+    static private void devParse(LineNumberReader in) throws IOException {
+        
         IRIImpl last = null;
         DEBUG = true;
 
         IRIFactory factory = IRIFactory.iriImplementation();
         while (true) {
-            String s = in.readLine().trim();
+            String s = in.readLine();
+            if ( s == null )
+                return;
+            s = s.trim();
             if (s.equals("quit"))
                 return;
             IRIImpl iri = (IRIImpl) factory.create(s);


### PR DESCRIPTION
This PR fixes for JENA-1924 (Turtle, NT etc, not RDF/XML) both the reported character and caharacters byond the Unicode Basic Plane. This in turn revealed illegal IRIs in WG 2 tests.

* Configurable `ErrorHandler` for TokenizerText.
* Differentiate "fatal" errors in tokens (always unrecoverable) and "error" where the data is wrong (bad IRI) but tokenizing can continue.
* Allow a configurable ErrorHandler for TokenizerText.
* Fix Turtle/Trig WG tests because the tests themselves contain bad IRIs.
* (unrelated) minor cleaning tweaks to StreamManager trigger noticed during recent users@ discussions.
