### PR TITLE
JENA-1948: Limited JSON-LD 1.1 Reader

### DIFF
--- a/jena-arq/pom.xml
+++ b/jena-arq/pom.xml
@@ -69,6 +69,27 @@
       <artifactId>jsonld-java</artifactId>
     </dependency>
 
+    <!-- For Titanium JSON-LD 1.1 -->
+    <dependency>
+      <!-- Apache License -->
+      <groupId>com.apicatalog</groupId>
+      <artifactId>titanium-json-ld</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- Eclipse Public License 2.0 (category-B) -->
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!--  And an implementation : Eclipse Public License 2.0 (category-B) -->
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.json</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- End Titanium JSON-LD 1.1 -->
+    
     <!-- See parent POM. Our choice of version here. -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/jena-arq/src/main/java/org/apache/jena/riot/Lang.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/Lang.java
@@ -58,6 +58,8 @@ public class Lang
     /** <a href="http://www.w3.org/TR/json-ld/">JSON-LD</a>. */
     public static Lang JSONLD ;
 
+    public static Lang JSONLD11 ;
+
     /**
      * <a href="http://www.w3.org/TR/rdf-json/">RDF/JSON</a>.
      *  This is not <a href="http://www.w3.org/TR/json-ld/">JSON-LD</a>.

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
@@ -101,8 +101,7 @@ public class RDFLanguages
      * and requiring an explicit language name {@code RDFParser.forceLang(Lang.JSONLD11)...}
      */
     public static final String strLangJSONLD11     = "JSON-LD-11";
-    public static final Lang JSONLD11   = LangBuilder.create()
-                                                     .langName(strLangJSONLD11)
+    public static final Lang JSONLD11   = LangBuilder.create(strLangJSONLD11, "x/ld-json-11")
                                                      .addAltNames("JSONLD11")
                                                      .addFileExtensions("jsonld11")
                                                      .build();
@@ -189,6 +188,7 @@ public class RDFLanguages
         Lang.TURTLE     = RDFLanguages.TURTLE;
         Lang.TTL        = RDFLanguages.TTL;
         Lang.JSONLD     = RDFLanguages.JSONLD;
+        Lang.JSONLD11   = RDFLanguages.JSONLD11;
         Lang.RDFJSON    = RDFLanguages.RDFJSON;
         Lang.NQUADS     = RDFLanguages.NQUADS;
         Lang.NQ         = RDFLanguages.NQ;
@@ -220,6 +220,7 @@ public class RDFLanguages
         register(N3);
         register(NTRIPLES);
         register(JSONLD);
+        register(JSONLD11);
         register(RDFJSON);
         register(TRIG);
         register(NQUADS);

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
@@ -23,10 +23,11 @@ import static org.apache.jena.riot.WebContent.*;
 import java.util.*;
 
 import org.apache.jena.atlas.io.IO;
-import org.apache.jena.atlas.logging.Log ;
-import org.apache.jena.atlas.web.ContentType ;
-import org.apache.jena.atlas.web.MediaType ;
-import org.apache.jena.util.FileUtils ;
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.atlas.web.ContentType;
+import org.apache.jena.atlas.web.MediaType;
+import org.apache.jena.riot.lang.LangJSONLD11;
+import org.apache.jena.util.FileUtils;
 
 /**
  * Central registry of RDF languages and syntaxes.
@@ -36,50 +37,48 @@ import org.apache.jena.util.FileUtils ;
 public class RDFLanguages
 {
     // Display names
-    public static final String strLangRDFXML     = "RDF/XML" ;
-    public static final String strLangTurtle     = "Turtle" ;
-    public static final String strLangNTriples   = "N-Triples" ;
-    public static final String strLangN3         = "N3" ;
-    public static final String strLangRDFJSON    = "RDF/JSON" ;
-    public static final String strLangJSONLD     = "JSON-LD" ;
-    public static final String strLangNQuads     = "N-Quads" ;
-    public static final String strLangTriG       = "TriG" ;
+    public static final String strLangRDFXML     = "RDF/XML";
+    public static final String strLangTurtle     = "Turtle";
+    public static final String strLangNTriples   = "N-Triples";
+    public static final String strLangN3         = "N3";
+    public static final String strLangRDFJSON    = "RDF/JSON";
+    public static final String strLangJSONLD     = "JSON-LD";
+    public static final String strLangNQuads     = "N-Quads";
+    public static final String strLangTriG       = "TriG";
     public static final String strLangCSV        = "CSV";
     public static final String strLangTSV        = "TSV";
     public static final String strLangTriX       = "TriX";
     public static final String strLangRDFTHRIFT  = "RDF-THRIFT";
 
-    /*
-     * ".owl" is not a formally registered file extension for OWL
-     *  using RDF/XML. It was mentioned in OWL1 (when there was
-     *  formally only one syntax for publishing RDF).
+    /* ".owl" is not a formally registered file extension for OWL using RDF/XML. It
+     * was mentioned in OWL1 (when there was formally only one syntax for publishing
+     * RDF).
      *
      * OWL2 does not mention it.
      *
-     * ".owx" is the OWL direct XML syntax.
-     */
+     * ".owx" is the OWL direct XML syntax. */
 
     /** <a href="http://www.w3.org/TR/rdf-syntax-grammar/">RDF/XML</a> */
     public static final Lang RDFXML     = LangBuilder.create(strLangRDFXML, contentTypeRDFXML)
                                                      .addAltNames("RDFXML", "RDF/XML-ABBREV", "RDFXML-ABBREV")
                                                      .addFileExtensions("rdf", "owl", "xml")
-                                                     .build() ;
+                                                     .build();
 
     /** <a href="http://www.w3.org/TR/turtle/">Turtle</a>*/
     public static final Lang TURTLE     = LangBuilder.create(strLangTurtle, contentTypeTurtle)
                                                      .addAltNames("TTL")
                                                      .addAltContentTypes(contentTypeTurtleAlt1)
                                                      .addFileExtensions("ttl")
-                                                     .build() ;
+                                                     .build();
 
     /** Alternative constant for {@link #TURTLE} */
-    public static final Lang TTL        = TURTLE ;
+    public static final Lang TTL        = TURTLE;
 
     /** N3 (treat as Turtle) */
     public static final Lang N3         = LangBuilder.create(strLangN3, contentTypeN3)
                                                      .addAltContentTypes(contentTypeN3, contentTypeN3Alt1, contentTypeN3Alt2)
                                                      .addFileExtensions("n3")
-                                                     .build() ;
+                                                     .build();
 
     /** <a href="http://www.w3.org/TR/n-triples/">N-Triples</a>*/
     public static final Lang NTRIPLES   = LangBuilder.create(strLangNTriples, contentTypeNTriples)
@@ -87,48 +86,59 @@ public class RDFLanguages
                                                      // Remove? Causes more trouble than it's worth.
                                                      .addAltContentTypes(contentTypeNTriplesAlt)
                                                      .addFileExtensions("nt")
-                                                     .build() ;
+                                                     .build();
     /** Alternative constant for {@link #NTRIPLES} */
-    public static final Lang NT         = NTRIPLES ;
+    public static final Lang NT         = NTRIPLES;
 
     /** <a href="http://www.w3.org/TR/json-ld/">JSON-LD</a>. */
     public static final Lang JSONLD     = LangBuilder.create(strLangJSONLD, "application/ld+json")
                                                      .addAltNames("JSONLD")
                                                      .addFileExtensions("jsonld")
-                                                     .build() ;
+                                                     .build();
+
+    /*
+     * Short term - have JSON-LD as an additional language for reading only
+     * and requiring an explicit language name {@code RDFParser.forceLang(Lang.JSONLD11)...}
+     */
+    public static final String strLangJSONLD11     = "JSON-LD-11";
+    public static final Lang JSONLD11   = LangBuilder.create()
+                                                     .langName(strLangJSONLD11)
+                                                     .addAltNames("JSONLD11")
+                                                     .addFileExtensions("jsonld11")
+                                                     .build();
 
     /** <a href="http://www.w3.org/TR/rdf-json/">RDF/JSON</a>.  This is not <a href="http://www.w3.org/TR/json-ld/">JSON-LD</a>. */
     public static final Lang RDFJSON    = LangBuilder.create(strLangRDFJSON, contentTypeRDFJSON)
                                                      .addAltNames("RDFJSON")
                                                      .addFileExtensions("rj")
-                                                     .build() ;
+                                                     .build();
 
     /** <a href="http://www.w3.org/TR/trig/">TriG</a> */
     public static final Lang TRIG       = LangBuilder.create(strLangTriG, contentTypeTriG)
                                                      .addAltContentTypes(contentTypeTriGAlt1)
                                                      .addFileExtensions("trig")
-                                                     .build() ;
+                                                     .build();
 
     /** <a href="http://www.w3.org/TR/n-quads">N-Quads</a> */
     public static final Lang NQUADS     = LangBuilder.create(strLangNQuads, contentTypeNQuads)
                                                      .addAltNames("NQ", "NQuads", "NQuad", "N-Quad", "N-Quads")
                                                      .addAltContentTypes(contentTypeNQuadsAlt1)
                                                      .addFileExtensions("nq")
-                                                     .build() ;
+                                                     .build();
 
     /** Alternative constant {@link #NQUADS} */
-    public static final Lang NQ         = NQUADS ;
+    public static final Lang NQ         = NQUADS;
 
     /** The RDF syntax <a href="https://jena.apache.org/documentation/io/rdf-binary.html">RDF Thrift</a> */
     public static final Lang RDFTHRIFT  = LangBuilder.create(strLangRDFTHRIFT, contentTypeRDFThrift)
                                                      .addAltNames("RDF_THRIFT", "RDFTHRIFT", "RDF/THRIFT", "TRDF")
                                                      .addFileExtensions("rt", "trdf")
-                                                     .build() ;
+                                                     .build();
     /** Text */
     public static final Lang TEXT       = LangBuilder.create("text", contentTypeTextPlain)
                                                      .addAltNames("TEXT")
                                                      .addFileExtensions("txt")
-                                                     .build() ;
+                                                     .build();
 
     /** TriX */
     public static final Lang TRIX       = LangBuilder.create(strLangTriX, contentTypeTriX)
@@ -136,12 +146,12 @@ public class RDFLanguages
                                                      .addAltNames("TRIX", "trix")
                                                      // Extension "xml" is used for RDF/XML.
                                                      .addFileExtensions("trix")
-                                                     .build() ;
+                                                     .build();
 
     /** The "null" language */
     public static final Lang RDFNULL    = LangBuilder.create("rdf/null", "null/rdf")
                                                      .addAltNames("NULL", "null")
-                                                     .build() ;
+                                                     .build();
 
     /** <a href="https://w3c.github.io/shacl/shacl-compact-syntax/">SHACL Compact Syntax</a> (2020-07-01) */
     public static final Lang SHACLC     = LangBuilder.create("SHACLC", "text/shaclc")
@@ -152,7 +162,7 @@ public class RDFLanguages
     // ---- Central registry
 
     /** Mapping of colloquial name to language */
-    private static Map<String, Lang> mapLabelToLang                    = new HashMap<>() ;
+    private static Map<String, Lang> mapLabelToLang                    = new HashMap<>();
 
     // For testing mainly.
     public static Collection<Lang> getRegisteredLanguages() {
@@ -160,108 +170,105 @@ public class RDFLanguages
     }
 
     /** Mapping of content type (main and alternatives) to language */
-    private static Map<String, Lang> mapContentTypeToLang              = new HashMap<>() ;
+    private static Map<String, Lang> mapContentTypeToLang              = new HashMap<>();
 
     /** Mapping of file extension to language */
-    private static Map<String, Lang> mapFileExtToLang                  = new HashMap<>() ;
+    private static Map<String, Lang> mapFileExtToLang                  = new HashMap<>();
 
     // ----------------------
     public static void init() {}
-    static { init$() ; }
+    static { init$(); }
 
     private static synchronized void init$() {
-        initStandard() ;
+        initStandard();
         // Needed to avoid a class initialization loop.
-        Lang.RDFXML     = RDFLanguages.RDFXML ;
-        Lang.NTRIPLES   = RDFLanguages.NTRIPLES ;
-        Lang.NT         = RDFLanguages.NT ;
-        Lang.N3         = RDFLanguages.N3 ;
-        Lang.TURTLE     = RDFLanguages.TURTLE ;
-        Lang.TTL        = RDFLanguages.TTL ;
-        Lang.JSONLD     = RDFLanguages.JSONLD ;
-        Lang.RDFJSON    = RDFLanguages.RDFJSON ;
-        Lang.NQUADS     = RDFLanguages.NQUADS ;
-        Lang.NQ         = RDFLanguages.NQ ;
-        Lang.TRIG       = RDFLanguages.TRIG ;
-        Lang.RDFTHRIFT  = RDFLanguages.RDFTHRIFT ;
-        Lang.TRIX       = RDFLanguages.TRIX ;
-        Lang.RDFNULL    = RDFLanguages.RDFNULL ;
-        Lang.SHACLC     = RDFLanguages.SHACLC ;
+        Lang.RDFXML     = RDFLanguages.RDFXML;
+        Lang.NTRIPLES   = RDFLanguages.NTRIPLES;
+        Lang.NT         = RDFLanguages.NT;
+        Lang.N3         = RDFLanguages.N3;
+        Lang.TURTLE     = RDFLanguages.TURTLE;
+        Lang.TTL        = RDFLanguages.TTL;
+        Lang.JSONLD     = RDFLanguages.JSONLD;
+        Lang.RDFJSON    = RDFLanguages.RDFJSON;
+        Lang.NQUADS     = RDFLanguages.NQUADS;
+        Lang.NQ         = RDFLanguages.NQ;
+        Lang.TRIG       = RDFLanguages.TRIG;
+        Lang.RDFTHRIFT  = RDFLanguages.RDFTHRIFT;
+        Lang.TRIX       = RDFLanguages.TRIX;
+        Lang.RDFNULL    = RDFLanguages.RDFNULL;
+        Lang.SHACLC     = RDFLanguages.SHACLC;
 
         // Used for result sets, not RDF syntaxes.
-
         Lang.CSV = LangBuilder.create(strLangCSV, contentTypeTextCSV)
             .addAltNames("csv")
             .addFileExtensions("csv")
-            .build() ;
+            .build();
         Lang.TSV = LangBuilder.create(strLangTSV, contentTypeTextTSV)
             .addAltNames("tsv")
             .addFileExtensions("tsv")
-            .build() ;
+            .build();
 
-
-   }
+        // JSON-LD 11
+        LangJSONLD11.Sys.init();
+    }
     // ----------------------
 
     /** Standard built-in languages */
-    private static void initStandard()
-    {
-        register(RDFXML) ;
-        register(TURTLE) ;
-        register(N3) ;
-        register(NTRIPLES) ;
-        register(JSONLD) ;
-        register(RDFJSON) ;
-        register(TRIG) ;
-        register(NQUADS) ;
-        register(RDFTHRIFT) ;
-        register(TRIX) ;
-        register(RDFNULL) ;
-        register(SHACLC) ;
+    private static void initStandard() {
+        register(RDFXML);
+        register(TURTLE);
+        register(N3);
+        register(NTRIPLES);
+        register(JSONLD);
+        register(RDFJSON);
+        register(TRIG);
+        register(NQUADS);
+        register(RDFTHRIFT);
+        register(TRIX);
+        register(RDFNULL);
+        register(SHACLC);
 
         // Check for JSON-LD engine.
-        String clsName = "com.github.jsonldjava.core.JsonLdProcessor" ;
+        String clsName = "com.github.jsonldjava.core.JsonLdProcessor";
         try {
-            Class.forName(clsName) ;
+            Class.forName(clsName);
         } catch (ClassNotFoundException ex) {
-            Log.warn(RDFLanguages.class, "java-jsonld classes not on the classpath - JSON-LD input-output not available.") ;
-            Log.warn(RDFLanguages.class, "Minimum jarfiles are jsonld-java, jackson-core, jackson-annotations") ;
-            Log.warn(RDFLanguages.class, "If using a Jena distribution, put all jars in the lib/ directory on the classpath") ;
-            return ;
+            Log.warn(RDFLanguages.class, "java-jsonld classes not on the classpath - JSON-LD input-output not available.");
+            Log.warn(RDFLanguages.class, "Minimum jarfiles are jsonld-java, jackson-core, jackson-annotations");
+            Log.warn(RDFLanguages.class, "If using a Jena distribution, put all jars in the lib/ directory on the classpath");
+            return;
         }
     }
 
-    /** Register a language.
+    /**
+     * Register a language.
      * To create a {@link Lang} object use {@link LangBuilder}.
-     * See also
-     * {@link RDFParserRegistry#registerLang}
-     * for registering a language and it's RDF parser factory.
+     * See also {@link RDFParserRegistry#registerLang} for registering a language and
+     * it's RDF parser factory.
      *
      * @see RDFParserRegistry
      */
-    public static void register(Lang lang)
-    {
+    public static void register(Lang lang) {
         if ( lang == null )
-            throw new IllegalArgumentException("null for language") ;
+            throw new IllegalArgumentException("null for language");
         // Expel previous registration.
         if ( isMimeTypeRegistered(lang) )
             unregister(lang);
 
-        checkRegistration(lang) ;
+        checkRegistration(lang);
 
-        mapLabelToLang.put(canonicalKey(lang.getLabel()),  lang) ;
+        mapLabelToLang.put(canonicalKey(lang.getLabel()), lang);
 
-        for (String altName : lang.getAltNames() )
-            mapLabelToLang.put(canonicalKey(altName), lang) ;
+        for ( String altName : lang.getAltNames() )
+            mapLabelToLang.put(canonicalKey(altName), lang);
 
-        mapContentTypeToLang.put(canonicalKey(lang.getContentType().getContentTypeStr()), lang) ;
+        mapContentTypeToLang.put(canonicalKey(lang.getContentType().getContentTypeStr()), lang);
         for ( String ct : lang.getAltContentTypes() )
-            mapContentTypeToLang.put(canonicalKey(ct), lang) ;
-        for ( String ext : lang.getFileExtensions() )
-        {
+            mapContentTypeToLang.put(canonicalKey(ct), lang);
+        for ( String ext : lang.getFileExtensions() ) {
             if ( ext.startsWith(".") )
-                ext = ext.substring(1) ;
-            mapFileExtToLang.put(canonicalKey(ext), lang) ;
+                ext = ext.substring(1);
+            mapFileExtToLang.put(canonicalKey(ext), lang);
         }
     }
 
@@ -273,147 +280,139 @@ public class RDFLanguages
     }
 
     /** Make sure the registration does not overlap or interfere with an existing registration.  */
-    private static void checkRegistration(Lang lang)
-    {
+    private static void checkRegistration(Lang lang) {
         if ( lang == null )
-            return ;
-        String label = canonicalKey(lang.getLabel()) ;
-        Lang existingRegistration = mapLabelToLang.get(label) ;
+            return;
+        String label = canonicalKey(lang.getLabel());
+        Lang existingRegistration = mapLabelToLang.get(label);
         if ( existingRegistration == null )
-            return ;
+            return;
         if ( lang.equals(existingRegistration) )
-            return ;
-
+            return;
 
         // Is the content type already registered?
-        if ( isMimeTypeRegistered(lang) )
-        {
+        if ( isMimeTypeRegistered(lang) ) {
             String contentType = lang.getContentType().getContentTypeStr();
-            error("Language overlap: " +lang+" and "+mapContentTypeToLang.get(contentType)+" on content type "+contentType) ;
+            error("Language overlap: " + lang + " and " + mapContentTypeToLang.get(contentType) + " on content type " + contentType);
             return;
         }
 
         // Check for clashes.
         for (String altName : lang.getAltNames() )
             if ( mapLabelToLang.containsKey(altName) )
-                error("Language overlap: " +lang+" and "+mapLabelToLang.get(altName)+" on name "+altName) ;
+                error("Language overlap: " +lang+" and "+mapLabelToLang.get(altName)+" on name "+altName);
         for (String ct : lang.getAltContentTypes() )
             if ( mapContentTypeToLang.containsKey(ct) )
-                error("Language overlap: " +lang+" and "+mapContentTypeToLang.get(ct)+" on content type "+ct) ;
+                error("Language overlap: " +lang+" and "+mapContentTypeToLang.get(ct)+" on content type "+ct);
         for (String ext : lang.getFileExtensions() )
             if ( mapFileExtToLang.containsKey(ext) )
-                error("Language overlap: " +lang+" and "+mapFileExtToLang.get(ext)+" on file extension type "+ext) ;
+                error("Language overlap: " +lang+" and "+mapFileExtToLang.get(ext)+" on file extension type "+ext);
     }
 
     /**
      * Remove a registration of a language - this also removes all recorded mapping
      * of content types and file extensions.
      */
-    public static void unregister(Lang lang)
-    {
+    public static void unregister(Lang lang) {
         if ( lang == null )
-            throw new IllegalArgumentException("null for language") ;
-        mapLabelToLang.remove(canonicalKey(lang.getLabel())) ;
-        mapContentTypeToLang.remove(canonicalKey(lang.getContentType().getContentTypeStr())) ;
+            throw new IllegalArgumentException("null for language");
+        mapLabelToLang.remove(canonicalKey(lang.getLabel()));
+        mapContentTypeToLang.remove(canonicalKey(lang.getContentType().getContentTypeStr()));
 
         for ( String ct : lang.getAltContentTypes() )
-            mapContentTypeToLang.remove(canonicalKey(ct)) ;
+            mapContentTypeToLang.remove(canonicalKey(ct));
         for ( String ext : lang.getFileExtensions() )
-            mapFileExtToLang.remove(canonicalKey(ext)) ;
+            mapFileExtToLang.remove(canonicalKey(ext));
     }
 
     /** Is this language registered? */
-    public static boolean isRegistered(Lang lang)
-    {
+    public static boolean isRegistered(Lang lang)    {
         if ( lang == null )
-            throw new IllegalArgumentException("null for language") ;
-        String label = canonicalKey(lang.getLabel()) ;
-        Lang lang2 = mapLabelToLang.get(label) ;
+            throw new IllegalArgumentException("null for language");
+        String label = canonicalKey(lang.getLabel());
+        Lang lang2 = mapLabelToLang.get(label);
         if ( lang2 == null )
-            return false ;
-        return true ;
+            return false;
+        return true;
     }
 
     /** return true if the language is registered as a triples language. */
-    public static boolean isTriples(Lang lang) { return RDFParserRegistry.isTriples(lang) ; }
+    public static boolean isTriples(Lang lang) { return RDFParserRegistry.isTriples(lang); }
 
     /** return true if the language is registered as a quads language. */
-    public static boolean isQuads(Lang lang) { return RDFParserRegistry.isQuads(lang) ; }
+    public static boolean isQuads(Lang lang) { return RDFParserRegistry.isQuads(lang); }
 
     /** return true if the language is registered for parsing as an RDF syntax. */
     public static boolean hasRegisteredParser(Lang lang) { return RDFParserRegistry.isRegistered(lang); }
 
     /** Map a content type (without charset) to a {@link Lang} */
-    public static Lang contentTypeToLang(String contentType)
-    {
+    public static Lang contentTypeToLang(String contentType) {
         if ( contentType == null )
-            return null ;
-        String key = canonicalKey(contentType) ;
-        return mapContentTypeToLang.get(key) ;
+            return null;
+        String key = canonicalKey(contentType);
+        return mapContentTypeToLang.get(key);
     }
 
     /** Map a content type (without charset) to a {@link Lang} */
-    public static Lang contentTypeToLang(ContentType ct)
-    {
+    public static Lang contentTypeToLang(ContentType ct) {
         if ( ct == null )
-            return null ;
-        String key = canonicalKey(ct.getContentTypeStr()) ;
-        return mapContentTypeToLang.get(key) ;
+            return null;
+        String key = canonicalKey(ct.getContentTypeStr());
+        return mapContentTypeToLang.get(key);
     }
 
-    public static String getCharsetForContentType(String contentType)
-    {
-        MediaType ct = MediaType.create(contentType) ;
+    public static String getCharsetForContentType(String contentType) {
+        MediaType ct = MediaType.create(contentType);
         if ( ct.getCharset() != null )
-            return ct.getCharset() ;
+            return ct.getCharset();
 
-        String mt = ct.getContentTypeStr() ;
-        if ( contentTypeNTriples.equals(mt) )        return charsetUTF8 ;
-        if ( contentTypeNTriplesAlt.equals(mt) )     return charsetASCII ;
-        if ( contentTypeNQuads.equals(mt) )          return charsetUTF8 ;
-        if ( contentTypeNQuadsAlt1.equals(mt) )      return charsetASCII ;
-        return charsetUTF8 ;
+        String mt = ct.getContentTypeStr();
+        if ( contentTypeNTriples.equals(mt) )        return charsetUTF8;
+        if ( contentTypeNTriplesAlt.equals(mt) )     return charsetASCII;
+        if ( contentTypeNQuads.equals(mt) )          return charsetUTF8;
+        if ( contentTypeNQuadsAlt1.equals(mt) )      return charsetASCII;
+        return charsetUTF8;
     }
-
 
     /** Map a colloquial name (e.g. "Turtle") to a {@link Lang} */
-    public static Lang shortnameToLang(String label)
-    {
+    public static Lang shortnameToLang(String label) {
         if ( label == null )
-            return null ;
-        String key = canonicalKey(label) ;
-        return mapLabelToLang.get(key) ;
+            return null;
+        String key = canonicalKey(label);
+        return mapLabelToLang.get(key);
     }
 
     /** Try to map a file extension to a {@link Lang}; return null on no registered mapping */
-    public static Lang fileExtToLang(String ext)
-    {
-        if ( ext == null ) return null ;
+    public static Lang fileExtToLang(String ext) {
+        if ( ext == null )
+            return null;
         if ( ext.startsWith(".") )
-            ext = ext.substring(1) ;
-        ext = canonicalKey(ext) ;
-        return mapFileExtToLang.get(ext) ;
+            ext = ext.substring(1);
+        ext = canonicalKey(ext);
+        return mapFileExtToLang.get(ext);
     }
 
     /** Try to map a resource name to a {@link Lang}; return null on no registered mapping */
-    public static Lang resourceNameToLang(String resourceName) { return pathnameToLang(resourceName) ; }
+    public static Lang resourceNameToLang(String resourceName) { return pathnameToLang(resourceName); }
 
     /** Try to map a resource name to a {@link Lang}; return the given default where there is no registered mapping */
-    public static Lang resourceNameToLang(String resourceName, Lang dftLang) { return filenameToLang(resourceName, dftLang) ; }
+    public static Lang resourceNameToLang(String resourceName, Lang dftLang) { return filenameToLang(resourceName, dftLang); }
 
     /** Try to map a file name to a {@link Lang}; return null on no registered mapping. */
     public static Lang filenameToLang(String uriOrFilename) { return pathnameToLang(uriOrFilename); }
 
-    /** Try to map a URI or URI path name to a {@link Lang}; return null on no registered mapping. */
-    public static Lang pathnameToLang(String pathname)
-    {
+    /**
+     * Try to map a URI or URI path name to a {@link Lang}; return null on no
+     * registered mapping.
+     */
+    public static Lang pathnameToLang(String pathname) {
         if ( pathname == null )
             return null;
         // Remove any URI fragment (there can be only one # in a URI).
         // Pragmatically, assume any # is URI related.
         // URIs can be relative.
         int iHash = pathname.indexOf('#');
-        if ( iHash  > 0 )
+        if ( iHash > 0 )
             pathname = pathname.substring(0, iHash);
         // Compressed?
         pathname = IO.filenameNoCompression(pathname);
@@ -421,50 +420,47 @@ public class RDFLanguages
     }
 
     /** Try to map a file name to a {@link Lang}; return the given default where there is no registered mapping */
-    public static Lang filenameToLang(String filename, Lang dftLang)
-    {
-        Lang lang = pathnameToLang(filename) ;
-        return (lang == null) ? dftLang : lang ;
+    public static Lang filenameToLang(String filename, Lang dftLang) {
+        Lang lang = pathnameToLang(filename);
+        return (lang == null) ? dftLang : lang;
     }
 
-
-    /** Turn a name for a language into a {@link Lang} object.
-     *  The name can be a label, or a content type.
+    /**
+     * Turn a name for a language into a {@link Lang} object. The name can be a
+     * label, or a content type.
      */
-    public static Lang nameToLang(String langName)
-    {
+    public static Lang nameToLang(String langName) {
         if ( langName == null )
-            return null ;
+            return null;
 
-        Lang lang = shortnameToLang(langName) ;
+        Lang lang = shortnameToLang(langName);
         if ( lang != null )
-            return lang ;
-        lang = contentTypeToLang(langName) ;
-        return lang ;
+            return lang;
+        lang = contentTypeToLang(langName);
+        return lang;
     }
 
-    static String canonicalKey(String x) { return x.toLowerCase(Locale.ROOT) ; }
+    static String canonicalKey(String x) { return x.toLowerCase(Locale.ROOT); }
 
-    public static ContentType guessContentType(String resourceName)
-    {
+    public static ContentType guessContentType(String resourceName) {
         if ( resourceName == null )
-            return null ;
-        Lang lang = pathnameToLang(resourceName) ;
+            return null;
+        Lang lang = pathnameToLang(resourceName);
         if ( lang == null )
-            return null ;
-        return lang.getContentType() ;
+            return null;
+        return lang.getContentType();
     }
 
-    private static void error(String message)
-    {
-        throw new RiotException(message) ;
+    private static void error(String message) {
+        throw new RiotException(message);
     }
 
-    public static boolean sameLang(Lang lang1, Lang lang2)
-    {
-        if ( lang1 == null || lang2 == null ) return false ;
-        if ( lang1 == lang2 ) return true ;
-        return lang1.getLabel() == lang2.getLabel() ;
+    public static boolean sameLang(Lang lang1, Lang lang2) {
+        if ( lang1 == null || lang2 == null )
+            return false;
+        if ( lang1 == lang2 )
+            return true;
+        return lang1.getLabel() == lang2.getLabel();
     }
 }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
@@ -20,23 +20,23 @@ package org.apache.jena.riot;
 
 import static org.apache.jena.riot.Lang.*;
 
-import java.io.InputStream ;
-import java.io.Reader ;
+import java.io.InputStream;
+import java.io.Reader;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map ;
-import java.util.Set ;
+import java.util.Map;
+import java.util.Set;
 
-import org.apache.jena.atlas.lib.InternalErrorException ;
-import org.apache.jena.atlas.web.ContentType ;
-import org.apache.jena.riot.lang.* ;
+import org.apache.jena.atlas.lib.InternalErrorException;
+import org.apache.jena.atlas.web.ContentType;
+import org.apache.jena.riot.lang.*;
 import org.apache.jena.riot.lang.extra.TurtleJCC;
 import org.apache.jena.riot.system.ErrorHandlerFactory;
 import org.apache.jena.riot.system.ParserProfile;
 import org.apache.jena.riot.system.StreamRDF;
-import org.apache.jena.riot.thrift.BinRDF ;
+import org.apache.jena.riot.thrift.BinRDF;
 import org.apache.jena.riot.thrift.RiotThriftException;
-import org.apache.jena.sparql.util.Context ;
+import org.apache.jena.sparql.util.Context;
 
 /** The registry of languages and parsers.
  * To register a new parser:
@@ -49,110 +49,106 @@ import org.apache.jena.sparql.util.Context ;
 public class RDFParserRegistry
 {
     /** map language to a parser factory */
-    private static Map<Lang, ReaderRIOTFactory> langToParserFactory    = new HashMap<>() ;
+    private static Map<Lang, ReaderRIOTFactory> langToParserFactory    = new HashMap<>();
 
     /** Known triples languages */
-    private static Set<Lang> langTriples  = new HashSet<>() ;
+    private static Set<Lang> langTriples  = new HashSet<>();
 
     /** Known quads languages */
-    private static Set<Lang> langQuads    = new HashSet<>() ;
+    private static Set<Lang> langQuads    = new HashSet<>();
 
-
-    private static boolean initialized = false ;
-    static { init() ; }
-    public static void init()
-    {
-        if ( initialized ) return ;
-        initialized = true ;
-        initStandard() ;
+    private static boolean initialized = false;
+    static { init(); }
+    public static void init() {
+        if ( initialized )
+            return;
+        initialized = true;
+        initStandard();
     }
 
-    private static void initStandard()
-    {
+    private static void initStandard() {
         // Make sure the constants are initialized.
-        RDFLanguages.init() ;
+        RDFLanguages.init();
 
         /** General parser factory for parsers implemented by "Lang" */
         ReaderRIOTFactory parserFactory          = ReaderRIOTLang.factory;
         // Others
-        ReaderRIOTFactory parserFactoryRDFXML    = ReaderRIOTRDFXML.factory ;
-        ReaderRIOTFactory parserFactoryJsonLD    = new ReaderRIOTFactoryJSONLD() ;
+        ReaderRIOTFactory parserFactoryRDFXML    = ReaderRIOTRDFXML.factory;
+        ReaderRIOTFactory parserFactoryJsonLD    = new ReaderRIOTFactoryJSONLD();
         ReaderRIOTFactory parserFactoryThrift    = ReaderRDFThrift.factory;
         ReaderRIOTFactory parserFactoryTriX      = ReaderTriX.factory;
         ReaderRIOTFactory parserFactoryRDFNULL   = ReaderRDFNULL.factory;
 
-        registerLangTriples(NTRIPLES,   parserFactory) ;
-        registerLangTriples(N3,         parserFactory) ;
-        registerLangTriples(TURTLE,     parserFactory) ;
-        registerLangTriples(RDFJSON,    parserFactory) ;
-        registerLangTriples(RDFXML,     ReaderRIOTRDFXML.factory) ;
-        registerLangTriples(JSONLD,     parserFactoryJsonLD) ;
-        registerLangTriples(RDFTHRIFT,  ReaderRDFThrift.factory) ;
-        registerLangTriples(TRIX,       ReaderTriX.factory) ;
-        registerLangTriples(RDFNULL,    ReaderRDFNULL.factory) ;
+        registerLangTriples(NTRIPLES,   parserFactory);
+        registerLangTriples(N3,         parserFactory);
+        registerLangTriples(TURTLE,     parserFactory);
+        registerLangTriples(RDFJSON,    parserFactory);
+        registerLangTriples(RDFXML,     ReaderRIOTRDFXML.factory);
+        registerLangTriples(JSONLD,     parserFactoryJsonLD);
+        registerLangTriples(RDFTHRIFT,  ReaderRDFThrift.factory);
+        registerLangTriples(TRIX,       ReaderTriX.factory);
+        registerLangTriples(RDFNULL,    ReaderRDFNULL.factory);
 
-        registerLangQuads(JSONLD,       parserFactoryJsonLD) ;
-        registerLangQuads(NQUADS,       parserFactory) ;
-        registerLangQuads(TRIG,         parserFactory) ;
-        registerLangQuads(RDFTHRIFT,    parserFactoryThrift) ;
-        registerLangQuads(TRIX,         parserFactoryTriX) ;
-        registerLangQuads(RDFNULL,      parserFactoryRDFNULL) ;
+        registerLangQuads(JSONLD,       parserFactoryJsonLD);
+        registerLangQuads(NQUADS,       parserFactory);
+        registerLangQuads(TRIG,         parserFactory);
+        registerLangQuads(RDFTHRIFT,    parserFactoryThrift);
+        registerLangQuads(TRIX,         parserFactoryTriX);
+        registerLangQuads(RDFNULL,      parserFactoryRDFNULL);
 
         // Javacc based Turtle parser, different language name.
         TurtleJCC.register();
     }
 
-    /** Register a language and it's parser factory.
+    /**
+     * Register a language and it's parser factory.
      * To create a {@link Lang} object use {@link LangBuilder}.
      */
-    private static void registerLang(Lang lang, ReaderRIOTFactory factory)
-    {
-        RDFLanguages.register(lang) ;
-        langToParserFactory.put(lang, factory) ;
-    }
-
-    /** Register a language and its parser factory.
-     * To create a {@link Lang} object use {@link LangBuilder}.
-     */
-    public static void registerLangTriples(Lang lang, ReaderRIOTFactory factory)
-    {
-        langTriples.add(lang) ;
-        registerLang(lang, factory) ;
-    }
-
-    /** Register a language and its parser factory.
-     * To create a {@link Lang} object use {@link LangBuilder}.
-     */
-    public static void registerLangQuads(Lang lang, ReaderRIOTFactory factory)
-    {
-        langQuads.add(lang) ;
-        registerLang(lang, factory) ;
-    }
-
-    /** Remove registration */
-    public static void removeRegistration(Lang lang)
-    {
-        RDFLanguages.unregister(lang) ;
-        langToParserFactory.remove(lang) ;
+    private static void registerLang(Lang lang, ReaderRIOTFactory factory) {
+        RDFLanguages.register(lang);
+        langToParserFactory.put(lang, factory);
     }
 
     /**
-     * Return the parser factory for the language, or null if not registered.
-     * Use {@code RDFParser.create() ... .build()}
+     * Register a language and its parser factory.
+     * To create a {@link Lang} object use {@link LangBuilder}.
      */
-    public static ReaderRIOTFactory getFactory(Lang language)
-    {
-        return langToParserFactory.get(language) ;
+    public static void registerLangTriples(Lang lang, ReaderRIOTFactory factory) {
+        langTriples.add(lang);
+        registerLang(lang, factory);
+    }
+
+    /**
+     * Register a language and its parser factory.
+     * To create a {@link Lang} object use {@link LangBuilder}.
+     */
+    public static void registerLangQuads(Lang lang, ReaderRIOTFactory factory) {
+        langQuads.add(lang);
+        registerLang(lang, factory);
+    }
+
+    /** Remove registration */
+    public static void removeRegistration(Lang lang) {
+        RDFLanguages.unregister(lang);
+        langToParserFactory.remove(lang);
+    }
+
+    /**
+     * Return the parser factory for the language, or null if not registered. Use
+     * {@code RDFParser.create() ... .build()}
+     */
+    public static ReaderRIOTFactory getFactory(Lang language) {
+        return langToParserFactory.get(language);
     }
 
     /** return true if the language has a registered parser. */
-    public static boolean isRegistered(Lang lang) { return langToParserFactory.containsKey(lang) ; }
+    public static boolean isRegistered(Lang lang) { return langToParserFactory.containsKey(lang); }
 
     /** return true if the language is registered with the triples parser factories */
-    public static boolean isTriples(Lang lang) { return langTriples.contains(lang) ; }
+    public static boolean isTriples(Lang lang) { return langTriples.contains(lang); }
 
     /** return true if the language is registered with the quads parser factories */
-    public static boolean isQuads(Lang lang)   { return langQuads.contains(lang) ; }
+    public static boolean isQuads(Lang lang)   { return langQuads.contains(lang); }
 
     // Parsers and factories.
 
@@ -161,11 +157,11 @@ public class RDFParserRegistry
         static ReaderRIOTFactory factory =
             (Lang lang, ParserProfile parserProfile) -> new ReaderRIOTLang(lang, parserProfile);
 
-        private final Lang lang ;
-        private ParserProfile parserProfile = null ;
+        private final Lang lang;
+        private ParserProfile parserProfile = null;
 
         ReaderRIOTLang(Lang lang, ParserProfile parserProfile) {
-            this.lang = lang ;
+            this.lang = lang;
             this.parserProfile = parserProfile;
         }
 
@@ -173,22 +169,22 @@ public class RDFParserRegistry
         public void read(InputStream in, String baseURI, ContentType ct, StreamRDF output, Context context) {
             // Unnecessary - RDFParser did it and set it in the ParserProfile
 //            if ( baseURI != null ) {
-//                IRIResolver newResolver = IRIResolver.create(baseURI) ;
+//                IRIResolver newResolver = IRIResolver.create(baseURI);
 //                parserProfile.setIRIResolver(newResolver);
 //            }
             LangRIOT parser = RiotParsers.createParser(in, lang, output, parserProfile);
-            parser.parse() ;
+            parser.parse();
         }
 
         @Override
         public void read(Reader in, String baseURI, ContentType ct, StreamRDF output, Context context) {
             // Unnecessary - RDFParser did it and set it in the ParserProfile
 //          if ( baseURI != null ) {
-//              IRIResolver newResolver = IRIResolver.create(baseURI) ;
+//              IRIResolver newResolver = IRIResolver.create(baseURI);
 //              parserProfile.setIRIResolver(newResolver);
 //          }
             LangRIOT parser = RiotParsers.createParser(in, lang, output, parserProfile);
-            parser.parse() ;
+            parser.parse();
         }
     }
 
@@ -196,7 +192,7 @@ public class RDFParserRegistry
         @Override
         public ReaderRIOT create(Lang language, ParserProfile profile) {
             if ( !Lang.JSONLD.equals(language) )
-                throw new InternalErrorException("Attempt to parse " + language + " as JSON-LD") ;
+                throw new InternalErrorException("Attempt to parse " + language + " as JSON-LD");
             return new JsonLDReader(language, profile, profile.getErrorHandler());
         }
     }
@@ -221,7 +217,7 @@ public class RDFParserRegistry
 
         @Override
         public void read(Reader reader, String baseURI, ContentType ct, StreamRDF output, Context context) {
-            throw new RiotException("RDF Thrift : Reading binary data from a java.io.reader is not supported. Please use an InputStream") ;
+            throw new RiotException("RDF Thrift : Reading binary data from a java.io.reader is not supported. Please use an InputStream");
         }
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangJSONLD11.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangJSONLD11.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.lang;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+
+import com.apicatalog.jsonld.JsonLd;
+import com.apicatalog.jsonld.document.Document;
+import com.apicatalog.jsonld.document.JsonDocument;
+import com.apicatalog.rdf.RdfDataset;
+import com.apicatalog.rdf.io.RdfWriter;
+import com.apicatalog.rdf.io.nquad.NQuadsWriter;
+
+import org.apache.jena.atlas.web.ContentType;
+import org.apache.jena.riot.*;
+import org.apache.jena.riot.system.StreamRDF;
+import org.apache.jena.sparql.util.Context;
+
+/**
+ * JSON-LD 1.1 {@link ReaderRIOT}.
+ * Placeholder implementation!
+ */
+public class LangJSONLD11 implements ReaderRIOT {
+    public LangJSONLD11() {}
+
+    @Override
+    public void read(InputStream in, String baseURI, ContentType ct, StreamRDF output, Context context) {
+        Sys.checkForTitanium();
+        try {
+            Document document = JsonDocument.of(in);
+            read(document, output, context);
+        } catch (Exception ex) {
+            throw new RiotException(ex);
+        }
+    }
+
+    @Override
+    public void read(Reader in, String baseURI, ContentType ct, StreamRDF output, Context context) {
+        Sys.checkForTitanium();
+        try {
+            Document document = JsonDocument.of(in);
+            read(document, output, context);
+        } catch (Exception ex) {
+            throw new RiotException(ex);
+        }
+    }
+
+    // Simple - read with Titanium, output N-Quads to a string, parser string.
+    // Minimal linkage!
+    private void read(Document document, StreamRDF output, Context context) throws Exception {
+        // JSON-LD to RDF
+        RdfDataset dataset = JsonLd.toRdf(document).get();
+
+        // Write N-Quads to string.
+        StringWriter writer = new StringWriter();
+        RdfWriter w = new NQuadsWriter(writer);
+        w.write(dataset);
+
+        // Do something with the string.
+        RDFParser.fromString(writer.toString()).forceLang(Lang.NQUADS).parse(output);
+    }
+
+    public static class Sys {
+
+        private static boolean titaniumPresent = false;
+        private static boolean jakartaJsonPresent = false;
+
+        public static void init() {
+            checkForTitaniumOnClassPath();
+            ReaderRIOTFactory factory;
+
+            if ( ! titaniumPresent ) {
+                factory = (language, profile) -> {
+                    throw new UnsupportedOperationException("Need both titanium-json-ld (1.1.0 or later) and org.glassfish:jakarta on the classpath");
+                };
+            } else {
+                factory = (language, profile) -> new LangJSONLD11();
+            }
+            RDFParserRegistry.registerLangTriples(Lang.JSONLD11, factory);
+        }
+
+        public static void checkForTitanium() {
+            if ( ! titaniumPresent )
+                throw new RiotException("Artifact com.apicatalog:titanium-json-ld not on classpath");
+            if ( ! jakartaJsonPresent )
+                throw new RiotException("Artifact org.glassfish:jakarta not on classpath");
+        }
+
+        static void checkForTitaniumOnClassPath() {
+            try {
+                // This class is in Titanium 1.1.0 (JakartaEE9 - jakarta.json) and not in
+                // 0.8.6 (which uses JakartaEE8 - javax.json) where it is "com.apicatalog.jsonld.lang.Version"
+                Class.forName("com.apicatalog.jsonld.JsonLdVersion", false, Thread.currentThread().getContextClassLoader());
+                titaniumPresent = true;
+            } catch (ClassNotFoundException ex) {
+                return;
+            }
+            try {
+                Class.forName("jakarta.json.Json", false, Thread.currentThread().getContextClassLoader());
+                jakartaJsonPresent = true;
+            } catch (ClassNotFoundException ex) {
+                return;
+            }
+        }
+
+    }
+}

--- a/jena-cmds/pom.xml
+++ b/jena-cmds/pom.xml
@@ -108,6 +108,12 @@
       <!-- This module can be used as a dependency downstream -->
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <!-- Titanium -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -85,7 +85,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
-            <version>${ver.slf4j}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,31 @@
         </exclusions>
       </dependency>
       
+      <!-- JSON-LD 1.1 read support -->
+      <!-- Titanium JSON-LD scope=provided -->
+      <dependency>
+        <!-- Apache License -->
+        <groupId>com.apicatalog</groupId>
+        <artifactId>titanium-json-ld</artifactId>
+        <version>1.1.0</version>
+        <scope>provided</scope>
+      </dependency>
+      <!-- Eclipse Public License 2.0 (category-B) -->
+      <dependency>
+        <groupId>jakarta.json</groupId>
+        <artifactId>jakarta.json-api</artifactId>
+        <version>2.0.1</version>
+        <scope>provided</scope>
+      </dependency>
+      <!-- Eclipse Public License 2.0 (category-B) -->
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>jakarta.json</artifactId>
+        <version>2.0.1</version>
+        <scope>provided</scope>
+      </dependency>
+      <!-- End JSON-LD 1.1 read support -->
+
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
@@ -552,6 +577,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
+        <version>${ver.slf4j}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
         <version>${ver.slf4j}</version>
       </dependency>
 


### PR DESCRIPTION
This PR contains a JSON-LD reader based on Titanium. Treat as experimental.

The linkage is minimal - it parses the JSON-LD 1.1 document, prints quads to bytes and reads the N-Quads bytes.

Better would be direct translation from the Titanium RDF abstraction to Jena - contributions welcome!

To use:
```
   RDFparser.create.forceLang(Lang.JSONLD11)...
```
Unfortunately, the JSON-Processing API, jakarta.json-api, is licensed under EPL-2.0 (even just the API, let alone an implementation) so needs careful handling.

For now, add to the application dependencies:
```
     <dependency>
        <!-- Apache License -->
        <groupId>com.apicatalog</groupId>
        <artifactId>titanium-json-ld</artifactId>
        <version>1.1.0</version>
      </dependency>

      <!-- Eclipse Public License 2.0 -->
      <dependency>
        <groupId>org.glassfish</groupId>
        <artifactId>jakarta.json</artifactId>
        <version>2.0.0</version>
      </dependency>
```
Gradle:
```
compile group: 'com.apicatalog', name: 'titanium-json-ld', version: '1.1.0'
compile group: 'org.glassfish', name: 'jakarta.json', version: '2.0.0'
```