### PR TITLE
JENA-2249: Update protobuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <ver.jetty>10.0.7</ver.jetty>
     <ver.shiro>1.8.0</ver.shiro>
 
-    <ver.protobuf>3.19.1</ver.protobuf>
+    <ver.protobuf>3.19.2</ver.protobuf>
     <ver.libthrift>0.15.0</ver.libthrift>
 
     <!-- jsonld-java depends on depends on Jackson core


### PR DESCRIPTION
Addresses [CVE-2021-22569](https://nvd.nist.gov/vuln/detail/CVE-2021-22569)