### PR TITLE
JENA-2125: Preparation to move misnamed QueryExecutionBuilder

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecution.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecution.java
@@ -30,10 +30,11 @@ import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.util.Context;
 
 /** A interface for a single execution of a query. */
-public interface QueryExecution extends AutoCloseable 
+public interface QueryExecution extends AutoCloseable
 {
+    @SuppressWarnings("deprecation")
     public static QueryExecutionBuilder create() { return QueryExecutionBuilder.create(); }
-    
+
     /** Set the initial association of variables and values.
      * May not be supported by all QueryExecution implementations.
      * @param binding
@@ -49,27 +50,27 @@ public interface QueryExecution extends AutoCloseable
     /**
      * The dataset against which the query will execute.
      * May be null, implying it is expected that the query itself
-     * has a dataset description. 
+     * has a dataset description.
      */
     public Dataset getDataset() ;
-    
-    /** The properties associated with a query execution -  
+
+    /** The properties associated with a query execution -
      *  implementation specific parameters  This includes
      *  Java objects (so it is not an RDF graph).
-     *  Keys should be URIs as strings.  
+     *  Keys should be URIs as strings.
      *  May be null (this implementation does not provide any configuration).
-     */ 
+     */
     public Context getContext() ;
-    
-    /** The query associated with a query execution.  
+
+    /** The query associated with a query execution.
      *  May be null (QueryExecution may have been created by other means)
-     */ 
+     */
     public Query getQuery() ;
 
     /**
-     *  Execute a SELECT query 
+     *  Execute a SELECT query
      *  <p>
-     *  <strong>Important:</strong> The name of this method is somewhat of a misnomer in that 
+     *  <strong>Important:</strong> The name of this method is somewhat of a misnomer in that
      *  depending on the underlying implementation this typically does not execute the
      *  SELECT query but rather answers a wrapper over an internal data structure that can be
      *  used to answer the query.  In essence calling this method only returns a plan for
@@ -78,7 +79,7 @@ public interface QueryExecution extends AutoCloseable
      *  </p>
      *  */
 	public ResultSet execSelect();
-    
+
     /** Execute a CONSTRUCT query */
     public Model execConstruct();
 
@@ -86,7 +87,7 @@ public interface QueryExecution extends AutoCloseable
      *  @return Model The model argument for cascaded code.
      */
     public Model execConstruct(Model model);
-    
+
     /**
      * Execute a CONSTRUCT query, returning the results as an iterator of {@link Triple}.
      * <p>
@@ -94,7 +95,7 @@ public interface QueryExecution extends AutoCloseable
      * need the results for stream processing, as it can avoid having to place the results in a Model.
      * </p>
      * <p>
-     * <strong>Important:</strong> The name of this method is somewhat of a misnomer in that 
+     * <strong>Important:</strong> The name of this method is somewhat of a misnomer in that
      * depending on the underlying implementation this typically does not execute the
      * CONSTRUCT query but rather answers a wrapper over an internal data structure that can be
      * used to answer the query.  In essence calling this method only returns a plan for
@@ -105,7 +106,7 @@ public interface QueryExecution extends AutoCloseable
      * by applying the CONSTRUCT template of the query to the bindings in the WHERE clause.
      */
     public Iterator<Triple> execConstructTriples();
-    
+
     /**
      * Execute a CONSTRUCT query, returning the results as an iterator of {@link Quad}.
      * <p>
@@ -119,17 +120,17 @@ public interface QueryExecution extends AutoCloseable
      * See {@link #execConstructTriples} for usage and features.
      */
     public Iterator<Quad> execConstructQuads();
-    
+
     /** Execute a CONSTRUCT query, putting the statements into 'dataset'.
-     *  This maybe an extended syntax query (if supported).   
+     *  This maybe an extended syntax query (if supported).
      */
     public Dataset execConstructDataset();
 
     /** Execute a CONSTRUCT query, putting the statements into 'dataset'.
-     *  This maybe an extended syntax query (if supported).   
+     *  This maybe an extended syntax query (if supported).
      */
     public Dataset execConstructDataset(Dataset dataset);
-    
+
     /** Execute a DESCRIBE query */
     public Model execDescribe();
 
@@ -137,7 +138,7 @@ public interface QueryExecution extends AutoCloseable
      *  @return Model The model argument for cascaded code.
      */
     public Model execDescribe(Model model);
-    
+
     /**
      * Execute a DESCRIBE query, returning the results as an iterator of {@link Triple}.
      * <p>
@@ -145,7 +146,7 @@ public interface QueryExecution extends AutoCloseable
      * need the results for stream processing, as it can avoid having to place the results in a Model.
      * </p>
      * <p>
-     * <strong>Important:</strong> The name of this method is somewhat of a misnomer in that 
+     * <strong>Important:</strong> The name of this method is somewhat of a misnomer in that
      * depending on the underlying implementation this typically does not execute the
      * DESCRIBE query but rather answers a wrapper over an internal data structure that can be
      * used to answer the query.  In essence calling this method only returns a plan for
@@ -175,10 +176,10 @@ public interface QueryExecution extends AutoCloseable
 	 */
 
 	public void abort();
-	
+
     /** Close the query execution and stop query evaluation as soon as convenient.
      *  QueryExecution objects, and a {@link ResultSet} from {@link #execSelect},
-     *  can not be used once the QueryExecution is closed.  
+     *  can not be used once the QueryExecution is closed.
      *  Model results from {@link #execConstruct} and {@link #execDescribe}
      *  are still valid.
      *  It is important to close query execution objects in order to release
@@ -190,10 +191,10 @@ public interface QueryExecution extends AutoCloseable
      */
     @Override
     public void close();
-	
+
     /**
      * Answer whether this QueryExecution object has been closed or not.
-     * @return boolean 
+     * @return boolean
      */
     public boolean isClosed();
 
@@ -203,14 +204,14 @@ public interface QueryExecution extends AutoCloseable
 	 * A timeout of less than zero means no timeout.
 	 */
 	public void setTimeout(long timeout, TimeUnit timeoutUnits) ;
-	
-	/** Set time, in milliseconds 
+
+	/** Set time, in milliseconds
 	 * @see #setTimeout(long, TimeUnit)
 	 */
 	public void setTimeout(long timeout) ;
-    
-	/** Set timeouts on the query execution; the first timeout refers to time to first result, 
-	 * the second refers to overall query execution after the first result.  
+
+	/** Set timeouts on the query execution; the first timeout refers to time to first result,
+	 * the second refers to overall query execution after the first result.
 	 * Processing will be aborted if a timeout expires.
 	 * Not all query execution systems support timeouts.
 	 * A timeout of less than zero means no timeout; this can be used for timeout1 or timeout2.
@@ -227,12 +228,12 @@ public interface QueryExecution extends AutoCloseable
     public long getTimeout1() ;
     /** Return the second timeout (overall query execution after first result), in milliseconds: negative if unset */
     public long getTimeout2() ;
-    
+
     //	/** Say whether this QueryExecution is useable or not.
 //	 * An active execution is one that has not been closed, ended or aborted yet.
 //     * May not be supported or meaningful for all QueryExecution implementations.
 //     * aborted queries may not immediate show as no longer active.
-//     * This should not be called in parallel with other QueryExecution methods. 
-//     */  
+//     * This should not be called in parallel with other QueryExecution methods.
+//     */
 //    public boolean isActive() ;
 }

--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionBuilder.java
@@ -30,13 +30,17 @@ import org.apache.jena.sparql.engine.QueryExecutionBase;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.util.Context;
 
-/** Query Execution builder. */
+/**
+ * Query Execution builder.
+ * @deprecated Avoid. This class will be renamed {@code QueryExecDatasetBuilder} and replaced with a model/dataset level builder.
+ */
+@Deprecated
 public class QueryExecutionBuilder {
 
     private DatasetGraph dataset = null;
     private Query        query   = null;
     private Context      context = null;
-    private Binding      binding = null;    
+    private Binding      binding = null;
 
     public static QueryExecutionBuilder create() {
         return new QueryExecutionBuilder();
@@ -53,7 +57,7 @@ public class QueryExecutionBuilder {
         this.query = QueryFactory.create(queryString);
         return this;
     }
-    
+
     public QueryExecutionBuilder dataset(DatasetGraph dsg) {
         this.dataset = dsg;
         return this;
@@ -79,7 +83,7 @@ public class QueryExecutionBuilder {
 
         query.setResultVars();
         Context cxt;
-        
+
         if ( context == null ) {
             // Default is to take the global context, the copy it and merge in the dataset context.
             // If a context is specified by context(Context), use that as given.

--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
@@ -39,16 +39,16 @@ import org.apache.jena.sparql.syntax.Element ;
 import org.apache.jena.sparql.util.Context ;
 
 /** Place to make QueryExecution objects from Query objects or a string. */
- 
+
 public class QueryExecutionFactory
 {
     protected QueryExecutionFactory() {}
-    
+
     // ---------------- Query
-    
+
     /**
      * Create a QueryExecution
-     * 
+     *
      * @param query Query
      * @return QueryExecution
      */
@@ -59,7 +59,7 @@ public class QueryExecutionFactory
 
     /**
      * Create a QueryExecution
-     * 
+     *
      * @param queryStr Query string
      * @return QueryExecution
      */
@@ -70,7 +70,7 @@ public class QueryExecutionFactory
 
     /**
      * Create a QueryExecution
-     * 
+     *
      * @param queryStr Query string
      * @param syntax Query syntax
      * @return QueryExecution
@@ -79,12 +79,12 @@ public class QueryExecutionFactory
         checkArg(queryStr) ;
         return create(makeQuery(queryStr, syntax)) ;
     }
-    
+
     // ---------------- Query + Dataset
-    
+
     /**
      * Create a QueryExecution to execute over the Dataset.
-     * 
+     *
      * @param query Query
      * @param dataset Target of the query
      * @return QueryExecution
@@ -93,10 +93,10 @@ public class QueryExecutionFactory
         // checkArg(dataset) ; // Allow null
         return make(query, dataset) ;
     }
-    
+
     /**
      * Create a QueryExecution to execute over the {@link DatasetGraph}.
-     * 
+     *
      * @param query Query
      * @param datasetGraph Target of the query
      * @return QueryExecution
@@ -106,9 +106,9 @@ public class QueryExecutionFactory
         Objects.requireNonNull(datasetGraph, "DatasetGraph is null") ;
         return make(query, datasetGraph) ;
     }
-    
+
     /** Create a QueryExecution to execute over the Dataset.
-     * 
+     *
      * @param queryStr     Query string
      * @param dataset      Target of the query
      * @return QueryExecution
@@ -120,7 +120,7 @@ public class QueryExecutionFactory
     }
 
     /** Create a QueryExecution to execute over the Dataset.
-     * 
+     *
      * @param queryStr     Query string
      * @param syntax       Query language
      * @param dataset      Target of the query
@@ -133,9 +133,9 @@ public class QueryExecutionFactory
     }
 
     // ---------------- Query + Model
-    
+
     /** Create a QueryExecution to execute over the Model.
-     * 
+     *
      * @param query     Query
      * @param model     Target of the query
      * @return QueryExecution
@@ -147,7 +147,7 @@ public class QueryExecutionFactory
     }
 
     /** Create a QueryExecution to execute over the Model.
-     * 
+     *
      * @param queryStr     Query string
      * @param model     Target of the query
      * @return QueryExecution
@@ -159,7 +159,7 @@ public class QueryExecutionFactory
     }
 
     /** Create a QueryExecution to execute over the Model.
-     * 
+     *
      * @param queryStr     Query string
      * @param lang         Query language
      * @param model        Target of the query
@@ -172,9 +172,9 @@ public class QueryExecutionFactory
     }
 
     /** Create a QueryExecution to execute over the Model.
-     * 
+     *
      * @param query         Query string
-     * @param initialBinding    Any initial binding of variables      
+     * @param initialBinding    Any initial binding of variables
      * @return QueryExecution
      */
     static public QueryExecution create(Query query, QuerySolution initialBinding) {
@@ -186,7 +186,7 @@ public class QueryExecutionFactory
     }
 
     /** Create a QueryExecution given some initial values of variables.
-     * 
+     *
      * @param queryStr          QueryString
      * @param initialBinding    Any initial binding of variables
      * @return QueryExecution
@@ -197,7 +197,7 @@ public class QueryExecutionFactory
     }
 
     /** Create a QueryExecution given some initial values of variables.
-     * 
+     *
      * @param queryStr          QueryString
      * @param syntax            Query language syntax
      * @param initialBinding    Any initial binding of variables
@@ -208,9 +208,9 @@ public class QueryExecutionFactory
         return create(makeQuery(queryStr, syntax), initialBinding) ;
     }
 
-    /** Create a QueryExecution to execute over the Model, 
+    /** Create a QueryExecution to execute over the Model,
      * given some initial values of variables.
-     * 
+     *
      * @param query            Query
      * @param model            Target of the query
      * @param initialBinding    Any initial binding of variables
@@ -220,10 +220,10 @@ public class QueryExecutionFactory
         checkArg(model) ;
         return create(query, DatasetFactory.wrap(model), initialBinding) ;
     }
-    
-    /** Create a QueryExecution to execute over the Model, 
+
+    /** Create a QueryExecution to execute over the Model,
      * given some initial values of variables.
-     * 
+     *
      * @param queryStr         Query string
      * @param model            Target of the query
      * @param initialBinding    Any initial binding of variables
@@ -234,10 +234,10 @@ public class QueryExecutionFactory
         checkArg(model) ;
         return create(makeQuery(queryStr), model, initialBinding) ;
     }
-    
-    /** Create a QueryExecution to execute over the Model, 
+
+    /** Create a QueryExecution to execute over the Model,
      * given some initial values of variables.
-     * 
+     *
      * @param queryStr         Query string
      * @param syntax           Query language
      * @param model            Target of the query
@@ -248,9 +248,9 @@ public class QueryExecutionFactory
         checkArg(queryStr) ;
         return create(makeQuery(queryStr, syntax), model, initialBinding) ;
     }
-    
+
     /** Create a QueryExecution over a Dataset given some initial values of variables.
-     * 
+     *
      * @param query            Query
      * @param dataset          Target of the query
      * @param initialBinding    Any initial binding of variables
@@ -265,7 +265,7 @@ public class QueryExecutionFactory
     }
 
     /** Create a QueryExecution over a Dataset given some initial values of variables.
-     * 
+     *
      * @param queryStr         Query string
      * @param dataset          Target of the query
      * @param initialBinding    Any initial binding of variables
@@ -277,7 +277,7 @@ public class QueryExecutionFactory
     }
 
     /** Create a QueryExecution over a Dataset given some initial values of variables.
-     * 
+     *
      * @param queryStr         Query string
      * @param dataset          Target of the query
      * @param initialBinding    Any initial binding of variables
@@ -289,101 +289,101 @@ public class QueryExecutionFactory
     }
 
     // ---------------- Remote query execution
-    
+
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service   URL of the remote service 
-     * @param query     Query string to execute 
+     * @param service   URL of the remote service
+     * @param query     Query string to execute
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, String query) {
         return sparqlService(service, query, (HttpClient)null) ;
     }
-    
+
     static public QueryExecution sparqlService(String service, String query, HttpClient client) {
         return sparqlService(service, query, client, null);
     }
         /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service   URL of the remote service 
-     * @param query     Query string to execute 
+     * @param service   URL of the remote service
+     * @param query     Query string to execute
      * @param client    HTTP client
      * @param httpContext HTTP Context
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, String query, HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
         checkArg(query) ;
         return sparqlService(service, QueryFactory.create(query), client) ;
     }
-    
+
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service       URL of the remote service 
+     * @param service       URL of the remote service
      * @param query         Query string to execute
      * @param defaultGraph  URI of the default graph
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, String query, String defaultGraph) {
         return sparqlService(service, query, defaultGraph, null) ;
     }
 
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service       URL of the remote service 
+     * @param service       URL of the remote service
      * @param query         Query string to execute
      * @param defaultGraph  URI of the default graph
      * @param client        HTTP client
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, String query, String defaultGraph, HttpClient client) {
         return sparqlService(service, query, defaultGraph, client, null) ;
     }
 
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service       URL of the remote service 
+     * @param service       URL of the remote service
      * @param query         Query string to execute
      * @param defaultGraph  URI of the default graph
      * @param client        HTTP client
      * @param httpContext   HTTP Context
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, String query, String defaultGraph, HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
         // checkNotNull(defaultGraph, "IRI for default graph is null") ;
         checkArg(query) ;
         return sparqlService(service, QueryFactory.create(query), defaultGraph, client, httpContext) ;
     }
-    
+
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service           URL of the remote service 
+     * @param service           URL of the remote service
      * @param query             Query string to execute
      * @param defaultGraphURIs  List of URIs to make up the default graph
      * @param namedGraphURIs    List of URIs to make up the named graphs
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, String query, List<String> defaultGraphURIs, List<String> namedGraphURIs) {
         return sparqlService(service, query, defaultGraphURIs, namedGraphURIs, null) ;
     }
 
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service           URL of the remote service 
+     * @param service           URL of the remote service
      * @param query             Query string to execute
      * @param defaultGraphURIs  List of URIs to make up the default graph
      * @param namedGraphURIs    List of URIs to make up the named graphs
      * @param client            HTTP client
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, String query, List<String> defaultGraphURIs, List<String> namedGraphURIs,
                                                HttpClient client) {
         return sparqlService(service, query, defaultGraphURIs, namedGraphURIs, client, null) ;
     }
-    
+
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service           URL of the remote service 
+     * @param service           URL of the remote service
      * @param query             Query string to execute
      * @param defaultGraphURIs  List of URIs to make up the default graph
      * @param namedGraphURIs    List of URIs to make up the named graphs
      * @param client            HTTP client
      * @param httpContext HTTP Context
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, String query, List<String> defaultGraphURIs, List<String> namedGraphURIs,
                                                HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
@@ -392,65 +392,65 @@ public class QueryExecutionFactory
         checkArg(query) ;
         return sparqlService(service, QueryFactory.create(query), defaultGraphURIs, namedGraphURIs, client, httpContext) ;
     }
-    
+
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service   URL of the remote service 
-     * @param query     Query to execute 
+     * @param service   URL of the remote service
+     * @param query     Query to execute
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, Query query) {
         return sparqlService(service, query, (HttpClient)null) ;
     }
-    
+
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service   URL of the remote service 
-     * @param query     Query to execute 
+     * @param service   URL of the remote service
+     * @param query     Query to execute
      * @param client    HTTP client
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, Query query, HttpClient client) {
         checkNotNull(service, "URL for service is null") ;
         checkArg(query) ;
         return createServiceRequest(service, query, client) ;
     }
-    
+
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service   URL of the remote service 
-     * @param query     Query to execute 
+     * @param service   URL of the remote service
+     * @param query     Query to execute
      * @param client    HTTP client
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, Query query, HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
         checkArg(query) ;
         return createServiceRequest(service, query, client, httpContext) ;
     }
-    
+
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service           URL of the remote service 
+     * @param service           URL of the remote service
      * @param query             Query to execute
      * @param defaultGraphURIs  List of URIs to make up the default graph
      * @param namedGraphURIs    List of URIs to make up the named graphs
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, Query query, List<String> defaultGraphURIs, List<String> namedGraphURIs) {
         return sparqlService(service, query, defaultGraphURIs, namedGraphURIs, null, null) ;
     }
 
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service           URL of the remote service 
+     * @param service           URL of the remote service
      * @param query             Query to execute
      * @param defaultGraphURIs  List of URIs to make up the default graph
      * @param namedGraphURIs    List of URIs to make up the named graphs
      * @param client            HTTP client
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, Query query, List<String> defaultGraphURIs, List<String> namedGraphURIs, HttpClient client) {
         return sparqlService(service, query, defaultGraphURIs, namedGraphURIs, client, null);
     }
 
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service           URL of the remote service 
+     * @param service           URL of the remote service
      * @param query             Query to execute
      * @param defaultGraphURIs  List of URIs to make up the default graph
      * @param namedGraphURIs    List of URIs to make up the named graphs
@@ -473,33 +473,33 @@ public class QueryExecutionFactory
     }
 
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service       URL of the remote service 
+     * @param service       URL of the remote service
      * @param query         Query to execute
      * @param defaultGraph  URI of the default graph
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, Query query, String defaultGraph) {
         return sparqlService(service, query, defaultGraph, null) ;
     }
 
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service       URL of the remote service 
+     * @param service       URL of the remote service
      * @param query         Query to execute
      * @param defaultGraph  URI of the default graph
      * @param client        HTTP client
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, Query query, String defaultGraph, HttpClient client) {
        return sparqlService(service, query, defaultGraph, client, null);
     }
-    
+
     /** Create a QueryExecution that will access a SPARQL service over HTTP
-     * @param service       URL of the remote service 
+     * @param service       URL of the remote service
      * @param query         Query to execute
      * @param defaultGraph  URI of the default graph
      * @param client        HTTP client
      * @return QueryExecution
-     */ 
+     */
     static public QueryExecution sparqlService(String service, Query query, String defaultGraph, HttpClient client, HttpContext httpContext) {
         checkNotNull(service, "URL for service is null") ;
         // checkNotNull(defaultGraph, "IRI for default graph is null") ;
@@ -510,7 +510,7 @@ public class QueryExecutionFactory
     }
     /** Create a service request for remote execution over HTTP.  The returned class,
      * {@link QueryEngineHTTP},
-     * allows various HTTP specific parameters to be set. 
+     * allows various HTTP specific parameters to be set.
      * @param service Endpoint URL
      * @param query Query
      * @return Remote Query Engine
@@ -521,10 +521,10 @@ public class QueryExecutionFactory
 
     /** Create a service request for remote execution over HTTP.  The returned class,
      * {@link QueryEngineHTTP},
-     * allows various HTTP specific parameters to be set. 
+     * allows various HTTP specific parameters to be set.
      * @param service Endpoint URL
      * @param query Query
-     * @param client HTTP client 
+     * @param client HTTP client
      * @return Remote Query Engine
      */
     static public QueryEngineHTTP createServiceRequest(String service, Query query, HttpClient client) {
@@ -534,10 +534,10 @@ public class QueryExecutionFactory
 
     /** Create a service request for remote execution over HTTP.  The returned class,
      * {@link QueryEngineHTTP},
-     * allows various HTTP specific parameters to be set. 
+     * allows various HTTP specific parameters to be set.
      * @param service Endpoint URL
      * @param query Query
-     * @param client HTTP client 
+     * @param client HTTP client
      * @param httpContext HTTP Context
      * @return Remote Query Engine
      */
@@ -547,7 +547,7 @@ public class QueryExecutionFactory
     }
 
     // -----------------
-    
+
     static public Plan createPlan(Query query, DatasetGraph dataset, Binding input, Context context) {
         return makePlan(query, dataset, input, context) ;
     }
@@ -569,14 +569,14 @@ public class QueryExecutionFactory
         if ( context == null )
             context = new Context(ARQ.getContext()) ;
         if ( input == null )
-            input = BindingRoot.create() ; 
+            input = BindingRoot.create() ;
         QueryEngineFactory f = QueryEngineRegistry.get().find(query, dataset, context);
         if ( f == null )
             return null ;
         return f.create(query, dataset, input, context) ;
     }
     // ---------------- Internal routines
-    
+
     static private Query makeQuery(String queryStr) {
         return QueryFactory.create(queryStr) ;
     }
@@ -584,7 +584,8 @@ public class QueryExecutionFactory
     static private Query makeQuery(String queryStr, Syntax syntax) {
         return QueryFactory.create(queryStr, syntax) ;
     }
-    
+
+    @SuppressWarnings("deprecation")
     static protected QueryExecution make(Query query) {
         return QueryExecution.create().query(query).build();
     }
@@ -595,12 +596,12 @@ public class QueryExecutionFactory
         Graph g = unwrap(graph);
         if ( g instanceof GraphView ) {
             GraphView gv = (GraphView)g;
-            // Copy context of the storage dataset to the wrapper dataset. 
+            // Copy context of the storage dataset to the wrapper dataset.
             dataset.getContext().putAll(gv.getDataset().getContext());
         }
         return make(query, dataset);
     }
-    
+
     private static Graph unwrap(Graph graph) {
         for(;;) {
             if ( graph instanceof GraphWrapper )
@@ -616,13 +617,14 @@ public class QueryExecutionFactory
         return make(query, dsg);
     }
 
+    @SuppressWarnings("deprecation")
     protected static QueryExecution make(Query query, DatasetGraph datasetGraph)
     { return QueryExecution.create().query(query).dataset(datasetGraph).build(); }
 
     static private <X> void checkNotNull(X obj, String msg) {
         Objects.requireNonNull(obj, msg);
     }
-    
+
     static private void checkArg(Model model)
     { checkNotNull(model, "Model is a null pointer") ; }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
@@ -303,6 +303,7 @@ public abstract class SPARQLQueryProcessor extends ActionService
      * @param dataset
      * @return QueryExecution
      */
+    @SuppressWarnings("deprecation")
     protected QueryExecution createQueryExecution(HttpAction action, Query query, DatasetGraph dataset) {
         return QueryExecution.create().query(query).dataset(dataset).context(action.getContext()).build();
     }


### PR DESCRIPTION
[JENA-2125](https://issues.apache.org/jira/browse/JENA-2125) provides QueryExec for DatasetGraph level operation and QueryExecution for Dataset/Model level.

The current `QueryExecutionBuilder` works with `DatasetGraph` so it is misnamed and in the way of a proper builder for QueryExecution [JENA-2128](https://issues.apache.org/jira/browse/JENA-2128).

See also PR https://github.com/apache/jena/pull/1030.