### PR TITLE
fix a few things in Lang and RDFLanguages

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/Lang.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/Lang.java
@@ -153,6 +153,7 @@ public class Lang
         Lang otherLang = (Lang)other ;
         return
             this.label == otherLang.label &&
+            this.altLabels.equals(otherLang.altLabels) &&
             this.contentType.equals(otherLang.contentType) &&
             this.altContentTypes.equals(otherLang.altContentTypes) &&
             this.fileExtensions.equals(otherLang.fileExtensions) ;


### PR DESCRIPTION
- Lang.equals(Object) did not compare altLabels
- RDFLanguages.register(Lang) unregistered the wrong lang
- RDFLanguages.checkRegistration(Lang) unnecessarily checked mapContentTypeToLang and used the wrong lookup keys to check the altNames, altContentTypes, and fileExtensions
- RDFLanguages.unregister(Lang) did not clear out the altNames