### PR TITLE
JENA-1898: Log output for webapp

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlLog4j2.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlLog4j2.java
@@ -24,10 +24,11 @@ import java.io.InputStream;
 
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.lib.StrUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
-import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory;
 
 /**
@@ -56,14 +57,10 @@ public class LogCtlLog4j2 {
             ? new PropertiesConfigurationFactory()
             : ConfigurationFactory.getInstance();
         Configuration configuration = factory.getConfiguration(null, source);
-        Configurator.initialize(configuration);
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        // This changes exising loggers.
+        ctx.setConfiguration(configuration);
     }
-
-//    public static void setCmdLogging() {
-//        LogCtl.setLog4j2();
-//        if ( ! LogCtl.isSetLog4j2property() )
-//            resetLogging(log4j2setupCmd);
-//    }
 
     // basic setup.
     // @formatter:off
@@ -71,7 +68,7 @@ public class LogCtlLog4j2 {
     public static String log4j2setup = StrUtils.strjoinNL
         ( "## Command default log4j2 setup : log4j2 properties syntax."
         , "status = error"
-        , "name = PropertiesConfig"
+        , "name = JenaLoggingDft"
 //        , "filters = threshold"
 //        , ""
 //        , "filter.threshold.type = ThresholdFilter"

--- a/jena-fuseki2/jena-fuseki-webapp/pom.xml
+++ b/jena-fuseki2/jena-fuseki-webapp/pom.xml
@@ -72,12 +72,13 @@
       <artifactId>shiro-web</artifactId>
     </dependency>
 
-    <!-- Logging :  Needed because the Fuseki command line manages logging -->  
+    <!-- Logging  -->  
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
 
+    <!-- Within-webapp use -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-web</artifactId>

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerEnvironmentInit.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerEnvironmentInit.java
@@ -36,12 +36,19 @@ public class FusekiServerEnvironmentInit implements ServletContextListener {
     public void contextInitialized(ServletContextEvent sce) {
         // These do not touch Jena.
         FusekiEnv.setEnvironment();
-        // Log4j2 name.
-        // If this is set, the webapp is controlling log4j setup via log4j-web and its own initialization.
-        String x = sce.getServletContext().getInitParameter(FusekiLogging.log4j2_web_configuration);
-        if ( x != null )
-            FusekiLogging.markInitialized(true);
-        FusekiLogging.setLogging(FusekiEnv.FUSEKI_BASE);
+        // The command line initializes Fuseki-full with FusekiLogging.setLogging()
+        if ( FusekiLogging.hasInitialized() ) {
+            // If this is set, the webapp is controlling log4j setup via log4j-web and its own initialization.
+            // The logging file in in log4j2.properties in the webapp root directory.
+            String x = sce.getServletContext().getInitParameter(FusekiLogging.log4j2_web_configuration);
+            if ( x != null ) {
+                // https://logging.apache.org/log4j/2.x/manual/webapp.html
+                System.err.println("log4jConfiguration = "+x);
+                FusekiLogging.markInitialized(true);
+            } else {
+                FusekiLogging.setLogging(FusekiEnv.FUSEKI_BASE);
+            }
+        }
         JenaSystem.init();
     }
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/WEB-INF/web.xml
@@ -93,6 +93,11 @@
     -->
     <param-value>shiro.ini</param-value>
   </context-param>
+
+  <context-param>
+    <param-name>log4jConfiguration</param-name>
+    <param-value>log4j2.properties</param-value>
+  </context-param>
   
   <!-- Fuseki datatset serviced calls -->
   <filter>

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/log4j2.properties
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/log4j2.properties
@@ -1,0 +1,61 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+## Plain output to stdout
+status = error
+name = FusekiLoggingWebapp
+
+appender.console.type = Console
+appender.console.name = OUT
+appender.console.target = SYSTEM_OUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-10c{1} %-5p %m%n
+
+rootLogger.level                  = INFO
+rootLogger.appenderRef.stdout.ref = OUT
+
+logger.jena.name  = org.apache.jena
+logger.jena.level = INFO
+
+logger.arq-exec.name  = org.apache.jena.arq.exec
+logger.arq-exec.level = INFO
+
+logger.riot.name  = org.apache.jena.riot
+logger.riot.level = INFO
+
+logger.fuseki.name  = org.apache.jena.fuseki
+logger.fuseki.level = INFO
+
+logger.fuseki-fuseki.name  = org.apache.jena.fuseki.Fuseki
+logger.fuseki-fuseki.level = INFO
+
+logger.fuseki-server.name  = org.apache.jena.fuseki.Server
+logger.fuseki-server.level = INFO
+
+logger.fuseki-config.name  = org.apache.jena.fuseki.Config
+logger.fuseki-config.level = INFO
+
+logger.fuseki-admin.name  = org.apache.jena.fuseki.Admin
+logger.fuseki-admin.level = INFO
+
+logger.jetty.name  = org.eclipse.jetty
+logger.jetty.level = WARN
+
+logger.apache-http.name   = org.apache.http
+logger.apache-http.level  = WARN
+logger.shiro.name = org.apache.shiro
+logger.shiro.level = WARN
+
+# Hide bug in Shiro 1.5.0
+logger.shiro-realm.name = org.apache.shiro.realm.text.IniRealm
+logger.shiro-realm.level = ERROR
+
+# This goes out in NCSA format
+appender.plain.type = Console
+appender.plain.name = PLAIN
+appender.plain.layout.type = PatternLayout
+appender.plain.layout.pattern = %m%n
+
+logger.fuseki-request.name                   = org.apache.jena.fuseki.Request
+logger.fuseki-request.additivity             = false
+logger.fuseki-request.level                  = OFF
+logger.fuseki-request.appenderRef.plain.ref  = PLAIN


### PR DESCRIPTION
Use web.xml setup when running from a WAR file.

See [JENA-1989](https://issues.apache.org/jira/browse/JENA-1989) for more - external configuration of systemd is necessary as well because it will route stdout to an different place for Tomcat9 than for Tomcat8.

