### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,9 @@ on: workflow_dispatch
 #  pull_request:
 #    branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -3,6 +3,9 @@
 name: Apache Jena CI (MacOS)
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/maven_windows.yml
+++ b/.github/workflows/maven_windows.yml
@@ -3,6 +3,9 @@
 name: Apache Jena CI (MS Windows)
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
