### PR TITLE
JENA-2313: Initial prefix map - support for parsing Turtle/TriG fragments

### DIFF
--- a/jena-arq/Grammar/Turtle/turtle.jj
+++ b/jena-arq/Grammar/Turtle/turtle.jj
@@ -89,7 +89,7 @@ void Statement() : {}
 void Directive() : { Token t ; String iri ; }
 {
     <PREFIX> t = <PNAME_NS> iri = IRIREF()
-    { String s = fixupPrefix(t.image, t.beginLine, t.beginColumn) ;
+    { String s = canonicalPrefix(t.image, t.beginLine, t.beginColumn) ;
       setPrefix(s, iri, t.beginLine, t.beginColumn) ; }
  |
     t = <BASE> iri = IRIREF()
@@ -99,7 +99,7 @@ void Directive() : { Token t ; String iri ; }
 void DirectiveOld() : { Token t ; String iri ; }
 {
     <PREFIX_OLD> t = <PNAME_NS> iri = IRIREF() <DOT>
-    { String s = fixupPrefix(t.image, t.beginLine, t.beginColumn) ;
+    { String s = canonicalPrefix(t.image, t.beginLine, t.beginColumn) ;
       setPrefix(s, iri, t.beginLine, t.beginColumn) ; }
  |
     t = <BASE_OLD> iri = IRIREF() <DOT>
@@ -158,7 +158,7 @@ Node Verb() : { Node p ; }
 Node Subject() : { Node s; String iri ; }
 {
   (
-    iri = iri() { s = createNode(iri, token.beginLine, token.beginColumn) ; }
+    iri = iri() { s = createURI(iri, token.beginLine, token.beginColumn) ; }
   |
     s = BlankNode()
   |
@@ -174,13 +174,13 @@ Node Subject() : { Node s; String iri ; }
 Node Predicate() : { String iri;}
 {
   iri = iri()
-  { return createNode(iri, token.beginLine, token.beginColumn); }
+  { return createURI(iri, token.beginLine, token.beginColumn); }
 }
 
 // Turtle [12] object
 Node Object(): { Node o ; String iri; }
 {
-  ( iri = iri() { o = createNode(iri, token.beginLine, token.beginColumn) ; }
+  ( iri = iri() { o = createURI(iri, token.beginLine, token.beginColumn) ; }
   | o = BlankNode()
   | o = Collection()
   | o = BlankNodePropertyList()
@@ -192,7 +192,7 @@ Node Object(): { Node o ; String iri; }
 
 Node EmbSubject(): { Node o ; String iri; }
 {
-  ( iri = iri() { o = createNode(iri, token.beginLine, token.beginColumn) ; }
+  ( iri = iri() { o = createURI(iri, token.beginLine, token.beginColumn) ; }
   | o = BlankNode()
   | o = EmbTriple()
   )
@@ -201,7 +201,7 @@ Node EmbSubject(): { Node o ; String iri; }
 
 Node EmbObject(): { Node o ; String iri; }
 {
-  ( iri = iri() { o = createNode(iri, token.beginLine, token.beginColumn) ; }
+  ( iri = iri() { o = createURI(iri, token.beginLine, token.beginColumn) ; }
   | o = BlankNode()
   | o = Literal()
   | o = EmbTriple()

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
@@ -102,13 +102,13 @@ public class RDFParser {
     private final boolean             strict;
     private final boolean             resolveURIs;
     private final IRIxResolver        resolver;
+    private final PrefixMap           prefixMap;
     private final boolean             canonicalLexicalValues;
     private final LangTagForm         langTagForm;
     private final Optional<Boolean>   checking;
     private final FactoryRDF          factory;
     private final ErrorHandler        errorHandler;
     private final Context             context;
-
     // Some cases the parser is reusable (read a file), some are not (input streams).
     private boolean                 canUseThisParser = true;
 
@@ -187,8 +187,8 @@ public class RDFParser {
                             HttpClient httpClient, Lang hintLang, Lang forceLang,
                             String parserBaseURI, boolean strict, Optional<Boolean> checking,
                             boolean canonicalLexicalValues, LangTagForm langTagForm,
-                            boolean resolveURIs, IRIxResolver resolver, FactoryRDF factory,
-                            ErrorHandler errorHandler, Context context) {
+                            boolean resolveURIs, IRIxResolver resolver, PrefixMap prefixMap,
+                            FactoryRDF factory, ErrorHandler errorHandler, Context context) {
         int x = countNonNull(uri, path, content, inputStream, javaReader);
         if ( x >= 2 )
             throw new IllegalArgumentException("Only one source allowed: one of uri, path, content, inputStream and javaReader must be set");
@@ -213,6 +213,7 @@ public class RDFParser {
         this.strict = strict;
         this.resolveURIs = resolveURIs;
         this.resolver = resolver;
+        this.prefixMap = prefixMap;
         this.canonicalLexicalValues = canonicalLexicalValues;
         this.langTagForm = langTagForm;
         this.checking = checking;
@@ -516,9 +517,9 @@ public class RDFParser {
         IRIxResolver parserResolver = (resolver != null)
                 ? resolver
                 : IRIxResolver.create().base(baseStr).resolve(resolve).allowRelative(allowRelative).build();
-        PrefixMap prefixMap = PrefixMapFactory.create();
+        PrefixMap pmap = ( this.prefixMap != null ) ? this.prefixMap : PrefixMapFactory.create();
         ParserProfileStd parserFactory = new ParserProfileStd(factory, errorHandler,
-                                                              parserResolver, prefixMap,
+                                                              parserResolver, pmap,
                                                               context, checking$, strict);
         return parserFactory;
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
@@ -98,6 +98,7 @@ public class RDFParserBuilder {
     private boolean strict = SysRIOT.isStrictMode();
     private boolean resolveURIs = true;
     private IRIxResolver resolver = null;
+    private PrefixMap prefixMap = null;
     // ----
 
     // Construction for the StreamRDF
@@ -306,6 +307,21 @@ public class RDFParserBuilder {
      * RDF syntax to be parsed.
      */
     public RDFParserBuilder resolver(IRIxResolver resolver) { this.resolver = resolver ; return this; }
+
+    /**
+     * Set an initial prefix map for parsing.
+     * <p>
+     * Using this, and {@link #base}, mean that Turtle and TriG fragments can be parsed.
+     * <p>
+     * The caller is responsible for setting any prefixes that are undeclared in the fragment.
+     * <p>
+     * Changes made to the prefix map argument after this call will not be seen by the parser.
+     * Passing null clears any previous setting.
+     */
+    public RDFParserBuilder prefixes(PrefixMap prefixMap) {
+        this.prefixMap = prefixMap == null ? null : PrefixMapFactory.create(prefixMap);
+        return this;
+    }
 
     /**
      * Convert the lexical form of literals to a canonical form.
@@ -682,7 +698,8 @@ public class RDFParserBuilder {
                              hintLang, forceLang,
                              parserBaseURI, strict, checking,
                              canonicalValues, langTagForm,
-                             resolveURIs, resolver, factory$, errorHandler$, context);
+                             resolveURIs, resolver, prefixMap,
+                             factory$, errorHandler$, context);
     }
 
     private FactoryRDF buildFactoryRDF() {

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/LangParserBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/LangParserBase.java
@@ -73,7 +73,10 @@ public class LangParserBase {
 
     // ----
 
-    protected String fixupPrefix(String prefix, int line, int column) {
+    /**
+     * Standardize a prefix - prefixes do not include the ":".
+     */
+    protected String canonicalPrefix(String prefix, int line, int column) {
         if ( prefix.endsWith(":") )
             prefix = prefix.substring(0, prefix.length() - 1) ;
         return prefix ;
@@ -181,7 +184,7 @@ public class LangParserBase {
     }
 
     protected void setPrefix(String prefix, String iri, int line, int column) {
-        prefix = fixupPrefix(prefix, line, column);
+        prefix = canonicalPrefix(prefix, line, column);
         profile.getPrefixMap().add(prefix,iri);
         stream.prefix(prefix, iri);
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/javacc/TurtleJavacc.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/javacc/TurtleJavacc.java
@@ -107,7 +107,7 @@ public class TurtleJavacc extends LangParserBase implements TurtleJavaccConstant
       jj_consume_token(PREFIX);
       t = jj_consume_token(PNAME_NS);
       iri = IRIREF();
-String s = fixupPrefix(t.image, t.beginLine, t.beginColumn) ;
+String s = canonicalPrefix(t.image, t.beginLine, t.beginColumn) ;
       setPrefix(s, iri, t.beginLine, t.beginColumn) ;
       break;
       }
@@ -131,7 +131,7 @@ setBase(iri, t.beginLine, t.beginColumn) ;
       t = jj_consume_token(PNAME_NS);
       iri = IRIREF();
       jj_consume_token(DOT);
-String s = fixupPrefix(t.image, t.beginLine, t.beginColumn) ;
+String s = canonicalPrefix(t.image, t.beginLine, t.beginColumn) ;
       setPrefix(s, iri, t.beginLine, t.beginColumn) ;
       break;
       }

--- a/jena-arq/src/test/java/org/apache/jena/riot/TS_RiotGeneral.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TS_RiotGeneral.java
@@ -35,6 +35,7 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestRDFParser.class
     , TestParserRegistry.class
     , TestRDFWriter.class
+    , TestRDFParser.class
     , TestParseURISchemeBases.class
 
     , TestTurtleWriter.class

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
@@ -19,6 +19,7 @@
 package org.apache.jena.riot;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -28,12 +29,16 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Map;
 
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.riot.lang.LabelToNode;
 import org.apache.jena.riot.system.ErrorHandlerFactory;
 import org.apache.jena.riot.system.FactoryRDFStd;
+import org.apache.jena.riot.system.PrefixMap;
+import org.apache.jena.riot.system.PrefixMapFactory;
 import org.apache.jena.riot.system.stream.LocatorFile;
 import org.apache.jena.riot.system.stream.StreamManager;
 import org.apache.jena.sparql.graph.GraphFactory;
@@ -236,6 +241,22 @@ public class TestRDFParser {
 
     @Test public void canonical_langTag_3() {
         testNormalization("'abc'@En-gB", "'abc'@en-GB", builder().langTagCanonical());
+    }
+
+    @Test
+    public void parser_fragment() {
+        PrefixMap pmap = PrefixMapFactory.create(Map.of("", "http://example/"));
+        Graph g = RDFParser.fromString("<s> :p :o .")
+                .lang(Lang.TTL)
+                .prefixes(pmap)
+                .base("http://base/")
+                .toGraph();
+        assertFalse(g.isEmpty());
+        Graph g2 = GraphFactory.createDefaultGraph();
+        g2.add(NodeFactory.createURI("http://base/s"),
+               NodeFactory.createURI("http://example/p"),
+               NodeFactory.createURI("http://example/o"));
+        assertTrue(g2.isIsomorphicWith(g));
     }
 
     private static String PREFIX = "PREFIX : <http://example/>\n ";

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
@@ -66,7 +66,7 @@ public class IOX {
         return new RuntimeIOException(message, ioException);
     }
 
-    /** Run IO code */
+    /** Run I/O code */
     @FunctionalInterface
     public interface ActionIO { void run() throws IOException; }
 
@@ -92,7 +92,7 @@ public class IOX {
 
     /** Write a file safely - the change happens (the function returns true) or
      * something went wrong (the function throws a runtime exception) and the file is not changed.
-     * Note that the tempfile must be in the same direct as the actual file so an OS-atomic rename can be done.
+     * Note that the tempfile must be in the same directory as the actual file so an OS-atomic rename can be done.
      */
     public static boolean safeWrite(Path file, Path tmpFile, IOConsumer<OutputStream> writerAction) {
         try {

--- a/jena-shacl/shaclc/shaclc.jj
+++ b/jena-shacl/shaclc/shaclc.jj
@@ -96,7 +96,7 @@ void baseDecl() : { String iri ; }
 void prefixDecl() : { Token t ; String iri ; }
 {
     <PREFIX> t = <PNAME_NS> iri = IRIREF()
-    { String s = fixupPrefix(t.image, t.beginLine, t.beginColumn) ;
+    { String s = canonicalPrefix(t.image, t.beginLine, t.beginColumn) ;
       rPrefix(s, iri);
     }
 }
@@ -383,7 +383,7 @@ Path pathPrimary() : { String str ; Path p ; Node n ; }
 {
   ( 
     str = iri()
-     { n = createNode(str, token.beginLine, token.beginColumn) ; p = PathFactory.pathLink(n) ; }
+     { n = createURI(str, token.beginLine, token.beginColumn) ; p = PathFactory.pathLink(n) ; }
   | <LPAREN> p = path() <RPAREN>
   )
  { return p ; }
@@ -418,7 +418,7 @@ List<Node> array() : { List<Node> x = new ArrayList<Node>(); Node n = null; }
 Node iriOrLiteral() : { Node n; String uriStr; }
 {
   (
-    uriStr = iri() { n = createNode(uriStr, token.beginLine, token.beginColumn); }
+    uriStr = iri() { n = createURI(uriStr, token.beginLine, token.beginColumn); }
   | n = literal()
   )
   { return n ; }

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/parser/ShaclCompactParserJJ.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/parser/ShaclCompactParserJJ.java
@@ -123,7 +123,7 @@ rBase(iri) ;
     jj_consume_token(PREFIX);
     t = jj_consume_token(PNAME_NS);
     iri = IRIREF();
-String s = fixupPrefix(t.image, t.beginLine, t.beginColumn) ;
+String s = canonicalPrefix(t.image, t.beginLine, t.beginColumn) ;
       rPrefix(s, iri);
   }
 


### PR DESCRIPTION
Rename of `fixupPrefix` -- a different "fixup" is a feature of SPARQL parsing to get displayable queries when prefixes not provided (as is all too common on StackOverflow).

The rename means that several grammars needed rebuilding.
