### PR TITLE
JENA-2068: Fuseki main jetty and port configuration

### DIFF
--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -1,12 +1,13 @@
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-name: Apache Jena CI
+name: Apache Jena CI - MacOS
+on: workflow_dispatch
 
-on:
-  push:
-    branches: [ main ]
-#  pull_request:
-#    branches: [ main ]
+## on:
+##   push:
+##     branches: [ main ]
+## #  pull_request:
+## #    branches: [ main ]
 
 jobs:
   build:
@@ -16,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/maven_windows.yml
+++ b/.github/workflows/maven_windows.yml
@@ -1,12 +1,20 @@
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-name: Apache Jena CI for Windows-latest
+name: Apache Jena CI (MS Windows)
 on: workflow_dispatch
+
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+
+    # "windows" takes up a lot of diskspace due a longstanding JDK issue
+    # Running on c: seems to work.
     steps:
     - uses: actions/checkout@v2
    


### PR DESCRIPTION
Includes handling port 0 - allocate atomically when the server starts then finding what we got - in place of the "ask" then use the given port which has a timing hole albeit small.