### PR TITLE
JENA-2256: Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,14 +53,14 @@
    <properties>
     <ver.junit>4.13.2</ver.junit>  
 
-    <ver.slf4j>1.7.32</ver.slf4j>
+    <ver.slf4j>1.7.33</ver.slf4j>
     <ver.log4j2>2.17.1</ver.log4j2>
     <ver.shade-plugin>3.2.4</ver.shade-plugin>
 
     <ver.jetty>10.0.7</ver.jetty>
     <ver.shiro>1.8.0</ver.shiro>
 
-    <ver.protobuf>3.19.2</ver.protobuf>
+    <ver.protobuf>3.19.3</ver.protobuf>
     <ver.libthrift>0.15.0</ver.libthrift>
 
     <!-- jsonld-java depends on depends on Jackson core
@@ -71,10 +71,10 @@
          POM for the correct dependency versions
          and use that or later.
     -->
-    <ver.jsonldjava>0.13.3</ver.jsonldjava>
-    <ver.jackson>2.13.0</ver.jackson>
+    <ver.jsonldjava>0.13.4</ver.jsonldjava>
+    <ver.jackson>2.13.1</ver.jackson>
     <ver.httpclient>4.5.13</ver.httpclient>
-    <ver.httpcore>4.4.14</ver.httpcore>
+    <ver.httpcore>4.4.15</ver.httpcore>
 
     <ver.shaded-guava>31.0.1-jre</ver.shaded-guava>
     <ver.commonsio>2.11.0</ver.commonsio>
@@ -85,13 +85,13 @@
     <ver.commons-codec>1.15</ver.commons-codec>
     <ver.commons-compress>1.21</ver.commons-compress>
     <ver.dexxcollection>0.7</ver.dexxcollection>
-    <ver.micrometer>1.8.1</ver.micrometer>
+    <ver.micrometer>1.8.2</ver.micrometer>
 
-    <ver.lucene>8.10.1</ver.lucene>
-    <ver.graalvm>21.3.0</ver.graalvm>
+    <ver.lucene>8.11.1</ver.lucene>
+    <ver.graalvm>21.3.1</ver.graalvm>
     <ver.jython>2.7.2</ver.jython>
-    <ver.jcommander>1.81</ver.jcommander>
-    <ver.mockito>4.0.0</ver.mockito>
+    <ver.jcommander>1.82</ver.jcommander>
+    <ver.mockito>4.2.0</ver.mockito>
     <ver.awaitility>4.1.1</ver.awaitility>
     <ver.contract.tests>0.2.0</ver.contract.tests>
 

--- a/pom.xml
+++ b/pom.xml
@@ -827,7 +827,6 @@
             <goals>
               <goal>enforce</goal>
             </goals>
-
             <configuration combine.self="override">
               <rules>
                 <dependencyConvergence />
@@ -840,6 +839,9 @@
                   <message>No SNAPSHOT dependencies are allowed!</message>
                   <onlyWhenRelease>true</onlyWhenRelease>
                 </requireReleaseDeps>
+                <requireMavenVersion>
+                  <version>3.8.1</version>
+                </requireMavenVersion>
               </rules>
               <fail>true</fail>
               <failFast>false</failFast>
@@ -898,7 +900,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.9.0</version>
           <configuration>
             <release>${java.version}</release>
           </configuration>
@@ -1076,7 +1078,7 @@
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
-          <version>5.1.2</version>
+          <version>5.1.4</version>
           <extensions>true</extensions>
         </plugin>
 


### PR DESCRIPTION
Of note:

Lucene: 8.10.1 -> 8.11.1
```
        <requireMavenVersion>
          <version>3.2.5</version>
        </requireMavenVersion>
```
This was noted by the maven-version-plugin. It is just making explicit the minimum maven version. Maven version 3.2.5 was released 2017-10-18. Current maven is 3.8.4.