### PR TITLE
GH-1257: Throw a CmdException in shex commands

### DIFF
--- a/jena-cmds/src/main/java/shex/shex_parse.java
+++ b/jena-cmds/src/main/java/shex/shex_parse.java
@@ -74,8 +74,7 @@ public class shex_parse extends CmdGeneral {
     protected void processModulesAndArgs() {
          super.processModulesAndArgs();
          if ( super.positionals.size() == 0 ) {
-             System.err.println(getSummary());
-             System.exit(0);
+             throw new CmdException(getSummary());
          }
 
          if ( super.hasArg(argOutput) ) {
@@ -133,8 +132,7 @@ public class shex_parse extends CmdGeneral {
         PrintStream err = System.err;
 
         if ( ! FileOps.exists(fn) ) {
-            err.println(fn+" : File not found");
-            return;
+            throw new CmdException(fn+" : File not found");
         }
 
         try {
@@ -142,10 +140,11 @@ public class shex_parse extends CmdGeneral {
         }
         catch ( RiotException ex ) { /*ErrorHandler logged this */ return; }
         catch (ShexParseException ex) {
+            StringBuilder sb = new StringBuilder();
             if ( multipleFiles )
-                err.println(fn+" : ");
-            err.println(ex.getMessage());
-            return;
+                sb.append(fn+" : ");
+            sb.append(ex.getMessage());
+            throw new CmdException(sb.toString());
         }
 
         boolean outputByPrev = false;

--- a/jena-cmds/src/main/java/shex/shex_validate.java
+++ b/jena-cmds/src/main/java/shex/shex_validate.java
@@ -120,15 +120,14 @@ public class shex_validate extends CmdGeneral {
         try {
             shapes = Shex.readSchema(shapesfile);
         } catch (ShexException ex) {
-            System.err.println("Failed to read shapes: " + ex.getMessage());
-            throw new CmdException();
+            throw new CmdException("Failed to read shapes: " + ex.getMessage());
         }
 
         Graph dataGraph;
         try {
             dataGraph = load(datafile, "data file");
         } catch (RiotException ex) {
-            throw new CmdException("Failed to data: " + ex.getMessage());
+            throw new CmdException("Failed to load data: " + ex.getMessage());
         }
 
 //        if ( targetNode != null ) {


### PR DESCRIPTION
Closes #1257 

Had a look at the shex validate code, and looks like that one is throwing `CmdException`'s, but not shex parse. Adapted the code to have the parse code similar to the validate code.

That should blow the exception up, and cause the command to exit with a code different than `0`.