### PR TITLE
JENA-2222: Update of dependencies used in geosparql

### DIFF
--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -34,225 +34,206 @@
     <description>GeoSPARQL with Fuseki</description>
 
     <properties>
-        <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
-        <automatic.module.name>org.apache.jena.fuseki.geosparql</automatic.module.name>
+      <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
+      <automatic.module.name>org.apache.jena.fuseki.geosparql</automatic.module.name>
     </properties>
 
     <dependencies>
 
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-geosparql</artifactId>
-            <version>4.4.0-SNAPSHOT</version>
-        </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-geosparql</artifactId>
+        <version>4.4.0-SNAPSHOT</version>
+      </dependency>
 
-        <dependency>
-            <groupId>io.github.galbiston</groupId>
-            <artifactId>rdf-tables</artifactId>
-            <version>1.0.4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.jena</groupId>
-                    <artifactId>jena-tdb</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.jena</groupId>
-                    <artifactId>jena-tdb2</artifactId>
-                </exclusion>
-                <exclusion>
-                  <groupId>com.beust</groupId>
-                  <artifactId>jcommander</artifactId>
-                </exclusion>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>jena-fuseki-main</artifactId>
+        <version>4.4.0-SNAPSHOT</version>
+      </dependency>
 
-                <exclusion>
-                  <groupId>commons-beanutils</groupId>
-                  <artifactId>commons-beanutils</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+      <dependency>
+        <groupId>io.github.galbiston</groupId>
+        <artifactId>rdf-tables</artifactId>
+      </dependency>
 
-        <dependency>
-          <!-- rdf-tables:1.0.4
-                  com.opencsv:opencsv:jar:3.9
-                       CVE-2019-10086 https://nvd.nist.gov/vuln/detail/CVE-2019-10086 
-                    commons-beanutils:commons-beanutils:jar:1.9.3
-                Needs to be 1.9.4.
-          -->
-          <groupId>commons-beanutils</groupId>
-          <artifactId>commons-beanutils</artifactId>
-          <version>1.9.4</version>
-        </dependency>
+      <dependency>
+        <!-- rdf-tables:1.0.4
+               -> com.opencsv:opencsv:jar:3.9 
+                 -> commons-beanutils:commons-beanutils:19.3
+             CVE-2019-10086 https://nvd.nist.gov/vuln/detail/CVE-2019-10086 
+             commons-beanutils:commons-beanutils:jar:1.9.3
+             Needs to be 1.9.4.
+             We exclude it from rdf-tables and directly depend on it here.
+        -->
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+      </dependency>
 
-        <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>jena-fuseki-main</artifactId>
-            <version>4.4.0-SNAPSHOT</version>
-        </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+      </dependency>
 
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
+      <dependency>
+        <groupId>com.beust</groupId>
+        <artifactId>jcommander</artifactId>
+      </dependency>
 
-        <dependency>
-            <groupId>com.beust</groupId>
-            <artifactId>jcommander</artifactId>
-        </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+      </dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
+      </dependency>
 
-        <dependency>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-slf4j-impl</artifactId>
-        </dependency>
+      <!-- Put in to ensure the dependency isn't optional. -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+      </dependency>
 
-        <!-- Put in to ensure the dependency isn't optional. -->
-        <dependency>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-api</artifactId>
-        </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+      </dependency>
 
-        <dependency>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-core</artifactId>
-        </dependency>
-
-        <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <scope>test</scope>
-        </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <scope>test</scope>
+      </dependency>
 
     </dependencies>
 
     <build>
 
-        <plugins>
+      <plugins>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+        </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <includes>
-                        <!--
-                          The test collections TC_General, TC_Riot, TC_Atlas
-                          are development support that collect the relevant
-                          tests for partial testing during development.
-                        -->
-                        <include>**/TS_*.java</include>
-                        <include>**/TC_Scripted.java</include>
-                        <include>**/TC_DAWG.java</include>
-                    </includes>
-                </configuration>
-            </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <includes>
+              <!--
+                  The test collections TC_General, TC_Riot, TC_Atlas
+                  are development support that collect the relevant
+                  tests for partial testing during development.
+              -->
+              <include>**/TS_*.java</include>
+              <include>**/TC_Scripted.java</include>
+              <include>**/TC_DAWG.java</include>
+            </includes>
+          </configuration>
+        </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
 
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <!-- <phase>package</phase> package is the default -->
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>attach-sources-test</id>
-                        <goals>
-                            <goal>test-jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <!-- <phase>package</phase> package is the default -->
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>attach-sources-test</id>
+              <goals>
+                <goal>test-jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
 
-            </plugin>
+        </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+              </manifestEntries>
+            </archive>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>test-jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <version>true</version>
-                    <show>public</show>
-                    <quiet>true</quiet>
-                    <encoding>UTF-8</encoding>
-                    <windowtitle>Apache Jena GeoSPARQL</windowtitle>
-                    <doctitle>Apache Jena GeoSPARQL ${project.version}</doctitle>
-                    <bottom>Licenced under the Apache License, Version 2.0</bottom>
-                </configuration>
-            </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <source>8</source>
+            <version>true</version>
+            <show>public</show>
+            <quiet>true</quiet>
+            <encoding>UTF-8</encoding>
+            <windowtitle>Apache Jena GeoSPARQL</windowtitle>
+            <doctitle>Apache Jena GeoSPARQL ${project.version}</doctitle>
+            <bottom>Licenced under the Apache License, Version 2.0</bottom>
+          </configuration>
+        </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <configuration>
-                    <shadedArtifactAttached>false</shadedArtifactAttached>
-                    <transformers>
-                        <!-- @@@ TODO @@ -->
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <mainClass>org.apache.jena.fuseki.geosparql.Main</mainClass>
-                        </transformer>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                            <addHeader>false</addHeader>
-                        </transformer>
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <!-- Some jars are signed but shading breaks that.
-                                     Don't include signing files.
-                                -->
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <!--<phase /><!- - Switch off -->
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <configuration>
+            <shadedArtifactAttached>false</shadedArtifactAttached>
+            <transformers>
+              <!-- @@@ TODO @@ -->
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                <mainClass>org.apache.jena.fuseki.geosparql.Main</mainClass>
+              </transformer>
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+              <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                <addHeader>false</addHeader>
+              </transformer>
+            </transformers>
+            <filters>
+              <filter>
+                <artifact>*:*</artifact>
+                <excludes>
+                  <!-- Some jars are signed but shading breaks that.
+                       Don't include signing files.
+                  -->
+                  <exclude>META-INF/*.SF</exclude>
+                  <exclude>META-INF/*.DSA</exclude>
+                  <exclude>META-INF/*.RSA</exclude>
+                </excludes>
+              </filter>
+            </filters>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <!--<phase /><!- - Switch off -->
+              <goals>
+                <goal>shade</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
 
-        </plugins>
+      </plugins>
 
     </build>
 
-</project>
+  </project>

--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -63,7 +63,24 @@
                   <groupId>com.beust</groupId>
                   <artifactId>jcommander</artifactId>
                 </exclusion>
+
+                <exclusion>
+                  <groupId>commons-beanutils</groupId>
+                  <artifactId>commons-beanutils</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+          <!-- rdf-tables:1.0.4
+                  com.opencsv:opencsv:jar:3.9
+                       CVE-2019-10086 https://nvd.nist.gov/vuln/detail/CVE-2019-10086 
+                    commons-beanutils:commons-beanutils:jar:1.9.3
+                Needs to be 1.9.4.
+          -->
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+          <version>1.9.4</version>
         </dependency>
 
         <dependency>

--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -36,18 +36,14 @@
 
   <dependencies>
 
-    <!-- Non-free; testing only -->
     <dependency>
-      <groupId>org.apache.sis.non-free</groupId>
-      <artifactId>sis-embedded-data</artifactId>
-      <version>1.0</version>
-      <scope>test</scope>
+      <groupId>io.github.galbiston</groupId>
+      <artifactId>expiring-map</artifactId>
     </dependency>
 
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
     </dependency>
 
     <dependency>
@@ -59,30 +55,29 @@
     <dependency>
       <groupId>org.apache.sis.core</groupId>
       <artifactId>sis-referencing</artifactId>
-      <version>1.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
-      <version>1.18.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.jdom</groupId>
       <artifactId>jdom2</artifactId>
-      <version>2.0.6.1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.github.galbiston</groupId>
-      <artifactId>expiring-map</artifactId>
-      <version>1.0.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
+    </dependency>
+
+    <!-- Non-free; testing only -->
+    <dependency>
+      <groupId>org.apache.sis.non-free</groupId>
+      <artifactId>sis-embedded-data</artifactId>
+      <version>${ver.sis}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -101,9 +96,9 @@
 
   <profiles>
     <!-- Tests: Java8 only
-         A change in the doubles is current resulting in 
-         test failures on precision but the test is string based
-         of WKT.
+         A change in the doubles is resulting in 
+         test failures on precision but the test 
+         is string based of WKT.
     -->
     <profile>
       <id>java-after-8</id>

--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.jdom</groupId>
       <artifactId>jdom2</artifactId>
-      <version>2.0.6</version>
+      <version>2.0.6.1</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,10 +96,13 @@
     <ver.awaitility>4.1.1</ver.awaitility>
     <ver.contract.tests>0.2.0</ver.contract.tests>
 
+    <!--- GeoSPARQL related -->
+    <ver.sis>1.0</ver.sis>
+    
     <java.version>11</java.version>
-
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>2021-12-17T18:49:10Z</project.build.outputTimestamp>
+
 
   </properties>
 
@@ -669,11 +672,75 @@
         <version>${ver.micrometer}</version>
       </dependency>
 
+      <!-- jena-geosparql, jena-fuseki-geosparql related -->
+
       <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
         <version>${ver.jcommander}</version>
       </dependency>
+
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.sis.core</groupId>
+        <artifactId>sis-referencing</artifactId>
+        <version>${ver.sis}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.locationtech.jts</groupId>
+        <artifactId>jts-core</artifactId>
+        <version>1.18.2</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jdom</groupId>
+        <artifactId>jdom2</artifactId>
+        <version>2.0.6.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.github.galbiston</groupId>
+        <artifactId>expiring-map</artifactId>
+        <version>1.0.2</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.github.galbiston</groupId>
+        <artifactId>rdf-tables</artifactId>
+        <version>1.0.4</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-tdb</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.jena</groupId>
+            <artifactId>jena-tdb2</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.4</version>
+      </dependency>
+
+      <!-- END jena geosparql -->
 
     </dependencies>
 
@@ -691,6 +758,7 @@
             <goals>
               <goal>enforce</goal>
             </goals>
+
             <configuration combine.self="override">
               <rules>
                 <dependencyConvergence />


### PR DESCRIPTION
This is "draft" initially.

It fixes the issue to make sure there is a fix available now.

It might be better to manage dependencies at the top level, partially or fully, or keep them specific to geosparql. Investigation needed.
