### PR TITLE
Fix copy/paste error in validation report message

### DIFF
--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/EqualsConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/EqualsConstraint.java
@@ -45,13 +45,13 @@ public class EqualsConstraint extends ConstraintPairwise {
                          Set<Node> pathNodes, Set<Node> compareNodes) {
         for ( Node vn : pathNodes ) {
             if ( ! compareNodes.contains(vn) ) {
-                String msg = toString()+": not disjoint: value node "+displayStr(vn)+" is not in "+compareNodes;
+                String msg = toString()+": not equal: value node "+displayStr(vn)+" is not in "+compareNodes;
                 vCxt.reportEntry(msg, shape, focusNode, path, vn, this);
             }
         }
         for ( Node v : compareNodes ) {
             if ( ! pathNodes.contains(v) ) {
-                String msg = toString()+": not disjoint: value "+displayStr(v)+" is not in "+pathNodes;
+                String msg = toString()+": not equal: value "+displayStr(v)+" is not in "+pathNodes;
                 vCxt.reportEntry(msg, shape, focusNode, path, v, this);
             }
         }


### PR DESCRIPTION
Not disjoint -> Not equal

(with this affecting two lines of code, and taking 30 seconds to approve, I think it's in everyone's interest to circumvent the normal process for PRs and just fix this as we go)