### PR TITLE
JENA-1948: Include Titanium and dependencies

### DIFF
--- a/apache-jena/dist/LICENSE
+++ b/apache-jena/dist/LICENSE
@@ -272,3 +272,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+Jakarta JSON Processing (JSON-P)
+https://eclipse-ee4j.github.io/jsonp/
+
+is licensed under the Eclipse Public License 2.0.
+http://www.eclipse.org/legal/epl-2.0
+
+org.glassfish:jakarta.json
+is licensed under the Eclipse Public License 2.0.
+http://www.eclipse.org/legal/epl-2.0
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/jena-arq/pom.xml
+++ b/jena-arq/pom.xml
@@ -74,19 +74,16 @@
       <!-- Apache License -->
       <groupId>com.apicatalog</groupId>
       <artifactId>titanium-json-ld</artifactId>
-      <scope>provided</scope>
     </dependency>
     <!-- Eclipse Public License 2.0 (category-B) -->
     <dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
-      <scope>provided</scope>
     </dependency>
-    <!--  And an implementation : Eclipse Public License 2.0 (category-B) -->
+    <!--  Eclipse Public License 2.0 (category-B) -->
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.json</artifactId>
-      <scope>provided</scope>
     </dependency>
     <!-- End Titanium JSON-LD 1.1 -->
     

--- a/jena-fuseki2/apache-jena-fuseki/dist/LICENSE
+++ b/jena-fuseki2/apache-jena-fuseki/dist/LICENSE
@@ -230,6 +230,16 @@ http://www.slf4j.org/license.html
 
 - - - - - - - - - - - - - - - - - - - - - - - 
 
+Jakarta JSON Processing (JSON-P)
+https://eclipse-ee4j.github.io/jsonp/
+
+is licensed under the Eclipse Public License 2.0.
+http://www.eclipse.org/legal/epl-2.0
+
+org.glassfish:jakarta.json
+is licensed under the Eclipse Public License 2.0.
+http://www.eclipse.org/legal/epl-2.0
+
 ==============================================================
  Jetty Web Container
  Copyright 1995-2012 Mort Bay Consulting Pty Ltd.
@@ -614,4 +624,4 @@ WHETHER IN  CONTRACT, STRICT LIABILITY, OR  TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
+---

--- a/pom.xml
+++ b/pom.xml
@@ -438,27 +438,24 @@
       </dependency>
       
       <!-- JSON-LD 1.1 read support -->
-      <!-- Titanium JSON-LD scope=provided -->
+      <!-- Titanium JSON-LD -->
       <dependency>
         <!-- Apache License -->
         <groupId>com.apicatalog</groupId>
         <artifactId>titanium-json-ld</artifactId>
         <version>1.1.0</version>
-        <scope>provided</scope>
       </dependency>
       <!-- Eclipse Public License 2.0 (category-B) -->
       <dependency>
         <groupId>jakarta.json</groupId>
         <artifactId>jakarta.json-api</artifactId>
         <version>2.0.1</version>
-        <scope>provided</scope>
       </dependency>
       <!-- Eclipse Public License 2.0 (category-B) -->
       <dependency>
         <groupId>org.glassfish</groupId>
         <artifactId>jakarta.json</artifactId>
         <version>2.0.1</version>
-        <scope>provided</scope>
       </dependency>
       <!-- End JSON-LD 1.1 read support -->
 


### PR DESCRIPTION
The is PR removes `<scope>provided</scope>` on `jakarta.json:jakarta.json-api` and `org.glassfish:jakarka.json`.

Both these are licensed as binaries under EPL 2.0 which is "category B" (may include in convenient binaries).

These are then in the `apache-jena` and `apache-jena-fuseki` convenient binaries.

Included LICENSE file in each has been updated.
