### PR TITLE
JENA-2169: Dataset interface should support blank node labels for graphs

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/Dataset.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/Dataset.java
@@ -21,6 +21,7 @@ package org.apache.jena.query;
 import java.util.Iterator ;
 
 import org.apache.jena.rdf.model.Model ;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.system.Prefixes;
 import org.apache.jena.shared.Lock ;
 import org.apache.jena.shared.PrefixMapping;
@@ -51,8 +52,14 @@ public interface Dataset extends Transactional
     /** Get a graph by name as a Jena Model */
     public Model getNamedModel(String uri) ;
 
+    /** Get a graph by name as a Jena Model */
+    public Model getNamedModel(Resource uri) ;
+
     /** Does the dataset contain a model with the name supplied? */
     public boolean containsNamedModel(String uri) ;
+
+    /** Does the dataset contain a model with the name supplied? */
+    public boolean containsNamedModel(Resource uri) ;
 
     /**
      * Set a named graph.
@@ -64,12 +71,29 @@ public interface Dataset extends Transactional
     public Dataset addNamedModel(String uri, Model model);
 
     /**
+     * Set a named graph.
+     *
+     * @param uri the name of the graph to set
+     * @param model the graph to set
+     * @return this {@code Dataset} for continued usage
+     */
+    public Dataset addNamedModel(Resource uri, Model model);
+
+    /**
      * Remove a named graph.
      *
      * @param uri the name of the gaph to remove
      * @return this {@code Dataset} for continued usage
      */
     public Dataset removeNamedModel(String uri);
+
+    /**
+     * Remove a named graph.
+     *
+     * @param uri the name of the gaph to remove
+     * @return this {@code Dataset} for continued usage
+     */
+    public Dataset removeNamedModel(Resource uri);
 
     /**
      * Change a named graph for another using the same name
@@ -80,8 +104,20 @@ public interface Dataset extends Transactional
      */
     public Dataset replaceNamedModel(String uri, Model model);
 
+    /**
+     * Change a named graph for another using the same name
+     *
+     * @param uri the name of the graph to replace
+     * @param model the graph with which to replace it
+     * @return this {@code Dataset} for continued usage
+     */
+    public Dataset replaceNamedModel(Resource uri, Model model);
+
     /** List the names */
     public Iterator<String> listNames() ;
+
+    /** List the names */
+    public Iterator<Resource> listModelNames() ;
 
     /** Get the lock for this dataset */
     public Lock getLock() ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetOne.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetOne.java
@@ -22,6 +22,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
 
 /**
  * A dataset that just hold a single model as the default graph. 
@@ -66,7 +67,17 @@ public class DatasetOne extends DatasetImpl {
     }
 
     @Override
+    public Dataset addNamedModel(Resource uri, Model model) {
+        throw new UnsupportedOperationException("Can not add a named mode to DatasetOne");
+    }
+
+    @Override
     public Dataset removeNamedModel(String uri) {
+        return this;
+    }
+
+    @Override
+    public Dataset removeNamedModel(Resource uri) {
         return this;
     }
 
@@ -74,6 +85,12 @@ public class DatasetOne extends DatasetImpl {
     public Dataset replaceNamedModel(String uri, Model model) {
         throw new UnsupportedOperationException("Can not replace a named model in DatasetOne");
     }
+
+    @Override
+    public Dataset replaceNamedModel(Resource uri, Model model) {
+        throw new UnsupportedOperationException("Can not replace a named model in DatasetOne");
+    }
+
     @Override
     public boolean containsNamedModel(String uri) {
         return false;


### PR DESCRIPTION
Draft for blank node name support, but not tested yet, as I did not manage to find the tests for `DatasetImpl` to add some.

As I didn't wanted to go the way over a IRI String in `DatasetImpl::listModelNames`, I decided to directly use the `ResourceImpl(Node, ModelCom)` constructor with second parameter `null`. In the end, that should have the same result as `ResourceImpl(String)`. But I was not sure, if it would make sense to add the default graph (or the named graph) as second parameter.