### PR TITLE
resolve JENA-2037 remove StandardFilter ref

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/analyzer/ConfigurableAnalyzer.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/analyzer/ConfigurableAnalyzer.java
@@ -37,7 +37,6 @@ import org.apache.lucene.analysis.core.LetterTokenizer;
 import org.apache.lucene.analysis.core.LowerCaseFilter ;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer ;
 import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter;
-import org.apache.lucene.analysis.standard.StandardFilter;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 
 /** 
@@ -67,7 +66,6 @@ public class ConfigurableAnalyzer extends Analyzer {
             
             filterSpecs.put(TextVocab.NS+"ASCIIFoldingFilter", new FilterSpec(ASCIIFoldingFilter.class, paramClasses, paramValues));
             filterSpecs.put(TextVocab.NS+"LowerCaseFilter", new FilterSpec(LowerCaseFilter.class, paramClasses, paramValues));
-            filterSpecs.put(TextVocab.NS+"StandardFilter", new FilterSpec(StandardFilter.class, paramClasses, paramValues));
         }
         
         public static void defineFilter(String id, FilterSpec spec) {


### PR DESCRIPTION
This resolves the issue w/ StandardFilter when upgrading to Lucene 8.8.0. There were no test with dependencies on StandardFilter