### PR TITLE
JENA-2075: Changed String.valueOf() to getModel().createTypeLiteral()

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/AltImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/AltImpl.java
@@ -153,32 +153,32 @@ public class AltImpl extends ContainerImpl implements Alt {
     
     @Override
     public Alt setDefault(boolean o)  {
-        return setDefault( String.valueOf( o ) );
+        return setDefault( getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Alt setDefault(long o)  {
-        return setDefault( String.valueOf( o ) );
+        return setDefault( getModel().createTypedLiteral( o ) );
     }    
     
     @Override
     public Alt setDefault(char o)  {
-        return setDefault( String.valueOf( o ) );
+        return setDefault( getModel().createTypedLiteral( o ) );
     }        
     
     @Override
     public Alt setDefault(float o)  {
-        return setDefault( String.valueOf( o ) );
+        return setDefault( getModel().createTypedLiteral( o ) );
     } 
     
     @Override
     public Alt setDefault(double o)  {
-        return setDefault( String.valueOf( o ) );
+        return setDefault( getModel().createTypedLiteral( o ) );
     }    
     
     @Override
     public Alt setDefault(Object o)  {
-        return setDefault( String.valueOf( o ) );
+        return setDefault( getModel().createTypedLiteral( o ) );
     }
    
     @Override

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ContainerImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ContainerImpl.java
@@ -87,32 +87,32 @@ public class ContainerImpl extends ResourceImpl
     
     @Override
     public Container add(boolean o)  {
-        return add( String.valueOf( o ) );
+        return add( getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Container add(long o)  {
-        return add( String.valueOf( o ) );
+        return add( getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Container add(char o)  {
-        return add( String.valueOf( o ) );
+        return add( getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Container add( float o )  {
-        return add( String.valueOf( o ) );
+        return add( getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Container add(double o)  {
-        return add( String.valueOf( o ) );
+        return add( getModel().createTypedLiteral( o ) );
     }
 
     @Override
     public Container add(Object o)  {
-        return add( String.valueOf( o ) );
+        return add( getModel().createTypedLiteral( o ) );
     }
      
     @Override
@@ -132,32 +132,32 @@ public class ContainerImpl extends ResourceImpl
 
     @Override
     public boolean contains(boolean o)  {
-        return contains( String.valueOf( o ) );
+        return contains( getModel().createTypedLiteral( o ) );
     }
 
     @Override
     public boolean contains(long o)  {
-        return contains( String.valueOf( o ) );
+        return contains( getModel().createTypedLiteral( o ) );
     }
 
     @Override
     public boolean contains(char o)  {
-        return contains( String.valueOf( o ) );
+        return contains( getModel().createTypedLiteral( o ) );
     }
 
     @Override
     public boolean contains(float o)  {
-        return contains( String.valueOf( o ) );
+        return contains( getModel().createTypedLiteral( o ) );
     }
 
     @Override
     public boolean contains(double o)  {
-        return contains( String.valueOf( o ) );
+        return contains( getModel().createTypedLiteral( o ) );
     }
 
     @Override
     public boolean contains(Object o)  {
-        return contains( String.valueOf( o ) );
+        return contains( getModel().createTypedLiteral( o ) );
     }
     
     @Override

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/SeqImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/SeqImpl.java
@@ -227,32 +227,32 @@ public class SeqImpl extends ContainerImpl implements Seq {
     
     @Override
     public Seq add(int index, boolean o)  {
-        return add( index, String.valueOf( o ) );
+        return add( index, getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Seq add(int index, long o)  {
-        return add( index, String.valueOf( o ) );
+        return add( index, getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Seq add(int index, char o)  {
-        return add( index, String.valueOf( o ) );
+        return add( index, getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Seq add(int index, float o)  {
-        return add( index, String.valueOf( o ) );
+        return add( index, getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Seq add(int index, double o)  {
-        return add( index, String.valueOf( o ) );
+        return add( index, getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public Seq add(int index, Object o)  {
-        return add( index, String.valueOf( o ) );
+        return add( index, getModel().createTypedLiteral( o ) );
     }
     
     @Override
@@ -304,32 +304,32 @@ public class SeqImpl extends ContainerImpl implements Seq {
     
     @Override
     public int indexOf(boolean o)  {
-        return indexOf( String.valueOf( o ) );
+        return indexOf( getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public int indexOf(long o)  {
-        return indexOf( String.valueOf( o ) );
+        return indexOf( getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public int indexOf(char o)  {
-        return indexOf( String.valueOf( o ) );
+        return indexOf( getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public int indexOf(float o)  {
-        return indexOf( String.valueOf( o ) );
+        return indexOf( getModel().createTypedLiteral( o ) );
     }
     
     @Override
     public int indexOf(double o)  {
-        return indexOf( String.valueOf( o ) );
+        return indexOf( getModel().createTypedLiteral( o ) );
     }
 
     @Override
     public int indexOf(Object o)  {
-        return indexOf( String.valueOf( o ) );
+        return indexOf( getModel().createTypedLiteral( o ) );
     }
         
     @Override


### PR DESCRIPTION
Changes are in AltImpl.setDefault(), ContainerImpl.add(),
ContainerImpl.contains(), SeqImpl.add(), and SeqImpl.indexOf()

This should fix JENA-2075 for ver 4.