### PR TITLE
JENA-2203: Set default redirect to ALWAYS

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpEnv.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpEnv.java
@@ -65,7 +65,9 @@ public class HttpEnv {
                 // By default, the client has polling and connection-caching.
                 // Version HTTP/2 is the default, negotiating up from HTTP 1.1.
                 .connectTimeout(Duration.ofSeconds(10))
-                .followRedirects(Redirect.NORMAL)
+                // Redirect.NORMAL - this does not follow https to http 3xx.
+                // (Dec 2021) http://purl.org first switches to https://purl.org, then will redirect to an http: URL.
+                .followRedirects(Redirect.ALWAYS)
                 //.sslContext
                 //.sslParameters
                 //.proxy

--- a/jena-examples/src/main/java/arq/examples/auth/ExAuth01_RDFConnectionPW.java
+++ b/jena-examples/src/main/java/arq/examples/auth/ExAuth01_RDFConnectionPW.java
@@ -83,6 +83,7 @@ public class ExAuth01_RDFConnectionPW {
         Authenticator authenticator = AuthLib.authenticator("u", "p");
         HttpClient httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
+                //.followRedirects -- the default is Redirect.NEVER
                 .authenticator(authenticator)
                 .build();
         try ( RDFConnection conn = RDFConnectionRemote.service(dataURL)

--- a/jena-examples/src/main/java/arq/examples/auth/ExAuth03_UpdateExecutionPW.java
+++ b/jena-examples/src/main/java/arq/examples/auth/ExAuth03_UpdateExecutionPW.java
@@ -67,6 +67,7 @@ public class ExAuth03_UpdateExecutionPW {
         System.out.println("HttpClient + UpdateExecutionHTTP");
         Authenticator authenticator = AuthLib.authenticator("u", "p");
         HttpClient httpClient = HttpClient.newBuilder()
+                //.followRedirect
                 .connectTimeout(Duration.ofSeconds(10))
                 .authenticator(authenticator)
                 .build();


### PR DESCRIPTION
[JENA-2203](https://issues.apache.org/jira/browse/JENA-2203) - Jena currently does not follow https -> http redirect (see Java `HttpClient.Redirect.NORMAL`). 

`purl.org` adds a https to http redirect.

See also [JENA-1263](https://issues.apache.org/jira/browse/JENA-1263). From that change, Jena, using Apache HttpClient, has been following all 303's including https to http.
