### PR TITLE
JENA-2220: Isolate Apache HTTP Client usage in jena-jdbc

### DIFF
--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/connections/AbstractJenaConnectionTests.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/connections/AbstractJenaConnectionTests.java
@@ -20,7 +20,6 @@ package org.apache.jena.jdbc.connections;
 import java.net.MalformedURLException ;
 import java.net.URL ;
 import java.sql.* ;
-import java.sql.ResultSet ;
 import java.util.HashMap ;
 import java.util.Properties ;
 
@@ -34,8 +33,11 @@ import org.apache.jena.jdbc.results.SelectResults ;
 import org.apache.jena.jdbc.results.TripleIteratorResults ;
 import org.apache.jena.jdbc.results.metadata.AskResultsMetadata ;
 import org.apache.jena.jdbc.results.metadata.TripleResultsMetadata ;
-import org.apache.jena.jdbc.utils.TestJdbcUtils ;
-import org.apache.jena.query.* ;
+import org.apache.jena.jdbc.utils.TestJdbcUtils;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
 import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sys.JenaSystem ;
 import org.apache.jena.update.UpdateFactory ;
@@ -46,7 +48,7 @@ import org.junit.Test ;
 
 /**
  * Abstract tests for {@link JenaConnection} implementations
- * 
+ *
  */
 @SuppressWarnings("resource")
 public abstract class AbstractJenaConnectionTests {
@@ -58,7 +60,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Method which derived test classes must implement to provide a connection
      * to an empty database for testing
-     * 
+     *
      * @return Connection
      * @throws SQLException
      */
@@ -67,7 +69,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Method which derived test classes must implement to provide a connection
      * to a database constructed from the given dataset for testing
-     * 
+     *
      * @return Connection
      * @throws SQLException
      */
@@ -81,7 +83,7 @@ public abstract class AbstractJenaConnectionTests {
      * By default assumed to be false, override if you need to make it true for
      * your connection
      * </p>
-     * 
+     *
      * @return Whether a named graph is used as the default graph
      */
     protected boolean usesNamedGraphAsDefault() {
@@ -91,7 +93,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Method which indicates whether the connection being tested supports query
      * timeouts
-     * 
+     *
      * @return True if query timeouts are supported
      */
     protected boolean supportsTimeouts() {
@@ -101,7 +103,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Method which returns the name of the default graph when a named graph is
      * being used as the default graph
-     * 
+     *
      * @return Named Graph being used as the default graph
      * @throws SQLException
      *             Thrown if this feature is not being used
@@ -113,7 +115,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Create and close a connection to an empty database
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -126,7 +128,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Create and close a connection to an explicitly provided empty database
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -139,7 +141,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Retrieve and close a statement
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -156,7 +158,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Trying to retrieve a statement from a closed connection is an error
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -172,7 +174,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Trying to use a statement from a closed connection is an error
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -191,7 +193,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Runs a SELECT query on an empty database and checks it returns empty
      * results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -223,7 +225,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Runs a SELECT query on a non-empty database and checks it returns
      * non-empty results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -267,7 +269,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Runs a SELECT query on a non-empty database and checks it returns
      * non-empty results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -312,7 +314,7 @@ public abstract class AbstractJenaConnectionTests {
      * Runs a SELECT query on a non-empty database and checks it returns
      * non-empty results. Uses high compatibility level to ensure that column
      * type detection doesn't consume the first row.
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -356,7 +358,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests use of prepared statements
-     * 
+     *
      * @throws SQLException
      * @throws MalformedURLException
      */
@@ -405,7 +407,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests use of prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -453,7 +455,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests use of prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -499,12 +501,12 @@ public abstract class AbstractJenaConnectionTests {
         Assert.assertTrue(conn.isClosed());
     }
 
-   
+
 
     /**
      * Runs a SELECT query on a non-empty database with max rows set and checks
      * that the appropriate number of rows are returned
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -548,7 +550,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Runs a SELECT query on a non-empty database with max rows set and checks
      * that the appropriate number of rows are returned
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -595,7 +597,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Runs a SELECT query on a non-empty database with max rows set and checks
      * that the appropriate number of rows are returned
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -641,7 +643,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a SELECT query on a non-empty database with timeout
-     * 
+     *
      * @throws SQLException
      * @throws InterruptedException
      */
@@ -680,7 +682,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a SELECT query on a non-empty database with timeout
-     * 
+     *
      * @throws SQLException
      * @throws InterruptedException
      */
@@ -719,7 +721,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a SELECT query on a non-empty database with timeout
-     * 
+     *
      * @throws SQLException
      * @throws InterruptedException
      */
@@ -758,7 +760,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a SELECT query on a non-empty database with timeout
-     * 
+     *
      * @throws SQLException
      * @throws InterruptedException
      */
@@ -807,7 +809,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs an ASK query on an empty database and checks it returns true
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -849,7 +851,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Runs a CONSTRUCT query on an empty database and checks it returns empty
      * results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -881,7 +883,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Runs a CONSTRUCT query on a non-empty database and checks it returns
      * non-empty results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -922,7 +924,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Runs a CONSTRUCT query on an empty database and checks it returns empty
      * results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -954,7 +956,7 @@ public abstract class AbstractJenaConnectionTests {
     /**
      * Runs a CONSTRUCT query on a non-empty database and checks it returns
      * non-empty results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1005,7 +1007,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Does a basic read transaction
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1039,7 +1041,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Does a basic write transaction
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1077,7 +1079,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Does a basic write transaction without auto-commit and then commits it
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1133,7 +1135,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Does a basic write transaction without auto-commit and then rolls it back
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1188,7 +1190,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for transactions
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1203,7 +1205,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for transactions
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1218,7 +1220,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1232,7 +1234,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1246,7 +1248,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1260,7 +1262,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -1277,7 +1279,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -1294,7 +1296,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1308,7 +1310,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1322,7 +1324,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1336,7 +1338,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1350,7 +1352,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1364,7 +1366,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1379,7 +1381,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -1396,7 +1398,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Test error cases for creating prepared statements
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -1413,7 +1415,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1458,7 +1460,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1518,7 +1520,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1592,7 +1594,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1621,7 +1623,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1667,7 +1669,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1712,7 +1714,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1777,7 +1779,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1804,7 +1806,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -1836,10 +1838,10 @@ public abstract class AbstractJenaConnectionTests {
             conn.close();
         }
     }
-    
+
     /**
      * Runs a batch of operations and checks the results results
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1855,25 +1857,25 @@ public abstract class AbstractJenaConnectionTests {
         stmt.close();
         conn.close();
     }
-    
+
     /**
      * Tests using batches with prepared statements
      * @throws SQLException
-     * @throws MalformedURLException 
+     * @throws MalformedURLException
      */
     @Test
     public void connection_prepared_statement_batch_01() throws SQLException, MalformedURLException {
         JenaConnection conn = this.getConnection();
         PreparedStatement stmt = conn.prepareStatement("SELECT * WHERE { ? ?p ?o }");
-        
+
         for (int i = 1; i <= 5; i++) {
             stmt.setURL(1, new URL("http://example/" + i));
             stmt.addBatch();
         }
-        
+
         int[] batchResults = stmt.executeBatch();
         Assert.assertEquals(5, batchResults.length);
-        
+
         // Expect all to be SELECT results
         ResultSet rset = stmt.getResultSet();
         checkSelectMetadata(rset, 2);
@@ -1881,14 +1883,14 @@ public abstract class AbstractJenaConnectionTests {
             rset = stmt.getResultSet();
             checkSelectMetadata(rset, 2);
         }
-        
+
         stmt.close();
         conn.close();
     }
 
     /**
      * Tests pre-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1913,7 +1915,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests pre-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = IndexOutOfBoundsException.class)
@@ -1937,7 +1939,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests pre-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1959,7 +1961,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests pre-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -1981,7 +1983,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests pre-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2003,7 +2005,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests pre-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2026,7 +2028,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests pre-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2049,7 +2051,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests pre-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2069,10 +2071,10 @@ public abstract class AbstractJenaConnectionTests {
 
         conn.close();
     }
-    
+
     /**
      * Tests post-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2097,7 +2099,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests post-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = IndexOutOfBoundsException.class)
@@ -2121,7 +2123,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests post-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2143,7 +2145,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests post-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2165,7 +2167,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests post-processor management operations
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2187,7 +2189,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases trying to set invalid options
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2204,7 +2206,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases trying to set invalid options
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -2221,7 +2223,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases trying to set invalid options
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)
@@ -2238,7 +2240,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases around savepoints which are unsupported
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2254,7 +2256,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases around savepoints which are unsupported
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2270,7 +2272,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases around savepoints which are unsupported
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2286,7 +2288,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases around savepoints which are unsupported
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2302,7 +2304,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases around type maps which are unsupported
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2318,7 +2320,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases around type maps which are unsupported
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2334,7 +2336,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported call functionality
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2350,7 +2352,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported call functionality
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2366,7 +2368,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported call functionality
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2382,7 +2384,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported native sql functionality
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2398,7 +2400,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests usage of client info
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2431,7 +2433,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests usage of client info
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2451,7 +2453,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Check catalog retrieval
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2465,7 +2467,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Check warnings usage
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2479,7 +2481,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Check warnings usage
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2497,7 +2499,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Check warnings usage
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2515,7 +2517,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Check warnings usage
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2533,7 +2535,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Check warnings usage
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2554,7 +2556,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported wrapper features
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2570,7 +2572,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported wrapper features
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2586,7 +2588,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported create operations
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2602,7 +2604,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported create operations
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2618,7 +2620,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported create operations
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2634,7 +2636,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported create operations
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2650,7 +2652,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported create operations
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2666,7 +2668,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests error cases for unsupported create operations
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -2682,7 +2684,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests connection validity
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2696,7 +2698,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests read only settings
-     * 
+     *
      * @throws SQLException
      */
     @Test
@@ -2711,7 +2713,7 @@ public abstract class AbstractJenaConnectionTests {
 
     /**
      * Tests read only settings
-     * 
+     *
      * @throws SQLException
      */
     @Test(expected = SQLException.class)

--- a/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/utils/TestJdbcUtils.java
+++ b/jena-jdbc/jena-jdbc-core/src/test/java/org/apache/jena/jdbc/utils/TestJdbcUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,29 +21,16 @@ package org.apache.jena.jdbc.utils;
 import static org.apache.jena.graph.Node.ANY;
 import static org.apache.jena.sparql.core.Quad.defaultGraphIRI;
 
-import java.io.ByteArrayOutputStream;
-import java.util.Iterator;
-
-import org.apache.http.client.HttpClient;
-import org.apache.http.entity.ByteArrayEntity;
-import org.apache.jena.atlas.io.IO;
-import org.apache.jena.atlas.lib.IRILib;
-import org.apache.jena.graph.Graph;
-import org.apache.jena.query.Dataset ;
-import org.apache.jena.query.DatasetFactory ;
-import org.apache.jena.rdf.model.Model ;
-import org.apache.jena.rdf.model.ModelFactory ;
-import org.apache.jena.riot.RDFDataMgr;
-import org.apache.jena.riot.RDFFormat;
-import org.apache.jena.riot.web.HttpOp1;
-import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
 
 /**
  * Test utility methods
  */
-@SuppressWarnings("deprecation")
 public class TestJdbcUtils {
-
     /**
      * Generates a synthetic dataset for testing
      *
@@ -121,92 +108,4 @@ public class TestJdbcUtils {
         source.listNames().forEachRemaining(uri->target.addNamedModel(uri, source.getNamedModel(uri)));
 
     }
-
-    /**
-     * Copies a dataset to a remote service that provides SPARQL 1.1 Graph Store
-     * protocol support
-     *
-     * @param source
-     *            Source Dataset
-     * @param service
-     *            Remote Graph Store protocol service
-     */
-    public static void copyToRemoteDataset(Dataset source, String service) {
-        copyToRemoteDataset(source, service, null);
-    }
-
-    /**
-     * Copies a dataset to a remote service that provides SPARQL 1.1 Graph Store
-     * protocol support
-     *
-     * @param source
-     *            Source Dataset
-     * @param service
-     *            Remote Graph Store protocol service
-     * @param client
-     *            HTTP Client
-     */
-    public static void copyToRemoteDataset(Dataset source, String service, HttpClient client) {
-        copyToRemoteGraph(service, source.getDefaultModel().getGraph(), null, client);
-        Iterator<String> uris = source.listNames();
-        while (uris.hasNext()) {
-            String uri = uris.next();
-            copyToRemoteGraph(service, source.getNamedModel(uri).getGraph(), uri, client);
-        }
-    }
-
-    // Code extracted from DatasetGraphAccessorHTTP so Apache Http Client still works.
-    private static void copyToRemoteGraph(String service, Graph data, String gn, HttpClient client) {
-        RDFFormat syntax = RDFFormat.TURTLE_BLOCKS;
-        String url = ( gn == null ) ? service+"?default" : service+"?graph="+IRILib.encodeUriComponent(gn);
-        String ct = syntax.getLang().getContentType().toHeaderString();
-        ByteArrayOutputStream out = new ByteArrayOutputStream(128*1024);
-        RDFDataMgr.write(out, data, syntax);
-        IO.close(out);
-        ByteArrayEntity entity = new ByteArrayEntity(out.toByteArray());
-        entity.setContentType(ct);
-        HttpOp1.execHttpPut(url, entity, client, null) ;
-    }
-
-    /**
-     * Renames a graph of a dataset producing a new dataset so as to not modify
-     * the original dataset
-     *
-     * @param ds
-     *            Dataset
-     * @param oldUri
-     *            Old URI
-     * @param newUri
-     *            New URI
-     * @return New Dataset
-     */
-    public static Dataset renameGraph(Dataset ds, String oldUri, String newUri) {
-        Dataset dest = DatasetFactory.createTxnMem();
-        if (oldUri == null) {
-            // Rename default graph
-            dest.addNamedModel(newUri, ds.getDefaultModel());
-        } else {
-            // Copy across default graph
-            dest.setDefaultModel(ds.getDefaultModel());
-        }
-
-        Iterator<String> uris = ds.listNames();
-        while (uris.hasNext()) {
-            String uri = uris.next();
-            if (uri.equals(oldUri)) {
-                // Rename named graph
-                if (newUri == null) {
-                    dest.setDefaultModel(ds.getNamedModel(oldUri));
-                } else {
-                    dest.addNamedModel(newUri, ds.getNamedModel(oldUri));
-                }
-            } else {
-                // Copy across named graph
-                dest.addNamedModel(uri, ds.getNamedModel(uri));
-            }
-        }
-
-        return dest;
-    }
-
 }

--- a/jena-jdbc/jena-jdbc-driver-remote/pom.xml
+++ b/jena-jdbc/jena-jdbc-driver-remote/pom.xml
@@ -39,6 +39,17 @@
       <artifactId>jena-jdbc-core</artifactId>
       <version>4.4.0-SNAPSHOT</version>
     </dependency>
+
+    <!-- Apache HTTP Client -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.apache.jena</groupId>

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpCaptureResponse.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpCaptureResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http;
+
+/** Act-on-HTTP-response and produce some object */
+@Deprecated
+public interface HttpCaptureResponse<T> extends HttpResponseHandler
+{
+    public T get() ;
+}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpOp1.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpOp1.java
@@ -1,0 +1,1156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http;
+
+import static java.lang.String.format ;
+import static org.apache.jena.ext.com.google.common.base.MoreObjects.firstNonNull;
+
+import java.io.IOException ;
+import java.io.InputStream ;
+import java.nio.charset.StandardCharsets ;
+import java.util.ArrayList ;
+import java.util.List ;
+import java.util.concurrent.atomic.AtomicLong ;
+
+import org.apache.http.* ;
+import org.apache.http.client.HttpClient ;
+import org.apache.http.client.entity.UrlEncodedFormEntity ;
+import org.apache.http.client.methods.* ;
+import org.apache.http.entity.ContentType ;
+import org.apache.http.entity.InputStreamEntity ;
+import org.apache.http.entity.StringEntity ;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder ;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair ;
+import org.apache.http.protocol.HttpContext ;
+import org.apache.http.util.EntityUtils ;
+import org.apache.jena.atlas.io.IO ;
+import org.apache.jena.atlas.web.HttpException ;
+import org.apache.jena.atlas.web.TypedInputStream ;
+import org.apache.jena.query.ARQ ;
+import org.apache.jena.riot.WebContent ;
+import org.apache.jena.riot.web.HttpNames;
+import org.apache.jena.sparql.engine.http.Params ;
+import org.apache.jena.web.HttpSC ;
+import org.slf4j.Logger ;
+import org.slf4j.LoggerFactory ;
+
+/**
+ * Simplified HTTP operations; simplification means only supporting certain uses
+ * of HTTP. The expectation is that the simplified operations in this class can
+ * be used by other code to generate more application specific HTTP interactions
+ * (e.g. SPARQL queries). For more complicated requirements of HTTP, then the
+ * application will need to use org.apache.http.client directly.
+ *
+ * <p>
+ * For HTTP GET, the application supplies a URL, the accept header string, and a
+ * list of handlers to deal with different content type responses.
+ * <p>
+ * For HTTP POST, the application supplies a URL, content, the accept header
+ * string, and a list of handlers to deal with different content type responses,
+ * or no response is expected.
+ * <p>
+ * For HTTP PUT, the application supplies a URL, content, the accept header
+ * string
+ * </p>
+ *
+ * @see HttpNames HttpNames, for HTTP related constants
+ * @see WebContent WebContent, for content type name constants
+ * @deprecated This class depends on Apache HttpClient. See {@link org.apache.jena.http.HttpOp}
+ */
+@Deprecated
+public class HttpOp1 {
+    static private Logger log = LoggerFactory.getLogger(HttpOp1.class);
+
+    /** System wide HTTP operation counter for log messages */
+    static private AtomicLong counter = new AtomicLong(0);
+
+    private static final LaxRedirectStrategy laxRedirectStrategy = new LaxRedirectStrategy();
+
+    /**
+     * Default HttpClient.
+     */
+    private static HttpClient defaultHttpClient = createDefaultHttpClient();
+
+    /**
+     * Used to reset {@link #defaultHttpClient} when needed
+     */
+    public static final HttpClient initialDefaultHttpClient = defaultHttpClient;
+
+    public static HttpClient createDefaultHttpClient() {
+        return createPoolingHttpClient();
+    }
+
+    /**
+     * Constant for the default User-Agent header that ARQ will use
+     */
+    public static final String ARQ_USER_AGENT = "Apache-Jena-ARQ/" + ARQ.VERSION;
+
+    /**
+     * User-Agent header to use
+     */
+    private static String userAgent = ARQ_USER_AGENT;
+
+    /**
+     * "Do nothing" response handler.
+     */
+    private static HttpResponseHandler nullHandler = HttpResponseLib.nullResponse;
+
+    private static HttpRequestTransformer reqTransformer = null;
+
+    /** Capture response as a string (UTF-8 assumed) */
+    public static class CaptureString implements HttpCaptureResponse<String> {
+        private String result;
+
+        @Override
+        public void handle(String baseIRI, HttpResponse response) throws IOException {
+            HttpEntity entity = response.getEntity();
+            if ( entity == null ) {
+                result = null ;
+                return ;
+            }
+            try(InputStream instream = entity.getContent()) {
+                result = IO.readWholeFileAsUTF8(instream);
+            }
+        }
+
+        @Override
+        public String get() {
+            return result;
+        }
+    }
+
+    /**
+     * TypedInputStream from an HTTP response. The TypedInputStream must be
+     * explicitly closed.
+     */
+    public static class CaptureInput implements HttpCaptureResponse<TypedInputStream> {
+        private TypedInputStream stream;
+
+        @Override
+        public void handle(String baseIRI, HttpResponse response) throws IOException {
+            HttpEntity entity = response.getEntity();
+            if ( entity == null ) {
+                stream = new TypedInputStream(EOFInputStream.empty, (String)null);
+                return;
+            }
+            String ct = (entity.getContentType() == null) ? null : entity.getContentType().getValue();
+            stream = new TypedInputStream(entity.getContent(), ct);
+        }
+
+        @Override
+        public TypedInputStream get() {
+            return stream;
+        }
+    }
+
+    static class EOFInputStream extends InputStream {
+        static InputStream empty = new EOFInputStream();
+
+        @Override
+        public int available() { return 0 ; }
+
+        @Override
+        public int read() { return -1 ; }
+    }
+
+    /**
+     * Return the current default {@link HttpClient}. This may be null, meaning
+     * a new {@link HttpClient} is created each time, if none is provided
+     * in the HttpOp function call.
+     *
+     * @return Default HTTP Client
+     */
+    public static HttpClient getDefaultHttpClient() {
+        return defaultHttpClient;
+    }
+
+    /**
+     * Performance can be improved by using a shared HttpClient that uses connection pooling. However, pool management
+     * is complicated and can lead to starvation (the system locks-up, especially on Java6; it's JVM sensitive). See the
+     * Apache HTTP Commons Client documentation for more details.
+     *
+     * @param client HTTP client to use, if this is null, reset to original default instead
+     */
+    public static void setDefaultHttpClient(HttpClient client) {
+        defaultHttpClient = firstNonNull(client, initialDefaultHttpClient);
+    }
+
+    /**
+     * Setting an {@link HttpRequestTransformer} allows manipulation or enhancement of HTTP requests.
+     *
+     * @param tform HttpRequestTransformer to use, {@code null} for none (the default)
+     * @return the previous HttpRequestTransformer in use
+     */
+    public static HttpRequestTransformer setRequestTransformer(HttpRequestTransformer tform) {
+        HttpRequestTransformer tmp = reqTransformer;
+        reqTransformer = tform;
+        return tmp;
+    }
+
+    /**
+     * Create an HttpClient that performs connection pooling. This can be used
+     * with {@link #setDefaultHttpClient} or provided in the HttpOp calls.
+     */
+    public static CloseableHttpClient createPoolingHttpClient() {
+        return createPoolingHttpClientBuilder().build() ;
+    }
+
+    /**
+     * Create an HttpClientBuilder that performs connection pooling.
+     */
+    public static HttpClientBuilder createPoolingHttpClientBuilder() {
+        String s = System.getProperty("http.maxConnections", "5");
+        int max = Integer.parseInt(s);
+        return HttpClientBuilder.create()
+            .disableContentCompression()
+            .useSystemProperties()
+            .setRedirectStrategy(laxRedirectStrategy)
+            .setMaxConnPerRoute(max)
+            .setMaxConnTotal(2*max);
+    }
+
+    /**
+     * Create an HttpClient that performs client-side caching and connection pooling.
+     * This can be used with {@link #setDefaultHttpClient} or provided in the HttpOp calls.
+     * Beware that content is cached in this process, including across remote server restart.
+     */
+    public static CloseableHttpClient createCachingHttpClient() {
+        String s = System.getProperty("http.maxConnections", "5");
+        int max = Integer.parseInt(s);
+        return CachingHttpClientBuilder.create()
+            .useSystemProperties()
+            .setRedirectStrategy(laxRedirectStrategy)
+            .setMaxConnPerRoute(max)
+            .setMaxConnTotal(2*max)
+            .build() ;
+    }
+
+    /**
+     * Gets the User-Agent string that ARQ is applying to all HTTP requests
+     *
+     * @return User-Agent string
+     */
+    public static String getUserAgent() {
+        return userAgent;
+    }
+
+    /**
+     * Sets the User-Agent string that ARQ will apply to all HTTP requests
+     *
+     * @param userAgent
+     *            User-Agent string
+     */
+    public static void setUserAgent(String userAgent) {
+        HttpOp1.userAgent = userAgent;
+    }
+
+    // ---- HTTP GET
+    /**
+     * Executes a HTTP Get request, handling the response with given handler.
+     * <p>
+     * HTTP responses 400 and 500 become exceptions.
+     * </p>
+     *
+     * @param url
+     *            URL
+     * @param acceptHeader
+     *            Accept Header
+     * @param handler
+     *            Response Handler
+     */
+    public static void execHttpGet(String url, String acceptHeader, HttpResponseHandler handler) {
+        execHttpGet(url, acceptHeader, handler, null, null);
+    }
+
+    /**
+     * Executes a HTTP Get request handling the response with one of the given
+     * handlers
+     * <p>
+     * The acceptHeader string is any legal value for HTTP Accept: field.
+     * <p>
+     * The handlers are the set of content types (without charset), used to
+     * dispatch the response body for handling.
+     * <p>
+     * HTTP responses 400 and 500 become exceptions.
+     *
+     * @param url
+     *            URL
+     * @param acceptHeader
+     *            Accept Header
+     * @param handler
+     *            Response handler called to process the response
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpGet(String url, String acceptHeader, HttpResponseHandler handler,
+                                   HttpClient httpClient, HttpContext httpContext) {
+        String requestURI = determineRequestURI(url);
+        HttpGet httpget = new HttpGet(requestURI);
+        exec(url, httpget, acceptHeader, handler, httpClient, httpContext);
+    }
+
+    /**
+     * Executes a HTTP GET and return a TypedInputStream. The stream must be
+     * closed after use.
+     * <p>
+     * The acceptHeader string is any legal value for HTTP Accept: field.
+     * </p>
+     *
+     * @param url
+     *            URL
+     * @return TypedInputStream
+     */
+    public static TypedInputStream execHttpGet(String url) {
+        HttpCaptureResponse<TypedInputStream> handler = new CaptureInput();
+        execHttpGet(url, null, handler, null, null);
+        return handler.get();
+    }
+
+    /**
+     * Executes a HTTP GET and return a TypedInputStream. The stream must be
+     * closed after use.
+     * <p>
+     * The acceptHeader string is any legal value for HTTP Accept: field.
+     * </p>
+     *
+     * @param url
+     *            URL
+     * @param acceptHeader
+     *            Accept Header
+     * @return TypedInputStream or null if the URL returns 404.
+     */
+    public static TypedInputStream execHttpGet(String url, String acceptHeader) {
+        HttpCaptureResponse<TypedInputStream> handler = new CaptureInput();
+        execHttpGet(url, acceptHeader, handler, null, null);
+        return handler.get();
+    }
+
+    /**
+     * Executes a HTTP GET and returns a TypedInputStream
+     * <p>
+     * A 404 will result in a null stream being returned, any other error code
+     * results in an exception.
+     * </p>
+     *
+     * @param url
+     *            URL
+     * @param acceptHeader
+     *            Accept Header
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     * @return TypedInputStream or null if the URL returns 404.
+     */
+    public static TypedInputStream execHttpGet(String url, String acceptHeader, HttpClient httpClient, HttpContext httpContext) {
+        HttpCaptureResponse<TypedInputStream> handler = new CaptureInput();
+        try {
+            execHttpGet(url, acceptHeader, handler, httpClient, httpContext);
+        } catch (HttpException ex) {
+            if (ex.getStatusCode() == HttpSC.NOT_FOUND_404)
+                return null;
+            throw ex;
+        }
+        return handler.get();
+    }
+
+    /**
+     * Convenience operation to execute a GET with no content negotiation and
+     * return the response as a string.
+     *
+     * @param url
+     *            URL
+     * @return Response as a string
+     */
+    public static String execHttpGetString(String url) {
+        return execHttpGetString(url, null);
+    }
+
+    /**
+     * Convenience operation to execute a GET and return the response as a
+     * string
+     *
+     * @param url
+     *            URL
+     * @param acceptHeader
+     *            Accept header.
+     * @return Response as a string
+     */
+    public static String execHttpGetString(String url, String acceptHeader) {
+        CaptureString handler = new CaptureString();
+        try {
+            execHttpGet(url, acceptHeader, handler);
+        } catch (HttpException ex) {
+            if (ex.getStatusCode() == HttpSC.NOT_FOUND_404)
+                return null;
+            throw ex;
+        }
+        return handler.get();
+    }
+
+    // ---- HTTP POST
+    /**
+     * Executes a HTTP POST with the given content-type/string as the request body
+     * and throws away success responses, failure responses will throw an error.
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type to POST
+     * @param content
+     *            Content to POST
+     */
+    public static void execHttpPost(String url, String contentType, String content) {
+        execHttpPost(url, contentType, content, null, nullHandler, null, null);
+    }
+
+    /**
+     * Execute a HTTP POST and return the typed return stream.
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type to POST
+     * @param content
+     *            Content to POST
+     * @param acceptType
+     *            Accept Type
+     */
+    public static TypedInputStream execHttpPostStream(String url, String contentType, String content, String acceptType) {
+        return execHttpPostStream(url, contentType, content, acceptType, null, null) ;
+    }
+
+    /**
+     * Executes a HTTP POST with a string as the request body and response
+     * handling
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type to POST
+     * @param content
+     *            Content to POST
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpPost(String url, String contentType, String content, HttpClient httpClient,
+                                    HttpContext httpContext) {
+        execHttpPost(url, contentType, content, null, nullHandler, httpClient, httpContext);
+    }
+
+    public static TypedInputStream execHttpPostStream(String url, String contentType, String content, String acceptType,
+                                                      HttpClient httpClient, HttpContext httpContext) {
+        CaptureInput handler = new CaptureInput();
+        try {
+            execHttpPost(url, contentType, content, acceptType, handler, httpClient, httpContext);
+        } catch (HttpException ex) {
+            if (ex.getStatusCode() == HttpSC.NOT_FOUND_404)
+                return null;
+            throw ex;
+        }
+        return handler.get();
+    }
+
+
+    /**
+     * Executes a HTTP POST with a string as the request body and response
+     * handling
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type to POST
+     * @param content
+     *            Content to POST
+     * @param acceptType
+     *            Accept Type
+     * @param handler
+     *            Response handler called to process the response
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpPost(String url, String contentType, String content, String acceptType,
+                                    HttpResponseHandler handler, HttpClient httpClient, HttpContext httpContext) {
+        StringEntity e = null;
+        try {
+            if ( content != null ) {
+                e = new StringEntity(content, StandardCharsets.UTF_8);
+                e.setContentType(contentType);
+            }
+            execHttpPost(url, e, acceptType, handler, httpClient, httpContext);
+        }
+        finally {
+            closeEntity(e);
+        }
+    }
+
+    /**
+     * Executes a HTTP POST with a request body from an input stream without
+     * response body with no response handling
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type to POST
+     * @param input
+     *            Input Stream to POST from
+     * @param length
+     *            Amount of content to POST
+     *
+     */
+    public static void execHttpPost(String url, String contentType, InputStream input, long length) {
+        execHttpPost(url, contentType, input, length, null, nullHandler, null, null);
+    }
+
+    /**
+     * Executes a HTTP POST with request body from an input stream and response
+     * handling.
+     * <p>
+     * The input stream is assumed to be UTF-8.
+     * </p>
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type to POST
+     * @param input
+     *            Input Stream to POST content from
+     * @param length
+     *            Length of content to POST
+     * @param acceptType
+     *            Accept Type
+     * @param handler
+     *            Response handler called to process the response
+     */
+    public static void execHttpPost(String url, String contentType, InputStream input, long length, String acceptType,
+                                    HttpResponseHandler handler) {
+        execHttpPost(url, contentType, input, length, acceptType, handler, null, null);
+    }
+
+    /**
+     * Executes a HTTP POST with request body from an input stream and response
+     * handling.
+     * <p>
+     * The input stream is assumed to be UTF-8.
+     * </p>
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type to POST
+     * @param input
+     *            Input Stream to POST content from
+     * @param length
+     *            Length of content to POST
+     * @param acceptType
+     *            Accept Type
+     * @param handler
+     *            Response handler called to process the response
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     *
+     */
+    public static void execHttpPost(String url, String contentType, InputStream input, long length, String acceptType,
+                                    HttpResponseHandler handler, HttpClient httpClient, HttpContext httpContext) {
+        InputStreamEntity e = new InputStreamEntity(input, length);
+        String ct = decideContentType(contentType);
+        e.setContentType(ct);
+        try {
+            execHttpPost(url, e, acceptType, handler, httpClient, httpContext);
+        } finally {
+            closeEntity(e);
+        }
+    }
+
+    /**
+     * Executes a HTTP POST of the given entity
+     *
+     * @param url
+     *            URL
+     * @param entity
+     *            Entity to POST
+     */
+    public static void execHttpPost(String url, HttpEntity entity) {
+        execHttpPost(url, entity, null, nullHandler);
+    }
+
+    /**
+     * Execute a HTTP POST and return the typed return stream.
+     *
+     * @param url
+     *            URL
+     * @param entity
+     *            Entity to POST
+     */
+    public static TypedInputStream execHttpPostStream(String url, HttpEntity entity, String acceptHeader) {
+        CaptureInput handler = new CaptureInput();
+        execHttpPost(url, entity, acceptHeader, handler);
+        return handler.get() ;
+    }
+
+    /**
+     * Executes a HTTP Post
+     *
+     * @param url
+     *            URL
+     * @param entity
+     *            Entity to POST
+     * @param acceptString
+     *            Accept Header
+     * @param handler
+     *            Response Handler
+     */
+    public static void execHttpPost(String url, HttpEntity entity, String acceptString, HttpResponseHandler handler) {
+        execHttpPost(url, entity, acceptString, handler, null, null);
+    }
+
+    /**
+     * POST with response body.
+     * <p>
+     * The content for the POST body comes from the HttpEntity.
+     * <p>
+     * Additional headers e.g. for authentication can be injected through an
+     * {@link HttpContext}
+     *
+     * @param url
+     *            URL
+     * @param entity
+     *            Entity to POST
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpPost(String url, HttpEntity entity, HttpClient httpClient, HttpContext httpContext) {
+
+        execHttpPost(url, entity, null, nullHandler, httpClient, httpContext);
+    }
+
+    /**
+     * POST with response body.
+     * <p>
+     * The content for the POST body comes from the HttpEntity.
+     * <p>
+     * Additional headers e.g. for authentication can be injected through an
+     * {@link HttpContext}
+     *
+     * @param url
+     *            URL
+     * @param entity
+     *            Entity to POST
+     * @param acceptHeader
+     *            Accept Header
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static TypedInputStream execHttpPostStream(String url, HttpEntity entity, String acceptHeader,
+                                    HttpClient httpClient, HttpContext httpContext) {
+        CaptureInput handler = new CaptureInput();
+        execHttpPost(url, entity, acceptHeader, handler, httpClient, httpContext) ;
+        return handler.get() ;
+    }
+
+    /**
+     * POST with response body.
+     * <p>
+     * The content for the POST body comes from the HttpEntity.
+     * <p>
+     * Additional headers e.g. for authentication can be injected through an
+     * {@link HttpContext}
+     *
+     * @param url
+     *            URL
+     * @param entity
+     *            Entity to POST
+     * @param acceptHeader
+     *            Accept Header
+     * @param handler
+     *            Response handler called to process the response
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpPost(String url, HttpEntity entity, String acceptHeader, HttpResponseHandler handler,
+            HttpClient httpClient, HttpContext httpContext) {
+        String requestURI = determineRequestURI(url);
+        HttpPost httppost = new HttpPost(requestURI);
+        if (entity != null)
+            httppost.setEntity(entity);
+        exec(url, httppost, acceptHeader, handler, httpClient, httpContext);
+    }
+
+    // ---- HTTP POST as a form.
+
+    /**
+     * Executes a HTTP POST.
+     *
+     * @param url
+     *            URL
+     * @param params
+     *            Parameters to POST
+     */
+    public static void execHttpPostForm(String url, Params params) {
+        execHttpPostForm(url, params, null, nullHandler);
+    }
+
+    /**
+     * Executes a HTTP POST and returns a TypedInputStream, The TypedInputStream
+     * must be closed.
+     *
+     * @param url
+     *            URL
+     * @param params
+     *            Parameters to POST
+     * @param acceptHeader
+     */
+    public static TypedInputStream execHttpPostFormStream(String url, Params params, String acceptHeader) {
+        return execHttpPostFormStream(url, params, acceptHeader, null, null);
+    }
+
+    // @formatter:off
+//    /**
+//     * Executes a HTTP POST Form.
+//     * @param url
+//     *            URL
+//     * @param acceptHeader
+//     *            Accept Header
+//     * @param params
+//     *            Parameters to POST
+//     * @param httpClient
+//     *            HTTP Client
+//     * @param httpContext
+//     *            HTTP Context
+//     * @param authenticator
+//     *            HTTP Authenticator
+//     */
+//    public static void execHttpPostForm(String url, Params params,
+//                                        String acceptHeader,
+//                                        HttpClient httpClient, HttpContext httpContext, HttpAuthenticator authenticator) {
+//        try {
+//            execHttpPostForm(url, params, acceptHeader, HttpResponseLib.nullResponse, httpClient, httpContext, authenticator);
+//        } catch (HttpException ex) {
+//            if (ex.getResponseCode() == HttpSC.NOT_FOUND_404)
+//                return ;
+//            throw ex;
+//        }
+//        return ;
+//    }
+    // @formatter:on
+
+    /**
+     * Executes a HTTP POST Form and returns a TypedInputStream
+     * <p>
+     * The acceptHeader string is any legal value for HTTP Accept: field.
+     * </p>
+     * <p>
+     * A 404 will result in a null stream being returned, any other error code
+     * results in an exception.
+     * </p>
+     *
+     * @param url
+     *            URL
+     * @param acceptHeader
+     *            Accept Header
+     * @param params
+     *            Parameters to POST
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static TypedInputStream execHttpPostFormStream(String url, Params params, String acceptHeader, HttpClient httpClient,
+            HttpContext httpContext) {
+        CaptureInput handler = new CaptureInput();
+        try {
+            execHttpPostForm(url, params, acceptHeader, handler, httpClient, httpContext);
+        } catch (HttpException ex) {
+            if (ex.getStatusCode() == HttpSC.NOT_FOUND_404)
+                return null;
+            throw ex;
+        }
+        return handler.get();
+    }
+
+    /**
+     * Executes a HTTP POST form operation
+     *
+     * @param url
+     *            URL
+     * @param params
+     *            Form parameters to POST
+     * @param acceptString
+     *            Accept Header
+     * @param handler
+     *            Response handler called to process the response
+     */
+    public static void execHttpPostForm(String url, Params params, String acceptString, HttpResponseHandler handler) {
+        execHttpPostForm(url, params, acceptString, handler, null, null);
+    }
+
+    /**
+     * Executes a HTTP POST form operation
+     *
+     * @param url
+     *            URL
+     * @param params
+     *            Form parameters to POST
+     * @param acceptHeader
+     *            Accept Header
+     * @param handler
+     *            Response handler called to process the response
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpPostForm(String url, Params params, String acceptHeader, HttpResponseHandler handler,
+            HttpClient httpClient, HttpContext httpContext) {
+        if (handler == null)
+            throw new IllegalArgumentException("A HttpResponseHandler must be provided (e.g. HttpResponseLib.nullhandler)");
+        String requestURI = url;
+        HttpPost httppost = new HttpPost(requestURI);
+        httppost.setEntity(convertFormParams(params));
+        exec(url, httppost, acceptHeader, handler, httpClient, httpContext);
+    }
+
+    /**
+     * Executes a HTTP PUT operation
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type for the PUT
+     * @param content
+     *            Content for the PUT
+     */
+    public static void execHttpPut(String url, String contentType, String content) {
+        execHttpPut(url, contentType, content, null, null);
+    }
+
+    /**
+     * Executes a HTTP PUT operation
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type for the PUT
+     * @param content
+     *            Content for the PUT
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpPut(String url, String contentType, String content, HttpClient httpClient,
+            HttpContext httpContext) {
+        StringEntity e = null;
+        try {
+            e = new StringEntity(content, StandardCharsets.UTF_8);
+            e.setContentType(contentType);
+            execHttpPut(url, e, httpClient, httpContext);
+        }
+        finally {
+            closeEntity(e);
+        }
+    }
+
+    /**
+     * Executes a HTTP PUT operation
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type for the PUT
+     * @param input
+     *            Input Stream to read PUT content from
+     * @param length
+     *            Amount of content to PUT
+     */
+    public static void execHttpPut(String url, String contentType, InputStream input, long length) {
+        execHttpPut(url, contentType, input, length, null, null);
+    }
+
+    /**
+     * Executes a HTTP PUT operation
+     *
+     * @param url
+     *            URL
+     * @param contentType
+     *            Content Type for the PUT
+     * @param input
+     *            Input Stream to read PUT content from
+     * @param length
+     *            Amount of content to PUT
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpPut(String url, String contentType, InputStream input, long length, HttpClient httpClient,
+            HttpContext httpContext) {
+        InputStreamEntity e = new InputStreamEntity(input, length);
+        String ct = decideContentType(contentType);
+        e.setContentType(ct);
+        try {
+            execHttpPut(url, e, httpClient, httpContext);
+        } finally {
+            closeEntity(e);
+        }
+    }
+
+    /**
+     * Executes a HTTP PUT operation
+     *
+     * @param url
+     *            URL
+     * @param entity
+     *            HTTP Entity to PUT
+     */
+    public static void execHttpPut(String url, HttpEntity entity) {
+        execHttpPut(url, entity, null, null);
+    }
+
+    /**
+     * Executes a HTTP PUT operation
+     *
+     * @param url
+     *            URL
+     * @param entity
+     *            HTTP Entity to PUT
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpPut(String url, HttpEntity entity, HttpClient httpClient, HttpContext httpContext) {
+        String requestURI = determineRequestURI(url);
+        HttpPut httpput = new HttpPut(requestURI);
+        httpput.setEntity(entity);
+        exec(url, httpput, null, nullHandler, httpClient, httpContext);
+    }
+
+    /**
+     * Executes a HTTP HEAD operation
+     *
+     * @param url
+     *            URL
+     */
+    public static void execHttpHead(String url) {
+        execHttpHead(url, null, nullHandler);
+    }
+
+    /**
+     * Executes a HTTP HEAD operation
+     *
+     * @param url
+     *            URL
+     * @param acceptString
+     *            Accept Header
+     * @param handler
+     *            Response Handler
+     */
+    public static void execHttpHead(String url, String acceptString, HttpResponseHandler handler) {
+        execHttpHead(url, acceptString, handler, null, null);
+    }
+
+    /**
+     * Executes a HTTP HEAD operation
+     *
+     * @param url
+     *            URL
+     * @param acceptString
+     *            Accept Header
+     * @param handler
+     *            Response Handler
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+
+    public static void execHttpHead(String url, String acceptString, HttpResponseHandler handler, HttpClient httpClient,
+            HttpContext httpContext) {
+        String requestURI = determineRequestURI(url);
+        HttpHead httpHead = new HttpHead(requestURI);
+        exec(url, httpHead, acceptString, handler, httpClient, httpContext);
+    }
+
+    /**
+     * Executes a HTTP DELETE operation
+     *
+     * @param url
+     *            URL
+     */
+    public static void execHttpDelete(String url) {
+        execHttpDelete(url, nullHandler);
+    }
+
+    /**
+     * Executes a HTTP DELETE operation
+     *
+     * @param url
+     *            URL
+     * @param handler
+     *            Response Handler
+     */
+    public static void execHttpDelete(String url, HttpResponseHandler handler) {
+        execHttpDelete(url, handler, null, null);
+    }
+
+    /**
+     * Executes a HTTP DELETE operation
+     *
+     * @param url
+     *            URL
+     * @param handler
+     *            Response Handler
+     * @param httpClient
+     *            HTTP Client
+     * @param httpContext
+     *            HTTP Context
+     */
+    public static void execHttpDelete(String url, HttpResponseHandler handler, HttpClient httpClient, HttpContext httpContext) {
+        HttpUriRequest httpDelete = new HttpDelete(url);
+        exec(url, httpDelete, null, handler, null, httpContext);
+    }
+
+    // ---- Perform the operation!
+    private static void exec(String url, HttpUriRequest req, String acceptHeader, HttpResponseHandler handler, HttpClient httpClient, HttpContext httpContext) {
+        // we should close the client after request execution if we built the client right here
+        httpClient = firstNonNull(httpClient, getDefaultHttpClient());
+        // or if the handler won't close the client for us
+        try {
+            if (handler == null)
+                // This cleans up left-behind streams
+                handler = nullHandler;
+            HttpUriRequest request = reqTransformer  == null ? req : reqTransformer.apply(req);
+
+            long id = counter.incrementAndGet();
+            String baseURI = determineBaseIRI(url);
+            if (log.isDebugEnabled())
+                log.debug(format("[%d] %s %s", id, request.getMethod(), request.getURI().toString()));
+            // Accept
+            if (acceptHeader != null)
+                request.addHeader(HttpNames.hAccept, acceptHeader);
+            // User-Agent
+            applyUserAgent(request);
+
+            HttpResponse response = httpClient.execute(request, httpContext);
+
+            // Response
+            StatusLine statusLine = response.getStatusLine();
+            int statusCode = statusLine.getStatusCode();
+            if (HttpSC.isClientError(statusCode) || HttpSC.isServerError(statusCode)) {
+                log.debug(format("[%d] %s %s", id, statusLine.getStatusCode(), statusLine.getReasonPhrase()));
+                // Error responses can have bodies so it is important to clear up.
+				final String contentPayload = readPayload(response.getEntity());
+				throw new HttpException(statusLine.getStatusCode(), statusLine.getReasonPhrase(), contentPayload);
+            }
+            if (handler != null) handler.handle(baseURI, response);
+        } catch (IOException ex) {
+            throw new HttpException(ex);
+        }
+    }
+
+	public static String readPayload(HttpEntity entity) throws IOException {
+        return entity == null ? null : EntityUtils.toString(entity, ContentType.getOrDefault(entity).getCharset());
+	}
+
+    /**
+     * Applies the configured User-Agent string to the HTTP request
+     *
+     * @param message
+     *            HTTP request
+     */
+    public static void applyUserAgent(HttpMessage message) {
+        if (userAgent != null) {
+            message.setHeader("User-Agent", userAgent);
+        }
+    }
+
+    private static HttpEntity convertFormParams(Params params) {
+        List<NameValuePair> nvps = new ArrayList<>();
+        for (Params.Param p : params.pairs())
+            nvps.add(new BasicNameValuePair(p.getName(), p.getValue()));
+        HttpEntity e = new UrlEncodedFormEntity(nvps, StandardCharsets.UTF_8);
+        return e;
+    }
+
+    private static void closeEntity(HttpEntity entity) {
+        if (entity == null)
+            return;
+        try {
+            entity.getContent().close();
+        } catch (Exception e) {
+        }
+    }
+
+    /**
+     * Content-Type, ensuring charset is present, defaulting to UTF-8.
+     */
+    private static String decideContentType(String contentType) {
+        String ct = contentType;
+        if ( ct != null && ! ct.contains("charset=") )
+            ct = ct+"; charset=UTF-8";
+        return ct;
+    }
+
+    /**
+     * Calculate the request URI from a general URI. This means remove any
+     * fragment.
+     */
+    private static String determineRequestURI(String uri) {
+        String requestURI = uri;
+        if (requestURI.contains("#")) {
+            // No frag ids.
+            int i = requestURI.indexOf('#');
+            requestURI = requestURI.substring(0, i);
+        }
+        return requestURI;
+    }
+
+    /**
+     * Calculate the base IRI to use from a URI. The base is without fragement
+     * and without query string.
+     */
+    private static String determineBaseIRI(String uri) {
+        // Defrag
+        String baseIRI = determineRequestURI(uri);
+        // Technically wrong, but including the query string is "unhelpful"
+        if (baseIRI.contains("?")) {
+            int i = baseIRI.indexOf('?');
+            baseIRI = baseIRI.substring(0, i);
+        }
+        return baseIRI;
+    }
+}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpQuery.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpQuery.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http;
+
+import static org.apache.jena.web.HttpSC.NOT_FOUND_404;
+import static org.apache.jena.web.HttpSC.REQUEST_URI_TOO_LONG_414;
+
+import java.io.InputStream ;
+import java.net.MalformedURLException ;
+import java.net.URL ;
+import java.util.Map;
+import java.util.regex.Pattern ;
+
+import org.apache.http.client.HttpClient ;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
+import org.apache.jena.atlas.web.HttpException ;
+import org.apache.jena.atlas.web.TypedInputStream ;
+import org.apache.jena.jdbc.remote.http.HttpOp1.CaptureInput;
+import org.apache.jena.query.ARQ ;
+import org.apache.jena.query.QueryExecException ;
+import org.apache.jena.riot.WebContent ;
+import org.apache.jena.shared.JenaException ;
+import org.apache.jena.sparql.engine.http.Params;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.apache.jena.sparql.util.Context;
+import org.apache.jena.web.HttpSC;
+import org.slf4j.Logger ;
+import org.slf4j.LoggerFactory ;
+
+/**
+ * Create an execution object for performing a query on a model over HTTP. This
+ * is the main protocol engine for HTTP query. There are higher level classes
+ * for doing a query and presenting the results in an API fashion.
+ *
+ * If the query string is large, then HTTP POST is used.
+ * @deprecated Use the QueryExecutionHTTP builder. {@code QueryExecutionHTTP.create()....execute()}
+ */
+@Deprecated
+public class HttpQuery extends Params {
+
+    // This is the previous Apache HttpClient version.
+    // See QueryExecHTTP for current JDK-based HTTP code.
+
+    static final Logger log = LoggerFactory.getLogger(HttpQuery.class.getName());
+
+    /** The definition of "large" queries */
+    // Not final so that other code can change it.
+    static public/* final */int urlLimit = 2 * 1024;
+
+    String serviceURL;
+    String contentTypeResult = WebContent.contentTypeResultsXML;
+
+    // An object indicate no value associated with parameter name
+    final static Object noValue = new Object();
+
+    private int responseCode = 0;
+    private String responseMessage = null;
+    private boolean forcePOST = false;
+    private String queryString = null;
+    private boolean serviceParams = false;
+    private final Pattern queryParamPattern = Pattern.compile(".+[&|\\?]query=.*");
+    private int connectTimeout = 0, readTimeout = 0;
+
+    // It is in HttpQuery that policy about supporting compression (client side) is
+    // made. Between compression, and transfer-encoding:chunked to maintain a reusable
+    // streaming connection, "it's complicated"
+    // Compressing e.g ResultSet (one time objects) isn't as valuable as being to
+    // upload gzip compressed objects (e.g. GSP data for a file).
+    private boolean allowCompression = false;
+
+    /**
+     * Whether to allow asking for compression of result sets.
+     * If false, ignore the "allowCompression" setting.
+     * See {@link #setAllowCompression}.
+     */
+    private static boolean globalCompressionAllow = false;
+
+    private HttpClient client;
+
+    private HttpContext context;
+
+    /**
+     * Create a execution object for a whole model GET
+     *
+     * @param serviceURL
+     *            The model
+     */
+    public HttpQuery(String serviceURL) {
+        init(serviceURL);
+    }
+
+    /**
+     * Create a execution object for a whole model GET
+     *
+     * @param url
+     *            The model
+     */
+    public HttpQuery(URL url) {
+        init(url.toString());
+    }
+
+    private void init(String serviceURL) {
+        if (log.isTraceEnabled())
+            log.trace("URL: " + serviceURL);
+
+        if (serviceURL.indexOf('?') >= 0)
+            serviceParams = true;
+
+        if (queryParamPattern.matcher(serviceURL).matches())
+            throw new QueryExecException("SERVICE URL overrides the 'query' SPARQL protocol parameter");
+
+        this.serviceURL = serviceURL;
+    }
+
+    private String getQueryString() {
+        if (queryString == null)
+            queryString = super.httpString();
+        return queryString;
+    }
+
+    /**
+     * Set the content type (Accept header) for the results
+     *
+     * @param contentType
+     *            Accept content type
+     */
+    public void setAccept(String contentType) {
+        contentTypeResult = contentType;
+    }
+
+    /**
+     * Gets the Content Type
+     * <p>
+     * If the query has been made this reflects the Content-Type header returns,
+     * if it has not been made this reflects only the Accept header that will be
+     * sent (as set via the {@link #setAccept(String)} method)
+     * </p>
+     *
+     * @return Content Type
+     */
+    public String getContentType() {
+        return contentTypeResult;
+    }
+
+    /**
+     * Gets the HTTP Response Code returned by the request (returns 0 if request
+     * has yet to be made)
+     *
+     * @return Response Code
+     */
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    /**
+     * Gets the HTTP Response Message returned by the request (returns null if request
+     * has yet to be made)
+     *
+     * @return Response Message
+     */
+    public String getResponseMessage() {
+        return responseMessage;
+    }
+
+    /**
+     * Sets whether the HTTP request will include compressed encoding
+     * header
+     *
+     * @param allow
+     *            Whether to allow compressed encoding
+     */
+    public void setAllowCompression(boolean allow) {
+        if ( globalCompressionAllow )
+            allowCompression = allow;
+    }
+
+    /**
+     * Sets the client to use
+     * @param client Client
+     */
+    public void setClient(HttpClient client) {
+        this.client = client;
+    }
+
+    /**
+     * Sets the context to use
+     * @param context HTTP context
+     */
+    public void setContext(HttpContext context) {
+        this.context = context;
+    }
+
+    /**
+     * Gets the HTTP client that is being used, may be null if no request has yet been made
+     * @return HTTP Client or null
+     */
+    public HttpClient getClient() {
+        Context arqContext = ARQ.getContext();
+        if (arqContext.isDefined(Service_AHC.serviceContext)) {
+            @SuppressWarnings("unchecked")
+            Map<String, Context> context = (Map<String, Context>) arqContext.get(Service_AHC.serviceContext);
+            if (context.containsKey(serviceURL)) {
+                Context serviceContext = context.get(serviceURL);
+                if (serviceContext.isDefined(Service_AHC.queryClient)) return serviceContext.get(Service_AHC.queryClient);
+            }
+        }
+        return client;
+    }
+
+    /**
+     * Gets the HTTP context that is being used, or sets and returns a default
+     * @return the {@code HttpContext} in scope
+     */
+    public HttpContext getContext() {
+        if (context == null)
+            context = new BasicHttpContext();
+        return context;
+    }
+
+    /**
+     * Return whether this request will go by GET or POST
+     *
+     * @return boolean
+     */
+    public boolean usesPOST() {
+        if (forcePOST)
+            return true;
+        String s = getQueryString();
+
+        return serviceURL.length() + s.length() >= urlLimit;
+    }
+
+    /**
+     * Force the use of HTTP POST for the query operation
+     */
+
+    public void setForcePOST() {
+        forcePOST = true;
+    }
+
+    /**
+     * Sets HTTP Connection timeout, any value {@literal <=} 0 is taken to mean no timeout
+     *
+     * @param timeout
+     *            Connection Timeout
+     */
+    public void setConnectTimeout(int timeout) {
+        connectTimeout = timeout;
+    }
+
+    /**
+     * Gets the HTTP Connection timeout
+     *
+     * @return Connection Timeout
+     */
+    public int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    /**
+     * Sets HTTP Read timeout, any value {@literal <=} 0 is taken to mean no timeout
+     *
+     * @param timeout
+     *            Read Timeout
+     */
+    public void setReadTimeout(int timeout) {
+        readTimeout = timeout;
+    }
+
+    /**
+     * Gets the HTTP Read timeout
+     *
+     * @return Read Timeout
+     */
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    /**
+     * Execute the operation
+     *
+     * @return Model The resulting model
+     * @throws QueryExceptionHTTP
+     */
+    public InputStream exec() throws QueryExceptionHTTP {
+        // Select the appropriate HttpClient to use
+        HttpClientContext hcc = HttpClientContext.adapt(getContext());
+        RequestConfig.Builder builder = RequestConfig.copy(hcc.getRequestConfig());
+        contextualizeCompressionSettings(builder);
+        contextualizeTimeoutSettings(builder);
+        hcc.setRequestConfig(builder.build());
+        try {
+            if (usesPOST())
+                return execPost();
+            return execGet();
+        } catch (QueryExceptionHTTP httpEx) {
+            log.trace("Exception in exec", httpEx);
+            throw httpEx;
+        } catch (JenaException jEx) {
+            log.trace("JenaException in exec", jEx);
+            throw jEx;
+        }
+    }
+
+    private void contextualizeCompressionSettings(RequestConfig.Builder builder) {
+        builder.setContentCompressionEnabled(allowCompression);
+    }
+
+    private void contextualizeTimeoutSettings(RequestConfig.Builder builder) {
+        if (connectTimeout > 0) builder.setConnectTimeout(connectTimeout);
+        if (readTimeout > 0) builder.setSocketTimeout(readTimeout);
+    }
+
+    private InputStream execGet() throws QueryExceptionHTTP {
+        URL target = null;
+        String qs = getQueryString();
+
+        ARQ.getHttpRequestLogger().trace(qs);
+
+        try {
+            if (count() == 0)
+                target = new URL(serviceURL);
+            else
+                target = new URL(serviceURL + (serviceParams ? "&" : "?") + qs);
+        } catch (MalformedURLException malEx) {
+            throw new QueryExceptionHTTP(0, "Malformed URL: " + malEx);
+        }
+        log.trace("GET " + target.toExternalForm());
+        try {
+            try {
+                // Get the actual response stream
+                TypedInputStream stream = execHttpGet(target.toString(), contentTypeResult, client, getContext());
+                if (stream == null)
+                    throw new QueryExceptionHTTP(NOT_FOUND_404, HttpSC.getMessage(NOT_FOUND_404));
+                return execCommon(stream);
+            } catch (HttpException httpEx) {
+                // Back-off and try POST if something complain about long URIs
+                if (httpEx.getStatusCode() == REQUEST_URI_TOO_LONG_414)
+                    return execPost();
+                throw httpEx;
+            }
+        } catch (HttpException httpEx) {
+            throw QueryExceptionHTTP.rewrap(httpEx);
+        }
+    }
+
+    // With exception.
+    private static TypedInputStream execHttpGet(String url, String acceptHeader, HttpClient httpClient, HttpContext httpContext) {
+        HttpCaptureResponse<TypedInputStream> handler = new CaptureInput();
+        HttpOp1.execHttpGet(url, acceptHeader, handler, httpClient, httpContext);
+        return handler.get();
+    }
+
+    private InputStream execPost() throws QueryExceptionHTTP {
+        URL target = null;
+        try {
+            target = new URL(serviceURL);
+        } catch (MalformedURLException malEx) {
+            throw new QueryExceptionHTTP(0, "Malformed URL: " + malEx);
+        }
+        log.trace("POST " + target.toExternalForm());
+
+        ARQ.getHttpRequestLogger().trace(target.toExternalForm());
+
+        try {
+            // Get the actual response stream
+            TypedInputStream stream = HttpOp1.execHttpPostFormStream(serviceURL, this, contentTypeResult, client, getContext());
+            if (stream == null)
+                throw new QueryExceptionHTTP(404);
+            return execCommon(stream);
+        } catch (HttpException httpEx) {
+            throw QueryExceptionHTTP.rewrap(httpEx);
+        }
+    }
+
+    private InputStream execCommon(TypedInputStream stream) throws QueryExceptionHTTP {
+        // Assume response code must be 200 if we got here
+        responseCode = 200;
+        responseMessage = "OK" ;
+
+        // Get the returned content type so we can expose this later via the
+        // getContentType() method
+        // We strip any parameters off the returned content type e.g.
+        // ;charset=UTF-8 since code that
+        // consumes our getContentType() method will expect a bare MIME type
+        contentTypeResult = stream.getContentType();
+        if (contentTypeResult != null && contentTypeResult.contains(";")) {
+            contentTypeResult = contentTypeResult.substring(0, contentTypeResult.indexOf(';'));
+        }
+
+        // NB - Content Encoding is now handled at a higher level
+        // so we don't have to worry about wrapping the stream at all
+
+        return stream;
+    }
+
+    @Override
+    public String toString() {
+        String s = httpString();
+        if (s != null && s.length() > 0)
+            return serviceURL + "?" + s;
+        return serviceURL;
+    }
+}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpRequestTransformer.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpRequestTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http;
+
+import java.util.function.Function;
+
+import org.apache.http.client.methods.HttpUriRequest;
+
+/**
+ * Transform an HTTP request (e.g. to add or manipulate headers)
+ *
+ */
+@Deprecated
+public interface HttpRequestTransformer extends Function<HttpUriRequest, HttpUriRequest> {}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpResponseHandler.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpResponseHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http ;
+
+import java.io.IOException ;
+
+import org.apache.http.HttpResponse ;
+
+/** General act-on-HTTP-response interface.*/
+@Deprecated
+public interface HttpResponseHandler
+{
+    void handle(String baseIRI , HttpResponse response ) throws IOException ;
+}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpResponseLib.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/HttpResponseLib.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http;
+
+import java.io.IOException ;
+import java.io.InputStream ;
+import java.nio.charset.StandardCharsets ;
+import java.util.HashMap ;
+import java.util.Map ;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity ;
+import org.apache.http.HttpResponse ;
+import org.apache.http.util.EntityUtils ;
+import org.apache.jena.atlas.io.IO ;
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.query.ResultSet ;
+import org.apache.jena.query.ResultSetFactory ;
+import org.apache.jena.riot.Lang ;
+import org.apache.jena.riot.RDFLanguages ;
+import org.apache.jena.riot.RDFParser ;
+import org.apache.jena.riot.WebContent ;
+import org.apache.jena.riot.system.StreamRDF ;
+import org.apache.jena.riot.system.StreamRDFLib ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.core.DatasetGraphFactory ;
+import org.apache.jena.sparql.graph.GraphFactory ;
+import org.apache.jena.sparql.resultset.ResultsFormat ;
+
+/** A collection of handlers for response handling.
+ * @see HttpOp1
+ * @deprecated This class is for Apache HttpClient. Switch to {@link org.apache.jena.http.HttpOp}
+ */
+@Deprecated
+public class HttpResponseLib
+{
+    /** Handle a Graph response */
+    public static HttpCaptureResponse<Graph> graphHandler() { return new GraphReader() ; }
+    static class GraphReader implements HttpCaptureResponse<Graph>
+    {
+        private Graph graph = null ;
+        @Override
+        final public void handle(String baseIRI, HttpResponse response) {
+            try {
+                Graph g = GraphFactory.createDefaultGraph() ;
+                HttpEntity entity = response.getEntity() ;
+                // org.apache.http.entity.ContentType ;
+                String ct = contentType(response) ;
+                Lang lang = RDFLanguages.contentTypeToLang(ct) ;
+                StreamRDF dest = StreamRDFLib.graph(g) ;
+                try(InputStream in = entity.getContent()) {
+                    RDFParser.source(in).lang(lang).base(baseIRI).parse(dest);
+                }
+                this.graph = g ;
+            } catch (IOException ex) { IO.exception(ex) ; }
+        }
+
+        @Override
+        public Graph get() { return graph ; }
+    }
+
+    /** Handle a DatasetGraph response */
+    public static HttpCaptureResponse<DatasetGraph> datasetHandler() { return new DatasetGraphReader() ; }
+    static class DatasetGraphReader implements HttpCaptureResponse<DatasetGraph>
+    {
+        private DatasetGraph dsg = null ;
+        @Override
+        final public void handle(String baseIRI, HttpResponse response) {
+            try {
+                DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
+                HttpEntity entity = response.getEntity() ;
+                // org.apache.http.entity.ContentType ;
+                String ct = contentType(response) ;
+                Lang lang = RDFLanguages.contentTypeToLang(ct) ;
+                StreamRDF dest = StreamRDFLib.dataset(dsg);
+                try(InputStream in = entity.getContent()) {
+                    RDFParser.source(in).lang(lang).base(baseIRI).parse(dest);
+                }
+                this.dsg = dsg ;
+            } catch (IOException ex) { IO.exception(ex) ; }
+        }
+
+        @Override
+        public DatasetGraph get() { return dsg ; }
+    }
+
+
+    /** Dump, to System.out, a response */
+    public static HttpResponseHandler httpDumpResponse = new HttpResponseHandler()
+    {
+        @Override
+        public void handle(String baseIRI , HttpResponse response )
+        {
+            try {
+                HttpEntity entity = response.getEntity() ;
+                org.apache.http.entity.ContentType ct = org.apache.http.entity.ContentType.get(entity) ;
+                System.out.println("Content-type: "+ct) ;
+                System.out.println() ;
+                try (InputStream in = entity.getContent()) {
+                    int l ;
+                    byte buffer[] = new byte[1024] ;
+                    while ((l = in.read(buffer)) != -1) {
+                        System.out.print(new String(buffer, 0, l, StandardCharsets.UTF_8)) ;
+                    }
+                }
+            } catch (IOException ex)
+            {
+                ex.printStackTrace(System.err) ;
+            }
+        }
+    } ;
+
+    /** Consume a response quietly. */
+    public static HttpResponseHandler nullResponse = (b, r) -> EntityUtils.consumeQuietly(r.getEntity());
+
+    // Old world.
+    // See also ResultSetFactory.load(in, fmt)
+    private static ResultsFormat contentTypeToResultsFormat(String contentType) { return mapContentTypeToResultSet.get(contentType) ; }
+    private static final Map<String, ResultsFormat> mapContentTypeToResultSet = new HashMap<>() ;
+    static {
+        mapContentTypeToResultSet.put(WebContent.contentTypeResultsXML, ResultsFormat.FMT_RS_XML) ;
+        mapContentTypeToResultSet.put(WebContent.contentTypeResultsJSON, ResultsFormat.FMT_RS_JSON) ;
+        mapContentTypeToResultSet.put(WebContent.contentTypeTextTSV, ResultsFormat.FMT_RS_TSV) ;
+    }
+
+    /** Response handling for SPARQL result sets. */
+    public static class HttpCaptureResponseResultSet implements HttpCaptureResponse<ResultSet>
+    {
+        private ResultSet rs = null;
+
+        @Override
+        public void handle(String baseIRI, HttpResponse response) throws IOException {
+            String ct = contentType(response);
+            ResultsFormat fmt = contentTypeToResultsFormat(ct);
+            InputStream in = response.getEntity().getContent();
+            rs = ResultSetFactory.load(in, fmt);
+            // Force reading
+            rs = ResultSetFactory.copyResults(rs);
+        }
+
+        @Override
+        public ResultSet get() {
+            return rs;
+        }
+    }
+
+    private static String contentType(HttpResponse response) {
+        HttpEntity entity = response.getEntity() ;
+        //org.apache.http.entity.ContentType ;
+        org.apache.http.entity.ContentType ct = org.apache.http.entity.ContentType.get(entity) ;
+        return ct.getMimeType() ;
+    }
+
+    // Development helper
+    public static void printResponse(HttpResponse response) {
+        response.headerIterator().forEachRemaining(obj->{
+            Header header = (Header)obj;
+            System.out.printf("  %-20s %s\n", header.getName()+":", header.getValue());
+        });
+    }
+}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/QueryEngineHTTP.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/QueryEngineHTTP.java
@@ -1,0 +1,870 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http;
+
+import java.io.ByteArrayInputStream ;
+import java.io.IOException;
+import java.io.InputStream ;
+import java.util.ArrayList ;
+import java.util.Iterator ;
+import java.util.List ;
+import java.util.Map ;
+import java.util.concurrent.TimeUnit ;
+
+import org.apache.http.client.HttpClient ;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.protocol.HttpContext ;
+import org.apache.jena.atlas.RuntimeIOException;
+import org.apache.jena.atlas.io.IO ;
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonArray;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.json.JsonValue;
+import org.apache.jena.atlas.lib.Pair ;
+import org.apache.jena.graph.Triple ;
+import org.apache.jena.query.* ;
+import org.apache.jena.rdf.model.Model ;
+import org.apache.jena.riot.*;
+import org.apache.jena.riot.resultset.ResultSetLang;
+import org.apache.jena.riot.resultset.ResultSetReaderRegistry;
+import org.apache.jena.sparql.ARQException ;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.engine.ResultSetCheckCondition ;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.http.HttpParams;
+import org.apache.jena.sparql.engine.http.Params;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.apache.jena.sparql.graph.GraphFactory ;
+import org.apache.jena.sparql.resultset.ResultSetException;
+import org.apache.jena.sparql.util.Context ;
+import org.slf4j.Logger ;
+import org.slf4j.LoggerFactory ;
+
+/**
+ * A query execution implementation where queries are executed against a remote
+ * service
+ * @deprecated Use the QueryExecutionHTTP builder. {@code QueryExecutionHTTP.create()....execute()}
+ */
+@Deprecated
+public class QueryEngineHTTP implements QueryExecution {
+    private static Logger log = LoggerFactory.getLogger(QueryEngineHTTP.class);
+
+    public static final String QUERY_MIME_TYPE = WebContent.contentTypeSPARQLQuery;
+    private final Query query;
+    private final String queryString;
+    private final String service;
+    private final Context context;
+
+    // Params
+    private Params params = null;
+
+    // Protocol
+    private List<String> defaultGraphURIs = new ArrayList<>();
+    private List<String> namedGraphURIs = new ArrayList<>();
+    private HttpClient client;
+    private HttpContext httpContext;
+
+    private boolean closed = false;
+
+    // Timeouts
+    private long connectTimeout = -1;
+    private TimeUnit connectTimeoutUnit = TimeUnit.MILLISECONDS;
+    private long readTimeout = -1;
+    private TimeUnit readTimeoutUnit = TimeUnit.MILLISECONDS;
+
+    // Compression Support
+    // Note that compression setting is used in HttpQuery.
+    /** See {@link HttpQuery} */
+    private boolean allowCompression = true;
+
+    // Updates default headers, same variables.
+    private String selectContentType    = WebContent.defaultSparqlResultsHeader;
+    private String askContentType       = WebContent.defaultSparqlAskHeader;
+    private String modelContentType     = WebContent.defaultGraphAcceptHeader;
+
+//    private String constructContentType = WebContent.defaultGraphAcceptHeader;
+    private String datasetContentType   = WebContent.defaultDatasetAcceptHeader;
+
+    // If this is non-null, it overrides the ???ContentType choice.
+    private String acceptHeader         = null;
+
+
+    // Received content type
+    private String httpResponseContentType = null ;
+    /**
+     * Supported content types for SELECT queries
+     */
+    public static String[] supportedSelectContentTypes = new String[] { WebContent.contentTypeResultsXML,
+            WebContent.contentTypeResultsJSON, WebContent.contentTypeTextTSV, WebContent.contentTypeTextCSV,
+            WebContent.contentTypeResultsThrift};
+    /**
+     * Supported content types for ASK queries
+     */
+    public static String[] supportedAskContentTypes = new String[] { WebContent.contentTypeResultsXML,
+            WebContent.contentTypeResultsJSON, WebContent.contentTypeTextTSV, WebContent.contentTypeTextCSV };
+
+    // Releasing HTTP input streams is important. We remember this for SELECT,
+    // and will close when the engine is closed
+    private InputStream retainedConnection = null;
+
+    public QueryEngineHTTP(String serviceURI, Query query) {
+        this(serviceURI, query, null, null);
+    }
+
+    public QueryEngineHTTP(String serviceURI, Query query, HttpClient client) {
+        this(serviceURI, query, client, null);
+    }
+
+    public QueryEngineHTTP(String serviceURI, Query query, HttpClient client, HttpContext httpContext) {
+        this(serviceURI, query, query.toString(), client, httpContext);
+    }
+
+    public QueryEngineHTTP(String serviceURI, String queryString) {
+        this(serviceURI, queryString, null, null);
+    }
+
+    public QueryEngineHTTP(String serviceURI, String queryString, HttpClient client) {
+        this(serviceURI, queryString, client, null);
+    }
+
+    public QueryEngineHTTP(String serviceURI, String queryString, HttpClient client, HttpContext httpContext) {
+        this(serviceURI, null, queryString, client, httpContext);
+    }
+
+    private QueryEngineHTTP(String serviceURI, Query query, String queryString, HttpClient client, HttpContext httpContext) {
+        this.query = query;
+        this.queryString = queryString;
+        this.service = serviceURI;
+        this.context = ARQ.getContext().copy();
+
+        // Apply service configuration if relevant
+        applyServiceConfig(serviceURI, this);
+
+        // Don't want to overwrite client config we may have picked up from
+        // service context in the parent constructor if the specified
+        // client is null
+        if (client != null) setClient(client);
+        if (httpContext != null) setHttpContext(httpContext);
+    }
+
+    /**
+     * <p>
+     * Helper method which applies configuration from the Context to the query
+     * engine if a service context exists for the given URI
+     * </p>
+     * <p>
+     * Based off proposed patch for JENA-405 but modified to apply all relevant
+     * configuration, this is in part also based off of the private
+     * {@code configureQuery()} method of the {@link Service_AHC} class though it
+     * omits parameter merging since that will be done automatically whenever
+     * the {@link QueryEngineHTTP} instance makes a query for remote submission.
+     * </p>
+     *
+     * @param serviceURI
+     *            Service URI
+     */
+    private static void applyServiceConfig(String serviceURI, QueryEngineHTTP engine) {
+        if (engine.context == null)
+            return;
+
+        @SuppressWarnings("unchecked")
+        Map<String, Context> serviceContextMap = (Map<String, Context>) engine.context.get(Service_AHC.serviceContext);
+        if (serviceContextMap != null && serviceContextMap.containsKey(serviceURI)) {
+            Context serviceContext = serviceContextMap.get(serviceURI);
+            if (log.isDebugEnabled())
+                log.debug("Endpoint URI {} has SERVICE Context: {} ", serviceURI, serviceContext);
+
+            // Apply behavioural options
+            engine.setAllowCompression(serviceContext.isTrueOrUndef(Service_AHC.queryCompression));
+            applyServiceTimeouts(engine, serviceContext);
+
+            // Apply context-supplied client settings
+            HttpClient client = serviceContext.get(Service_AHC.queryClient);
+
+            if (client != null) {
+                if (log.isDebugEnabled())
+                    log.debug("Using context-supplied HTTP client for endpoint URI {}", serviceURI);
+                engine.setClient(client);
+            }
+        }
+    }
+
+    /**
+     * Applies context provided timeouts to the given engine
+     *
+     * @param engine
+     *            Engine
+     * @param context
+     *            Context
+     */
+    private static void applyServiceTimeouts(QueryEngineHTTP engine, Context context) {
+        if (context.isDefined(Service_AHC.queryTimeout)) {
+            Object obj = context.get(Service_AHC.queryTimeout);
+            if (obj instanceof Number) {
+                int x = ((Number) obj).intValue();
+                engine.setTimeout(-1, x);
+            } else if (obj instanceof String) {
+                try {
+                    String str = obj.toString();
+                    if (str.contains(",")) {
+                        String[] a = str.split(",");
+                        int connect = Integer.parseInt(a[0]);
+                        int read = Integer.parseInt(a[1]);
+                        engine.setTimeout(read, connect);
+                    } else {
+                        int x = Integer.parseInt(str);
+                        engine.setTimeout(-1, x);
+                    }
+                } catch (NumberFormatException ex) {
+                    throw new QueryExecException("Can't interpret string for timeout: " + obj);
+                }
+            } else {
+                throw new QueryExecException("Can't interpret timeout: " + obj);
+            }
+        }
+    }
+
+    // public void setParams(Params params)
+    // { this.params = params ; }
+
+    @Override
+    public void setInitialBinding(QuerySolution binding) {
+        throw new UnsupportedOperationException(
+                "Initial bindings not supported for remote queries, consider using a ParameterizedSparqlString to prepare a query for remote execution");
+    }
+
+    @Override
+    public void setInitialBinding(Binding binding) {
+        throw new UnsupportedOperationException(
+                "Initial bindings not supported for remote queries, consider using a ParameterizedSparqlString to prepare a query for remote execution");
+    }
+    /**
+     * @param defaultGraphURIs
+     *            The defaultGraphURIs to set.
+     */
+    public void setDefaultGraphURIs(List<String> defaultGraphURIs) {
+        this.defaultGraphURIs = defaultGraphURIs;
+    }
+
+    /**
+     * @param namedGraphURIs
+     *            The namedGraphURIs to set.
+     */
+    public void setNamedGraphURIs(List<String> namedGraphURIs) {
+        this.namedGraphURIs = namedGraphURIs;
+    }
+
+    /**
+     * Sets whether the HTTP requests will permit compressed encoding
+     */
+    public void setAllowCompression(boolean allowed) {
+        allowCompression = allowed;
+    }
+
+    public void addParam(String field, String value) {
+        if (params == null)
+            params = new Params();
+        params.addParam(field, value);
+    }
+
+    /**
+     * @param defaultGraph
+     *            The defaultGraph to add.
+     */
+    public void addDefaultGraph(String defaultGraph) {
+        if (defaultGraphURIs == null)
+            defaultGraphURIs = new ArrayList<>();
+        defaultGraphURIs.add(defaultGraph);
+    }
+
+    /**
+     * @param name
+     *            The URI to add.
+     */
+    public void addNamedGraph(String name) {
+        if (namedGraphURIs == null)
+            namedGraphURIs = new ArrayList<>();
+        namedGraphURIs.add(name);
+    }
+
+    /**
+     * Sets the HTTP client to use, if none is set then the default
+     * client is used.
+     *
+     * @param client
+     *            HTTP client
+     */
+    public void setClient(HttpClient client) {
+        this.client = client;
+    }
+
+    /**
+     * Get the HTTP client in use, if none is set then null.
+     *
+     * @return client HTTP client
+     */
+    public HttpClient getClient() {
+        return client;
+    }
+
+    /**
+     * Sets the HTTP context to use, if none is set then the default context is used.
+     *
+     * @param context HTTP context
+     */
+    public void setHttpContext(HttpContext context) {
+        this.httpContext = context;
+    }
+
+    /**
+     * Get the HTTP context in use, if none is set then null.
+     *
+     * @return the {@code HttpContext} in scope
+     */
+    public HttpContext getHttpContext() {
+        return httpContext;
+    }
+
+    /** The Content-Type response header received (null before the remote operation is attempted). */
+    public String getHttpResponseContentType() {
+		return httpResponseContentType;
+	}
+
+	@Override
+    public ResultSet execSelect() {
+        checkNotClosed() ;
+        ResultSet rs = execResultSetInner() ;
+        return new ResultSetCheckCondition(rs, this) ;
+    }
+
+	private ResultSet execResultSetInner() {
+        HttpQuery httpQuery = makeHttpQuery();
+        httpQuery.setAccept(chooseAcceptHeader(acceptHeader, selectContentType));
+        InputStream in = httpQuery.exec();
+
+        if (false) {
+            byte b[] = IO.readWholeFile(in);
+            String str = new String(b);
+            System.out.println(str);
+            in = new ByteArrayInputStream(b);
+        }
+
+        retainedConnection = in; // This will be closed on close()
+
+        // Don't assume the endpoint actually gives back the
+        // content type we asked for
+        String actualContentType = httpQuery.getContentType();
+        httpResponseContentType = actualContentType;
+
+        // If the server fails to return a Content-Type then we will assume
+        // the server returned the type we asked for
+        if (actualContentType == null || actualContentType.equals("")) {
+            actualContentType = selectContentType;
+        }
+
+        // Map to lang, with pragmatic alternatives.
+        Lang lang = WebContent.contentTypeToLangResultSet(actualContentType);
+        if ( lang == null )
+            throw new QueryException("Endpoint returned Content-Type: " + actualContentType + " which is not recognized for SELECT queries");
+        if ( !ResultSetReaderRegistry.isRegistered(lang) )
+            throw new QueryException("Endpoint returned Content-Type: " + actualContentType + " which is not supported for SELECT queries");
+        // This returns a streaming result set for some formats.
+        // Do not close the InputStream at this point.
+
+        ResultSet result = ResultSetMgr.read(in, lang);
+        return result;
+    }
+
+    private static String chooseAcceptHeader(String acceptHeader, String contentType) {
+        if ( acceptHeader != null )
+            return acceptHeader;
+        return contentType;
+    }
+
+    @Override
+    public Model execConstruct() {
+        return execConstruct(GraphFactory.makeJenaDefaultModel());
+    }
+
+    @Override
+    public Model execConstruct(Model model) {
+        return execModel(model);
+    }
+
+    @Override
+    public Iterator<Triple> execConstructTriples() {
+        return execTriples();
+    }
+
+    @Override
+    public Iterator<Quad> execConstructQuads(){
+        return execQuads();
+    }
+
+    @Override
+    public Dataset execConstructDataset(){
+        return execConstructDataset(DatasetFactory.createTxnMem());
+    }
+
+    @Override
+    public Dataset execConstructDataset(Dataset dataset){
+        return execDataset(dataset) ;
+    }
+
+    @Override
+    public Model execDescribe() {
+        return execDescribe(GraphFactory.makeJenaDefaultModel());
+    }
+
+    @Override
+    public Model execDescribe(Model model) {
+        return execModel(model);
+    }
+
+    @Override
+    public Iterator<Triple> execDescribeTriples() {
+        return execTriples();
+    }
+
+    private Model execModel(Model model) {
+        Pair<InputStream, Lang> p = execConstructWorker(modelContentType) ;
+        try(InputStream in = p.getLeft()) {
+            Lang lang = p.getRight() ;
+            RDFDataMgr.read(model, in, lang);
+        } catch (IOException ex) { IO.exception(ex); }
+        finally { this.close(); }
+        return model;
+    }
+
+    private Dataset execDataset(Dataset dataset) {
+        Pair<InputStream, Lang> p = execConstructWorker(datasetContentType);
+        try(InputStream in = p.getLeft()) {
+            Lang lang = p.getRight() ;
+            RDFDataMgr.read(dataset, in, lang);
+        } catch (IOException ex) { IO.exception(ex); }
+        finally { this.close(); }
+        return dataset;
+    }
+
+    private Iterator<Triple> execTriples() {
+        Pair<InputStream, Lang> p = execConstructWorker(modelContentType) ;
+        InputStream in = p.getLeft() ;
+        Lang lang = p.getRight() ;
+        // Base URI?
+        return RDFDataMgr.createIteratorTriples(in, lang, null);
+    }
+
+    private Iterator<Quad> execQuads() {
+        Pair<InputStream, Lang> p = execConstructWorker(datasetContentType) ;
+        InputStream in = p.getLeft() ;
+        Lang lang = p.getRight() ;
+        // Base URI?
+        return RDFDataMgr.createIteratorQuads(in, lang, null);
+    }
+
+    private Pair<InputStream, Lang> execConstructWorker(String contentType) {
+        checkNotClosed() ;
+        HttpQuery httpQuery = makeHttpQuery();
+        httpQuery.setAccept(chooseAcceptHeader(acceptHeader, contentType));
+        InputStream in = httpQuery.exec();
+
+        // Don't assume the endpoint actually gives back the content type we
+        // asked for
+        String actualContentType = httpQuery.getContentType();
+        httpResponseContentType = actualContentType;
+
+        // If the server fails to return a Content-Type then we will assume
+        // the server returned the type we asked for
+        if (actualContentType == null || actualContentType.equals("")) {
+            actualContentType = WebContent.defaultDatasetAcceptHeader;
+        }
+        Lang lang = RDFLanguages.contentTypeToLang(actualContentType);
+        if ( ! RDFLanguages.isQuads(lang) && ! RDFLanguages.isTriples(lang) )
+            throw new QueryException("Endpoint returned Content Type: "
+                                     + actualContentType
+                                     + " which is not a valid RDF syntax");
+        return Pair.create(in, lang) ;
+    }
+
+    @Override
+    public boolean execAsk() {
+        checkNotClosed() ;
+        HttpQuery httpQuery = makeHttpQuery();
+        httpQuery.setAccept(chooseAcceptHeader(acceptHeader, askContentType));
+        try(InputStream in = httpQuery.exec()) {
+            // Don't assume the endpoint actually gives back the content type we
+            // asked for
+            String actualContentType = httpQuery.getContentType();
+            httpResponseContentType = actualContentType;
+
+            // If the server fails to return a Content-Type then we will assume
+            // the server returned the type we asked for
+            if (actualContentType == null || actualContentType.equals("")) {
+                actualContentType = askContentType;
+            }
+
+            Lang lang = RDFLanguages.contentTypeToLang(actualContentType);
+            if ( lang == null ) {
+                // Any specials :
+                // application/xml for application/sparql-results+xml
+                // application/json for application/sparql-results+json
+                if (actualContentType.equals(WebContent.contentTypeXML))
+                    lang = ResultSetLang.RS_XML;
+                else if ( actualContentType.equals(WebContent.contentTypeJSON))
+                    lang = ResultSetLang.RS_JSON;
+            }
+            if ( lang == null )
+                throw new QueryException("Endpoint returned Content-Type: " + actualContentType + " which is not supported for ASK queries");
+            Boolean result = ResultSetMgr.readBoolean(in, lang);
+            return result;
+        } catch (ResultSetException e) {
+            log.warn("Returned content is not a boolean result", e);
+            throw e;
+        } catch (QueryExceptionHTTP e) {
+            throw e ;
+        }
+        catch (java.io.IOException e) {
+            log.warn("Failed to close connection", e);
+            return false ;
+        }
+        finally { this.close(); }
+    }
+
+    @Override
+    public JsonArray execJson()
+    {
+        checkNotClosed();
+        HttpQuery httpQuery = makeHttpQuery();
+        httpQuery.setAccept(WebContent.contentTypeJSON);
+        JsonArray result = new JsonArray();
+        try(InputStream in = httpQuery.exec()) {
+            JsonValue v = JSON.parseAny(in);
+            if ( ! v.isArray() )
+                throw new QueryExecException("Return from a JSON query isn't an array");
+            result = v.getAsArray();
+        } catch (IOException e) { IO.exception(e); }
+        finally { this.close(); }
+        return result;
+    }
+
+    @Override
+    public Iterator<JsonObject> execJsonItems()
+    {
+        // Non-streaming.
+        // TODO Integrate with the JSON parser to stream the results.
+        JsonArray array = execJson().getAsArray();
+        List<JsonObject> x = new ArrayList<>(array.size());
+        array.forEach(elt->{
+            if ( ! elt.isObject())
+                throw new QueryExecException("Item in an array from a JSON query isn't an object");
+            x.add(elt.getAsObject());
+        });
+        return x.iterator();
+    }
+
+    private void checkNotClosed() {
+        if ( closed )
+            throw new QueryExecException("HTTP QueryExecution has been closed") ;
+    }
+
+    @Override
+    public Context getContext() {
+        return context;
+    }
+
+    @Override
+    public Dataset getDataset() {
+        return null;
+    }
+
+    // This may be null - if we were created form a query string,
+    // we don't guarantee to parse it so we let through non-SPARQL
+    // extensions to the far end.
+    @Override
+    public Query getQuery() {
+        if ( query != null )
+            return query;
+        if ( queryString != null ) {
+            // Object not created with a Query object, may be because there is forgein
+            // syntax in the query or may be because the queystrign was available and the app
+            // didn't want the overhead of parsing it everytime.
+            // Try to parse it else return null;
+            try { return QueryFactory.create(queryString, Syntax.syntaxARQ); }
+            catch (QueryParseException ex) {}
+            return null ;
+        }
+        return null;
+    }
+
+    /**
+     * Return the query string. If this was supplied in a constructor, there is no
+     * guarantee this is legal SPARQL syntax.
+     */
+    @Override
+    public String getQueryString() {
+        return queryString;
+    }
+
+    @Override
+    public void setTimeout(long readTimeout) {
+        this.readTimeout = readTimeout;
+        this.readTimeoutUnit = TimeUnit.MILLISECONDS;
+    }
+
+    @Override
+    public void setTimeout(long readTimeout, long connectTimeout) {
+        this.readTimeout = readTimeout;
+        this.readTimeoutUnit = TimeUnit.MILLISECONDS;
+        this.connectTimeout = connectTimeout;
+        this.connectTimeoutUnit = TimeUnit.MILLISECONDS;
+    }
+
+    @Override
+    public void setTimeout(long readTimeout, TimeUnit timeoutUnits) {
+        this.readTimeout = readTimeout;
+        this.readTimeoutUnit = timeoutUnits;
+    }
+
+    @Override
+    public void setTimeout(long timeout1, TimeUnit timeUnit1, long timeout2, TimeUnit timeUnit2) {
+        this.readTimeout = timeout1;
+        this.readTimeoutUnit = timeUnit1;
+        this.connectTimeout = timeout2;
+        this.connectTimeoutUnit = timeUnit2;
+    }
+
+    @Override
+    public long getTimeout1() {
+        return asMillis(readTimeout, readTimeoutUnit);
+    }
+
+    @Override
+    public long getTimeout2() {
+        return asMillis(connectTimeout, connectTimeoutUnit);
+    }
+
+    /**
+     * Gets whether HTTP requests will indicate to the remote server that
+     * compressed encoding of responses is accepted
+     *
+     * @return True if compressed encoding will be accepted
+     */
+    public boolean getAllowCompression() {
+        return allowCompression;
+    }
+
+    private static long asMillis(long duration, TimeUnit timeUnit) {
+        return (duration < 0) ? duration : timeUnit.toMillis(duration);
+    }
+
+    private HttpQuery makeHttpQuery() {
+        if (closed)
+            throw new ARQException("HTTP execution already closed");
+
+        HttpQuery httpQuery = new HttpQuery(service);
+        httpQuery.merge(getServiceParams(service, context));
+        httpQuery.addParam(HttpParams.pQuery, queryString);
+
+        for ( String dft : defaultGraphURIs )
+        {
+            httpQuery.addParam( HttpParams.pDefaultGraph, dft );
+        }
+        for ( String name : namedGraphURIs )
+        {
+            httpQuery.addParam( HttpParams.pNamedGraph, name );
+        }
+
+        if (params != null) httpQuery.merge(params);
+
+        httpQuery.setAllowCompression(allowCompression);
+
+        // check for service context overrides
+        if (context.isDefined(Service_AHC.serviceContext)) {
+            Map<String, Context> servicesContext = context.get(Service_AHC.serviceContext);
+            if (servicesContext.containsKey(service)) {
+                Context serviceContext = servicesContext.get(service);
+                if (serviceContext.isDefined(Service_AHC.queryClient)) client = serviceContext.get(Service_AHC.queryClient);
+            }
+        }
+        httpQuery.setClient(client);
+        HttpClientContext hcc = ( httpContext == null ) ? null : HttpClientContext.adapt(httpContext);
+        httpQuery.setContext(hcc);
+
+        // Apply timeouts
+        if (connectTimeout > 0) httpQuery.setConnectTimeout((int) connectTimeoutUnit.toMillis(connectTimeout));
+
+        if (readTimeout > 0) httpQuery.setReadTimeout((int) readTimeoutUnit.toMillis(readTimeout));
+
+        return httpQuery;
+    }
+
+    // This is to allow setting additional/optional query parameters on a per
+    // SERVICE level, see: JENA-195
+    protected static Params getServiceParams(String serviceURI, Context context) throws QueryExecException {
+        Params params = new Params();
+        @SuppressWarnings("unchecked")
+        Map<String, Map<String, List<String>>> serviceParams = (Map<String, Map<String, List<String>>>) context
+                .get(ARQ.serviceParams);
+        if (serviceParams != null) {
+            Map<String, List<String>> paramsMap = serviceParams.get(serviceURI);
+            if (paramsMap != null) {
+                for (String param : paramsMap.keySet()) {
+                    if (HttpParams.pQuery.equals(param))
+                        throw new QueryExecException("ARQ serviceParams overrides the 'query' SPARQL protocol parameter");
+
+                    List<String> values = paramsMap.get(param);
+                    for (String value : values)
+                        params.addParam(param, value);
+                }
+            }
+        }
+        return params;
+    }
+
+    /**
+     * Cancel query evaluation
+     */
+    public void cancel() {
+        closed = true;
+    }
+
+    @Override
+    public void abort() {
+        try {
+            close();
+        } catch (Exception ex) {
+            log.warn("Error during abort", ex);
+        }
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+        if (retainedConnection != null) {
+            try {
+                // JENA-1063 - WARNING
+                // This call may take a long time if the response has not been consumed
+                // as HTTP client will consume the remaining response so it can re-use the
+                // connection
+                // If we're closing when we're not at the end of the stream then issue a
+                // warning to the logs
+                if (retainedConnection.read() != -1)
+                    log.warn("HTTP response not fully consumed, if HTTP Client is reusing connections (its default behaviour) then it will consume the remaining response data which may take a long time and cause this application to become unresponsive");
+                retainedConnection.close();
+            } catch (RuntimeIOException e) {
+                // If we are closing early and the underlying stream is chunk encoded
+                // the close() can result in a IOException.  Unfortunately our TypedInputStream
+                // catches and re-wraps that and we want to suppress it when we are cleaning up
+                // and so we catch the wrapped exception and log it instead
+                log.debug("Failed to close connection", e);
+            } catch (java.io.IOException e) {
+                log.debug("Failed to close connection", e);
+            } finally {
+                retainedConnection = null;
+            }
+        }
+    }
+
+    @Override
+    public boolean isClosed() { return closed ; }
+
+    @Override
+    public String toString() {
+        HttpQuery httpQuery = makeHttpQuery();
+        return "GET " + httpQuery.toString();
+    }
+
+    /**
+     * Sets the Content Type for SELECT queries provided that the format is
+     * supported
+     *
+     * @param contentType
+     */
+    public void setSelectContentType(String contentType) {
+        boolean ok = false;
+        for (String supportedType : supportedSelectContentTypes) {
+            if (supportedType.equals(contentType)) {
+                ok = true;
+                break;
+            }
+        }
+        if (!ok)
+            throw new IllegalArgumentException("Given Content Type '" + contentType
+                    + "' is not a supported SELECT results format");
+        selectContentType = contentType;
+    }
+
+    /**
+     * Sets the Content Type for ASK queries provided that the format is
+     * supported
+     *
+     * @param contentType
+     */
+    public void setAskContentType(String contentType) {
+        boolean ok = false;
+        for (String supportedType : supportedAskContentTypes) {
+            if (supportedType.equals(contentType)) {
+                ok = true;
+                break;
+            }
+        }
+        if (!ok)
+            throw new IllegalArgumentException("Given Content Type '" + contentType + "' is not a supported ASK results format");
+        askContentType = contentType;
+    }
+
+    /**
+     * Sets the Content Type for CONSTRUCT/DESCRIBE queries provided that the
+     * format is supported
+     *
+     * @param contentType
+     */
+    public void setModelContentType(String contentType) {
+        // Check that this is a valid setting
+        Lang lang = RDFLanguages.contentTypeToLang(contentType);
+        if (lang == null)
+            throw new IllegalArgumentException("Given Content Type '" + contentType + "' is not supported by RIOT");
+        if (!RDFLanguages.isTriples(lang))
+            throw new IllegalArgumentException("Given Content Type '" + contentType + "' is not a RDF Graph format");
+        modelContentType = contentType;
+    }
+
+    public void setDatasetContentType(String contentType) {
+        // Check that this is a valid setting
+        Lang lang = RDFLanguages.contentTypeToLang(contentType);
+        if (lang == null)
+            throw new IllegalArgumentException("Given Content Type '" + contentType + "' is not supported by RIOT");
+        if (!RDFLanguages.isQuads(lang))
+            throw new IllegalArgumentException("Given Content Type '" + contentType + "' is not a RDF Dataset format");
+        datasetContentType = contentType;
+    }
+
+    /** Get the HTTP Accept header for the request. */
+    public String getAcceptHeader() {
+        return this.acceptHeader;
+    }
+
+    /** Set the HTTP Accept header for the request.
+     * Unlike the {@code set??ContentType} operations, this is not checked
+     * for validity.
+     */
+    public void setAcceptHeader(String acceptHeader) {
+        this.acceptHeader = acceptHeader;
+    }
+}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/Service_AHC.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/Service_AHC.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.http.client.HttpClient;
+import org.apache.jena.query.Query ;
+import org.apache.jena.query.QueryExecException ;
+import org.apache.jena.query.ResultSet ;
+import org.apache.jena.query.ResultSetFactory ;
+import org.apache.jena.sparql.SystemARQ ;
+import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.algebra.OpAsQuery ;
+import org.apache.jena.sparql.algebra.OpVars ;
+import org.apache.jena.sparql.algebra.op.OpService ;
+import org.apache.jena.sparql.core.Var ;
+import org.apache.jena.sparql.engine.QueryIterator ;
+import org.apache.jena.sparql.engine.Rename ;
+import org.apache.jena.sparql.engine.http.HttpParams;
+import org.apache.jena.sparql.engine.iterator.QueryIter ;
+import org.apache.jena.sparql.engine.iterator.QueryIteratorResultSet ;
+import org.apache.jena.sparql.mgt.Explain ;
+import org.apache.jena.sparql.util.Context ;
+import org.apache.jena.sparql.util.Symbol ;
+
+/** Execution of OpService */
+@SuppressWarnings("deprecation")
+public class Service_AHC {
+    /* define the symbols that Service will use to set the HttpQuery parameters */
+    public static final String base = "http://jena.hpl.hp.com/Service#";
+
+    /**
+     * Use to set the HttpQuery.allowCompression flag.
+     */
+    public static final Symbol queryCompression = SystemARQ.allocSymbol(base, "queryCompression");
+
+    /**
+     * Use to set the HTTP client for a service.
+     */
+    public static final Symbol queryClient = SystemARQ.allocSymbol(base, "queryClient");
+
+    /**
+     * Use this Symbol to allow passing additional service context variables
+     * {@literal SERVICE <IRI>} call. Parameters need to be grouped by {@literal SERVICE <IRI>}, a
+     * {@literal Map<String, Context>} is assumed. The key of the first map is the SERVICE
+     * IRI, the value is a Context who's values will override any defaults in
+     * the original context.
+     */
+    public static final Symbol serviceContext = SystemARQ.allocSymbol(base, "serviceContext");
+
+    /**
+     * Control whether SERVICE processing is allowed.
+     * If the context contains this, and it is set to "false",
+     * then SERVICE is not allowed.
+     */
+
+    public static final Symbol serviceAllowed = SystemARQ.allocSymbol(base, "serviceAllowed");
+
+    /**
+     * Set timeout. The value of this symbol gives the value of the timeout in
+     * milliseconds
+     * <ul>
+     * <li>A Number; the long value is used</li>
+     * <li>A string, e.g. "1000", parsed as a number</li>
+     * <li>A string, as two numbers separated by a comma, e.g. "500,10000"
+     * parsed as two numbers</li>
+     * </ul>
+     * The first value is passed to HttpQuery.setConnectTimeout() the second, if
+     * it exists, is passed to HttpQuery.setReadTimeout()
+     */
+    public static final Symbol queryTimeout = SystemARQ.allocSymbol(base, "queryTimeout");
+
+    /**
+     * Executes a service operator
+     *
+     * @param op
+     *            Service
+     * @param context
+     *            Context
+     * @return Query iterator of service results
+     */
+    public static QueryIterator exec(OpService op, Context context) {
+        if ( context != null && context.isFalse(serviceAllowed) )
+            throw new QueryExecException("SERVICE execution disabled") ;
+
+        if (!op.getService().isURI())
+            throw new QueryExecException("Service URI not bound: " + op.getService());
+
+        // This relies on the observation that the query was originally correct,
+        // so reversing the scope renaming is safe (it merely restores the
+        // algebra expression).
+        // Any variables that reappear should be internal ones that were hidden
+        // by renaming in the first place.
+        // Any substitution is also safe because it replaced variables by
+        // values.
+        Op opRemote = Rename.reverseVarRename(op.getSubOp(), true);
+
+        // JENA-494 There is a bug here that the renaming means that if this is
+        // deeply nested and joined to other things at the same level of you end
+        // up with the variables being disjoint and the same results
+        // The naive fix for this is to map the variables visible in the inner
+        // operator to those visible in the rewritten operator
+        // There may be some cases where the re-mapping is incorrect due to
+        // deeply nested SERVICE clauses
+        Map<Var, Var> varMapping = new HashMap<>();
+        Set<Var> originalVars = OpVars.visibleVars(op);
+        Set<Var> remoteVars = OpVars.visibleVars(opRemote);
+
+        boolean requiresRemapping = false;
+        for (Var v : originalVars) {
+            if (v.getName().contains("/")) {
+                // A variable which was scope renamed so has a different name
+                String origName = v.getName().substring(v.getName().lastIndexOf('/') + 1);
+                Var remoteVar = Var.alloc(origName);
+                if (remoteVars.contains(remoteVar)) {
+                    varMapping.put(remoteVar, v);
+                    requiresRemapping = true;
+                }
+            } else {
+                // A variable which does not have a different name
+                if (remoteVars.contains(v))
+                    varMapping.put(v, v);
+            }
+        }
+
+        // Explain.explain("HTTP", opRemote, context) ;
+
+        Query query;
+
+        //@formatter:off
+        // Comment (for the future?)
+//        if ( false )
+//        {
+//            // ***** Interacts with substitution.
+//            Element el = op.getServiceElement().getElement() ;
+//            if ( el instanceof ElementSubQuery )
+//                query = ((ElementSubQuery)el).getQuery() ;
+//            else
+//            {
+//                query = QueryFactory.create() ;
+//                query.setQueryPattern(el) ;
+//                query.setResultVars() ;
+//            }
+//        }
+//        else
+        //@formatter:on
+        query = OpAsQuery.asQuery(opRemote);
+
+        Explain.explain("HTTP", query, context);
+        String uri = op.getService().getURI();
+        HttpQuery httpQuery = configureQuery(uri, context, query);
+        QueryIterator qIter;
+        try (InputStream in = httpQuery.exec()) {
+            // Read the whole of the results now.
+            // Avoids the problems with calling back into the same system e.g.
+            // Fuseki+SERVICE <http://localhost:3030/...>
+
+            ResultSet rs = ResultSetFactory.fromXML(in);
+            qIter = QueryIter.materialize(new QueryIteratorResultSet(rs));
+            // And close connection now, not when qIter is closed.
+        } catch (IOException e) {
+            throw new QueryExecException("Could not parse result set from XML", e);
+        }
+
+        // In some cases we may need to apply a re-mapping
+        // This solves JENA-494 the naive way and may be brittle for complex
+        // nested SERVICE clauses
+        if (requiresRemapping) {
+            qIter = QueryIter.map(qIter, varMapping);
+        }
+
+        return qIter;
+    }
+
+    /**
+     * Create and configure the HttpQuery object.
+     *
+     * The parentContext is not modified but is used to create a new context
+     * copy.
+     *
+     * @param uri
+     *            The uri of the endpoint
+     * @param parentContext
+     *            The initial context.
+     * @param Query
+     *            the Query to execute.
+     * @return An HttpQuery configured as per the context.
+     */
+    private static HttpQuery configureQuery(String uri, Context parentContext, Query query) {
+        HttpQuery httpQuery = new HttpQuery(uri);
+        Context context = new Context(parentContext);
+
+        // add the context settings from the service context
+        @SuppressWarnings("unchecked")
+        Map<String, Context> serviceContextMap = (Map<String, Context>) context.get(serviceContext);
+        if (serviceContextMap != null) {
+            Context serviceContext = serviceContextMap.get(uri);
+            if (serviceContext != null)
+                context.putAll(serviceContext);
+        }
+
+        // configure the query object.
+        httpQuery.merge(QueryEngineHTTP.getServiceParams(uri, context));
+        httpQuery.addParam(HttpParams.pQuery, query.toString());
+        httpQuery.setAllowCompression(context.isTrueOrUndef(queryCompression));
+
+        HttpClient client = context.get(queryClient);
+        if (client != null) httpQuery.setClient(client);
+
+        setAnyTimeouts(httpQuery, context);
+
+        return httpQuery;
+    }
+
+    /**
+     * Modified from QueryExecutionBase
+     *
+     * @see org.apache.jena.sparql.engine.QueryExecutionBase
+     */
+    private static void setAnyTimeouts(HttpQuery query, Context context) {
+        if (context.isDefined(queryTimeout)) {
+            Object obj = context.get(queryTimeout);
+            if (obj instanceof Number) {
+                int x = ((Number) obj).intValue();
+                query.setConnectTimeout(x);
+            } else if (obj instanceof String) {
+                try {
+                    String str = obj.toString();
+                    if (str.contains(",")) {
+
+                        String[] a = str.split(",");
+                        int x1 = Integer.parseInt(a[0]);
+                        int x2 = Integer.parseInt(a[1]);
+                        query.setConnectTimeout(x1);
+                        query.setReadTimeout(x2);
+                    } else {
+                        int x = Integer.parseInt(str);
+                        query.setConnectTimeout(x);
+                    }
+                } catch (NumberFormatException ex) {
+                    throw new QueryExecException("Can't interpret string for timeout: " + obj);
+                }
+            } else {
+                throw new QueryExecException("Can't interpret timeout: " + obj);
+            }
+        }
+    }
+}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/UpdateProcessRemote.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/UpdateProcessRemote.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.protocol.HttpContext;
+import org.apache.jena.riot.WebContent ;
+import org.apache.jena.sparql.ARQException ;
+import org.apache.jena.sparql.util.Context ;
+import org.apache.jena.update.UpdateRequest ;
+
+/**
+ * UpdateProcess that send the request to a SPARQL endpoint by using POST of application/sparql-update.
+ * @deprecated Use {@code UpdateExecutionHTTP} created with {@code UpdateExecutionHTTPBuilder}.
+ */
+@Deprecated
+public class UpdateProcessRemote extends UpdateProcessRemoteBase
+{
+    /**
+     * Creates a new remote update processor that uses the application/sparql-update submission method
+     * @param request Update request
+     * @param endpoint Update endpoint
+     * @param context Context
+     */
+    public UpdateProcessRemote(UpdateRequest request, String endpoint, Context context )
+    {
+        super(request, endpoint, context);
+    }
+
+    /**
+     * Creates a new remote update processor that uses the application/sparql-update submission method
+     * @param request Update request
+     * @param endpoint Update endpoint
+     * @param context Context
+     * @param client HTTP client
+     * @param httpContext HTTP Context
+     */
+    public UpdateProcessRemote(UpdateRequest request, String endpoint, Context context, HttpClient client, HttpContext httpContext)
+    {
+        this(request, endpoint, context);
+        // Don't want to overwrite config we may have picked up from
+        // service context in the parent constructor if the specified
+        // client is null
+        if (client != null) this.setClient(client);
+        if (httpContext != null) this.setHttpContext(httpContext);
+    }
+
+    @Override
+    public void execute()
+    {
+        // Validation
+        if ( this.getEndpoint() == null )
+            throw new ARQException("Null endpoint for remote update") ;
+        if ( this.getUpdateRequest() == null )
+            throw new ARQException("Null update request for remote update") ;
+
+        // Build endpoint URL
+        String endpoint = this.getEndpoint();
+        String querystring = this.getUpdateString();
+        if (querystring != null && !querystring.equals("")) {
+            endpoint = endpoint.contains("?") ? endpoint + "&" + querystring : endpoint + "?" + querystring;
+        }
+
+        // Execution
+        String reqStr = this.getUpdateRequest().toString() ;
+        HttpOp1.execHttpPost(endpoint, WebContent.contentTypeSPARQLUpdate, reqStr, getClient(), getHttpContext()) ;
+    }
+}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/UpdateProcessRemoteBase.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/http/UpdateProcessRemoteBase.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.http;
+
+import java.util.ArrayList ;
+import java.util.List ;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.protocol.HttpContext ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.engine.http.HttpParams ;
+import org.apache.jena.sparql.engine.http.Params ;
+import org.apache.jena.sparql.exec.UpdateExec;
+import org.apache.jena.sparql.exec.http.Service;
+import org.apache.jena.sparql.util.Context ;
+import org.apache.jena.sparql.util.Symbol ;
+import org.apache.jena.update.UpdateRequest ;
+import org.slf4j.Logger ;
+import org.slf4j.LoggerFactory ;
+
+/**
+ * Abstract base class for update processors that perform remote updates over
+ * HTTP
+ * @deprecated Use {@code UpdateExecutionHTTP} created with {@code UpdateExecutionHTTPBuilder}.
+ */
+@Deprecated
+public abstract class UpdateProcessRemoteBase implements UpdateExec {
+    private static Logger log = LoggerFactory.getLogger(UpdateProcessRemoteBase.class);
+
+    /**
+     * Symbol used to set a {@link HttpContext} which will be used for HTTP
+     * requests
+     */
+    public static final Symbol HTTP_CONTEXT = Symbol.create("httpContext");
+
+    private final UpdateRequest request;
+    private final String endpoint;
+    private final Context context;
+    private HttpClient client;
+    private Params params;
+
+    protected List<String> defaultGraphURIs = new ArrayList<>();
+    protected List<String> namedGraphURIs = new ArrayList<>();
+
+    /**
+     * Creates a new remote update processor
+     *
+     * @param request
+     *            Update request
+     * @param endpoint
+     *            Update endpoint
+     * @param context
+     *            Context
+     */
+    public UpdateProcessRemoteBase(UpdateRequest request, String endpoint, Context context) {
+        super();
+
+        this.request = request;
+        this.endpoint = endpoint;
+        this.context = Context.setupContextForDataset(context, null);
+
+        // Apply service configuration if applicable
+        UpdateProcessRemoteBase.applyServiceConfig(endpoint, this);
+    }
+
+    /**
+     * <p>
+     * Helper method which applies configuration from the Context to the query
+     * engine if a service context exists for the given URI
+     * </p>
+     * <p>
+     * Based off proposed patch for JENA-405 but modified to apply all relevant
+     * configuration, this is in part also based off of the private
+     * {@code configureQuery()} method of the {@link Service_AHC} class though it
+     * omits parameter merging since that will be done automatically whenever
+     * the {@link QueryEngineHTTP} instance makes a query for remote submission.
+     * </p>
+     *
+     * @param serviceURI
+     *            Service URI
+     */
+    private static void applyServiceConfig(String serviceURI, UpdateProcessRemoteBase engine) {
+        if ( engine.context.isDefined(Service.oldServiceContext) )
+            System.err.println("************ UpdateProcessRemoteBase.applyServiceConfig NOT IMPLEMENTED *************");
+
+//        @SuppressWarnings("unchecked")
+//        Map<String, Context> serviceContextMap = (Map<String, Context>) engine.context.get(Service_AHC.serviceContext);
+//        if (serviceContextMap != null && serviceContextMap.containsKey(serviceURI)) {
+//            Context serviceContext = serviceContextMap.get(serviceURI);
+//            if (log.isDebugEnabled())
+//                log.debug("Endpoint URI {} has SERVICE Context: {} ", serviceURI, serviceContext);
+//
+//            // Apply client settings
+//            HttpClient client = serviceContext.get(Service_AHC.queryClient);
+//
+//            if (client != null) {
+//                if (log.isDebugEnabled())
+//                    log.debug("Using context-supplied client for endpoint URI {}", serviceURI);
+//                engine.setClient(client);
+//            }
+//        }
+    }
+
+    @Override
+    public DatasetGraph getDatasetGraph() {
+        return null;
+    }
+
+    /**
+     * Gets the endpoint
+     *
+     * @return Endpoint URI
+     */
+    public String getEndpoint() {
+        return this.endpoint;
+    }
+
+    /**
+     * Gets the generated HTTP query string portion of the endpoint URL if applicable
+     * <p>
+     * Generated string will not include leading ? so that consuming code can
+     * decide whether to add this themselves since the generated query string
+     * may be being used in addition to an existing query string.
+     * </p>
+     *
+     * @return Generated query string
+     */
+    public String getUpdateString() {
+        return this.getParams().httpString();
+    }
+
+    /**
+     * Gets the parameters for the execution
+     *
+     * @return Parameters
+     */
+    public Params getParams() {
+        Params ps = this.params != null ? new Params(this.params) : new Params();
+        if (this.defaultGraphURIs != null) {
+            for (String defaultGraph : this.defaultGraphURIs) {
+                ps.addParam(HttpParams.pUsingGraph, defaultGraph);
+            }
+        }
+        if (this.namedGraphURIs != null) {
+            for (String namedGraph : this.namedGraphURIs) {
+                ps.addParam(HttpParams.pUsingNamedGraph, namedGraph);
+            }
+        }
+        return ps;
+    }
+
+    /**
+     * Gets the update request
+     *
+     * @return Update request
+     */
+    public UpdateRequest getUpdateRequest() {
+        return this.request;
+    }
+
+    /**
+     * Adds a default graph
+     *
+     * @param defaultGraph
+     *            Default Graph URI
+     */
+    public void addDefaultGraph(String defaultGraph) {
+        if (this.defaultGraphURIs == null) {
+            this.defaultGraphURIs = new ArrayList<>();
+        }
+        this.defaultGraphURIs.add(defaultGraph);
+    }
+
+    /**
+     * Adds a named graph
+     *
+     * @param namedGraph
+     *            Named Graph URi
+     */
+    public void addNamedGraph(String namedGraph) {
+        if (this.namedGraphURIs == null) {
+            this.namedGraphURIs = new ArrayList<>();
+        }
+        this.namedGraphURIs.add(namedGraph);
+    }
+
+    /**
+     * Adds a custom parameter to the request
+     *
+     * @param field
+     *            Field
+     * @param value
+     *            Value
+     */
+    public void addParam(String field, String value) {
+        if (this.params == null)
+            this.params = new Params();
+        this.params.addParam(field, value);
+    }
+
+    /**
+     * Sets the default graphs
+     *
+     * @param defaultGraphs
+     *            Default Graphs
+     */
+    public void setDefaultGraphs(List<String> defaultGraphs) {
+        this.defaultGraphURIs = defaultGraphs;
+    }
+
+    /**
+     * Sets the named graphs
+     *
+     * @param namedGraphs
+     *            Named Graphs
+     */
+    public void setNamedGraphs(List<String> namedGraphs) {
+        this.namedGraphURIs = namedGraphs;
+    }
+
+    /**
+     * Convenience method to set the {@link HttpContext}
+     *
+     * @param httpContext
+     *            HTTP Context
+     */
+    public void setHttpContext(HttpContext httpContext) {
+        getContext().put(HTTP_CONTEXT, httpContext);
+    }
+
+    /**
+     * Convenience method to get the {@link HttpContext}
+     *
+     * @return HttpContext
+     */
+    public HttpContext getHttpContext() {
+        return (HttpContext) getContext().get(HTTP_CONTEXT);
+    }
+
+    @Override
+    public Context getContext() {
+        return context;
+    }
+
+    /**
+     * Sets the client to use
+     * <p>
+     * Note that you can globally set an client via
+     * {@link HttpOp1#setDefaultHttpClient(HttpClient)} to avoid the
+     * need to set client on a per-request basis
+     * </p>
+     *
+     * @param client
+     *            HTTP client
+     */
+    public void setClient(HttpClient client) {
+        this.client = client;
+    }
+
+    /**
+     * Gets the client that has been set (if any)
+     * <p>
+     * If no client is used then the default client will be used,
+     * this can be configured via the
+     * {@link HttpOp1#setDefaultHttpClient(HttpClient)} method.
+     * </p>
+     *
+     * @return HTTP client if set, null otherwise
+     */
+    public HttpClient getClient() {
+        return this.client;
+    }
+}

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/statements/RemoteEndpointPreparedStatement.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/statements/RemoteEndpointPreparedStatement.java
@@ -24,13 +24,13 @@ import java.sql.SQLFeatureNotSupportedException;
 
 import org.apache.http.client.HttpClient;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
+import org.apache.jena.jdbc.remote.http.QueryEngineHTTP;
+import org.apache.jena.jdbc.remote.http.UpdateProcessRemote;
+import org.apache.jena.jdbc.remote.http.UpdateProcessRemoteBase;
 import org.apache.jena.jdbc.statements.JenaPreparedStatement;
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryExecution ;
 import org.apache.jena.query.ReadWrite ;
-import org.apache.jena.sparql.engine.http.QueryEngineHTTP ;
-import org.apache.jena.sparql.modify.UpdateProcessRemote;
-import org.apache.jena.sparql.modify.UpdateProcessRemoteBase ;
 import org.apache.jena.update.UpdateProcessor ;
 import org.apache.jena.update.UpdateRequest ;
 

--- a/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/statements/RemoteEndpointStatement.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/main/java/org/apache/jena/jdbc/remote/statements/RemoteEndpointStatement.java
@@ -24,13 +24,13 @@ import java.sql.SQLFeatureNotSupportedException;
 
 import org.apache.http.client.HttpClient;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
+import org.apache.jena.jdbc.remote.http.QueryEngineHTTP;
+import org.apache.jena.jdbc.remote.http.UpdateProcessRemote;
+import org.apache.jena.jdbc.remote.http.UpdateProcessRemoteBase;
 import org.apache.jena.jdbc.statements.JenaStatement;
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryExecution ;
 import org.apache.jena.query.ReadWrite ;
-import org.apache.jena.sparql.engine.http.QueryEngineHTTP ;
-import org.apache.jena.sparql.modify.UpdateProcessRemote;
-import org.apache.jena.sparql.modify.UpdateProcessRemoteBase ;
 import org.apache.jena.update.UpdateProcessor ;
 import org.apache.jena.update.UpdateRequest ;
 

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/FusekiJdbcTestServer.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/FusekiJdbcTestServer.java
@@ -29,7 +29,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.main.FusekiServer;
-import org.apache.jena.riot.web.HttpOp1;
+import org.apache.jena.jdbc.remote.http.HttpOp1;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.modify.request.Target;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnection.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnection.java
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.remote.FusekiJdbcTestServer;
-import org.apache.jena.jdbc.utils.TestJdbcUtils;
+import org.apache.jena.jdbc.remote.utils.TestJdbcRemoteUtils;
 import org.apache.jena.query.Dataset ;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -55,7 +55,7 @@ public class TestRemoteEndpointConnection extends AbstractRemoteEndpointConnecti
     @Override
     protected JenaConnection getConnection(Dataset ds) throws SQLException {
         // Set up the dataset
-        TestJdbcUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
+        TestJdbcRemoteUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
         return new RemoteEndpointConnection(FusekiJdbcTestServer.serviceQuery(), FusekiJdbcTestServer.serviceUpdate(), JenaConnection.DEFAULT_HOLDABILITY, JdbcCompatibility.DEFAULT);
     }
 

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithAuth.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithAuth.java
@@ -29,9 +29,9 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.jena.jdbc.JdbcCompatibility ;
 import org.apache.jena.jdbc.connections.JenaConnection ;
 import org.apache.jena.jdbc.remote.FusekiTestAuth;
-import org.apache.jena.jdbc.utils.TestJdbcUtils ;
+import org.apache.jena.jdbc.remote.http.HttpOp1;
+import org.apache.jena.jdbc.remote.utils.TestJdbcRemoteUtils;
 import org.apache.jena.query.Dataset ;
-import org.apache.jena.riot.web.HttpOp1;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.system.Txn;
 import org.eclipse.jetty.security.SecurityHandler;
@@ -102,7 +102,7 @@ public class TestRemoteEndpointConnectionWithAuth extends AbstractRemoteEndpoint
     @Override
     protected JenaConnection getConnection(Dataset ds) throws SQLException {
         // Set up the dataset
-        TestJdbcUtils.copyToRemoteDataset(ds, FusekiTestAuth.serviceGSP(), client);
+        TestJdbcRemoteUtils.copyToRemoteDataset(ds, FusekiTestAuth.serviceGSP(), client);
         return new RemoteEndpointConnection(FusekiTestAuth.serviceQuery(), FusekiTestAuth.serviceUpdate(), null, null, null, null,
                 client, JenaConnection.DEFAULT_HOLDABILITY,
                 JdbcCompatibility.DEFAULT, null, null);

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithGraphUris.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithGraphUris.java
@@ -26,7 +26,7 @@ import java.util.List;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.remote.FusekiJdbcTestServer;
-import org.apache.jena.jdbc.utils.TestJdbcUtils;
+import org.apache.jena.jdbc.remote.utils.TestJdbcRemoteUtils;
 import org.apache.jena.query.Dataset ;
 import org.junit.* ;
 
@@ -77,9 +77,9 @@ public class TestRemoteEndpointConnectionWithGraphUris extends AbstractRemoteEnd
         }
 
         // Set up the dataset
-        ds = TestJdbcUtils.renameGraph(ds, null, DEFAULT_GRAPH_URI);
+        ds = TestJdbcRemoteUtils.renameGraph(ds, null, DEFAULT_GRAPH_URI);
         Assert.assertEquals(0, ds.getDefaultModel().size());
-        TestJdbcUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
+        TestJdbcRemoteUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
         return new RemoteEndpointConnection(FusekiJdbcTestServer.serviceQuery(), FusekiJdbcTestServer.serviceUpdate(), defaultGraphs, namedGraphs,
                 defaultGraphs, namedGraphs, null, JenaConnection.DEFAULT_HOLDABILITY, JdbcCompatibility.DEFAULT, null, null);
     }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithResultSetTypes.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/connections/TestRemoteEndpointConnectionWithResultSetTypes.java
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.remote.FusekiJdbcTestServer;
-import org.apache.jena.jdbc.utils.TestJdbcUtils;
+import org.apache.jena.jdbc.remote.utils.TestJdbcRemoteUtils;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.riot.WebContent;
 import org.junit.After;
@@ -56,7 +56,7 @@ public class TestRemoteEndpointConnectionWithResultSetTypes extends AbstractRemo
     @Override
     protected JenaConnection getConnection(Dataset ds) throws SQLException {
         // Set up the dataset
-        TestJdbcUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
+        TestJdbcRemoteUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
         return new RemoteEndpointConnection(FusekiJdbcTestServer.serviceQuery(), FusekiJdbcTestServer.serviceUpdate(), null, null, null, null, null, JenaConnection.DEFAULT_HOLDABILITY, JdbcCompatibility.DEFAULT, WebContent.contentTypeTextTSV, WebContent.contentTypeRDFJSON);
     }
 }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/AbstractRemoteEndpointResultSetTests.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/AbstractRemoteEndpointResultSetTests.java
@@ -20,8 +20,8 @@ package org.apache.jena.jdbc.remote.results;
 
 import org.apache.http.client.HttpClient;
 import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.jdbc.remote.http.HttpOp1;
 import org.apache.jena.jdbc.results.AbstractResultSetTests;
-import org.apache.jena.riot.web.HttpOp1;
 import org.apache.jena.sys.JenaSystem ;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResults.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResults.java
@@ -26,7 +26,7 @@ import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.remote.FusekiJdbcTestServer;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
-import org.apache.jena.jdbc.utils.TestJdbcUtils;
+import org.apache.jena.jdbc.remote.utils.TestJdbcRemoteUtils;
 import org.apache.jena.query.Dataset ;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -74,7 +74,7 @@ public class TestRemoteEndpointResults extends AbstractRemoteEndpointResultSetTe
     
     @Override
     protected ResultSet createResults(Dataset ds, String query, int resultSetType) throws SQLException {
-        TestJdbcUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
+        TestJdbcRemoteUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
         Statement stmt = connection.createStatement(resultSetType, ResultSet.CONCUR_READ_ONLY);
         return stmt.executeQuery(query);
     }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithAuth.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithAuth.java
@@ -32,10 +32,10 @@ import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.remote.FusekiTestAuth;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
-import org.apache.jena.jdbc.utils.TestJdbcUtils;
+import org.apache.jena.jdbc.remote.http.HttpOp1;
+import org.apache.jena.jdbc.remote.http.UpdateProcessRemote;
+import org.apache.jena.jdbc.remote.utils.TestJdbcRemoteUtils;
 import org.apache.jena.query.Dataset ;
-import org.apache.jena.riot.web.HttpOp1;
-import org.apache.jena.sparql.modify.UpdateProcessRemote;
 import org.apache.jena.sparql.modify.request.Target ;
 import org.apache.jena.sparql.modify.request.UpdateDrop ;
 import org.apache.jena.update.Update ;
@@ -110,7 +110,7 @@ public class TestRemoteEndpointResultsWithAuth extends AbstractRemoteEndpointRes
 
     @Override
     protected ResultSet createResults(Dataset ds, String query, int resultSetType) throws SQLException {
-        TestJdbcUtils.copyToRemoteDataset(ds, FusekiTestAuth.serviceGSP(), client);
+        TestJdbcRemoteUtils.copyToRemoteDataset(ds, FusekiTestAuth.serviceGSP(), client);
         Statement stmt = connection.createStatement(resultSetType, ResultSet.CONCUR_READ_ONLY);
         return stmt.executeQuery(query);
     }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithGraphUris.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithGraphUris.java
@@ -28,7 +28,7 @@ import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.remote.FusekiJdbcTestServer;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
-import org.apache.jena.jdbc.utils.TestJdbcUtils;
+import org.apache.jena.jdbc.remote.utils.TestJdbcRemoteUtils;
 import org.apache.jena.query.Dataset ;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -83,8 +83,8 @@ public class TestRemoteEndpointResultsWithGraphUris extends AbstractRemoteEndpoi
     
     @Override
     protected ResultSet createResults(Dataset ds, String query, int resultSetType) throws SQLException {
-        ds = TestJdbcUtils.renameGraph(ds, null, DEFAULT_GRAPH_URI);
-        TestJdbcUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
+        ds = TestJdbcRemoteUtils.renameGraph(ds, null, DEFAULT_GRAPH_URI);
+        TestJdbcRemoteUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
         Statement stmt = connection.createStatement(resultSetType, ResultSet.CONCUR_READ_ONLY);
         return stmt.executeQuery(query);
     }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithResultSetTypes.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/results/TestRemoteEndpointResultsWithResultSetTypes.java
@@ -26,7 +26,7 @@ import org.apache.jena.jdbc.JdbcCompatibility;
 import org.apache.jena.jdbc.connections.JenaConnection;
 import org.apache.jena.jdbc.remote.FusekiJdbcTestServer;
 import org.apache.jena.jdbc.remote.connections.RemoteEndpointConnection;
-import org.apache.jena.jdbc.utils.TestJdbcUtils;
+import org.apache.jena.jdbc.remote.utils.TestJdbcRemoteUtils;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.riot.WebContent;
 import org.junit.After;
@@ -75,7 +75,7 @@ public class TestRemoteEndpointResultsWithResultSetTypes extends AbstractRemoteE
     
     @Override
     protected ResultSet createResults(Dataset ds, String query, int resultSetType) throws SQLException {
-        TestJdbcUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
+        TestJdbcRemoteUtils.copyToRemoteDataset(ds, FusekiJdbcTestServer.serviceGSP());
         Statement stmt = connection.createStatement(resultSetType, ResultSet.CONCUR_READ_ONLY);
         return stmt.executeQuery(query);
     }

--- a/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/utils/TestJdbcRemoteUtils.java
+++ b/jena-jdbc/jena-jdbc-driver-remote/src/test/java/org/apache/jena/jdbc/remote/utils/TestJdbcRemoteUtils.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.jdbc.remote.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Iterator;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.jena.atlas.io.IO;
+import org.apache.jena.atlas.lib.IRILib;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.jdbc.remote.http.HttpOp1;
+import org.apache.jena.query.Dataset ;
+import org.apache.jena.query.DatasetFactory ;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+
+/**
+ * Test utility methods - network
+ */
+@SuppressWarnings("deprecation")
+public class TestJdbcRemoteUtils {
+    /**
+     * Copies a dataset to a remote service that provides SPARQL 1.1 Graph Store
+     * protocol support
+     *
+     * @param source
+     *            Source Dataset
+     * @param service
+     *            Remote Graph Store protocol service
+     */
+    public static void copyToRemoteDataset(Dataset source, String service) {
+        copyToRemoteDataset(source, service, null);
+    }
+
+    /**
+     * Copies a dataset to a remote service that provides SPARQL 1.1 Graph Store
+     * protocol support
+     *
+     * @param source
+     *            Source Dataset
+     * @param service
+     *            Remote Graph Store protocol service
+     * @param client
+     *            HTTP Client
+     */
+    public static void copyToRemoteDataset(Dataset source, String service, HttpClient client) {
+        copyToRemoteGraph(service, source.getDefaultModel().getGraph(), null, client);
+        Iterator<String> uris = source.listNames();
+        while (uris.hasNext()) {
+            String uri = uris.next();
+            copyToRemoteGraph(service, source.getNamedModel(uri).getGraph(), uri, client);
+        }
+    }
+
+    // Code extracted from DatasetGraphAccessorHTTP so Apache Http Client still works.
+    private static void copyToRemoteGraph(String service, Graph data, String gn, HttpClient client) {
+        RDFFormat syntax = RDFFormat.TURTLE_BLOCKS;
+        String url = ( gn == null ) ? service+"?default" : service+"?graph="+IRILib.encodeUriComponent(gn);
+        String ct = syntax.getLang().getContentType().toHeaderString();
+        ByteArrayOutputStream out = new ByteArrayOutputStream(128*1024);
+        RDFDataMgr.write(out, data, syntax);
+        IO.close(out);
+        ByteArrayEntity entity = new ByteArrayEntity(out.toByteArray());
+        entity.setContentType(ct);
+        HttpOp1.execHttpPut(url, entity, client, null) ;
+    }
+
+    /**
+     * Renames a graph of a dataset producing a new dataset so as to not modify
+     * the original dataset
+     *
+     * @param ds
+     *            Dataset
+     * @param oldUri
+     *            Old URI
+     * @param newUri
+     *            New URI
+     * @return New Dataset
+     */
+    public static Dataset renameGraph(Dataset ds, String oldUri, String newUri) {
+        Dataset dest = DatasetFactory.createTxnMem();
+        if (oldUri == null) {
+            // Rename default graph
+            dest.addNamedModel(newUri, ds.getDefaultModel());
+        } else {
+            // Copy across default graph
+            dest.setDefaultModel(ds.getDefaultModel());
+        }
+
+        Iterator<String> uris = ds.listNames();
+        while (uris.hasNext()) {
+            String uri = uris.next();
+            if (uri.equals(oldUri)) {
+                // Rename named graph
+                if (newUri == null) {
+                    dest.setDefaultModel(ds.getNamedModel(oldUri));
+                } else {
+                    dest.addNamedModel(newUri, ds.getNamedModel(oldUri));
+                }
+            } else {
+                // Copy across named graph
+                dest.addNamedModel(uri, ds.getNamedModel(uri));
+            }
+        }
+
+        return dest;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,27 @@
         <artifactId>httpclient</artifactId>
         <version>${ver.httpclient}</version>
         <exclusions>
-          <!-- Replace with slf4j adapter -->
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+          </exclusion>
+          <!-- JENA 2137: scope=provided and the enforcer plugin -->
+          <exclusion>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpcore</artifactId>
+        <version>${ver.httpcore}</version>
+        <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>


### PR DESCRIPTION
This is part 1 of a 2 change. This PR copies the Apache HttpClient code used by jen-jdbc into that subsystem and puts in a compile-time dependency on Apache HttpClient into jena-jdbc-driver-remote.

The second part removes the legacy classes from jena-arq. See [JENA-2221](https://issues.apache.org/jira/browse/JENA-2221) and #1134.
