### PR TITLE
JENA-1939: fix getUpdateCount() in the JDBC driver

### DIFF
--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/JenaStatement.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/statements/JenaStatement.java
@@ -62,6 +62,8 @@ public abstract class JenaStatement implements Statement {
     protected static final int NO_LIMIT = 0;
     protected static final int DEFAULT_TYPE = ResultSet.TYPE_FORWARD_ONLY;
     protected static final int USE_CONNECTION_COMPATIBILITY = Integer.MIN_VALUE;
+    protected static final int UNKNOWN_UPDATE_COUNT = 0;
+    protected static final int NOT_AN_UPDATE = -1;
 
     private List<String> commands = new ArrayList<>();
     private SQLWarning warnings = null;
@@ -74,7 +76,7 @@ public abstract class JenaStatement implements Statement {
     private int fetchDirection = DEFAULT_FETCH_DIRECTION;
     private int fetchSize = DEFAULT_FETCH_SIZE;
     private int holdability = DEFAULT_HOLDABILITY;
-    private int updateCount = 0;
+    private int updateCount = NOT_AN_UPDATE;
     private boolean autoCommit = DEFAULT_AUTO_COMMIT;
     private int transactionLevel = DEFAULT_TRANSACTION_LEVEL;
     private int maxRows = NO_LIMIT;
@@ -288,6 +290,7 @@ public abstract class JenaStatement implements Statement {
     }
 
     private boolean executeQuery(Query q) throws SQLException {
+        updateCount = NOT_AN_UPDATE;
         if (this.isClosed())
             throw new SQLException("The Statement is closed");
 
@@ -422,6 +425,7 @@ public abstract class JenaStatement implements Statement {
     protected abstract QueryExecution createQueryExecution(Query q) throws SQLException;
 
     private int executeUpdate(UpdateRequest u) throws SQLException {
+        updateCount = UNKNOWN_UPDATE_COUNT;
         if (this.isClosed())
             throw new SQLException("The Statement is closed");
         if (this.connection.isReadOnly())
@@ -654,6 +658,7 @@ public abstract class JenaStatement implements Statement {
         }
         if (!this.results.isEmpty()) {
             this.currResults = this.results.poll();
+            this.updateCount = this.currResults == null ? UNKNOWN_UPDATE_COUNT : NOT_AN_UPDATE;
             return true;
         } else {
             return false;


### PR DESCRIPTION
The method JenaStatement.getUpdateCount() returns 0. But java.sql.Statement documentation says:

    Returns: the current result as an update count; -1 if the current result is a ResultSet object or there are no more results

Returning correct value is important because a single statement may have multiple result sets and cause mutiple updates (not only multiple updated records, but multiple sets of updated records).

Applications (e.g. SQL-DK) iterate over these multiple results and need to know when finish. The getMoreResults() documentation says:

    There are no more results when the following is true: ((stmt.getMoreResults() == false) && (stmt.getUpdateCount() == -1))

But if 0 is returned, the application enters infinite loop.