### PR TITLE
JENA-2132 - Added RDFStar/NodeTriple handling to Rename.java

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/Rename.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/Rename.java
@@ -21,8 +21,12 @@ package org.apache.jena.sparql.engine;
 import java.util.Collection ;
 import java.util.HashMap ;
 import java.util.Map ;
+import java.util.Objects;
 import java.util.Set ;
 import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Node_Triple;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.ARQConstants ;
 import org.apache.jena.sparql.algebra.Op ;
 import org.apache.jena.sparql.core.Var ;
@@ -117,7 +121,13 @@ public class Rename
         
         @Override
         public final Node apply(Node node) {
-            if ( ! Var.isVar(node) ) return node ;
+            if ( node.isNodeTriple() ) {
+                Triple t1 = node.getTriple();
+                Triple t2 = NodeTransformLib.transform(this, t1);
+                return Objects.equals(t1, t2) ? node : NodeFactory.createTripleNode(t2);
+            } else if ( ! Var.isVar(node) ) {
+                return node ;
+            }
             if ( constants.contains(node) ) return node ;
 
             Var var = (Var)node ;
@@ -149,8 +159,14 @@ public class Rename
 
         @Override
         public Node apply(Node node) {
-            if ( !Var.isVar(node) )
+            if ( node.isNodeTriple() ) {
+                Triple t1 = node.getTriple();
+                Triple t2 = NodeTransformLib.transform(this, t1);
+                return Objects.equals(t1, t2) ? node : NodeFactory.createTripleNode(t2);
+            } else if ( !Var.isVar(node) ) {
                 return node ;
+            }
+
             Var var = (Var)node ;
             String varName = var.getName() ;
             

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestVarRename.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestVarRename.java
@@ -206,6 +206,32 @@ public class TestVarRename
             "    (bgp (triple ?/x ?/y ?/v))))" ;
         checkRename(queryString, opExpectedString) ;
     }
+
+
+    // JENA-2132 : Renaming must descend into RDFStar TripleNodes
+    @Test public void query_rename_08()
+    {
+        String queryString
+                = "SELECT COUNT(*) {\n"
+                + "  SELECT ?src {\n"
+                + "    ?src  <urn:connectedTo>  ?tgt .\n"
+                + "    << ?src <urn:connectedTo> ?tgt >>\n"
+                + "                  <urn:hasValue>  ?v\n"
+                + "  }\n"
+                + "}";
+
+        String opExpectedString
+                = "(project (?.1)\n"
+                + "  (extend ((?.1 ?.0))\n"
+                + "    (group () ((?.0 (count)))\n"
+                + "      (project (?src)\n"
+                + "        (bgp\n"
+                + "          (triple ?src <urn:connectedTo> ?/tgt)\n"
+                + "          (triple << ?src <urn:connectedTo> ?/tgt >> <urn:hasValue> ?/v)\n"
+                + "        )))))";
+
+        checkRename(queryString, opExpectedString) ;
+    }
     
     // JENA-1275
     @Test


### PR DESCRIPTION
Fix for [JENA-2132](https://issues.apache.org/jira/browse/JENA-2132)

The NodeTransformers now check for NodeTriple arguments and apply themselves recursively in that case.