### PR TITLE
JENA-1950: Make GraalVM a test dependency

### DIFF
--- a/jena-arq/pom.xml
+++ b/jena-arq/pom.xml
@@ -114,15 +114,13 @@
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
To support custom SPARQL functions written in JavaScript, ARQ can interchangeably use Nashorn or Graal.js scripting engines (the former will be removed in JDK 15).

On JDK  versions prior to JDK 15 ARQ can be compiled and used without any Graal-related dependencies.

On JDK 15 onward using JavaScript would require having org.graalvm.js:js and org.graalvm.js-scriptengine on the class path. 
However, as Java Scripting API uses a SPI-based mechanism, they don't have to be included as compile-time dependencies. 
They still need to be included as test dependencies to make it possible to compile ARQ on JDK 15+.

See also the discussion in https://github.com/apache/jena/pull/787