### PR TITLE
JENA-2070: Split into separate github workflows

### DIFF
--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -1,12 +1,7 @@
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-name: Apache Jena CI
-
-on:
-  push:
-    branches: [ main ]
-#  pull_request:
-#    branches: [ main ]
+name: Apache Jena CI (MacOS)
+on: workflow_dispatch
 
 jobs:
   build:
@@ -16,13 +11,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest]
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: '11'
+
     - name: Build with Maven
       run: mvn -B verify -Pdev --file pom.xml

--- a/.github/workflows/maven_windows.yml
+++ b/.github/workflows/maven_windows.yml
@@ -1,15 +1,23 @@
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-name: Apache Jena CI for Windows-latest
+name: Apache Jena CI (MS Windows)
 on: workflow_dispatch
+
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+
+    # "windows" takes up a lot of diskspace due a longstanding JDK issue
+    # Running on c: seems to work.
     steps:
     - uses: actions/checkout@v2
-   
+
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
Tweaking the GH workflows.

This PR is the current best I have managed to achieve.

The MacOS workflow does sometimes pass at quiet times without a test change but only sometimes and only quiet times (e.g before work, European time).

There is a test change - the MacOS environment seems to be heavily loaded and as a result some tests expecting timeouts are unstable. It seems that pauses of the test VM with no thread scheduled can be many seconds due to load.

Windows and MacOS workflows set to manual trigger (`workflow_dispatch`).



