### PR TITLE
xloader: set LC_ALL=C for external sort command

### DIFF
--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/xloader/ProcIndexBuildX.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/xloader/ProcIndexBuildX.java
@@ -145,6 +145,7 @@ public class ProcIndexBuildX
         InputStream fromSortInputStream;
 
         try {
+            ProcessBuilder pb2;
             //LOG.info("Step : external sort : "+indexName);
             //if ( sortArgs != null ) {}
 
@@ -163,7 +164,9 @@ public class ProcIndexBuildX
                 sortCmd.add(datafile);
             // else this process will decompress and send the data.
 
-            proc2 = new ProcessBuilder(sortCmd).start();
+            pb2 = new ProcessBuilder(sortCmd);
+            pb2.environment().put("LC_ALL","C");
+            proc2 = pb2.start();
 
             // To process. Not used if uncompressed file.
             toSortOutputStream = proc2.getOutputStream();

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/xloader/ProcNodeTableBuilderX.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/xloader/ProcNodeTableBuilderX.java
@@ -103,6 +103,7 @@ public class ProcNodeTableBuilderX {
         // ** Step 2: The sort
         Process proc2;
         try {
+            ProcessBuilder pb2;
             //LOG.info("Step : external sort");
             List<String> sortCmdBasics = Arrays.asList(
                   "sort",
@@ -119,7 +120,9 @@ public class ProcNodeTableBuilderX {
             // See javadoc for CompressSortNodeTableFiles - usually false
             if ( BulkLoaderX.CompressSortNodeTableFiles )
                 sortCmd.add("--compress-program=/usr/bin/gzip");
-            proc2 = new ProcessBuilder(sortCmd).start();
+            pb2 = new ProcessBuilder(sortCmd);
+            pb2.environment().put("LC_ALL","C");
+            proc2 = pb2.start();
 
             // To process.
             toSortOutputStream = proc2.getOutputStream(); // Needs buffering


### PR DESCRIPTION
`LC_ALL=C`  could maybe be added to the beginning of the sortCmd array instead of adding it in as environment var for the process builder?