### PR TITLE
Fix running mvn with the dev profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,8 @@
 
         <module>jena-geosparql</module>
         <module>jena-fuseki2/jena-fuseki-geosparql</module>
-        
+
+        <module>jena-extras/jena-querybuilder</module>
         <module>jena-examples</module>
 
         <module>jena-integration-tests</module>


### PR DESCRIPTION
@afs :wave: 

After syncing the code today, and trying `mvn clean install -Pdev` it failed with

```bash
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13:09 min
[INFO] Finished at: 2021-11-22T18:13:57+13:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project jena-examples: Could not resolve dependencies for project org.apache.jena:jena-examples:jar:4.3.0-SNAPSHOT: Could not find artifact org.apache.jena:jena-querybuilder:jar:4.3.0-SNAPSHOT in repo.jenkins-ci.org (https://repo.jenkins-ci.org/public/) -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :jena-examples
```

Had a look at Jenkins, but it runs `mvn clean verify`. Then confirmed that the examples project uses Jena QueryBuilder. Didn't know whether I should remove the examples using it, or add the dependency in the `pom.xml`. WDYT?

Thanks!
Bruno