### PR TITLE
Update mockito(testing) to 3.6.28

### DIFF
--- a/jena-core/pom.xml
+++ b/jena-core/pom.xml
@@ -78,7 +78,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-elephas/jena-elephas-mapreduce/pom.xml
+++ b/jena-elephas/jena-elephas-mapreduce/pom.xml
@@ -28,6 +28,7 @@
 
   <properties>
     <automatic.module.name>org.apache.jena.elephas.mapreduce</automatic.module.name>
+    <ver.mockito>1.9.5</ver.mockito>
   </properties>
 
   <dependencies>
@@ -37,7 +38,6 @@
       <artifactId>jena-elephas-common</artifactId>
       <version>${project.version}</version>
     </dependency>
-
 		<!-- Hadoop Dependencies -->
 		<!-- Note these will be provided on the Hadoop cluster hence the provided 
 			scope -->
@@ -69,6 +69,11 @@
       <artifactId>mrunit</artifactId>
       <scope>test</scope>
       <classifier>hadoop2</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/jena-elephas/jena-elephas-mapreduce/src/test/java/org/apache/jena/hadoop/rdf/mapreduce/AbstractMapReduceTests.java
+++ b/jena-elephas/jena-elephas-mapreduce/src/test/java/org/apache/jena/hadoop/rdf/mapreduce/AbstractMapReduceTests.java
@@ -21,6 +21,7 @@ package org.apache.jena.hadoop.rdf.mapreduce;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mrunit.mapreduce.MapReduceDriver;
+import org.apache.jena.sys.JenaSystem;
 
 /**
  * Abstract tests for mappers
@@ -43,6 +44,8 @@ import org.apache.hadoop.mrunit.mapreduce.MapReduceDriver;
  */
 public abstract class AbstractMapReduceTests<TKey, TValue, TIntermediateKey, TIntermediateValue, TReducedKey, TReducedValue> {
 
+    static { JenaSystem.init(); }
+    
     /**
      * Gets the mapper instance to test
      * 

--- a/jena-elephas/jena-elephas-mapreduce/src/test/java/org/apache/jena/hadoop/rdf/mapreduce/AbstractMapperTests.java
+++ b/jena-elephas/jena-elephas-mapreduce/src/test/java/org/apache/jena/hadoop/rdf/mapreduce/AbstractMapperTests.java
@@ -20,6 +20,7 @@ package org.apache.jena.hadoop.rdf.mapreduce;
 
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mrunit.mapreduce.MapDriver;
+import org.apache.jena.sys.JenaSystem;
 
 /**
  * Abstract tests for mappers
@@ -37,6 +38,8 @@ import org.apache.hadoop.mrunit.mapreduce.MapDriver;
  */
 public abstract class AbstractMapperTests<TKeyIn, TValueIn, TKeyOut, TValueOut> {
 
+    static { JenaSystem.init(); }
+    
     /**
      * Gets the mapper instance to test
      * 

--- a/jena-elephas/pom.xml
+++ b/jena-elephas/pom.xml
@@ -35,6 +35,7 @@ limitations under the License.
     <mrunit.version>1.1.0</mrunit.version>
     <airline.version>2.8.0</airline.version>
     <automatic.module.name>org.apache.jena.elephas</automatic.module.name>
+    <hadoop.version>2.6.0</hadoop.version>
   </properties>
 
   <!-- Profiles to allow building for different Hadoop versions -->
@@ -46,9 +47,6 @@ limitations under the License.
       <activation>
         <jdk>1.8</jdk>
       </activation>
-      <properties>
-        <hadoop.version>2.6.0</hadoop.version>
-      </properties>
       <modules>
         <module>jena-elephas-io</module>
         <module>jena-elephas-common</module>
@@ -107,7 +105,7 @@ limitations under the License.
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-	<version>11.0.2</version>
+	      <version>11.0.2</version>
       </dependency>
 
       <!-- CLI Related Dependencies -->

--- a/jena-extras/jena-querybuilder/pom.xml
+++ b/jena-extras/jena-querybuilder/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
     	<groupId>org.mockito</groupId>
-    	<artifactId>mockito-all</artifactId> 
+    	<artifactId>mockito-core</artifactId> 
       <scope>test</scope>
     </dependency>
 

--- a/jena-permissions/pom.xml
+++ b/jena-permissions/pom.xml
@@ -228,9 +228,9 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 
     <ver.spatial4j>0.8</ver.spatial4j>
 
-    <ver.mockito>1.10.19</ver.mockito>
+    <ver.mockito>3.6.28</ver.mockito>
     <ver.awaitility>4.0.3</ver.awaitility>
     <ver.micrometer>1.6.2</ver.micrometer>
 
@@ -594,7 +594,7 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>${ver.mockito}</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Not an automatic dependabot upgrade. 

The artifact name has changed from `mockito-all` (stuck on v1) to `mockito-core` (v2, v3).

mockito-all seems to now have problem when used on Java16 (https://ci-builds.apache.org/job/Jena/job/Jena_JDK16/org.apache.jena$jena-core/18/testReport/ 03-Jan-2021 13:38:33)

This change seems to work (java8, java11) so hoping it works for Java16 as well.
