### PR TITLE
GH-1228: Process update flag for file datasets

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiInfo.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiInfo.java
@@ -56,16 +56,15 @@ public class FusekiInfo {
     public static void logServerSetup(Logger log, boolean verbose,
                                       DataAccessPointRegistry dapRegistry,
                                       String datasetPath, String datasetDescription, String serverConfigFile, String staticFiles) {
-        if ( datasetPath != null ) {
-            FmtLog.info(log,  "Database: %s", datasetDescription);
-        }
+        if ( datasetPath != null )
+            FmtLog.info(log, "Database: %s", datasetDescription);
         if ( serverConfigFile != null )
-            FmtLog.info(log,  "Configuration file: %s", serverConfigFile);
+            FmtLog.info(log, "Configuration file: %s", serverConfigFile);
 
         FusekiInfo.logDataAccessPointRegistry(log, dapRegistry, verbose);
 
         if ( staticFiles != null )
-            FmtLog.info(log,  "Static files: %s", staticFiles);
+            FmtLog.info(log, "Static files: %s", staticFiles);
 
         FmtLog.info(log,"System");
         if ( verbose )

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -318,6 +318,8 @@ public class FusekiMain extends CmdARQ {
         if ( contains(argFile) ) {
             List<String> filenames = getValues(argFile);
             serverConfig.datasetDescription = "in-memory, with files loaded";
+            // Update is not enabled by default for --file
+            serverConfig.allowUpdate = contains(argUpdate);
             serverConfig.dsg = DatasetGraphFactory.createTxnMem();
 
             for(String filename : filenames ) {
@@ -450,12 +452,6 @@ public class FusekiMain extends CmdARQ {
         serverConfig.withStats = contains(argWithStats);
         serverConfig.withMetrics = contains(argWithMetrics);
         serverConfig.withCompact = contains(argWithCompact);
-
-//            if ( contains(argGZip) ) {
-//                if ( !hasValueOfTrue(argGZip) && !hasValueOfFalse(argGZip) )
-//                    throw new CmdException(argGZip.getNames().get(0) + ": Not understood: " + getValue(argGZip));
-//                jettyServerConfig.enableCompression = super.hasValueOfTrue(argGZip);
-//            }
     }
 
     private int portNumber(ArgDecl arg) {

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiCmd.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiCmd.java
@@ -266,6 +266,8 @@ public class FusekiCmd {
                 // Directly populate the dataset.
                 cmdLine.reset();
                 cmdLine.dsg = DatasetGraphFactory.createTxnMem();
+                // Update is not enabled by default for --file
+                cmdLine.allowUpdate = contains(argUpdate);
                 cmdLine.datasetDescription = "in-memory, with files loaded";
                 for ( String filename : filenames ) {
                     String pathname = filename;


### PR DESCRIPTION
Resolves #1228.

The `--update` flag is not handled for `--file` datasets, which stil default to read-only.

Updates do not cause the file to be updated, only the in-memory database that the file was read into.

If you want persisted update, please use a TDB database.