### PR TITLE
JENA-2042 FusekiServer::getPort() returns actual port

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -149,7 +149,7 @@ public class FusekiServer {
      */
     public int getPort() {
         //TODO garantee to return the HTTPS port, if HTTPS is enabled
-        return ((ServerConnector) fuseki.getJettyServer().getConnectors()[0]).getLocalPort();
+        return ((ServerConnector) getJettyServer().getConnectors()[0]).getLocalPort();
     }
 
     /** Get the underlying Jetty server which has also been set up. */

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -148,7 +148,8 @@ public class FusekiServer {
      * If https in use, this is the HTTPS port.
      */
     public int getPort() {
-        return httpsPort > 0 ? httpsPort : httpPort;
+        //TODO garantee to return the HTTPS port, if HTTPS is enabled
+        return ((ServerConnector) fuseki.getJettyServer().getConnectors()[0]).getLocalPort();
     }
 
     /** Get the underlying Jetty server which has also been set up. */


### PR DESCRIPTION
`FusekiServer::getPort()` returns actual port, if it was randomly selected from the free ports. However, this does not guarantee to return the HTTPS port as described in the Java Doc.