### PR TITLE
Fix RDF grammar

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/RiotChars.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/RiotChars.java
@@ -102,13 +102,13 @@ public class RiotChars
     }
 
     public static boolean isPNChars_U(int ch) {
-        //PN_CHARS_BASE | '_'
-        return isPNCharsBase(ch) || ( ch == '_' );
+        // PN_CHARS_BASE | '_' | ':'
+        return isPNCharsBase(ch) || ( ch == '_' ) || ( ch == ':' );
     }
 
     public static boolean isPNChars_U_N(int ch) {
         // PN_CHARS_U | [0-9]
-        return isPNCharsBase(ch) || ( ch == '_' ) || isDigit(ch);
+        return isPNChars_U(ch) || isDigit(ch);
     }
 
     public static boolean isPNChars(int ch) {


### PR DESCRIPTION
According to the specification [[0]](https://www.w3.org/TR/n-triples/#grammar-production-PN_CHARS_U), `PN_CHARS_U` is defined as:

```
PN_CHARS_U ::= PN_CHARS_BASE | '_' | ':'
```

The previous implementation was missing the `':'` part.

Additionally, according to the code comment, `PN_CHARS_U_N` is defined as:

```
PN_CHARS_U_N ::= PN_CHARS_U | [0-9]
```

The previous implementation did not match the spec by deferring to `PN_CHARS_U`, and instead repeated its definition. Changing (in this case fixing) `PN_CHARS_U` should also affect `PN_CHARS_U_N`, which can be achieved simply by following the specification.