### PR TITLE
JENA-2094: Run tests in strict environment

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileStd.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileStd.java
@@ -105,16 +105,14 @@ public class ParserProfileStd implements ParserProfile
             return iri;
         } catch (IRIException ex) {
             // This should only be errors and the errorHandler may be set to "don't continue".
+            // if it does continue, assume it prints something.
             if ( SystemIRIx.getProvider() instanceof IRIProviderJenaIRI )
-                // Checking did this error/warning.
+                // Checking using JenaIRI puts the URI string in the message.
                 // Puts the IRI in the message.
                 errorHandler.error("Bad IRI: "+ex.getMessage(), line, col);
             else
                 // Does not put the IRI in the message.
                 errorHandler.error("Bad IRI: <" + uriStr + "> : "+ex.getMessage(), line, col);
-//            // Error handler let it pass, but should have printed something so don't out duplicate messages.
-//            if ( checking )
-//                doChecking(null, uriStr, line, col);
             return IRIx.createAny(uriStr);
         }
     }

--- a/jena-core/src/test/java/org/apache/jena/irix/AbstractTestIRIx.java
+++ b/jena-core/src/test/java/org/apache/jena/irix/AbstractTestIRIx.java
@@ -27,7 +27,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.runners.Parameterized.Parameters;
 
-/** Test suite driver for IRIx */
+/** Test suite driver for IRIx.
+ * The test execution environment is set to be "strict".
+ * Tests can change this; it is reset after each test.
+ */
 public class AbstractTestIRIx {
 
     @Parameters(name = "{index}: {0}")
@@ -42,8 +45,10 @@ public class AbstractTestIRIx {
     }
 
     protected static void setProvider(IRIProvider provider) {
-        provider.strictMode("urn", true);
+        provider.strictMode("http", true);
+        provider.strictMode("urn",  true);
         provider.strictMode("file", true);
+        provider.strictMode("did",  true);
         SystemIRIx.setProvider(provider);
     }
 
@@ -60,20 +65,41 @@ public class AbstractTestIRIx {
     private final IRIProvider provider;
     private static IRIProvider systemProvider;
 
-    @BeforeClass static public void beforeClass() {
+    // Strictness is managed statically by providers.
+    private static boolean StrictHTTP;
+    private static boolean StrictURN;
+    private static boolean StrictFILE;
+    private static boolean StrictDID;
+
+    @BeforeClass static public void beforeClass_StoreSystemProvider() {
         systemProvider = getProvider();
+        StrictHTTP = systemProvider.isStrictMode("http");
+        StrictURN  = systemProvider.isStrictMode("urn");
+        StrictFILE = systemProvider.isStrictMode("file");
+        StrictDID  = systemProvider.isStrictMode("did");
     }
 
-    @AfterClass static public void afterClass() {
-        setProvider(systemProvider);
+    @AfterClass static public void afterClass_RestoreSystemProvider() {
+        restore();
     }
 
-    @Before public void beforeTest() {
-        systemProvider = getProvider();
+    @Before public void beforeTest_setStrict() {
+        provider.strictMode("http", true);
+        provider.strictMode("urn",  true);
+        provider.strictMode("file", true);
+        provider.strictMode("did",  true);
         setProvider(provider);
     }
 
-    @After public void afterTest() {
+    @After public void afterTest_restoreSystemProvider() {
+        restore();
+    }
+
+    private static void restore() {
+        systemProvider.strictMode("http", StrictHTTP);
+        systemProvider.strictMode("urn",  StrictURN);
+        systemProvider.strictMode("file", StrictFILE);
+        systemProvider.strictMode("did",  StrictDID);
         setProvider(systemProvider);
     }
 


### PR DESCRIPTION
PR #986 fixed the problem reported but it broke some test that run in "strict" mode ("strict" mode validates the IRIProvider, not the way Jena uses it). 

This PR runs the TS_IRIx tests in strict mode.

