### PR TITLE
JENA-2260: Upgrade yarn from 0.16.x to 1.22.x

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/pom.xml
+++ b/jena-fuseki2/jena-fuseki-ui/pom.xml
@@ -57,7 +57,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
-                            <arguments>install</arguments>
+                            <arguments>install --frozen-lockfile</arguments>
                         </configuration>
                     </execution>
                     <execution>

--- a/jena-fuseki2/jena-fuseki-ui/pom.xml
+++ b/jena-fuseki2/jena-fuseki-ui/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <node.version>v16.13.1</node.version>
-        <yarn.version>v0.16.1</yarn.version>
+        <yarn.version>v1.22.17</yarn.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Would be better to go to v2.x (called Berry), but I couldn't figure out how to tell the Maven plug-in to use the 2.x version yet. 1.x is still maintained, so we should be fine.

Also adds `--frozen-lockfile`. It won't update `yarn.lock` anymore, and will fail in case the lock file gets updated/out of sync. Hopefully that should improve the UI build.

Tested with `mvn clean test install -Pdev`, no changes to `yarn.lock`, build passed OK.