### PR TITLE
JENA-2068: Fuseki main jetty and port configuration

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/atlas/web/WebLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/atlas/web/WebLib.java
@@ -24,7 +24,7 @@ import java.net.ServerSocket;
 public class WebLib
 {
     /** Split a string, removing whitespace around the split string.
-     * e.g. Use in splitting HTTP accept/content-type headers.  
+     * e.g. Use in splitting HTTP accept/content-type headers.
      */
     public static String[] split(String s, String splitStr)
     {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -34,7 +34,6 @@ import org.apache.http.protocol.HttpContext;
 import org.apache.jena.atlas.lib.DateTimeUtils;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.jena.atlas.web.HttpException;
-import org.apache.jena.fuseki.system.FusekiNetLib;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.rdfconnection.RDFConnectionRemote;
 import org.apache.jena.riot.system.stream.LocatorFTP;
@@ -296,11 +295,6 @@ public class Fuseki {
     // Force a call to init.
     static {
         init();
-    }
-
-    /** Retrun a free port */
-    public static int choosePort() {
-        return FusekiNetLib.choosePort();
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiNetLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiNetLib.java
@@ -168,6 +168,8 @@ public class FusekiNetLib {
         pmapDest.withDefaultMappings(pmapSrc);
     }
 
+    /** Use {@link WebLib#choosePort} or start servers with port 0 and then ask which port was allocated. */
+    @Deprecated
     public static int choosePort() {
         try {
             return WebLib.choosePort();

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -19,8 +19,11 @@
 package org.apache.jena.fuseki.main;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.jena.fuseki.Fuseki.serverLog;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Predicate;
 
@@ -30,6 +33,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.lib.FileOps;
 import org.apache.jena.atlas.lib.Pair;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.jena.atlas.web.AuthScheme;
@@ -125,8 +131,8 @@ public class FusekiServer {
     }
 
     private final Server server;
-    private final int httpPort;
-    private final int httpsPort;
+    private int httpPort;
+    private int httpsPort;
     private final String staticContentDir;
     private final ServletContext servletContext;
 
@@ -142,12 +148,83 @@ public class FusekiServer {
 
     /**
      * Return the port being used.
-     * This will be the give port, which defaults to 3330, or
-     * the one actually allocated if the port was 0 ("choose a free port").
-     * If https in use, this is the HTTPS port.
+     * <p>
+     * This will be the server port, which defaults to 3330 for embedded use,
+     * and to 3030 for command line use,
+     * or one actually allocated if the port was 0 ("choose a free port").
+     * <p>
+     * If https is in-use, this is the HTTPS port.
+     * <p>
+     * If http and https are in-use, this is the HTTPS port.
+     * <p>
+     * If there multiple ports of the same schema, return any one port in use.
+     * <p>
+     * See also {@link #getHttpPort} or Use {@link #getHttpsPort}.
      */
     public int getPort() {
         return httpsPort > 0 ? httpsPort : httpPort;
+    }
+
+    /**
+     * Get the HTTP port.
+     * <p>
+     * Returns -1 for no HTTP port.
+     * <p>
+     * If there are multiple HTTP ports configured, returns one of them.
+     */
+    public int getHttpPort() {
+        return httpPort;
+    }
+
+    /**
+     * Get the HTTPS port.
+     * <p>
+     * Returns -1 for no HTTPS port.
+     * <p>
+     * If there are multiple HTTPS ports configured, returns one of them.
+     */
+    public int getHttpsPort() {
+        return httpsPort;
+    }
+
+    /**
+     * Calculate the server URL for "localhost".
+     * <p>
+     * Example: {@code http://localhost:3330/}.
+     * The URL ends in "/".
+     * The host name is "localhost".
+     * If both HTTP and HTTPS are available, then reply with an HTTPS URL.
+     * <p>
+     * This operation is useful when using Fuseki as an embedded test server.
+     */
+    public String serverURL() {
+        return schemeHostPort()+"/";
+    }
+
+    /**
+     * Return the URL for a local dataset.
+     * <p>
+     * Example: {@code http://localhost:3330/dataset}.
+     * The host name is "localhost".
+     * If both HTTP and HTTPS are available, then reply with an HTTPS URL.
+     * <p>
+     * This operation is useful when using Fuseki as an embedded test server.
+     */
+    public String datasetURL(String dsName) {
+        if ( ! dsName.startsWith("/") )
+            dsName = "/"+dsName;
+        return schemeHostPort()+dsName;
+    }
+
+    // schema://host:port, no trailing "/".
+    private String schemeHostPort() {
+        int port = getHttpPort();
+        String scheme = "http";
+        if ( getHttpsPort() > 0 ) { //&& server.getHttpPort() < 0 ) {
+            scheme = "https";
+            port =  getHttpsPort();
+        }
+        return scheme+"://localhost:"+port;
     }
 
     /** Get the underlying Jetty server which has also been set up. */
@@ -182,7 +259,6 @@ public class FusekiServer {
      */
     public FusekiServer start() {
         try { server.start(); }
-
         catch (IOException ex) {
             if ( ex.getCause() instanceof java.security.UnrecoverableKeyException )
                 // Unbundle for clearer message.
@@ -195,16 +271,49 @@ public class FusekiServer {
         catch (Exception ex) {
             throw new FusekiException(ex);
         }
-        if ( httpsPort > 0 )
-            Fuseki.serverLog.info("Start Fuseki (port="+httpPort+"/"+httpsPort+")");
+
+        Connector[] connectors = server.getServer().getConnectors();
+        if ( connectors.length == 0 )
+            serverLog.warn("Start Fuseki: No connectors");
+
+        // Extract the ports from the Connectors.
+        Arrays.stream(connectors).forEach(c->{
+            if ( c instanceof ServerConnector ) {
+                ServerConnector connector = (ServerConnector)c;
+                String protocol = connector.getDefaultConnectionFactory().getProtocol();
+                String scheme = (protocol.startsWith("SSL-") || protocol.equals("SSL")) ? "https" : "http";
+                int port = connector.getLocalPort();
+                connector(scheme, port);
+            }
+        });
+
+        if ( httpsPort > 0 && httpPort > 0 )
+            Fuseki.serverLog.info("Start Fuseki (http="+httpPort+" https="+httpsPort+")");
+        else if ( httpsPort > 0 )
+            Fuseki.serverLog.info("Start Fuseki (https="+httpsPort+")");
+        else if ( httpPort > 0 )
+            Fuseki.serverLog.info("Start Fuseki (http="+httpPort+")");
         else
-            Fuseki.serverLog.info("Start Fuseki (port="+getPort()+")");
+            Fuseki.serverLog.info("Start Fuseki");
         return this;
+    }
+
+    private void connector(String scheme, int port) {
+        switch (scheme) {
+            case "http":
+                if ( httpPort <= 0 )
+                    httpPort = port;
+                break;
+            case "https":
+                if ( httpsPort <= 0 )
+                    httpsPort = port;
+                break;
+        }
     }
 
     /** Stop the server. */
     public void stop() {
-        Fuseki.serverLog.info("Stop Fuseki (port="+getPort()+")");
+        Fuseki.serverLog.info("Stop Fuseki");
         try { server.stop(); }
         catch (Exception e) { throw new FusekiException(e); }
     }
@@ -233,12 +342,16 @@ public class FusekiServer {
 
     /** FusekiServer.Builder */
     public static class Builder {
+        private static final int DefaultServerPort  = 3330;
+        private static final int PortUnset          = -2;
+        private static final int PortInactive       = -3;
+
         private final DataAccessPointRegistry  dataAccessPoints =
             new DataAccessPointRegistry( MetricsProviderRegistry.get().getMeterRegistry() );
         private final OperationRegistry  operationRegistry;
         // Default values.
-        private int                      serverPort         = 3330;
-        private int                      serverHttpsPort    = -1;
+        private int                      serverHttpPort     = PortUnset;
+        private int                      serverHttpsPort    = PortUnset;
         private boolean                  networkLoopback    = false;
         private int                      minThreads         = -1;
         private int                      maxThreads         = -1;
@@ -247,6 +360,8 @@ public class FusekiServer {
         private boolean                  withPing           = false;
         private boolean                  withMetrics        = false;
         private boolean                  withStats          = false;
+
+        private String                   jettyServerConfig  = null;
 
         private Map<String, String>      corsInitParams     = null;
 
@@ -299,14 +414,18 @@ public class FusekiServer {
         }
 
         /**
-         * Set the port to run on.
+         * Set the HTTP port to run on.
          * <p>
          * If set to 0, a random free port will be used.
          */
         public Builder port(int port) {
+            if ( port == -1 ) {
+                this.serverHttpPort = PortInactive;
+                return this;
+            }
             if ( port < 0 )
-                throw new IllegalArgumentException("Illegal port="+port+" : Port must be greater than or equal to zero.");
-            this.serverPort = port;
+                throw new IllegalArgumentException("Illegal port="+port+" : Port must be greater than or equal to zero, or -1 to unset");
+            this.serverHttpPort = port;
             return this;
         }
 
@@ -485,6 +604,19 @@ public class FusekiServer {
         }
 
         /**
+         * Build the server using a Jetty configuration file.
+         * See <a href="https://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax">Jetty/Reference/jetty.xml_syntax</a>
+         * This is instead of any other HTTP server settings such as port and HTTPs.
+         */
+        public Builder jettyServerConfig(String filename) {
+            requireNonNull(filename, "filename");
+            if ( ! FileOps.exists(filename) )
+                throw new FusekiConfigException("File no found: "+filename);
+            this.jettyServerConfig = filename;
+            return this;
+        }
+
+        /**
          * Server level setting specific to Fuseki main.
          * General settings done by {@link FusekiConfig#processServerConfiguration}.
          */
@@ -573,13 +705,70 @@ public class FusekiServer {
             return this;
         }
 
+        /**
+         * Set the HTTPs port and provide the certificate store and password.
+         * <br/>
+         * Pass -1 for the httpsPort to clear the settings.
+         * <br/>
+         * Pass port 0 to get an allocated free port on startup.
+         */
         public Builder https(int httpsPort, String certStore, String certStorePasswd) {
             requireNonNull(certStore, "certStore");
             requireNonNull(certStorePasswd, "certStorePasswd");
+            if ( httpsPort <= -1 ) {
+                this.serverHttpsPort = PortInactive;
+                this.httpsKeystore = null;
+                this.httpsKeystorePasswd = null;
+                return this;
+            }
             this.httpsKeystore = certStore;
             this.httpsKeystorePasswd = certStorePasswd;
             this.serverHttpsPort = httpsPort;
             return this;
+        }
+
+        /**
+         * Set the HTTPs port and read the certificate store location and password from a file.
+         * The file can be secured by the host OS.
+         * This means the password for the certificate is not in the application code.
+         * <p>
+         * The file format is a JSON object:
+         * <pre>
+         * {
+         *     "keystore" : "mykey.jks" ,
+         *     "passwd"   : "certificate password"
+         * }
+         * </pre>
+         * Pass -1 for the httpsPort to clear the settings.
+         * <br/>
+         * Pass port 0 to get an allocated free port on startup.
+         */
+        public Builder https(int httpsPort, String certificate) {
+            requireNonNull(certificate, "certificate file");
+            if ( httpsPort <= -1 ) {
+                this.serverHttpsPort = PortInactive;
+                this.httpsKeystore = null;
+                this.httpsKeystorePasswd = null;
+                return this;
+            }
+            setHttpsCert(certificate);
+            this.serverHttpsPort = httpsPort;
+            return this;
+        }
+
+        private void setHttpsCert(String filename) {
+            try {
+                JsonObject httpsConf = JSON.read(filename);
+                Path path = Paths.get(filename).toAbsolutePath();
+                String keystore = httpsConf.get("keystore").getAsString().value();
+                // Resolve relative to the https setup file.
+                this.httpsKeystore = path.getParent().resolve(keystore).toString();
+                this.httpsKeystorePasswd = httpsConf.get("passwd").getAsString().value();
+            } catch (Exception ex) {
+                this.httpsKeystore = null;
+                this.httpsKeystorePasswd = null;
+                throw new FusekiConfigException("Failed to read the HTTP details file: "+ex.getMessage());
+            }
         }
 
         /**
@@ -772,7 +961,6 @@ public class FusekiServer {
             return this;
         }
 
-
         /**
          * Build a server according to the current description.
          */
@@ -784,17 +972,25 @@ public class FusekiServer {
                     securityHandler = buildSecurityHandler();
                 ServletContextHandler handler = buildFusekiContext();
 
+                if ( jettyServerConfig != null ) {
+                    Server server = jettyServer(handler, jettyServerConfig);
+                    return new FusekiServer(-1, -1, server, staticContentDir, handler.getServletContext());
+                }
+
                 Server server;
-                if ( serverHttpsPort == -1 ) {
-                    // HTTP
-                    server = jettyServer(handler, serverPort, minThreads, maxThreads);
+                int httpPort = Math.max(-1, serverHttpPort);
+                int httpsPort = Math.max(-1, serverHttpsPort);
+
+                if ( httpsPort <= -1 ) {
+                    // HTTP only
+                    server = jettyServer(handler, httpPort, minThreads, maxThreads);
                 } else {
                     // HTTPS, no http redirection.
-                    server = jettyServerHttps(handler, serverPort, serverHttpsPort, minThreads, maxThreads, httpsKeystore, httpsKeystorePasswd);
+                    server = jettyServerHttps(handler, httpPort, httpsPort, minThreads, maxThreads, httpsKeystore, httpsKeystorePasswd);
                 }
                 if ( networkLoopback )
                     applyLocalhost(server);
-                return new FusekiServer(serverPort, serverHttpsPort, server, staticContentDir, handler.getServletContext());
+                return new FusekiServer(httpPort, httpsPort, server, staticContentDir, handler.getServletContext());
             } finally {
                 buildFinish();
             }
@@ -823,6 +1019,9 @@ public class FusekiServer {
         private List<DatasetGraph> datasets = null;
 
         private void buildStart() {
+            if ( serverHttpPort < 0 && serverHttpsPort < 0 )
+                serverHttpPort = DefaultServerPort;
+
             // -- Server and dataset authentication
             hasAuthenticationHandler = (passwordFile != null) || (securityHandler != null);
 
@@ -1066,20 +1265,23 @@ public class FusekiServer {
         /** Jetty server with one connector/port. */
         private static Server jettyServer(ServletContextHandler handler, int port, int minThreads, int maxThreads) {
             Server server = JettyServer.jettyServer(minThreads, maxThreads);
-            // Missed when HTTPS.
-            // TODO Share with jettyServer :: jettyServerHttps
-            HttpConfiguration httpConfig = new HttpConfiguration();
-            // Some people do try very large operations ... really, should use POST.
-            httpConfig.setRequestHeaderSize(512 * 1024);
-            httpConfig.setOutputBufferSize(1024 * 1024);
-            // Do not add "Server: Jetty(....) when not a development system.
-            if ( ! Fuseki.outputJettyServerHeader )
-                httpConfig.setSendServerVersion(false);
+            HttpConfiguration httpConfig = JettyLib.httpConfiguration();
+
+            // Do not add "Server: Jetty(....) unless configured to do so.
+            if ( Fuseki.outputJettyServerHeader )
+                httpConfig.setSendServerVersion(true);
 
             HttpConnectionFactory f1 = new HttpConnectionFactory(httpConfig);
             ServerConnector connector = new ServerConnector(server, f1);
             connector.setPort(port);
             server.addConnector(connector);
+            server.setHandler(handler);
+            return server;
+        }
+
+        private Server jettyServer(ServletContextHandler handler, String jettyServerConfig) {
+            serverLog.info("Jetty server config file = " + jettyServerConfig);
+            Server server = JettyServer.jettyServer(jettyServerConfig);
             server.setHandler(handler);
             return server;
         }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyHttps.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyHttps.java
@@ -26,7 +26,8 @@ import org.eclipse.jetty.server.handler.SecuredRedirectHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-/** Library of functions to help with setting Jetty up with HTTPS.
+/**
+ * Library of functions to help with setting Jetty up with HTTPS.
  * This code is not supposed to be fully general.
  * It sets up "http" to redirect to "https".
  */
@@ -91,7 +92,7 @@ public class JettyHttps {
 
     /** Add HTTP to a {@link Server}, setting the secure redirection port. */
     private static ServerConnector httpConnector(Server server, int httpPort, int httpsPort) {
-        HttpConfiguration http_config = httpConfiguration();
+        HttpConfiguration http_config = JettyLib.httpConfiguration();
         http_config.setSendServerVersion(false);
         if ( httpPort >  0 ) {
             http_config.setSecureScheme(HttpScheme.HTTPS.asString());
@@ -112,7 +113,7 @@ public class JettyHttps {
         src.setStsMaxAge(2000);
         src.setStsIncludeSubDomains(true);
 
-        HttpConfiguration https_config = httpConfiguration();
+        HttpConfiguration https_config = JettyLib.httpConfiguration();
         https_config.setSecureScheme(HttpScheme.HTTPS.asString());
         https_config.setSecurePort(httpsPort);
         https_config.addCustomizer(src);
@@ -123,16 +124,5 @@ public class JettyHttps {
             new HttpConnectionFactory(https_config));
         sslConnector.setPort(httpsPort);
         return sslConnector;
-    }
-
-    /** HTTP configuration with setting for Fuseki workload. No "secure" settings. */
-    private static HttpConfiguration httpConfiguration() {
-        HttpConfiguration http_config = new HttpConfiguration();
-        // Some people do try very large operations ... really, should use POST.
-        http_config.setRequestHeaderSize(512 * 1024);
-        http_config.setOutputBufferSize(1024 * 1024);
-//      http_config.setResponseHeaderSize(8192);
-        http_config.setSendServerVersion(false);
-        return http_config;
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
@@ -27,9 +27,17 @@ import org.apache.jena.sparql.core.DatasetGraph;
  */
 class ServerConfig {
     /** Server port. This is the http port when both http and https are active. */
-    public int port;
+    public int port                   = -1;
     /** Loopback */
     public boolean   loopback         = false;
+
+    // https
+    public int httpsPort              = -1;
+    public String httpsKeysDetails    = null;
+
+    // Jetty server configuration file.
+    public String jettyConfigFile     = null;
+
     /** The dataset name (canonical form) */
     public String    datasetPath      = null;
     /** Allow update */
@@ -54,16 +62,11 @@ class ServerConfig {
 
     public boolean validators         = false;
     /** An informative label */
-    public String datasetDescription;
+    public String datasetDescription  = null;
     public String contentDirectory    = null;
 
     // Server authentication
     public AuthScheme authScheme      = null;
     public String passwdFile          = null;
     public String realm               = null;
-
-    // https
-    public int httpsPort              = -1;
-    public String httpsKeystore       = null;
-    public String httpsKeystorePasswd = null;
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
@@ -33,6 +33,7 @@ import org.junit.runners.Suite.SuiteClasses;
   , TestStdSetup.class
   , TestConfigFile.class
   , TestHTTP.class
+  , TestFusekiServerBuild.class
   , TestFusekiShaclValidation.class
 })
 public class TS_FusekiMain {}

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.main;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.rdfconnection.RDFConnection;
+import org.apache.jena.rdfconnection.RDFConnectionFactory;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.Test;
+
+public class TestFusekiServerBuild {
+    // Most testing happens by use in the test suite.
+
+    @Test public void fuseki_build_1() {
+        FusekiServer server = FusekiServer.create().port(3456).build();
+        // Not started. Port not assigned.
+        assertTrue(server.getHttpPort() == 3456 );
+        assertTrue(server.getHttpsPort() == -1 );
+    }
+
+    @Test public void fuseki_build_2() {
+        FusekiServer server = FusekiServer.create().port(0).build();
+        // Not started. Port not assigned.
+        assertTrue(server.getHttpPort() == 0 );
+        assertTrue(server.getHttpsPort() == -1 );
+        server.start();
+        try {
+            assertFalse(server.getHttpPort() == 0 );
+            assertTrue(server.getHttpsPort() == -1 );
+        } finally { server.stop(); }
+    }
+
+    // The port in "testing/jetty.xml" is 1077
+
+    @Test public void fuseki_ext_jetty_xml_1() {
+        FusekiServer server = FusekiServer.create()
+                .jettyServerConfig("testing/jetty.xml")
+                .add("/ds", DatasetGraphFactory.createTxnMem())
+                .build();
+        server.start();
+        try {
+            assertEquals(1077, server.getHttpPort());
+            assertEquals(1077, server.getPort());
+            String URL = "http://localhost:1077/ds";
+            assertEquals(URL, server.datasetURL("ds"));
+            try ( RDFConnection conn = RDFConnectionFactory.connect(URL) ) {
+                boolean b = conn.queryAsk("ASK{}");
+            }
+
+
+        } finally { server.stop(); }
+    }
+}

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestSecurityBuilderSetup.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestSecurityBuilderSetup.java
@@ -59,18 +59,23 @@ import org.junit.Test;
 public class TestSecurityBuilderSetup {
 
     private static FusekiServer fusekiServer = null;
-    private static int port = WebLib.choosePort();
-    private static String serverURL = "http://localhost:"+port+"/";
-    private static AuthSetup authSetup1 = new AuthSetup("localhost", port, "user1", "pw1", "TripleStore");
-    private static AuthSetup authSetup2 = new AuthSetup("localhost", port, "user2", "pw2", "TripleStore");
+    private static String serverURL;
+    private static AuthSetup authSetup1;
+    private static AuthSetup authSetup2;
     // Not in the user store.
-    private static AuthSetup authSetupX = new AuthSetup("localhost", port, "userX", "pwX", "TripleStore");
+    private static AuthSetup authSetupX;
 
     @BeforeClass
     public static void beforeClass() {
         if ( false )
             // To watch the HTTP headers
             LogCtl.enable("org.apache.http.headers");
+
+        int port = WebLib.choosePort();
+
+        authSetup1 = new AuthSetup("localhost", port, "user1", "pw1", "TripleStore");
+        authSetup2 = new AuthSetup("localhost", port, "user2", "pw2", "TripleStore");
+        authSetupX = new AuthSetup("localhost", port, "userX", "pwX", "TripleStore");
 
         // Two authorized users.
         UserStore userStore = new UserStore();
@@ -106,6 +111,9 @@ public class TestSecurityBuilderSetup {
                 //.staticFileBase(".")
                 .build();
         fusekiServer.start();
+
+        serverURL = fusekiServer.serverURL();
+
     }
 
     @Before

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestSecurityFilterFuseki.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestSecurityFilterFuseki.java
@@ -33,7 +33,6 @@ import org.apache.jena.fuseki.access.SecurityContextView;
 import org.apache.jena.fuseki.access.SecurityRegistry;
 import org.apache.jena.fuseki.jetty.JettyLib;
 import org.apache.jena.fuseki.main.FusekiServer;
-import org.apache.jena.fuseki.system.FusekiNetLib;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.rdf.model.Model;
@@ -77,7 +76,6 @@ public class TestSecurityFilterFuseki {
 
     // Set up Fuseki with two datasets, "data1" backed by TDB and "data2" backed by TDB2.
     @BeforeClass public static void beforeClass() {
-        int port = FusekiNetLib.choosePort();
         addTestData(testdsg1);
         addTestData(testdsg2);
         addTestData(testdsg3);
@@ -100,7 +98,7 @@ public class TestSecurityFilterFuseki {
 
         fusekiServer = FusekiServer.create()
             .securityHandler(sh)
-            .port(port)
+            .port(0)
             .add("data1", testdsg1)
             .add("data2", testdsg2)
             .add("data3", testdsg3)
@@ -130,8 +128,7 @@ public class TestSecurityFilterFuseki {
     }
 
     public TestSecurityFilterFuseki(String label, String dsName) {
-        int port = fusekiServer.getPort();
-        baseUrl = "http://localhost:"+port+"/"+dsName;
+        baseUrl = fusekiServer.datasetURL(dsName);
     }
 
     private static String queryAll        = "SELECT * { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }";

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthBuild.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthBuild.java
@@ -18,21 +18,32 @@
 
 package org.apache.jena.fuseki.main.access;
 
-import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.main.FusekiServer;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 /**
- * AbstractTestServiceDatasetAuth with a config file.
+ * AbstractTestServiceDatasetAuth with a configuration file.
  */
 public class TestServiceDataAuthBuild extends AbstractTestServiceDatasetAuth {
+
+    static FusekiServer server;
+
     @BeforeClass public static void beforeClass () {
-        port = WebLib.choosePort();
         server = FusekiServer.create()
             //.verbose(true)
             .port(port)
             .parseConfigFile("testing/Access/config-auth.ttl")
             .build();
         server.start();
+    }
+
+    @AfterClass public static void afterClass () {
+        server.stop();
+    }
+
+    @Override
+    protected FusekiServer server() {
+        return server;
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthConfig.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthConfig.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.fuseki.main.access;
 
-import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.auth.Auth;
 import org.apache.jena.fuseki.auth.AuthPolicy;
 import org.apache.jena.fuseki.main.FusekiServer;
@@ -27,20 +26,31 @@ import org.apache.jena.fuseki.server.Endpoint;
 import org.apache.jena.fuseki.server.Operation;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 /**
- * AbstractTestServiceDatasetAuth with a programtically built server which should be
- * the same as the {@link TestServiceDataAuthConfig config file version}.
+ * AbstractTestServiceDatasetAuth with a programmatically built server which should be
+ * the same as the {@link TestServiceDataAuthConfig configuration file version}.
  */
 public class TestServiceDataAuthConfig extends AbstractTestServiceDatasetAuth {
+    private static FusekiServer server;
+
     @BeforeClass public static void beforeClass () {
-        port = WebLib.choosePort();
         server = build(port, null);
         server.start();
-    }        
-        
-    public static FusekiServer build(int port, AuthPolicy policy) { 
+    }
+
+    @AfterClass public static void afterClass () {
+        server.stop();
+    }
+
+    @Override
+    protected FusekiServer server() {
+        return server;
+    }
+
+    public static FusekiServer build(int port, AuthPolicy policy) {
         AuthPolicy policy12 = Auth.policyAllowSpecific("user1", "user2");
         AuthPolicy policy13 = Auth.policyAllowSpecific("user1", "user3");
         DatasetGraph dsg = DatasetGraphFactory.createTxnMem();

--- a/jena-fuseki2/jena-fuseki-main/testing/jetty.xml
+++ b/jena-fuseki2/jena-fuseki-main/testing/jetty.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <!-- Mininal jetty.xml to run on a specific port, locked to localhost -->
+  <Call name="addConnector">
+    <Arg>
+      <New id="httpConnector" class="org.eclipse.jetty.server.ServerConnector">
+        <Arg name="server"><Ref refid="Server" /></Arg>
+        <Arg name="factories">
+          <Array type="org.eclipse.jetty.server.ConnectionFactory">
+            <Item>
+              <New class="org.eclipse.jetty.server.HttpConnectionFactory"/>
+            </Item>
+          </Array>
+        </Arg>
+        <Set name="port">1077</Set>
+      </New>
+    </Arg>
+  </Call>
+</Configure>

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/ServerCtl.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/ServerCtl.java
@@ -30,10 +30,10 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.cmd.FusekiArgs;
 import org.apache.jena.fuseki.cmd.JettyFusekiWebapp;
 import org.apache.jena.fuseki.jetty.JettyServerConfig;
-import org.apache.jena.fuseki.system.FusekiNetLib;
 import org.apache.jena.fuseki.webapp.FusekiEnv;
 import org.apache.jena.fuseki.webapp.FusekiServerListener;
 import org.apache.jena.fuseki.webapp.FusekiWebapp;
@@ -115,7 +115,7 @@ public class ServerCtl {
 
     /*package : for import static */ enum ServerScope { SUITE, CLASS, TEST }
     private static ServerScope serverScope = ServerScope.CLASS;
-    private static int currentPort = FusekiNetLib.choosePort();
+    private static int currentPort = WebLib.choosePort();
 
     public static int port() {
         return currentPort;

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionFuseki.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionFuseki.java
@@ -24,7 +24,7 @@ import org.apache.jena.rdfconnection.RDFConnectionFactory;
 public class TestRDFConnectionFuseki extends TestRDFConnectionRemote {
     @Override
     protected RDFConnection connection() {
-        return RDFConnectionFactory.connectFuseki("http://localhost:"+PORT+"/ds");
+        return RDFConnectionFactory.connectFuseki(server.datasetURL("/ds"));
     }
 }
 

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionRemote.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionRemote.java
@@ -18,9 +18,6 @@
 
 package org.apache.jena.test.rdfconnection;
 
-import org.apache.jena.atlas.logging.LogCtl ;
-import org.apache.jena.atlas.web.WebLib;
-import org.apache.jena.fuseki.Fuseki ;
 import org.apache.jena.fuseki.main.FusekiServer ;
 import org.apache.jena.rdfconnection.AbstractTestRDFConnection;
 import org.apache.jena.rdfconnection.RDFConnection;
@@ -33,23 +30,15 @@ import org.junit.Before ;
 import org.junit.BeforeClass ;
 
 public class TestRDFConnectionRemote extends AbstractTestRDFConnection {
-    private static FusekiServer server ;
+    protected static FusekiServer server ;
     private static DatasetGraph serverdsg = DatasetGraphFactory.createTxnMem() ;
-    protected static int PORT; 
-    
+
     @BeforeClass
     public static void beforeClass() {
-        PORT = WebLib.choosePort();
         server = FusekiServer.create().loopback(true)
-            .port(PORT)
+            .port(0)
             .add("/ds", serverdsg)
             .build() ;
-        LogCtl.setLevel(Fuseki.serverLogName,  "WARN");
-        LogCtl.setLevel(Fuseki.actionLogName,  "WARN");
-        LogCtl.setLevel(Fuseki.requestLogName, "WARN");
-        LogCtl.setLevel(Fuseki.adminLogName,   "WARN");
-        LogCtl.setLevel(Fuseki.adminLogName,   "WARN");
-        LogCtl.setLevel("org.eclipse.jetty",   "WARN");
         server.start() ;
     }
 
@@ -61,18 +50,18 @@ public class TestRDFConnectionRemote extends AbstractTestRDFConnection {
 
 //  @After
 //  public void afterTest() {}
-    
+
     @AfterClass
     public static void afterClass() {
-        server.stop(); 
+        server.stop();
     }
-    
+
     @Override
     protected boolean supportsAbort() { return false ; }
 
     @Override
     protected RDFConnection connection() {
-        return RDFConnectionFactory.connect("http://localhost:"+PORT+"/ds");
+        return RDFConnectionFactory.connect(server.datasetURL("/ds"));
     }
 }
 

--- a/jena-integration-tests/src/test/resources/log4j2.properties
+++ b/jena-integration-tests/src/test/resources/log4j2.properties
@@ -1,5 +1,4 @@
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
-
 status = error
 name = PropertiesConfig
 filters = threshold
@@ -10,7 +9,6 @@ filter.threshold.level = ALL
 appender.console.type = Console
 appender.console.name = OUT
 appender.console.target = SYSTEM_ERR
-appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-10c{1} :: %m%n
 #appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-10c{1} :: %m%n
@@ -19,16 +17,25 @@ rootLogger.level                  = INFO
 rootLogger.appenderRef.stdout.ref = OUT
 
 logger.jena.name  = org.apache.jena
-logger.jena.level = WARN
+logger.jena.level = INFO
 
-logger.arq-info.name  = org.apache.jena.arq.info
-logger.arq-info.level = INFO
+logger.arq-exec.name  = org.apache.jena.arq.exec
+logger.arq-exec.level = INFO
 
 logger.riot.name  = org.apache.jena.riot
 logger.riot.level = INFO
 
 logger.fuseki.name  = org.apache.jena.fuseki
 logger.fuseki.level = INFO
+
+logger.fuseki-fuseki.name  = org.apache.jena.fuseki.Fuseki
+logger.fuseki-fuseki.level = WARN
+
+logger.fuseki-server.name  = org.apache.jena.fuseki.Server
+logger.fuseki-server.level = WARN
+
+logger.fuseki-admin.name  = org.apache.jena.fuseki.Admin
+logger.fuseki-admin.level = WARN
 
 logger.jetty.name  = org.eclipse.jetty
 logger.jetty.level = WARN

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/FusekiTestServer.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/FusekiTestServer.java
@@ -16,11 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.jena.fuseki.main;
+package org.apache.jena.jdbc.remote;
 
-import static org.apache.jena.fuseki.main.FusekiTestServer.ServerScope.CLASS;
-import static org.apache.jena.fuseki.main.FusekiTestServer.ServerScope.SUITE;
-import static org.apache.jena.fuseki.main.FusekiTestServer.ServerScope.TEST;
+import static org.apache.jena.jdbc.remote.FusekiTestServer.ServerScope.CLASS;
+import static org.apache.jena.jdbc.remote.FusekiTestServer.ServerScope.SUITE;
+import static org.apache.jena.jdbc.remote.FusekiTestServer.ServerScope.TEST;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -28,6 +28,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.web.WebLib;
+import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.riot.web.HttpOp;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/TS_JdbcDriverRemote.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/TS_JdbcDriverRemote.java
@@ -17,7 +17,6 @@
  */
 package org.apache.jena.jdbc.remote;
 
-import org.apache.jena.fuseki.main.FusekiTestServer ;
 import org.apache.jena.jdbc.remote.connections.TestRemoteEndpointConnection;
 import org.apache.jena.jdbc.remote.connections.TestRemoteEndpointConnectionWithAuth;
 import org.apache.jena.jdbc.remote.connections.TestRemoteEndpointConnectionWithGraphUris;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnection.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnection.java
@@ -20,9 +20,9 @@ package org.apache.jena.jdbc.remote.connections;
 
 import java.sql.SQLException;
 
-import org.apache.jena.fuseki.main.FusekiTestServer;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
+import org.apache.jena.jdbc.remote.FusekiTestServer;
 import org.apache.jena.jdbc.utils.TestUtils;
 import org.apache.jena.query.Dataset ;
 import org.junit.After;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithGraphUris.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithGraphUris.java
@@ -23,9 +23,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.jena.fuseki.main.FusekiTestServer;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
+import org.apache.jena.jdbc.remote.FusekiTestServer;
 import org.apache.jena.jdbc.utils.TestUtils;
 import org.apache.jena.query.Dataset ;
 import org.junit.* ;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithResultSetTypes.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithResultSetTypes.java
@@ -20,9 +20,9 @@ package org.apache.jena.jdbc.remote.connections;
 
 import java.sql.SQLException;
 
-import org.apache.jena.fuseki.main.FusekiTestServer;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
+import org.apache.jena.jdbc.remote.FusekiTestServer;
 import org.apache.jena.jdbc.utils.TestUtils;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.riot.WebContent;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/metadata/TestRemoteConnectionMetadata.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/metadata/TestRemoteConnectionMetadata.java
@@ -23,10 +23,10 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.jena.fuseki.main.FusekiTestServer;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.metadata.results.AbstractDatabaseMetadataTests;
+import org.apache.jena.jdbc.remote.FusekiTestServer;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
 import org.junit.After;
 import org.junit.AfterClass;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResults.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResults.java
@@ -22,9 +22,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.apache.jena.fuseki.main.FusekiTestServer ;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
+import org.apache.jena.jdbc.remote.FusekiTestServer;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
 import org.apache.jena.jdbc.utils.TestUtils;
 import org.apache.jena.query.Dataset ;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithGraphUris.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithGraphUris.java
@@ -24,9 +24,9 @@ import java.sql.Statement;
 import java.util.List;
 
 import org.apache.jena.ext.com.google.common.collect.Lists;
-import org.apache.jena.fuseki.main.FusekiTestServer ;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
+import org.apache.jena.jdbc.remote.FusekiTestServer;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
 import org.apache.jena.jdbc.utils.TestUtils;
 import org.apache.jena.query.Dataset ;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithResultSetTypes.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithResultSetTypes.java
@@ -22,9 +22,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.apache.jena.fuseki.main.FusekiTestServer ;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
+import org.apache.jena.jdbc.remote.FusekiTestServer;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
 import org.apache.jena.jdbc.utils.TestUtils;
 import org.apache.jena.query.Dataset ;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/statements/TestRemoteEndpointStatements.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/statements/TestRemoteEndpointStatements.java
@@ -20,9 +20,9 @@ package org.apache.jena.jdbc.remote.statements;
 
 import java.sql.SQLException;
 
-import org.apache.jena.fuseki.main.FusekiTestServer ;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
+import org.apache.jena.jdbc.remote.FusekiTestServer;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
 import org.apache.jena.jdbc.statements.AbstractJenaStatementTests;
 import org.junit.After;


### PR DESCRIPTION
Includes handling port 0 - allocate atomically when the server starts then finding what we got - in place of the "ask" then use the given port which has a timing hole albeit small.