### PR TITLE
JENA-2012: Test for UTF-16 high-low surrogates pairs

### DIFF
--- a/jena-arq/Grammar/arq.jj
+++ b/jena-arq/Grammar/arq.jj
@@ -1620,7 +1620,7 @@ String String() : { Token t ; String lex ; }
   | t = <STRING_LITERAL_LONG1> { lex = stripQuotes3(t.image) ; }
   | t = <STRING_LITERAL_LONG2> { lex = stripQuotes3(t.image) ; }
   )
-    {
+    { checkString(lex, t.beginLine, t.beginColumn) ;
       lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
       return lex ;
     }

--- a/jena-arq/Grammar/main.jj
+++ b/jena-arq/Grammar/main.jj
@@ -2271,8 +2271,8 @@ String String() : { Token t ; String lex ; }
   | t = <STRING_LITERAL_LONG1> { lex = stripQuotes3(t.image) ; }
   | t = <STRING_LITERAL_LONG2> { lex = stripQuotes3(t.image) ; }
   )
-    {
-      lex = unescapeStr(lex,  t.beginLine, t.beginColumn) ;
+    { checkString(lex, t.beginLine, t.beginColumn) ;
+      lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
       return lex ;
     }
 }

--- a/jena-arq/Grammar/sparql_11.jj
+++ b/jena-arq/Grammar/sparql_11.jj
@@ -1407,7 +1407,7 @@ String String() : { Token t ; String lex ; }
   | t = <STRING_LITERAL_LONG1> { lex = stripQuotes3(t.image) ; }
   | t = <STRING_LITERAL_LONG2> { lex = stripQuotes3(t.image) ; }
   )
-    {
+    { checkString(lex, t.beginLine, t.beginColumn) ;
       lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
       return lex ;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
@@ -6070,7 +6070,8 @@ lex = stripQuotes3(t.image) ;
       jj_consume_token(-1);
       throw new ParseException();
     }
-lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
+checkString(lex, t.beginLine, t.beginColumn) ;
+      lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
       {if ("" != null) return lex ;}
     throw new Error("Missing return statement in function");
   }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_11/SPARQLParser11.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_11/SPARQLParser11.java
@@ -5055,7 +5055,8 @@ lex = stripQuotes3(t.image) ;
       jj_consume_token(-1);
       throw new ParseException();
     }
-lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
+checkString(lex, t.beginLine, t.beginColumn) ;
+      lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
       {if ("" != null) return lex ;}
     throw new Error("Missing return statement in function");
   }

--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/runners/AbstractRunnerOfTests.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/runners/AbstractRunnerOfTests.java
@@ -88,7 +88,7 @@ public abstract class AbstractRunnerOfTests extends ParentRunner<Runner> {
     // Print all manifests, top level and included.
     private static boolean PrintManifests = false;
     private static IndentedWriter out = IndentedWriter.stdout;
-    
+
     /**
      * Do one level of tests. test are {@link Runnable Runnables} that each succeed or fail with an exception.
      */
@@ -102,7 +102,7 @@ public abstract class AbstractRunnerOfTests extends ParentRunner<Runner> {
         while(sub.hasNext() ) {
             if ( PrintManifests )
                 out.incIndent();
-            
+
             String mf = sub.next();
             Manifest manifestSub = Manifest.parse(mf);
             Runner runner = build(report, manifestSub, maker, prefix);
@@ -110,6 +110,16 @@ public abstract class AbstractRunnerOfTests extends ParentRunner<Runner> {
             if ( PrintManifests )
                 out.decIndent();
         }
+
+        // Check entries do have test targets.
+
+        manifest.entries().forEach(entry->{
+            if ( entry.getAction() == null )
+                throw new RuntimeException("Missing: action ["+entry.getEntry()+"]");
+            if ( entry.getName() == null )
+                throw new RuntimeException("Missing: label ["+entry.getEntry()+"]");
+        });
+
         prepareTests(report, thisLevel, manifest, maker, prefix);
         return thisLevel;
     }

--- a/jena-cmds/src/main/java/riotcmd/utf8.java
+++ b/jena-cmds/src/main/java/riotcmd/utf8.java
@@ -60,7 +60,7 @@ public class utf8
                     } else
                         colNum++ ;
                     if ( !Character.isDefined(ch) )
-                        throw new AtlasException(String.format("No such codepoint: 0x%04X", ch)) ;
+                        System.out.printf("No such codepoint: 0x%04X\n", ch);
                 }
                 System.out.printf("%s: chars = %d , lines = %d\n", fn, charCount, lineNum) ;
             }


### PR DESCRIPTION
Add `checkString` into the parsing process that makes sure a high-surrogate is followed by a low-surrogate.