### PR TITLE
Fix unquoted path

### DIFF
--- a/apache-jena/bin/tdbloader2index
+++ b/apache-jena/bin/tdbloader2index
@@ -360,7 +360,7 @@ generate_index()
     # Sort the input data
     info "Sort $IDX"
     debug "Sorting $DATA into work file $WORK"
-    sort $SORT_ARGS -u $KEYS < "$DATA" > $WORK
+    sort $SORT_ARGS -u $KEYS < "$DATA" > "$WORK"
     info "Sort $IDX Completed"
 
     # Build into an index


### PR DESCRIPTION
The `$WORK` path is not surrounded by quotes. This leads to problems, if the path contains spaces.

Example:

```bash
tdbloader2 --loc="$HOME/a path that contains spaces/my-target-dir" "$HOME/Downloads/example.nt"
```

This leads to the following error:

```
/Users/niclasvaneyk/Code/apache-jena-3.17.0/bin/tdbloader2index: line 363: $WORK: ambiguous redirect
 19:27:26 ERROR Failed during data phase
```

After applying the proposed changes everything works as expected.