### PR TITLE
JENA-1959 Added JsonLdReadContext

### DIFF
--- a/jena-arq/src-examples/arq/examples/riot/Ex_WriteJsonLD.java
+++ b/jena-arq/src-examples/arq/examples/riot/Ex_WriteJsonLD.java
@@ -200,7 +200,8 @@ public class Ex_WriteJsonLD
         DatasetGraph g = DatasetFactory.wrap(m).asDatasetGraph();
         JsonLDWriteContext ctx = new JsonLDWriteContext();
 
-        // The following should work, but unfortunately it doesn't (with JSONLD-java 0.8.3):
+        // The following should work for Uris returning JSON-LD,
+        // but unfortunately it doesn't for schema.org due to the following bug: https://github.com/jsonld-java/jsonld-java/issues/289:
         ctx.setJsonLDContext("\"http://schema.org/\"");
         System.out.println("\n--- Setting the context to a URI, WRONG WAY: it's slow, and the output is not JSON-LD. Sorry about that. ---");
         write(g, RDFFormat.JSONLD_COMPACT_PRETTY, ctx);
@@ -214,7 +215,6 @@ public class Ex_WriteJsonLD
         // the output process must download the vocab before anything.
         // (that's why the previous attempt was slow)
         // -> that would not be an very efficient way to output your data.
-        // -> it doesn't work, (with JSONLD-java 0.8.3), but no regret.
 
         // To achieve the expected result,
         // you have to do 2 things:

--- a/jena-arq/src/main/java/org/apache/jena/riot/JsonLDReadContext.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/JsonLDReadContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jena-arq/src/main/java/org/apache/jena/riot/JsonLDReadContext.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/JsonLDReadContext.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/jena-arq/src/main/java/org/apache/jena/riot/JsonLDReadContext.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/JsonLDReadContext.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot;
+
+import com.github.jsonldjava.core.JsonLdOptions;
+import org.apache.jena.atlas.web.ContentType;
+import org.apache.jena.riot.lang.JsonLDReader;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.sparql.util.Context;
+
+import java.io.InputStream;
+
+/**
+ * Set of parameters that can be used to control the reading of JSON-LD.
+ *
+ * This class provides setters to define a "Context" suitable to be passed as 
+ * last argument to  {@link ReaderRIOT#read(InputStream, String, ContentType, StreamRDF, Context)}
+ * when the ReaderRIOT has been created with one of the JSON-LD RDFFormat variants (that is, when it is
+ * an instance of {@link JsonLDReader})
+ *
+ * Parameters that are actually useful are ''documentLoader'' and ''produceGeneralizedRdf''.
+ *
+ */
+public class JsonLDReadContext extends Context {
+    /**
+     * Set the value of the JSON-LD "@context" node, used when reading a jsonld (overriding the actual @context in the jsonld). "Compact" and "Flattened" JSON-LD outputs.
+     *
+     * @param jsonLdContext the value of the "@context" node (a JSON value). Note that the use of an URI to pass an external context is not supported (as of JSONLD-java API 0.8.3)
+     *
+     * @see #setJsonLDContext(Object)
+     */
+    public void setJsonLDContext(String jsonLdContext) {
+        set(JsonLDReader.JSONLD_CONTEXT, jsonLdContext);
+    }
+
+    /**
+     * Set the value of the JSON-LD "@context" node, used when reading a jsonld (overriding the actual @context in the jsonld). "Compact" and "Flattened" JSON-LD outputs.
+     *
+     *
+     * @param jsonLdContext the context as expected by JSON-LD java API. As of JSON-LD java 0.8.3, a Map
+     * defining the properties and the prefixes is OK. Note that the use an URI to pass an external context is not supported (JSONLD-java RDF 0.8.3)
+     *
+     * @see #setJsonLDContext(String)
+     */
+    public void setJsonLDContext(Object jsonLdContext) {
+        set(JsonLDReader.JSONLD_CONTEXT, jsonLdContext);
+    }
+    /**
+     * Set the JSON-LD java API's options
+     *
+     * If not set, a default value is used.
+     *
+     * @param opts the options as defined by the JSON-LD java API
+     */
+    public void setOptions(JsonLdOptions opts) {
+        set(JsonLDReader.JSONLD_OPTIONS, opts);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/JsonLDWriteContext.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/JsonLDWriteContext.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/jena-arq/src/main/java/org/apache/jena/riot/JsonLDWriteContext.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/JsonLDWriteContext.java
@@ -6,15 +6,16 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.jena.riot;
 
 import java.io.OutputStream;
@@ -59,7 +60,7 @@ public class JsonLDWriteContext extends Context {
      * Only useful for "Compact" and "Flattened" JSON-LD outputs, and not required: if not set,
      * a value for the "@Context" node is computed, based on the content of the dataset and its prefix mappings.
      * 
-     * @param jsonLdContext the value of the "@context" node (a JSON value). Note that the use of an URI to pass an external context is not supported (as of JSONLD-java API 0.8.3)
+     * @param jsonLdContext the value of the "@context" node (a JSON value). Some remote contexts might not be resolved property.
      * @see #setJsonLDContextSubstitution(String) for a way to overcome this problem.
      * 
      * @see #setJsonLDContext(Object)
@@ -74,8 +75,7 @@ public class JsonLDWriteContext extends Context {
      * Only useful for "Compact" and "Flattened" JSON-LD outputs, and not required: if not set,
      * a value for the "@Context" node is computed, based on the content of the dataset and its prefix mappings.
      * 
-     * @param jsonLdContext the context as expected by JSON-LD java API. As of JSON-LD java 0.8.3, a Map 
-     * defining the properties and the prefixes is OK. Note that the use an URI to pass an external context is not supported (JSONLD-java RDF 0.8.3)
+     * @param jsonLdContext the context as expected by JSON-LD java API. Some remote contexts might not be resolved property.
      * @see #setJsonLDContextSubstitution(String) for a way to overcome this problem.
      * 
      * @see #setJsonLDContext(String)

--- a/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
@@ -109,13 +109,6 @@ public class RIOT {
 
     // ---- Symbols
 
-    /**
-     * Symbol to use to pass (in a Context object) the "@context" to be used when reading jsonld
-     * (overriding the actual @context in the jsonld)
-     * Expected value: the value of the "@context",
-     * as expected by the JSONLD-java API (a Map) */
-    public static final Symbol JSONLD_CONTEXT = Symbol.create("http://jena.apache.org/riot/jsonld#JSONLD_CONTEXT");
-
     private static String TURTLE_SYMBOL_BASE = "http://jena.apache.org/riot/turtle#";
 
     /**

--- a/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
@@ -19,6 +19,7 @@
 package org.apache.jena.riot ;
 
 import org.apache.jena.query.ARQ ;
+import org.apache.jena.riot.lang.JsonLDReader;
 import org.apache.jena.riot.resultset.ResultSetLang;
 import org.apache.jena.sparql.SystemARQ ;
 import org.apache.jena.sparql.mgt.SystemInfo ;
@@ -108,6 +109,10 @@ public class RIOT {
     }
 
     // ---- Symbols
+
+    /** @deprecated Use {@link JsonLDReader#JSONLD_CONTEXT} */
+    @Deprecated
+    public static final Symbol JSONLD_CONTEXT = JsonLDReader.JSONLD_CONTEXT;
 
     private static String TURTLE_SYMBOL_BASE = "http://jena.apache.org/riot/turtle#";
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/JsonLDReader.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/JsonLDReader.java
@@ -111,7 +111,6 @@ public class JsonLDReader implements ReaderRIOT
         }
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public void read(InputStream in, String baseURI, ContentType ct, StreamRDF output, Context context) {
         try {
@@ -131,6 +130,7 @@ public class JsonLDReader implements ReaderRIOT
         }
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     private void readWithJsonLDCtxOptions(Object jsonObject, String baseURI, final StreamRDF output, Context context)  throws JsonParseException, IOException {
         JsonLdOptions options = getJsonLdOptions(baseURI, context) ;
         Object jsonldCtx = getJsonLdContext(context);

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/JsonLDReader.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/JsonLDReader.java
@@ -26,6 +26,7 @@ import java.util.Map ;
 import java.util.Map.Entry;
 import java.util.Objects;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.jena.atlas.io.IO ;
 import org.apache.jena.atlas.lib.InternalErrorException ;
 import org.apache.jena.atlas.web.ContentType ;
@@ -47,14 +48,42 @@ import com.github.jsonldjava.core.JsonLdProcessor;
 import com.github.jsonldjava.core.JsonLdTripleCallback;
 import com.github.jsonldjava.core.RDFDataset;
 import com.github.jsonldjava.utils.JsonUtils ;
+import org.apache.jena.sparql.util.Symbol;
 
 /**
+ * One can pass a jsonld context using the (jena) Context mechanism, defining a (jena) Context
+ * (sorry for this clash of "contexts"), (cf. last argument in
+ * {@link ReaderRIOT#read(InputStream in, String baseURI, ContentType ct, StreamRDF output, Context context)})
+ * with:
+ * <pre>
+ * Context jenaContext = new Context()
+ * jenaCtx.set(JsonLdReader.JSONLD_CONTEXT, contextAsJsonString);
+ * </pre>
+ * where contextAsJsonString is a JSON string containing the value of the "@context".
+ *
+ * It is also possible to define the different options supported
+ * by JSONLD-java using the {@link #JSONLD_OPTIONS} Symbol
+ *
+ * The {@link JsonLDReadContext} is a convenience class that extends Context and
+ * provides methods to set the values of these different Symbols that are used in controlling the writing of JSON-LD.
  * Note: it is possible to override jsonld's "@context" value by providing one,
- * using a {@link org.apache.jena.sparql.util.Context}, and setting the {@link RIOT#JSONLD_CONTEXT} Symbol's value
+ * using a {@link org.apache.jena.sparql.util.Context}, and setting the {@link JsonLDReader#JSONLD_CONTEXT} Symbol's value
  * to the data expected by JSON-LD java API (a {@link Map}).
  */
 public class JsonLDReader implements ReaderRIOT
 {
+    private static final String SYMBOLS_NS = "http://jena.apache.org/riot/jsonld#" ;
+    private static Symbol createSymbol(String localName) {
+        return Symbol.create(SYMBOLS_NS + localName);
+    }
+    /**
+     * Symbol to use to pass (in a Context object) the "@context" to be used when reading jsonld
+     * (overriding the actual @context in the jsonld)
+     * Expected value: the value of the "@context",
+     * as expected by the JSONLD-java API (a Map) */
+    public static final Symbol JSONLD_CONTEXT = createSymbol("JSONLD_CONTEXT");
+    /** value: the option object expected by JsonLdProcessor (instance of JsonLdOptions) */
+    public static final Symbol JSONLD_OPTIONS = createSymbol("JSONLD_OPTIONS");
     private /*final*/ ErrorHandler errorHandler = ErrorHandlerFactory.getDefaultErrorHandler() ;
     private /*final*/ ParserProfile profile;
     
@@ -67,7 +96,7 @@ public class JsonLDReader implements ReaderRIOT
     public void read(Reader reader, String baseURI, ContentType ct, StreamRDF output, Context context) {
         try {
             Object jsonObject = JsonUtils.fromReader(reader) ;
-            read$(jsonObject, baseURI, ct, output, context) ;
+            readWithJsonLDCtxOptions(jsonObject, baseURI, output, context) ;
         }
         catch (JsonProcessingException ex) {    
             // includes JsonParseException
@@ -87,18 +116,7 @@ public class JsonLDReader implements ReaderRIOT
     public void read(InputStream in, String baseURI, ContentType ct, StreamRDF output, Context context) {
         try {
             Object jsonObject = JsonUtils.fromInputStream(in) ;
-            
-            if (context != null) {
-                Object jsonldCtx = context.get(RIOT.JSONLD_CONTEXT);
-                if (jsonldCtx != null) {
-                    if (jsonObject instanceof Map) {
-                        ((Map) jsonObject).put("@context", jsonldCtx);
-                    } else {
-                        errorHandler.warning("Unexpected: not a Map; unable to set JsonLD's @context",-1,-1);
-                    }
-                }
-            }
-            read$(jsonObject, baseURI, ct, output, context) ;
+            readWithJsonLDCtxOptions(jsonObject, baseURI, output, context) ;
         }
         catch (JsonProcessingException ex) {    
             // includes JsonParseException
@@ -112,8 +130,21 @@ public class JsonLDReader implements ReaderRIOT
             IO.exception(e) ;
         }
     }
-    
-    private void read$(Object jsonObject, String baseURI, ContentType ct, final StreamRDF output, Context context) {
+
+    private void readWithJsonLDCtxOptions(Object jsonObject, String baseURI, final StreamRDF output, Context context)  throws JsonParseException, IOException {
+        JsonLdOptions options = getJsonLdOptions(baseURI, context) ;
+        Object jsonldCtx = getJsonLdContext(context);
+        if (jsonldCtx != null) {
+            if (jsonObject instanceof Map) {
+                ((Map) jsonObject).put("@context", jsonldCtx);
+            } else {
+                errorHandler.warning("Unexpected: not a Map; unable to set JsonLD's @context",-1,-1);
+            }
+        }
+        read$(jsonObject, options, output);
+    }
+
+    private void read$(Object jsonObject, JsonLdOptions options, final StreamRDF output) {
         output.start() ;
         try {       	
             JsonLdTripleCallback callback = new JsonLdTripleCallback() {
@@ -154,8 +185,6 @@ public class JsonLDReader implements ReaderRIOT
                     return null ;
                 }
             } ;
-            JsonLdOptions options = new JsonLdOptions(baseURI);
-            options.useNamespaces = true;
             JsonLdProcessor.toRDF(jsonObject, callback, options) ;
         }
         catch (JsonLdError e) {
@@ -163,6 +192,44 @@ public class JsonLDReader implements ReaderRIOT
             throw new RiotException(e) ;
         }
         output.finish() ;
+    }
+
+    /** Get the (jsonld) options from the jena context if exists or create default */
+    static private JsonLdOptions getJsonLdOptions(String baseURI, Context jenaContext) {
+        JsonLdOptions opts = null;
+        if (jenaContext != null) {
+            opts = (JsonLdOptions) jenaContext.get(JSONLD_OPTIONS);
+        }
+        if (opts == null) {
+            opts = defaultJsonLdOptions(baseURI);
+        }
+        return opts;
+    }
+
+    static private JsonLdOptions defaultJsonLdOptions(String baseURI) {
+        JsonLdOptions opts = new JsonLdOptions(baseURI);
+        opts.useNamespaces = true ; // this is NOT jsonld-java's default
+        return opts;
+    }
+
+    /** Get the (jsonld) context from the jena context if exists */
+    static private Object getJsonLdContext(Context jenaContext) throws JsonParseException, IOException {
+        Object ctx = null;
+        boolean isCtxDefined = false; // to allow jenaContext to set ctx to null. Useful?
+
+        if (jenaContext != null) {
+            if (jenaContext.isDefined(JSONLD_CONTEXT)) {
+                Object o = jenaContext.get(JSONLD_CONTEXT);
+                if (o != null) {
+                    if (o instanceof String) { // supposed to be a json string
+                        String jsonString = (String) o;
+                        o = JsonUtils.fromString(jsonString);
+                    }
+                    ctx = o;
+                }
+            }
+        }
+        return ctx;
     }
 
     public static String LITERAL    = "literal" ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/JsonLDWriter.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/JsonLDWriter.java
@@ -193,7 +193,6 @@ public class JsonLDWriter extends WriterDatasetRIOTBase
         JsonLdOptions opts = getJsonLdOptions(baseURI, jenaContext) ;
 
         // we can benefit from the fact we know that there are no duplicates in the jsonld RDFDataset that we create
-        // (optimization in jsonld-java 0.8.3)
         // see https://github.com/jsonld-java/jsonld-java/pull/173
 
         // with this, we cannot call the json-ld fromRDF method that assumes no duplicates in RDFDataset

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
@@ -1,4 +1,4 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,127 +18,123 @@
 
 package org.apache.jena.riot;
 
-import static org.junit.Assert.assertTrue;
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.github.jsonldjava.core.DocumentLoader;
+import com.github.jsonldjava.core.JsonLdOptions;
+import com.github.jsonldjava.utils.JsonUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.lang.JsonLDReader;
+import org.apache.jena.riot.system.ErrorHandlerFactory;
+import org.apache.jena.sparql.util.Context;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import com.fasterxml.jackson.core.JsonGenerationException;
-import com.github.jsonldjava.utils.JsonUtils;
-
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.riot.system.ErrorHandlerFactory;
-import org.apache.jena.sparql.util.Context;
-import org.apache.jena.vocabulary.RDF;
-import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 
 public class TestJsonLDReader {
 
     @Test
-    public final void simpleReadTest() {
-        try {
-            String jsonld = someSchemaDorOrgJsonld();
-            Model m = ModelFactory.createDefaultModel();
-            RDFParser.create()
-                .errorHandler(ErrorHandlerFactory.errorHandlerNoLogging)
-                .fromString(jsonld)
-                .lang(Lang.JSONLD)
-                .parse(m);
-            assertJohnDoeIsOK(m);
-        } catch (RiotException e) {
-            // cf. org.apache.jena.riot.RiotException: loading remote context failed: http://schema.org/
-            // There's a line printed anyway
-            // e.printStackTrace();
-        }
+    public final void simpleReadTest() throws IOException {
+        String jsonld = someSchemaDorOrgJsonld();
+        Model m = jsonld2model(jsonld, null);
+        assertJohnDoeIsOK(m);
     }
 
-    /** Test using the jena Context mechanism to pass the jsonld "@context" */
-    @Test public final void overrideAtContextTest() throws JsonGenerationException, IOException {
+    /**
+     * Test using the jena Context mechanism to pass the jsonld "@context"
+     */
+    @Test
+    public final void overrideAtContextTest() throws JsonGenerationException, IOException {
         // some jsonld using schema.org's URI as "@context"
         String jsonld = someSchemaDorOrgJsonld();
 
         // a subset of schema.org that can be used as @context for jsonld
-        String jsonldContext = "{\"name\":{\"@id\":\"http://schema.org/name\"},\"Person\": {\"@id\": \"http://schema.org/Person\"}}";
+        String jsonldContext = "{\"name\":{\"@id\":\"http://schema.org/name\", \"@type\": \"http://www.w3.org/2001/XMLSchema#other\"},\"Person\": {\"@id\": \"http://schema.org/Person\"}}";
 
         // pass the jsonldContext to the read using a jena Context
         Context jenaCtx = new Context();
         Object jsonldContextAsMap = JsonUtils.fromInputStream(new ByteArrayInputStream(jsonldContext.getBytes(StandardCharsets.UTF_8)));
-        jenaCtx.set(RIOT.JSONLD_CONTEXT, jsonldContextAsMap);
+        jenaCtx.set(JsonLDReader.JSONLD_CONTEXT, jsonldContextAsMap);
 
         // read the jsonld, replacing its "@context"
-        Dataset ds = jsonld2dataset(jsonld, jenaCtx);
+        Model m = jsonld2model(jsonld, jenaCtx);
 
         // check ds is correct
-        assertJohnDoeIsOK(ds.getDefaultModel());
+        assertJohnDoeIsOK(m);
     }
 
-    /** Not really useful, but one can replace the @context by a URI: in this case, this URI is used when expanding the json
-     * (letting JSON-LD java API taking care of downloading the context. */
-    // well, as of this writing, it doesn't work, as we get a "loading remote context failed"
-    // But it is about the replacing URI, not the replaced one, showing that the mechanism does work
-    @Test public final void overrideAtContextByURITest() throws JsonGenerationException, IOException {
+    /**
+     * Not really useful, but one can replace the @context by a URI: in this case, this URI is used when expanding the json
+     * (letting JSON-LD java API taking care of downloading the context.
+     */
+    @Test
+    public final void overrideJsonLdOptionsAndContextUri() throws JsonGenerationException, IOException {
         // some jsonld using a (fake) pseudo.schema.org's URI as "@context"
         String jsonld = "{\"@id\":\"_:b0\",\"@type\":\"Person\",\"name\":\"John Doe\",\"@context\":\"http://pseudo.schema.org/\"}";
 
         // a subset of schema.org that can be used as @context for jsonld
         String jsonldContext = "\"http://schema.org\"";
 
-        // pass the jsonldContext to the read using a jena Context
-        Context jenaCtx = new Context();
-        Object jsonldContextAsObject = JsonUtils.fromInputStream(new ByteArrayInputStream(jsonldContext.getBytes(StandardCharsets.UTF_8)));
-        jenaCtx.set(RIOT.JSONLD_CONTEXT, jsonldContextAsObject);
+        JsonLdOptions options = new JsonLdOptions();
+        DocumentLoader dl = new DocumentLoader();
+        dl.addInjectedDoc("http://schema.org", String.format("{%s}", schemaOrgContext()));
+        options.setDocumentLoader(dl);
 
-        try {
-            // read the jsonld, replacing its "@context"
-            Dataset ds = jsonld2dataset(jsonld, jenaCtx);
+        // pass the jsonldContext and JsonLdOptions to the read using a jena Context
+        JsonLDReadContext jenaCtx = new JsonLDReadContext();
+        jenaCtx.setJsonLDContext(jsonldContext);
+        jenaCtx.setOptions(options);
 
-            // check ds is correct
-            assertJohnDoeIsOK(ds.getDefaultModel());
-        } catch (RiotException e) {
-            // cf. org.apache.jena.riot.RiotException: loading remote context failed: http://schema.org/
-            // There's a line printed anyway
-            // e.printStackTrace();
-        }
+        // read the jsonld, replacing its "@context"
+        Model m = jsonld2model(jsonld, jenaCtx);
+
+        // check ds is correct
+        assertJohnDoeIsOK(m);
     }
 
     //
     //
     //
 
-    /**
-     * Reading some jsonld String, using a Context
-     * @return a new Dataset
-     * @throws IOException
-     */
-    private Dataset jsonld2dataset(String jsonld, Context jenaCtx) throws IOException {
-        Dataset ds = DatasetFactory.create();
+    private Model jsonld2model(String jsonld, Context jenaCtx) throws IOException {
+        Model m = ModelFactory.createDefaultModel();
 
         try (InputStream in = new ByteArrayInputStream(jsonld.getBytes(StandardCharsets.UTF_8))) {
             RDFParser.create()
-                .source(in)
-                .errorHandler(ErrorHandlerFactory.errorHandlerNoLogging)
-                .lang(Lang.JSONLD)
-                .context(jenaCtx)
-                .parse(ds.asDatasetGraph());
+                    .source(in)
+                    .errorHandler(ErrorHandlerFactory.errorHandlerNoLogging)
+                    .lang(Lang.JSONLD)
+                    .context(jenaCtx)
+                    .parse(m);
         }
 
-        return ds;
+        return m;
     }
 
-    /** Example data */
+    /**
+     * Example data
+     */
     private String someSchemaDorOrgJsonld() {
-        return "{\"@id\":\"_:b0\",\"@type\":\"Person\",\"name\":\"John Doe\",\"@context\":\"http://schema.org/\"}";
+        return String.format("{\"@id\": \"_:b0\", \"@type\": \"Person\", \"name\": \"John Doe\", %s }", schemaOrgContext());
     }
 
-    /** Checking that the data loaded from someSchemaDorOrgJsonld into a model, is OK */
+    private String schemaOrgContext() {
+        return "\"@context\": {\"@vocab\": \"http://schema.org/\", \"name\": {\"@type\": \"http://www.w3.org/2001/XMLSchema#other\"} }";
+    }
+
+    /**
+     * Checking that the data loaded from someSchemaDorOrgJsonld into a model, is OK
+     */
     private void assertJohnDoeIsOK(Model m) {
         assertTrue(m.contains(null, RDF.type, m.createResource("http://schema.org/Person")));
-        assertTrue(m.contains(null, m.createProperty("http://schema.org/name"), "John Doe"));       
+        assertTrue(m.contains(null, m.createProperty("http://schema.org/name"),
+                m.createTypedLiteral("John Doe", "http://www.w3.org/2001/XMLSchema#other")));
     }
 
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
@@ -22,8 +22,9 @@ import com.fasterxml.jackson.core.JsonGenerationException;
 import com.github.jsonldjava.core.DocumentLoader;
 import com.github.jsonldjava.core.JsonLdOptions;
 import com.github.jsonldjava.utils.JsonUtils;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.lang.JsonLDReader;
 import org.apache.jena.riot.system.ErrorHandlerFactory;
 import org.apache.jena.sparql.util.Context;
@@ -42,8 +43,8 @@ public class TestJsonLDReader {
     @Test
     public final void simpleReadTest() throws IOException {
         String jsonld = someSchemaDorOrgJsonld();
-        Model m = jsonld2model(jsonld, null);
-        assertJohnDoeIsOK(m);
+        Dataset ds = jsonld2dataset(jsonld, null);
+        assertJohnDoeIsOK(ds.getDefaultModel());
     }
 
     /**
@@ -63,10 +64,10 @@ public class TestJsonLDReader {
         jenaCtx.set(JsonLDReader.JSONLD_CONTEXT, jsonldContextAsMap);
 
         // read the jsonld, replacing its "@context"
-        Model m = jsonld2model(jsonld, jenaCtx);
+        Dataset ds = jsonld2dataset(jsonld, jenaCtx);
 
         // check ds is correct
-        assertJohnDoeIsOK(m);
+        assertJohnDoeIsOK(ds.getDefaultModel());
     }
 
     /**
@@ -92,18 +93,23 @@ public class TestJsonLDReader {
         jenaCtx.setOptions(options);
 
         // read the jsonld, replacing its "@context"
-        Model m = jsonld2model(jsonld, jenaCtx);
+        Dataset ds = jsonld2dataset(jsonld, jenaCtx);
 
         // check ds is correct
-        assertJohnDoeIsOK(m);
+        assertJohnDoeIsOK(ds.getDefaultModel());
     }
 
     //
     //
     //
 
-    private Model jsonld2model(String jsonld, Context jenaCtx) throws IOException {
-        Model m = ModelFactory.createDefaultModel();
+    /**
+     * Reading some jsonld String, using a Context
+     * @return a new Dataset
+     * @throws IOException
+     */
+    private Dataset jsonld2dataset(String jsonld, Context jenaCtx) throws IOException {
+        Dataset ds = DatasetFactory.create();
 
         try (InputStream in = new ByteArrayInputStream(jsonld.getBytes(StandardCharsets.UTF_8))) {
             RDFParser.create()
@@ -111,10 +117,10 @@ public class TestJsonLDReader {
                     .errorHandler(ErrorHandlerFactory.errorHandlerNoLogging)
                     .lang(Lang.JSONLD)
                     .context(jenaCtx)
-                    .parse(m);
+                    .parse(ds.asDatasetGraph());
         }
 
-        return m;
+        return ds;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
          POM for the correct dependency versions
          and use that or later.
     -->
-    <ver.jsonldjava>0.12.5</ver.jsonldjava>
+    <ver.jsonldjava>0.13.0</ver.jsonldjava>
     <ver.jackson>2.10.1</ver.jackson>
     <ver.jackson-databind>${ver.jackson}</ver.jackson-databind>
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/JENA-1959

- Adds the analogous to `JsonLdWriteContext` when converting JSON to RDF (toRdf on the JSON-LD high level API)

- Updates Json-LD Java from 0.12.5 to 0.13.0