### PR TITLE
JENA-2258 LiteralLabelImpl: forward Throwabl, not only the message

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/graph/impl/LiteralLabelImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/impl/LiteralLabelImpl.java
@@ -78,10 +78,10 @@ final /*public*/ class LiteralLabelImpl implements LiteralLabel {
 	private boolean wellformed = true;
 	
 	/**
-	 * keeps the message provided by the DatatypeFormatException
-	 * if parsing failed for delayed exception thrown in getValue()
+	 * keeps the DatatypeFormatException if parsing failed for delayed
+	 * exception thrown in getValue()
 	 */
-	private String exceptionMsg = null; // Suggested by Andreas Langegger
+	private Throwable exception = null;
 	
 	//=======================================================================
 	// Constructors
@@ -223,7 +223,7 @@ final /*public*/ class LiteralLabelImpl implements LiteralLabel {
 				throw e;
 			} else {
 				wellformed = false;
-				exceptionMsg  = e.getMessage();
+				exception  = e;
 			}
 		}
 	}
@@ -383,7 +383,7 @@ final /*public*/ class LiteralLabelImpl implements LiteralLabel {
 			throw new DatatypeFormatException(
 				lexicalForm,
 				dtype,
-				exceptionMsg);
+				exception);
 		}
 	}
 


### PR DESCRIPTION
`LiteralLabelImpl`: forward `Throwable` instead of only the message to preserve causes.