### PR TITLE
JENA-1949: Docker tools for Fuseki

### DIFF
--- a/jena-fuseki2/jena-fuseki-docker/Dockerfile
+++ b/jena-fuseki2/jena-fuseki-docker/Dockerfile
@@ -1,0 +1,115 @@
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+## Apache Jena Fuseki server Dockerfile.
+
+## This Dockefile builds a reduced footprint container.
+
+ARG OPENJDK_VERSION=14
+ARG ALPINE_VERSION=3.12.0
+ARG JENA_VERSION=""
+
+# Internal, passed between stages.
+ARG FUSEKI_DIR=/fuseki
+ARG FUSEKI_JAR=jena-fuseki-server-${JENA_VERSION}.jar
+ARG JAVA_MINIMAL=/opt/java-minimal
+
+## ---- Stage: Download and build java.
+FROM openjdk:${OPENJDK_VERSION}-alpine AS base
+
+ARG JAVA_MINIMAL
+ARG JENA_VERSION
+ARG FUSEKI_DIR
+ARG FUSEKI_JAR
+ARG REPO=https://repo1.maven.org/maven2
+ARG JAR_URL=${REPO}/org/apache/jena/jena-fuseki-server/${JENA_VERSION}/${FUSEKI_JAR}
+
+RUN [ "${JENA_VERSION}" != "" ] || { echo -e '\n**** Set JENA_VERSION ****\n' ; exit 1 ; }
+RUN echo && echo "==== Docker build for Apache Jena Fuseki ${JENA_VERSION} ====" && echo
+
+# Alpine: For objcopy used in jlink
+RUN apk add --no-cache curl binutils
+
+## -- Fuseki installed and runs in /fuseki.
+WORKDIR $FUSEKI_DIR
+
+## -- Download the jar file.
+COPY download.sh .
+RUN chmod a+x download.sh
+
+# Download, with check of the SHA1 checksum.
+RUN ./download.sh --chksum sha1 "$JAR_URL"
+
+## -- Alternatives to download : copy already downloaded.
+## COPY ${FUSEKI_JAR} .
+
+## Use Docker ADD - does not retry, does not check checksum, and may run every build.
+## ADD "$JAR_URL"
+
+## -- Make reduced Java JDK
+RUN \
+  JDEPS="$(jdeps --multi-release base --print-module-deps --ignore-missing-deps ${FUSEKI_JAR})" && \
+  jlink \
+        --compress 2 --strip-debug --no-header-files --no-man-pages \
+        --output "${JAVA_MINIMAL}" \
+        --add-modules "${JDEPS}"
+
+ADD entrypoint.sh .
+ADD log4j2.properties .
+
+# Run as this user
+# -H : no home directorry
+# -D : no password
+
+RUN adduser -H -D fuseki fuseki
+
+## ---- Stage: Build runtime
+FROM alpine:${ALPINE_VERSION}
+
+## Import ARGs
+ARG JENA_VERSION
+ARG JAVA_MINIMAL
+ARG FUSEKI_DIR
+ARG FUSEKI_JAR
+
+COPY --from=base /opt/java-minimal /opt/java-minimal
+COPY --from=base /fuseki /fuseki
+COPY --from=base /etc/passwd /etc/passwd
+
+WORKDIR $FUSEKI_DIR
+
+ARG LOGS=${FUSEKI_DIR}/logs
+ARG DATA=${FUSEKI_DIR}/databases
+
+RUN \
+    mkdir -p $LOGS && \
+    mkdir -p $DATA && \
+    chown -R fuseki ${FUSEKI_DIR} && \
+    chmod a+x entrypoint.sh 
+
+## Default environment variables.
+ENV \
+    JAVA_HOME=${JAVA_MINIMAL}           \
+    JAVA_OPTIONS="-Xmx2048m -Xms2048m"  \
+    JENA_VERSION=${JENA_VERSION}        \
+    FUSEKI_JAR="${FUSEKI_JAR}"          \
+    FUSEKI_DIR="${FUSEKI_DIR}"
+
+USER fuseki
+
+EXPOSE 3030
+
+ENTRYPOINT ["./entrypoint.sh" ]
+CMD []

--- a/jena-fuseki2/jena-fuseki-docker/README.md
+++ b/jena-fuseki2/jena-fuseki-docker/README.md
@@ -1,0 +1,109 @@
+# Apache Jena Fuseki Docker Tools
+
+This package contains a Dockerfile, docker-compose file, and helper scripts to
+create a docker container for Apache Jena Fuseki.
+
+The docker container is based on 
+[Fuseki main](https://jena.apache.org/documentation/fuseki2/fuseki-main)
+for running a SPARQL server.
+
+There is no UI - all configuration is by command line and all usage by via the
+network protocols.
+
+Databases can be mounted outside the docker container so they are preserved when
+the container terminates.
+
+This build system allows the user to customize the docker image.
+
+The docker build downloads the server binary from 
+[Maven central](https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-server/),
+checking the download against the SHA1 checksum.
+
+## Database
+
+There is a volume mapping "./databases" in the current directory into the server.
+This can be used to contain databases outside, but accessible to, the container
+that do not get deleted when the container exits.
+
+See examples below.
+
+## Build
+
+Choose the version number of Apache Jena release you wish to use. This toolkit
+defaults to the version of the overall Jena release it was part of. It is best
+to use the release of this set of tools from the same release of the desired
+server.
+
+    docker-compose build --build-arg JENA_VERSION=3.16.0
+
+Note the build command must provide the version number.
+
+## Test Run
+
+`docker-compose run` cam be used to test the build from the previous section.
+
+Examples:
+
+Start Fuseki with an in-memory, updatable dataset at http://<i>host</i>:3030/ds
+
+    docker-compose run --rm --service-ports fuseki --mem /ds
+
+Load a TDB2 database, and expose, read-only, via docker:
+
+    mkdir -p databases/DB2
+    tdb2.tdbloader --loc databases/DB2 MyData.ttl
+    # Publish read-only
+    docker-compose run --rm --name MyServer --service-ports fuseki --tdb2 --loc databases/DB2 /ds
+
+To allow update on the database, add `--update`. Updates are persisted.
+
+    docker-compose run --rm --name MyServer --service-ports fuseki --tdb2 --update --loc databases/DB2 /ds
+
+See
+[fuseki-configuration](https://jena.apache.org/documentation/fuseki2/fuseki-configuration.html)
+for more information on command line arguments.
+
+To use `docker-compose up`, edit the `docker-compose.yaml` to set the Fuseki
+command line arguments appropriately.
+
+## Layout
+
+The default layout in the container is:
+
+| Path  | Use | 
+| ----- | --- |
+| /opt/java-minimal | A reduced size Java runtime                      |
+| /fuseki | The Fuseki installation                                    |
+| /fuseki/log4j2.properties | Logging configuration                    |
+| /fuseki/databases/ | Directory for a volume for persistent databases |
+
+## Setting JVM arguments
+
+Use `JAVA_OPTIONS`:
+
+    docker-compose run --service-ports --rm -e JAVA_OPTIONS="-Xmx1048m -Xms1048m" --name MyServer fuseki --mem /ds
+
+## Docker Commands
+
+If you prefer to use `docker` directly:
+
+Build:
+
+    docker build --force-rm --build-arg JENA_VERSION=3.16.0 -t fuseki .
+
+Run:
+
+    docker run -i --rm -p "3030:3030" --name MyServer -t fuseki --mem /ds
+
+With databases on a bind mount to host filesystem directory:
+
+    MNT="--mount type=bind,src=$PWD/databases,dst=/fuseki/databases"
+    docker run -i --rm -p "3030:3030" $MNT --name MyServer -t fuseki --tdb2 --update --loc databases/DB2 /ds
+
+## Version specific notes:
+
+* Versions of Jena up to 3.14.0 use Log4j1 for logging. The docker will build will ignore
+   the log4j2.properties file
+* Version 3.15.0: When run, a warning will be emitted.  
+  `WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.`  
+  This can be ignored.

--- a/jena-fuseki2/jena-fuseki-docker/assembly-docker.xml
+++ b/jena-fuseki2/jena-fuseki-docker/assembly-docker.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<!-- 
+  The docker tools distribution.
+-->
+
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  
+  <id>distribution</id>
+
+  <formats>
+    <format>zip</format>
+  </formats>
+
+  <baseDirectory>${project.artifactId}-${project.version}</baseDirectory>
+
+  <!-- If including the jar
+  <dependencySets>
+    <dependencySet>
+      <useProjectArtifact>false</useProjectArtifact>
+      <includes>
+        <include>org.apache.jena:jena-fuseki-server:jar</include>
+      </includes>
+      <outputFileNameMapping>fuseki-server.jar</outputFileNameMapping>
+      <outputFileNameMapping>jena-fuseki-server-${artifact.version}.jar</outputFileNameMapping>
+    </dependencySet>
+  </dependencySets>
+  -->
+
+  <files>
+    <file>
+      <source>dist/LICENSE</source>
+      <destName>LICENSE</destName>
+    </file>
+    <file>
+      <source>dist/NOTICE</source>
+      <destName>NOTICE</destName>
+    </file>
+  </files>
+
+  <fileSets>
+    <fileSet>
+      <outputDirectory></outputDirectory>
+      <includes>
+        <include>Dockerfile*</include>
+        <include>docker-compose.yml</include>
+        <include>README*</include>
+        <include>log4j2.properties</include>
+        <include>entrypoint.sh</include>
+        <include>download.sh</include>
+        <include>.dockerignore</include>
+      </includes>
+    </fileSet>
+
+  </fileSets>
+</assembly>

--- a/jena-fuseki2/jena-fuseki-docker/dist/LICENSE
+++ b/jena-fuseki2/jena-fuseki-docker/dist/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/jena-fuseki2/jena-fuseki-docker/dist/NOTICE
+++ b/jena-fuseki2/jena-fuseki-docker/dist/NOTICE
@@ -1,0 +1,5 @@
+Apache Jena - module Fuseki (Docker tools)
+Copyright - The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).

--- a/jena-fuseki2/jena-fuseki-docker/docker-compose.yaml
+++ b/jena-fuseki2/jena-fuseki-docker/docker-compose.yaml
@@ -1,0 +1,32 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3.0'
+services:
+  fuseki:
+    ## Example:
+    ## command: [ "--tdb2", "--update", "--loc", "databases/DB2", "/ds" ]
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: fuseki
+    ports:
+      - "3030:3030"
+    volumes:
+      - ./logs:/fuseki/logs
+      - ./databases:/fuseki/databases
+#volumes:

--- a/jena-fuseki2/jena-fuseki-docker/download.sh
+++ b/jena-fuseki2/jena-fuseki-docker/download.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an ash/dash script (it uses "local"), not a bash script.
+# It can run in an Alpine image durign a docker build.
+#
+# The advantage over using docker ADD is that it checks
+# whether download file is already present and does not
+# download each time.
+#
+# Shell script to download URL and check the checksum
+
+USAGE="Usage: $(basename "$0") --chksum [sha1|sha512] URL"
+
+if [ $# -eq 0 ]
+then
+    echo "$USAGE" 2>&1
+    exit 1
+fi
+
+CHKSUM_TYPE='unset'
+
+while [ $# -gt 0 ] ; do
+    case "$1" in
+	--chksum|-chksum|-sha|--sha)
+	    if [ $# -lt 2 ]
+	    then
+		echo "$USAGE" 1>&2
+		exit 1
+	    fi
+	    CHKSUM_TYPE=$2
+	    shift
+	    shift
+	    ;;
+	-h|--help)
+	    echo "$USAGE" 1>&2
+	    exit 0
+	    ;;
+	-*)
+	    echo "$USAGE" 1>&2
+	    exit 1
+	    ;;
+	*)
+	    if [ $# -ne 1 ]
+	    then
+		echo "$USAGE" 1>&2
+		exit 1
+	    fi
+	    URL="$1"
+	    shift
+	    ;;
+    esac
+done
+
+case "${CHKSUM_TYPE}" in
+    unset)
+	echo "$USAGE" 1>&2
+	exit 1
+	;;
+    sha*|md5) ;;
+    *)
+	echo "Bad checksum type: '$CHKSUM_TYPE' (must start 'sha' or be 'md5')" 2>&1
+	exit 1	 
+	;;
+esac
+
+## ---- Script starts ----
+
+ARTIFACT_URL="${URL}"
+ARTIFACT_NAME="$(basename "$ARTIFACT_URL")"
+
+# -------- Checksum details
+
+CHKSUM_EXT=".${CHKSUM_TYPE}"
+CHKSUM_URL="${ARTIFACT_URL}${CHKSUM_EXT}"
+CHKSUM_FILE="${ARTIFACT_NAME}${CHKSUM_EXT}"
+CHKSUMPROG="${CHKSUM_TYPE}sum"
+# --------
+
+CURL_FETCH_OPTS="-s -S --fail --location --max-redirs 3"
+if false
+then
+    echo "ARTIFACT_URL=$ARTIFACT_URL"
+    echo "CHKSUM_URL=$CHKSUM_URL"
+fi
+
+download() { # URL
+    local URL="$1"
+    local FN="$(basename "$URL")"
+    if [ ! -e "$FN" ]
+    then
+	echo "Fetching $URL"
+	curl $CURL_FETCH_OPTS "$URL" --output "$FN" \
+	    || { echo "Bad download of $FN" 2>&1 ; return 1 ; }
+    else
+	echo "$FN already present"
+    fi
+    return 0
+}
+
+checkChksum() { # Filename checksum
+    local FN="$1"
+    local CHKSUM="$2"
+    if [ ! -e "$FN" ]
+    then
+	echo "No such file: '$FN'" 2>&1
+	exit 1
+    fi
+    # NB Two spaces required for busybox
+    echo "$CHKSUM  $FN" | ${CHKSUMPROG} -c > /dev/null
+}
+
+download "$ARTIFACT_URL" || exit 1
+
+if [ -z "$CHKSUM" ]
+then
+    # Checksum not previously set.
+    # Extract from file, copes with variations in content (filename or not)
+    download "$CHKSUM_URL" || exit 1
+    CHKSUM="$(cut -d' ' -f1 "$CHKSUM_FILE")"
+fi
+
+checkChksum "${ARTIFACT_NAME}" "$CHKSUM"
+if [ $? = 0 ]
+then
+    echo "Good download: $ARTIFACT_NAME"
+else
+    echo "BAD download !!!! $ARTIFACT_NAME"
+    echo "To retry: delete downloaded files and try again"
+    exit 1
+fi

--- a/jena-fuseki2/jena-fuseki-docker/entrypoint.sh
+++ b/jena-fuseki2/jena-fuseki-docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+## env | sort
+exec "$JAVA_HOME/bin/java" $JAVA_OPTIONS -jar "${FUSEKI_DIR}/${FUSEKI_JAR}" "$@"

--- a/jena-fuseki2/jena-fuseki-docker/log4j2.properties
+++ b/jena-fuseki2/jena-fuseki-docker/log4j2.properties
@@ -1,0 +1,70 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+status = error
+name = PropertiesConfig
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = INFO
+
+appender.console.type = Console
+appender.console.name = OUT
+appender.console.target = SYSTEM_OUT
+appender.console.layout.type = PatternLayout
+## appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
+## Include date.
+appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
+
+## To a file.
+## appender.file.type = File
+## appender.file.name = FILE
+## appender.file.fileName=/fuseki/logs/log.fuseki
+## appender.file.layout.type=PatternLayout
+## appender.file.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
+
+rootLogger.level                  = INFO
+rootLogger.appenderRef.stdout.ref = OUT
+
+logger.jena.name  = org.apache.jena
+logger.jena.level = INFO
+
+logger.arq-exec.name  = org.apache.jena.arq.exec
+logger.arq-exec.level = INFO
+
+logger.riot.name  = org.apache.jena.riot
+logger.riot.level = INFO
+
+logger.fuseki.name  = org.apache.jena.fuseki
+logger.fuseki.level = INFO
+
+logger.fuseki-fuseki.name  = org.apache.jena.fuseki.Fuseki
+logger.fuseki-fuseki.level = INFO
+
+logger.fuseki-server.name  = org.apache.jena.fuseki.Server
+logger.fuseki-server.level = INFO
+
+logger.fuseki-admin.name  = org.apache.jena.fuseki.Admin
+logger.fuseki-admin.level = INFO
+
+logger.jetty.name  = org.eclipse.jetty
+logger.jetty.level = WARN
+
+# May be useful to turn up to DEBUG if debugging HTTP communication issues
+logger.apache-http.name   = org.apache.http
+logger.apache-http.level  = WARN
+
+logger.shiro.name = org.apache.shiro
+logger.shiro.level = WARN
+# Hide bug in Shiro 1.5.x
+logger.shiro-realm.name = org.apache.shiro.realm.text.IniRealm
+logger.shiro-realm.level = ERROR
+
+# This goes out in NCSA format
+appender.plain.type = Console
+appender.plain.name = PLAIN
+appender.plain.layout.type = PatternLayout
+appender.plain.layout.pattern = %m%n
+
+logger.request-log.name                   = org.apache.jena.fuseki.Request
+logger.request-log.additivity             = false
+logger.request-log.level                  = OFF
+logger.request-log.appenderRef.plain.ref  = PLAIN

--- a/jena-fuseki2/jena-fuseki-docker/pom.xml
+++ b/jena-fuseki2/jena-fuseki-docker/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Apache Jena - Fuseki Docker Tools</name>
+  <artifactId>jena-fuseki-docker</artifactId>
+  <version>3.17.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <parent>
+    <groupId>org.apache.jena</groupId>
+    <artifactId>jena-fuseki</artifactId>
+    <version>3.17.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent> 
+  
+  <description>Fuseki Docker</description>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-zip-assembly</id>
+            <phase>package</phase>
+            <!--<phase />-->
+            <goals><goal>single</goal></goals>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <tarLongFileMode>posix</tarLongFileMode>
+              <descriptors>
+                <descriptor>assembly-docker.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      
+    </plugins>
+
+  </build>
+
+</project>


### PR DESCRIPTION
This creates a zip that would be part of a Jena release.

The zip file has the Dockerfile/docker-compose.yml and documentation to build locally.

The container is based on alpine.
The build creates a trimmed down Java11 runtime.

The Fuseki container is about 82 Mb.