### PR TITLE
fix documentation link for tdb-xloader documentation in cli-info

### DIFF
--- a/apache-jena/bin/tdb2.xloader
+++ b/apache-jena/bin/tdb2.xloader
@@ -74,7 +74,7 @@ $(basename $0) TDB2 Bulk Loader
 Usage: ${TDB_CMD} --loc <Directory> [--tmpdir=DIR] FILE ...
 
 Bulk loader for TDB2.
-See https://jena.apache/org/documentation/tdb/tdb-xloader.html
+See https://jena.apache.org/documentation/tdb/tdb-xloader.html
 
 Environment variables:
 


### PR DESCRIPTION
Hi, and thanks for the new version!

I'm looking forward to try out the new xloader, and noticed that I was unable to follow the url in the help text.