### PR TITLE
JENA-2142: Extend DatatypeFormatException

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/datatypes/DatatypeFormatException.java
+++ b/jena-core/src/main/java/org/apache/jena/datatypes/DatatypeFormatException.java
@@ -26,15 +26,41 @@ import org.apache.jena.shared.* ;
  */
 public class DatatypeFormatException extends JenaException 
 {
+
     /**
-     * Preferred constructor.
-     * @param lexicalForm the illegal string discovered
-     * @param dtype the datatype that found the problem
-     * @param msg additional context for the error
+     * Constructs a new {@code DatatypeFormatException} with the specified
+     * illegal lexical form, datatype and cause. The detail message (for later
+     * retrieval by the {@link #getMessage()} method) is generated using the given 
+     * datatype and illegal lexical form.
+     * 
+     * @param  lexicalForm the illegal lexical form discovered. The illegal lexical form 
+     *         is saved for later retrieval by the {@link #getLexicalForm()} method.
+     * @param  dtype the datatype that found the problem. The datatype is saved for
+     *         later retrieval by the {@link #getDataType()} method.
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link #getCause()} method).  (A {@code null} value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
      */
-    public DatatypeFormatException(String lexicalForm, RDFDatatype dtype, String msg) {
-        super("Lexical form '" + lexicalForm +
-               "' is not a legal instance of " + dtype + " " + msg);
+    public DatatypeFormatException(String lexicalForm, RDFDatatype dtype, Throwable cause) {
+        super(String.format("Lexical form '%s' is not a legal instance of %s.", lexicalForm, dtype), cause);
+        this.lexicalForm = lexicalForm;
+        this.dataType = dtype;
+    }
+
+    /**
+     * Constructs a new {@code DatatypeFormatException} with the specified
+     * illegal lexical form, datatype and detail message.
+     * 
+     * @param  lexicalForm the illegal lexical form discovered. The illegal lexical form 
+     *         is saved for later retrieval by the {@link #getLexicalForm()} method.
+     * @param  dtype the datatype that found the problem. The datatype is saved for
+     *         later retrieval by the {@link #getDataType()} method.
+     * @param  message the detail message (which is saved for later retrieval
+     *         by the {@link #getMessage()} method).
+     */
+    public DatatypeFormatException(String lexicalForm, RDFDatatype dtype, String message) {
+        super(String.format("Lexical form '%s' is not a legal instance of %s %s", lexicalForm, dtype, message));
         this.lexicalForm = lexicalForm;
         this.dataType = dtype;
     }
@@ -52,12 +78,32 @@ public class DatatypeFormatException extends JenaException
     }
 
     /**
-     * Constructs an instance of <code>DatatypeFormatException</code> 
-     * with the specified detail message.
-     * @param msg the detail message.
+     * Constructs a new {@code DatatypeFormatException} with the specified
+     * detail message and cause.
+     * 
+     * @param  message the detail message (which is saved for later retrieval
+     *         by the {@link #getMessage()} method).
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link #getCause()} method).  (A {@code null} value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
      */
-    public DatatypeFormatException(String msg) {
-        super(msg);
+    public DatatypeFormatException(String message, Throwable cause) {
+        super(message, cause);
+        this.lexicalForm = null;
+        this.dataType = null;
+    }
+
+    /**
+     * Constructs a new @code DatatypeFormatException} with the specified
+     * detail message. The cause is not initialized, and may subsequently be
+     * initialized by a call to {@link #initCause}.
+     *
+     * @param  message the detail message. The detail message is saved for
+     *         later retrieval by the {@link #getMessage()} method.
+     */
+    public DatatypeFormatException(String message) {
+        super(message);
         this.lexicalForm = null;
         this.dataType = null;
     }


### PR DESCRIPTION
This PR changes the class `DatatypeFormatException` in the following way:
* add constructors with cause parameter (I have a use case this would be helpful for)
* improve JavaDoc

All changes should be API and binary compatible.