### PR TITLE
JENA-2271: Do not remove slashes from graph name (with tests)

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/src/services/fuseki.service.js
+++ b/jena-fuseki2/jena-fuseki-ui/src/services/fuseki.service.js
@@ -48,8 +48,13 @@ class FusekiService {
    * @return {string} a new route URL that includes any pathname in the URL
    */
   getFusekiUrl (url) {
-    // modified version from: https://stackoverflow.com/a/24381515
-    return `${this.pathname}/${url}`.replace(/(\/)\/+/g, '$1')
+    // remove leading `/`'s
+    let normalizedUrl = url
+    while (normalizedUrl.startsWith('/') && normalizedUrl.length > 0) {
+      normalizedUrl = normalizedUrl.slice(1)
+    }
+    const pathname = this.pathname.endsWith('/') ? this.pathname : `${this.pathname}/`
+    return `${pathname}${normalizedUrl}`
   }
 
   async getServerData () {

--- a/jena-fuseki2/jena-fuseki-ui/tests/unit/services/fuseki.service.spec.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/unit/services/fuseki.service.spec.js
@@ -314,4 +314,48 @@ describe('FusekiService', () => {
     expect(stub.called).to.equal(true)
     stub.restore()
   })
+  it('creates a valid URL when using a URL graph name', () => {
+    // pathname is managed by the browser, we don't need to test if it has
+    // multiple `/`'s... in case it does, the only way to call this code
+    // is if the server accepted the URL like that, so it should be OK to
+    // keep using it as it is.
+    const tests = [
+      {
+        pathname: '/',
+        url: '/ds/data?graph=http://example.com',
+        expected: '/ds/data?graph=http://example.com'
+      },
+      {
+        pathname: '/',
+        url: '//ds/data?graph=http://example.com',
+        expected: '/ds/data?graph=http://example.com'
+      },
+      {
+        pathname: '',
+        url: '//ds/data?graph=http://example.com',
+        expected: '/ds/data?graph=http://example.com'
+      },
+      {
+        pathname: '',
+        url: '',
+        expected: '/'
+      },
+      {
+        pathname: '/',
+        url: '/ds/data?graph=',
+        expected: '/ds/data?graph='
+      },
+      {
+        pathname: '/',
+        url: '/ds/data?graph=default',
+        expected: '/ds/data?graph=default'
+      }
+    ]
+    const originalPathname = fusekiService.pathname
+    for (const test of tests) {
+      fusekiService.pathname = test.pathname
+      expect(fusekiService.getFusekiUrl(test.url)).to.equal(test.expected)
+    }
+    fusekiService.pathname = originalPathname
+  })
 })


### PR DESCRIPTION
Mea culpa. At least now we are able to add unit tests, so in theory this bug should not happen again (:crossed_fingers: ).

Bruno