### PR TITLE
[JENA-2311] query rewrite index does too expensive caching on geo literals

### DIFF
--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/geo/topological/GenericPropertyFunction.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/geo/topological/GenericPropertyFunction.java
@@ -30,9 +30,7 @@ import org.apache.jena.geosparql.spatial.SpatialIndexException;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
@@ -323,8 +321,7 @@ public abstract class GenericPropertyFunction extends PFuncSimple {
         }
 
         //Check the QueryRewriteIndex for the result.
-        Property predicateProp = ResourceFactory.createProperty(predicate.getURI());
-        Boolean isPositive = queryRewriteIndex.test(subjectSpatialLiteral.getGeometryLiteral(), predicateProp, objectSpatialLiteral.getGeometryLiteral(), this);
+        Boolean isPositive = queryRewriteIndex.test(subjectSpatialLiteral.getGeometryLiteral(), predicate, objectSpatialLiteral.getGeometryLiteral(), this);
         return isPositive;
     }
 

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/index/GeometryLiteralIndex.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/index/GeometryLiteralIndex.java
@@ -60,17 +60,15 @@ public class GeometryLiteralIndex {
 
         if (INDEX_ACTIVE) {
 
-            if (index.containsKey(geometryLiteral)) {
-                geometryWrapper = index.get(geometryLiteral);
-            } else {
-                if (otherIndex.containsKey(geometryLiteral)) {
-                    geometryWrapper = otherIndex.get(geometryLiteral);
-                } else {
+            geometryWrapper = index.get(geometryLiteral);
+            if (geometryWrapper == null) {
+                geometryWrapper = otherIndex.get(geometryLiteral);
+                if (geometryWrapper == null) {
                     geometryWrapper = geometryDatatype.read(geometryLiteral);
                 }
                 index.put(geometryLiteral, geometryWrapper);
             }
-
+         
             return geometryWrapper;
         }
 

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/index/GeometryTransformIndex.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/index/GeometryTransformIndex.java
@@ -57,22 +57,18 @@ public class GeometryTransformIndex {
         String key = sourceGeometryWrapper.getLexicalForm() + "@" + srsURI;
 
         if (INDEX_ACTIVE && storeSRSTransform) {
-            try {
-                if (GEOMETRY_TRANSFORM_INDEX.containsKey(key)) {
-
-                    transformedGeometryWrapper = GEOMETRY_TRANSFORM_INDEX.get(key);
-
-                } else {
-                    transformedGeometryWrapper = transform(sourceGeometryWrapper, srsURI);
-                    GEOMETRY_TRANSFORM_INDEX.put(key, transformedGeometryWrapper);
-                }
-                return transformedGeometryWrapper;
-            } catch (NullPointerException ex) {
-                //Catch NullPointerException and fall through to default action.
+            
+            transformedGeometryWrapper = GEOMETRY_TRANSFORM_INDEX.get(key);
+            if (transformedGeometryWrapper == null) {
+                transformedGeometryWrapper = transform(sourceGeometryWrapper, srsURI);
+                GEOMETRY_TRANSFORM_INDEX.put(key, transformedGeometryWrapper);
             }
+                        
+        } else {
+            transformedGeometryWrapper = transform(sourceGeometryWrapper, srsURI);
         }
-        return transform(sourceGeometryWrapper, srsURI);
-
+        
+        return transformedGeometryWrapper;
     }
 
     private static GeometryWrapper transform(GeometryWrapper sourceGeometryWrapper, String srsURI) throws MismatchedDimensionException, FactoryException, TransformException {

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/index/QueryRewriteIndex.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/index/QueryRewriteIndex.java
@@ -83,14 +83,7 @@ public class QueryRewriteIndex {
         if (indexActive) {
             String key = subjectGeometryLiteral.getLiteralLexicalForm() + KEY_SEPARATOR + predicate.getURI() + KEY_SEPARATOR + objectGeometryLiteral.getLiteralLexicalForm();
             try {
-                Boolean result;
-                if (index.containsKey(key)) {
-                    result = index.get(key);
-                } else {
-                    result = propertyFunction.testFilterFunction(subjectGeometryLiteral, objectGeometryLiteral);
-                    index.put(key, result);
-                }
-                return result;
+                return index.computeIfAbsent(key, k -> propertyFunction.testFilterFunction(subjectGeometryLiteral, objectGeometryLiteral));                
             } catch (NullPointerException ex) {
                 //Catch NullPointerException and fall through to default action.
             }


### PR DESCRIPTION
Replaced string concatenation for map key with test against separate string values to address issues highlighted in [JENA-2311](https://issues.apache.org/jira/browse/JENA-2311).