### PR TITLE
JENA-2144: Print nodeKind in long form

### DIFF
--- a/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/ShaclcParseException.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/ShaclcParseException.java
@@ -21,6 +21,7 @@ package org.apache.jena.shacl.compact.reader;
 import org.apache.jena.shacl.ShaclException;
 
 public class ShaclcParseException extends ShaclException {
+    // Not a "ShaclParseException", which refers to errors in the RDF graph of SHACL shapes.
     private int line ;
     private int column ;
 

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/compact/writer/CompactOut.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/compact/writer/CompactOut.java
@@ -70,7 +70,7 @@ public class CompactOut {
     public static void compactArrayString(IndentedWriter out, NodeFormatter nodeFmt, String param, Collection<String> values) {
         out.print(param);
         out.print("=");
-        out.print("(");
+        out.print("[");
         boolean first = true;
         for ( String str : values ) {
             if ( ! first )
@@ -78,7 +78,7 @@ public class CompactOut {
             printQuotedString(out, str);
             first = false;
         }
-        out.print(")");
+        out.print("]");
     }
 
     private static void printQuotedString(IndentedWriter out, String str) {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/NodeKindConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/NodeKindConstraint.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.shacl.engine.constraint;
 
+import static org.apache.jena.shacl.compact.writer.CompactOut.compact;
 import static org.apache.jena.shacl.lib.ShLib.displayStr;
 
 import java.util.Objects;
@@ -77,8 +78,10 @@ public class NodeKindConstraint extends ConstraintTerm {
 
     @Override
     public void printCompact(IndentedWriter out, NodeFormatter nodeFmt) {
-        String s = getKind().getLocalName();
-        out.print(s);
+        compact(out, nodeFmt, "nodeKind", getKind());
+        // Property context only.
+//        String s = getKind().getLocalName();
+//        out.print(s);
     }
 
     @Override

--- a/jena-shacl/src/test/files/local/shaclc-syntax/nodeParam-bad-01.shc
+++ b/jena-shacl/src/test/files/local/shaclc-syntax/nodeParam-bad-01.shc
@@ -1,0 +1,8 @@
+PREFIX : <http://example/>
+PREFIX ex:      <http://example.org/test#>
+PREFIX sh:      <http://www.w3.org/ns/shacl#>
+
+shapeClass ex:TestBadNodeParam {
+   # Property sytax in the node position.
+   IRI .
+}

--- a/jena-shacl/src/test/files/local/shaclc-syntax/nodeParams.shc
+++ b/jena-shacl/src/test/files/local/shaclc-syntax/nodeParams.shc
@@ -1,0 +1,14 @@
+PREFIX : <http://example/>
+PREFIX ex:      <http://example.org/test#>
+PREFIX sh:      <http://www.w3.org/ns/shacl#>
+
+shapeClass ex:TestNodeParams {
+   nodeKind=sh:IRI .
+   datatype=xsd:double .
+   pattern="^.*$" .
+   languageIn=["en" "fr"] .
+   minLength=3 . 
+   maxLength=5 .
+   minExclusive="fred" .
+   in=[2 4 6] .
+}

--- a/jena-shacl/src/test/files/local/shaclc-syntax/propertyParams.shc
+++ b/jena-shacl/src/test/files/local/shaclc-syntax/propertyParams.shc
@@ -1,0 +1,17 @@
+PREFIX : <http://example/>
+PREFIX ex:      <http://example.org/test#>
+PREFIX sh:      <http://www.w3.org/ns/shacl#>
+
+shapeClass ex:TestPropertyParams {
+   :prop1  nodeKind=sh:IRI .
+   :prop2  datatype=xsd:double .
+   :prop3  pattern="^.*$" .
+   :prop4  languageIn=["en" "fr"] .
+   :prop5  minLength=3 . 
+   :prop6  maxLength=5 .
+   :prop7  minExclusive="fred" .
+   :prop8  in=[2 4 6] .
+   ## Short forms
+   :propA  BlankNode .
+   :propB  xsd:integer .
+}

--- a/jena-shacl/src/test/java/org/apache/jena/shacl/compact/TS_Compact.java
+++ b/jena-shacl/src/test/java/org/apache/jena/shacl/compact/TS_Compact.java
@@ -26,5 +26,6 @@ import org.junit.runners.Suite;
     TestReadShaclCompact.class
     , TestWriteShaclCompact.class
     , TestReaderWriterShaclCompact.class
+    , TestCompactSyntax.class
 })
 public class TS_Compact {}

--- a/jena-shacl/src/test/java/org/apache/jena/shacl/compact/TestCompactSyntax.java
+++ b/jena-shacl/src/test/java/org/apache/jena/shacl/compact/TestCompactSyntax.java
@@ -23,21 +23,38 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-import org.apache.jena.atlas.lib.IRILib;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.shacl.compact.reader.ShaclcParseException;
 import org.apache.jena.sparql.graph.GraphFactory;
+import org.junit.Test;
 
-/** RIOT reader-writer tests for SHACL Compact Syntax */
-public class TestReaderWriterShaclCompact  extends AbstractTestShaclCompact {
+/**
+ * Test compact reading and writing by round-tripping. Unlike
+ * AbstractTestShaclCompact, this test suite is concerned with
+ * round-trip of compact syntax.
+ */
+public class TestCompactSyntax {
+    protected final String DIR = "src/test/files/local/shaclc-syntax/";
 
-    @Override
-    protected void runTest(String fn, String ttl, String fileBaseName) {
-        String uri = IRILib.filenameToIRI(fn);
+    @Test public void roundTrip_01() {
+        rttTest("nodeParams.shc");
+    }
 
-        Graph graph1 = GraphFactory.createDefaultGraph();
-        RDFDataMgr.read(graph1, uri, BASE, Lang.SHACLC);
+    @Test public void roundTrip_02() {
+        rttTest("propertyParams.shc");
+    }
+
+    @Test(expected=ShaclcParseException.class)
+    public void badSyntax_01() {
+        badSyntax("nodeParam-bad-01.shc");
+    }
+
+    private void rttTest(String fn) {
+        fn = DIR+fn;
+        //String uri = IRILib.filenameToIRI(fn);
+        Graph graph1 = RDFDataMgr.loadGraph(fn);
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         RDFDataMgr.write(bout, graph1, Lang.SHACLC);
 
@@ -45,16 +62,12 @@ public class TestReaderWriterShaclCompact  extends AbstractTestShaclCompact {
         RDFDataMgr.read(graph2, new ByteArrayInputStream(bout.toByteArray()), Lang.SHACLC);
 
         assertTrue(graph1.isIsomorphicWith(graph2));
+    }
 
-        Graph graph0 = RDFDataMgr.loadGraph(ttl);
-//        RDFDataMgr.write(System.out, graph1, Lang.SHACLC);
-//        System.out.println("----");
-//        RDFDataMgr.write(System.out, graph0, Lang.SHACLC);
-//        System.out.println("----");
-        assertTrue(graph0.isIsomorphicWith(graph2));
-
+    private void badSyntax(String fn) {
+        fn = DIR+fn;
+        RDFDataMgr.loadGraph(fn);
     }
 
 
 }
-


### PR DESCRIPTION
This fixes JENA-2144 by always printing `nodeKind` in full form89 _i.e._ `nodeKind=sh:IRI`. The full form is legal in both property and node parameters.