### PR TITLE
JENA-1967: Bumped JsonLD Java dependency; fixed tests

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/JsonLDWriteContext.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/JsonLDWriteContext.java
@@ -60,7 +60,7 @@ public class JsonLDWriteContext extends Context {
      * Only useful for "Compact" and "Flattened" JSON-LD outputs, and not required: if not set,
      * a value for the "@Context" node is computed, based on the content of the dataset and its prefix mappings.
      * 
-     * @param jsonLdContext the value of the "@context" node (a JSON value). Some remote contexts might not be resolved property.
+     * @param jsonLdContext the value of the "@context" node (a JSON value).
      * @see #setJsonLDContextSubstitution(String) for a way to overcome this problem.
      * 
      * @see #setJsonLDContext(Object)
@@ -75,7 +75,7 @@ public class JsonLDWriteContext extends Context {
      * Only useful for "Compact" and "Flattened" JSON-LD outputs, and not required: if not set,
      * a value for the "@Context" node is computed, based on the content of the dataset and its prefix mappings.
      * 
-     * @param jsonLdContext the context as expected by JSON-LD java API. Some remote contexts might not be resolved property.
+     * @param jsonLdContext the context as expected by JSON-LD java API.
      * @see #setJsonLDContextSubstitution(String) for a way to overcome this problem.
      * 
      * @see #setJsonLDContext(String)

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestJsonLDWriter.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestJsonLDWriter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.jena.riot.writer;
 
+import static com.github.jsonldjava.core.JsonLdOptions.JSON_LD_1_1;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -31,6 +32,7 @@ import java.util.Map.Entry;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.github.jsonldjava.core.JsonLdError;
 import com.github.jsonldjava.core.JsonLdOptions;
+import com.github.jsonldjava.core.JsonLdProcessor;
 import com.github.jsonldjava.utils.JsonUtils;
 
 import org.apache.jena.atlas.json.JsonObject;
@@ -250,9 +252,8 @@ public class TestJsonLDWriter {
     /**
      * Checks that one can pass a context defined by its URI
      * 
-     * -- well NO, this doesn't work in a test setup.
      */
-    //@Test 
+    @Test
     public final void testContextByUri() {
         Model m = ModelFactory.createDefaultModel();
         String ns = "http://schema.org/";
@@ -263,33 +264,13 @@ public class TestJsonLDWriter {
 
         // we can pass an uri in the context, as a quoted string (it is a JSON string)
         JsonLDWriteContext jenaContext = new JsonLDWriteContext();
-        try {
-            jenaContext.set(JsonLDWriter.JSONLD_CONTEXT, "{\"@context\" : \"http://schema.org/\"}");
-            String jsonld = toString(m, RDFFormat.JSONLD, jenaContext);
-            // check it parses ok
-            Model m2 = parse(jsonld);
-
-            // assertTrue(m2.isIsomorphicWith(m)); // It should be the case, but no.
-
-        } catch (Throwable e) {
-            // maybe test run in a setting without external connectivity - not a real problem
-            String mess = e.getMessage();
-            if ((mess != null) && (mess.contains("loading remote context failed"))) {
-                LoggerFactory.getLogger(getClass()).info(mess);
-                e.printStackTrace();
-            } else {
-                throw e;
-            }
-        }
-
-        // But anyway, that's not what we want to do:
-        // there's no point in passing the uri of a context to have it dereferenced by jsonld-java
-        // (this is for a situation where one would want to parse a jsonld file containing a context defined by a uri)
-        // What we want is to pass a context to jsonld-java (in order for json-ld java to produce the correct jsonld output)
-        // and then we want to replace the @context in the output by "@context":"ourUri"
-
-        // How would we do that? see testSubstitutingContext()
+        jenaContext.setJsonLDContext("{\"@context\" : \"http://schema.org/\"}");
+        String jsonld = toString(m, RDFFormat.JSONLD, jenaContext);
+        // check it parses ok
+        Model m2 = parse(jsonld);
+        assertTrue(m2.isIsomorphicWith(m));
     }
+
 
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
          POM for the correct dependency versions
          and use that or later.
     -->
-    <ver.jsonldjava>0.13.1</ver.jsonldjava>
+    <ver.jsonldjava>0.13.2</ver.jsonldjava>
     <ver.jackson>2.10.1</ver.jackson>
     <ver.jackson-databind>${ver.jackson}</ver.jackson-databind>
 


### PR DESCRIPTION
JsonLD Java version 0.13.1 [fixed support for remote context Uris](https://github.com/jsonld-java/jsonld-java/issues/289) and 0.13.2 fixes some minor issues with the returned context.

I have updated also the `Ex_WriteJsonLD` example to clarify the different options dealing with context when converting from Rdf back to JSON-LD.

I'm not sure if Jena has some docs where it talks about all of that besides this example file in the repo, but probably they could be reviewed. Can someone point me to them?