### PR TITLE
JENA-2154: Custom SERVICE executors

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
@@ -33,6 +33,7 @@ import org.apache.jena.sparql.mgt.Explain ;
 import org.apache.jena.sparql.mgt.Explain.InfoLevel ;
 import org.apache.jena.sparql.mgt.SystemInfo ;
 import org.apache.jena.sparql.pfunction.PropertyFunctionRegistry ;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
 import org.apache.jena.sparql.util.Context ;
 import org.apache.jena.sparql.util.MappingRegistry ;
 import org.apache.jena.sparql.util.Symbol ;
@@ -611,6 +612,7 @@ public class ARQ
 
             // Initialise the standard library.
             FunctionRegistry.init() ;
+            ServiceExecutorRegistry.init();
             AggregateRegistry.init() ;
             PropertyFunctionRegistry.init() ;
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/ARQConstants.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/ARQConstants.java
@@ -290,6 +290,10 @@ public class ARQConstants
     public static final Symbol registryFunctions =
         SystemARQ.allocSymbol("registryFunctions") ;
 
+    /** The service executor library registry key */
+    public static final Symbol registryServiceExecutors =
+        SystemARQ.allocSymbol("registryServiceExecutors") ;
+
     /** The function library registry key */
     public static final Symbol registryProcedures =
         SystemARQ.allocSymbol("registryProcedures") ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecutorFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecutorFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.service;
+
+import java.util.function.Supplier;
+
+import org.apache.jena.sparql.algebra.op.OpService;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
+
+/**
+ * Interface for custom handling of service execution requests.
+ */
+public interface ServiceExecutorFactory {
+
+    /**
+     * Whether the OpService instance passed to {@link #createExecutor(OpService, Binding, ExecutionContext)}
+     * should already be substituted with the binding. Defaults to true.
+     */
+    default boolean substituteOp() {
+        return true;
+    }
+
+    /**
+     * If this factory cannot handle the execution request then this method needs to return null.
+     * Otherwise, a supplier with the corresponding QueryIterator needs to be supplied.
+     *
+     * @return A QueryIterator supplier if this factory can handle the request, null otherwise.
+     */
+    Supplier<QueryIterator> createExecutor(OpService op, Binding binding, ExecutionContext execCxt);
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecutorRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecutorRegistry.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.jena.query.ARQ;
+import org.apache.jena.sparql.ARQConstants;
+import org.apache.jena.sparql.util.Context;
+
+public class ServiceExecutorRegistry
+{
+    // A list of custom service executors which are tried in the given order
+    List<ServiceExecutorFactory> registry = new ArrayList<>();
+
+    public static ServiceExecutorRegistry standardRegistry()
+    {
+        ServiceExecutorRegistry reg = get(ARQ.getContext()) ;
+        return reg ;
+    }
+
+    public static void init() {
+        // Initialize if there is no registry already set
+        ServiceExecutorRegistry reg = new ServiceExecutorRegistry() ;
+        set(ARQ.getContext(), reg) ;
+    }
+
+    public static ServiceExecutorRegistry get()
+    {
+        // Initialize if there is no registry already set
+        ServiceExecutorRegistry reg = get(ARQ.getContext()) ;
+        if ( reg == null )
+        {
+            init() ;
+            reg = get(ARQ.getContext()) ;
+        }
+
+        return reg ;
+    }
+
+    public static ServiceExecutorRegistry get(Context context)
+    {
+        if ( context == null )
+            return null ;
+        return (ServiceExecutorRegistry)context.get(ARQConstants.registryServiceExecutors) ;
+    }
+
+    public static void set(Context context, ServiceExecutorRegistry reg)
+    {
+        context.set(ARQConstants.registryServiceExecutors, reg) ;
+    }
+
+    public ServiceExecutorRegistry()
+    {}
+
+
+    /** Insert a service executor factory. Must not be null. */
+    public ServiceExecutorRegistry add(ServiceExecutorFactory f) {
+        Objects.requireNonNull(f) ;
+        registry.add(f) ;
+        return this;
+    }
+
+    /** Remove the given service executor factory. */
+    public ServiceExecutorRegistry remove(ServiceExecutorFactory f) {
+        registry.remove(f) ;
+        return this;
+    }
+
+    /** Retrieve the actual list of factories; allows for re-ordering */
+    public List<ServiceExecutorFactory> getFactories() {
+        return registry;
+    }
+
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/service/TestCustomServiceExecutor.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/service/TestCustomServiceExecutor.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.service;
+
+import java.util.function.Consumer;
+
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.ResultSetRewindable;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.ResultSetMgr;
+import org.apache.jena.riot.resultset.ResultSetLang;
+import org.apache.jena.sparql.algebra.Table;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.apache.jena.sparql.resultset.ResultSetCompare;
+import org.apache.jena.sparql.sse.SSE;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCustomServiceExecutor {
+
+    static Table table = SSE.parseTable("(table (row (?s 1) (?p 2) (?o 3) ) )");
+
+    /** A custom service factory that yields the above table for any request
+     *  to urn:customService */
+    static ServiceExecutorFactory factory = (op, binding, execCxt) ->
+        op.getService().getURI().equals("urn:customService")
+            ? () -> table.iterator(execCxt)
+            : null;
+
+    static ServiceExecutorRegistry customRegistry = new ServiceExecutorRegistry().add(factory);
+
+    @Test
+    public void testGlobalServiceExecutorRegistry() {
+        ServiceExecutorRegistry.get().add(factory);
+
+        try {
+            assertResult("urn:customService", qe -> {});
+        } finally {
+            // Better eventually remove the global registration
+            ServiceExecutorRegistry.get().remove(factory);
+        }
+    }
+
+    /** Test setting the registory on a local context*/
+    @Test
+    public void testLocalServiceExecutorRegistry() {
+        ServiceExecutorRegistry registry = new ServiceExecutorRegistry();
+        registry.add(factory);
+
+        assertResult("urn:customService", qe -> ServiceExecutorRegistry.set(qe.getContext(), registry));
+    }
+
+    /** Sanity check: Use of an illegal service iri */
+    @Test(expected = QueryExceptionHTTP.class)
+    public void testIllegalServiceIri() {
+        assertResult("urn:illegalServiceIri",
+                qe -> ServiceExecutorRegistry.set(qe.getContext(), customRegistry));
+    }
+
+    // Sanity check to rule out interference where access to remote endpoints
+    // Uncommenting @Test is expected to print out data from the remote endpoint
+    // @Test
+    public void testAgainstDBpedia() {
+        assertResult("http://dbpedia.org/sparql",
+                qe -> ServiceExecutorRegistry.set(qe.getContext(), customRegistry));
+    }
+
+
+    public static void assertResult(String serviceIri, Consumer<QueryExecution> qePostProcessor) {
+
+        String queryStr = "SELECT * { SERVICE <" + serviceIri + "> { { SELECT * { ?s ?p ?o } LIMIT 10 } } }";
+
+        Model model = ModelFactory.createDefaultModel();
+        try (QueryExecution qe = QueryExecutionFactory.create(queryStr, model)) {
+            qePostProcessor.accept(qe);
+            ResultSetRewindable actual = qe.execSelect().rewindable();
+
+            boolean isEqual = ResultSetCompare.equalsExact(actual, table.toResultSet());
+
+            if (!isEqual) {
+                actual.reset();
+                ResultSetMgr.write(System.err, actual, ResultSetLang.RS_Text);
+            }
+
+            Assert.assertTrue(isEqual);
+        }
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/service/TestCustomServiceExecutor.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/service/TestCustomServiceExecutor.java
@@ -62,10 +62,8 @@ public class TestCustomServiceExecutor {
     /** Test setting the registory on a local context*/
     @Test
     public void testLocalServiceExecutorRegistry() {
-        ServiceExecutorRegistry registry = new ServiceExecutorRegistry();
-        registry.add(factory);
-
-        assertResult("urn:customService", qe -> ServiceExecutorRegistry.set(qe.getContext(), registry));
+        assertResult("urn:customService",
+                qe -> ServiceExecutorRegistry.set(qe.getContext(), customRegistry));
     }
 
     /** Sanity check: Use of an illegal service iri */

--- a/jena-arq/src/test/java/org/apache/jena/sparql/service/TestCustomServiceExecutor.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/service/TestCustomServiceExecutor.java
@@ -73,7 +73,7 @@ public class TestCustomServiceExecutor {
                 qe -> ServiceExecutorRegistry.set(qe.getContext(), customRegistry));
     }
 
-    // Sanity check to rule out interference where access to remote endpoints
+    // Sanity check to rule out interference with conventional access to remote endpoints
     // Uncommenting @Test is expected to print out data from the remote endpoint
     // @Test
     public void testAgainstDBpedia() {


### PR DESCRIPTION
The implementation introduces a ServiceExecutorRegistry akin to the existing FunctionRegistry.
Motivation and design are outlined at https://issues.apache.org/jira/browse/JENA-2154.
Test cases are provided in the TestCustomServiceExecutor class.

Cheers,
Claus