### PR TITLE
Add public getters to SHACL constraint implementations

### DIFF
--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/CardinalityConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/CardinalityConstraint.java
@@ -39,14 +39,6 @@ public abstract class CardinalityConstraint extends ConstraintEntity {
         throw new ShaclParseException("Cardinality constraint on a node shape");
     }
 
-    public int getMinCount(){
-        return minCount;
-    }
-
-    public int getMaxCount(){
-        return maxCount;
-    }
-
     // -1 => no test
     protected CardinalityConstraint(int minCardinality, int maxCardinality) {
         this.minCount = minCardinality;

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/CardinalityConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/CardinalityConstraint.java
@@ -38,7 +38,15 @@ public abstract class CardinalityConstraint extends ConstraintEntity {
         // Node shape with cardinality. Can this usefully be checked for in the parser?
         throw new ShaclParseException("Cardinality constraint on a node shape");
     }
-    
+
+    public int getMinCount(){
+        return minCount;
+    }
+
+    public int getMaxCount(){
+        return maxCount;
+    }
+
     // -1 => no test
     protected CardinalityConstraint(int minCardinality, int maxCardinality) {
         this.minCount = minCardinality;

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClosedConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClosedConstraint.java
@@ -58,11 +58,11 @@ public class ClosedConstraint implements Constraint {
     }
 
     public Set<Node> getExpected(){
-        return expected;
+        return Collections.unmodifiableSet(expected);
     }
 
     public List<Node> getIgnoredProperties() {
-        return ignoredProperties;
+        return Collections.unmodifiableList(ignoredProperties);
     }
 
     public boolean isActive() {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClosedConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClosedConstraint.java
@@ -57,6 +57,18 @@ public class ClosedConstraint implements Constraint {
         ignoredProperties = (ignored == null) ? Collections.emptyList() : ignored;
     }
 
+    public Set<Node> getExpected(){
+        return expected;
+    }
+
+    public List<Node> getIgnoredProperties() {
+        return ignoredProperties;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
     private static List<Node> ignoredProperties(Graph shapesGraph, Node shNode) {
         List<Node> ignoredProperties = null;
         if ( G.contains(shapesGraph, shNode, SHACL.ignoredProperties, null) ) {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintComponentSPARQL.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintComponentSPARQL.java
@@ -59,6 +59,18 @@ public class ConstraintComponentSPARQL implements Constraint {
         }
     }
 
+    public SparqlComponent getSparqlConstraintComponent() {
+        return sparqlConstraintComponent;
+    }
+
+    public Multimap<Parameter, Node> getParameterMap() {
+        return parameterMap;
+    }
+
+    public Query getQuery() {
+        return query;
+    }
+
     @Override
     public void validateNodeShape(ValidationContext vCxt, Graph data, Shape shape, Node focusNode) {
         SparqlValidation.validate(vCxt, data, shape, focusNode, null, focusNode, query, parameterMap,

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintComponentSPARQL.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintComponentSPARQL.java
@@ -59,18 +59,6 @@ public class ConstraintComponentSPARQL implements Constraint {
         }
     }
 
-    public SparqlComponent getSparqlConstraintComponent() {
-        return sparqlConstraintComponent;
-    }
-
-    public Multimap<Parameter, Node> getParameterMap() {
-        return parameterMap;
-    }
-
-    public Query getQuery() {
-        return query;
-    }
-
     @Override
     public void validateNodeShape(ValidationContext vCxt, Graph data, Shape shape, Node focusNode) {
         SparqlValidation.validate(vCxt, data, shape, focusNode, null, focusNode, query, parameterMap,

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintOp1.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintOp1.java
@@ -31,6 +31,10 @@ public abstract class ConstraintOp1 extends ConstraintOp {
         other = subShape;
     }
 
+    public Shape getOther() {
+        return other;
+    }
+
     @Override
     public void print(IndentedWriter out, NodeFormatter nodeFmt) {
         out.print(toString());

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintOpN.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintOpN.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.shacl.engine.constraint;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.jena.atlas.io.IndentedWriter;
@@ -34,7 +35,7 @@ public abstract class ConstraintOpN extends ConstraintOp {
     }
 
     public List<Shape> getOthers() {
-        return others;
+        return Collections.unmodifiableList(others);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintOpN.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintOpN.java
@@ -33,6 +33,10 @@ public abstract class ConstraintOpN extends ConstraintOp {
         others = subShapes;
     }
 
+    public List<Shape> getOthers() {
+        return others;
+    }
+
     @Override
     public void print(IndentedWriter out, NodeFormatter nodeFmt) {
         out.print(toString());

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintPairwise.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintPairwise.java
@@ -45,6 +45,14 @@ public abstract class ConstraintPairwise implements Constraint {
         this.constraintComponent = constraintComponent;
     }
 
+    public Node getValue() {
+        return value;
+    }
+
+    public Node getConstraintComponent() {
+        return constraintComponent;
+    }
+
     @Override
     final
     public Node getComponent() {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/HasValueConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/HasValueConstraint.java
@@ -43,6 +43,10 @@ public class HasValueConstraint extends ConstraintEntity {
         this.value = value;
     }
 
+    public Node getValue() {
+        return value;
+    }
+
     @Override
     public Node getComponent() {
         return SHACL.HasValueConstraintComponent;

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/InConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/InConstraint.java
@@ -22,6 +22,7 @@ import static org.apache.jena.shacl.compact.writer.CompactOut.compactArrayNodes;
 import static org.apache.jena.shacl.lib.ShLib.displayStr;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -42,7 +43,7 @@ public class InConstraint extends ConstraintTerm {
     }
 
     public List<Node> getValues() {
-        return values;
+        return Collections.unmodifiableList(values);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/InConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/InConstraint.java
@@ -41,6 +41,10 @@ public class InConstraint extends ConstraintTerm {
         values.addAll(list);
     }
 
+    public List<Node> getValues() {
+        return values;
+    }
+
     @Override
     public Node getComponent() {
         return SHACL.InConstraintComponent;

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JLogConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JLogConstraint.java
@@ -36,6 +36,10 @@ public class JLogConstraint extends ConstraintTerm {
         this.message = message;
     }
 
+    public String getMessage() {
+        return message;
+    }
+
     @Override
     public Node getComponent() {
         return SHJ.LogConstraintComponent;

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JViolationConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JViolationConstraint.java
@@ -35,6 +35,10 @@ public class JViolationConstraint extends ConstraintTerm {
         this.generateViolation = generateViolation;
     }
 
+    public boolean isGenerateViolation() {
+        return generateViolation;
+    }
+
     @Override
     public Node getComponent() {
         return SHJ.ViolationConstraintComponent;

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JViolationConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JViolationConstraint.java
@@ -35,7 +35,7 @@ public class JViolationConstraint extends ConstraintTerm {
         this.generateViolation = generateViolation;
     }
 
-    public boolean isGenerateViolation() {
+    public boolean generatesViolation() {
         return generateViolation;
     }
 

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/NodeKindConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/NodeKindConstraint.java
@@ -57,6 +57,18 @@ public class NodeKindConstraint extends ConstraintTerm {
 
     public  Node getKind() { return kind; }
 
+    public boolean isCanBeIRI() {
+        return canBeIRI;
+    }
+
+    public boolean isCanBeBlankNode() {
+        return canBeBlankNode;
+    }
+
+    public boolean isCanBeLiteral() {
+        return canBeLiteral;
+    }
+
     @Override
     public void printCompact(IndentedWriter out, NodeFormatter nodeFmt) {
         String s = getKind().getLocalName();

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/PatternConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/PatternConstraint.java
@@ -53,6 +53,18 @@ public class PatternConstraint extends ConstraintTerm {
         this.pattern = Pattern.compile(pattern, flags);
     }
 
+    public Pattern getPattern() {
+        return pattern;
+    }
+
+    public String getPatternString() {
+        return patternString;
+    }
+
+    public String getFlagsStr() {
+        return flagsStr;
+    }
+
     @Override
     public ReportItem validate(ValidationContext vCxt, Node n) {
         if ( n.isBlank() ) {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/PatternConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/PatternConstraint.java
@@ -53,11 +53,7 @@ public class PatternConstraint extends ConstraintTerm {
         this.pattern = Pattern.compile(pattern, flags);
     }
 
-    public Pattern getPattern() {
-        return pattern;
-    }
-
-    public String getPatternString() {
+    public String getPattern() {
         return patternString;
     }
 

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/QualifiedValueShape.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/QualifiedValueShape.java
@@ -50,6 +50,22 @@ public class QualifiedValueShape implements Constraint {
         this.qDisjoint = qDisjoint;
     }
 
+    public Shape getSub() {
+        return sub;
+    }
+
+    public int getqMin() {
+        return qMin;
+    }
+
+    public int getqMax() {
+        return qMax;
+    }
+
+    public boolean isqDisjoint() {
+        return qDisjoint;
+    }
+
     @Override
     public void validateNodeShape(ValidationContext vCxt, Graph data, Shape shape, Node focusNode) {
         throw new ShaclException("sh:qualifiedValueShape only valid in a property shape");

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/QualifiedValueShape.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/QualifiedValueShape.java
@@ -54,15 +54,15 @@ public class QualifiedValueShape implements Constraint {
         return sub;
     }
 
-    public int getqMin() {
+    public int qMin() {
         return qMin;
     }
 
-    public int getqMax() {
+    public int qMax() {
         return qMax;
     }
 
-    public boolean isqDisjoint() {
+    public boolean qDisjoint() {
         return qDisjoint;
     }
 

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/SparqlConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/SparqlConstraint.java
@@ -50,6 +50,14 @@ public class SparqlConstraint implements Constraint {
         this.message = message;
     }
 
+    public Query getQuery() {
+        return query;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
     @Override
     public void validateNodeShape(ValidationContext vCxt, Graph data, Shape shape, Node focusNode) {
         SparqlValidation.validate(vCxt, data, shape, focusNode, null, focusNode, query, null, message, this);

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMaxLengthConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMaxLengthConstraint.java
@@ -39,7 +39,11 @@ public class StrMaxLengthConstraint extends ConstraintTerm {
     public StrMaxLengthConstraint(int maxLength) {
         this.maxLength = maxLength;
     }
-    
+
+    public int getMaxLength() {
+        return maxLength;
+    }
+
     @Override
     public ReportItem validate(ValidationContext vCxt, Node n) {
         if ( n.isBlank() ) {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMinLengthConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMinLengthConstraint.java
@@ -40,6 +40,10 @@ public class StrMinLengthConstraint extends ConstraintTerm {
         this.minLength = minLength;
     }
 
+    public int getMinLength() {
+        return minLength;
+    }
+
     @Override
     public ReportItem validate(ValidationContext vCxt, Node n) {
         if ( n.isBlank() ) {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/UniqueLangConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/UniqueLangConstraint.java
@@ -47,6 +47,10 @@ public class UniqueLangConstraint implements Constraint {
         this.flag = flag;
     }
 
+    public boolean isFlag() {
+        return flag;
+    }
+
     @Override
     public void validateNodeShape(ValidationContext vCxt, Graph data, Shape shape, Node focusNode) {
         // Node shape -> not allowed

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueRangeConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueRangeConstraint.java
@@ -43,6 +43,14 @@ public abstract class ValueRangeConstraint extends ConstraintTerm {
         this.constraintComponent = constraintComponent;
     }
 
+    public NodeValue getNodeValue() {
+        return nodeValue;
+    }
+
+    public Node getConstraintComponent() {
+        return constraintComponent;
+    }
+
     @Override
     final public ReportItem validate(ValidationContext vCxt, Node n) {
         NodeValue nv = NodeValue.makeNode(n);


### PR DESCRIPTION
As documented in https://issues.apache.org/jira/browse/JENA-2002, this commit adds public getters for accessing internal data in SHACL constraints.