### PR TITLE
JENA-2009: Implement Visitor Pattern for SHACL Constraints

### DIFF
--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClassConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClassConstraint.java
@@ -30,6 +30,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.riot.other.G;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
 
@@ -75,6 +76,11 @@ public class ClassConstraint extends ConstraintDataTerm {
     @Override
     public Node getComponent() {
         return SHACL.ClassConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClassConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClassConstraint.java
@@ -49,6 +49,11 @@ public class ClassConstraint extends ConstraintDataTerm {
     }
 
     @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
+    }
+
+    @Override
     public void printCompact(IndentedWriter out, NodeFormatter nodeFmt) {
         compact(out, nodeFmt, "class", expectedClass);
         // Only allowed in a property shape without OR or NOT.
@@ -76,11 +81,6 @@ public class ClassConstraint extends ConstraintDataTerm {
     @Override
     public Node getComponent() {
         return SHACL.ClassConstraintComponent;
-    }
-
-    @Override
-    public void visit(ConstraintVisitor visitor){
-        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClosedConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClosedConstraint.java
@@ -95,11 +95,6 @@ public class ClosedConstraint implements Constraint {
         validate(vCxt, data, shape, focusNode);
     }
 
-    @Override
-    public void visit(ConstraintVisitor visitor){
-        visitor.visit(this);
-    }
-
     private void validate(ValidationContext vCxt, Graph data, Shape shape, Node focusNode) {
         if ( ! active )
             return;
@@ -148,6 +143,11 @@ public class ClosedConstraint implements Constraint {
     @Override
     public Node getComponent() {
         return SHACL.ClosedConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClosedConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ClosedConstraint.java
@@ -32,6 +32,7 @@ import org.apache.jena.riot.other.G;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.Constraint;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.ShaclParseException;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.vocabulary.SHACL;
@@ -92,6 +93,11 @@ public class ClosedConstraint implements Constraint {
     @Override
     public void validatePropertyShape(ValidationContext vCxt, Graph data, Shape shape, Node focusNode, Path path, Set<Node> valueNodes) {
         validate(vCxt, data, shape, focusNode);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     private void validate(ValidationContext vCxt, Graph data, Shape shape, Node focusNode) {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintComponentSPARQL.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ConstraintComponentSPARQL.java
@@ -32,6 +32,7 @@ import org.apache.jena.shacl.engine.Parameter;
 import org.apache.jena.shacl.engine.SparqlConstraints;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.Constraint;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.ShaclParseException;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.vocabulary.SHACL;
@@ -77,6 +78,11 @@ public class ConstraintComponentSPARQL implements Constraint {
     @Override
     public Node getComponent() {
         return SHACL.SPARQLConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/DatatypeConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/DatatypeConstraint.java
@@ -30,6 +30,7 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.lib.ShLib;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.vocabulary.XSD;
@@ -96,6 +97,11 @@ public class DatatypeConstraint extends ConstraintTerm {
     @Override
     public Node getComponent() {
         return SHACL.DatatypeConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/DisjointConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/DisjointConstraint.java
@@ -28,6 +28,7 @@ import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.path.Path;
@@ -48,6 +49,11 @@ public class DisjointConstraint extends ConstraintPairwise {
                 vCxt.reportEntry(msg, shape, focusNode, path, vn, this);
             }
         }
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/EqualsConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/EqualsConstraint.java
@@ -28,6 +28,7 @@ import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.path.Path;
@@ -54,6 +55,11 @@ public class EqualsConstraint extends ConstraintPairwise {
                 vCxt.reportEntry(msg, shape, focusNode, path, v, this);
             }
         }
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/HasValueConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/HasValueConstraint.java
@@ -29,6 +29,7 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
@@ -68,6 +69,11 @@ public class HasValueConstraint extends ConstraintEntity {
             return null;
         String errMsg = toString()+" : No value "+displayStr(value)+" in "+pathNodes;
         return new ReportItem(errMsg, null);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/InConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/InConstraint.java
@@ -30,6 +30,7 @@ import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
 
@@ -49,6 +50,11 @@ public class InConstraint extends ConstraintTerm {
     @Override
     public Node getComponent() {
         return SHACL.InConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/InConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/InConstraint.java
@@ -53,16 +53,16 @@ public class InConstraint extends ConstraintTerm {
     }
 
     @Override
-    public void visit(ConstraintVisitor visitor){
-        visitor.visit(this);
-    }
-
-    @Override
     public ReportItem validate(ValidationContext vCxt, Node n) {
         if ( values.contains(n) )
             return null;
         String errMsg = toString()+" : RDF term "+displayStr(n)+" not in expected values";
         return new ReportItem(errMsg, n);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JLogConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JLogConstraint.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.apache.jena.graph.Node;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.lib.ShLib;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.sys.ShaclSystem;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHJ;
@@ -43,6 +44,11 @@ public class JLogConstraint extends ConstraintTerm {
     @Override
     public Node getComponent() {
         return SHJ.LogConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JLogConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JLogConstraint.java
@@ -47,15 +47,15 @@ public class JLogConstraint extends ConstraintTerm {
     }
 
     @Override
-    public void visit(ConstraintVisitor visitor){
-        visitor.visit(this);
-    }
-
-    @Override
     public ReportItem validate(ValidationContext vCxt, Node n) {
         String msg = String.format("%s[%s]", message, ShLib.displayStr(n));
         ShaclSystem.systemShaclLogger.warn(msg);
         return null;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JViolationConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JViolationConstraint.java
@@ -23,6 +23,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.compact.writer.CompactOut;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHJ;
 
@@ -42,6 +43,11 @@ public class JViolationConstraint extends ConstraintTerm {
     @Override
     public Node getComponent() {
         return SHJ.ViolationConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JViolationConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JViolationConstraint.java
@@ -46,15 +46,15 @@ public class JViolationConstraint extends ConstraintTerm {
     }
 
     @Override
-    public void visit(ConstraintVisitor visitor){
-        visitor.visit(this);
-    }
-
-    @Override
     public ReportItem validate(ValidationContext vCxt, Node n) {
         if ( ! generateViolation )
             return null;
         return new ReportItem("Violation");
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/LessThanConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/LessThanConstraint.java
@@ -28,6 +28,7 @@ import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.Expr;
@@ -52,6 +53,11 @@ public class LessThanConstraint extends ConstraintPairwise {
                 }
             }
         }
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/LessThanOrEqualsConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/LessThanOrEqualsConstraint.java
@@ -28,6 +28,7 @@ import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.Expr;
@@ -52,6 +53,11 @@ public class LessThanOrEqualsConstraint extends ConstraintPairwise {
                 }
             }
         }
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/MaxCount.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/MaxCount.java
@@ -22,6 +22,7 @@ import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.atlas.lib.InternalErrorException;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.vocabulary.SHACL;
 
 /** sh:maxCount */
@@ -39,6 +40,11 @@ public class MaxCount extends CardinalityConstraint {
     @Override
     public Node getComponent() {
         return SHACL.MaxCountConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     // Special syntax. Handled in ShapeOutputVisitor

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/MinCount.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/MinCount.java
@@ -22,6 +22,7 @@ import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.atlas.lib.InternalErrorException;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.vocabulary.SHACL;
 
 /** sh:minCount */
@@ -38,6 +39,11 @@ public class MinCount extends CardinalityConstraint {
     @Override
     public Node getComponent() {
         return SHACL.MinCountConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     // Special syntax. Handled in ShapeOutputVisitor property shape. Ignore here.

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/NodeKindConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/NodeKindConstraint.java
@@ -26,6 +26,7 @@ import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
 
@@ -67,6 +68,11 @@ public class NodeKindConstraint extends ConstraintTerm {
 
     public boolean isCanBeLiteral() {
         return canBeLiteral;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/PatternConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/PatternConstraint.java
@@ -28,6 +28,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.lib.ShLib;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.RegexJava;
@@ -78,6 +79,11 @@ public class PatternConstraint extends ConstraintTerm {
     @Override
     public Node getComponent() {
         return SHACL.PatternConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/QualifiedValueShape.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/QualifiedValueShape.java
@@ -31,6 +31,7 @@ import org.apache.jena.shacl.compact.writer.CompactOut;
 import org.apache.jena.shacl.compact.writer.CompactWriter;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.Constraint;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.validation.ValidationProc;
 import org.apache.jena.shacl.vocabulary.SHACL;
@@ -134,6 +135,11 @@ public class QualifiedValueShape implements Constraint {
             vCxt.reportEntry(msg, shape, focusNode, path, null,
                 new ReportConstraint(SHACL.QualifiedMaxCountConstraintComponent));
         }
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     private boolean conformsSiblings(ValidationContext vCxt, Node v, Collection<Node> sibs) {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/QualifiedValueShape.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/QualifiedValueShape.java
@@ -137,11 +137,6 @@ public class QualifiedValueShape implements Constraint {
         }
     }
 
-    @Override
-    public void visit(ConstraintVisitor visitor){
-        visitor.visit(this);
-    }
-
     private boolean conformsSiblings(ValidationContext vCxt, Node v, Collection<Node> sibs) {
         for ( Node sib : sibs ) {
             Shape sibShape = vCxt.getShapes().getShape(sib);
@@ -181,6 +176,11 @@ public class QualifiedValueShape implements Constraint {
     @Override
     public Node getComponent() {
         return SHACL.qualifiedValueShape;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ReportConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ReportConstraint.java
@@ -57,7 +57,7 @@ public class ReportConstraint implements Constraint {
 
     @Override
     public void visit(ConstraintVisitor visitor){
-        visitor.visit(this);
+        //empty
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ReportConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ReportConstraint.java
@@ -28,6 +28,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.Constraint;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.sparql.path.Path;
 
@@ -52,6 +53,11 @@ public class ReportConstraint implements Constraint {
     @Override
     public void validatePropertyShape(ValidationContext vCxt, Graph data, Shape shape, Node focusNode, Path path, Set<Node> valueNodes) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShAnd.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShAnd.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.validation.ValidationProc;
@@ -54,6 +55,11 @@ public class ShAnd extends ConstraintOpN {
             }
         }
         return null;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShNode.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShNode.java
@@ -26,6 +26,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.compact.writer.CompactWriter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.validation.ValidationProc;
@@ -53,6 +54,11 @@ public class ShNode extends ConstraintOp1 {
             return null;
         String msg = toString()+" at focusNode "+displayStr(node);
         return new ReportItem(msg, node);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShNot.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShNot.java
@@ -28,6 +28,7 @@ import org.apache.jena.shacl.compact.writer.CompactWriter;
 import org.apache.jena.shacl.compact.writer.ShaclNotCompactException;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.Constraint;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.validation.ValidationProc;
@@ -54,6 +55,11 @@ public class ShNot extends ConstraintOp1 {
             return null;
         String msg = "Not["+other+"] at focusNode "+displayStr(node);
         return new ReportItem(msg, node);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShOr.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShOr.java
@@ -30,6 +30,7 @@ import org.apache.jena.shacl.compact.writer.CompactWriter;
 import org.apache.jena.shacl.compact.writer.ShaclNotCompactException;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.Constraint;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.validation.ValidationProc;
@@ -58,6 +59,11 @@ public class ShOr extends ConstraintOpN {
             }
         String msg = toString()+" at focusNode "+displayStr(node);
         return new ReportItem(msg, node);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShXone.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ShXone.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.validation.ValidationProc;
@@ -60,6 +61,11 @@ public class ShXone extends ConstraintOpN {
             return null;
         String msg = toString()+" has "+c+" conforming shapes at focusNode "+displayStr(node);
         return new ReportItem(msg, node);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/SparqlConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/SparqlConstraint.java
@@ -29,6 +29,7 @@ import org.apache.jena.query.*;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.Constraint;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.core.Var;
@@ -72,6 +73,11 @@ public class SparqlConstraint implements Constraint {
     @Override
     public Node getComponent() {
         return SHACL.SPARQLConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrLanguageIn.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrLanguageIn.java
@@ -29,6 +29,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.impl.Util;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
@@ -74,6 +75,11 @@ public class StrLanguageIn extends ConstraintTerm {
     @Override
     public Node getComponent() {
         return SHACL.LanguageInConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
 //    @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMaxLengthConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMaxLengthConstraint.java
@@ -27,6 +27,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.lib.ShLib;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
@@ -60,6 +61,11 @@ public class StrMaxLengthConstraint extends ConstraintTerm {
     @Override
     public Node getComponent() {
         return SHACL.MaxLengthConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMinLengthConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/StrMinLengthConstraint.java
@@ -27,6 +27,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.lib.ShLib;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
@@ -60,6 +61,11 @@ public class StrMinLengthConstraint extends ConstraintTerm {
     @Override
     public Node getComponent() {
         return SHACL.MinLengthConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/UniqueLangConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/UniqueLangConstraint.java
@@ -32,6 +32,7 @@ import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shacl.ShaclException;
 import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.Constraint;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.path.Path;
@@ -82,6 +83,11 @@ public class UniqueLangConstraint implements Constraint {
     @Override
     public Node getComponent() {
         return SHACL.UniqueLangConstraintComponent;
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueMaxExclusiveConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueMaxExclusiveConstraint.java
@@ -20,6 +20,7 @@ package org.apache.jena.shacl.engine.constraint;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.shacl.lib.ShLib;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.Expr;
 
@@ -28,6 +29,11 @@ public class ValueMaxExclusiveConstraint extends ValueRangeConstraint {
 
     public ValueMaxExclusiveConstraint(Node value) {
         super(value, SHACL.MaxExclusiveConstraintComponent);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueMaxInclusiveConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueMaxInclusiveConstraint.java
@@ -20,6 +20,7 @@ package org.apache.jena.shacl.engine.constraint;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.shacl.lib.ShLib;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.Expr;
 
@@ -28,6 +29,11 @@ public class ValueMaxInclusiveConstraint extends ValueRangeConstraint {
 
     public ValueMaxInclusiveConstraint(Node value) {
         super(value, SHACL.MaxInclusiveConstraintComponent);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueMinExclusiveConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueMinExclusiveConstraint.java
@@ -20,6 +20,7 @@ package org.apache.jena.shacl.engine.constraint;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.shacl.lib.ShLib;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.Expr;
 
@@ -28,6 +29,11 @@ public class ValueMinExclusiveConstraint extends ValueRangeConstraint {
 
     public ValueMinExclusiveConstraint(Node value) {
         super(value, SHACL.MinExclusiveConstraintComponent);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueMinInclusiveConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ValueMinInclusiveConstraint.java
@@ -21,6 +21,7 @@ package org.apache.jena.shacl.engine.constraint;
 import static org.apache.jena.shacl.lib.ShLib.displayStr;
 
 import org.apache.jena.graph.Node;
+import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.vocabulary.SHACL;
 import org.apache.jena.sparql.expr.Expr;
 
@@ -29,6 +30,11 @@ public class ValueMinInclusiveConstraint extends ValueRangeConstraint {
 
     public ValueMinInclusiveConstraint(Node value) {
         super(value, SHACL.MinInclusiveConstraintComponent);
+    }
+
+    @Override
+    public void visit(ConstraintVisitor visitor){
+        visitor.visit(this);
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Constraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Constraint.java
@@ -46,4 +46,6 @@ public interface Constraint {
 
     public Node getComponent();
 
+    public void visit(ConstraintVisitor visitor);
+
 }

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitor.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitor.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.shacl.parser;
+
+import org.apache.jena.shacl.engine.constraint.*;
+
+public interface ConstraintVisitor {
+    default void visit(ReportConstraint constraint){}
+    default void visit(SparqlConstraint constraint){}
+    default void visit(ConstraintComponentSPARQL constraint){}
+    default void visit(UniqueLangConstraint constraint){}
+    default void visit(HasValueConstraint constraint){}
+    default void visit(MinCount constraint){}
+    default void visit(MaxCount constraint){}
+    default void visit(ShXone constraint){}
+    default void visit(ShAnd constraint){}
+    default void visit(ShOr constraint){}
+    default void visit(ShNot constraint){}
+    default void visit(ShNode constraint){}
+    default void visit(QualifiedValueShape constraint){}
+    default void visit(LessThanOrEqualsConstraint constraint){}
+    default void visit(DisjointConstraint constraint){}
+    default void visit(EqualsConstraint constraint){}
+    default void visit(LessThanConstraint constraint){}
+    default void visit(ClosedConstraint constraint){}
+    default void visit(ClassConstraint constraint){}
+    default void visit(StrMaxLengthConstraint constraint){}
+    default void visit(StrLanguageIn constraint){}
+    default void visit(StrMinLengthConstraint constraint){}
+    default void visit(JViolationConstraint constraint){}
+    default void visit(DatatypeConstraint constraint){}
+    default void visit(JLogConstraint constraint){}
+    default void visit(PatternConstraint constraint){}
+    default void visit(ValueMinExclusiveConstraint constraint){}
+    default void visit(ValueMinInclusiveConstraint constraint){}
+    default void visit(ValueMaxInclusiveConstraint constraint){}
+    default void visit(ValueMaxExclusiveConstraint constraint){}
+    default void visit(InConstraint constraint){}
+    default void visit(NodeKindConstraint constraint){}
+}

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitor.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitor.java
@@ -21,7 +21,6 @@ package org.apache.jena.shacl.parser;
 import org.apache.jena.shacl.engine.constraint.*;
 
 public interface ConstraintVisitor {
-    void visit(ReportConstraint constraint);
     void visit(SparqlConstraint constraint);
     void visit(ConstraintComponentSPARQL constraint);
     void visit(UniqueLangConstraint constraint);

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitor.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitor.java
@@ -21,36 +21,36 @@ package org.apache.jena.shacl.parser;
 import org.apache.jena.shacl.engine.constraint.*;
 
 public interface ConstraintVisitor {
-    default void visit(ReportConstraint constraint){}
-    default void visit(SparqlConstraint constraint){}
-    default void visit(ConstraintComponentSPARQL constraint){}
-    default void visit(UniqueLangConstraint constraint){}
-    default void visit(HasValueConstraint constraint){}
-    default void visit(MinCount constraint){}
-    default void visit(MaxCount constraint){}
-    default void visit(ShXone constraint){}
-    default void visit(ShAnd constraint){}
-    default void visit(ShOr constraint){}
-    default void visit(ShNot constraint){}
-    default void visit(ShNode constraint){}
-    default void visit(QualifiedValueShape constraint){}
-    default void visit(LessThanOrEqualsConstraint constraint){}
-    default void visit(DisjointConstraint constraint){}
-    default void visit(EqualsConstraint constraint){}
-    default void visit(LessThanConstraint constraint){}
-    default void visit(ClosedConstraint constraint){}
-    default void visit(ClassConstraint constraint){}
-    default void visit(StrMaxLengthConstraint constraint){}
-    default void visit(StrLanguageIn constraint){}
-    default void visit(StrMinLengthConstraint constraint){}
-    default void visit(JViolationConstraint constraint){}
-    default void visit(DatatypeConstraint constraint){}
-    default void visit(JLogConstraint constraint){}
-    default void visit(PatternConstraint constraint){}
-    default void visit(ValueMinExclusiveConstraint constraint){}
-    default void visit(ValueMinInclusiveConstraint constraint){}
-    default void visit(ValueMaxInclusiveConstraint constraint){}
-    default void visit(ValueMaxExclusiveConstraint constraint){}
-    default void visit(InConstraint constraint){}
-    default void visit(NodeKindConstraint constraint){}
+    void visit(ReportConstraint constraint);
+    void visit(SparqlConstraint constraint);
+    void visit(ConstraintComponentSPARQL constraint);
+    void visit(UniqueLangConstraint constraint);
+    void visit(HasValueConstraint constraint);
+    void visit(MinCount constraint);
+    void visit(MaxCount constraint);
+    void visit(ShXone constraint);
+    void visit(ShAnd constraint);
+    void visit(ShOr constraint);
+    void visit(ShNot constraint);
+    void visit(ShNode constraint);
+    void visit(QualifiedValueShape constraint);
+    void visit(LessThanOrEqualsConstraint constraint);
+    void visit(DisjointConstraint constraint);
+    void visit(EqualsConstraint constraint);
+    void visit(LessThanConstraint constraint);
+    void visit(ClosedConstraint constraint);
+    void visit(ClassConstraint constraint);
+    void visit(StrMaxLengthConstraint constraint);
+    void visit(StrLanguageIn constraint);
+    void visit(StrMinLengthConstraint constraint);
+    void visit(JViolationConstraint constraint);
+    void visit(DatatypeConstraint constraint);
+    void visit(JLogConstraint constraint);
+    void visit(PatternConstraint constraint);
+    void visit(ValueMinExclusiveConstraint constraint);
+    void visit(ValueMinInclusiveConstraint constraint);
+    void visit(ValueMaxInclusiveConstraint constraint);
+    void visit(ValueMaxExclusiveConstraint constraint);
+    void visit(InConstraint constraint);
+    void visit(NodeKindConstraint constraint);
 }

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitor.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitor.java
@@ -21,35 +21,38 @@ package org.apache.jena.shacl.parser;
 import org.apache.jena.shacl.engine.constraint.*;
 
 public interface ConstraintVisitor {
-    void visit(SparqlConstraint constraint);
-    void visit(ConstraintComponentSPARQL constraint);
-    void visit(UniqueLangConstraint constraint);
-    void visit(HasValueConstraint constraint);
+    // SHACL Core Constraint Components
+    void visit(ClassConstraint constraint);
+    void visit(DatatypeConstraint constraint);
+    void visit(NodeKindConstraint constraint);
     void visit(MinCount constraint);
     void visit(MaxCount constraint);
-    void visit(ShXone constraint);
-    void visit(ShAnd constraint);
-    void visit(ShOr constraint);
-    void visit(ShNot constraint);
-    void visit(ShNode constraint);
-    void visit(QualifiedValueShape constraint);
-    void visit(LessThanOrEqualsConstraint constraint);
-    void visit(DisjointConstraint constraint);
-    void visit(EqualsConstraint constraint);
-    void visit(LessThanConstraint constraint);
-    void visit(ClosedConstraint constraint);
-    void visit(ClassConstraint constraint);
-    void visit(StrMaxLengthConstraint constraint);
-    void visit(StrLanguageIn constraint);
-    void visit(StrMinLengthConstraint constraint);
-    void visit(JViolationConstraint constraint);
-    void visit(DatatypeConstraint constraint);
-    void visit(JLogConstraint constraint);
-    void visit(PatternConstraint constraint);
     void visit(ValueMinExclusiveConstraint constraint);
     void visit(ValueMinInclusiveConstraint constraint);
     void visit(ValueMaxInclusiveConstraint constraint);
     void visit(ValueMaxExclusiveConstraint constraint);
+    void visit(StrMinLengthConstraint constraint);
+    void visit(StrMaxLengthConstraint constraint);
+    void visit(PatternConstraint constraint);
+    void visit(StrLanguageIn constraint);
+    void visit(UniqueLangConstraint constraint);
+    void visit(EqualsConstraint constraint);
+    void visit(DisjointConstraint constraint);
+    void visit(LessThanConstraint constraint);
+    void visit(LessThanOrEqualsConstraint constraint);
+    void visit(ShNot constraint);
+    void visit(ShAnd constraint);
+    void visit(ShOr constraint);
+    void visit(ShXone constraint);
+    void visit(ShNode constraint);
+    void visit(QualifiedValueShape constraint);
+    void visit(ClosedConstraint constraint);
+    void visit(HasValueConstraint constraint);
     void visit(InConstraint constraint);
-    void visit(NodeKindConstraint constraint);
+    void visit(ConstraintComponentSPARQL constraint);
+    void visit(SparqlConstraint constraint);
+
+    // Other Constraints
+    void visit(JViolationConstraint constraint);
+    void visit(JLogConstraint constraint);
 }

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitorBase.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitorBase.java
@@ -23,9 +23,6 @@ import org.apache.jena.shacl.engine.constraint.*;
 public abstract class ConstraintVisitorBase implements ConstraintVisitor {
 
     @Override
-    public void visit(ReportConstraint constraint) {}
-
-    @Override
     public void visit(SparqlConstraint constraint) {}
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitorBase.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitorBase.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.shacl.parser;
+
+import org.apache.jena.shacl.engine.constraint.*;
+
+public abstract class ConstraintVisitorBase implements ConstraintVisitor {
+
+    @Override
+    public void visit(ReportConstraint constraint) {}
+
+    @Override
+    public void visit(SparqlConstraint constraint) {}
+
+    @Override
+    public void visit(ConstraintComponentSPARQL constraint) {}
+
+    @Override
+    public void visit(UniqueLangConstraint constraint) {}
+
+    @Override
+    public void visit(HasValueConstraint constraint) {}
+
+    @Override
+    public void visit(MinCount constraint) {}
+
+    @Override
+    public void visit(MaxCount constraint) {}
+
+    @Override
+    public void visit(ShXone constraint) {}
+
+    @Override
+    public void visit(ShAnd constraint) {}
+
+    @Override
+    public void visit(ShOr constraint) {}
+
+    @Override
+    public void visit(ShNot constraint) {}
+
+    @Override
+    public void visit(ShNode constraint) {}
+
+    @Override
+    public void visit(QualifiedValueShape constraint) {}
+
+    @Override
+    public void visit(LessThanOrEqualsConstraint constraint) {}
+
+    @Override
+    public void visit(DisjointConstraint constraint) {}
+
+    @Override
+    public void visit(EqualsConstraint constraint) {}
+
+    @Override
+    public void visit(LessThanConstraint constraint) {}
+
+    @Override
+    public void visit(ClosedConstraint constraint) {}
+
+    @Override
+    public void visit(ClassConstraint constraint) {}
+
+    @Override
+    public void visit(StrMaxLengthConstraint constraint) {}
+
+    @Override
+    public void visit(StrLanguageIn constraint) {}
+
+    @Override
+    public void visit(StrMinLengthConstraint constraint) {}
+
+    @Override
+    public void visit(JViolationConstraint constraint) {}
+
+    @Override
+    public void visit(DatatypeConstraint constraint) {}
+
+    @Override
+    public void visit(JLogConstraint constraint) {}
+
+    @Override
+    public void visit(PatternConstraint constraint) {}
+
+    @Override
+    public void visit(ValueMinExclusiveConstraint constraint) {}
+
+    @Override
+    public void visit(ValueMinInclusiveConstraint constraint) {}
+
+    @Override
+    public void visit(ValueMaxInclusiveConstraint constraint) {}
+
+    @Override
+    public void visit(ValueMaxExclusiveConstraint constraint) {}
+
+    @Override
+    public void visit(InConstraint constraint) {}
+
+    @Override
+    public void visit(NodeKindConstraint constraint) {}
+}

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitorBase.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ConstraintVisitorBase.java
@@ -21,81 +21,20 @@ package org.apache.jena.shacl.parser;
 import org.apache.jena.shacl.engine.constraint.*;
 
 public abstract class ConstraintVisitorBase implements ConstraintVisitor {
+    @Override
+    public void visit(ClassConstraint constraint) {}
 
     @Override
-    public void visit(SparqlConstraint constraint) {}
+    public void visit(DatatypeConstraint constraint) {}
 
     @Override
-    public void visit(ConstraintComponentSPARQL constraint) {}
-
-    @Override
-    public void visit(UniqueLangConstraint constraint) {}
-
-    @Override
-    public void visit(HasValueConstraint constraint) {}
+    public void visit(NodeKindConstraint constraint) {}
 
     @Override
     public void visit(MinCount constraint) {}
 
     @Override
     public void visit(MaxCount constraint) {}
-
-    @Override
-    public void visit(ShXone constraint) {}
-
-    @Override
-    public void visit(ShAnd constraint) {}
-
-    @Override
-    public void visit(ShOr constraint) {}
-
-    @Override
-    public void visit(ShNot constraint) {}
-
-    @Override
-    public void visit(ShNode constraint) {}
-
-    @Override
-    public void visit(QualifiedValueShape constraint) {}
-
-    @Override
-    public void visit(LessThanOrEqualsConstraint constraint) {}
-
-    @Override
-    public void visit(DisjointConstraint constraint) {}
-
-    @Override
-    public void visit(EqualsConstraint constraint) {}
-
-    @Override
-    public void visit(LessThanConstraint constraint) {}
-
-    @Override
-    public void visit(ClosedConstraint constraint) {}
-
-    @Override
-    public void visit(ClassConstraint constraint) {}
-
-    @Override
-    public void visit(StrMaxLengthConstraint constraint) {}
-
-    @Override
-    public void visit(StrLanguageIn constraint) {}
-
-    @Override
-    public void visit(StrMinLengthConstraint constraint) {}
-
-    @Override
-    public void visit(JViolationConstraint constraint) {}
-
-    @Override
-    public void visit(DatatypeConstraint constraint) {}
-
-    @Override
-    public void visit(JLogConstraint constraint) {}
-
-    @Override
-    public void visit(PatternConstraint constraint) {}
 
     @Override
     public void visit(ValueMinExclusiveConstraint constraint) {}
@@ -110,8 +49,68 @@ public abstract class ConstraintVisitorBase implements ConstraintVisitor {
     public void visit(ValueMaxExclusiveConstraint constraint) {}
 
     @Override
+    public void visit(StrMinLengthConstraint constraint) {}
+
+    @Override
+    public void visit(StrMaxLengthConstraint constraint) {}
+
+    @Override
+    public void visit(PatternConstraint constraint) {}
+
+    @Override
+    public void visit(StrLanguageIn constraint) {}
+
+    @Override
+    public void visit(UniqueLangConstraint constraint) {}
+
+    @Override
+    public void visit(EqualsConstraint constraint) {}
+
+    @Override
+    public void visit(DisjointConstraint constraint) {}
+
+    @Override
+    public void visit(LessThanConstraint constraint) {}
+
+    @Override
+    public void visit(LessThanOrEqualsConstraint constraint) {}
+
+    @Override
+    public void visit(ShNot constraint) {}
+
+    @Override
+    public void visit(ShAnd constraint) {}
+
+    @Override
+    public void visit(ShOr constraint) {}
+
+    @Override
+    public void visit(ShXone constraint) {}
+
+    @Override
+    public void visit(ShNode constraint) {}
+
+    @Override
+    public void visit(QualifiedValueShape constraint) {}
+
+    @Override
+    public void visit(ClosedConstraint constraint) {}
+
+    @Override
+    public void visit(HasValueConstraint constraint) {}
+
+    @Override
     public void visit(InConstraint constraint) {}
 
     @Override
-    public void visit(NodeKindConstraint constraint) {}
+    public void visit(ConstraintComponentSPARQL constraint) {}
+
+    @Override
+    public void visit(SparqlConstraint constraint) {}
+
+    @Override
+    public void visit(JViolationConstraint constraint) {}
+
+    @Override
+    public void visit(JLogConstraint constraint) {}
 }


### PR DESCRIPTION
Notes:
* added `visit` method to `Constraint` interface. I experimented with providing a default implementation (calling `visitor.visit(Constraint)`) to avoid having to add an implementation to all implementing classes. This approach does not work, which I did not expect. Learned something about Java method invocation target selection there.
* added `visit` method non-abstract subclasses of `Constraint`. The pattern suggests they should be named `accept`, but jena uses `visit` wherever I checked. I guess it's better to stick with the existing flavor.
* Currently no unit tests as there is no logic apart from `visitor.visit(this)`. Please let me know if you feel differently. Using the PR in my client code, so I'm positive it works.
