### PR TITLE
JENA-2243: Move RDFWriterRegistry static initialization block.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
@@ -45,11 +45,11 @@ public class RDFWriterRegistry
     // Let the serializer deal with the character issues.
     // UTF-8 is universal - but UTF-8 is not the default in Java ("platform encoding" is).
 
-    static { JenaSystem.init() ; }
-
     private static Map<RDFFormat, WriterGraphRIOTFactory> registryGraph     = new HashMap<>() ;
     private static Map<RDFFormat, WriterDatasetRIOTFactory> registryDataset = new HashMap<>() ;
     private static Map<Lang, RDFFormat> langToFormat                        = new HashMap<>() ;
+
+    static { JenaSystem.init() ; }
 
     // Writing a graph
     static WriterGraphRIOTFactory wgfactory = new WriterGraphRIOTFactory() {


### PR DESCRIPTION
... so it executes after static fields are initialized

Since this not easy to test without starting a new JVM, a simple program demonstrates the problem:
```
import org.apache.jena.riot.RDFFormat;
import org.apache.jena.riot.RDFWriterRegistry;
import org.apache.jena.riot.WriterGraphRIOTFactory;

public class TestRDFWriterRegistry {

	public static void main(String[] args) {
		RDFWriterRegistry.register((RDFFormat) null, (WriterGraphRIOTFactory) null);
		System.out.println("done");
	}
}
```
Running the program will result in this exception:
```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at TestRDFWriterRegistry.main(TestRDFWriterRegistry.java:27)
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Map.put(Object, Object)" because "org.apache.jena.riot.RDFWriterRegistry.registryGraph" is null
	at org.apache.jena.riot.RDFWriterRegistry.register(RDFWriterRegistry.java:224)
	at org.apache.jena.riot.system.SysJSONLD11.init(SysJSONLD11.java:62)
	at org.apache.jena.riot.RIOT.init(RIOT.java:84)
	at org.apache.jena.riot.system.InitRIOT.start(InitRIOT.java:29)
	at org.apache.jena.base.module.Subsystem.lambda$initialize$2(Subsystem.java:117)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.apache.jena.base.module.Subsystem.forEach(Subsystem.java:193)
	at org.apache.jena.base.module.Subsystem.forEach(Subsystem.java:169)
	at org.apache.jena.base.module.Subsystem.initialize(Subsystem.java:115)
	at org.apache.jena.sys.JenaSystem.init(JenaSystem.java:88)
	at org.apache.jena.riot.RDFWriterRegistry.<clinit>(RDFWriterRegistry.java:48)
	... 1 more
```
