### PR TITLE
JENA-2081: add /$/compact/* endpoint to fuseki main

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionCompact.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionCompact.java
@@ -16,15 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.jena.fuseki.mgt;
+package org.apache.jena.fuseki.ctl;
 
 import static java.lang.String.format;
 
 import com.github.jsonldjava.shaded.com.google.common.base.Predicate;
 
 import org.apache.jena.fuseki.Fuseki;
-import org.apache.jena.fuseki.ctl.ActionAsyncTask;
-import org.apache.jena.fuseki.ctl.TaskBase;
 import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.fuseki.servlets.ServletOps;
 import org.apache.jena.sparql.core.DatasetGraph;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiVocab.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiVocab.java
@@ -57,6 +57,7 @@ public class FusekiVocab
     public static final Property pServerPing        = property("pingEP");
     public static final Property pServerStats       = property("statsEP");
     public static final Property pServerMetrics     = property("metricsEP");
+    public static final Property pServerCompact     = property("compactEP");
 
     // Endpoint description - old style.
     public static final Property pServiceQueryEP                = property("serviceQuery");

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -46,6 +46,7 @@ import org.apache.jena.fuseki.access.DataAccessCtl;
 import org.apache.jena.fuseki.auth.Auth;
 import org.apache.jena.fuseki.auth.AuthPolicy;
 import org.apache.jena.fuseki.build.FusekiConfig;
+import org.apache.jena.fuseki.ctl.ActionCompact;
 import org.apache.jena.fuseki.ctl.ActionMetrics;
 import org.apache.jena.fuseki.ctl.ActionPing;
 import org.apache.jena.fuseki.ctl.ActionStats;
@@ -357,6 +358,7 @@ public class FusekiServer {
         private int                      maxThreads         = -1;
 
         private boolean                  verbose            = false;
+        private boolean                  withCompact        = false;
         private boolean                  withPing           = false;
         private boolean                  withMetrics        = false;
         private boolean                  withStats          = false;
@@ -501,6 +503,12 @@ public class FusekiServer {
             return this;
         }
 
+        /** Add the "/$/compact/*" servlet that triggers compaction for specified dataset. */
+        public Builder enableCompact(boolean withCompact) {
+            this.withCompact = withCompact;
+            return this;
+        }
+
         /**
          * Add the dataset with given name and a default set of services including update.
          * This is equivalent to {@code add(name, dataset, true)}.
@@ -627,6 +635,7 @@ public class FusekiServer {
             withPing  = argBoolean(server, FusekiVocab.pServerPing,  false);
             withStats = argBoolean(server, FusekiVocab.pServerStats, false);
             withMetrics = argBoolean(server, FusekiVocab.pServerMetrics, false);
+            withCompact = argBoolean(server, FusekiVocab.pServerCompact, false);
 
             // Extract settings - the server building is done in buildSecurityHandler,
             // buildAccessControl.  Dataset and graph level happen in assemblers.
@@ -1207,7 +1216,9 @@ public class FusekiServer {
                 addServlet(context, "/$/stats/*", new ActionStats());
             if ( withMetrics )
                 addServlet(context, "/$/metrics", new ActionMetrics());
-            // TODO Should we support registering other functionality e.g. /$/backup/* and /$/compact/*
+            if ( withCompact )
+                addServlet(context, "/$/compact/*", new ActionCompact());
+            // TODO Should we support registering other functionality e.g. /$/backup/*
 
             servlets.forEach(p-> addServlet(context, p.getLeft(), p.getRight()));
             filters.forEach (p-> addFilter(context, p.getLeft(), p.getRight()));

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -88,6 +88,7 @@ public class FusekiMain extends CmdARQ {
     private static ArgDecl  argWithPing     = new ArgDecl(ArgDecl.NoValue, "withPing", "ping");
     private static ArgDecl  argWithStats    = new ArgDecl(ArgDecl.NoValue, "withStats", "stats");
     private static ArgDecl  argWithMetrics  = new ArgDecl(ArgDecl.NoValue,  "withMetrics", "metrics");
+    private static ArgDecl  argWithCompact  = new ArgDecl(ArgDecl.NoValue,  "withCompact", "compact");
 
     private static ArgDecl  argAuth         = new ArgDecl(ArgDecl.HasValue, "auth");
 
@@ -175,6 +176,7 @@ public class FusekiMain extends CmdARQ {
         add(argWithPing,    "--ping",   "Enable /$/ping");
         add(argWithStats,   "--stats",  "Enable /$/stats");
         add(argWithMetrics, "--metrics",  "Enable /$/metrics");
+        add(argWithCompact, "--compact", "Enable /$/compact/*");
 
         super.modVersion.addClass(Fuseki.class);
     }
@@ -423,6 +425,7 @@ public class FusekiMain extends CmdARQ {
         serverConfig.withPing = contains(argWithPing);
         serverConfig.withStats = contains(argWithStats);
         serverConfig.withMetrics = contains(argWithMetrics);
+        serverConfig.withCompact = contains(argWithCompact);
 
 //            if ( contains(argGZip) ) {
 //                if ( !hasValueOfTrue(argGZip) && !hasValueOfFalse(argGZip) )
@@ -542,6 +545,9 @@ public class FusekiMain extends CmdARQ {
 
         if ( serverConfig.withMetrics )
             builder.enableMetrics(true);
+
+        if ( serverConfig.withCompact )
+            builder.enableCompact(true);
 
         return builder.build();
     }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
@@ -49,6 +49,7 @@ class ServerConfig {
     public boolean withPing           = false;
     public boolean withStats          = false;
     public boolean withMetrics        = false;
+    public boolean withCompact        = false;
 
     // This is set ...
     public DatasetGraph dsg           = null;

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestConfigFile.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestConfigFile.java
@@ -18,14 +18,19 @@
 
 package org.apache.jena.fuseki.main;
 
+import java.io.IOException;
+
 import static org.apache.jena.fuseki.test.FusekiTest.expect400;
 import static org.apache.jena.fuseki.test.FusekiTest.expect404;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.lib.StrUtils;
+import org.apache.jena.atlas.web.TypedInputStream;
 import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.query.QueryExecution;
@@ -225,6 +230,28 @@ public class TestConfigFile {
             assertNotNull(x2);
             String x3 = HttpOp.execHttpGetString("http://localhost:"+port+"/$/metrics");
             assertNotNull(x3);
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test public void serverTDB2() {
+        int port = WebLib.choosePort();
+        FusekiServer server = server(port, "server-tdb2.ttl");
+        server.start();
+        try {
+            String x1 = HttpOp.execHttpGetString("http://localhost:"+port+"/$/ping");
+            assertNotNull(x1);
+            String x2 = HttpOp.execHttpGetString("http://localhost:"+port+"/$/stats");
+            assertNotNull(x2);
+            String x3 = HttpOp.execHttpGetString("http://localhost:"+port+"/$/metrics");
+            assertNotNull(x3);
+            try(TypedInputStream x4 = HttpOp.execHttpPostStream("http://localhost:"+port+"/$/compact/ds", null, "application/json")) {
+                assertNotNull(x4);
+                assertNotEquals(0, x4.readAllBytes().length);
+            } catch (IOException ex) {
+                IO.exception(ex);
+            }
         } finally {
             server.stop();
         }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestConfigFile.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestConfigFile.java
@@ -246,12 +246,16 @@ public class TestConfigFile {
             assertNotNull(x2);
             String x3 = HttpOp.execHttpGetString("http://localhost:"+port+"/$/metrics");
             assertNotNull(x3);
-            try(TypedInputStream x4 = HttpOp.execHttpPostStream("http://localhost:"+port+"/$/compact/ds", null, "application/json")) {
-                assertNotNull(x4);
-                assertNotEquals(0, x4.readAllBytes().length);
+            String x4 = HttpOp.execHttpGetString("http://localhost:"+port+"/$/tasks");
+            assertNotNull(x4);
+            try(TypedInputStream x5 = HttpOp.execHttpPostStream("http://localhost:"+port+"/$/compact/ds", null, "application/json")) {
+                assertNotNull(x5);
+                assertNotEquals(0, x5.readAllBytes().length);
             } catch (IOException ex) {
                 IO.exception(ex);
             }
+            String x6 = HttpOp.execHttpGetString("http://localhost:"+port+"/$/tasks/1");
+            assertNotNull(x6);
         } finally {
             server.stop();
         }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestEmbeddedFuseki.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestEmbeddedFuseki.java
@@ -242,12 +242,29 @@ public class TestEmbeddedFuseki {
             .enableCompact(true)
             .build();
         server.start();
-        try(TypedInputStream x = HttpOp.execHttpPostStream("http://localhost:"+port+"/$/compact/FuTest", null, "application/json")) {
-            assertNotNull(x);
-            assertNotEquals(0, x.readAllBytes().length);
+        try(TypedInputStream x0 = HttpOp.execHttpPostStream("http://localhost:"+port+"/$/compact/FuTest", null, "application/json")) {
+            assertNotNull(x0);
+            assertNotEquals(0, x0.readAllBytes().length);
+
+            String x1 = HttpOp.execHttpGetString("http://localhost:"+port+"/$/tasks");
+            assertNotNull(x1);
         } finally {
             server.stop();
         }
+    }
+
+    @Test public void embedded_tasks() {
+        DatasetGraph dsg = dataset();
+        int port = WebLib.choosePort();
+        FusekiServer server = FusekiServer.create()
+            .port(port)
+            .add("/ds0", dsg)
+            .enableTasks(true)
+            .build();
+        server.start();
+        String x = HttpOp.execHttpGetString("http://localhost:"+port+"/$/tasks");
+        assertNotNull(x);
+        server.stop();
     }
 
     // Context path.

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmd.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmd.java
@@ -19,12 +19,15 @@
 package org.apache.jena.fuseki.main;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
 import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.web.TypedInputStream;
 import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.main.cmds.FusekiMain;
 import org.apache.jena.fuseki.system.FusekiLogging;
@@ -90,5 +93,13 @@ public class TestFusekiMainCmd {
         server("--mem", "--metrics", "/ds");
         String x = HttpOp.execHttpGetString(serverURL+"/$/metrics");
         assertNotNull(x);
+    }
+
+    @Test public void compact_01() throws IOException {
+        server("--memTDB", "--tdb2", "--compact", "/ds");
+        try(TypedInputStream x = HttpOp.execHttpPostStream(serverURL+"/$/compact/ds", null, "application/json")) {
+            assertNotNull(x);
+            assertNotEquals(0, x.readAllBytes().length);
+        }
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmd.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmd.java
@@ -97,9 +97,13 @@ public class TestFusekiMainCmd {
 
     @Test public void compact_01() throws IOException {
         server("--memTDB", "--tdb2", "--compact", "/ds");
-        try(TypedInputStream x = HttpOp.execHttpPostStream(serverURL+"/$/compact/ds", null, "application/json")) {
-            assertNotNull(x);
-            assertNotEquals(0, x.readAllBytes().length);
+        try(TypedInputStream x0 = HttpOp.execHttpPostStream(serverURL+"/$/compact/ds", null, "application/json")) {
+            assertNotNull(x0);
+            assertNotEquals(0, x0.readAllBytes().length);
         }
+
+        String x1 = HttpOp.execHttpGetString(serverURL+"/$/tasks");
+        assertNotNull(x1);
+        JSON.parseAny(x1);
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/server-tdb2.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/server-tdb2.ttl
@@ -1,0 +1,30 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
+
+[] rdf:type fuseki:Server ;
+   fuseki:services   ( <#service1> ) ;
+   fuseki:pingEP     true ;
+   fuseki:statsEP    true ;
+   fuseki:metricsEP  true ;
+   fuseki:compactEP  true ;
+.
+
+<#service1> rdf:type fuseki:Service ;
+    fuseki:name         "ds" ;
+    fuseki:endpoint     [
+       fuseki:operation  fuseki:query;
+       fuseki:name       "" ;
+    ] ;
+    fuseki:dataset      <#emptyDataset> ;
+.
+
+<#emptyDataset> rdf:type tdb2:DatasetTDB ;
+    tdb2:location "--mem--" ;
+.

--- a/jena-fuseki2/jena-fuseki-main/testing/FusekiEmbedded/tdb2-config.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/FusekiEmbedded/tdb2-config.ttl
@@ -1,0 +1,19 @@
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
+
+<#serviceInMemory> rdf:type fuseki:Service;
+    rdfs:label "test";
+    fuseki:name "FuTest";
+    fuseki:serviceQuery "query";
+    fuseki:serviceUpdate "update";
+    fuseki:serviceUpload "upload" ;
+    fuseki:dataset <#dataset> ;
+.
+
+<#dataset> rdf:type tdb2:DatasetTDB ;
+    tdb2:location "--mem--" ;
+.

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/WEB-INF/web.xml
@@ -210,7 +210,7 @@
   
   <servlet>
     <servlet-name>ActionCompact</servlet-name>
-    <servlet-class>org.apache.jena.fuseki.mgt.ActionCompact</servlet-class>
+    <servlet-class>org.apache.jena.fuseki.ctl.ActionCompact</servlet-class>
   </servlet>
 
   <!-- An action that only creates a background task that sleeps. -->


### PR DESCRIPTION
Compaction can be a very important feature. But, if you're using something like rdf-delta to run your fuseki server, you don't have any way to run compaction while the server is still running. This PR moves the `/$/compact/*` endpoint from the webapp into main so that it can be supplied even when the non-full version of Fuseki is being used.