### PR TITLE
Jena-2052 run github action maven.yml also for windows server and macos

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,12 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The  [commit](https://github.com/apache/jena/pull/928/commits/669ffcabc11ca85501e69cce383ded733b0d7d95)   contains [the last run](https://github.com/OyvindLGjesdal/jena/actions/runs/579527299) where the action behaves like I would expect, returning success for ubuntu, and failures (different failing tests) for macos and windows. There's a commit, removing branch `jena-2052` from branches, to only run the job on `main`. 