### PR TITLE
JENA-1262: Sorting of prefixes in Turtle serializer

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
@@ -269,12 +269,13 @@ public class RiotLib
 
     /** Write prefixes */
     public static void writePrefixes(IndentedWriter out, PrefixMap prefixMap, boolean newStyle) {
-        if ( prefixMap != null && !prefixMap.isEmpty() ) {
-            for ( Map.Entry<String, String> e : prefixMap.getMapping().entrySet() ) {
-                if ( newStyle )
-                    writePrefixNewStyle(out, e.getKey(), e.getValue());
-                else
-                    writePrefixOldStyle(out, e.getKey(), e.getValue());
+        if (prefixMap != null && !prefixMap.isEmpty()) {
+            int maxPrefixLenght = prefixMap.getMapping().keySet().stream()
+                    .map(String::length)
+                    .max(Comparator.naturalOrder())
+                    .orElse(0);
+            for (Map.Entry<String, String> e : sortPrefixes(prefixMap)) {
+                writePrefix(out, e.getKey(), e.getValue(), newStyle, maxPrefixLenght);
             }
         }
     }
@@ -283,10 +284,14 @@ public class RiotLib
      * Write using {@code @prefix} or {@code PREFIX}.
      */
     public static void writePrefix(IndentedWriter out, String prefix, String uri, boolean newStyle) {
-        if ( newStyle )
-            writePrefixNewStyle(out, prefix, uri);
+        writePrefix(out, prefix, uri, newStyle, 0);
+    }
+
+    private static void writePrefix(IndentedWriter out, String prefix, String uri, boolean newStyle, int maxPrefixLenght) {
+        if (newStyle)
+            writePrefixNewStyle(out, prefix, uri, maxPrefixLenght);
         else
-            writePrefixOldStyle(out, prefix, uri);
+            writePrefixOldStyle(out, prefix, uri, maxPrefixLenght);
     }
 
     /** Write prefix, using {@code PREFIX} */
@@ -294,7 +299,7 @@ public class RiotLib
         out.print("PREFIX ");
         out.print(prefix);
         out.print(": ");
-        out.pad(PREFIX_IRI);
+        out.pad(9 + intent); // 9 e.q. length of "PREFIX" plus ": "
         out.print("<");
         out.print(uri);
         out.print(">");
@@ -306,7 +311,7 @@ public class RiotLib
         out.print("@prefix ");
         out.print(prefix);
         out.print(": ");
-        out.pad(PREFIX_IRI);
+        out.pad(10 + intent); // 10 e.q. length of "@prefix" plus ": "
         out.print("<");
         out.print(uri);
         out.print(">");

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotLib.java
@@ -18,20 +18,6 @@
 
 package org.apache.jena.riot.system;
 
-import static org.apache.jena.riot.RDFLanguages.NQUADS;
-import static org.apache.jena.riot.RDFLanguages.NTRIPLES;
-import static org.apache.jena.riot.RDFLanguages.RDFJSON;
-import static org.apache.jena.riot.RDFLanguages.sameLang;
-import static org.apache.jena.riot.writer.WriterConst.PREFIX_IRI;
-import static org.apache.jena.riot.writer.WriterConst.RDF_type;
-import static org.apache.jena.riot.writer.WriterConst.rdfNS;
-
-import java.io.OutputStream;
-import java.io.Writer;
-import java.util.*;
-import java.util.function.Function;
-import java.util.function.Predicate;
-
 import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Graph;
@@ -52,48 +38,65 @@ import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.NodeFactoryExtra;
 import org.apache.jena.util.iterator.ExtendedIterator;
 
-/** Misc RIOT code */
-public class RiotLib
-{
+import java.io.OutputStream;
+import java.io.Writer;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.apache.jena.riot.RDFLanguages.*;
+import static org.apache.jena.riot.writer.WriterConst.PREFIX_IRI;
+
+/**
+ * Misc RIOT code
+ */
+public class RiotLib {
     // ---- BlankNode skolemization as IRIs
     private final static boolean skolomizedBNodes = ARQ.isTrueOrUndef(ARQ.constantBNodeLabels);
-    /** "Skolemize" to a node.
+
+    /**
+     * "Skolemize" to a node.
      * Returns a Node_URI.
      */
     public static Node blankNodeToIri(Node node) {
-        if ( node.isBlank() )
+        if (node.isBlank())
             return NodeFactory.createURI(blankNodeToIriString(node));
         return node;
     }
 
-    /** "Skolemize" to a string. */
+    /**
+     * "Skolemize" to a string.
+     */
     public static String blankNodeToIriString(Node node) {
-        if ( node.isBlank() ) {
+        if (node.isBlank()) {
             String x = node.getBlankNodeLabel();
             return "_:" + x;
         }
-        if ( node.isURI())
+        if (node.isURI())
             return node.getURI();
         throw new RiotException("Not a blank node or URI");
     }
 
     private final static String bNodeLabelStart = "_:";
-    /** Implement {@code <_:....>} as a "Node IRI"
+
+    /**
+     * Implement {@code <_:....>} as a "Node IRI"
      * that is, use the given label as the BNode internal label.
      * Use with care.
      * Returns a Node_URI.
      */
     public static Node createIRIorBNode(String str) {
         // Is it a bNode label? i.e. <_:xyz>
-        if ( skolomizedBNodes && isBNodeIRI(str) ) {
+        if (skolomizedBNodes && isBNodeIRI(str)) {
             String s = str.substring(bNodeLabelStart.length());
-            Node n = NodeFactory.createBlankNode(s);
-            return n;
+            return NodeFactory.createBlankNode(s);
         }
         return NodeFactory.createURI(str);
     }
 
-    /** Test whether a IRI is a ARQ-encoded blank node. */
+    /**
+     * Test whether a IRI is a ARQ-encoded blank node.
+     */
     public static boolean isBNodeIRI(String iri) {
         return iri.startsWith(bNodeLabelStart);
     }
@@ -101,111 +104,133 @@ public class RiotLib
     private static final String URI_PREFIX_FIXUP = "::";
 
     // These two must be in-step.
-    /** Function applied to undefined prefixes to convert to a URI string */
-    public static final Function<String,String> fixupPrefixes      = (x) -> URI_PREFIX_FIXUP.concat(x);
+    /**
+     * Function applied to undefined prefixes to convert to a URI string
+     */
+    public static final Function<String, String> fixupPrefixes = URI_PREFIX_FIXUP::concat;
 
-    /** Function to test for undefined prefix URIs*/
-    public static final Predicate<String> testFixupedPrefixURI     = (x) -> x.startsWith(URI_PREFIX_FIXUP);
+    /**
+     * Function to test for undefined prefix URIs
+     */
+    public static final Predicate<String> testFixupedPrefixURI = (x) -> x.startsWith(URI_PREFIX_FIXUP);
 
-    /** Test whether a IRI is a ARQ-encoded blank node. */
+    /**
+     * Test whether a IRI is a ARQ-encoded blank node.
+     */
     public static boolean isPrefixIRI(String iri) {
         return testFixupedPrefixURI.test(iri);
     }
 
-    /** Convert an prefix name (qname) to an IRI, for when the prerix is nor defined.
+    /**
+     * Convert an prefix name (qname) to an IRI, for when the prerix is nor defined.
+     *
      * @see ARQ#fixupUndefinedPrefixes
      */
     public static String fixupPrefixIRI(String prefix, String localPart) {
-        return fixupPrefixIRI(prefix+":"+localPart);
+        return fixupPrefixIRI(prefix + ":" + localPart);
     }
 
-    /** Convert an prefix name (qname) to an IRI, for when the prefix is not defined.
+    /**
+     * Convert an prefix name (qname) to an IRI, for when the prefix is not defined.
+     *
      * @see ARQ#fixupUndefinedPrefixes
      */
     public static String fixupPrefixIRI(String prefixedName) {
         return fixupPrefixes.apply(prefixedName);
     }
 
-    /** Parse a string to get one Node (the first token in the string) */
+    /**
+     * Parse a string to get one Node (the first token in the string)
+     */
     public static Node parse(String string) {
         return NodeFactoryExtra.parseNode(string, null);
     }
 
-    public static ParserProfile profile(Lang lang, String baseIRI, ErrorHandler handler)
-    {
-        if ( sameLang(NTRIPLES, lang) || sameLang(NQUADS, lang) )
-        {
+    public static ParserProfile profile(Lang lang, String baseIRI, ErrorHandler handler) {
+        if (sameLang(NTRIPLES, lang) || sameLang(NQUADS, lang)) {
             boolean checking = SysRIOT.isStrictMode();
             // If strict mode, do checking e.g. URIs
             return profile(baseIRI, false, checking, handler);
         }
-        if ( sameLang(RDFJSON, lang) )
+        if (sameLang(RDFJSON, lang))
             return profile(baseIRI, false, true, handler);
         return profile(baseIRI, true, true, handler);
     }
 
-    /** Create a parser profile for the given setup */
+    /**
+     * Create a parser profile for the given setup
+     */
     private static ParserProfile profile(String baseIRI, boolean resolveIRIs, boolean checking, ErrorHandler handler) {
         LabelToNode labelToNode = SyntaxLabels.createLabelToNode();
         IRIx base = resolveIRIs
                 ? IRIs.resolveIRI(baseIRI)
                 : IRIx.create(baseIRI);
-        IRIxResolver resolver = IRIxResolver.create(base).resolve(resolveIRIs).allowRelative(false).build();
-        ParserProfile profile = RiotLib.createParserProfile(factoryRDF(labelToNode), handler, resolver, checking);
-        return profile;
+        IRIxResolver resolver = IRIxResolver
+                .create(base)
+                .resolve(resolveIRIs)
+                .allowRelative(false)
+                .build();
+        return RiotLib.createParserProfile(factoryRDF(labelToNode), handler, resolver, checking);
     }
 
-    /** Create a new (not influenced by anything else) {@code FactoryRDF}
+    /**
+     * Create a new (not influenced by anything else) {@code FactoryRDF}
      * using the label to blank node scheme provided.
      */
     public static FactoryRDF factoryRDF(LabelToNode labelMapping) {
         return new FactoryRDFCaching(FactoryRDFCaching.DftNodeCacheSize, labelMapping);
     }
 
-    /** Create a new (not influenced by anything else) {@code FactoryRDF}
+    /**
+     * Create a new (not influenced by anything else) {@code FactoryRDF}
      * using the default label to blank node scheme.
      */
     public static FactoryRDF factoryRDF() {
         return factoryRDF(SyntaxLabels.createLabelToNode());
     }
 
-    /** Create a {@link ParserProfile} with default settings. */
+    /**
+     * Create a {@link ParserProfile} with default settings.
+     */
     public static ParserProfile dftProfile() {
         return createParserProfile(RiotLib.factoryRDF(), ErrorHandlerFactory.errorHandlerStd, true);
     }
 
-    /** Create a {@link ParserProfile} with default settings, and a specific error handler. */
-    public static ParserProfile createParserProfile(ErrorHandler errorHandler) {
-        return createParserProfile(RiotLib.factoryRDF(), errorHandler, true);
-    }
-
-    /** Create a {@link ParserProfile} with default settings, and a specific error handler. */
+    /**
+     * Create a {@link ParserProfile} with default settings, and a specific error handler.
+     */
     public static ParserProfile createParserProfile(FactoryRDF factory, ErrorHandler errorHandler, boolean checking) {
         return new ParserProfileStd(factory,
-                                    errorHandler,
-                                    IRIxResolver.create(IRIs.getSystemBase()).build(),
-                                    PrefixMapFactory.create(),
-                                    RIOT.getContext().copy(),
-                                    checking, false);
+                errorHandler,
+                IRIxResolver.create(IRIs.getSystemBase()).build(),
+                PrefixMapFactory.create(),
+                RIOT.getContext().copy(),
+                checking, false);
     }
 
-    /** Create a {@link ParserProfile}. */
+    /**
+     * Create a {@link ParserProfile}.
+     */
     public static ParserProfile createParserProfile(FactoryRDF factory, ErrorHandler errorHandler,
                                                     IRIxResolver resolver, boolean checking) {
         return new ParserProfileStd(factory,
-                                    errorHandler,
-                                    resolver,
-                                    PrefixMapFactory.create(),
-                                    RIOT.getContext().copy(),
-                                    checking, false);
+                errorHandler,
+                resolver,
+                PrefixMapFactory.create(),
+                RIOT.getContext().copy(),
+                checking, false);
     }
 
-    /** Get triples with the same subject */
+    /**
+     * Get triples with the same subject
+     */
     public static Collection<Triple> triplesOfSubject(Graph graph, Node subj) {
         return triples(graph, subj, Node.ANY, Node.ANY);
     }
 
-    /** Get all the triples for the graph.find */
+    /**
+     * Get all the triples for the graph.find
+     */
     public static List<Triple> triples(Graph graph, Node s, Node p, Node o) {
         List<Triple> acc = new ArrayList<>();
         accTriples(acc, graph, s, p, o);
@@ -215,8 +240,11 @@ public class RiotLib
     /* Count the triples for the graph.find */
     public static long countTriples(Graph graph, Node s, Node p, Node o) {
         ExtendedIterator<Triple> iter = graph.find(s, p, o);
-        try { return Iter.count(iter); }
-        finally { iter.close(); }
+        try {
+            return Iter.count(iter);
+        } finally {
+            iter.close();
+        }
     }
 
     /* Count the matches to a pattern across the dataset  */
@@ -225,27 +253,25 @@ public class RiotLib
         return Iter.count(iter);
     }
 
-    /** Collect all the matching triples */
+    /**
+     * Collect all the matching triples
+     */
     public static void accTriples(Collection<Triple> acc, Graph graph, Node s, Node p, Node o) {
         ExtendedIterator<Triple> iter = graph.find(s, p, o);
-        for (; iter.hasNext(); )
+        while (iter.hasNext())
             acc.add(iter.next());
         iter.close();
     }
 
-    public static boolean strSafeFor(String str, char ch) {
-        return str.indexOf(ch) == -1;
-    }
-
     public static void writeBase(IndentedWriter out, String base, boolean newStyle) {
-        if ( newStyle )
+        if (newStyle)
             writeBaseNewStyle(out, base);
         else
             writeBaseOldStyle(out, base);
     }
 
     private static void writeBaseNewStyle(IndentedWriter out, String base) {
-        if ( base != null ) {
+        if (base != null) {
             out.print("BASE ");
             out.pad(PREFIX_IRI);
             out.print("<");
@@ -256,7 +282,7 @@ public class RiotLib
     }
 
     private static void writeBaseOldStyle(IndentedWriter out, String base) {
-        if ( base != null ) {
+        if (base != null) {
             out.print("@base ");
             out.pad(PREFIX_IRI);
             out.print("<");
@@ -267,7 +293,9 @@ public class RiotLib
         }
     }
 
-    /** Write prefixes */
+    /**
+     * Write prefixes
+     */
     public static void writePrefixes(IndentedWriter out, PrefixMap prefixMap, boolean newStyle) {
         if (prefixMap != null && !prefixMap.isEmpty()) {
             int maxPrefixLenght = prefixMap.getMapping().keySet().stream()
@@ -280,7 +308,17 @@ public class RiotLib
         }
     }
 
-    /** Write a prefix.
+    /**
+     * Sort the entries of a prefix map by their key
+     */
+    private static List<Map.Entry<String, String>> sortPrefixes(PrefixMap prefixMap) {
+        List<Map.Entry<String, String>> prefixesMappings = new ArrayList<>(prefixMap.getMapping().entrySet());
+        prefixesMappings.sort(Map.Entry.comparingByKey());
+        return prefixesMappings;
+    }
+
+    /**
+     * Write a prefix.
      * Write using {@code @prefix} or {@code PREFIX}.
      */
     public static void writePrefix(IndentedWriter out, String prefix, String uri, boolean newStyle) {
@@ -294,8 +332,10 @@ public class RiotLib
             writePrefixOldStyle(out, prefix, uri, maxPrefixLenght);
     }
 
-    /** Write prefix, using {@code PREFIX} */
-    private static void writePrefixNewStyle(IndentedWriter out, String prefix, String uri) {
+    /**
+     * Write prefix, using {@code PREFIX}
+     */
+    private static void writePrefixNewStyle(IndentedWriter out, String prefix, String uri, int intent) {
         out.print("PREFIX ");
         out.print(prefix);
         out.print(": ");
@@ -306,8 +346,10 @@ public class RiotLib
         out.println();
     }
 
-    /** Write prefixes, using {@code @prefix} */
-    public static void writePrefixOldStyle(IndentedWriter out, String prefix, String uri) {
+    /**
+     * Write prefixes, using {@code @prefix}
+     */
+    public static void writePrefixOldStyle(IndentedWriter out, String prefix, String uri, int intent) {
         out.print("@prefix ");
         out.print(prefix);
         out.print(": ");
@@ -323,85 +365,50 @@ public class RiotLib
         return PrefixMapFactory.create(dsg.getDefaultGraph().getPrefixMapping());
     }
 
-    public static int calcWidth(PrefixMap prefixMap, String baseURI, Node p)
-    {
-        if ( ! prefixMap.containsPrefix(rdfNS) && RDF_type.equals(p) )
-            return 1;
-
-        String x = prefixMap.abbreviate(p.getURI());
-        if ( x == null )
-            return p.getURI().length()+2;
-        return x.length();
+    /**
+     * IndentedWriter over a java.io.Writer (better to use an IndentedWriter over an OutputStream)
+     */
+    public static IndentedWriter create(Writer writer) {
+        return new IndentedWriterWriter(writer);
     }
 
-    public static int calcWidth(PrefixMap prefixMap, String baseURI, Collection<Node> nodes, int minWidth, int maxWidth)
-    {
-        Node prev = null;
-        int nodeMaxWidth = minWidth;
+    public static PrefixMap prefixMap(Graph graph) {
+        return PrefixMapFactory.create(graph.getPrefixMapping());
+    }
 
-        for ( Node n : nodes )
-        {
-            if ( prev != null && prev.equals(n) )
-                continue;
-            int len = calcWidth(prefixMap, baseURI, n);
-            if ( len > maxWidth )
-                continue;
-            if ( nodeMaxWidth < len )
-                nodeMaxWidth = len;
-            prev = n;
+    public static WriterGraphRIOTBase adapter(WriterDatasetRIOT writer) {
+        return new WriterAdapter(writer);
+    }
+
+    /**
+     * Hidden to direct program to using OutputStreams (for RDF, that gets the charset right)
+     */
+    private static class IndentedWriterWriter extends IndentedWriter {
+        IndentedWriterWriter(Writer w) {
+            super(w);
         }
-        return nodeMaxWidth;
     }
 
-    public static int calcWidthTriples(PrefixMap prefixMap, String baseURI, Collection<Triple> triples, int minWidth, int maxWidth)
-    {
-        Node prev = null;
-        int nodeMaxWidth = minWidth;
-
-        for ( Triple triple : triples )
-        {
-            Node n = triple.getPredicate();
-            if ( prev != null && prev.equals(n) )
-                continue;
-            int len = calcWidth(prefixMap, baseURI, n);
-            if ( len > maxWidth )
-                continue;
-            if ( nodeMaxWidth < len )
-                nodeMaxWidth = len;
-            prev = n;
-        }
-        return nodeMaxWidth;
-    }
-
-    /** IndentedWriter over a java.io.Writer (better to use an IndentedWriter over an OutputStream) */
-    public static IndentedWriter create(Writer writer)  { return new IndentedWriterWriter(writer); }
-
-    public static PrefixMap prefixMap(Graph graph)      { return PrefixMapFactory.create(graph.getPrefixMapping()); }
-
-    public static WriterGraphRIOTBase adapter(WriterDatasetRIOT writer)
-    { return new WriterAdapter(writer); }
-
-    /** Hidden to direct program to using OutputStreams (for RDF, that gets the charset right) */
-    private static class IndentedWriterWriter extends IndentedWriter
-    {
-        IndentedWriterWriter(Writer w) { super(w); }
-    }
-
-    private static class WriterAdapter extends WriterGraphRIOTBase
-    {
+    private static class WriterAdapter extends WriterGraphRIOTBase {
         private WriterDatasetRIOT writer;
 
-        WriterAdapter(WriterDatasetRIOT writer) { this.writer = writer; }
-        @Override
-        public Lang getLang()
-        { return writer.getLang(); }
+        WriterAdapter(WriterDatasetRIOT writer) {
+            this.writer = writer;
+        }
 
         @Override
-        public void write(OutputStream out, Graph graph, PrefixMap prefixMap, String baseURI, Context context)
-        { writer.write(out, DatasetGraphFactory.wrap(graph), prefixMap, baseURI, context); }
+        public Lang getLang() {
+            return writer.getLang();
+        }
 
         @Override
-        public void write(Writer out, Graph graph, PrefixMap prefixMap, String baseURI, Context context)
-        { writer.write(out, DatasetGraphFactory.wrap(graph), prefixMap, baseURI, context); }
+        public void write(OutputStream out, Graph graph, PrefixMap prefixMap, String baseURI, Context context) {
+            writer.write(out, DatasetGraphFactory.wrap(graph), prefixMap, baseURI, context);
+        }
+
+        @Override
+        public void write(Writer out, Graph graph, PrefixMap prefixMap, String baseURI, Context context) {
+            writer.write(out, DatasetGraphFactory.wrap(graph), prefixMap, baseURI, context);
+        }
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TS_RiotSystem.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TS_RiotSystem.java
@@ -18,9 +18,9 @@
 
 package org.apache.jena.riot.system;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
-import org.junit.runners.Suite.SuiteClasses ;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
 /**
  * Test suite for RIOT system
@@ -45,6 +45,7 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestJsonLDReadWrite.class         // Some simple testing of the jsonld-java engine.
     , TestSerializable.class
     , TestIRIxRIOT.class
+    , TestRiotLib.class
 })
 
 public class TS_RiotSystem

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestRiotLib.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestRiotLib.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.atlas.io.IndentedLineBuffer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestRiotLib {
+
+    private PrefixMap prefixMap;
+
+    @Before
+    public void setupMaps() {
+        // Mappings from requirement JENA-1262
+        this.prefixMap = new PrefixMapStd();
+        this.prefixMap.add("lcc-3166-1", "http://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/");
+        this.prefixMap.add("dct", "http://purl.org/dc/terms/");
+        this.prefixMap.add("owl", "http://www.w3.org/2002/07/owl#");
+        this.prefixMap.add("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+        this.prefixMap.add("lcc-3166-2", "http://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/");
+        this.prefixMap.add("xsd", "http://www.w3.org/2001/XMLSchema#");
+        this.prefixMap.add("skos", "http://www.w3.org/2004/02/skos/core#");
+        this.prefixMap.add("sm", "http://www.omg.org/techprocess/ab/SpecificationMetadata/");
+        this.prefixMap.add("rdfs", "http://www.w3.org/2000/01/rdf-schema#");
+        this.prefixMap.add("lcc-lr", "http://www.omg.org/spec/LCC/Languages/LanguageRepresentation/");
+        this.prefixMap.add("lcc-cr", "http://www.omg.org/spec/LCC/Countries/CountryRepresentation/");
+    }
+
+    // Expected result transformed into new style from requirement JENA-1262
+    private static final String expectedNewStyle = "PREFIX dct:        <http://purl.org/dc/terms/>\n" +
+            "PREFIX lcc-3166-1: <http://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/>\n" +
+            "PREFIX lcc-3166-2: <http://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/>\n" +
+            "PREFIX lcc-cr:     <http://www.omg.org/spec/LCC/Countries/CountryRepresentation/>\n" +
+            "PREFIX lcc-lr:     <http://www.omg.org/spec/LCC/Languages/LanguageRepresentation/>\n" +
+            "PREFIX owl:        <http://www.w3.org/2002/07/owl#>\n" +
+            "PREFIX rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n" +
+            "PREFIX rdfs:       <http://www.w3.org/2000/01/rdf-schema#>\n" +
+            "PREFIX skos:       <http://www.w3.org/2004/02/skos/core#>\n" +
+            "PREFIX sm:         <http://www.omg.org/techprocess/ab/SpecificationMetadata/>\n" +
+            "PREFIX xsd:        <http://www.w3.org/2001/XMLSchema#>\n";
+
+    // Expected result from requirement JENA-1262
+    private static final String expectedOldStyle = "@prefix dct:        <http://purl.org/dc/terms/> .\n" +
+            "@prefix lcc-3166-1: <http://www.omg.org/spec/LCC/Countries/ISO3166-1-CountryCodes/> .\n" +
+            "@prefix lcc-3166-2: <http://www.omg.org/spec/LCC/Countries/ISO3166-2-SubdivisionCodes/> .\n" +
+            "@prefix lcc-cr:     <http://www.omg.org/spec/LCC/Countries/CountryRepresentation/> .\n" +
+            "@prefix lcc-lr:     <http://www.omg.org/spec/LCC/Languages/LanguageRepresentation/> .\n" +
+            "@prefix owl:        <http://www.w3.org/2002/07/owl#> .\n" +
+            "@prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
+            "@prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .\n" +
+            "@prefix skos:       <http://www.w3.org/2004/02/skos/core#> .\n" +
+            "@prefix sm:         <http://www.omg.org/techprocess/ab/SpecificationMetadata/> .\n" +
+            "@prefix xsd:        <http://www.w3.org/2001/XMLSchema#> .\n";
+
+    @Test
+    public void sortPrefixesNewStyle() {
+        IndentedLineBuffer writer = new IndentedLineBuffer();
+        RiotLib.writePrefixes(writer, prefixMap, true);
+
+        String result = writer.asString();
+
+        Assert.assertEquals(expectedNewStyle, result);
+    }
+
+    @Test
+    public void sortPrefixesOldStyle() {
+        IndentedLineBuffer writer = new IndentedLineBuffer();
+        RiotLib.writePrefixes(writer, prefixMap, false);
+
+        String result = writer.asString();
+
+        Assert.assertEquals(expectedOldStyle, result);
+    }
+}


### PR DESCRIPTION
With [Jena-1262](https://issues.apache.org/jira/browse/JENA-1262) the Turtle serialization is improved.
In this PR I've implemented the first section of the ticket, which requires the prefixes to be sorted and aligned.
Also, I've removed unused code and reformated the RiotLib.java file

The second part needs refinement, I will start a discussion within the ticket.