### PR TITLE
JENA-2003: Handle file URIs with URI scheme name

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFDataMgr.java
@@ -707,7 +707,7 @@ public class RDFDataMgr
         if ( base == null )
             base = SysRIOT.chooseBaseIRI(uri) ;
         if ( hintLang == null )
-            hintLang = RDFLanguages.filenameToLang(uri) ;
+            hintLang = RDFLanguages.pathnameToLang(uri) ;
         parseFromURI(sink, uri, base, hintLang, context);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
@@ -28,7 +28,8 @@ import org.apache.jena.atlas.web.ContentType ;
 import org.apache.jena.atlas.web.MediaType ;
 import org.apache.jena.util.FileUtils ;
 
-/** Central registry of RDF languages and syntaxes.
+/**
+ * Central registry of RDF languages and syntaxes.
  * @see RDFParserRegistry
  * @see RDFFormat
  */
@@ -399,31 +400,34 @@ public class RDFLanguages
     }
 
     /** Try to map a resource name to a {@link Lang}; return null on no registered mapping */
-    public static Lang resourceNameToLang(String resourceName) { return filenameToLang(resourceName) ; }
+    public static Lang resourceNameToLang(String resourceName) { return pathnameToLang(resourceName) ; }
 
     /** Try to map a resource name to a {@link Lang}; return the given default where there is no registered mapping */
     public static Lang resourceNameToLang(String resourceName, Lang dftLang) { return filenameToLang(resourceName, dftLang) ; }
 
-    /** Try to map a URI or file name to a {@link Lang}; return null on no registered mapping. */
-    public static Lang filenameToLang(String filename)
+    /** Try to map a file name to a {@link Lang}; return null on no registered mapping. */
+    public static Lang filenameToLang(String uriOrFilename) { return pathnameToLang(uriOrFilename); }
+
+    /** Try to map a URI or URI path name to a {@link Lang}; return null on no registered mapping. */
+    public static Lang pathnameToLang(String pathname)
     {
-        if ( filename == null )
+        if ( pathname == null )
             return null;
         // Remove any URI fragment (there can be only one # in a URI).
         // Pragmatically, assume any # is URI related.
         // URIs can be relative.
-        int iHash = filename.indexOf('#');
+        int iHash = pathname.indexOf('#');
         if ( iHash  > 0 )
-            filename = filename.substring(0, iHash);
-        // Gzip or BZip2 compressed?
-        filename = IO.filenameNoCompression(filename);
-        return fileExtToLang(FileUtils.getFilenameExt(filename));
+            pathname = pathname.substring(0, iHash);
+        // Compressed?
+        pathname = IO.filenameNoCompression(pathname);
+        return fileExtToLang(FileUtils.getFilenameExt(pathname));
     }
 
     /** Try to map a file name to a {@link Lang}; return the given default where there is no registered mapping */
     public static Lang filenameToLang(String filename, Lang dftLang)
     {
-        Lang lang = filenameToLang(filename) ;
+        Lang lang = pathnameToLang(filename) ;
         return (lang == null) ? dftLang : lang ;
     }
 
@@ -449,7 +453,7 @@ public class RDFLanguages
     {
         if ( resourceName == null )
             return null ;
-        Lang lang = filenameToLang(resourceName) ;
+        Lang lang = pathnameToLang(resourceName) ;
         if ( lang == null )
             return null ;
         return lang.getContentType() ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocatorFile.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocatorFile.java
@@ -34,14 +34,11 @@ import org.slf4j.LoggerFactory ;
 
 /** Location files in the filing system.
  *  A FileLocator can have a "current directory" - this is separate from any
- *  location mapping (see @link{LocationMapping}) as it applies only to files.
+ *  location mapping (see {@link LocationMapper}) as it applies only to files.
  */
 
 public class LocatorFile implements Locator
 {
-    // Implementation note:
-    // Java7: Path.resolve may provide an answer from the intricies of MS Windows
-    
     static Logger log = LoggerFactory.getLogger(LocatorFile.class) ;
     private final String thisDir ;
     private final String thisDirLogStr ;
@@ -50,7 +47,7 @@ public class LocatorFile implements Locator
      * Relative file names are relative to the working directory of the JVM.
      */
     public LocatorFile() { this(null) ; }
-    
+
     /** Create a LocatorFile that uses the argument as it's working directory.
      * <p>
      * The working directory should be a UNIX style file name,
@@ -58,7 +55,7 @@ public class LocatorFile implements Locator
      * <p>
      * For MS Window, if asked to {@link #open} a file name with a drive letter,
      * the code assumes it is not relative to the working directory
-     * of this {@code LocatorFile}.  
+     * of this {@code LocatorFile}.
      */
     public LocatorFile(String dir)
     {
@@ -74,24 +71,24 @@ public class LocatorFile implements Locator
     }
 
     /** Processing the filename for file: or relative filename
-     *  and return a filename suitable for file operations. 
+     *  and return a filename suitable for file operations.
      */
     public String toFileName(String filenameIRI)
     {
-        // Do not use directly : it will ignore the directory. 
+        // Do not use directly : it will ignore the directory.
         //IRILib.filenameToIRI
-        
+
         String scheme = FileUtils.getScheme(filenameIRI) ;
         String fn = filenameIRI ;
         // Windows : C:\\ is not a scheme name!
-        if ( scheme != null ) 
+        if ( scheme != null )
         {
             if ( scheme.length() == 1 )
             {
                 // Not perfect for MS Windows but if thisDir is set then
                 // the main use case is resolving relative (no drive)
                 // filenames against thisDir. Treat the presence of a
-                // drive letter as making this a JVM relative filename. 
+                // drive letter as making this a JVM relative filename.
                 return fn ;
             }
             else if ( scheme.length() > 1 )
@@ -101,14 +98,14 @@ public class LocatorFile implements Locator
                     return null ;
                 fn = IRILib.IRIToFilename(filenameIRI) ;
                 // fall through
-            } 
+            }
         }
         // fn is the file name to use.
         return absolute(fn) ;
     }
 
     /** Make a filename (no URI scheme, no windows drive) absolute if there is
-     * a setting for directory name thisDir  
+     * a setting for directory name thisDir
      */
     private String absolute(String fn)
     {
@@ -116,7 +113,7 @@ public class LocatorFile implements Locator
             fn = thisDir+File.separator+fn ;
         return fn ;
     }
-    
+
     public String getThisDir()
     {
         return thisDir ;
@@ -133,10 +130,10 @@ public class LocatorFile implements Locator
         String fn = toFileName(fileIRI) ;
         if ( fn == null )
             return false ;
-        
+
         return exists$(fn) ;
     }
-    
+
     private boolean exists$(String fn)
     {
         if ( fn.equals("-") )
@@ -144,14 +141,14 @@ public class LocatorFile implements Locator
         return new File(fn).exists() ;
     }
 
-    /** Open anything that looks a bit like a file name */ 
+    /** Open anything that looks a bit like a file name */
     @Override
     public TypedInputStream open(String filenameIRI)
     {
         String fn = toFileName(filenameIRI) ;
         if ( fn == null )
             return null ;
-        
+
         try {
             if ( ! exists$(fn) )
             {
@@ -163,13 +160,13 @@ public class LocatorFile implements Locator
             log.warn("Security problem testing for file", e);
             return null;
         }
-        
+
         try {
             InputStream in = IO.openFileEx(fn) ;
 
             if ( StreamManager.logAllLookups && log.isTraceEnabled() )
                 log.trace("Found: "+filenameIRI+thisDirLogStr) ;
-            
+
             ContentType ct = RDFLanguages.guessContentType(filenameIRI) ;
             return new TypedInputStream(in, ct, filenameIRI) ;
         } catch (IOException ioEx)
@@ -180,7 +177,7 @@ public class LocatorFile implements Locator
             return null ;
         }
     }
-    
+
     @Override
     public String getName()
     {

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/IRILib.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/IRILib.java
@@ -181,7 +181,7 @@ public class IRILib
         // so need strip the leading "/"
         fn = fixupWindows(fn);
 
-        return decode(fn) ;
+        return decodeHex(fn) ;
     }
 
     /** Convert a plain file name (no file:) to a file: URL */

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/Upload.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/Upload.java
@@ -134,7 +134,7 @@ public class Upload {
                     String name = fileStream.getName();
                     if ( name == null || name.equals("") )
                         ServletOps.errorBadRequest("No name for content - can't determine RDF syntax");
-                    lang = RDFLanguages.filenameToLang(name);
+                    lang = RDFLanguages.pathnameToLang(name);
                     if (name.endsWith(".gz"))
                         input = new GZIPInputStream(input);
                 }
@@ -240,7 +240,7 @@ public class Upload {
 
                     lang = RDFLanguages.contentTypeToLang(ct.getContentTypeStr());
                     if ( lang == null ) {
-                        lang = RDFLanguages.filenameToLang(name);
+                        lang = RDFLanguages.pathnameToLang(name);
 
                         // JENA-600 filenameToLang() strips off certain
                         // extensions such as .gz and


### PR DESCRIPTION
This fixes the problems with "file:".

Before passing to the OS, this has always been stripped and converted to an OS file name. There are other uses of filename handling code from Apache Commons IO, one of which `RDFLangauages.filenameToLang`, which takes a resource name (URI of filename) and uses the extension to guess the RDF syntax. It is used for file names and also URIs when there isn't content negotiation.

The fix, in IO.java, around line 100  (the rest of the PR is naming and cosmetic changes), is to extract the code from Apache Commons IO , remove the check for ":" as a trailing component of the filename ([NTFS ADS](https://en.wikipedia.org/wiki/NTFS#Alternate_data_streams_(ADS))) - windows uses ":" in two places, drive and ADS. This clashes with the use of URI scheme name, which also uses ":".

The fix is the safest approach - copying and restoring the old behaviour in a low risk fashion. Further factoring can be done after the 3.17.0 release to be tidier.