### PR TITLE
JENA-2289: fix to setup the precomputed geospatial index properly

### DIFF
--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/assembler/GeoAssembler.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/assembler/GeoAssembler.java
@@ -176,14 +176,21 @@ public class GeoAssembler extends DatasetAssembler {
             return;
 
         try {
+            // no file given, i.e. in-memory index only
             if ( spatialIndex == null ) {
                 GeoSPARQLConfig.setupSpatialIndex(dataset);
                 return;
             }
 
+            // file given but empty -> compute and serialize index
             Path spatialIndexPath = Path.of(spatialIndex);
-            if ( ! Files.exists(spatialIndexPath) || Files.size(spatialIndexPath) == 0 )
+            if ( ! Files.exists(spatialIndexPath) || Files.size(spatialIndexPath) == 0 ) {
                 GeoSPARQLConfig.setupSpatialIndex(dataset, spatialIndexPath.toFile());
+                return;
+            }
+
+            // load and setup the precomputed index
+            GeoSPARQLConfig.setupPrecomputedSpatialIndex(dataset, spatialIndexPath.toFile());
         }
         catch (SrsException ex) {
             // Data but no spatial data.

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/GeoSPARQLConfig.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/GeoSPARQLConfig.java
@@ -272,6 +272,19 @@ public class GeoSPARQLConfig {
     }
 
     /**
+     * Setup the precomputed Spatial Index using Dataset Dataset.<br>
+     * We assume that the spatial index was computed before and written to the given file.
+     *
+     * @param dataset the dataset
+     * @param spatialIndexFile the file containing the serialized spatial index
+     * @throws SpatialIndexException
+     */
+    public static final void setupPrecomputedSpatialIndex(Dataset dataset, File spatialIndexFile) throws SpatialIndexException {
+        SpatialIndex si = SpatialIndex.load(spatialIndexFile);
+        SpatialIndex.setSpatialIndex(dataset, si);
+    }
+
+    /**
      * Setup Spatial Index using Dataset and most frequent SRS URI in
      * Dataset.<br>
      * Spatial Index written to file once created.


### PR DESCRIPTION
Fixes a bug where the precomputed geospatial index isn't loaded from file and thus not being registered to the dataset context.