### PR TITLE
JENA-2053: Use SslContextFactory.Server 

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
@@ -248,7 +248,7 @@ public class ARQ
 
     /**
      * Control whether SERVICE processing is allowed.
-     * If the context of the query exexcution contains this,
+     * If the context of the query execution contains this,
      * and it's set to "false", then SERVICE is not allowed.
      */
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/jetty/JettyHttps.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/jetty/JettyHttps.java
@@ -91,9 +91,9 @@ public class JettyHttps {
 
     /** Add HTTPS to a {@link Server}. */
     private static ServerConnector httpsConnector(Server server, int httpsPort, String keystore, String certPassword) {
-        SslContextFactory sslContextFactory = new SslContextFactory.Server();
-        sslContextFactory.setKeyStorePath(keystore);
-        sslContextFactory.setKeyStorePassword(certPassword);
+        SslContextFactory.Server sslContextFactoryServer = new SslContextFactory.Server();
+        sslContextFactoryServer.setKeyStorePath(keystore);
+        sslContextFactoryServer.setKeyStorePassword(certPassword);
 
         SecureRequestCustomizer src = new SecureRequestCustomizer();
         src.setStsMaxAge(2000);
@@ -106,7 +106,7 @@ public class JettyHttps {
 
         // HTTPS Connector
         ServerConnector sslConnector = new ServerConnector(server,
-            new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()),
+            new SslConnectionFactory(sslContextFactoryServer, HttpVersion.HTTP_1_1.asString()),
             new HttpConnectionFactory(https_config));
         sslConnector.setPort(httpsPort);
         return sslConnector;


### PR DESCRIPTION
Other that his one change, which also works on 9.4.36, Fuseki runs with Jetty10.
