### PR TITLE
Fix OSGi import for titanium dependency

### DIFF
--- a/apache-jena-osgi/jena-osgi/pom.xml
+++ b/apache-jena-osgi/jena-osgi/pom.xml
@@ -279,6 +279,9 @@
               !com.google.errorprone.annotations.*,
               !com.google.appengine.api,
               !com.google.apphosting.api,
+              com.apicatalog.jsonld.*;resolution:=optional,
+              com.apicatalog.rdf.*;resolution:=optional,
+              jakarta.json;resolution:=optional,
               org.apache.logging.*;resolution:=optional,
               sun.misc;resolution:=optional,
               *


### PR DESCRIPTION
The titanium JSON-LD project makes installing Jena in an OSGi runtime difficult. Since titanium does not seem to support OSGi deployment, this marks that dependency as optional