### PR TITLE
JENA-2231: Fix - remove root logger (console)

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlJUL.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlJUL.java
@@ -124,11 +124,9 @@ public class LogCtlJUL {
      * Route JUL to SLF4J.
      * Do not include org.slf4j:slf4j-jdk14.
      */
-    public static void routeJULtoSLF4J(boolean removeExistingHandlersForRootLogger) {
+    public static void routeJULtoSLF4J() {
         try {
-            if ( removeExistingHandlersForRootLogger )
-                SLF4JBridgeHandler.removeHandlersForRootLogger();
-            // Route to slf4j for logger created from now on.
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
             SLF4JBridgeHandler.install();
         } catch (Throwable th) {}
     }

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/InitGeoSPARQL.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/InitGeoSPARQL.java
@@ -31,10 +31,10 @@ public class InitGeoSPARQL implements JenaSubsystemLifecycle {
     @Override
     public void start() {
         // SIS uses JUL for logging.
-        LogCtlJUL.routeJULtoSLF4J(false);
+        LogCtlJUL.routeJULtoSLF4J();
 
-        // Not RDF Tables.
         GeometryDatatype.registerDatatypes();
+        // Logs "SIS_DATA is not set"
         GeoSPARQLConfig.loadFunctions();
         AssemblerUtils.registerDataset(VocabGeoSPARQL.tGeoDataset, new GeoAssembler());
     }


### PR DESCRIPTION
Leaving the default setup of JUL leaves the JUL console as a handler of the root logger. 
The effect is getting two log message direct, from JUL and via SLF4J->Log4j2, for each logger call.