### PR TITLE
[JENA-1985] Adding TriG and N-Quads content-type in Fuseki2.

### DIFF
--- a/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/dataset.html
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/dataset.html
@@ -138,6 +138,8 @@
                                       <option value="text/turtle">Turtle</option>
                                       <option value="application/ld+json">JSON-LD</option>
                                       <option value="application/n-triples">N-Triples</option>
+                                      <option value="application/n-quads">N-Quads</option>
+                                      <option value="application/trig">TriG</option>
                                       <option value="application/rdf+xml">XML</option>
                                     </select>
                                   </div>


### PR DESCRIPTION
Jena already work with N-Quads and Trig serialization. This is also useful for dataset page on Fuseki Webpage.