### PR TITLE
JENA-1933: Prefer const RDFLanguages.RDFTHRIFT to .THRIFT

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
@@ -123,6 +123,7 @@ public class RDFLanguages
                                                      .addAltNames("RDF_THRIFT", "RDFTHRIFT", "RDF/THRIFT", "TRDF")
                                                      .addFileExtensions("rt", "trdf")
                                                      .build() ;
+    /** @deprecated Use {@link #RDFTHRIFT} */
     public static final Lang THRIFT     = RDFTHRIFT;
 
     /** Text */
@@ -184,7 +185,7 @@ public class RDFLanguages
         Lang.NQUADS     = RDFLanguages.NQUADS ;
         Lang.NQ         = RDFLanguages.NQ ;
         Lang.TRIG       = RDFLanguages.TRIG ;
-        Lang.RDFTHRIFT  = RDFLanguages.THRIFT ;
+        Lang.RDFTHRIFT  = RDFLanguages.RDFTHRIFT ;
         Lang.TRIX       = RDFLanguages.TRIX ;
         Lang.RDFNULL    = RDFLanguages.RDFNULL ;
         Lang.SHACLC     = RDFLanguages.SHACLC ;
@@ -215,7 +216,7 @@ public class RDFLanguages
         register(RDFJSON) ;
         register(TRIG) ;
         register(NQUADS) ;
-        register(THRIFT) ;
+        register(RDFTHRIFT) ;
         register(TRIX) ;
         register(RDFNULL) ;
         register(SHACLC) ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/thrift/StreamRDF2Thrift.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/thrift/StreamRDF2Thrift.java
@@ -18,117 +18,118 @@
 
 package org.apache.jena.riot.thrift;
 
-import java.io.OutputStream ;
+import java.io.OutputStream;
 
-import org.apache.jena.atlas.logging.Log ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.riot.RiotException ;
-import org.apache.jena.riot.system.PrefixMap ;
-import org.apache.jena.riot.system.PrefixMapFactory ;
-import org.apache.jena.riot.system.StreamRDF ;
-import org.apache.jena.riot.thrift.wire.* ;
-import org.apache.jena.sparql.core.Quad ;
-import org.apache.thrift.TException ;
-import org.apache.thrift.protocol.TProtocol ;
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.riot.RiotException;
+import org.apache.jena.riot.system.PrefixMap;
+import org.apache.jena.riot.system.PrefixMapFactory;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.riot.thrift.wire.*;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TProtocol;
 
 /** Encode StreamRDF in Thrift.
- *  Usually used via {@link BinRDF} functions. 
- * 
+ *  Usually used via {@link BinRDF} functions.
+ *
  * @see Thrift2StreamRDF (for each RDF_StreamRow) for the reverse process.
- */ 
-public class StreamRDF2Thrift implements StreamRDF, AutoCloseable 
+ */
+public class StreamRDF2Thrift implements StreamRDF, AutoCloseable
 {
     // No REPEAT support.
-    private final OutputStream out ;
-    private final TProtocol protocol ;
-    private PrefixMap pmap = PrefixMapFactory.create() ;
-    private final boolean encodeValues ;
+    private final OutputStream out;
+    private final TProtocol protocol;
+    private PrefixMap pmap = PrefixMapFactory.create();
+    private final boolean encodeValues;
 
-//    public StreamRDF2Thrift(OutputStream out) {
-//        this(out, false) ;
-//    }
-    
+    public StreamRDF2Thrift(OutputStream out) {
+        this(out, false);
+    }
+
     public StreamRDF2Thrift(OutputStream out, boolean encodeValues) {
-        this.out = out ;
-        this.protocol = TRDF.protocol(out) ;
-        this.encodeValues = encodeValues ;
+        this(TRDF.protocol(out), encodeValues);
     }
 
 //    public StreamRDF2Thrift(TProtocol out) {
-//        this(out, false) ;
+//        this(out, false);
 //    }
-    
-    public StreamRDF2Thrift(TProtocol out, boolean encodeValues) { 
-        this.out = null ;
-        this.protocol = out ;
-        this.pmap = PrefixMapFactory.create() ;
-        this.encodeValues = encodeValues ;
+
+    public StreamRDF2Thrift(TProtocol out, boolean encodeValues) {
+        this.out = null;
+        this.protocol = out;
+        this.pmap = PrefixMapFactory.create();
+        this.encodeValues = encodeValues;
     }
 
     @Override
     public void start() { }
 
-    private final RDF_StreamRow  tStreamRow   = new RDF_StreamRow() ;
-    
-    private final RDF_Triple ttriple    = new RDF_Triple() ;
-    private final RDF_Quad   tquad      = new RDF_Quad() ;
-    
-    private final RDF_Term   tsubject   = new RDF_Term() ;
-    private final RDF_Term   tpredicate = new RDF_Term() ;
-    private final RDF_Term   tobject    = new RDF_Term() ;
-    private final RDF_Term   tgraph     = new RDF_Term() ;
-    
+    private final RDF_StreamRow  tStreamRow   = new RDF_StreamRow();
+
+    private final RDF_Triple ttriple    = new RDF_Triple();
+    private final RDF_Quad   tquad      = new RDF_Quad();
+
+    private final RDF_Term   tsubject   = new RDF_Term();
+    private final RDF_Term   tpredicate = new RDF_Term();
+    private final RDF_Term   tobject    = new RDF_Term();
+    private final RDF_Term   tgraph     = new RDF_Term();
+
     @Override
     public void triple(Triple triple) {
-        doTriple(triple.getSubject(), triple.getPredicate(), triple.getObject()) ;
+        doTriple(triple.getSubject(), triple.getPredicate(), triple.getObject());
     }
 
     private void doTriple(Node subject, Node predicate, Node object) {
-        ThriftConvert.toThrift(subject, pmap, tsubject, encodeValues) ;
-        ThriftConvert.toThrift(predicate, pmap, tpredicate, encodeValues) ;
-        ThriftConvert.toThrift(object, pmap, tobject, encodeValues) ;
-        ttriple.setS(tsubject) ;
-        ttriple.setP(tpredicate) ;
-        ttriple.setO(tobject) ;
+        ThriftConvert.toThrift(subject, pmap, tsubject, encodeValues);
+        ThriftConvert.toThrift(predicate, pmap, tpredicate, encodeValues);
+        ThriftConvert.toThrift(object, pmap, tobject, encodeValues);
+        ttriple.setS(tsubject);
+        ttriple.setP(tpredicate);
+        ttriple.setO(tobject);
 
-        tStreamRow.setTriple(ttriple) ;
-        try { tStreamRow.write(protocol) ; }
-        catch (TException e) { TRDF.exception(e) ; }
-        tStreamRow.clear();
-        ttriple.clear();
-        tsubject.clear();
-        tpredicate.clear() ;
-        tobject.clear() ;
+        tStreamRow.setTriple(ttriple);
+        try { tStreamRow.write(protocol); }
+        catch (TException e) { TRDF.exception(e); }
+        finally {
+            tStreamRow.clear();
+            ttriple.clear();
+            tsubject.clear();
+            tpredicate.clear();
+            tobject.clear();
+        }
     }
-    
+
     @Override
     public void quad(Quad quad) {
         if ( quad.getGraph() == null || quad.isDefaultGraph() ) {
-            doTriple(quad.getSubject(), quad.getPredicate(), quad.getObject()) ;
-            return ;
+            doTriple(quad.getSubject(), quad.getPredicate(), quad.getObject());
+            return;
         }
-        
-        ThriftConvert.toThrift(quad.getGraph(), pmap, tgraph, encodeValues) ;
-        ThriftConvert.toThrift(quad.getSubject(), pmap, tsubject, encodeValues) ;
-        ThriftConvert.toThrift(quad.getPredicate(), pmap, tpredicate, encodeValues) ;
-        ThriftConvert.toThrift(quad.getObject(), pmap, tobject, encodeValues) ;
-        
-        tquad.setG(tgraph) ;
-        tquad.setS(tsubject) ;
-        tquad.setP(tpredicate) ;
-        tquad.setO(tobject) ;
-        tStreamRow.setQuad(tquad) ;
-        
-        try { tStreamRow.write(protocol) ; } 
-        catch (TException e) { TRDF.exception(e) ; }
-        
-        tStreamRow.clear() ;
-        tquad.clear();
-        tgraph.clear();
-        tsubject.clear();
-        tpredicate.clear() ;
-        tobject.clear() ;
+
+        ThriftConvert.toThrift(quad.getGraph(), pmap, tgraph, encodeValues);
+        ThriftConvert.toThrift(quad.getSubject(), pmap, tsubject, encodeValues);
+        ThriftConvert.toThrift(quad.getPredicate(), pmap, tpredicate, encodeValues);
+        ThriftConvert.toThrift(quad.getObject(), pmap, tobject, encodeValues);
+
+        tquad.setG(tgraph);
+        tquad.setS(tsubject);
+        tquad.setP(tpredicate);
+        tquad.setO(tobject);
+        tStreamRow.setQuad(tquad);
+
+        try { tStreamRow.write(protocol); }
+        catch (TException e) { TRDF.exception(e); }
+        finally {
+            tStreamRow.clear();
+            tquad.clear();
+            tgraph.clear();
+            tsubject.clear();
+            tpredicate.clear();
+            tobject.clear();
+        }
     }
 
     @Override
@@ -138,24 +139,24 @@ public class StreamRDF2Thrift implements StreamRDF, AutoCloseable
 
     @Override
     public void prefix(String prefix, String iri) {
-        try { pmap.add(prefix, iri) ; }
+        try { pmap.add(prefix, iri); }
         catch ( RiotException ex) {
-            Log.warn(this, "Prefix mapping error", ex) ;
+            Log.warn(this, "Prefix mapping error", ex);
         }
-        RDF_PrefixDecl tprefix = new RDF_PrefixDecl(prefix, iri) ; 
-        tStreamRow.setPrefixDecl(tprefix) ;
-        try { tStreamRow.write(protocol) ; }
-        catch (TException e) { TRDF.exception(e) ; }
-        tStreamRow.clear(); 
+        RDF_PrefixDecl tprefix = new RDF_PrefixDecl(prefix, iri);
+        tStreamRow.setPrefixDecl(tprefix);
+        try { tStreamRow.write(protocol); }
+        catch (TException e) { TRDF.exception(e); }
+        tStreamRow.clear();
     }
 
     @Override
     public void close() {
-        finish() ;
+        finish();
     }
-    
+
     @Override
     public void finish() {
-        TRDF.flush(protocol) ;
+        TRDF.flush(protocol);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/thrift/TRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/thrift/TRDF.java
@@ -41,9 +41,9 @@ import org.apache.thrift.transport.TTransport ;
 
 /** Support operations for RDF Thrift */
 public class TRDF {
-    public static final int InputBufferSize     = 128*1024 ; 
-    public static final int OutputBufferSize    = 128*1024 ; 
-    
+    public static final int InputBufferSize     = 128*1024 ;
+    public static final int OutputBufferSize    = 128*1024 ;
+
     /**
      * Create Thrift protocol for the InputStream.
      * @param in InputStream
@@ -61,13 +61,13 @@ public class TRDF {
 
     /**
      * Create Thrift protocol for the OutputStream.
-     * The caller must call {@link TRDF#flush(TProtocol)} 
-     * which will flush the underlying (internally buffered) output stream. 
+     * The caller must call {@link TRDF#flush(TProtocol)}
+     * which will flush the underlying (internally buffered) output stream.
      * @param out OutputStream
      */
     public static TProtocol protocol(OutputStream out) {
         try {
-            // Flushing the protocol will flush the BufferedOutputStream 
+            // Flushing the protocol will flush the BufferedOutputStream
             if ( !( out instanceof BufferedOutputStream ) )
                 out = new BufferedOutputStream(out, OutputBufferSize) ;
             TTransport transport = new TIOStreamTransport(out) ;
@@ -89,26 +89,26 @@ public class TRDF {
 
     public static TProtocol protocol(TTransport transport) {
         if ( true ) return new TCompactProtocol(transport) ;
-    
+
         // Keep the warnings down.
         if ( false ) return new TTupleProtocol(transport) ;
         if ( false ) return new TJSONProtocol(transport) ;
         throw new RiotThriftException("No protocol impl choosen") ;
     }
 
-    /** Flush a TProtocol; exceptions converted to {@link RiotException} */  
+    /** Flush a TProtocol; exceptions converted to {@link RiotException} */
     public static void flush(TProtocol protocol) {
         flush(protocol.getTransport()) ;
     }
 
-    /** Flush a TTransport; exceptions converted to {@link RiotException} */  
+    /** Flush a TTransport; exceptions converted to {@link RiotException} */
     public static void flush(TTransport transport) {
         try { transport.flush() ; }
         catch (TException ex) { TRDF.exception(ex) ; }
     }
 
     public static final RDF_ANY ANY = new RDF_ANY() ;
-    /** The Thrift RDF Term 'ANY' */ 
+    /** The Thrift RDF Term 'ANY' */
     public static final RDF_Term tANY = new RDF_Term() ;
     /** The Thrift RDF Term 'UNDEF' */
     public static final RDF_UNDEF UNDEF = new RDF_UNDEF() ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/thrift/WriterDatasetThrift.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/thrift/WriterDatasetThrift.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.riot.thrift;
 
-import static org.apache.jena.riot.RDFLanguages.THRIFT ;
+import static org.apache.jena.riot.RDFLanguages.RDFTHRIFT ;
 
 import java.io.OutputStream ;
 import java.io.Writer ;
@@ -41,7 +41,7 @@ public class WriterDatasetThrift implements WriterDatasetRIOT
     }
     @Override
     public Lang getLang() {
-        return THRIFT ;
+        return RDFTHRIFT ;
     }
     @Override
     public void write(Writer out, DatasetGraph dsg, PrefixMap prefixMap, String baseURI, Context context) {

--- a/jena-arq/src/main/java/org/apache/jena/riot/thrift/WriterGraphThrift.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/thrift/WriterGraphThrift.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.riot.thrift;
 
-import static org.apache.jena.riot.RDFLanguages.THRIFT ;
+import static org.apache.jena.riot.RDFLanguages.RDFTHRIFT ;
 
 import java.io.OutputStream ;
 import java.io.Writer ;
@@ -42,12 +42,13 @@ public class WriterGraphThrift implements WriterGraphRIOT
     }
     @Override
     public Lang getLang() {
-        return THRIFT ;
+        return RDFTHRIFT ;
     }
     @Override
     public void write(Writer out, Graph graph, PrefixMap prefixMap, String baseURI, Context context) {
         throw new NotImplemented("Writing binary data to a java.io.Writer is not supported. Please use an OutputStream") ;
     }
+
     @Override
     public void write(OutputStream out, Graph graph, PrefixMap prefixMap, String baseURI, Context context) {
         StreamRDF stream = BinRDF.streamToOutputStream(out, withValues) ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestThriftSetup.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/thrift/TestThriftSetup.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.riot.thrift;
 
-import static org.apache.jena.riot.RDFLanguages.THRIFT ;
+import static org.apache.jena.riot.RDFLanguages.RDFTHRIFT ;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -29,25 +29,25 @@ import org.junit.Test ;
 public class TestThriftSetup {
 
     @Test public void setup_01() {
-        assertTrue(RDFLanguages.isRegistered(THRIFT)) ;
+        assertTrue(RDFLanguages.isRegistered(RDFTHRIFT)) ;
     }
 
     @Test public void setup_02() {
         Lang lang = RDFLanguages.filenameToLang("data.rt") ;
-        assertEquals(lang, THRIFT) ;
+        assertEquals(lang, RDFTHRIFT) ;
     }
 
     @SuppressWarnings("deprecation")
     @Test public void setup_03() {
-        assertTrue(RDFParserRegistry.isQuads(THRIFT)) ;
-        assertTrue(RDFParserRegistry.isTriples(THRIFT)) ;
-        assertTrue(RDFParserRegistry.isRegistered(THRIFT));
-        assertNotNull(RDFParserRegistry.getFactory(THRIFT)) ;
+        assertTrue(RDFParserRegistry.isQuads(RDFTHRIFT)) ;
+        assertTrue(RDFParserRegistry.isTriples(RDFTHRIFT)) ;
+        assertTrue(RDFParserRegistry.isRegistered(RDFTHRIFT));
+        assertNotNull(RDFParserRegistry.getFactory(RDFTHRIFT)) ;
     }
-    
+
     @Test public void setup_04() {
-        assertTrue(RDFWriterRegistry.contains(THRIFT)) ;
-        assertNotNull(RDFWriterRegistry.getWriterDatasetFactory(THRIFT)) ;
+        assertTrue(RDFWriterRegistry.contains(RDFTHRIFT)) ;
+        assertNotNull(RDFWriterRegistry.getWriterDatasetFactory(RDFTHRIFT)) ;
         assertTrue(RDFWriterRegistry.contains(RDFFormat.RDF_THRIFT)) ;
         assertNotNull(RDFWriterRegistry.getWriterDatasetFactory(RDFFormat.RDF_THRIFT)) ;
         assertTrue(RDFWriterRegistry.contains(RDFFormat.RDF_THRIFT_VALUES)) ;

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemoteBuilder.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemoteBuilder.java
@@ -286,7 +286,7 @@ public class RDFConnectionRemoteBuilder {
         return this;
     }
 
-    /** Build an {RDFConnection}. */
+    /** Build an {@link RDFConnection}. */
     public RDFConnection build() {
         requireNonNull(txnLifecycle);
 


### PR DESCRIPTION
More clean-up for JENA-1933 and also triggered by user@ investigation of RDF Thrift usage.

No functional changes.