### PR TITLE
JENA-2232: Undo the javadoc11 fixup for modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,26 +258,6 @@
 
       </modules>
     </profile>
-    
-    <profile>
-      <!-- https://bugs.openjdk.java.net/browse/JDK-8215291 -->
-      <id>java11-javadoc</id>
-      <activation>
-        <jdk>11</jdk>
-      </activation>      
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <!-- Java 11 only, removed at Java13 -->
-              <additionalOptions>--no-module-directories</additionalOptions>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
 
   </profiles>
 


### PR DESCRIPTION
The changes to generating the javadoc under java11 don't work.

This PR removes the fixup.
