### PR TITLE
Add Dockerfile.snapshot for creating image from snapshot builds

### DIFF
--- a/jena-fuseki2/jena-fuseki-docker/Dockerfile.snapshot
+++ b/jena-fuseki2/jena-fuseki-docker/Dockerfile.snapshot
@@ -1,0 +1,125 @@
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+## 
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+## Apache Jena Fuseki server Dockerfile.
+
+## This Dockefile builds a reduced footprint container.
+
+ARG OPENJDK_VERSION=14
+ARG ALPINE_VERSION=3.12.0
+ARG JENA_VERSION=""
+ARG JENA_SNAPSHOT_VERSION=""
+
+# Internal, passed between stages.
+ARG FUSEKI_DIR=/fuseki
+ARG FUSEKI_JAR=fuseki-server.jar
+ARG FUSEKI_TAR=apache-jena-fuseki-${JENA_SNAPSHOT_VERSION}.tar.gz
+ARG JAVA_MINIMAL=/opt/java-minimal
+
+## ---- Stage: Download and build java.
+FROM openjdk:${OPENJDK_VERSION}-alpine AS base
+
+ARG JAVA_MINIMAL
+ARG JENA_VERSION
+ARG JENA_SNAPSHOT_VERSION
+ARG FUSEKI_DIR
+ARG FUSEKI_JAR
+ARG FUSEKI_TAR
+ARG REPO=https://repository.apache.org/content/groups/snapshots
+ARG TAR_URL=${REPO}/org/apache/jena/apache-jena-fuseki/${JENA_VERSION}/${FUSEKI_TAR}
+
+RUN [ "${JENA_VERSION}" != "" ] || { echo -e '\n**** Set JENA_VERSION ****\n' ; exit 1 ; }
+RUN [ "${JENA_SNAPSHOT_VERSION}" != "" ] || { echo -e '\n**** Set JENA_SNAPSHOT_VERSION ****\n' ; exit 1 ; }
+RUN echo && echo "==== Docker build for Apache Jena Fuseki ${JENA_VERSION} ====" && echo
+
+# Alpine: For objcopy used in jlink
+RUN apk add --no-cache curl binutils
+
+## -- Fuseki installed and runs in /fuseki.
+WORKDIR $FUSEKI_DIR
+
+## -- Download the jar file.
+COPY download.sh .
+RUN chmod a+x download.sh
+
+# Download, with check of the SHA1 checksum.
+RUN ./download.sh --chksum sha1 "$TAR_URL"
+
+RUN tar -xvzf "${FUSEKI_DIR}/${FUSEKI_TAR}"
+RUN cd "apache-jena-fuseki-${JENA_VERSION}/" && mv ./* ../
+
+## -- Alternatives to download : copy already downloaded.
+## COPY ${FUSEKI_JAR} .
+
+## Use Docker ADD - does not retry, does not check checksum, and may run every build.
+## ADD "$JAR_URL"
+
+## -- Make reduced Java JDK
+
+ARG JDEPS_EXTRA="jdk.crypto.cryptoki,jdk.crypto.ec"
+RUN \
+  JDEPS="$(jdeps --multi-release base --print-module-deps --ignore-missing-deps ${FUSEKI_JAR})"  && \
+  jlink \
+        --compress 2 --strip-debug --no-header-files --no-man-pages \
+        --output "${JAVA_MINIMAL}" \
+        --add-modules "${JDEPS},${JDEPS_EXTRA}"
+
+ADD entrypoint.sh .
+ADD log4j2.properties .
+
+# Run as this user
+# -H : no home directorry
+# -D : no password
+
+RUN adduser -H -D fuseki fuseki
+
+## ---- Stage: Build runtime
+FROM alpine:${ALPINE_VERSION}
+
+## Import ARGs
+ARG JENA_VERSION
+ARG JAVA_MINIMAL
+ARG FUSEKI_DIR
+ARG FUSEKI_JAR
+
+COPY --from=base /opt/java-minimal /opt/java-minimal
+COPY --from=base /fuseki /fuseki
+COPY --from=base /etc/passwd /etc/passwd
+
+WORKDIR $FUSEKI_DIR
+
+ARG LOGS=${FUSEKI_DIR}/logs
+ARG DATA=${FUSEKI_DIR}/databases
+
+RUN \
+    mkdir -p $LOGS && \
+    mkdir -p $DATA && \
+    chown -R fuseki ${FUSEKI_DIR} && \
+    chmod a+x entrypoint.sh 
+
+## Default environment variables.
+ENV \
+    JAVA_HOME=${JAVA_MINIMAL}           \
+    JAVA_OPTIONS="-Xmx2048m -Xms2048m"  \
+    JENA_VERSION=${JENA_VERSION}        \
+    FUSEKI_JAR="${FUSEKI_JAR}"          \
+    FUSEKI_DIR="${FUSEKI_DIR}"
+
+USER fuseki
+
+EXPOSE 3030
+
+ENTRYPOINT ["./entrypoint.sh" ]
+CMD []

--- a/jena-fuseki2/jena-fuseki-docker/README.md
+++ b/jena-fuseki2/jena-fuseki-docker/README.md
@@ -38,6 +38,12 @@ server.
 
 Note the build command must provide the version number.
 
+### Build from snapshot version
+
+For building Docker image of a snapshot version from https://repository.apache.org/content/groups/snapshots/org/apache/jena/apache-jena-fuseki/ use `Dockerfile.snapshot`. Both JENA_VERSION and JENA_SNAPSHOT_VERSION must be provided.
+
+    docker build -f Dockerfile.snapshot -t fuseki-snapshot --build-arg JENA_VERSION=3.17.0-SNAPSHOT --build-arg JENA_SNAPSHOT_VERSION=3.17.0-20201119.075025-46 .
+
 ## Test Run
 
 `docker-compose run` cam be used to test the build from the previous section.


### PR DESCRIPTION
For building Docker image of a snapshot version from https://repository.apache.org/content/groups/snapshots/org/apache/jena/apache-jena-fuseki/ use `Dockerfile.snapshot`.

Both JENA_VERSION and JENA_SNAPSHOT_VERSION must be provided.

    docker build -f Dockerfile.snapshot -t fuseki-snapshot --build-arg JENA_VERSION=3.17.0-SNAPSHOT --build-arg JENA_SNAPSHOT_VERSION=3.17.0-20201119.075025-46 .