### PR TITLE
JENA-1984: Fixed to XSD casting

### DIFF
--- a/jena-arq/Grammar/arq.jj
+++ b/jena-arq/Grammar/arq.jj
@@ -1547,7 +1547,7 @@ Expr Aggregate() : { Aggregator agg = null ; String sep = null ;
     if ( ! getAllowAggregatesInExpressions() )
         throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
     if ( getAggregateDepth() > 1 )
-        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
+        throwParseException("Nested aggregate in expression not legal", t.beginLine, t.beginColumn) ;
   }
   { Expr exprAgg = getQuery().allocAggregate(agg) ;
     finishAggregate();

--- a/jena-arq/Grammar/arq.jj
+++ b/jena-arq/Grammar/arq.jj
@@ -1489,6 +1489,7 @@ Expr Aggregate() : { Aggregator agg = null ; String sep = null ;
                      ExprList ordered = new ExprList() ;
                      Token t ; }
 {
+  { startAggregate(); }
   ( t = <COUNT> <LPAREN>
     ( <DISTINCT> { distinct = true ; } )?
     ( <STAR> | expr = Expression() )
@@ -1544,10 +1545,12 @@ Expr Aggregate() : { Aggregator agg = null ; String sep = null ;
   )
   {
     if ( ! getAllowAggregatesInExpressions() )
-           throwParseException("Aggregate expression not legal at this point",
-                                t.beginLine, t.beginColumn) ;
+        throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
+    if ( getAggregateDepth() > 1 )
+        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
   }
   { Expr exprAgg = getQuery().allocAggregate(agg) ;
+    finishAggregate();
     return exprAgg ; }
 }
 Expr iriOrFunction() : { String iri ; Args a = null ; }

--- a/jena-arq/Grammar/main.jj
+++ b/jena-arq/Grammar/main.jj
@@ -231,10 +231,6 @@ void SelectClause() : {  Var v ; Expr expr ; Node n ; }
   { setAllowAggregatesInExpressions(false) ; }
 }
 
-#if 0
-#include  "json-extra.jj"
-#endif
-
 #ifdef ARQ
 void ConstructQuery() : { Template t ; 
                           QuadAcc acc = new QuadAcc() ; }
@@ -2167,7 +2163,7 @@ Expr Aggregate() : { Aggregator agg = null ; String sep = null ;
         // Do late so we have the token for line/column
         throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
     if ( getAggregateDepth() > 1 )
-        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
+        throwParseException("Nested aggregate in expression not legal", t.beginLine, t.beginColumn) ;
   }
   { Expr exprAgg = getQuery().allocAggregate(agg) ;
     finishAggregate();

--- a/jena-arq/Grammar/main.jj
+++ b/jena-arq/Grammar/main.jj
@@ -2079,6 +2079,8 @@ Expr Aggregate() : { Aggregator agg = null ; String sep = null ;
 {
   // Count is special because of COUNT(*)
   // GROUP_CONCAT is special because of separator=
+  
+  { startAggregate(); }
 
   ( t = <COUNT> <LPAREN> 
     ( <DISTINCT> { distinct = true ; } )?
@@ -2162,10 +2164,13 @@ Expr Aggregate() : { Aggregator agg = null ; String sep = null ;
 
   {
     if ( ! getAllowAggregatesInExpressions() )
-           throwParseException("Aggregate expression not legal at this point",
-                                t.beginLine, t.beginColumn) ;
+        // Do late so we have the token for line/column
+        throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
+    if ( getAggregateDepth() > 1 )
+        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
   }
   { Expr exprAgg = getQuery().allocAggregate(agg) ;
+    finishAggregate();
     return exprAgg ; }
 }
 

--- a/jena-arq/Grammar/sparql_11.jj
+++ b/jena-arq/Grammar/sparql_11.jj
@@ -1334,7 +1334,7 @@ Expr Aggregate() : { Aggregator agg = null ; String sep = null ;
     if ( ! getAllowAggregatesInExpressions() )
         throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
     if ( getAggregateDepth() > 1 )
-        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
+        throwParseException("Nested aggregate in expression not legal", t.beginLine, t.beginColumn) ;
   }
   { Expr exprAgg = getQuery().allocAggregate(agg) ;
     finishAggregate();

--- a/jena-arq/Grammar/sparql_11.jj
+++ b/jena-arq/Grammar/sparql_11.jj
@@ -1304,6 +1304,7 @@ Expr Aggregate() : { Aggregator agg = null ; String sep = null ;
                      ExprList ordered = new ExprList() ;
                      Token t ; }
 {
+  { startAggregate(); }
   ( t = <COUNT> <LPAREN>
     ( <DISTINCT> { distinct = true ; } )?
     ( <STAR> | expr = Expression() )
@@ -1331,10 +1332,12 @@ Expr Aggregate() : { Aggregator agg = null ; String sep = null ;
   )
   {
     if ( ! getAllowAggregatesInExpressions() )
-           throwParseException("Aggregate expression not legal at this point",
-                                t.beginLine, t.beginColumn) ;
+        throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
+    if ( getAggregateDepth() > 1 )
+        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
   }
   { Expr exprAgg = getQuery().allocAggregate(agg) ;
+    finishAggregate();
     return exprAgg ; }
 }
 Expr iriOrFunction() : { String iri ; Args a = null ; }

--- a/jena-arq/src/main/java/org/apache/jena/riot/WebContent.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/WebContent.java
@@ -67,16 +67,16 @@ public class WebContent
     public static final String      contentTypeXMLAlt            = "text/xml" ;
     public static final ContentType ctXMLAlt                     = ContentType.create(contentTypeXMLAlt) ;
 
-    public static final String      contentTypeTriG              = "text/trig" ;
+    public static final String      contentTypeTriG              = "application/trig" ;
     public static final ContentType ctTriG                       = ContentType.create(contentTypeTriG) ;
 
     public static final String      contentTypeNQuads            = "application/n-quads" ;
     public static final ContentType ctNQuads                     = ContentType.create(contentTypeNQuads) ;
 
-    public static final String      contentTypeTriGAlt1          = "application/x-trig" ;
+    public static final String      contentTypeTriGAlt1          = "text/trig" ;
     public static final ContentType ctTriGAlt1                   = ContentType.create(contentTypeTriGAlt1) ;
 
-    public static final String      contentTypeTriGAlt2          = "application/trig" ;
+    public static final String      contentTypeTriGAlt2          = "application/x-trig" ;
     public static final ContentType ctTriGAlt2                   = ContentType.create(contentTypeTriGAlt2) ;
 
     // Unofficial

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Cast.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Cast.java
@@ -20,7 +20,7 @@ package org.apache.jena.sparql.expr;
 
 import org.apache.jena.sparql.ARQNotImplemented ;
 
-
+// CAST(string, Y/IRI)
 public class E_Cast extends ExprFunction2
 {
     // See E_StrDatatype

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -118,8 +118,12 @@ public abstract class NodeValue extends ExprNode
     public static final NodeValue FALSE  = NodeValue.makeNode("false", XSDboolean) ;
     
     public static final NodeValue nvZERO = NodeValue.makeNode(NodeConst.nodeZero) ;
+    public static final NodeValue nvNegZERO = NodeValue.makeNode("-0.0e0", XSDdouble);
     public static final NodeValue nvONE  = NodeValue.makeNode(NodeConst.nodeOne) ;
     public static final NodeValue nvTEN  = NodeValue.makeNode(NodeConst.nodeTen) ;
+    
+    public static final NodeValue nvDecimalZERO = NodeValue.makeNode("0.0", XSDdecimal);
+    public static final NodeValue nvDecimalONE  = NodeValue.makeNode("1.0", XSDdecimal);
     
     public static final NodeValue nvNaN     = NodeValue.makeNode("NaN", XSDdouble) ;
     public static final NodeValue nvINF     = NodeValue.makeNode("INF", XSDdouble) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -943,24 +943,48 @@ public class XSDFuncOp
         integerSubTypes.add(XSDDatatype.XSDnegativeInteger) ;
     }
 
-    public static boolean isNumericType(XSDDatatype xsdDatatype) {
+    public static boolean isNumericDatatype(XSDDatatype xsdDatatype) {
         if ( XSDDatatype.XSDfloat.equals(xsdDatatype) )
             return true ;
         if ( XSDDatatype.XSDdouble.equals(xsdDatatype) )
             return true ;
-        return isDecimalType(xsdDatatype) ;
+        return isDecimalDatatype(xsdDatatype) ;
     }
 
-    public static boolean isDecimalType(XSDDatatype xsdDatatype) {
+    public static boolean isDecimalDatatype(XSDDatatype xsdDatatype) {
         if ( XSDDatatype.XSDdecimal.equals(xsdDatatype) )
             return true ;
-        return isIntegerType(xsdDatatype) ;
+        return isIntegerDatatype(xsdDatatype) ;
     }
 
-    public static boolean isIntegerType(XSDDatatype xsdDatatype) {
+    public static boolean isIntegerDatatype(XSDDatatype xsdDatatype) {
         return integerSubTypes.contains(xsdDatatype) ;
     }
 
+    public static boolean isTemporalDatatype(XSDDatatype datatype) {
+        return
+            datatype.equals(XSDDatatype.XSDdateTime) ||
+            datatype.equals(XSDDatatype.XSDtime) ||
+            datatype.equals(XSDDatatype.XSDdate) ||
+            datatype.equals(XSDDatatype.XSDgYear) ||
+            datatype.equals(XSDDatatype.XSDgYearMonth) ||
+            datatype.equals(XSDDatatype.XSDgMonth) ||
+            datatype.equals(XSDDatatype.XSDgMonthDay) ||
+            datatype.equals(XSDDatatype.XSDgDay);
+    }
+
+    public static boolean isDurationDatatype(XSDDatatype datatype) {
+        return
+            datatype.equals(XSDDatatype.XSDduration) ||
+            datatype.equals(XSDDatatype.XSDyearMonthDuration) ||
+            datatype.equals(XSDDatatype.XSDdayTimeDuration );
+    }
+
+    public static boolean isBinaryDatatype(XSDDatatype datatype) {
+        return datatype.equals(XSDDatatype.XSDhexBinary) || datatype.equals(XSDDatatype.XSDbase64Binary);
+    }
+
+    
     // --------------------------------
     // Comparisons operations
     // Do not confuse with sameValueAs/notSamevalueAs

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/CastXSD.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/CastXSD.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,47 +18,143 @@
 
 package org.apache.jena.sparql.function;
 
-import java.math.BigDecimal ;
-import java.math.BigInteger ;
-import java.util.Objects ;
+import static org.apache.jena.sparql.expr.NodeValue.nvNaN;
+import static org.apache.jena.sparql.expr.NodeValue.nvNegZERO;
+import static org.apache.jena.sparql.expr.NodeValue.nvZERO;
 
-import javax.xml.datatype.DatatypeConstants ;
-import javax.xml.datatype.Duration ;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Objects;
 
-import org.apache.jena.datatypes.xsd.XSDDatatype ;
-import org.apache.jena.datatypes.xsd.impl.XSDAbstractDateTimeType ;
-import org.apache.jena.datatypes.xsd.impl.XSDBaseNumericType ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.sparql.expr.ExprEvalException ;
-import org.apache.jena.sparql.expr.ExprEvalTypeException ;
-import org.apache.jena.sparql.expr.ExprException ;
-import org.apache.jena.sparql.expr.NodeValue ;
-import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp ;
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.Duration;
 
-public class CastXSD extends FunctionBase1 implements FunctionFactory {
-    
-    protected final XSDDatatype castType ;
-    
-    public CastXSD(XSDDatatype dt)
-    {
-        this.castType = dt ; 
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.datatypes.xsd.impl.XSDAbstractDateTimeType;
+import org.apache.jena.datatypes.xsd.impl.XSDBaseNumericType;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.expr.ExprEvalException;
+import org.apache.jena.sparql.expr.ExprEvalTypeException;
+import org.apache.jena.sparql.expr.ExprException;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp;
+
+/**
+ * Code for all casting between XSD datatypes.
+ * From <a href="https://www.w3.org/TR/xpath-functions/#casting">XPath and XQuery Functions and Operators</a>
+ * v3.1
+ *
+ * @see FunctionCastXSD
+ */
+public class CastXSD {
+    private CastXSD() {}
+
+    /** Cast a NodeValue to an XSD datatype.
+     * This includes "by value" so 1e0 (an xsd:double) casts to 1 (an xsd:integer)
+     * @param nv
+     * @param castType
+     * @return NodeValue
+     * @throws ExprEvalException
+     */
+    public static NodeValue cast(NodeValue nv, XSDDatatype castType) {
+        // https://www.w3.org/TR/xpath-functions/#casting
+        /*
+            Casting
+            19.1 Casting from primitive types to primitive types
+                19.1.1 Casting to xs:string and xs:untypedAtomic
+                19.1.2 Casting to numeric types
+                19.1.3 Casting to duration types
+                19.1.4 Casting to date and time types
+                19.1.5 Casting to xs:boolean
+                19.1.6 Casting to xs:base64Binary and xs:hexBinary
+                19.1.7 Casting to xs:anyURI
+                19.1.8 Casting to xs:QName and xs:NOTATION
+                19.1.9 Casting to xs:ENTITY
+            19.2 Casting from xs:string and xs:untypedAtomic
+            19.3 Casting involving non-primitive types
+                19.3.1 Casting to derived types
+                19.3.2 Casting from derived types to parent types
+                19.3.3 Casting within a branch of the type hierarchy
+                19.3.4 Casting across the type hierarchy
+                19.3.5 Casting to union types
+                19.3.6 Casting to list types
+         */
+
+        Node n = nv.asNode();
+
+        if ( n.isBlank() )
+            throw exception("Can't cast blank nodes: "+nv);
+
+        if ( n.isURI() ) {
+            if ( castType.equals(XSDDatatype.XSDstring) )
+                return cast$(n.getURI(), castType);
+            else
+                throw exception("Can't cast URIs to "+castType.getURI());
+        }
+
+        if ( ! n.isLiteral() )
+            throw exception("Can't cast (not a literal, nor URI to string) "+nv+" : "+castType.getURI());
+
+        // It's a literal.
+
+        // Cast to self but may be an invalid lexical form.
+        if ( Objects.equals(nv.getNode().getLiteralDatatype(), castType) ) {
+            String lex = nv.getNode().getLiteralLexicalForm();
+            if ( castType.isValid(lex) )
+                return nv;
+            throw exception("Invalid lexical form for "+castType.getURI());
+        }
+
+        if ( isNumericDatatype(castType) )
+            return castToNumber(nv, castType);
+
+        // To xs:duration, xs:yearMonthDuration, xs:dayTimeDuration
+        if ( isDurationDatatype(castType) )
+            return castToDuration(nv, castType);
+
+        // To a temporal xs:dateTime, xs:time, xs:g* (Gregorian).
+        if ( isTemporalDatatype(castType) )
+            return XSDFuncOp.dateTimeCast(nv, castType);
+
+        // To xsd:boolean
+        if ( castType.equals(XSDDatatype.XSDboolean) )
+            return castToBoolean(nv, castType);
+
+        // To xsd:string
+        if ( castType.equals(XSDDatatype.XSDstring) )
+            return castToString(nv, castType);
+
+        // 19.1.6 Casting to xs:base64Binary and xs:hexBinary
+        if ( isBinaryDatatype(castType) ) {
+            try {
+                Node nValue = nv.getNode();
+                // Already tested for "same datatype"
+                byte[] binary = (byte[])nValue.getLiteralValue();
+                Node nx = NodeFactory.createLiteralByValue(binary, castType);
+                return NodeValue.makeNode(nx);
+
+            } catch (Exception ex) {
+                // Keep doing.
+            }
+        }
+
+        // Values of type xs:base64Binary can be cast as xs:hexBinary and vice versa,
+        // since the two types have the same value space. Casting to xs:base64Binary
+        // and xs:hexBinary is also supported from the same type and from
+        // xs:untypedAtomic, xs:string and subtypes of xs:string using [XML Schema
+        // Part 2: Datatypes Second Edition] semantics.
+
+        // 19.1.7 Casting to xs:anyURI
+
+        // Fall through. Try by lexical - may produce junk - includes bad lexicals etc.
+        return castByLex(nv, castType);
     }
-    
-    @Override
-    public Function create(String uri)
-    {        
-        return this ;
-    }
-    
-    @Override
-    public NodeValue exec(NodeValue v)
-    {
-        return cast(v, castType) ;
-    }
 
-    
+    // XXX Merge into XSDFuncOp
     private static boolean isTemporalDatatype(XSDDatatype datatype) {
-        return 
+        return
             datatype.equals(XSDDatatype.XSDdateTime) ||
             datatype.equals(XSDDatatype.XSDtime) ||
             datatype.equals(XSDDatatype.XSDdate) ||
@@ -66,204 +162,301 @@ public class CastXSD extends FunctionBase1 implements FunctionFactory {
             datatype.equals(XSDDatatype.XSDgYearMonth) ||
             datatype.equals(XSDDatatype.XSDgMonth) ||
             datatype.equals(XSDDatatype.XSDgMonthDay) ||
-            datatype.equals(XSDDatatype.XSDgDay) ;
+            datatype.equals(XSDDatatype.XSDgDay);
     }
-    
+
     private static boolean isDurationDatatype(XSDDatatype datatype) {
-        return 
-            datatype.equals(XSDDatatype.XSDduration) || 
+        return
+            datatype.equals(XSDDatatype.XSDduration) ||
             datatype.equals(XSDDatatype.XSDyearMonthDuration) ||
-            datatype.equals(XSDDatatype.XSDdayTimeDuration ) ;
+            datatype.equals(XSDDatatype.XSDdayTimeDuration );
     }
-    
-    /** Cast a NodeValue to an XSD datatype.
-     * This includes "by value" so 1e0 (an xsd:double) casts to 1 (an xsd:integer) 
-     * @param nv
-     * @param castType
-     * @return NodeValue
-     * @throws ExprEvalException
-     */
-    public static NodeValue cast(NodeValue nv, XSDDatatype castType) {
-        // http://www.w3.org/TR/xpath-functions/#casting
-        Node n = nv.asNode() ;
-    
-        if ( n.isBlank() )
-            throw exception("Can't cast blank nodes: "+nv) ;
-    
-        if ( n.isURI() ) {
-            if ( castType.equals(XSDDatatype.XSDstring) )
-                return cast$(n.getURI(), castType) ;
-            else
-                throw exception("Can't cast URIs to "+castType.getURI()) ;
-        }
-    
-        if ( ! n.isLiteral() )
-            throw exception("Can't cast (not a literal, nor URI to string) "+nv+" : "+castType.getURI()) ;
 
-        // It's a literal.
-        
-        // Cast to self but may be an  invalid lexical form.
-        if ( Objects.equals(nv.getNode().getLiteralDatatype(), castType) ) {
-            String lex = nv.getNode().getLiteralLexicalForm() ;
-            if ( castType.isValid(lex) )
-                return nv ;
-            throw exception("Invalid lexical form for "+castType.getURI()) ;  
-        }
+    private static boolean isNumericDatatype(XSDDatatype datatype) {
+        // XXX Check sharing
+        return XSDFuncOp.isNumericType(datatype);
+    }
 
-        
-        // Many casts can be done by testing the lexical is valid for the datatype.
-        // But some cases need to consider values.
-        //  e.g. boolean -> numeric , double -> integer (doubles have "e" in them)
-        
-        // To a temporal
-        if ( isTemporalDatatype(castType) ) {
-            return XSDFuncOp.dateTimeCast(nv, castType) ;
+    private static boolean isBinaryDatatype(XSDDatatype datatype) {
+        return datatype.equals(XSDDatatype.XSDhexBinary) || datatype.equals(XSDDatatype.XSDbase64Binary);
+    }
+
+    private static NodeValue castToNumber(NodeValue nv, XSDDatatype castType) {
+        if ( castType.equals(XSDDatatype.XSDdecimal) ) {
+            // Number to decimal.
+            if ( isDouble(nv) || isFloat(nv) ) {
+                // FP to decimal.
+                double d = nv.getDouble();
+                if ( Double.isNaN(d) )
+                    throw exception("Can't cast NaN to xsd:decimal");
+                if ( Double.isInfinite(d) )
+                    throw exception("Can't cast Inf or -Inf to xsd:decimal");
+                String lex = doubleToDecimalLex(d);
+                if ( lex == null )
+                    throw exception(nv, castType);
+                return NodeValue.makeDecimal(lex);
+            }
+            if ( nv.isBoolean() ) {
+                boolean b = nv.getBoolean();
+                return b ? NodeValue.nvDecimalONE : NodeValue.nvDecimalZERO;
+            }
+            // Integer, or derived type -> decimal.
+            return castByLex(nv, castType);
         }
-        
-        if ( isDurationDatatype(castType) ) {
-            // Duration cast.
-            // yearMonthDuration and TT is xs:dayTimeDuration -> 0.0S
-            // xs:dayTimeDuration and TT is yearMonthDuration -> P0M
-            
-            if ( nv.isDuration() ) {
-                Duration d = nv.getDuration() ;
-                if ( castType.equals(XSDDatatype.XSDyearMonthDuration) ) {
-                    
-                    // Include xsd:duration only covering year-month.
-                    if ( nv.isDayTimeDuration() )
-                        return NodeValue.makeNode("P0M", castType) ;
-                    
-                    Duration d2 =  NodeValue.xmlDatatypeFactory.newDuration
-                        (d.getSign()>=0,
-                            (BigInteger)d.getField(DatatypeConstants.YEARS), (BigInteger)d.getField(DatatypeConstants.MONTHS), null,
-                        null, null, null) ;
-                    return NodeValue.makeNode(d2.toString(), castType) ;
-                }
-                if ( castType.equals(XSDDatatype.XSDdayTimeDuration) ) {
-                    if ( nv.isYearMonthDuration() )
-                        return NodeValue.makeNode("PT0S", castType) ;
-                    Duration d2 =  NodeValue.xmlDatatypeFactory.newDuration
-                        (d.getSign()>=0,
-                        null, null, (BigInteger)d.getField(DatatypeConstants.DAYS),
-                        (BigInteger)d.getField(DatatypeConstants.HOURS), (BigInteger)d.getField(DatatypeConstants.MINUTES), (BigDecimal)d.getField(DatatypeConstants.SECONDS)) ;
-                    // return NodeValue.makeDuration(d2) ;
-                    return NodeValue.makeNode(d2.toString(), castType) ;
-                }
+        if ( XSDFuncOp.isIntegerType(castType) ) {
+            // Number to integer
+            if ( isDouble(nv) || isFloat(nv) ) {
+                // FP to integer
+                double d = nv.getDouble();
+                if ( Double.isNaN(d) )
+                    throw exception("Can't cast NaN to xsd:integer");
+                if ( Double.isInfinite(d) )
+                    throw exception("Can't cast Inf or -Inf to xsd:integer");
+                String lex = doubleToIntegerLex(d);
+                if ( lex != null )
+                    return castByLex(lex, castType);
+                throw exception(nv, castType);
+            } else if ( isDecimal(nv) ) {
+                // Decimal to integer
+                BigDecimal bd = nv.getDecimal();
+                String lex = decimalToIntegerLex(bd);
+                if ( lex != null )
+                    return castByLex(lex, castType);
+                throw exception(nv, castType);
+            } else if ( nv.isBoolean() ) {
+                boolean b = nv.getBoolean();
+                return b ? NodeValue.nvONE : NodeValue.nvZERO;
+            } else {
+                // Integer derived type -> integer derived type.
+                return castByLex(nv, castType);
             }
         }
 
-        // From number, can consider value.
+        if ( castType.equals(XSDDatatype.XSDdouble) || castType.equals(XSDDatatype.XSDfloat) ) {
+            if ( nv.isBoolean() ) {
+                boolean b = nv.getBoolean();
+                return cast$( ( b ? "1.0E0" : "0.0E0" ) , castType);
+            }
+        }
+        return castByLex(nv, castType);
+    }
+
+    private static NodeValue castToDuration(NodeValue nv, XSDDatatype castType) {
+        // Duration cast.
+        // yearMonthDuration and TT is xs:dayTimeDuration -> 0.0S
+        // xs:dayTimeDuration and TT is yearMonthDuration -> P0M
+
+        if ( isDuration(nv) ) {
+            Duration d = nv.getDuration();
+            if ( castType.equals(XSDDatatype.XSDyearMonthDuration) ) {
+                // Include xsd:duration only covering year-month.
+                if ( nv.isDayTimeDuration() )
+                    return NodeValue.makeNode("P0M", castType);
+
+                Duration d2 = NodeValue.xmlDatatypeFactory.newDuration
+                    (d.getSign()>=0,
+                    (BigInteger)d.getField(DatatypeConstants.YEARS), (BigInteger)d.getField(DatatypeConstants.MONTHS), null,
+                    null, null, null);
+                return NodeValue.makeNode(d2.toString(), castType);
+            }
+            if ( castType.equals(XSDDatatype.XSDdayTimeDuration) ) {
+                if ( nv.isYearMonthDuration() )
+                    return NodeValue.makeNode("PT0S", castType);
+                Duration d2 =  NodeValue.xmlDatatypeFactory.newDuration
+                    (d.getSign()>=0,
+                    null, null, (BigInteger)d.getField(DatatypeConstants.DAYS),
+                    (BigInteger)d.getField(DatatypeConstants.HOURS), (BigInteger)d.getField(DatatypeConstants.MINUTES), (BigDecimal)d.getField(DatatypeConstants.SECONDS));
+                // return NodeValue.makeDuration(d2);
+                return NodeValue.makeNode(d2.toString(), castType);
+            }
+            // Upcast - it wasn't same datatype.
+            if ( castType.equals(XSDDatatype.XSDduration) )
+                return castByLex(nv, XSDDatatype.XSDduration);
+        }
+        if ( nv.isString() )
+            return castByLex(nv, castType);
+
+        throw exception(nv, castType);
+    }
+
+    private static NodeValue castToBoolean(NodeValue nv, XSDDatatype castType) {
+        /* https://www.w3.org/TR/xpath-functions/#casting-boolean
+         * SV = source value
+         * ST = source datatype
+         * TV = target value
+         * When a value of any ·primitive type· is cast as xs:boolean, the xs:boolean value TV is derived from ST and SV as follows:
+         *   If ST is xs:boolean, then TV is SV.
+         *   If ST is xs:float, xs:double, xs:decimal or xs:integer and SV is 0, +0, -0, 0.0, 0.0E0 or NaN, then TV is false.
+         *   If ST is xs:float, xs:double, xs:decimal or xs:integer and SV is not one of the above values, then TV is true.
+         *   If ST is xs:untypedAtomic or xs:string, see 19.2 Casting from xs:string and xs:untypedAtomic.
+         */
+        if ( nv.isBoolean() )
+            return nv;
         if ( nv.isNumber() ) {
-            if ( castType.equals(XSDDatatype.XSDdecimal) ) {   
-                // Number to decimal.
-                if ( isDouble(nv) || isFloat(nv) ) {
-                    // FP to decimal.
-                    double d = nv.getDouble() ;
-                    if ( Double.isNaN(d) )
-                        throw exception("Can't cast NaN to xsd:decimal") ;
-                    if ( Double.isInfinite(d) )
-                        throw exception("Can't cast Inf or -Inf to xsd:decimal") ;
-                    // BigDecimal.valueOf(d) can lead to trailing zeros
-                    // BigDecimal.valueOf(d) goes via strings.
-                    String lex = doubleToDecimalString(d) ;
-                    return NodeValue.makeDecimal(lex) ;
-                }
-                // Integer, or derived type -> decimal. 
-                return castByLex(nv, castType) ;
-            }
-            if ( XSDFuncOp.isIntegerType(castType) ) {
-                // Number to integer
-                if ( isDouble(nv) || isFloat(nv) ) {
-                    // FP to integer
-                    double d = nv.getDouble() ;
-                    boolean isIntegerValue = ( Math.rint(d) == d ) ;
-                    if ( isIntegerValue ) {
-                        String lex = doubleIntegerToString(d) ;
-                        if ( lex != null )
-                            return castByLex(lex, castType) ;
-                    }
-                    throw exception(nv, castType) ;
-                } else if ( isDecimal(nv) ) {
-                    // Decimal to integer
-                    BigDecimal bd = nv.getDecimal() ;
-                    try {
-                        // Exception on fraction. 
-                        BigInteger bi = bd.toBigIntegerExact() ;
-                        return castByLex(bi.toString(), castType) ;
-                    } catch (ArithmeticException ex) {
-                        throw new ExprEvalException("CastXSD: Not a valid cast: '"+nv+"'") ;
-                    }
-                } else {
-                    // Integer derived type -> integer derived type.
-                    return castByLex(nv, castType) ;
-                }
+            if ( NodeValue.sameAs(nv, nvZERO) || NodeValue.sameAs(nv, nvNaN) || NodeValue.sameAs(nv, nvNegZERO) )
+                return NodeValue.FALSE;
+            return NodeValue.TRUE;
+        }
+        if ( nv.isString() ) {
+            String str = nv.getString();
+            switch (str) {
+                case "0":
+                case "false":
+                    return NodeValue.FALSE;
+                case "1":
+                case "true":
+                    return NodeValue.TRUE;
+                default:
+                    throw exception(nv, castType);
             }
         }
-    
-        // Boolean -> xsd:
-        if ( nv.isBoolean() ) { 
-            boolean b = nv.getBoolean() ;
-            // Boolean to boolean covered above.
-            String lex ;
-            if ( XSDDatatype.XSDfloat.equals(castType) || XSDDatatype.XSDdouble.equals(castType) )
-                return cast$( ( b ? "1.0E0" : "0.0E0" ) , castType) ;
-            else if ( XSDDatatype.XSDdecimal.equals(castType) )
-                return cast$( ( b ? "1.0" : "0.0" ) , castType) ;
-            else if ( XSDFuncOp.isIntegerType(castType)) 
-                return cast$(  ( b ? "1" : "0" ) , castType ) ;
-            else if ( XSDDatatype.XSDstring.equals(castType) ) 
-                return cast$( nv.getNode().getLiteralLexicalForm(), castType ) ;
-            throw exception("Can't cast xsd:boolean to "+castType) ;
+        return castByLex(nv, castType);
+    }
+
+    private static NodeValue castToString(NodeValue nv, XSDDatatype castType) {
+        // https://www.w3.org/TR/xpath-functions/#casting-to-string
+        if ( isDecimal(nv) ) {
+            BigDecimal bd = nv.getDecimal();
+            String str = XSDFuncOp.canonicalDecimalStrNoIntegerDot(bd);
+            return NodeValue.makeString(str);
         }
 
-        // Try by lexical
-        return castByLex(nv, castType) ;
+        if ( isBoolean(nv) ) {
+            boolean b = nv.getBoolean();
+            String str = b ? "true" : "false";
+            return NodeValue.makeString(str);
+        }
+
+        if ( isDouble(nv) || isFloat(nv) ) {
+            double dValue = nv.getDouble();
+
+            if ( dValue == 0d ) {
+                int cmp = Double.compare(dValue, 0.0d);
+                if ( cmp >= 0 )
+                    return NodeValue.makeString("0");
+                else
+                    return NodeValue.makeString("-0");
+            }
+            if ( Double.isNaN(dValue) )
+                return NodeValue.makeString("NaN");
+            if ( dValue == Double.POSITIVE_INFINITY )
+                return NodeValue.makeString("INF");
+            if ( dValue == Double.NEGATIVE_INFINITY )
+                return NodeValue.makeString("-INF");
+
+            if ( inSmallAboluteRange(dValue)) {
+                // Convert to decimal
+                BigDecimal bd = BigDecimal.valueOf(dValue);
+                return NodeValue.makeString(XSDFuncOp.canonicalDecimalStrNoIntegerDot(bd));
+            }
+            // Canonical lexical.
+            return castByLex(nv, castType);
+        }
+
+        // isTemporal -- no correction necessary
+        // isDuration -- no correction necessary
+
+//        if ( isTemporal(nv) ) {
+//            // If ST is xs:dateTime, xs:date or xs:time, TV is the local value. The components of
+//            // TV are individually cast to xs:string using the functions described in
+//            // [casting-to-datetimes] and the results are concatenated together. The year
+//            // component is cast to xs:string using eg:convertYearToString. The month, day, hour
+//            // and minute components are cast to xs:string using eg:convertTo2CharString. The
+//            // second component is cast to xs:string using eg:convertSecondsToString. The
+//            // timezone component, if present, is cast to xs:string using eg:convertTZtoString.
+//
+//            // Note that the hours component of the resulting string will never be "24". Midnight
+//            // is always represented as "00:00:00".
+//        }
+//
+//        if ( isDuration(nv) ) {
+//            // If ST is xs:yearMonthDuration or xs:dayTimeDuration, TV is the
+//            // canonical representation of SV as defined in [Schema 1.1 Part 2].
+//            //
+//            // If ST is xs:duration then let SYM be SV cast as xs:yearMonthDuration,
+//            // and let SDT be SV cast as xs:dayTimeDuration; Now, let the next
+//            // intermediate value, TYM, be SYM cast as TT , and let TDT be SDT cast
+//            // as TT . If TYM is "P0M", then TV is TDT. Otherwise, TYM and TDT are
+//            // merged according to the following rules:
+//            //
+//            //    1. If TDT is "PT0S", then TV is TYM.
+//            //
+//            //    2. Otherwise, TV is the concatenation of all the characters in TYM
+//            //       and all the characters except the first "P" and the optional
+//            //       negative sign in TDT.
+//        }
+        return castByLex(nv, castType);
     }
+
+    // Casting rules for double and floats.
+    private static boolean inSmallAboluteRange(double d) {
+        return ( d >= 0.000001d && d < 1000000d ) || ( d <= -0.000001d && d > -1000000d );
+    }
+
+    private static boolean isIntegerValue(BigDecimal bd) {
+        return bd.signum() == 0 || bd.scale() <= 0 || bd.stripTrailingZeros().scale() <= 0;
+      }
 
     /** Presentation form of an XSD datatype URI */
-    private static String xsdName(String datatype) {
-        return datatype.replaceAll(XSDDatatype.XSD+"#", "xsd:") ;
+    private static String xsdName(XSDDatatype datatype) {
+        return datatype.getURI().replaceAll(XSDDatatype.XSD+"#", "xsd:");
     }
 
-    /** Test to see if a NodeValue is a valid double value and is of datatype xsd:double. */ 
+    /** Test to see if a NodeValue is a valid double value and is of datatype xsd:double. */
     private static boolean isDouble(NodeValue nv) {
-        return nv.isDouble() && nv.getDatatypeURI().equals(XSDDatatype.XSDdouble.getURI()) ;
+        return nv.isDouble() && nv.getDatatypeURI().equals(XSDDatatype.XSDdouble.getURI());
     }
 
-    /** Test to see if a NodeValue is a valid float value and is of datatype float. */ 
+    /** Test to see if a NodeValue is a valid float value and is of datatype float. */
     private static boolean isFloat(NodeValue nv) {
-        return nv.isFloat() && nv.getDatatypeURI().equals(XSDDatatype.XSDfloat.getURI()) ;
+        return nv.isFloat() && nv.getDatatypeURI().equals(XSDDatatype.XSDfloat.getURI());
     }
 
-    /** Test to see if a NodeValue is a valid decimal value and is of datatype decimal. */ 
+    /** Test to see if a NodeValue is a valid decimal value and is of datatype decimal. */
     private static boolean isDecimal(NodeValue nv) {
-        return nv.isDecimal() && nv.getDatatypeURI().equals(XSDDatatype.XSDdecimal.getURI()) ;
+        return nv.isDecimal() && nv.getDatatypeURI().equals(XSDDatatype.XSDdecimal.getURI());
     }
 
-    /** Test to see if a NodeValue is a valid numeric value. */ 
+    /** Test to see if a NodeValue is a valid numeric value. */
     private static boolean isNumeric(NodeValue nv) {
-        return nv.isNumber() ;
+        return nv.isNumber();
+    }
+
+    /** Test to see if a NodeValue is a temporal includes Gregorian.. */
+    private static boolean isTemporal(NodeValue nv) {
+        //
+        return nv.hasDateTime();
+    }
+
+    /** Test to see if a NodeValue is a duration */
+    private static boolean isDuration(NodeValue nv) {
+        return nv.isDuration();
+    }
+
+    /** Test to see if a NodeValue is a valid numeric value. */
+    private static boolean isBoolean(NodeValue nv) {
+        return nv.isBoolean();
     }
 
     private static ExprException exception(NodeValue nv, XSDDatatype dt) {
-        return exception("Invalid cast: "+nv+" -> "+xsdName(dt.getURI())) ;
+        return exception("Invalid cast: "+nv+" -> "+xsdName(dt));
     }
-    
+
     private static ExprException exception(String msg) {
-        return new ExprEvalTypeException(msg) ;
+        return new ExprEvalTypeException(msg);
     }
 
     // Cast by lexical form with checking.
     private static NodeValue castByLex(NodeValue nv, XSDDatatype castType) {
-        String lex = nv.getNode().getLiteralLexicalForm() ;
-        return castByLex(lex, castType) ;
+        String lex = nv.getNode().getLiteralLexicalForm();
+        return castByLex(lex, castType);
     }
 
     // Cast by lexical form with checking.
     private static NodeValue castByLex(String lex, XSDDatatype castType) {
         if ( ! castType.isValid(lex) )
-            throw exception("Invalid lexical form: '"+lex+"' for "+castType.getURI()) ;
-        if ( castType instanceof XSDBaseNumericType || 
+            throw exception("Invalid lexical form: '"+lex+"' for "+castType.getURI());
+        if ( castType instanceof XSDBaseNumericType ||
             castType.equals(XSDDatatype.XSDfloat) ||
             castType.equals(XSDDatatype.XSDdouble) ||
             castType.equals(XSDDatatype.XSDboolean) ||
@@ -271,45 +464,57 @@ public class CastXSD extends FunctionBase1 implements FunctionFactory {
         {
             // More helpful error message.
             if ( lex.startsWith(" ") || lex.endsWith(" ") )
-                throw exception("Not a valid literal form (has whitespace): '"+lex+"'") ;
+                throw exception("Not a valid literal form (has whitespace): '"+lex+"'");
         }
-        return NodeValue.makeNode(lex, castType) ;
-
+        NodeValue nv2 = NodeValue.makeNode(lex, castType);
+        RDFDatatype dt = nv2.getNode().getLiteralDatatype();
+        if ( castType.equals(dt) )
+            return nv2;
+        throw exception("Can not cast '"+lex+"' to a "+castType);
     }
 
     // Known to work casts.  No checking.
     private static NodeValue cast$(String lex, XSDDatatype castType) {
-        return NodeValue.makeNode(lex, castType) ;
+        return NodeValue.makeNode(lex, castType);
     }
 
-    // Return the integer lexical form for a double, where the double is known to be integer valued.
-    private static String doubleIntegerToString(double d) {
+    // Return the integer lexical form for a double
+    private static String doubleToIntegerLex(double d) {
         // Fast path
-        long x = Math.round(d) ;
-        if ( x != Long.MAX_VALUE && x != Long.MIN_VALUE )
-            return  Long.toString(x) ;
-
-        String lex = BigDecimal.valueOf(d).toPlainString() ;
-        int i = lex.indexOf('.') ;
+        long x = Math.round(d);
+        if ( x == d && x != Long.MAX_VALUE && x != Long.MIN_VALUE )
+            return Long.toString(x);
+        // Discard fractional part.
+        String lex = BigDecimal.valueOf(d).toPlainString();
+        int i = lex.indexOf('.');
         if ( i >= 0 )
-            // Adds .0 for some (small) doubles. 
-            lex = lex.substring(0, i) ;
+            lex = lex.substring(0, i);
         return lex;
     }
 
     // Return the decimal lexical form for a double value.
     // Java big decimal allows "E" forms, XSD does not.
-    // For RDF purposes, return ".0" forms (which are 
+    // For RDF purposes, return ".0" forms (which are
     // short-forms in Turtle and SPARQL).
-    private static String doubleToDecimalString(double d) {
+    private static String doubleToDecimalLex(double d) {
         // BigDecimal.valueOf(d) can lead to trailing zeros.
-        String lex = BigDecimal.valueOf(d).toPlainString() ;
-        // Clean the string. 
-        int i = lex.indexOf('.') ;
+        String lex = BigDecimal.valueOf(d).toPlainString();
+        // Clean the string.
+        int i = lex.indexOf('.');
         if ( i < 0 )
-            return lex+".0" ;
+            return lex+".0";
         while((i < lex.length()-2) && lex.endsWith("0"))
-            lex = lex.substring(0,  lex.length()-1) ;
-        return lex ;
+            lex = lex.substring(0,  lex.length()-1);
+        return lex;
+    }
+
+    private static String decimalToIntegerLex(BigDecimal d) {
+        String lex = d.toPlainString();
+        // Clean the string.
+        int i = lex.indexOf('.');
+        if ( i >= 0 )
+            lex = lex.substring(0, i);
+        return lex;
     }
 }
+

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/CastXSD.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/CastXSD.java
@@ -21,7 +21,7 @@ package org.apache.jena.sparql.function;
 import static org.apache.jena.sparql.expr.NodeValue.nvNaN;
 import static org.apache.jena.sparql.expr.NodeValue.nvNegZERO;
 import static org.apache.jena.sparql.expr.NodeValue.nvZERO;
-
+import static org.apache.jena.sparql.expr.nodevalue.XSDFuncOp.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Objects;
@@ -152,35 +152,6 @@ public class CastXSD {
         return castByLex(nv, castType);
     }
 
-    // XXX Merge into XSDFuncOp
-    private static boolean isTemporalDatatype(XSDDatatype datatype) {
-        return
-            datatype.equals(XSDDatatype.XSDdateTime) ||
-            datatype.equals(XSDDatatype.XSDtime) ||
-            datatype.equals(XSDDatatype.XSDdate) ||
-            datatype.equals(XSDDatatype.XSDgYear) ||
-            datatype.equals(XSDDatatype.XSDgYearMonth) ||
-            datatype.equals(XSDDatatype.XSDgMonth) ||
-            datatype.equals(XSDDatatype.XSDgMonthDay) ||
-            datatype.equals(XSDDatatype.XSDgDay);
-    }
-
-    private static boolean isDurationDatatype(XSDDatatype datatype) {
-        return
-            datatype.equals(XSDDatatype.XSDduration) ||
-            datatype.equals(XSDDatatype.XSDyearMonthDuration) ||
-            datatype.equals(XSDDatatype.XSDdayTimeDuration );
-    }
-
-    private static boolean isNumericDatatype(XSDDatatype datatype) {
-        // XXX Check sharing
-        return XSDFuncOp.isNumericType(datatype);
-    }
-
-    private static boolean isBinaryDatatype(XSDDatatype datatype) {
-        return datatype.equals(XSDDatatype.XSDhexBinary) || datatype.equals(XSDDatatype.XSDbase64Binary);
-    }
-
     private static NodeValue castToNumber(NodeValue nv, XSDDatatype castType) {
         if ( castType.equals(XSDDatatype.XSDdecimal) ) {
             // Number to decimal.
@@ -203,7 +174,7 @@ public class CastXSD {
             // Integer, or derived type -> decimal.
             return castByLex(nv, castType);
         }
-        if ( XSDFuncOp.isIntegerType(castType) ) {
+        if ( isIntegerDatatype(castType) ) {
             // Number to integer
             if ( isDouble(nv) || isFloat(nv) ) {
                 // FP to integer
@@ -393,49 +364,49 @@ public class CastXSD {
         return ( d >= 0.000001d && d < 1000000d ) || ( d <= -0.000001d && d > -1000000d );
     }
 
+    /** Test to see if a BuigDecimal is integer valued  */
     private static boolean isIntegerValue(BigDecimal bd) {
         return bd.signum() == 0 || bd.scale() <= 0 || bd.stripTrailingZeros().scale() <= 0;
       }
 
-    /** Presentation form of an XSD datatype URI */
-    private static String xsdName(XSDDatatype datatype) {
-        return datatype.getURI().replaceAll(XSDDatatype.XSD+"#", "xsd:");
-    }
-
-    /** Test to see if a NodeValue is a valid double value and is of datatype xsd:double. */
+    /** Test to see if a {@link NodeValue} is a valid double value and is of datatype xsd:double. */
     private static boolean isDouble(NodeValue nv) {
         return nv.isDouble() && nv.getDatatypeURI().equals(XSDDatatype.XSDdouble.getURI());
     }
 
-    /** Test to see if a NodeValue is a valid float value and is of datatype float. */
+    /** Test to see if a {@link NodeValue} is a valid float value and is of datatype float. */
     private static boolean isFloat(NodeValue nv) {
         return nv.isFloat() && nv.getDatatypeURI().equals(XSDDatatype.XSDfloat.getURI());
     }
 
-    /** Test to see if a NodeValue is a valid decimal value and is of datatype decimal. */
+    /** Test to see if a {@link NodeValue} is a valid decimal value and is of datatype decimal. */
     private static boolean isDecimal(NodeValue nv) {
         return nv.isDecimal() && nv.getDatatypeURI().equals(XSDDatatype.XSDdecimal.getURI());
     }
 
-    /** Test to see if a NodeValue is a valid numeric value. */
+    /** Test to see if a {@link NodeValue} is a valid numeric value. */
     private static boolean isNumeric(NodeValue nv) {
         return nv.isNumber();
     }
 
-    /** Test to see if a NodeValue is a temporal includes Gregorian.. */
+    /** Test to see if a {@link NodeValue} is a temporal includes Gregorian.. */
     private static boolean isTemporal(NodeValue nv) {
-        //
         return nv.hasDateTime();
     }
 
-    /** Test to see if a NodeValue is a duration */
+    /** Test to see if a {@link NodeValue} is a duration */
     private static boolean isDuration(NodeValue nv) {
         return nv.isDuration();
     }
 
-    /** Test to see if a NodeValue is a valid numeric value. */
+    /** Test to see if a {@link NodeValue} is a valid numeric value. */
     private static boolean isBoolean(NodeValue nv) {
         return nv.isBoolean();
+    }
+
+    /** Presentation form of an XSD datatype URI */
+    private static String xsdName(XSDDatatype datatype) {
+        return datatype.getURI().replaceAll(XSDDatatype.XSD+"#", "xsd:");
     }
 
     private static ExprException exception(NodeValue nv, XSDDatatype dt) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/FunctionCastXSD.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/FunctionCastXSD.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.function;
+
+import org.apache.jena.datatypes.xsd.XSDDatatype ;
+import org.apache.jena.sparql.expr.NodeValue ;
+
+public class FunctionCastXSD extends FunctionBase1 implements FunctionFactory {
+
+    protected final XSDDatatype castType;
+
+    public FunctionCastXSD(XSDDatatype dt) {
+        this.castType = dt;
+    }
+
+    @Override
+    public Function create(String uri) {
+        return this;
+    }
+
+    @Override
+    public NodeValue exec(NodeValue v) {
+        return CastXSD.cast(v, castType);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/StandardFunctions.java
@@ -316,15 +316,15 @@ public class StandardFunctions
     }
     
     private static void addCastXSD(FunctionRegistry registry, XSDDatatype dt) {
-        registry.put(dt.getURI(), new CastXSD(dt)) ;
+        registry.put(dt.getURI(), new FunctionCastXSD(dt)) ;
     }
 
     private static void addCastNumeric(FunctionRegistry registry, XSDDatatype dt) {
-        registry.put(dt.getURI(), new CastXSD(dt)) ;
+        registry.put(dt.getURI(), new FunctionCastXSD(dt)) ;
     }
 
     private static void addCastTemporal(FunctionRegistry registry, XSDDatatype dt) {
-        registry.put(dt.getURI(), new CastXSD(dt)) ;
+        registry.put(dt.getURI(), new FunctionCastXSD(dt)) ;
     }
 
     private static void add(FunctionRegistry registry, String uri, Class<? > funcClass) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/ParserBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/ParserBase.java
@@ -97,6 +97,7 @@ public class ParserBase
     // Aggregates are only allowed in places where grouping can happen.
     // e.g. SELECT clause but not a FILTER.
     private boolean allowAggregatesInExpressions = false ;
+    private int     aggregateDepth               = 0 ;
 
     //LabelToNodeMap listLabelMap = new LabelToNodeMap(true, new VarAlloc("L")) ;
     // ----
@@ -148,6 +149,11 @@ public class ParserBase
         this.allowAggregatesInExpressions = allowAggregatesInExpressions;
     }
 
+    // Tracking for nested aggregates.
+    protected void startAggregate()   { aggregateDepth++; }
+    protected int getAggregateDepth() { return aggregateDepth; }
+    protected void finishAggregate()  { aggregateDepth--; }
+    
     protected Element compressGroupOfOneGroup(ElementGroup elg) {
         // remove group of one group.
         if ( elg.size() == 1 ) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
@@ -5415,6 +5415,7 @@ a.add(expr) ;
                      boolean distinct = false ;
                      ExprList ordered = new ExprList() ;
                      Token t ;
+startAggregate();
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case COUNT:{
       t = jj_consume_token(COUNT);
@@ -5852,9 +5853,11 @@ agg = AggregatorFactory.createCustom(iri, a) ;
       throw new ParseException();
     }
 if ( ! getAllowAggregatesInExpressions() )
-           throwParseException("Aggregate expression not legal at this point",
-                                t.beginLine, t.beginColumn) ;
+        throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
+    if ( getAggregateDepth() > 1 )
+        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
 Expr exprAgg = getQuery().allocAggregate(agg) ;
+    finishAggregate();
     {if ("" != null) return exprAgg ;}
     throw new Error("Missing return statement in function");
   }
@@ -6177,13 +6180,6 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     try { return !jj_3_5(); }
     catch(LookaheadSuccess ls) { return true; }
     finally { jj_save(4, xla); }
-  }
-
-  private boolean jj_3R_128()
- {
-    if (jj_scan_token(STDEV)) return true;
-    if (jj_scan_token(LPAREN)) return true;
-    return false;
   }
 
   private boolean jj_3_5()
@@ -7033,15 +7029,15 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3_1()
- {
-    if (jj_3R_43()) return true;
-    return false;
-  }
-
   private boolean jj_3R_173()
  {
     if (jj_scan_token(ANON)) return true;
+    return false;
+  }
+
+  private boolean jj_3_1()
+ {
+    if (jj_3R_43()) return true;
     return false;
   }
 
@@ -7074,12 +7070,6 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_105()
- {
-    if (jj_3R_118()) return true;
-    return false;
-  }
-
   private boolean jj_3R_159()
  {
     Token xsp;
@@ -7088,6 +7078,18 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     jj_scanpos = xsp;
     if (jj_3R_165()) return true;
     }
+    return false;
+  }
+
+  private boolean jj_3R_105()
+ {
+    if (jj_3R_118()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_152()
+ {
+    if (jj_3R_159()) return true;
     return false;
   }
 
@@ -7108,19 +7110,6 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3_4()
- {
-    if (jj_scan_token(DOT)) return true;
-    if (jj_3R_45()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_152()
- {
-    if (jj_3R_159()) return true;
-    return false;
-  }
-
   private boolean jj_3R_144()
  {
     Token xsp;
@@ -7135,6 +7124,13 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
   private boolean jj_3R_151()
  {
     if (jj_3R_145()) return true;
+    return false;
+  }
+
+  private boolean jj_3_4()
+ {
+    if (jj_scan_token(DOT)) return true;
+    if (jj_3R_45()) return true;
     return false;
   }
 
@@ -7153,12 +7149,6 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
   private boolean jj_3R_175()
  {
     if (jj_scan_token(STRING_LITERAL2)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_116()
- {
-    if (jj_3R_138()) return true;
     return false;
   }
 
@@ -7185,17 +7175,23 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_138()
+  private boolean jj_3R_116()
  {
-    if (jj_scan_token(PREFIX)) return true;
-    if (jj_scan_token(PNAME_NS)) return true;
-    if (jj_3R_145()) return true;
+    if (jj_3R_138()) return true;
     return false;
   }
 
   private boolean jj_3R_171()
  {
     if (jj_scan_token(FALSE)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_138()
+ {
+    if (jj_scan_token(PREFIX)) return true;
+    if (jj_scan_token(PNAME_NS)) return true;
+    if (jj_3R_145()) return true;
     return false;
   }
 
@@ -7216,9 +7212,27 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
+  private boolean jj_3R_189()
+ {
+    if (jj_scan_token(DOUBLE_NEGATIVE)) return true;
+    return false;
+  }
+
   private boolean jj_3R_135()
  {
     if (jj_scan_token(LPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_188()
+ {
+    if (jj_scan_token(DECIMAL_NEGATIVE)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_187()
+ {
+    if (jj_scan_token(INTEGER_NEGATIVE)) return true;
     return false;
   }
 
@@ -7229,15 +7243,17 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_189()
+  private boolean jj_3R_180()
  {
-    if (jj_scan_token(DOUBLE_NEGATIVE)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_188()
- {
-    if (jj_scan_token(DECIMAL_NEGATIVE)) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_187()) {
+    jj_scanpos = xsp;
+    if (jj_3R_188()) {
+    jj_scanpos = xsp;
+    if (jj_3R_189()) return true;
+    }
+    }
     return false;
   }
 
@@ -7258,12 +7274,6 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_187()
- {
-    if (jj_scan_token(INTEGER_NEGATIVE)) return true;
-    return false;
-  }
-
   private boolean jj_3R_109()
  {
     Token xsp;
@@ -7275,17 +7285,9 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_180()
+  private boolean jj_3R_186()
  {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_187()) {
-    jj_scanpos = xsp;
-    if (jj_3R_188()) {
-    jj_scanpos = xsp;
-    if (jj_3R_189()) return true;
-    }
-    }
+    if (jj_scan_token(DOUBLE_POSITIVE)) return true;
     return false;
   }
 
@@ -7299,12 +7301,6 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_186()
- {
-    if (jj_scan_token(DOUBLE_POSITIVE)) return true;
-    return false;
-  }
-
   private boolean jj_3R_185()
  {
     if (jj_scan_token(DECIMAL_POSITIVE)) return true;
@@ -7314,12 +7310,6 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
   private boolean jj_3R_184()
  {
     if (jj_scan_token(INTEGER_POSITIVE)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_158()
- {
-    if (jj_scan_token(NIL)) return true;
     return false;
   }
 
@@ -7337,21 +7327,9 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_157()
+  private boolean jj_3R_158()
  {
-    if (jj_3R_163()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_156()
- {
-    if (jj_3R_162()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_155()
- {
-    if (jj_3R_161()) return true;
+    if (jj_scan_token(NIL)) return true;
     return false;
   }
 
@@ -7361,15 +7339,53 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_154()
+  private boolean jj_3R_157()
  {
-    if (jj_3R_160()) return true;
+    if (jj_3R_163()) return true;
     return false;
   }
 
   private boolean jj_3R_182()
  {
     if (jj_scan_token(DECIMAL)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_156()
+ {
+    if (jj_3R_162()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_181()
+ {
+    if (jj_scan_token(INTEGER)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_155()
+ {
+    if (jj_3R_161()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_178()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_181()) {
+    jj_scanpos = xsp;
+    if (jj_3R_182()) {
+    jj_scanpos = xsp;
+    if (jj_3R_183()) return true;
+    }
+    }
+    return false;
+  }
+
+  private boolean jj_3R_154()
+ {
+    if (jj_3R_160()) return true;
     return false;
   }
 
@@ -7402,23 +7418,9 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_181()
+  private boolean jj_3R_169()
  {
-    if (jj_scan_token(INTEGER)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_178()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_181()) {
-    jj_scanpos = xsp;
-    if (jj_3R_182()) {
-    jj_scanpos = xsp;
-    if (jj_3R_183()) return true;
-    }
-    }
+    if (jj_3R_180()) return true;
     return false;
   }
 
@@ -7430,12 +7432,6 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
     jj_scanpos = xsp;
     if (jj_scan_token(15)) return true;
     }
-    return false;
-  }
-
-  private boolean jj_3R_169()
- {
-    if (jj_3R_180()) return true;
     return false;
   }
 
@@ -7547,6 +7543,13 @@ lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
   private boolean jj_3R_129()
  {
     if (jj_scan_token(STDEV_SAMP)) return true;
+    if (jj_scan_token(LPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_128()
+ {
+    if (jj_scan_token(STDEV)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
@@ -5855,7 +5855,7 @@ agg = AggregatorFactory.createCustom(iri, a) ;
 if ( ! getAllowAggregatesInExpressions() )
         throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
     if ( getAggregateDepth() > 1 )
-        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
+        throwParseException("Nested aggregate in expression not legal", t.beginLine, t.beginColumn) ;
 Expr exprAgg = getQuery().allocAggregate(agg) ;
     finishAggregate();
     {if ("" != null) return exprAgg ;}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_11/SPARQLParser11.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_11/SPARQLParser11.java
@@ -4840,7 +4840,7 @@ agg = AggregatorFactory.createGroupConcat(distinct, expr, sep, ordered) ;
 if ( ! getAllowAggregatesInExpressions() )
         throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
     if ( getAggregateDepth() > 1 )
-        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
+        throwParseException("Nested aggregate in expression not legal", t.beginLine, t.beginColumn) ;
 Expr exprAgg = getQuery().allocAggregate(agg) ;
     finishAggregate();
     {if ("" != null) return exprAgg ;}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_11/SPARQLParser11.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_11/SPARQLParser11.java
@@ -4594,6 +4594,7 @@ expr1 = new E_Divide(expr1, expr2) ;
                      boolean distinct = false ;
                      ExprList ordered = new ExprList() ;
                      Token t ;
+startAggregate();
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case COUNT:{
       t = jj_consume_token(COUNT);
@@ -4837,9 +4838,11 @@ agg = AggregatorFactory.createGroupConcat(distinct, expr, sep, ordered) ;
       throw new ParseException();
     }
 if ( ! getAllowAggregatesInExpressions() )
-           throwParseException("Aggregate expression not legal at this point",
-                                t.beginLine, t.beginColumn) ;
+        throwParseException("Aggregate expression not legal at this point", t.beginLine, t.beginColumn) ;
+    if ( getAggregateDepth() > 1 )
+        throwParseException("Nested aggregate in expression not legal ", t.beginLine, t.beginColumn) ;
 Expr exprAgg = getQuery().allocAggregate(agg) ;
+    finishAggregate();
     {if ("" != null) return exprAgg ;}
     throw new Error("Missing return statement in function");
   }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestCastXSD.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestCastXSD.java
@@ -62,20 +62,37 @@ public class TestCastXSD {
     @Test public void cast_to_integer_18()  { testCast      ("xsd:integer('1000'^^xsd:int)",        "'1000'^^xsd:integer") ; }
     @Test public void cast_to_integer_19()  { testNoCast    ("xsd:negativeInteger('1000'^^xsd:int)") ; }
     @Test public void cast_to_integer_20()  { testCast      ("xsd:integer('+1'^^xsd:decimal)",      "'1'^^xsd:integer") ; }
-    @Test public void cast_to_integer_21()  { testNoCast    ("xsd:integer('1.4'^^xsd:decimal)") ; }
+    @Test public void cast_to_integer_21()  { testCast      ("xsd:integer('1.4'^^xsd:decimal)",     "'1'^^xsd:integer") ; }
     @Test public void cast_to_integer_22()  { testCast      ("xsd:byte('01.0'^^xsd:decimal)",       "'1'^^xsd:byte") ; }
     @Test public void cast_to_integer_23()  { testNoCast    ("xsd:byte('HaHa'^^xsd:decimal)") ; }
     @Test public void cast_to_integer_24()  { testCast      ("xsd:byte('-1'^^xsd:decimal)",         "'-1'^^xsd:byte") ; }
     @Test public void cast_to_integer_25()  { testNoCast    ("xsd:unsignedInt('-1'^^xsd:decimal)") ; }
     @Test public void cast_to_integer_26()  { testNoCast    ("xsd:byte('500'^^xsd:decimal)") ; }
 
-    @Test public void cast_decimal_10()     { testCast      ("xsd:decimal('1e-20'^^xsd:double)",    "0.00000000000000000001") ; }
-    @Test public void cast_decimal_11()     { testCast      ("xsd:decimal('1e-19'^^xsd:double)",    "0.0000000000000000001") ; }
-    @Test public void cast_decimal_12()     { testCast      ("xsd:decimal('1e-18'^^xsd:double)",    "0.000000000000000001") ; }
-    @Test public void cast_decimal_13()     { testCast      ("xsd:decimal('1e0'^^xsd:double)",      "1.0") ; }
-    @Test public void cast_decimal_14()     { testCast      ("xsd:decimal('11e0'^^xsd:double)",     "11.0") ; }
-    @Test public void cast_decimal_15()     { testCast      ("xsd:decimal('-0.01'^^xsd:double)",    "-0.01") ; }
-    @Test public void cast_decimal_16()     { testCast      ("xsd:decimal('1'^^xsd:double)",        "'1.0'^^xsd:decimal") ; }
+    @Test public void cast_to_decimal_01()  { testCast      ("xsd:decimal('1e-20'^^xsd:double)",    "0.00000000000000000001") ; }
+    @Test public void cast_to_decimal_02()  { testCast      ("xsd:decimal('1e-19'^^xsd:double)",    "0.0000000000000000001") ; }
+    @Test public void cast_to_decimal_03()  { testCast      ("xsd:decimal('1e-18'^^xsd:double)",    "0.000000000000000001") ; }
+    @Test public void cast_to_decimal_04()  { testCast      ("xsd:decimal('1e0'^^xsd:double)",      "1.0") ; }
+    @Test public void cast_to_decimal_05()  { testCast      ("xsd:decimal('11e0'^^xsd:double)",     "11.0") ; }
+    @Test public void cast_to_decimal_06()  { testCast      ("xsd:decimal('-0.01'^^xsd:double)",    "-0.01") ; }
+    @Test public void cast_to_decimal_07()  { testCast      ("xsd:decimal('1'^^xsd:double)",        "'1.0'^^xsd:decimal") ; }
+    
+    @Test public void cast_to_boolean_01()  { testCast      ("xsd:boolean('1'^^xsd:double)",        "true") ; }
+    @Test public void cast_to_boolean_02()  { testCast      ("xsd:boolean('+1.0e5'^^xsd:double)",   "true") ; }
+    @Test public void cast_to_boolean_03()  { testCast      ("xsd:boolean('0'^^xsd:float)",         "false") ; }
+    @Test public void cast_to_boolean_04()  { testCast      ("xsd:boolean(0.0e0)",                  "false") ; }
+    @Test public void cast_to_boolean_05()  { testCast      ("xsd:boolean(-0.0e0)",                 "false") ; }
+    @Test public void cast_to_boolean_06()  { testCast      ("xsd:boolean('NaN'^^xsd:float)",       "false") ; }
+    
+    @Test public void cast_to_boolean_07()  { testCast      ("xsd:boolean(1.0)",                    "true") ; }
+    @Test public void cast_to_boolean_08()  { testCast      ("xsd:boolean(0.0)",                    "false") ; }
+    @Test public void cast_to_boolean_09()  { testCast      ("xsd:boolean(-1.00)",                  "true") ; }
+    @Test public void cast_to_boolean_10()  { testCast      ("xsd:boolean(0)",                      "false") ; }
+    
+    @Test public void cast_to_boolean_11()  { testCast      ("xsd:boolean('1')",                    "true") ; }
+    @Test public void cast_to_boolean_12()  { testCast      ("xsd:boolean('true')",                 "true") ; }
+    @Test public void cast_to_boolean_13()  { testCast      ("xsd:boolean('0')",                    "false") ; }
+    @Test public void cast_to_boolean_14()  { testCast      ("xsd:boolean('false')",                "false") ; }
 
     @Test public void cast_from_string_01() { testCast      ("xsd:integer('+1'^^xsd:string)",           "'+1'^^xsd:integer") ; }
     @Test public void cast_from_string_02() { testNoCast    ("xsd:integer('a'^^xsd:string)") ; }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestXSDFuncOp.java
@@ -34,57 +34,85 @@ import org.junit.Test ;
 public class TestXSDFuncOp
 {
     private static final double accuracyExact_D = 0.0d ;
-    private static final double accuracyExact_F = 0.0d ;
+    private static final double accuracyExact_F = 0.0f ;
     private static final double accuracyClose_D = 0.000001d ;
     private static final double accuracyClose_F = 0.000001f ;
     
     
     @Test public void lex_decimal_1() {
-        lex_decimal(BigDecimal.valueOf(0), "0.0");
+        lex_decimal_value(BigDecimal.valueOf(0), "0.0");
     }
     
     @Test public void lex_decimal_2() {
-        lex_decimal(BigDecimal.valueOf(1), "1.0");
+        lex_decimal_value(BigDecimal.valueOf(1), "1.0");
     }
     
     @Test public void lex_decimal_3() {
-        lex_decimal(BigDecimal.valueOf(0.5), "0.5");
+        lex_decimal_value(BigDecimal.valueOf(0.5), "0.5");
     }
     
     @Test public void lex_decimal_4() {
-        lex_decimal(BigDecimal.valueOf(-0.5), "-0.5");
+        lex_decimal_value(BigDecimal.valueOf(-0.5), "-0.5");
     }
     
     @Test public void lex_decimal_5() {
-        lex_decimal(BigDecimal.valueOf(1_000_000_000_000_000L), "1000000000000000.0");
+        lex_decimal_value(BigDecimal.valueOf(1_000_000_000_000_000L), "1000000000000000.0");
     }
     
     @Test public void lex_decimal_6() {
-        lex_decimal(BigDecimal.valueOf(-1_000_000_000_000_000L), "-1000000000000000.0");
+        lex_decimal_value(BigDecimal.valueOf(-1_000_000_000_000_000L), "-1000000000000000.0");
     }
 
-    @Test public void lex_decimal_7() {
-        lex_decimal("0.0","0.0");
+    @Test public void lex_decimal_canonical_1() {
+        lex_decimal_canonical("+.0","0.0");
     }
     
-    @Test public void lex_decimal_8() {
+    @Test public void lex_decimal_canonical_2() {
+        lex_decimal_canonical("-.0","0.0");
+    }
+
+    @Test public void lex_decimal_canonical_3() {
+        lex_decimal_canonical("0010","10.0");
+    }
+
+    @Test public void lex_decimal_canonical_4() {
+        lex_decimal_canonical("0012.0000","12.0");
+    }
+    
+    @Test public void lex_decimal_canonical_5() {
+        lex_decimal_canonical("-0012.0000","-12.0");
+    }
+
+    
+    // Exact given lexical form preserved.
+    @Test public void lex_decimal_nodevalue_1() {
+        lex_decimal_nodevalue("0.0","0.0");
+    }
+    
+    @Test public void lex_decimal_nodevalue_2() {
         // As input.
-        lex_decimal("0.","0.");
+        lex_decimal_nodevalue("0.","0.");
     }
     
-    @Test public void lex_decimal_9() {
+    @Test public void lex_decimal_nodevalue3() {
         // As input.
-        lex_decimal("+.0","+.0");
+        lex_decimal_nodevalue("+.0","+.0");
     }
     
-    private static void lex_decimal(BigDecimal decimal, String expected) {
+    private static void lex_decimal_value(BigDecimal decimal, String expected) {
         String lex = XSDFuncOp.canonicalDecimalStr(decimal);
         assertEquals(expected, lex);
     }
     
-    private static void lex_decimal(String input, String expected) {
+    private static void lex_decimal_nodevalue(String input, String expected) {
         NodeValue nv = NodeValue.makeDecimal(input);
         String lex = nv.asString(); 
+        assertEquals(expected, lex);
+    }
+
+    private static void lex_decimal_canonical(String input, String expected) {
+        BigDecimal decimal = new BigDecimal(input);
+        String lex = XSDFuncOp.canonicalDecimalStr(decimal);
         assertEquals(expected, lex);
     }
 

--- a/jena-arq/testing/ARQ/Syntax/Syntax-ARQ/manifest.ttl
+++ b/jena-arq/testing/ARQ/Syntax/Syntax-ARQ/manifest.ttl
@@ -67,6 +67,9 @@
 :test_39
 :test_40
 :test_41
+:test_42
+:test_43
+:test_44
 ) .
 
 :test_1 rdf:type   mfx:PositiveSyntaxTestARQ ;
@@ -256,20 +259,35 @@
 
 :test_38 rdf:type   mfx:NegativeSyntaxTestARQ ;
    dawgt:approval dawgt:NotClassified ;
+   mf:name    "syntax-agg-expr-bad-01.arq" ;
+   mf:action  <syntax-agg-expr-bad-01.arq> ;.
+
+:test_39 rdf:type   mfx:NegativeSyntaxTestARQ ;
+   dawgt:approval dawgt:NotClassified ;
+   mf:name    "syntax-agg-expr-bad-02.arq" ;
+   mf:action  <syntax-agg-expr-bad-02.arq> ;.
+
+:test_40 rdf:type   mfx:NegativeSyntaxTestARQ ;
+   dawgt:approval dawgt:NotClassified ;
+   mf:name    "syntax-agg-expr-bad-03.arq" ;
+   mf:action  <syntax-agg-expr-bad-03.arq> ;.
+
+:test_41 rdf:type   mfx:NegativeSyntaxTestARQ ;
+   dawgt:approval dawgt:NotClassified ;
    mf:name    "syntax-subquery-bad-01.arq" ;
    mf:action  <syntax-subquery-bad-01.arq> ;.
 
-:test_39 rdf:type   mfx:NegativeSyntaxTestARQ ;
+:test_42 rdf:type   mfx:NegativeSyntaxTestARQ ;
    dawgt:approval dawgt:NotClassified ;
    mf:name    "syntax-subquery-bad-02.arq" ;
    mf:action  <syntax-subquery-bad-02.arq> ;.
 
-:test_40 rdf:type   mfx:NegativeSyntaxTestARQ ;
+:test_43 rdf:type   mfx:NegativeSyntaxTestARQ ;
    dawgt:approval dawgt:NotClassified ;
    mf:name    "syntax-let-bad-01.arq" ;
    mf:action  <syntax-let-bad-01.arq> ;.
 
-:test_41 rdf:type   mfx:NegativeSyntaxTestARQ ;
+:test_44 rdf:type   mfx:NegativeSyntaxTestARQ ;
    dawgt:approval dawgt:NotClassified ;
    mf:name    "syntax-quad-construct-bad-01.arq" ;
    mf:action  <syntax-quad-construct-bad-01.arq> ;.

--- a/jena-arq/testing/ARQ/Syntax/Syntax-ARQ/syntax-agg-expr-bad-01.arq
+++ b/jena-arq/testing/ARQ/Syntax/Syntax-ARQ/syntax-agg-expr-bad-01.arq
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+SELECT (SUM(COUNT(*)) AS ?Z) {}

--- a/jena-arq/testing/ARQ/Syntax/Syntax-ARQ/syntax-agg-expr-bad-02.arq
+++ b/jena-arq/testing/ARQ/Syntax/Syntax-ARQ/syntax-agg-expr-bad-02.arq
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+SELECT ?Z {} HAVING (COUNT(AVG(?x)) > 0)

--- a/jena-arq/testing/ARQ/Syntax/Syntax-ARQ/syntax-agg-expr-bad-03.arq
+++ b/jena-arq/testing/ARQ/Syntax/Syntax-ARQ/syntax-agg-expr-bad-03.arq
@@ -1,0 +1,2 @@
+PREFIX : <http://example/>
+SELECT ?Z {} ORDER BY COUNT(AVG(?x))

--- a/jena-arq/testing/ARQ/Syntax/syn-arq.sh
+++ b/jena-arq/testing/ARQ/Syntax/syn-arq.sh
@@ -46,6 +46,25 @@ N=$((N+1)) ; testGood $ARQ $(fname "syntax-select-expr-" $N arq) <<EOF
 PREFIX : <http://example/>
 SELECT str(?z) ?z {}
 EOF
+## ---- Nested aggregates
+
+N=0
+
+N=$((N+1)) ; testBad $ARQ $(fname "syntax-agg-expr-bad-" $N arq) <<EOF
+PREFIX : <http://example/>
+SELECT (SUM(COUNT(*)) AS ?Z) {}
+EOF
+
+N=$((N+1)) ; testBad $ARQ $(fname "syntax-agg-expr-bad-" $N arq) <<EOF
+PREFIX : <http://example/>
+SELECT ?Z {} HAVING (COUNT(AVG(?x)) > 0)
+EOF
+
+N=$((N+1)) ; testBad $ARQ $(fname "syntax-agg-expr-bad-" $N arq) <<EOF
+PREFIX : <http://example/>
+SELECT ?Z {} ORDER BY COUNT(AVG(?x))
+EOF
+
 
 ## ---- SERVICE
 

--- a/jena-arq/testing/ARQ/Syntax/syn-reification.sh
+++ b/jena-arq/testing/ARQ/Syntax/syn-reification.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-## Reification
+## Original reification support.
+## This is not RDF*
+## This is not all currently valid.
 N=0
 
 N=$((N+1)) ; testGood $ARQ $(fname "syntax-reif-arq-" $N arq) <<EOF


### PR DESCRIPTION
There is a new set of tests in the CG [w3c/rdf-tests](https://github.com/w3c/rdf-tests/) to cover XSD casting as defined in F&O 3.1.

JENA-1984 fixes problems encountered.


This PR includes 
  JENA-1986: Error for nested aggregates
which was reported offline 
