### PR TITLE
Handle shortened IpV6 as resolved by chrome

### DIFF
--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/authz/LocalhostFilter.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/authz/LocalhostFilter.java
@@ -53,14 +53,14 @@ public class LocalhostFilter extends AuthorizationFilter403 {
 
     private static String LOCALHOST_IpV6_a = "[0:0:0:0:0:0:0:1]";
     private static String LOCALHOST_IpV6_b = "0:0:0:0:0:0:0:1";
+    private static String LOCALHOST_IpV6_c = "[::1]";
     private static String LOCALHOST_IpV4 =  "127.0.0.1";   // Strictly, 127.*.*.*
 
     private static final Collection<String> localhosts = new HashSet<>(
-        Arrays.asList(LOCALHOST_IpV4, LOCALHOST_IpV6_a, LOCALHOST_IpV6_b));  
+        Arrays.asList(LOCALHOST_IpV4, LOCALHOST_IpV6_a, LOCALHOST_IpV6_b, LOCALHOST_IpV6_c));
 
     @Override
     protected boolean isAccessAllowed(ServletRequest request, ServletResponse response, Object mappedValue) throws Exception {
-        String remoteAddr = request.getRemoteAddr();
         return localhosts.contains(request.getRemoteAddr());
     }
 }


### PR DESCRIPTION
Chrome browser appears to resolve localhost as IpV6 in the form [::1] which does not work as part of the `LocalhostFilter` and we get 403 forbidden
OS: Ubuntu 20.04.2 LTS
Browser: Chrome 89.0.4389.90