### PR TITLE
JENA-2323: shex print compact syntax

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/out/NodeFmtLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/out/NodeFmtLib.java
@@ -40,7 +40,7 @@ import org.apache.jena.sparql.core.Quad;
  * <p>
  * Methods <tt>str</tt> generate a re-parseable string.
  * <p>
- * Methods <tt>displayStr</tt> do not guarantee a re-parsable string
+ * Methods <tt>displayStr</tt> do not guarantee a re-parseable string
  * e.g. may use abbreviations or common prefixes.
  */
 public class NodeFmtLib
@@ -63,7 +63,7 @@ public class NodeFmtLib
             dftPrefixMap.add(e.getKey(), e.getValue() );
     }
 
-    /** Format a triple, using Tutle literal abbreviations. */
+    /** Format a triple, using Turtle literal abbreviations. */
     public static String str(Triple t) {
         return strNodesTTL(t.getSubject(), t.getPredicate(), t.getObject());
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphSPARQLService.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphSPARQLService.java
@@ -30,8 +30,10 @@ import org.apache.jena.util.iterator.ExtendedIterator ;
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
 
-/** This class provides the Jena Graph interface to a remote SPARQL endpoint.
- *  Efficiency not guaranteed. */
+/**
+ * This class provides the Jena Graph interface to a remote SPARQL endpoint.
+ * Efficiency not guaranteed.
+ */
 
 public class GraphSPARQLService extends GraphBase implements Graph
 {
@@ -39,30 +41,30 @@ public class GraphSPARQLService extends GraphBase implements Graph
 
     private String serviceURI ;
     private String graphIRI = null ;
-    
+
     // Remote default graph
     public GraphSPARQLService(String serviceURI)
-    {  
+    {
         this.serviceURI = serviceURI ;
         this.graphIRI = null ;
     }
-    
+
     // Remote named graph
     public GraphSPARQLService(String serviceURI, String graphIRI)
-    {  
+    {
         this.serviceURI = serviceURI ;
         this.graphIRI = graphIRI ;
     }
 
 //    @Override
 //    public Capabilities getCapabilities()
-//    { 
+//    {
 //    	if (capabilities == null)
 //            capabilities = new AllCapabilities()
 //        	  { @Override public boolean handlesLiteralTyping() { return false; } };
 //        return capabilities;
 //    }
-    
+
     @Override
     protected ExtendedIterator<Triple> graphBaseFind(Triple m)
     {
@@ -73,7 +75,7 @@ public class GraphSPARQLService extends GraphBase implements Graph
             sVar = Var.alloc("s") ;
             s = sVar ;
         }
-        
+
         Node p = m.getMatchPredicate() ;
         Var pVar = null ;
         if ( p == null )
@@ -81,7 +83,7 @@ public class GraphSPARQLService extends GraphBase implements Graph
             pVar = Var.alloc("p") ;
             p = pVar ;
         }
-        
+
         Node o = m.getMatchObject() ;
         Var oVar = null ;
         if ( o == null )
@@ -89,22 +91,21 @@ public class GraphSPARQLService extends GraphBase implements Graph
             oVar = Var.alloc("o") ;
             o = oVar ;
         }
-        
+
         Triple triple = new Triple(s, p ,o) ;
-        
+
         // Evaluate as an algebra expression
         BasicPattern pattern = new BasicPattern() ;
         pattern.add(triple) ;
         Op op = new OpBGP(pattern) ;
-        
-//        // Make remote execution object. 
+
+//        // Make remote execution object.
 //        System.err.println("GraphSPARQLService.graphBaseFind: Unimplemented : remote service execution") ;
 //        //Plan plan = factory.create(op, getDataset(), BindingRoot.create(), null) ;
 //
 //        QueryIterator qIter = plan.iterator() ;
 //        List<Triple> triples = new ArrayList<Triple>() ;
-//        
-//        
+//
 //        for (; qIter.hasNext() ; )
 //        {
 //            Binding b = qIter.nextBinding() ;

--- a/jena-cmds/src/main/java/shex/shex_parse.java
+++ b/jena-cmds/src/main/java/shex/shex_parse.java
@@ -18,12 +18,14 @@
 
 package shex;
 
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.atlas.lib.FileOps;
 import org.apache.jena.atlas.lib.StreamOps;
 import org.apache.jena.atlas.logging.LogCtl;
@@ -34,6 +36,7 @@ import org.apache.jena.riot.RiotException;
 import org.apache.jena.shex.Shex;
 import org.apache.jena.shex.ShexSchema;
 import org.apache.jena.shex.parser.ShexParseException;
+import org.apache.jena.shex.writer.WriterShExC;
 import org.apache.jena.sys.JenaSystem;
 
 /** ShEx parsing.
@@ -67,7 +70,7 @@ public class shex_parse extends CmdGeneral {
 
     @Override
     protected String getSummary() {
-        return "Usage: "+getCommandName()+" --out=FMT[,FMT] FILE";
+        return "Usage: "+getCommandName()+" --output=FMT[,FMT] FILE";
     }
 
     @Override
@@ -168,28 +171,8 @@ public class shex_parse extends CmdGeneral {
         }
     }
 
-    private boolean printText(PrintStream out, PrintStream err, ShexSchema shapes) {
+    private boolean printText(OutputStream out, PrintStream err, ShexSchema shapes) {
         Shex.printSchema(shapes);
-//        IndentedWriter iOut  = new IndentedWriter(out);
-//        ShLib.printShapes(iOut, shapes);
-//        iOut.ensureStartOfLine();
-//        iOut.flush();
-//        int numShapes = shapes.numShapes();
-//        int numRootShapes = shapes.numRootShapes();
-//        if ( isVerbose() ) {
-//            System.out.println();
-//            System.out.println("Target shapes: ");
-//            shapes.getShapeMap().forEach((n,shape)->{
-//                if ( shape.hasTarget() )
-//                    System.out.println("  "+ShLib.displayStr(shape.getShapeNode()));
-//            });
-//
-//            System.out.println("Other Shapes: ");
-//            shapes.getShapeMap().forEach((n,shape)->{
-//                if ( ! shape.hasTarget() )
-//                    System.out.println("  "+ShLib.displayStr(shape.getShapeNode()));
-//            });
-//        }
         return true;
     }
 
@@ -200,12 +183,14 @@ public class shex_parse extends CmdGeneral {
     }
 
     private boolean printCompact(PrintStream out, PrintStream err, ShexSchema shapes) {
-//        try {
-//            ShaclcWriter.print(out, shapes);
-//        } catch (ShaclException ex) {
-//            err.println(ex.getMessage());
-//        }
-//        return ! shapes.getGraph().isEmpty() && ! shapes.getGraph().getPrefixMapping().hasNoMappings();
-        return false;
+        IndentedWriter iOut = new IndentedWriter(out);
+        int row = iOut.getRow();
+        int col = iOut.getCol();
+        WriterShExC.print(iOut, shapes);
+        iOut.flush();
+        // Do not close the underlying stream.
+        // All the components of printing.
+        return shapes.getShapes().isEmpty() && shapes.getImports().isEmpty() &&
+               shapes.getBase() == null && shapes.getPrefixMap().isEmpty();
     }
 }

--- a/jena-shacl/shaclc/shaclc.jj
+++ b/jena-shacl/shaclc/shaclc.jj
@@ -593,14 +593,18 @@ TOKEN:
 | <LANGTAG: <AT> (<A2Z>)+("-" (<A2ZN>)+)* >
 | <#A2Z: ["a"-"z","A"-"Z"]>
 | <#A2ZN: ["a"-"z","A"-"Z","0"-"9"]>
+
+| <#SURROGATE_PAIR: ["\uD800"-"\uDBFF"] ["\uDC00"-"\uDFFF"] >
+
 | <#PN_CHARS_BASE:
           ["A"-"Z"] | ["a"-"z"] |
           ["\u00C0"-"\u00D6"] | ["\u00D8"-"\u00F6"] | ["\u00F8"-"\u02FF"] |
           ["\u0370"-"\u037D"] | ["\u037F"-"\u1FFF"] |
           ["\u200C"-"\u200D"] | ["\u2070"-"\u218F"] | ["\u2C00"-"\u2FEF"] |
           ["\u3001"-"\uD7FF"] | ["\uF900"-"\uFFFD"] 
-          >
           // [#x10000-#xEFFFF]
+          | <SURROGATE_PAIR>
+          >
 |
   // With underscore
   <#PN_CHARS_U: <PN_CHARS_BASE> | "_" >

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/parser/ShaclCompactParserJJ.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/parser/ShaclCompactParserJJ.java
@@ -1575,7 +1575,7 @@ lex = unescapeStr(lex,  t.beginLine, t.beginColumn) ;
   /** Generate ParseException. */
   public ParseException generateParseException() {
     jj_expentries.clear();
-    boolean[] la1tokens = new boolean[112];
+    boolean[] la1tokens = new boolean[113];
     if (jj_kind >= 0) {
       la1tokens[jj_kind] = true;
       jj_kind = -1;
@@ -1598,7 +1598,7 @@ lex = unescapeStr(lex,  t.beginLine, t.beginColumn) ;
         }
       }
     }
-    for (int i = 0; i < 112; i++) {
+    for (int i = 0; i < 113; i++) {
       if (la1tokens[i]) {
         jj_expentry = new int[1];
         jj_expentry[0] = i;

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/parser/ShaclCompactParserJJConstants.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/parser/ShaclCompactParserJJConstants.java
@@ -129,25 +129,27 @@ public interface ShaclCompactParserJJConstants {
   /** RegularExpression Id. */
   int A2ZN = 101;
   /** RegularExpression Id. */
-  int PN_CHARS_BASE = 102;
+  int SURROGATE_PAIR = 102;
   /** RegularExpression Id. */
-  int PN_CHARS_U = 103;
+  int PN_CHARS_BASE = 103;
   /** RegularExpression Id. */
-  int PN_CHARS = 104;
+  int PN_CHARS_U = 104;
   /** RegularExpression Id. */
-  int PN_PREFIX = 105;
+  int PN_CHARS = 105;
   /** RegularExpression Id. */
-  int PN_LOCAL = 106;
+  int PN_PREFIX = 106;
   /** RegularExpression Id. */
-  int VARNAME = 107;
+  int PN_LOCAL = 107;
   /** RegularExpression Id. */
-  int PN_LOCAL_ESC = 108;
+  int VARNAME = 108;
   /** RegularExpression Id. */
-  int PLX = 109;
+  int PN_LOCAL_ESC = 109;
   /** RegularExpression Id. */
-  int PERCENT = 110;
+  int PLX = 110;
   /** RegularExpression Id. */
-  int UNKNOWN = 111;
+  int PERCENT = 111;
+  /** RegularExpression Id. */
+  int UNKNOWN = 112;
 
   /** Lexical state. */
   int DEFAULT = 0;
@@ -256,6 +258,7 @@ public interface ShaclCompactParserJJConstants {
     "<LANGTAG>",
     "<A2Z>",
     "<A2ZN>",
+    "<SURROGATE_PAIR>",
     "<PN_CHARS_BASE>",
     "<PN_CHARS_U>",
     "<PN_CHARS>",

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/parser/ShaclCompactParserJJTokenManager.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/compact/reader/parser/ShaclCompactParserJJTokenManager.java
@@ -1321,6 +1321,12 @@ static final long[] jjbitVec11 = {
 static final long[] jjbitVec12 = {
    0x8000000000003000L, 0xffff000000000001L, 0xffffffffffffffffL, 0xffffffffffffffffL
 };
+static final long[] jjbitVec13 = {
+   0x0L, 0x0L, 0x0L, 0xf000000L
+};
+static final long[] jjbitVec14 = {
+   0x0L, 0x0L, 0x0L, 0xf0000000L
+};
 private int jjMoveNfa_0(int startState, int curPos)
 {
    int strKind = jjmatchedKind;
@@ -1331,7 +1337,7 @@ private int jjMoveNfa_0(int startState, int curPos)
    catch(java.io.IOException e) { throw new Error("Internal Error"); }
    curPos = 0;
    int startsAt = 0;
-   jjnewStateCnt = 181;
+   jjnewStateCnt = 210;
    int i = 1;
    jjstateSet[0] = startState;
    int kind = 0x7fffffff;
@@ -1356,36 +1362,36 @@ private int jjMoveNfa_0(int startState, int curPos)
                   else if ((0x280000000000L & l) != 0L)
                      { jjCheckNAddStates(7, 11); }
                   else if (curChar == 46)
-                     { jjCheckNAddTwoStates(162, 164); }
+                     { jjCheckNAddTwoStates(191, 193); }
                   else if (curChar == 58)
                   {
                      if (kind > 80)
                         kind = 80;
-                     { jjCheckNAddStates(12, 14); }
+                     { jjCheckNAddStates(12, 15); }
                   }
                   else if (curChar == 34)
                      jjstateSet[jjnewStateCnt++] = 104;
                   else if (curChar == 39)
                      jjstateSet[jjnewStateCnt++] = 80;
                   else if (curChar == 60)
-                     { jjCheckNAddStates(15, 17); }
+                     { jjCheckNAddStates(16, 18); }
                   else if (curChar == 35)
                   {
                      if (kind > 52)
                         kind = 52;
-                     { jjCheckNAddStates(18, 20); }
+                     { jjCheckNAddStates(19, 21); }
                   }
                   if (curChar == 34)
-                     { jjCheckNAddStates(21, 23); }
+                     { jjCheckNAddStates(22, 24); }
                   else if (curChar == 39)
-                     { jjCheckNAddStates(24, 26); }
+                     { jjCheckNAddStates(25, 27); }
                   break;
                case 1:
                   if ((0xffffffffffffdbffL & l) == 0L)
                      break;
                   if (kind > 52)
                      kind = 52;
-                  { jjCheckNAddStates(18, 20); }
+                  { jjCheckNAddStates(19, 21); }
                   break;
                case 2:
                   if ((0x2400L & l) != 0L && kind > 52)
@@ -1401,11 +1407,11 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 5:
                   if (curChar == 60)
-                     { jjCheckNAddStates(15, 17); }
+                     { jjCheckNAddStates(16, 18); }
                   break;
                case 6:
                   if ((0xaffffffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(15, 17); }
+                     { jjCheckNAddStates(16, 18); }
                   break;
                case 7:
                   if (curChar == 62 && kind > 79)
@@ -1442,7 +1448,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 17:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(15, 17); }
+                     { jjCheckNAddStates(16, 18); }
                   break;
                case 19:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1454,11 +1460,11 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 22:
                   if (curChar == 39)
-                     { jjCheckNAddStates(24, 26); }
+                     { jjCheckNAddStates(25, 27); }
                   break;
                case 23:
                   if ((0xffffff7fffffdbffL & l) != 0L)
-                     { jjCheckNAddStates(24, 26); }
+                     { jjCheckNAddStates(25, 27); }
                   break;
                case 24:
                   if (curChar == 39 && kind > 90)
@@ -1466,7 +1472,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 26:
                   if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(24, 26); }
+                     { jjCheckNAddStates(25, 27); }
                   break;
                case 28:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1499,7 +1505,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 35:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(24, 26); }
+                     { jjCheckNAddStates(25, 27); }
                   break;
                case 37:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1511,11 +1517,11 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 40:
                   if (curChar == 34)
-                     { jjCheckNAddStates(21, 23); }
+                     { jjCheckNAddStates(22, 24); }
                   break;
                case 41:
                   if ((0xfffffffbffffdbffL & l) != 0L)
-                     { jjCheckNAddStates(21, 23); }
+                     { jjCheckNAddStates(22, 24); }
                   break;
                case 42:
                   if (curChar == 34 && kind > 91)
@@ -1523,7 +1529,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 44:
                   if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(21, 23); }
+                     { jjCheckNAddStates(22, 24); }
                   break;
                case 46:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1556,7 +1562,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 53:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(21, 23); }
+                     { jjCheckNAddStates(22, 24); }
                   break;
                case 55:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1568,7 +1574,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 58:
                   if (curChar == 39)
-                     { jjCheckNAddStates(27, 30); }
+                     { jjCheckNAddStates(28, 31); }
                   break;
                case 59:
                case 62:
@@ -1577,15 +1583,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 60:
                   if ((0xffffff7fffffffffL & l) != 0L)
-                     { jjCheckNAddStates(27, 30); }
+                     { jjCheckNAddStates(28, 31); }
                   break;
                case 61:
                   if (curChar == 39)
-                     { jjAddStates(31, 32); }
+                     { jjAddStates(32, 33); }
                   break;
                case 64:
                   if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(27, 30); }
+                     { jjCheckNAddStates(28, 31); }
                   break;
                case 66:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1618,7 +1624,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 73:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(27, 30); }
+                     { jjCheckNAddStates(28, 31); }
                   break;
                case 75:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1646,7 +1652,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 82:
                   if (curChar == 34)
-                     { jjCheckNAddStates(33, 36); }
+                     { jjCheckNAddStates(34, 37); }
                   break;
                case 83:
                case 86:
@@ -1655,15 +1661,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 84:
                   if ((0xfffffffbffffffffL & l) != 0L)
-                     { jjCheckNAddStates(33, 36); }
+                     { jjCheckNAddStates(34, 37); }
                   break;
                case 85:
                   if (curChar == 34)
-                     { jjAddStates(37, 38); }
+                     { jjAddStates(38, 39); }
                   break;
                case 88:
                   if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(33, 36); }
+                     { jjCheckNAddStates(34, 37); }
                   break;
                case 90:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1696,7 +1702,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 97:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(33, 36); }
+                     { jjCheckNAddStates(34, 37); }
                   break;
                case 99:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1724,7 +1730,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 107:
                   if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(39, 40); }
+                     { jjAddStates(40, 42); }
                   break;
                case 108:
                   if ((0x3ff200000000000L & l) != 0L)
@@ -1734,287 +1740,287 @@ private int jjMoveNfa_0(int startState, int curPos)
                   if (curChar == 58 && kind > 80)
                      kind = 80;
                   break;
-               case 110:
-                  if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(41, 42); }
-                  break;
-               case 111:
-                  if ((0x3ff200000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 112;
-                  break;
-               case 112:
-                  if (curChar == 58)
-                     { jjCheckNAddStates(12, 14); }
-                  break;
                case 113:
+                  if ((0x3ff600000000000L & l) != 0L)
+                     { jjAddStates(43, 45); }
+                  break;
+               case 114:
+                  if ((0x3ff200000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 115;
+                  break;
+               case 115:
+                  if (curChar == 58)
+                     { jjCheckNAddStates(12, 15); }
+                  break;
+               case 116:
                   if ((0x7ff000000000000L & l) == 0L)
                      break;
                   if (kind > 81)
                      kind = 81;
-                  { jjCheckNAddStates(43, 46); }
+                  { jjCheckNAddStates(46, 50); }
                   break;
-               case 114:
+               case 117:
                   if ((0x7ff600000000000L & l) != 0L)
-                     { jjCheckNAddStates(43, 46); }
+                     { jjCheckNAddStates(46, 50); }
                   break;
-               case 115:
+               case 118:
                   if ((0x7ff200000000000L & l) != 0L && kind > 81)
                      kind = 81;
                   break;
-               case 117:
-                  if ((0xa800fffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(43, 46); }
-                  break;
-               case 118:
-                  if (curChar == 37)
-                     { jjAddStates(47, 48); }
-                  break;
-               case 119:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 120;
-                  break;
-               case 120:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(43, 46); }
-                  break;
-               case 121:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 122;
-                  break;
                case 122:
+                  if ((0xa800fffa00000000L & l) != 0L)
+                     { jjCheckNAddStates(46, 50); }
+                  break;
+               case 123:
+                  if (curChar == 37)
+                     { jjAddStates(51, 52); }
+                  break;
+               case 124:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 125;
+                  break;
+               case 125:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(46, 50); }
+                  break;
+               case 126:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 127;
+                  break;
+               case 127:
                   if ((0x3ff000000000000L & l) != 0L && kind > 81)
                      kind = 81;
                   break;
-               case 123:
+               case 128:
                   if ((0xa800fffa00000000L & l) != 0L && kind > 81)
                      kind = 81;
                   break;
-               case 125:
+               case 131:
                   if ((0xa800fffa00000000L & l) == 0L)
                      break;
                   if (kind > 81)
                      kind = 81;
-                  { jjCheckNAddStates(43, 46); }
+                  { jjCheckNAddStates(46, 50); }
                   break;
-               case 126:
+               case 132:
                   if (curChar == 37)
-                     jjstateSet[jjnewStateCnt++] = 127;
+                     jjstateSet[jjnewStateCnt++] = 133;
                   break;
-               case 127:
+               case 133:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 128;
+                     jjstateSet[jjnewStateCnt++] = 134;
                   break;
-               case 128:
+               case 134:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 81)
                      kind = 81;
-                  { jjCheckNAddStates(43, 46); }
+                  { jjCheckNAddStates(46, 50); }
                   break;
-               case 129:
+               case 143:
                   if (curChar != 58)
                      break;
                   if (kind > 80)
                      kind = 80;
-                  { jjCheckNAddStates(12, 14); }
+                  { jjCheckNAddStates(12, 15); }
                   break;
-               case 132:
+               case 146:
                   if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(49, 50); }
+                     { jjAddStates(53, 55); }
                   break;
-               case 133:
+               case 147:
                   if ((0x3ff200000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 134;
+                     jjstateSet[jjnewStateCnt++] = 148;
                   break;
-               case 134:
+               case 148:
                   if (curChar == 58 && kind > 82)
                      kind = 82;
                   break;
-               case 136:
+               case 155:
                   if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(51, 52); }
+                     { jjAddStates(56, 58); }
                   break;
-               case 137:
+               case 156:
                   if ((0x3ff200000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 138;
+                     jjstateSet[jjnewStateCnt++] = 157;
                   break;
-               case 138:
+               case 157:
                   if (curChar == 58)
-                     { jjAddStates(53, 55); }
+                     { jjAddStates(59, 62); }
                   break;
-               case 139:
+               case 158:
                   if ((0x7ff000000000000L & l) == 0L)
                      break;
                   if (kind > 83)
                      kind = 83;
-                  { jjCheckNAddStates(56, 59); }
+                  { jjCheckNAddStates(63, 67); }
                   break;
-               case 140:
+               case 159:
                   if ((0x7ff600000000000L & l) != 0L)
-                     { jjCheckNAddStates(56, 59); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
-               case 141:
+               case 160:
                   if ((0x7ff200000000000L & l) != 0L && kind > 83)
                      kind = 83;
                   break;
-               case 143:
+               case 164:
                   if ((0xa800fffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(56, 59); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
-               case 144:
+               case 165:
                   if (curChar == 37)
-                     { jjAddStates(60, 61); }
+                     { jjAddStates(68, 69); }
                   break;
-               case 145:
+               case 166:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 146;
+                     jjstateSet[jjnewStateCnt++] = 167;
                   break;
-               case 146:
+               case 167:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(56, 59); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
-               case 147:
+               case 168:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 148;
+                     jjstateSet[jjnewStateCnt++] = 169;
                   break;
-               case 148:
+               case 169:
                   if ((0x3ff000000000000L & l) != 0L && kind > 83)
                      kind = 83;
                   break;
-               case 149:
+               case 170:
                   if ((0xa800fffa00000000L & l) != 0L && kind > 83)
                      kind = 83;
                   break;
-               case 151:
+               case 173:
                   if ((0xa800fffa00000000L & l) == 0L)
                      break;
                   if (kind > 83)
                      kind = 83;
-                  { jjCheckNAddStates(56, 59); }
+                  { jjCheckNAddStates(63, 67); }
                   break;
-               case 152:
+               case 174:
                   if (curChar == 37)
-                     jjstateSet[jjnewStateCnt++] = 153;
+                     jjstateSet[jjnewStateCnt++] = 175;
                   break;
-               case 153:
+               case 175:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 154;
+                     jjstateSet[jjnewStateCnt++] = 176;
                   break;
-               case 154:
+               case 176:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 83)
                      kind = 83;
-                  { jjCheckNAddStates(56, 59); }
+                  { jjCheckNAddStates(63, 67); }
                   break;
-               case 156:
+               case 185:
                   if (curChar == 45)
-                     { jjCheckNAdd(157); }
+                     { jjCheckNAdd(186); }
                   break;
-               case 157:
+               case 186:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 99)
                      kind = 99;
-                  { jjCheckNAddTwoStates(156, 157); }
+                  { jjCheckNAddTwoStates(185, 186); }
                   break;
-               case 158:
+               case 187:
                   if ((0x280000000000L & l) != 0L)
                      { jjCheckNAddStates(7, 11); }
                   break;
-               case 159:
+               case 188:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 95)
                      kind = 95;
-                  { jjCheckNAdd(159); }
+                  { jjCheckNAdd(188); }
                   break;
-               case 160:
+               case 189:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(160, 161); }
+                     { jjCheckNAddTwoStates(189, 190); }
                   break;
-               case 161:
+               case 190:
                   if (curChar == 46)
-                     { jjCheckNAdd(162); }
+                     { jjCheckNAdd(191); }
                   break;
-               case 162:
+               case 191:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 96)
                      kind = 96;
-                  { jjCheckNAdd(162); }
+                  { jjCheckNAdd(191); }
                   break;
-               case 163:
+               case 192:
                   if (curChar == 46)
-                     { jjCheckNAdd(164); }
+                     { jjCheckNAdd(193); }
                   break;
-               case 164:
+               case 193:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(164, 165); }
+                     { jjCheckNAddTwoStates(193, 194); }
                   break;
-               case 166:
+               case 195:
                   if ((0x280000000000L & l) != 0L)
-                     { jjCheckNAdd(167); }
+                     { jjCheckNAdd(196); }
                   break;
-               case 167:
+               case 196:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAdd(167); }
+                  { jjCheckNAdd(196); }
                   break;
-               case 168:
+               case 197:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(62, 65); }
+                     { jjCheckNAddStates(70, 73); }
                   break;
-               case 169:
+               case 198:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(169, 170); }
+                     { jjCheckNAddTwoStates(198, 199); }
                   break;
-               case 170:
+               case 199:
                   if (curChar == 46)
-                     { jjCheckNAddTwoStates(171, 172); }
+                     { jjCheckNAddTwoStates(200, 201); }
                   break;
-               case 171:
+               case 200:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(171, 172); }
+                     { jjCheckNAddTwoStates(200, 201); }
                   break;
-               case 173:
+               case 202:
                   if ((0x280000000000L & l) != 0L)
-                     { jjCheckNAdd(174); }
+                     { jjCheckNAdd(203); }
                   break;
-               case 174:
+               case 203:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAdd(174); }
+                  { jjCheckNAdd(203); }
                   break;
-               case 175:
+               case 204:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(175, 176); }
+                     { jjCheckNAddTwoStates(204, 205); }
                   break;
-               case 177:
+               case 206:
                   if ((0x280000000000L & l) != 0L)
-                     { jjCheckNAdd(178); }
+                     { jjCheckNAdd(207); }
                   break;
-               case 178:
+               case 207:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 97)
                      kind = 97;
-                  { jjCheckNAdd(178); }
+                  { jjCheckNAdd(207); }
                   break;
-               case 179:
+               case 208:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 95)
                      kind = 95;
                   { jjCheckNAddStates(0, 6); }
                   break;
-               case 180:
+               case 209:
                   if (curChar == 46)
-                     { jjCheckNAddTwoStates(162, 164); }
+                     { jjCheckNAddTwoStates(191, 193); }
                   break;
                default : break;
             }
@@ -2029,22 +2035,22 @@ private int jjMoveNfa_0(int startState, int curPos)
             {
                case 0:
                   if ((0x7fffffe07fffffeL & l) != 0L)
-                     { jjCheckNAddStates(66, 71); }
+                     { jjCheckNAddStates(74, 81); }
                   else if (curChar == 64)
-                     { jjCheckNAddStates(72, 76); }
+                     { jjCheckNAddStates(82, 88); }
                   break;
                case 1:
                   if (kind > 52)
                      kind = 52;
-                  { jjAddStates(18, 20); }
+                  { jjAddStates(19, 21); }
                   break;
                case 6:
                   if ((0xc7fffffeafffffffL & l) != 0L)
-                     { jjCheckNAddStates(15, 17); }
+                     { jjCheckNAddStates(16, 18); }
                   break;
                case 8:
                   if (curChar == 92)
-                     { jjAddStates(77, 78); }
+                     { jjAddStates(89, 90); }
                   break;
                case 9:
                   if (curChar == 85)
@@ -2081,7 +2087,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 17:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(15, 17); }
+                     { jjCheckNAddStates(16, 18); }
                   break;
                case 18:
                   if (curChar == 117)
@@ -2097,15 +2103,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 23:
                   if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(24, 26); }
+                     { jjCheckNAddStates(25, 27); }
                   break;
                case 25:
                   if (curChar == 92)
-                     { jjAddStates(79, 81); }
+                     { jjAddStates(91, 93); }
                   break;
                case 26:
                   if ((0x14404410000000L & l) != 0L)
-                     { jjCheckNAddStates(24, 26); }
+                     { jjCheckNAddStates(25, 27); }
                   break;
                case 27:
                   if (curChar == 85)
@@ -2142,7 +2148,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 35:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(24, 26); }
+                     { jjCheckNAddStates(25, 27); }
                   break;
                case 36:
                   if (curChar == 117)
@@ -2158,15 +2164,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 41:
                   if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(21, 23); }
+                     { jjCheckNAddStates(22, 24); }
                   break;
                case 43:
                   if (curChar == 92)
-                     { jjAddStates(82, 84); }
+                     { jjAddStates(94, 96); }
                   break;
                case 44:
                   if ((0x14404410000000L & l) != 0L)
-                     { jjCheckNAddStates(21, 23); }
+                     { jjCheckNAddStates(22, 24); }
                   break;
                case 45:
                   if (curChar == 85)
@@ -2203,7 +2209,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 53:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(21, 23); }
+                     { jjCheckNAddStates(22, 24); }
                   break;
                case 54:
                   if (curChar == 117)
@@ -2219,15 +2225,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 60:
                   if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(27, 30); }
+                     { jjCheckNAddStates(28, 31); }
                   break;
                case 63:
                   if (curChar == 92)
-                     { jjAddStates(85, 87); }
+                     { jjAddStates(97, 99); }
                   break;
                case 64:
                   if ((0x14404410000000L & l) != 0L)
-                     { jjCheckNAddStates(27, 30); }
+                     { jjCheckNAddStates(28, 31); }
                   break;
                case 65:
                   if (curChar == 85)
@@ -2264,7 +2270,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 73:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(27, 30); }
+                     { jjCheckNAddStates(28, 31); }
                   break;
                case 74:
                   if (curChar == 117)
@@ -2280,15 +2286,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 84:
                   if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(33, 36); }
+                     { jjCheckNAddStates(34, 37); }
                   break;
                case 87:
                   if (curChar == 92)
-                     { jjAddStates(88, 90); }
+                     { jjAddStates(100, 102); }
                   break;
                case 88:
                   if ((0x14404410000000L & l) != 0L)
-                     { jjCheckNAddStates(33, 36); }
+                     { jjCheckNAddStates(34, 37); }
                   break;
                case 89:
                   if (curChar == 85)
@@ -2325,7 +2331,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 97:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(33, 36); }
+                     { jjCheckNAddStates(34, 37); }
                   break;
                case 98:
                   if (curChar == 117)
@@ -2341,207 +2347,207 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 106:
                   if ((0x7fffffe07fffffeL & l) != 0L)
-                     { jjCheckNAddStates(66, 71); }
+                     { jjCheckNAddStates(74, 81); }
                   break;
                case 107:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(107, 108); }
+                     { jjCheckNAddStates(40, 42); }
                   break;
                case 108:
                   if ((0x7fffffe87fffffeL & l) != 0L)
                      { jjCheckNAdd(109); }
                   break;
-               case 110:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(110, 111); }
-                  break;
-               case 111:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAdd(112); }
-                  break;
                case 113:
-                  if ((0x7fffffe87fffffeL & l) == 0L)
-                     break;
-                  if (kind > 81)
-                     kind = 81;
-                  { jjCheckNAddStates(43, 46); }
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAddStates(43, 45); }
                   break;
                case 114:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddStates(43, 46); }
+                     { jjCheckNAdd(115); }
                   break;
-               case 115:
+               case 116:
+                  if ((0x7fffffe87fffffeL & l) == 0L)
+                     break;
+                  if (kind > 81)
+                     kind = 81;
+                  { jjCheckNAddStates(46, 50); }
+                  break;
+               case 117:
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAddStates(46, 50); }
+                  break;
+               case 118:
                   if ((0x7fffffe87fffffeL & l) != 0L && kind > 81)
                      kind = 81;
                   break;
-               case 116:
-                  if (curChar == 92)
-                     { jjAddStates(91, 92); }
-                  break;
-               case 117:
-                  if ((0x4000000080000001L & l) != 0L)
-                     { jjCheckNAddStates(43, 46); }
-                  break;
-               case 119:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 120;
-                  break;
-               case 120:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(43, 46); }
-                  break;
                case 121:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 122;
+                  if (curChar == 92)
+                     { jjAddStates(103, 104); }
                   break;
                case 122:
-                  if ((0x7e0000007eL & l) != 0L && kind > 81)
-                     kind = 81;
-                  break;
-               case 123:
-                  if ((0x4000000080000001L & l) != 0L && kind > 81)
-                     kind = 81;
+                  if ((0x4000000080000001L & l) != 0L)
+                     { jjCheckNAddStates(46, 50); }
                   break;
                case 124:
-                  if (curChar == 92)
+                  if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 125;
                   break;
                case 125:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(46, 50); }
+                  break;
+               case 126:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 127;
+                  break;
+               case 127:
+                  if ((0x7e0000007eL & l) != 0L && kind > 81)
+                     kind = 81;
+                  break;
+               case 128:
+                  if ((0x4000000080000001L & l) != 0L && kind > 81)
+                     kind = 81;
+                  break;
+               case 130:
+                  if (curChar == 92)
+                     jjstateSet[jjnewStateCnt++] = 131;
+                  break;
+               case 131:
                   if ((0x4000000080000001L & l) == 0L)
                      break;
                   if (kind > 81)
                      kind = 81;
-                  { jjCheckNAddStates(43, 46); }
+                  { jjCheckNAddStates(46, 50); }
                   break;
-               case 127:
+               case 133:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 128;
+                     jjstateSet[jjnewStateCnt++] = 134;
                   break;
-               case 128:
+               case 134:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 81)
                      kind = 81;
-                  { jjCheckNAddStates(43, 46); }
+                  { jjCheckNAddStates(46, 50); }
                   break;
-               case 130:
+               case 144:
                   if (curChar == 64)
-                     { jjCheckNAddStates(72, 76); }
+                     { jjCheckNAddStates(82, 88); }
                   break;
-               case 131:
+               case 145:
                   if ((0x7fffffe07fffffeL & l) != 0L)
-                     { jjCheckNAddStates(93, 95); }
+                     { jjCheckNAddStates(105, 108); }
                   break;
-               case 132:
+               case 146:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(132, 133); }
+                     { jjCheckNAddStates(53, 55); }
                   break;
-               case 133:
+               case 147:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAdd(134); }
+                     { jjCheckNAdd(148); }
                   break;
-               case 135:
+               case 154:
                   if ((0x7fffffe07fffffeL & l) != 0L)
-                     { jjCheckNAddStates(96, 98); }
+                     { jjCheckNAddStates(109, 112); }
                   break;
-               case 136:
+               case 155:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(136, 137); }
+                     { jjCheckNAddStates(56, 58); }
                   break;
-               case 137:
+               case 156:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAdd(138); }
+                     { jjCheckNAdd(157); }
                   break;
-               case 139:
+               case 158:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
                   if (kind > 83)
                      kind = 83;
-                  { jjCheckNAddStates(56, 59); }
+                  { jjCheckNAddStates(63, 67); }
                   break;
-               case 140:
+               case 159:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddStates(56, 59); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
-               case 141:
+               case 160:
                   if ((0x7fffffe87fffffeL & l) != 0L && kind > 83)
                      kind = 83;
                   break;
-               case 142:
+               case 163:
                   if (curChar == 92)
-                     { jjAddStates(99, 100); }
+                     { jjAddStates(113, 114); }
                   break;
-               case 143:
+               case 164:
                   if ((0x4000000080000001L & l) != 0L)
-                     { jjCheckNAddStates(56, 59); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
-               case 145:
+               case 166:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 146;
+                     jjstateSet[jjnewStateCnt++] = 167;
                   break;
-               case 146:
+               case 167:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(56, 59); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
-               case 147:
+               case 168:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 148;
+                     jjstateSet[jjnewStateCnt++] = 169;
                   break;
-               case 148:
+               case 169:
                   if ((0x7e0000007eL & l) != 0L && kind > 83)
                      kind = 83;
                   break;
-               case 149:
+               case 170:
                   if ((0x4000000080000001L & l) != 0L && kind > 83)
                      kind = 83;
                   break;
-               case 150:
+               case 172:
                   if (curChar == 92)
-                     jjstateSet[jjnewStateCnt++] = 151;
+                     jjstateSet[jjnewStateCnt++] = 173;
                   break;
-               case 151:
+               case 173:
                   if ((0x4000000080000001L & l) == 0L)
                      break;
                   if (kind > 83)
                      kind = 83;
-                  { jjCheckNAddStates(56, 59); }
+                  { jjCheckNAddStates(63, 67); }
                   break;
-               case 153:
+               case 175:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 154;
+                     jjstateSet[jjnewStateCnt++] = 176;
                   break;
-               case 154:
+               case 176:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
                   if (kind > 83)
                      kind = 83;
-                  { jjCheckNAddStates(56, 59); }
+                  { jjCheckNAddStates(63, 67); }
                   break;
-               case 155:
+               case 184:
                   if ((0x7fffffe07fffffeL & l) == 0L)
                      break;
                   if (kind > 99)
                      kind = 99;
-                  { jjCheckNAddTwoStates(155, 156); }
+                  { jjCheckNAddTwoStates(184, 185); }
                   break;
-               case 157:
+               case 186:
                   if ((0x7fffffe07fffffeL & l) == 0L)
                      break;
                   if (kind > 99)
                      kind = 99;
-                  { jjCheckNAddTwoStates(156, 157); }
+                  { jjCheckNAddTwoStates(185, 186); }
                   break;
-               case 165:
+               case 194:
                   if ((0x2000000020L & l) != 0L)
-                     { jjAddStates(101, 102); }
+                     { jjAddStates(115, 116); }
                   break;
-               case 172:
+               case 201:
                   if ((0x2000000020L & l) != 0L)
-                     { jjAddStates(103, 104); }
+                     { jjAddStates(117, 118); }
                   break;
-               case 176:
+               case 205:
                   if ((0x2000000020L & l) != 0L)
-                     { jjAddStates(105, 106); }
+                     { jjAddStates(119, 120); }
                   break;
                default : break;
             }
@@ -2560,104 +2566,232 @@ private int jjMoveNfa_0(int startState, int curPos)
             {
                case 0:
                   if (jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(66, 71); }
+                     { jjCheckNAddStates(74, 81); }
+                  if (jjCanMove_14(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(121, 122); }
                   break;
                case 1:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 52)
                      kind = 52;
-                  { jjAddStates(18, 20); }
+                  { jjAddStates(19, 21); }
                   break;
                case 6:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(15, 17); }
+                     { jjAddStates(16, 18); }
                   break;
                case 23:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(24, 26); }
+                     { jjAddStates(25, 27); }
                   break;
                case 41:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(21, 23); }
+                     { jjAddStates(22, 24); }
                   break;
                case 60:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(27, 30); }
+                     { jjAddStates(28, 31); }
                   break;
                case 84:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(33, 36); }
+                     { jjAddStates(34, 37); }
+                  break;
+               case 106:
+                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(74, 81); }
                   break;
                case 107:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(107, 108); }
+                     { jjCheckNAddStates(40, 42); }
                   break;
                case 108:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
                      { jjCheckNAdd(109); }
                   break;
                case 110:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(110, 111); }
+                  if (jjCanMove_3(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(123, 124); }
                   break;
                case 111:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAdd(112); }
+                  if (jjCanMove_4(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(40, 42); }
+                  break;
+               case 112:
+                  if (jjCanMove_5(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(109); }
                   break;
                case 113:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(43, 45); }
+                  break;
+               case 114:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(115); }
+                  break;
+               case 116:
                   if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 81)
                      kind = 81;
-                  { jjCheckNAddStates(43, 46); }
+                  { jjCheckNAddStates(46, 50); }
                   break;
-               case 114:
+               case 117:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(43, 46); }
+                     { jjCheckNAddStates(46, 50); }
                   break;
-               case 115:
+               case 118:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 81)
                      kind = 81;
                   break;
-               case 131:
-                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(93, 95); }
+               case 119:
+                  if (jjCanMove_6(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(125, 126); }
                   break;
-               case 132:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(132, 133); }
+               case 120:
+                  if (jjCanMove_7(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(46, 50); }
                   break;
-               case 133:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAdd(134); }
+               case 129:
+                  if (jjCanMove_8(hiByte, i1, i2, l1, l2) && kind > 81)
+                     kind = 81;
                   break;
                case 135:
-                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(96, 98); }
+                  if (jjCanMove_9(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 136;
                   break;
                case 136:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(136, 137); }
+                  if (!jjCanMove_10(hiByte, i1, i2, l1, l2))
+                     break;
+                  if (kind > 81)
+                     kind = 81;
+                  { jjCheckNAddStates(46, 50); }
                   break;
                case 137:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAdd(138); }
+                  if (jjCanMove_11(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(127, 128); }
+                  break;
+               case 138:
+                  if (jjCanMove_12(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(43, 45); }
                   break;
                case 139:
+                  if (jjCanMove_13(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(115); }
+                  break;
+               case 140:
+                  if (jjCanMove_14(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(121, 122); }
+                  break;
+               case 141:
+                  if (jjCanMove_15(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(129, 132); }
+                  break;
+               case 142:
+                  if (jjCanMove_16(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(133, 136); }
+                  break;
+               case 145:
+                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(105, 108); }
+                  break;
+               case 146:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(53, 55); }
+                  break;
+               case 147:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(148); }
+                  break;
+               case 149:
+                  if (jjCanMove_17(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(137, 138); }
+                  break;
+               case 150:
+                  if (jjCanMove_18(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(53, 55); }
+                  break;
+               case 151:
+                  if (jjCanMove_19(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(148); }
+                  break;
+               case 152:
+                  if (jjCanMove_20(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 153;
+                  break;
+               case 153:
+                  if (jjCanMove_21(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(105, 108); }
+                  break;
+               case 154:
+                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(109, 112); }
+                  break;
+               case 155:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(56, 58); }
+                  break;
+               case 156:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(157); }
+                  break;
+               case 158:
                   if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 83)
                      kind = 83;
-                  { jjCheckNAddStates(56, 59); }
+                  { jjCheckNAddStates(63, 67); }
                   break;
-               case 140:
+               case 159:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(56, 59); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
-               case 141:
+               case 160:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 83)
                      kind = 83;
+                  break;
+               case 161:
+                  if (jjCanMove_22(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(139, 140); }
+                  break;
+               case 162:
+                  if (jjCanMove_23(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(63, 67); }
+                  break;
+               case 171:
+                  if (jjCanMove_24(hiByte, i1, i2, l1, l2) && kind > 83)
+                     kind = 83;
+                  break;
+               case 177:
+                  if (jjCanMove_25(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 178;
+                  break;
+               case 178:
+                  if (!jjCanMove_26(hiByte, i1, i2, l1, l2))
+                     break;
+                  if (kind > 83)
+                     kind = 83;
+                  { jjCheckNAddStates(63, 67); }
+                  break;
+               case 179:
+                  if (jjCanMove_27(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(141, 142); }
+                  break;
+               case 180:
+                  if (jjCanMove_28(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(56, 58); }
+                  break;
+               case 181:
+                  if (jjCanMove_29(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(157); }
+                  break;
+               case 182:
+                  if (jjCanMove_30(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 183;
+                  break;
+               case 183:
+                  if (jjCanMove_31(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(109, 112); }
                   break;
                default : if (i1 == 0 || l1 == 0 || i2 == 0 ||  l2 == 0) break; else break;
             }
@@ -2670,7 +2804,7 @@ private int jjMoveNfa_0(int startState, int curPos)
          kind = 0x7fffffff;
       }
       ++curPos;
-      if ((i = jjnewStateCnt) == (startsAt = 181 - (jjnewStateCnt = startsAt)))
+      if ((i = jjnewStateCnt) == (startsAt = 210 - (jjnewStateCnt = startsAt)))
          break;
       try { curChar = input_stream.readChar(); }
       catch(java.io.IOException e) { break; }
@@ -2696,13 +2830,15 @@ private int jjMoveNfa_0(int startState, int curPos)
    return toRet;
 }
 static final int[] jjnextStates = {
-   159, 160, 161, 169, 170, 175, 176, 159, 160, 161, 163, 168, 113, 124, 126, 6, 
-   7, 8, 1, 2, 4, 41, 42, 43, 23, 24, 25, 59, 60, 61, 63, 62, 
-   79, 83, 84, 85, 87, 86, 103, 107, 108, 110, 111, 114, 115, 116, 118, 119, 
-   121, 132, 133, 136, 137, 139, 150, 152, 140, 141, 142, 144, 145, 147, 169, 170, 
-   175, 176, 107, 108, 109, 110, 111, 112, 131, 134, 135, 138, 155, 9, 18, 26, 
-   27, 36, 44, 45, 54, 64, 65, 74, 88, 89, 98, 117, 123, 132, 133, 134, 
-   136, 137, 138, 143, 149, 166, 167, 173, 174, 177, 178, 
+   188, 189, 190, 198, 199, 204, 205, 188, 189, 190, 192, 197, 116, 130, 132, 135, 
+   6, 7, 8, 1, 2, 4, 41, 42, 43, 23, 24, 25, 59, 60, 61, 63, 
+   62, 79, 83, 84, 85, 87, 86, 103, 107, 108, 110, 113, 114, 137, 117, 118, 
+   119, 121, 123, 124, 126, 146, 147, 149, 155, 156, 179, 158, 172, 174, 177, 159, 
+   160, 161, 163, 165, 166, 168, 198, 199, 204, 205, 107, 108, 109, 113, 114, 115, 
+   137, 110, 145, 152, 148, 154, 182, 157, 184, 9, 18, 26, 27, 36, 44, 45, 
+   54, 64, 65, 74, 88, 89, 98, 122, 128, 146, 147, 148, 149, 155, 156, 157, 
+   179, 164, 170, 195, 196, 202, 203, 206, 207, 141, 142, 111, 112, 120, 129, 138, 
+   139, 107, 108, 109, 110, 113, 114, 115, 137, 150, 151, 162, 171, 180, 181, 
 };
 private static final boolean jjCanMove_0(int hiByte, int i1, int i2, long l1, long l2)
 {
@@ -2764,6 +2900,296 @@ private static final boolean jjCanMove_2(int hiByte, int i1, int i2, long l1, lo
          return false;
    }
 }
+private static final boolean jjCanMove_3(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_4(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_5(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_6(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_7(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_8(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_9(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_10(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_11(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_12(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_13(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_14(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_15(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_16(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_17(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_18(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_19(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_20(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_21(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_22(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_23(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_24(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_25(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_26(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_27(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_28(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_29(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_30(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_31(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
 
 /** Token literal values. */
 public static final String[] jjstrLiteralImages = {
@@ -2791,7 +3217,7 @@ null, null, null, null, "\ufeff", null, null, null, null, null, null, null, null
 "\53", "\55", "\174", "\100", "\136", "\56", "\41", "\77", "\57", "\52", "\75", 
 "\50", "\51", "\173", "\175", "\133", "\135", null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
-null, null, null, null, null, null, null, null, null, null, null, null, null, };
+null, null, null, null, null, null, null, null, null, null, null, null, null, null, };
 protected Token jjFillToken()
 {
    final Token t;
@@ -2953,7 +3379,7 @@ private void jjCheckNAddStates(int start, int end)
   {
     int i;
     jjround = 0x80000001;
-    for (i = 181; i-- > 0;)
+    for (i = 210; i-- > 0;)
       jjrounds[i] = 0x80000000;
   }
 
@@ -2988,8 +3414,8 @@ static final long[] jjtoSpecial = {
 };
     protected SimpleCharStream  input_stream;
 
-    private final int[] jjrounds = new int[181];
-    private final int[] jjstateSet = new int[2 * 181];
+    private final int[] jjrounds = new int[210];
+    private final int[] jjstateSet = new int[2 * 210];
 
     
     protected char curChar;

--- a/jena-shex/shexc/README
+++ b/jena-shex/shexc/README
@@ -16,3 +16,4 @@ and cleans up the output files to remove or surpress Java warnings.
 
 The generated javacc java is checked into git so you don't need to install
 javacc to build this module unless you want to change the parser.
+ 

--- a/jena-shex/shexc/shex.jj
+++ b/jena-shex/shexc/shex.jj
@@ -412,17 +412,10 @@ TripleExpression tripleExpression() : { int idx; }
 
 void tripleExpressionClause() : { int idx; } {
    { idx = startTripleExpressionClause(); }
+   // One of the rules below.
    tripleExpressionClause_1()
    { finishTripleExpressionClause(idx); }
 }
-
-// // Can end in single ";"
-// void tripleExpressionClause_0() : {}
-// {
-//     unaryTripleExpr()
-// // Allows ";;;"
-//     (<SEMI_COLON> ( unaryTripleExpr() )?)*
-// }
 
 // Iterative, but needs LOOKAHEAD(2)
 void tripleExpressionClause_1() : { }

--- a/jena-shex/shexc/shex.jj
+++ b/jena-shex/shexc/shex.jj
@@ -258,10 +258,10 @@ void litNodeConstraint() : { String str; Token t; int idx; } {
   { idx = startLiteralNodeConstraint(token.beginLine, token.beginColumn); }
   (
     t = <LITERAL>
-    { cNodeKind(t.image, t.beginLine, t.beginColumn); }
+    { constraintNodeKind(t.image, t.beginLine, t.beginColumn); }
     (xsFacet())*
   | str = datatype()
-    { cDatatype(str, token.beginLine, token.beginColumn); }
+    { constraintDatatype(str, token.beginLine, token.beginColumn); }
     (xsFacet())*
   | valueSet()
     (xsFacet())*
@@ -283,7 +283,7 @@ void nonLitNodeConstraint() : { int idx; } {
 void nonLiteralKind() : { Token t; }
 {
     ( t = <IRI> | t = <BNODE> | t = <NONLITERAL> )
-    { cNodeKind(t.image, t.beginLine, t.beginColumn); }
+    { constraintNodeKind(t.image, t.beginLine, t.beginColumn); }
 }
 
 void xsFacet() : { }
@@ -334,8 +334,7 @@ String numericLength() : { Token t; }
 
 // "{ ... }"
 void shapeDefinition() :
-{ boolean closed = false ;
-  TripleExpression tripleExpr = null;
+{ boolean closed = false; TripleExpression tripleExpr = null;
   List<Node> extras = new ArrayList<Node>();
 }
 {

--- a/jena-shex/shexc/shex.jj
+++ b/jena-shex/shexc/shex.jj
@@ -1054,14 +1054,16 @@ TOKEN [IGNORE_CASE] :
 | <LANGTAG: <AT> (<A2Z>)+("-" (<A2ZN>)+)* >
 | <#A2Z: ["a"-"z","A"-"Z"]>
 | <#A2ZN: ["a"-"z","A"-"Z","0"-"9"]>
+| <#SURROGATE_PAIR: ["\uD800"-"\uDBFF"] ["\uDC00"-"\uDFFF"] >
 | <#PN_CHARS_BASE:
           ["A"-"Z"] | ["a"-"z"] |
           ["\u00C0"-"\u00D6"] | ["\u00D8"-"\u00F6"] | ["\u00F8"-"\u02FF"] |
           ["\u0370"-"\u037D"] | ["\u037F"-"\u1FFF"] |
           ["\u200C"-"\u200D"] | ["\u2070"-"\u218F"] | ["\u2C00"-"\u2FEF"] |
           ["\u3001"-"\uD7FF"] | ["\uF900"-"\uFFFD"] 
-          >
           // [#x10000-#xEFFFF]
+          | <SURROGATE_PAIR>
+          >
 |
   // With underscore
   <#PN_CHARS_U: <PN_CHARS_BASE> | "_" >

--- a/jena-shex/src/main/java/org/apache/jena/shex/ShexSchema.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/ShexSchema.java
@@ -142,7 +142,7 @@ public class ShexSchema {
                 mergeOne(importedSchema, mergedShapes, mergedShapeMap, mergedTripleRefs);
             }
             // Does not include the start shape.
-            // The "get" operation of a ShexSchem know about "start"
+            // The "get" operation of a ShexScheme knows about "start"
 //            if ( this.startShape != null )
 //                mergedShapeMap.put(SysShex.startNode, startShape);
             shapesWithImports = new ShexSchema(sourceURI, baseURI, prefixes,

--- a/jena-shex/src/main/java/org/apache/jena/shex/ShexSchema.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/ShexSchema.java
@@ -48,10 +48,10 @@ public class ShexSchema {
         shapes = new ArrayList<>(shapes);
         Map<Node, ShexShape> shapeMap = new LinkedHashMap<>();
         for ( ShexShape shape:  shapes) {
-        if ( shape.getLabel() == null )
-            System.err.println("No shape label");
-        else
-            shapeMap.put(shape.getLabel(), shape);
+            if ( shape.getLabel() == null )
+                System.err.println("No shape label");
+            else
+                shapeMap.put(shape.getLabel(), shape);
         }
 
         tripleRefs = new LinkedHashMap<>(tripleRefs);
@@ -152,7 +152,8 @@ public class ShexSchema {
         }
     }
 
-    /** Merge a schema into the accumulators.
+    /**
+     * Merge a schema into the accumulators.
      * Any start node is skipped.
      */
     private static void mergeOne(ShexSchema schema,
@@ -192,4 +193,22 @@ public class ShexSchema {
     }
 
     public PrefixMap getPrefixMap() { return prefixes; }
+
+
+    // .equals on imports, shapMap, shapes, and startShape.
+    /**
+     * Equivalence: same shapes (.equals), same imports, same label to shapes map.
+     */
+    public boolean sameAs(Object obj) {
+        if ( this == obj )
+            return true;
+        if ( obj == null )
+            return false;
+        if ( getClass() != obj.getClass() )
+            return false;
+        ShexSchema other = (ShexSchema)obj;
+        return Objects.equals(imports, other.imports) &&
+               Objects.equals(shapeMap, other.shapeMap) &&
+               Objects.equals(startShape, other.startShape);
+    }
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/ShexShape.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/ShexShape.java
@@ -47,7 +47,6 @@ public class ShexShape {
     public boolean satisfies(ValidationContext vCxt, Node data) {
         vCxt.startValidate(this, data);
         try {
-            // [shex] ShexShape.validate?
             return shExpression.satisfies(vCxt, data);
         } finally {
             vCxt.finishValidate(this, data);
@@ -66,6 +65,37 @@ public class ShexShape {
         // Consolidate adjacent TripleConstraints.
         getShapeExpression().print(iOut, nFmt);
         iOut.decIndent();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((label == null) ? 0 : label.hashCode());
+        result = prime * result + ((shExpression == null) ? 0 : shExpression.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj )
+            return true;
+        if ( obj == null )
+            return false;
+        if ( getClass() != obj.getClass() )
+            return false;
+        ShexShape other = (ShexShape)obj;
+        if ( label == null ) {
+            if ( other.label != null )
+                return false;
+        } else if ( !label.equals(other.label) )
+            return false;
+        if ( shExpression == null ) {
+            if ( other.shExpression != null )
+                return false;
+        } else if ( !shExpression.equals(other.shExpression) )
+            return false;
+        return true;
     }
 
     @Override

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/DatatypeConstraint.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/DatatypeConstraint.java
@@ -32,7 +32,7 @@ import org.apache.jena.shex.sys.ValidationContext;
 // ----
 import org.apache.jena.vocabulary.XSD;
 
-public class DatatypeConstraint extends NodeConstraint {
+public class DatatypeConstraint extends NodeConstraintComponent {
     private final Node datatype;
     private final String dtURI;
     private final RDFDatatype rdfDatatype;
@@ -97,7 +97,7 @@ public class DatatypeConstraint extends NodeConstraint {
     }
 
     @Override
-    public void visit(ShapeExprVisitor visitor) {
+    public void visit(NodeConstraintVisitor visitor) {
         visitor.visit(this);
     }
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/Facet.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/Facet.java
@@ -18,11 +18,6 @@
 
 package org.apache.jena.shex.expressions;
 
-public interface TripleExprVisitor {
-    public default void visit(TripleExprCardinality tripleExpr) {}
-    public default void visit(TripleExprEachOf tripleExpr) {}
-    public default void visit(TripleExprOneOf tripleExpr) {}
-    public default void visit(TripleExprNone tripleExpr) {}
-    public default void visit(TripleExprRef tripleExpr) {}
-    public default void visit(TripleConstraint tripleExpr) {}
+public interface Facet {
+
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraint.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraint.java
@@ -68,4 +68,34 @@ implements Satisfies, ShexPrintable
         }
         return true;
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((constraints == null) ? 0 : constraints.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj )
+            return true;
+        if ( obj == null )
+            return false;
+        if ( getClass() != obj.getClass() )
+            return false;
+        NodeConstraint other = (NodeConstraint)obj;
+        if ( constraints == null ) {
+            if ( other.constraints != null )
+                return false;
+        } else if ( !constraints.equals(other.constraints) )
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeConstraint [constraints=" + constraints + "]";
+    }
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraintComponent.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraintComponent.java
@@ -18,19 +18,14 @@
 
 package org.apache.jena.shex.expressions;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
+import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shex.sys.ReportItem;
 import org.apache.jena.shex.sys.ValidationContext;
 
-public class NodeConstraint
-//extends ShapeExpression
-implements Satisfies, ShexPrintable
-{
-
-    /*
+/** The elements making up
+    <pre>
     NodeConstraint  {
         id:shapeExprLabel?
         nodeKind:("iri" | "bnode" | "nonliteral" | "literal")?
@@ -38,34 +33,36 @@ implements Satisfies, ShexPrintable
         xsFacet*
         values:[valueSetValue+]?
     }
-     */
-
-
-    private List<NodeConstraintComponent> constraints = new ArrayList<>();
-
-    public NodeConstraint(List<NodeConstraintComponent> constraints) {
-        this.constraints = List.copyOf(constraints);
-    }
-
-    public List<NodeConstraintComponent> components() { return constraints; }
-
-    static class NodeConstraintBuilder {
-        NodeKindConstraint nodeKind;
-        DatatypeConstraint datatype = null;
-        List<NodeConstraint> facets = new ArrayList<>();
-        ValueConstraint values;
-    }
-
+    </pre>
+ */
+public abstract class NodeConstraintComponent implements Satisfies, ShexPrintable {
 
     @Override
     public boolean satisfies(ValidationContext vCxt, Node data) {
-        for ( NodeConstraintComponent ncc : constraints ) {
-            ReportItem item = ncc.nodeSatisfies(vCxt, data);
-            if ( item != null ) {
-                vCxt.reportEntry(item);
-                return false;
-            }
+        ReportItem item = nodeSatisfies(vCxt, data);
+        if ( item != null ) {
+            vCxt.reportEntry(item);
+            return false;
         }
         return true;
     }
+
+    /** The function "nodeSatisfies" == satisfies2(n, nc)*/
+    public abstract ReportItem nodeSatisfies(ValidationContext vCxt, Node data);
+
+    public abstract void visit(NodeConstraintVisitor visitor);
+
+    @Override
+    public void print(IndentedWriter out, NodeFormatter nFmt) {
+        out.println(toString());
+    }
+
+    @Override
+    public abstract int hashCode();
+
+    @Override
+    public abstract boolean equals(Object other);
+
+    @Override
+    public abstract String toString();
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraintDOT.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraintDOT.java
@@ -18,40 +18,45 @@
 
 package org.apache.jena.shex.expressions;
 
-import java.util.Locale;
+import org.apache.jena.graph.Node;
+import org.apache.jena.shex.sys.ReportItem;
+import org.apache.jena.shex.sys.ValidationContext;
 
-import org.apache.jena.shex.ShexException;
+public class NodeConstraintDOT extends NodeConstraintComponent
+{
+    //See ShapeExprTrue
 
-public enum NodeKind {
-    IRI("IRI"), BNODE("BNode"), NONLITERAL("NonLiteral"), LITERAL("Literal"), TRIPLE("Triple");
+    public NodeConstraintDOT() {}
 
-    private final String label;
-    private final String ucLabel;
-
-    NodeKind(String string) {
-        this.label = string;
-        this.ucLabel = string.toUpperCase(Locale.ROOT);
+    @Override
+    public int hashCode() {
+        // Fixed random number.
+        return 634032653;
     }
 
-    public static NodeKind create(String nodeKind) {
-        switch(nodeKind.toLowerCase()) {
-            case "iri":         return IRI;
-            case "bnode":       return BNODE;
-            case "literal":     return LITERAL;
-            case "nonliteral":  return NONLITERAL;
-            case "triple":      return TRIPLE;
-            default:
-                throw new ShexException("NodeKind not recognized: '"+nodeKind+"'");
-        }
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj )
+            return true;
+        if ( obj == null )
+            return false;
+        if ( getClass() != obj.getClass() )
+            return false;
+        return true;
     }
 
-    public String label() {
-        // Print label.
-        return ucLabel;
+    @Override
+    public ReportItem nodeSatisfies(ValidationContext vCxt, Node data) {
+        return null;
     }
 
     @Override
     public String toString() {
-        return label;
+        return ".";
+    }
+
+    @Override
+    public void visit(NodeConstraintVisitor visitor) {
+        visitor.visit(this);
     }
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraintVisitor.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraintVisitor.java
@@ -18,11 +18,21 @@
 
 package org.apache.jena.shex.expressions;
 
-public interface TripleExprVisitor {
-    public default void visit(TripleExprCardinality tripleExpr) {}
-    public default void visit(TripleExprEachOf tripleExpr) {}
-    public default void visit(TripleExprOneOf tripleExpr) {}
-    public default void visit(TripleExprNone tripleExpr) {}
-    public default void visit(TripleExprRef tripleExpr) {}
-    public default void visit(TripleConstraint tripleExpr) {}
+/** Visotr for NodeConstainComponents. */
+public interface NodeConstraintVisitor {
+
+    public default void visit(NodeConstraintDOT constraint) {}
+
+    public default void visit(NodeKindConstraint constraint) {}
+
+    public default void visit(DatatypeConstraint constraint) {}
+
+    public default void visit(NumLengthConstraint constraint) {}
+    public default void visit(NumRangeConstraint constraint) {}
+
+    public default void visit(StrRegexConstraint constraint) {}
+    public default void visit(StrLengthConstraint constraint) {}
+
+    public default void visit(ValueConstraint constraint) {}
+
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraintVisitor.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeConstraintVisitor.java
@@ -18,10 +18,8 @@
 
 package org.apache.jena.shex.expressions;
 
-/** Visotr for NodeConstainComponents. */
+/** Visitor for NodeConstainComponents. */
 public interface NodeConstraintVisitor {
-
-    public default void visit(NodeConstraintDOT constraint) {}
 
     public default void visit(NodeKindConstraint constraint) {}
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeKindConstraint.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/NodeKindConstraint.java
@@ -28,12 +28,14 @@ import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shex.sys.ReportItem;
 import org.apache.jena.shex.sys.ValidationContext;
 
-public class NodeKindConstraint extends NodeConstraint {
+public class NodeKindConstraint extends NodeConstraintComponent {
     private NodeKind nodeKind;
 
     public NodeKindConstraint(NodeKind nodeKind) {
         this.nodeKind = nodeKind;
     }
+
+    public NodeKind getNodeKind() { return nodeKind; }
 
     @Override
     public ReportItem nodeSatisfies(ValidationContext vCxt, Node n) {
@@ -70,7 +72,7 @@ public class NodeKindConstraint extends NodeConstraint {
     }
 
     @Override
-    public void visit(ShapeExprVisitor visitor) {
+    public void visit(NodeConstraintVisitor visitor) {
         visitor.visit(this);
     }
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/NumLengthConstraint.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/NumLengthConstraint.java
@@ -29,7 +29,7 @@ import org.apache.jena.shex.sys.ReportItem;
 import org.apache.jena.shex.sys.ShexLib;
 import org.apache.jena.shex.sys.ValidationContext;
 
-public class NumLengthConstraint extends NodeConstraint {
+public class NumLengthConstraint extends NodeConstraintComponent {
 
     private final NumLengthKind lengthType;
     private final int length;
@@ -38,6 +38,14 @@ public class NumLengthConstraint extends NodeConstraint {
         Objects.requireNonNull(lengthType);
         this.lengthType = lengthType;
         this.length = len;
+    }
+
+    public NumLengthKind getLengthType() {
+        return lengthType;
+    }
+
+    public int getLength() {
+        return length;
     }
 
     @Override
@@ -120,7 +128,7 @@ public class NumLengthConstraint extends NodeConstraint {
     }
 
     @Override
-    public void visit(ShapeExprVisitor visitor) {
+    public void visit(NodeConstraintVisitor visitor) {
         visitor.visit(this);
     }
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/NumRangeConstraint.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/NumRangeConstraint.java
@@ -29,7 +29,7 @@ import org.apache.jena.shex.sys.ReportItem;
 import org.apache.jena.shex.sys.ValidationContext;
 import org.apache.jena.sparql.expr.NodeValue;
 
-public class NumRangeConstraint extends NodeConstraint {
+public class NumRangeConstraint extends NodeConstraintComponent {
 
     private final NumRangeKind rangeKind;
     private final Node value;
@@ -43,6 +43,18 @@ public class NumRangeConstraint extends NodeConstraint {
         if ( ! nv.isNumber() )
             throw new ShexException("Not a number: "+value);
         this.numericValue = nv;
+    }
+
+    public NumRangeKind getRangeKind() {
+        return rangeKind;
+    }
+
+    public Node getValue() {
+        return value;
+    }
+
+    public NodeValue getNumericValue() {
+        return numericValue;
     }
 
     @Override
@@ -73,7 +85,7 @@ public class NumRangeConstraint extends NodeConstraint {
     }
 
     @Override
-    public void visit(ShapeExprVisitor visitor) {
+    public void visit(NodeConstraintVisitor visitor) {
         visitor.visit(this);
     }
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/Satisfies.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/Satisfies.java
@@ -18,11 +18,11 @@
 
 package org.apache.jena.shex.expressions;
 
-public interface TripleExprVisitor {
-    public default void visit(TripleExprCardinality tripleExpr) {}
-    public default void visit(TripleExprEachOf tripleExpr) {}
-    public default void visit(TripleExprOneOf tripleExpr) {}
-    public default void visit(TripleExprNone tripleExpr) {}
-    public default void visit(TripleExprRef tripleExpr) {}
-    public default void visit(TripleConstraint tripleExpr) {}
+import org.apache.jena.graph.Node;
+import org.apache.jena.shex.sys.ValidationContext;
+
+/** The "satisfies" realtionship. */
+public interface Satisfies {
+    /** The "satisfies" function. Return true for OK, false for not OK. */
+    public boolean satisfies(ValidationContext vCxt, Node data);
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeElement.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeElement.java
@@ -18,11 +18,4 @@
 
 package org.apache.jena.shex.expressions;
 
-public interface TripleExprVisitor {
-    public default void visit(TripleExprCardinality tripleExpr) {}
-    public default void visit(TripleExprEachOf tripleExpr) {}
-    public default void visit(TripleExprOneOf tripleExpr) {}
-    public default void visit(TripleExprNone tripleExpr) {}
-    public default void visit(TripleExprRef tripleExpr) {}
-    public default void visit(TripleConstraint tripleExpr) {}
-}
+public interface ShapeElement extends Satisfies, ShexPrintable {}

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprAtom.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprAtom.java
@@ -25,32 +25,16 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shex.sys.ValidationContext;
 
-/** A node constraint (nonLitNodeConstraint or litNodeConstraint) in a shape atom.
-<pre>
-ShapeAtom := ( nonLitNodeConstraint ( inlineShapeOrRef )?
-             | litNodeConstraint
-             | inlineShapeOrRef ( nonLitNodeConstraint )?
-             | <LPAREN> shapeExpression <RPAREN>
-             | <DOT>
-             )
-</pre>
-*/
-public class ShapeNodeConstraint extends ShapeExpression {
+/** ShapeAtom - element of the ShEx abstract syntax. */
+public class ShapeExprAtom extends ShapeExpression {
 
-    private final NodeConstraint nodeConstraint;
+    private final ShapeExpression other;
 
-    public ShapeNodeConstraint(NodeConstraint nodeConstraint) {
-        this(null, Objects.requireNonNull(nodeConstraint, "NodeConstraint"));
+    public ShapeExprAtom(ShapeExpression other) {
+        this.other = other;
     }
 
-    private ShapeNodeConstraint(ShapeExpression shapeExpression, NodeConstraint nodeConstraint) {
-        this.nodeConstraint = nodeConstraint;
-
-    }
-
-    public NodeConstraint getNodeConstraint() {
-        return nodeConstraint;
-    }
+    public ShapeExpression getShape() { return other; }
 
     @Override
     public void print(IndentedWriter out, NodeFormatter nFmt) {
@@ -59,7 +43,7 @@ public class ShapeNodeConstraint extends ShapeExpression {
 
     @Override
     public boolean satisfies(ValidationContext vCxt, Node data) {
-        return nodeConstraint.satisfies(vCxt, data);
+        return true;
     }
 
     @Override
@@ -69,7 +53,7 @@ public class ShapeNodeConstraint extends ShapeExpression {
 
     @Override
     public int hashCode() {
-        return 1+Objects.hash(nodeConstraint);
+        return Objects.hash(other);
     }
 
     @Override
@@ -80,14 +64,10 @@ public class ShapeNodeConstraint extends ShapeExpression {
             return false;
         if ( getClass() != obj.getClass() )
             return false;
-        ShapeNodeConstraint other = (ShapeNodeConstraint)obj;
-        return Objects.equals(nodeConstraint, other.nodeConstraint);
+        ShapeExprAtom other = (ShapeExprAtom)obj;
+        return Objects.equals(this.other, other.other);
     }
 
     @Override
-    public String toString() {
-        if ( nodeConstraint != null )
-            return "ShapeNodeConstraint [ "+nodeConstraint+" ]";
-        return "ShapeNodeConstraint []";
-    }
+    public String toString() { return "ShapeExprAtom[ "+other+" ]"; }
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprDot.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprDot.java
@@ -18,20 +18,37 @@
 
 package org.apache.jena.shex.expressions;
 
+import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
-import org.apache.jena.shex.sys.ReportItem;
+import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shex.sys.ValidationContext;
 
-public class NodeConstraintDOT extends NodeConstraintComponent
-{
-    //See ShapeExprTrue
+/** A DOT expression -- "{ . }"  */
+public class ShapeExprDot extends ShapeExpression {
 
-    public NodeConstraintDOT() {}
+    public ShapeExprDot() {}
+
+    @Override
+    public void print(IndentedWriter out, NodeFormatter nFmt) {
+        out.println(" .");
+    }
+
+    @Override
+    public boolean satisfies(ValidationContext vCxt, Node data) {
+        return true;
+    }
+
+    @Override
+    public void visit(ShapeExprVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String toString() { return "ShapeExprDot"; }
 
     @Override
     public int hashCode() {
-        // Fixed random number.
-        return 634032653;
+        return ShexConst.hashShExprDot;
     }
 
     @Override
@@ -43,20 +60,5 @@ public class NodeConstraintDOT extends NodeConstraintComponent
         if ( getClass() != obj.getClass() )
             return false;
         return true;
-    }
-
-    @Override
-    public ReportItem nodeSatisfies(ValidationContext vCxt, Node data) {
-        return null;
-    }
-
-    @Override
-    public String toString() {
-        return ".";
-    }
-
-    @Override
-    public void visit(NodeConstraintVisitor visitor) {
-        visitor.visit(this);
     }
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprTripleExpr.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprTripleExpr.java
@@ -64,6 +64,18 @@ public class ShapeExprTripleExpr extends ShapeExpression {
 
     public TripleExpression getTripleExpr() { return tripleExpr; }
 
+    public Node getLabel() {
+        return label;
+    }
+
+    public Set<Node> getExtras() {
+        return extras;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+
     @Override
     public boolean satisfies(ValidationContext vCxt, Node node) {
         // Pass extras

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprTrue.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprTrue.java
@@ -44,7 +44,7 @@ public class ShapeExprTrue extends ShapeExpression {
     }
 
     @Override
-    public String toString() { return "ShapeExprNoOp"; }
+    public String toString() { return "ShapeExprTrue"; }
 
     @Override
     public int hashCode() {

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprTrue.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprTrue.java
@@ -23,10 +23,13 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.shex.sys.ValidationContext;
 
-/** A shape expression that is always true. For example "{ . }"  */
+/**
+ *  A shape expression that is always true.
+ *  This is not a syntax element (see ShapeExprDOT).
+ */
 public class ShapeExprTrue extends ShapeExpression {
 
-    public ShapeExprTrue() {}
+    public ShapeExprTrue(int x) {}
 
     @Override
     public void print(IndentedWriter out, NodeFormatter nFmt) {

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprVisitor.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprVisitor.java
@@ -18,16 +18,19 @@
 
 package org.apache.jena.shex.expressions;
 
-public interface ShapeExprVisitor extends NodeConstraintVisitor
+public interface ShapeExprVisitor //extends NodeConstraintVisitor
 {
     public default void visit(ShapeExprAND shape) {}
     public default void visit(ShapeExprOR shape) {}
     public default void visit(ShapeExprNOT shape) {}
-    public default void visit(ShapeExprFalse shape) {}
+    public default void visit(ShapeExprDot shape) {}
+    public default void visit(ShapeExprAtom shape) {}
     public default void visit(ShapeExprNone shape) {}
     public default void visit(ShapeExprRef shape) {}
-    public default void visit(ShapeExprTrue shape) {}
     public default void visit(ShapeExprExternal shape) {}
     public default void visit(ShapeExprTripleExpr shape) {}
     public default void visit(ShapeNodeConstraint shape) {}
+
+    public default void visit(ShapeExprTrue shape) {}
+    public default void visit(ShapeExprFalse shape) {}
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprVisitor.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprVisitor.java
@@ -18,7 +18,8 @@
 
 package org.apache.jena.shex.expressions;
 
-public interface ShapeExprVisitor {
+public interface ShapeExprVisitor extends NodeConstraintVisitor
+{
     public default void visit(ShapeExprAND shape) {}
     public default void visit(ShapeExprOR shape) {}
     public default void visit(ShapeExprNOT shape) {}
@@ -28,12 +29,5 @@ public interface ShapeExprVisitor {
     public default void visit(ShapeExprTrue shape) {}
     public default void visit(ShapeExprExternal shape) {}
     public default void visit(ShapeExprTripleExpr shape) {}
-
-    public default void visit(StrRegexConstraint constraint) {}
-    public default void visit(StrLengthConstraint constraint) {}
-    public default void visit(DatatypeConstraint constraint) {}
-    public default void visit(NodeKindConstraint constraint) {}
-    public default void visit(NumLengthConstraint constraint) {}
-    public default void visit(NumRangeConstraint constraint) {}
-    public default void visit(ValueConstraint constraint) {}
+    public default void visit(ShapeNodeConstraint shape) {}
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprWalker.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExprWalker.java
@@ -23,16 +23,24 @@ public class ShapeExprWalker implements ShapeExprVisitor {
     private final ShapeExprVisitor beforeVisitor;
     private final ShapeExprVisitor afterVisitor;
     private final TripleExprVisitor tripleExprWalker;
+    private NodeConstraintVisitor nodeConstraintVisitor;
 
 //    public ShapeExpressionWalker(ShapeExpressionVisitor beforeVisitor, ShapeExpressionVisitor afterVisitor) {
 //        this(beforeVisitor, afterVisitor, null, null);
 //    }
 
     public ShapeExprWalker(ShapeExprVisitor beforeVisitor, ShapeExprVisitor afterVisitor,
-                                 TripleExprVisitor beforeTripleExprVisitor, TripleExprVisitor afterTripleExprVisitor) {
+                           TripleExprVisitor beforeTripleExprVisitor, TripleExprVisitor afterTripleExprVisitor,
+                           NodeConstraintVisitor nodeConstraintVisitor
+                           // NodeConstraintVisitor beforeNodeConstraintVisitor,
+                           //, NodeConstraintVisitor afterNodeConstraintVisitor
+                           ) {
         this.beforeVisitor = beforeVisitor;
         this.afterVisitor = afterVisitor;
+        // Walker because TripleExpr can contain a ShapeExpression
         this.tripleExprWalker = new TripleExprWalker(beforeTripleExprVisitor, afterTripleExprVisitor, this);
+        // XXX [NodeConstraint] - no recursion.
+        this.nodeConstraintVisitor = nodeConstraintVisitor;
     }
 
 
@@ -97,50 +105,16 @@ public class ShapeExprWalker implements ShapeExprVisitor {
     @Override
     public void visit(ShapeExprTripleExpr shape) {
         before(shape);
-        if ( shape.getTripleExpr() != null )
+        if ( tripleExprWalker != null && shape.getTripleExpr() != null )
             shape.getTripleExpr().visit(tripleExprWalker);
         after(shape);
     }
 
     @Override
-    public void visit(StrRegexConstraint constraint) {
-        before(constraint);
-        after(constraint);
-    }
-
-    @Override
-    public void visit(StrLengthConstraint constraint) {
-        before(constraint);
-        after(constraint);
-    }
-
-    @Override
-    public void visit(DatatypeConstraint constraint) {
-        before(constraint);
-        after(constraint);
-    }
-
-    @Override
-    public void visit(NodeKindConstraint constraint) {
-        before(constraint);
-        after(constraint);
-    }
-
-    @Override
-    public void visit(NumLengthConstraint constraint) {
-        before(constraint);
-        after(constraint);
-    }
-
-    @Override
-    public void visit(NumRangeConstraint constraint) {
-        before(constraint);
-        after(constraint);
-    }
-
-    @Override
-    public void visit(ValueConstraint constraint) {
-        before(constraint);
-        after(constraint);
+    public void visit(ShapeNodeConstraint shape) {
+        before(shape);
+        if ( nodeConstraintVisitor != null && shape.getNodeConstraint() != null )
+            shape.getNodeConstraint().components().forEach(ncc->ncc.visit(nodeConstraintVisitor));
+        after(shape);
     }
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExpression.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeExpression.java
@@ -18,44 +18,20 @@
 
 package org.apache.jena.shex.expressions;
 
-import org.apache.jena.atlas.io.IndentedLineBuffer;
 import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.out.NodeFormatter;
-import org.apache.jena.riot.out.NodeFormatterTTL;
-import org.apache.jena.riot.system.PrefixMap;
-import org.apache.jena.riot.system.PrefixMapFactory;
 import org.apache.jena.shex.sys.ValidationContext;
-import org.apache.jena.vocabulary.OWL;
-import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.RDFS;
-import org.apache.jena.vocabulary.XSD;
 
-public abstract class ShapeExpression {
+public abstract class ShapeExpression implements ShapeElement {
 
     public ShapeExpression() { }
 
-    /** The "satisfies" function. Return true for OK, false for not OK. */
+    @Override
     public abstract boolean satisfies(ValidationContext vCxt, Node data);
 
-    private static PrefixMap displayPrefixMap = PrefixMapFactory.createForOutput();
-    static {
-        displayPrefixMap.add("owl",  OWL.getURI());
-        displayPrefixMap.add("rdf",  RDF.getURI());
-        displayPrefixMap.add("rdfs", RDFS.getURI());
-        displayPrefixMap.add("xsd",  XSD.getURI());
-    }
-
-    public static NodeFormatter nodeFmtAbbrev = new NodeFormatterTTL(null, displayPrefixMap);
-
+    @Override
     public abstract void print(IndentedWriter out, NodeFormatter nFmt);
-
-    public String asString() {
-        IndentedLineBuffer x = new IndentedLineBuffer();
-        x.setFlatMode(true);
-        print(x, nodeFmtAbbrev);
-        return x.asString();
-    }
 
     public abstract void visit(ShapeExprVisitor visitor);
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShexConst.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShexConst.java
@@ -24,6 +24,7 @@ class ShexConst {
     static final int hashShExprFalse    = 61;
     static final int hashShExprNone     = 62;
     static final int hashShExprExternal = 63;
+    static final int hashShExprDot      = 64;
 
     static final int hashTripleExprNone     = 60;
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShexPrintOps.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShexPrintOps.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.shex.expressions;
+
+import org.apache.jena.atlas.io.IndentedLineBuffer;
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.riot.out.NodeFormatter;
+import org.apache.jena.riot.out.NodeFormatterTTL;
+import org.apache.jena.riot.system.PrefixMap;
+import org.apache.jena.riot.system.PrefixMapFactory;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.vocabulary.OWL;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.apache.jena.vocabulary.XSD;
+
+class ShexPrintOps {
+
+    private static PrefixMap displayPrefixMap = PrefixMapFactory.createForOutput();
+    static {
+        displayPrefixMap.add("owl",  OWL.getURI());
+        displayPrefixMap.add("rdf",  RDF.getURI());
+        displayPrefixMap.add("rdfs", RDFS.getURI());
+        displayPrefixMap.add("xsd",  XSD.getURI());
+    }
+
+    public static void print(ShexPrintable printable) {
+        IndentedWriter iOut = IndentedWriter.clone(IndentedWriter.stdout);
+        NodeFormatter nFmt = new NodeFormatterTTL(null, PrefixMapFactory.create(SSE.getPrefixMapRead()));
+        printable.print(iOut, nFmt);
+    }
+
+    public static NodeFormatter nodeFmtAbbrev = new NodeFormatterTTL(null, displayPrefixMap);
+
+    public static String asString(ShexPrintable printable) {
+        IndentedLineBuffer x = new IndentedLineBuffer();
+        x.setFlatMode(true);
+        printable.print(x, nodeFmtAbbrev);
+        return x.asString();
+    }
+
+}

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShexPrintable.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShexPrintable.java
@@ -21,19 +21,19 @@ package org.apache.jena.shex.expressions;
 import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.atlas.lib.NotImplemented;
 import org.apache.jena.riot.out.NodeFormatter;
-import org.apache.jena.riot.out.NodeFormatterTTL;
-import org.apache.jena.riot.system.PrefixMapFactory;
-import org.apache.jena.sparql.sse.SSE;
 
+/** Printable */
 public interface ShexPrintable {
 
     public default void print() {
-        IndentedWriter iOut = IndentedWriter.clone(IndentedWriter.stdout);
-        NodeFormatter nFmt = new NodeFormatterTTL(null, PrefixMapFactory.create(SSE.getPrefixMapRead()));
-        print(iOut, nFmt);
+        ShexPrintOps.print(this);
     }
 
     public default void print(IndentedWriter iOut, NodeFormatter nFmt) {
         throw new NotImplemented(this.getClass().getSimpleName().toString()+".print");
+    }
+
+    public default String asString() {
+        return ShexPrintOps.asString(this);
     }
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/StrLengthConstraint.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/StrLengthConstraint.java
@@ -28,7 +28,7 @@ import org.apache.jena.shex.sys.ShexLib;
 import org.apache.jena.shex.sys.ValidationContext;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
 
-public class StrLengthConstraint extends NodeConstraint {
+public class StrLengthConstraint extends NodeConstraintComponent {
 
     private final StrLengthKind lengthType;
     private final int length;
@@ -81,7 +81,7 @@ public class StrLengthConstraint extends NodeConstraint {
     }
 
     @Override
-    public void visit(ShapeExprVisitor visitor) {
+    public void visit(NodeConstraintVisitor visitor) {
         visitor.visit(this);
     }
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/StrRegexConstraint.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/StrRegexConstraint.java
@@ -33,7 +33,7 @@ import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
  *
  * This applies to literals and URI through the use of SPARQL str().
  */
-public class StrRegexConstraint extends NodeConstraint {
+public class StrRegexConstraint extends NodeConstraintComponent {
     //See SHACL PatternConstraint.
 
     private final Pattern pattern;
@@ -75,7 +75,7 @@ public class StrRegexConstraint extends NodeConstraint {
     }
 
     @Override
-    public void visit(ShapeExprVisitor visitor) {
+    public void visit(NodeConstraintVisitor visitor) {
         visitor.visit(this);
     }
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/TripleExprWalker.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/TripleExprWalker.java
@@ -24,8 +24,9 @@ public class TripleExprWalker implements TripleExprVisitor {
     private final TripleExprVisitor afterVisitor;
     private final ShapeExprVisitor shapeVisitor;
 
-    public TripleExprWalker(TripleExprVisitor beforeVisitor, TripleExprVisitor afterVisitor,
-                                  ShapeExprVisitor shapeVisitor) {
+    public TripleExprWalker(TripleExprVisitor beforeVisitor,
+                            TripleExprVisitor afterVisitor,
+                            ShapeExprVisitor shapeVisitor) {
         this.beforeVisitor = beforeVisitor;
         this.afterVisitor = afterVisitor;
         this.shapeVisitor = shapeVisitor;

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ValueConstraint.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ValueConstraint.java
@@ -20,6 +20,7 @@ package org.apache.jena.shex.expressions;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Node;
@@ -28,12 +29,16 @@ import org.apache.jena.shex.sys.ReportItem;
 import org.apache.jena.shex.sys.ShexLib;
 import org.apache.jena.shex.sys.ValidationContext;
 
-public class ValueConstraint extends NodeConstraint {
+public class ValueConstraint extends NodeConstraintComponent {
 
     private final List<ValueSetRange> valueSetRanges;
 
     public ValueConstraint(List<ValueSetRange> valueSetRanges) {
         this.valueSetRanges = valueSetRanges;
+    }
+
+    public void forEach(Consumer<ValueSetRange> action) {
+        valueSetRanges.forEach(action);
     }
 
     @Override
@@ -77,7 +82,7 @@ public class ValueConstraint extends NodeConstraint {
     }
 
     @Override
-    public void visit(ShapeExprVisitor visitor) {
+    public void visit(NodeConstraintVisitor visitor) {
         visitor.visit(this);
     }
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ValueSetItem.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ValueSetItem.java
@@ -31,6 +31,7 @@ public class ValueSetItem {
     String langStr;
     Node literal;
     boolean isStem;
+
     public ValueSetItem(String iriStr, String lang, Node literal, boolean isStem) {
         this.iriStr = iriStr;
         // [shex] In ValueSetRange :: ( item.langStr.isEmpty() ) ? "*" : item.langStr;
@@ -39,6 +40,14 @@ public class ValueSetItem {
         this.isStem = isStem;
         if ( literal != null && ! literal.isLiteral() )
             throw new ShexException("Not literal: "+ShexLib.displayStr(literal));
+    }
+
+    public boolean isStem() {
+        return isStem;
+    }
+
+    public boolean isEmpty() {
+        return iriStr == null && langStr == null && literal == null;
     }
 
     public void print(IndentedWriter out, NodeFormatter nFmt) {

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ValueSetItem.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ValueSetItem.java
@@ -42,10 +42,9 @@ public class ValueSetItem {
     }
 
     public void print(IndentedWriter out, NodeFormatter nFmt) {
-        if ( iriStr != null ) out.printf("<%s>", iriStr);
+        if ( iriStr != null ) nFmt.formatURI(out, iriStr);
         else if ( langStr != null ) out.printf("@%s", langStr);
         else if ( literal != null ) nFmt.format(out, literal);
-
         if ( isStem )
             out.print("~");
     }
@@ -56,7 +55,6 @@ public class ValueSetItem {
         if ( iriStr != null ) str = "<"+iriStr+">";
         else if ( langStr != null ) str = "@"+langStr;
         else if ( literal != null ) str = ShexLib.strDatatype(literal);
-
         if ( isStem )
             str = str+"~";
         return str;

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ValueSetRange.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ValueSetRange.java
@@ -20,6 +20,7 @@ package org.apache.jena.shex.expressions;
 
 import java.util.ArrayList;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
@@ -41,6 +42,10 @@ public class ValueSetRange {
         return "unknown";
     }
 
+    public ValueSetItem item() {
+        return item;
+    }
+
     public boolean included(Node data) {
         return contains(item, data);
     }
@@ -51,6 +56,14 @@ public class ValueSetRange {
                 return true;
         }
         return false;
+    }
+
+    public int numExclusions() {
+        return exclusions.size();
+    }
+
+    public void exclusions(Consumer<ValueSetItem> action) {
+        exclusions.forEach(action);
     }
 
     @Override

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/ParserShExC.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/ParserShExC.java
@@ -254,28 +254,6 @@ public class ParserShExC extends LangParserBase {
 
     // ---- TripleExpression
 
-//    private void startTripleExpressionTop() {
-//        start("startTripleExpressionTop");
-//        // Stack is empty.
-//        if ( DEBUG ) {
-//            if ( ! tripleExprStack.isEmpty() )
-//                debug("startTripleExpressionTop: Stack not empty");
-//        }
-//    }
-//
-//    private TripleExpression finishTripleExpressionTop() {
-//        if ( tripleExprStack.isEmpty() )
-//            return TripleExpressionNone.get();
-//
-//        TripleExpression tExpr = pop(tripleExprStack);
-//        if ( DEBUG ) {
-//            if ( ! tripleExprStack.isEmpty() )
-//                debug("finishShapeExpressionTop: Stack not empty");
-//        }
-//        finish("finishShapeExpressionTop");
-//        return tExpr;
-//    }
-
     private int startTripleOp() {
         return front(tripleExprStack);
     }
@@ -303,7 +281,6 @@ public class ParserShExC extends LangParserBase {
                 push(tripleExprStack, tExpr);
         }
     }
-
 
     // -- Shape Structure
 
@@ -370,9 +347,8 @@ public class ParserShExC extends LangParserBase {
         finish(inline, "ShapeAtom");
     }
 
-
     protected void shapeAtomDOT() {
-        push(shapeExprStack, new ShapeExprTrue());
+        push(shapeExprStack, new ShapeExprDot());
     }
 
     protected void shapeReference(Node ref) {
@@ -386,8 +362,8 @@ public class ParserShExC extends LangParserBase {
     protected void finishShapeDefinition(TripleExpression tripleExpr, List<Node> extras, boolean closed) {
         if ( tripleExpr == null )
             return;
-            // XXX [NodeConstraint]
-            // tripleExpr = TripleExprNone.get();
+            // XXX [Print] Below causes "{ ; }"
+            //tripleExpr = TripleExprNone.get();
         ShapeExprTripleExpr shape = ShapeExprTripleExpr.newBuilder()
                 //.label(???)
                 .closed(closed)
@@ -397,7 +373,6 @@ public class ParserShExC extends LangParserBase {
         finish("ShapeDefinition");
     }
 
-    // ?? Top of TripleExpression
     protected int startTripleExpression() {
         start("TripleExpression");
         return startTripleOp();

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/ParserShExC.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/ParserShExC.java
@@ -44,9 +44,13 @@ import org.apache.jena.shex.sys.SysShex;
 public class ParserShExC extends LangParserBase {
 
     private IndentedWriter out;
-    public static boolean DEBUG = false;
+    /** Print the call nesting */
     public static boolean DEBUG_PARSE = false;
+    /** Print the stack operations */
     public static boolean DEBUG_STACK = false;
+
+    /** Print various unexpected situations */
+    public static boolean DEBUG_DEV = false;
 
     static enum Inline { INLINE, NOT_INLINE }
 
@@ -76,7 +80,7 @@ public class ParserShExC extends LangParserBase {
     private TripleExpression currentTripleExpression() { return peek(tripleExprStack); }
 
     private void printState() {
-        if ( DEBUG ) {
+        if ( DEBUG_DEV ) {
             printStack("shapeExprStack", shapeExprStack);
             printStack("tripleExprStack", tripleExprStack);
         }
@@ -195,7 +199,7 @@ public class ParserShExC extends LangParserBase {
     private void startShapeExpressionTop() {
         start("startShapeExpressionTop");
         // Stack is empty.
-        if ( DEBUG ) {
+        if ( DEBUG_DEV ) {
             if ( ! shapeExprStack.isEmpty() )
                 debug("startShapeExpressionTop: Stack not empty");
         }
@@ -206,7 +210,7 @@ public class ParserShExC extends LangParserBase {
             return ShapeExprNone.get();
 
         ShapeExpression sExpr = pop(shapeExprStack);
-        if ( DEBUG ) {
+        if ( DEBUG_DEV ) {
             if ( ! shapeExprStack.isEmpty() )
                 debug("finishShapeExpressionTop: Stack not empty");
         }
@@ -363,7 +367,6 @@ public class ParserShExC extends LangParserBase {
     }
 
     protected void shapeReference(Node ref) {
-        debug("shapeReference");
         push(shapeExprStack, new ShapeExprRef(ref));
     }
 
@@ -660,7 +663,6 @@ public class ParserShExC extends LangParserBase {
     }
 
     protected void ampTripleExprLabel(Node ref) {
-        debug("& TripleExprLabel");
         push(tripleExprStack, new TripleExprRef(ref));
     }
 
@@ -769,14 +771,14 @@ public class ParserShExC extends LangParserBase {
     }
 
     private void debug(String fmt, Object...args) {
-        if ( DEBUG ) {
+        if ( DEBUG_DEV ) {
             out.print(String.format(fmt, args));
             out.println();
         }
     }
 
     private void debugNoIndent(String fmt, Object...args) {
-        if ( DEBUG ) {
+        if ( DEBUG_DEV ) {
             int x = out.getAbsoluteIndent();
             out.setAbsoluteIndent(0);
             out.print(String.format(fmt, args));

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/ShExC.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/ShExC.java
@@ -22,7 +22,6 @@ import static java.lang.String.format;
 
 import java.io.*;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.apache.jena.atlas.io.IO;
@@ -206,26 +205,20 @@ public class ShExC {
     private static void validatePhase2(ShexSchema shapes, ShexShape shape) {
         ShapeExpression shExpr = shape.getShapeExpression();
         ShapeExprVisitor checker = new CheckFacets();
-        TripleExprVisitor tExprVisitor = new TripleExprVisitor() {
-            @Override public void visit(TripleConstraint object) {
-                // One level call of visitor.
-                //object.getPredicate();
-                ShapeExpression theShapeExpression = object.getShapeExpression();
-                if ( theShapeExpression != null )
-                    theShapeExpression.visit(checker);
-            }
-        };
-        ShexLib.walk(shExpr, checker, null);
+        ShexLib.walk(shExpr, checker, null, null);
     }
 
     private static class CheckFacets implements ShapeExprVisitor {
-        // Inside TripleConstraint
         @Override
-        public void visit(ShapeExprAND shape) {
-            List<ShapeExpression> elements = shape.expressions();
-            Set<StrLengthKind> x = new HashSet<>(3);
+        public void visit(ShapeNodeConstraint shape) {
+            NodeConstraint nc = shape.getNodeConstraint();
+            if ( nc == null )
+                return;
+            // XXX [NodeConstraint]
             DatatypeConstraint dtConstraint = null;
-            for ( ShapeExpression expr : elements ) {
+            Set<StrLengthKind> x = new HashSet<>(3);
+            for ( NodeConstraintComponent expr: nc.components() ) {
+                // Visitor!
                 if ( expr instanceof StrLengthConstraint ) {
                     StrLengthConstraint constraint = (StrLengthConstraint)expr;
                     StrLengthKind lenType = constraint.getLengthType();
@@ -256,7 +249,9 @@ public class ShExC {
                         }
                     }
                 }
+
             }
+
         }
     }
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavacc.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavacc.java
@@ -2827,7 +2827,7 @@ o = focusNode;
   /** Generate ParseException. */
   public ParseException generateParseException() {
     jj_expentries.clear();
-    boolean[] la1tokens = new boolean[107];
+    boolean[] la1tokens = new boolean[108];
     if (jj_kind >= 0) {
       la1tokens[jj_kind] = true;
       jj_kind = -1;
@@ -2850,7 +2850,7 @@ o = focusNode;
         }
       }
     }
-    for (int i = 0; i < 107; i++) {
+    for (int i = 0; i < 108; i++) {
       if (la1tokens[i]) {
         jj_expentry = new int[1];
         jj_expentry[0] = i;

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavacc.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavacc.java
@@ -1198,14 +1198,6 @@ idx = startTripleExpressionClause();
 finishTripleExpressionClause(idx);
   }
 
-// // Can end in single ";"
-// void tripleExpressionClause_0() : {}
-// {
-//     unaryTripleExpr()
-// // Allows ";;;"
-//     (<SEMI_COLON> ( unaryTripleExpr() )?)*
-// }
-
 // Iterative, but needs LOOKAHEAD(2)
   final public void tripleExpressionClause_1() throws ParseException {
     unaryTripleExpr();
@@ -2444,6 +2436,15 @@ o = focusNode;
     finally { jj_save(0, xla); }
   }
 
+  private boolean jj_3R_38()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_40()) jj_scanpos = xsp;
+    if (jj_3R_41()) return true;
+    return false;
+  }
+
   private boolean jj_3R_48()
  {
     if (jj_scan_token(IRIref)) return true;
@@ -2474,15 +2475,15 @@ o = focusNode;
     return false;
   }
 
-  private boolean jj_3R_39()
- {
-    if (jj_scan_token(LPAREN)) return true;
-    return false;
-  }
-
   private boolean jj_3R_43()
  {
     if (jj_3R_45()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_39()
+ {
+    if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
@@ -2595,15 +2596,6 @@ o = focusNode;
   private boolean jj_3R_40()
  {
     if (jj_3R_42()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_38()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_40()) jj_scanpos = xsp;
-    if (jj_3R_41()) return true;
     return false;
   }
 

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavacc.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavacc.java
@@ -654,7 +654,7 @@ idx = startLiteralNodeConstraint(token.beginLine, token.beginColumn);
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case LITERAL:{
       t = jj_consume_token(LITERAL);
-cNodeKind(t.image, t.beginLine, t.beginColumn);
+constraintNodeKind(t.image, t.beginLine, t.beginColumn);
       label_8:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -683,7 +683,7 @@ cNodeKind(t.image, t.beginLine, t.beginColumn);
     case PNAME_NS:
     case PNAME_LN:{
       str = datatype();
-cDatatype(str, token.beginLine, token.beginColumn);
+constraintDatatype(str, token.beginLine, token.beginColumn);
       label_9:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -844,7 +844,7 @@ finishNonLiteralNodeConstraint(idx, token.beginLine, token.beginColumn);
       jj_consume_token(-1);
       throw new ParseException();
     }
-cNodeKind(t.image, t.beginLine, t.beginColumn);
+constraintNodeKind(t.image, t.beginLine, t.beginColumn);
   }
 
   final public void xsFacet() throws ParseException {
@@ -991,8 +991,7 @@ int num = integer(t.image, t.beginLine, t.beginColumn);
   }
 
 // "{ ... }"
-  final public void shapeDefinition() throws ParseException {boolean closed = false ;
-  TripleExpression tripleExpr = null;
+  final public void shapeDefinition() throws ParseException {boolean closed = false; TripleExpression tripleExpr = null;
   List<Node> extras = new ArrayList<Node>();
 startShapeDefinition();
     label_14:

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavaccConstants.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavaccConstants.java
@@ -199,25 +199,27 @@ public interface ShExJavaccConstants {
   /** RegularExpression Id. */
   int A2ZN = 96;
   /** RegularExpression Id. */
-  int PN_CHARS_BASE = 97;
+  int SURROGATE_PAIR = 97;
   /** RegularExpression Id. */
-  int PN_CHARS_U = 98;
+  int PN_CHARS_BASE = 98;
   /** RegularExpression Id. */
-  int PN_CHARS = 99;
+  int PN_CHARS_U = 99;
   /** RegularExpression Id. */
-  int PN_PREFIX = 100;
+  int PN_CHARS = 100;
   /** RegularExpression Id. */
-  int PN_LOCAL = 101;
+  int PN_PREFIX = 101;
   /** RegularExpression Id. */
-  int VARNAME = 102;
+  int PN_LOCAL = 102;
   /** RegularExpression Id. */
-  int PN_LOCAL_ESC = 103;
+  int VARNAME = 103;
   /** RegularExpression Id. */
-  int PLX = 104;
+  int PN_LOCAL_ESC = 104;
   /** RegularExpression Id. */
-  int PERCENT = 105;
+  int PLX = 105;
   /** RegularExpression Id. */
-  int UNKNOWN = 106;
+  int PERCENT = 106;
+  /** RegularExpression Id. */
+  int UNKNOWN = 107;
 
   /** Lexical state. */
   int DEFAULT = 0;
@@ -323,6 +325,7 @@ public interface ShExJavaccConstants {
     "<LANGTAG>",
     "<A2Z>",
     "<A2ZN>",
+    "<SURROGATE_PAIR>",
     "<PN_CHARS_BASE>",
     "<PN_CHARS_U>",
     "<PN_CHARS>",

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavaccTokenManager.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/javacc/ShExJavaccTokenManager.java
@@ -1038,6 +1038,12 @@ static final long[] jjbitVec11 = {
 static final long[] jjbitVec12 = {
    0x8000000000003000L, 0xffff000000000001L, 0xffffffffffffffffL, 0xffffffffffffffffL
 };
+static final long[] jjbitVec13 = {
+   0x0L, 0x0L, 0x0L, 0xf000000L
+};
+static final long[] jjbitVec14 = {
+   0x0L, 0x0L, 0x0L, 0xf0000000L
+};
 private int jjMoveNfa_0(int startState, int curPos)
 {
    int strKind = jjmatchedKind;
@@ -1048,7 +1054,7 @@ private int jjMoveNfa_0(int startState, int curPos)
    catch(java.io.IOException e) { throw new Error("Internal Error"); }
    curPos = 0;
    int startsAt = 0;
-   jjnewStateCnt = 366;
+   jjnewStateCnt = 414;
    int i = 1;
    jjstateSet[0] = startState;
    int kind = 0x7fffffff;
@@ -1073,7 +1079,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   else if ((0x280000000000L & l) != 0L)
                      { jjCheckNAddStates(7, 11); }
                   else if (curChar == 46)
-                     { jjCheckNAddTwoStates(347, 349); }
+                     { jjCheckNAddTwoStates(395, 397); }
                   else if (curChar == 34)
                      { jjAddStates(12, 13); }
                   else if (curChar == 39)
@@ -1082,14 +1088,14 @@ private int jjMoveNfa_0(int startState, int curPos)
                   {
                      if (kind > 71)
                         kind = 71;
-                     { jjCheckNAddStates(16, 18); }
+                     { jjCheckNAddStates(16, 19); }
                   }
                   else if (curChar == 47)
-                     { jjCheckNAddTwoStates(92, 95); }
+                     { jjCheckNAddTwoStates(106, 109); }
                   else if (curChar == 60)
-                     { jjCheckNAddStates(19, 21); }
+                     { jjCheckNAddStates(20, 22); }
                   else if (curChar == 37)
-                     { jjCheckNAddStates(22, 25); }
+                     { jjCheckNAddStates(23, 27); }
                   else if (curChar == 35)
                   {
                      if (kind > 8)
@@ -1097,9 +1103,9 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAdd(1); }
                   }
                   if (curChar == 34)
-                     { jjCheckNAddStates(26, 31); }
+                     { jjCheckNAddStates(28, 33); }
                   else if (curChar == 39)
-                     { jjCheckNAddStates(32, 37); }
+                     { jjCheckNAddStates(34, 39); }
                   break;
                case 1:
                   if ((0xffffffffffffdbffL & l) == 0L)
@@ -1110,19 +1116,19 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 2:
                   if (curChar == 37)
-                     { jjCheckNAddStates(22, 25); }
+                     { jjCheckNAddStates(23, 27); }
                   break;
                case 3:
                   if (curChar == 32)
-                     { jjCheckNAddStates(22, 25); }
+                     { jjCheckNAddStates(23, 27); }
                   break;
                case 4:
                   if (curChar == 60)
-                     { jjCheckNAddStates(38, 40); }
+                     { jjCheckNAddStates(40, 42); }
                   break;
                case 5:
                   if ((0xaffffffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(38, 40); }
+                     { jjCheckNAddStates(40, 42); }
                   break;
                case 8:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1139,19 +1145,19 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 11:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(38, 40); }
+                     { jjCheckNAddStates(40, 42); }
                   break;
                case 12:
                   if (curChar == 62)
-                     { jjCheckNAddStates(41, 43); }
+                     { jjCheckNAddStates(43, 45); }
                   break;
                case 13:
                   if (curChar == 32)
-                     { jjCheckNAddStates(41, 43); }
+                     { jjCheckNAddStates(43, 45); }
                   break;
                case 15:
                   if ((0xffffffdfffffffffL & l) != 0L)
-                     { jjCheckNAddStates(44, 46); }
+                     { jjCheckNAddStates(46, 48); }
                   break;
                case 16:
                   if (curChar == 37)
@@ -1159,7 +1165,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 19:
                   if (curChar == 37)
-                     { jjCheckNAddStates(44, 46); }
+                     { jjCheckNAddStates(46, 48); }
                   break;
                case 21:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1176,7 +1182,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 24:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(44, 46); }
+                     { jjCheckNAddStates(46, 48); }
                   break;
                case 25:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1232,7 +1238,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 41:
                   if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(47, 48); }
+                     { jjAddStates(49, 51); }
                   break;
                case 42:
                   if ((0x3ff200000000000L & l) != 0L)
@@ -1240,35 +1246,27 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 43:
                   if (curChar == 58)
-                     { jjCheckNAddStates(49, 51); }
+                     { jjCheckNAddStates(52, 55); }
                   break;
                case 44:
                   if ((0x7ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(52, 57); }
+                     { jjCheckNAddStates(56, 62); }
                   break;
                case 45:
                   if ((0x7ff600000000000L & l) != 0L)
-                     { jjCheckNAddStates(58, 61); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
                case 46:
                   if ((0x7ff200000000000L & l) != 0L)
-                     { jjCheckNAddStates(41, 43); }
-                  break;
-               case 48:
-                  if ((0xa800fffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(58, 61); }
-                  break;
-               case 49:
-                  if (curChar == 37)
-                     { jjCheckNAddTwoStates(50, 52); }
+                     { jjCheckNAddStates(43, 45); }
                   break;
                case 50:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 51;
+                  if ((0xa800fffa00000000L & l) != 0L)
+                     { jjCheckNAddStates(63, 67); }
                   break;
                case 51:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(58, 61); }
+                  if (curChar == 37)
+                     { jjCheckNAddTwoStates(52, 54); }
                   break;
                case 52:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1276,150 +1274,119 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 53:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(41, 43); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
                case 54:
-                  if ((0xa800fffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(41, 43); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 55;
                   break;
                case 55:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(43, 45); }
+                  break;
+               case 56:
+                  if ((0xa800fffa00000000L & l) != 0L)
+                     { jjCheckNAddStates(43, 45); }
+                  break;
+               case 58:
                   if (curChar != 37)
                      break;
                   if (kind > 40)
                      kind = 40;
-                  { jjCheckNAddTwoStates(50, 52); }
-                  break;
-               case 57:
-                  if ((0xa800fffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(52, 57); }
-                  break;
-               case 58:
-                  if (curChar == 37)
-                     jjstateSet[jjnewStateCnt++] = 59;
-                  break;
-               case 59:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 60;
+                  { jjCheckNAddTwoStates(52, 54); }
                   break;
                case 60:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(52, 57); }
+                  if ((0xa800fffa00000000L & l) != 0L)
+                     { jjCheckNAddStates(56, 62); }
                   break;
                case 61:
-                  if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(62, 63); }
+                  if (curChar == 37)
+                     jjstateSet[jjnewStateCnt++] = 62;
                   break;
                case 62:
-                  if ((0x3ff200000000000L & l) != 0L)
+                  if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 63;
                   break;
                case 63:
-                  if (curChar == 58)
-                     { jjCheckNAddStates(41, 43); }
-                  break;
-               case 64:
-                  if (curChar == 58)
-                     { jjCheckNAddStates(64, 69); }
-                  break;
-               case 66:
-                  if ((0x280000000000L & l) != 0L)
-                     { jjCheckNAdd(67); }
-                  break;
-               case 67:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(70, 72); }
-                  break;
-               case 68:
-                  if (curChar == 44)
-                     { jjCheckNAddStates(73, 76); }
+                     { jjCheckNAddStates(56, 62); }
                   break;
                case 69:
-                  if ((0x280000000000L & l) != 0L)
-                     { jjCheckNAdd(70); }
+                  if ((0x3ff600000000000L & l) != 0L)
+                     { jjAddStates(68, 70); }
                   break;
                case 70:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(70, 71); }
+                  if ((0x3ff200000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 71;
                   break;
-               case 72:
-                  if (curChar == 42)
-                     { jjCheckNAdd(71); }
-                  break;
-               case 73:
-                  if (curChar == 60)
-                     { jjCheckNAddStates(19, 21); }
-                  break;
-               case 74:
-                  if ((0xaffffffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(19, 21); }
-                  break;
-               case 77:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 78;
+               case 71:
+                  if (curChar == 58)
+                     { jjCheckNAddStates(43, 45); }
                   break;
                case 78:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 79;
-                  break;
-               case 79:
-               case 88:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(80); }
+                  if (curChar == 58)
+                     { jjCheckNAddStates(71, 77); }
                   break;
                case 80:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(19, 21); }
+                  if ((0x280000000000L & l) != 0L)
+                     { jjCheckNAdd(81); }
                   break;
                case 81:
-                  if (curChar == 62 && kind > 70)
-                     kind = 70;
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(78, 80); }
                   break;
                case 82:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 83;
+                  if (curChar == 44)
+                     { jjCheckNAddStates(81, 84); }
                   break;
                case 83:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 84;
+                  if ((0x280000000000L & l) != 0L)
+                     { jjCheckNAdd(84); }
                   break;
                case 84:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 85;
-                  break;
-               case 85:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 86;
+                     { jjCheckNAddTwoStates(84, 85); }
                   break;
                case 86:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 87;
+                  if (curChar == 42)
+                     { jjCheckNAdd(85); }
                   break;
                case 87:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 88;
+                  if (curChar == 60)
+                     { jjCheckNAddStates(20, 22); }
                   break;
-               case 90:
-                  if ((0x8400000000L & l) != 0L && kind > 78)
-                     kind = 78;
+               case 88:
+                  if ((0xaffffffa00000000L & l) != 0L)
+                     { jjCheckNAddStates(20, 22); }
                   break;
                case 91:
-                  if (curChar == 47)
-                     { jjCheckNAddTwoStates(92, 95); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 92;
                   break;
                case 92:
-                  if ((0xffff7fffffffdbffL & l) != 0L)
-                     { jjCheckNAddStates(77, 79); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 93;
                   break;
                case 93:
-                  if (curChar != 47)
-                     break;
-                  if (kind > 92)
-                     kind = 92;
-                  jjstateSet[jjnewStateCnt++] = 94;
+               case 102:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAdd(94); }
+                  break;
+               case 94:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(20, 22); }
+                  break;
+               case 95:
+                  if (curChar == 62 && kind > 70)
+                     kind = 70;
                   break;
                case 96:
-                  if ((0x8000ef1000000000L & l) != 0L)
-                     { jjCheckNAddStates(77, 79); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 97;
+                  break;
+               case 97:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 98;
                   break;
                case 98:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1430,156 +1397,111 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 100;
                   break;
                case 100:
-               case 108:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(101); }
+                     jjstateSet[jjnewStateCnt++] = 101;
                   break;
                case 101:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(77, 79); }
-                  break;
-               case 102:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 103;
-                  break;
-               case 103:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 104;
+                     jjstateSet[jjnewStateCnt++] = 102;
                   break;
                case 104:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 105;
+                  if ((0x8400000000L & l) != 0L && kind > 78)
+                     kind = 78;
                   break;
                case 105:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 106;
+                  if (curChar == 47)
+                     { jjCheckNAddTwoStates(106, 109); }
                   break;
                case 106:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 107;
+                  if ((0xffff7fffffffdbffL & l) != 0L)
+                     { jjCheckNAddStates(85, 87); }
                   break;
                case 107:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 108;
-                  break;
-               case 109:
-                  if (curChar == 58)
-                     jjstateSet[jjnewStateCnt++] = 110;
+                  if (curChar != 47)
+                     break;
+                  if (kind > 92)
+                     kind = 92;
+                  jjstateSet[jjnewStateCnt++] = 108;
                   break;
                case 110:
+                  if ((0x8000ef1000000000L & l) != 0L)
+                     { jjCheckNAddStates(85, 87); }
+                  break;
+               case 112:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 113;
+                  break;
+               case 113:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 114;
+                  break;
+               case 114:
+               case 122:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAdd(115); }
+                  break;
+               case 115:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(85, 87); }
+                  break;
+               case 116:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 117;
+                  break;
+               case 117:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 118;
+                  break;
+               case 118:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 119;
+                  break;
+               case 119:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 120;
+                  break;
+               case 120:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 121;
+                  break;
+               case 121:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 122;
+                  break;
+               case 123:
+                  if (curChar == 58)
+                     { jjAddStates(88, 89); }
+                  break;
+               case 124:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 93)
                      kind = 93;
-                  { jjCheckNAddTwoStates(111, 112); }
+                  { jjCheckNAddStates(90, 92); }
                   break;
-               case 111:
+               case 125:
                   if ((0x3ff600000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(111, 112); }
+                     { jjCheckNAddStates(90, 92); }
                   break;
-               case 112:
+               case 126:
                   if ((0x3ff200000000000L & l) != 0L && kind > 93)
                      kind = 93;
                   break;
-               case 115:
-                  if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(80, 81); }
-                  break;
-               case 116:
-                  if ((0x3ff200000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 117;
-                  break;
-               case 117:
-                  if (curChar == 58 && kind > 71)
-                     kind = 71;
-                  break;
-               case 118:
-                  if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(82, 83); }
-                  break;
-               case 119:
-                  if ((0x3ff200000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 120;
-                  break;
-               case 120:
-                  if (curChar == 58)
-                     { jjCheckNAddStates(16, 18); }
-                  break;
-               case 121:
-                  if ((0x7ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 72)
-                     kind = 72;
-                  { jjCheckNAddStates(84, 87); }
-                  break;
-               case 122:
-                  if ((0x7ff600000000000L & l) != 0L)
-                     { jjCheckNAddStates(84, 87); }
-                  break;
-               case 123:
-                  if ((0x7ff200000000000L & l) != 0L && kind > 72)
-                     kind = 72;
-                  break;
-               case 125:
-                  if ((0xa800fffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(84, 87); }
-                  break;
-               case 126:
-                  if (curChar == 37)
-                     { jjAddStates(88, 89); }
-                  break;
-               case 127:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 128;
-                  break;
-               case 128:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(84, 87); }
-                  break;
-               case 129:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 130;
-                  break;
-               case 130:
-                  if ((0x3ff000000000000L & l) != 0L && kind > 72)
-                     kind = 72;
-                  break;
-               case 131:
-                  if ((0xa800fffa00000000L & l) != 0L && kind > 72)
-                     kind = 72;
-                  break;
-               case 133:
-                  if ((0xa800fffa00000000L & l) == 0L)
-                     break;
-                  if (kind > 72)
-                     kind = 72;
-                  { jjCheckNAddStates(84, 87); }
-                  break;
                case 134:
-                  if (curChar == 37)
-                     jjstateSet[jjnewStateCnt++] = 135;
+                  if ((0x3ff600000000000L & l) != 0L)
+                     { jjAddStates(93, 95); }
                   break;
                case 135:
-                  if ((0x3ff000000000000L & l) != 0L)
+                  if ((0x3ff200000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 136;
                   break;
                case 136:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 72)
-                     kind = 72;
-                  { jjCheckNAddStates(84, 87); }
-                  break;
-               case 137:
-                  if (curChar != 58)
-                     break;
-                  if (kind > 71)
+                  if (curChar == 58 && kind > 71)
                      kind = 71;
-                  { jjCheckNAddStates(16, 18); }
                   break;
                case 140:
                   if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(90, 91); }
+                     { jjAddStates(96, 98); }
                   break;
                case 141:
                   if ((0x3ff200000000000L & l) != 0L)
@@ -1587,140 +1509,114 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 142:
                   if (curChar == 58)
-                     { jjAddStates(92, 94); }
+                     { jjCheckNAddStates(16, 19); }
                   break;
                case 143:
                   if ((0x7ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 73)
-                     kind = 73;
-                  { jjCheckNAddStates(95, 98); }
+                  if (kind > 72)
+                     kind = 72;
+                  { jjCheckNAddStates(99, 103); }
                   break;
                case 144:
                   if ((0x7ff600000000000L & l) != 0L)
-                     { jjCheckNAddStates(95, 98); }
+                     { jjCheckNAddStates(99, 103); }
                   break;
                case 145:
-                  if ((0x7ff200000000000L & l) != 0L && kind > 73)
-                     kind = 73;
-                  break;
-               case 147:
-                  if ((0xa800fffa00000000L & l) != 0L)
-                     { jjCheckNAddStates(95, 98); }
-                  break;
-               case 148:
-                  if (curChar == 37)
-                     { jjAddStates(99, 100); }
+                  if ((0x7ff200000000000L & l) != 0L && kind > 72)
+                     kind = 72;
                   break;
                case 149:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 150;
+                  if ((0xa800fffa00000000L & l) != 0L)
+                     { jjCheckNAddStates(99, 103); }
                   break;
                case 150:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(95, 98); }
+                  if (curChar == 37)
+                     { jjAddStates(104, 105); }
                   break;
                case 151:
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 152;
                   break;
                case 152:
-                  if ((0x3ff000000000000L & l) != 0L && kind > 73)
-                     kind = 73;
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(99, 103); }
                   break;
                case 153:
-                  if ((0xa800fffa00000000L & l) != 0L && kind > 73)
-                     kind = 73;
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 154;
+                  break;
+               case 154:
+                  if ((0x3ff000000000000L & l) != 0L && kind > 72)
+                     kind = 72;
                   break;
                case 155:
-                  if ((0xa800fffa00000000L & l) == 0L)
-                     break;
-                  if (kind > 73)
-                     kind = 73;
-                  { jjCheckNAddStates(95, 98); }
-                  break;
-               case 156:
-                  if (curChar == 37)
-                     jjstateSet[jjnewStateCnt++] = 157;
-                  break;
-               case 157:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 158;
+                  if ((0xa800fffa00000000L & l) != 0L && kind > 72)
+                     kind = 72;
                   break;
                case 158:
+                  if ((0xa800fffa00000000L & l) == 0L)
+                     break;
+                  if (kind > 72)
+                     kind = 72;
+                  { jjCheckNAddStates(99, 103); }
+                  break;
+               case 159:
+                  if (curChar == 37)
+                     jjstateSet[jjnewStateCnt++] = 160;
+                  break;
+               case 160:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 161;
+                  break;
+               case 161:
                   if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 72)
+                     kind = 72;
+                  { jjCheckNAddStates(99, 103); }
+                  break;
+               case 170:
+                  if (curChar != 58)
+                     break;
+                  if (kind > 71)
+                     kind = 71;
+                  { jjCheckNAddStates(16, 19); }
+                  break;
+               case 173:
+                  if ((0x3ff600000000000L & l) != 0L)
+                     { jjAddStates(106, 108); }
+                  break;
+               case 174:
+                  if ((0x3ff200000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 175;
+                  break;
+               case 175:
+                  if (curChar == 58)
+                     { jjAddStates(109, 112); }
+                  break;
+               case 176:
+                  if ((0x7ff000000000000L & l) == 0L)
                      break;
                   if (kind > 73)
                      kind = 73;
-                  { jjCheckNAddStates(95, 98); }
-                  break;
-               case 160:
-                  if ((0x3ff600000000000L & l) != 0L)
-                     { jjAddStates(101, 102); }
-                  break;
-               case 161:
-                  if ((0x3ff200000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 162;
-                  break;
-               case 162:
-                  if (curChar == 58 && kind > 74)
-                     kind = 74;
-                  break;
-               case 169:
-                  if (curChar == 45)
-                     { jjCheckNAdd(170); }
-                  break;
-               case 170:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 94)
-                     kind = 94;
-                  { jjCheckNAddTwoStates(169, 170); }
-                  break;
-               case 171:
-                  if (curChar == 39)
-                     { jjCheckNAddStates(32, 37); }
-                  break;
-               case 172:
-                  if ((0xffffff7fffffdbffL & l) != 0L)
-                     { jjCheckNAddStates(103, 105); }
-                  break;
-               case 173:
-                  if (curChar == 39 && kind > 79)
-                     kind = 79;
-                  break;
-               case 175:
-                  if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(103, 105); }
+                  { jjCheckNAddStates(113, 117); }
                   break;
                case 177:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 178;
+                  if ((0x7ff600000000000L & l) != 0L)
+                     { jjCheckNAddStates(113, 117); }
                   break;
                case 178:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 179;
-                  break;
-               case 179:
-               case 187:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(180); }
-                  break;
-               case 180:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(103, 105); }
-                  break;
-               case 181:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 182;
+                  if ((0x7ff200000000000L & l) != 0L && kind > 73)
+                     kind = 73;
                   break;
                case 182:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 183;
+                  if ((0xa800fffa00000000L & l) != 0L)
+                     { jjCheckNAddStates(113, 117); }
                   break;
                case 183:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 184;
+                  if (curChar == 37)
+                     { jjAddStates(118, 119); }
                   break;
                case 184:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1728,254 +1624,201 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 185:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 186;
+                     { jjCheckNAddStates(113, 117); }
                   break;
                case 186:
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 187;
                   break;
-               case 188:
-                  if ((0xffffff7fffffdbffL & l) != 0L)
-                     { jjCheckNAddStates(106, 108); }
+               case 187:
+                  if ((0x3ff000000000000L & l) != 0L && kind > 73)
+                     kind = 73;
                   break;
-               case 189:
-                  if (curChar == 39)
-                     jjstateSet[jjnewStateCnt++] = 190;
+               case 188:
+                  if ((0xa800fffa00000000L & l) != 0L && kind > 73)
+                     kind = 73;
+                  break;
+               case 191:
+                  if ((0xa800fffa00000000L & l) == 0L)
+                     break;
+                  if (kind > 73)
+                     kind = 73;
+                  { jjCheckNAddStates(113, 117); }
                   break;
                case 192:
-                  if (curChar == 45)
-                     { jjCheckNAdd(193); }
+                  if (curChar == 37)
+                     jjstateSet[jjnewStateCnt++] = 193;
                   break;
                case 193:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 194;
+                  break;
+               case 194:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 83)
-                     kind = 83;
-                  { jjCheckNAddTwoStates(192, 193); }
-                  break;
-               case 195:
-                  if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(106, 108); }
-                  break;
-               case 197:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 198;
-                  break;
-               case 198:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 199;
-                  break;
-               case 199:
-               case 207:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(200); }
-                  break;
-               case 200:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(106, 108); }
-                  break;
-               case 201:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 202;
-                  break;
-               case 202:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 203;
+                  if (kind > 73)
+                     kind = 73;
+                  { jjCheckNAddStates(113, 117); }
                   break;
                case 203:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 204;
+                  if ((0x3ff600000000000L & l) != 0L)
+                     { jjAddStates(120, 122); }
                   break;
                case 204:
-                  if ((0x3ff000000000000L & l) != 0L)
+                  if ((0x3ff200000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 205;
                   break;
                case 205:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 206;
-                  break;
-               case 206:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 207;
-                  break;
-               case 208:
-                  if (curChar == 34)
-                     { jjCheckNAddStates(26, 31); }
-                  break;
-               case 209:
-                  if ((0xfffffffbffffdbffL & l) != 0L)
-                     { jjCheckNAddStates(109, 111); }
-                  break;
-               case 210:
-                  if (curChar == 34 && kind > 80)
-                     kind = 80;
-                  break;
-               case 212:
-                  if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(109, 111); }
-                  break;
-               case 214:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 215;
-                  break;
-               case 215:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 216;
-                  break;
-               case 216:
-               case 224:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(217); }
+                  if (curChar == 58 && kind > 74)
+                     kind = 74;
                   break;
                case 217:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(109, 111); }
+                  if (curChar == 45)
+                     { jjCheckNAdd(218); }
                   break;
                case 218:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 219;
-                  break;
-               case 219:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 220;
-                  break;
-               case 220:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 221;
-                  break;
-               case 221:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 222;
-                  break;
-               case 222:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 223;
-                  break;
-               case 223:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 224;
-                  break;
-               case 225:
-                  if ((0xfffffffbffffdbffL & l) != 0L)
-                     { jjCheckNAddStates(112, 114); }
-                  break;
-               case 226:
-                  if (curChar == 34)
-                     jjstateSet[jjnewStateCnt++] = 227;
-                  break;
-               case 229:
-                  if (curChar == 45)
-                     { jjCheckNAdd(230); }
-                  break;
-               case 230:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 84)
-                     kind = 84;
-                  { jjCheckNAddTwoStates(229, 230); }
+                  if (kind > 94)
+                     kind = 94;
+                  { jjCheckNAddTwoStates(217, 218); }
+                  break;
+               case 219:
+                  if (curChar == 39)
+                     { jjCheckNAddStates(34, 39); }
+                  break;
+               case 220:
+                  if ((0xffffff7fffffdbffL & l) != 0L)
+                     { jjCheckNAddStates(123, 125); }
+                  break;
+               case 221:
+                  if (curChar == 39 && kind > 79)
+                     kind = 79;
+                  break;
+               case 223:
+                  if ((0x8400000000L & l) != 0L)
+                     { jjCheckNAddStates(123, 125); }
+                  break;
+               case 225:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 226;
+                  break;
+               case 226:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 227;
+                  break;
+               case 227:
+               case 235:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAdd(228); }
+                  break;
+               case 228:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(123, 125); }
+                  break;
+               case 229:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 230;
+                  break;
+               case 230:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 231;
+                  break;
+               case 231:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 232;
                   break;
                case 232:
-                  if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(112, 114); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 233;
+                  break;
+               case 233:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 234;
                   break;
                case 234:
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 235;
                   break;
-               case 235:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 236;
-                  break;
                case 236:
-               case 244:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(237); }
+                  if ((0xffffff7fffffdbffL & l) != 0L)
+                     { jjCheckNAddStates(126, 128); }
                   break;
                case 237:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(112, 114); }
-                  break;
-               case 238:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 239;
-                  break;
-               case 239:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 240;
+                  if (curChar == 39)
+                     jjstateSet[jjnewStateCnt++] = 238;
                   break;
                case 240:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 241;
+                  if (curChar == 45)
+                     { jjCheckNAdd(241); }
                   break;
                case 241:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 242;
-                  break;
-               case 242:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 243;
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 83)
+                     kind = 83;
+                  { jjCheckNAddTwoStates(240, 241); }
                   break;
                case 243:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 244;
+                  if ((0x8400000000L & l) != 0L)
+                     { jjCheckNAddStates(126, 128); }
                   break;
                case 245:
-                  if (curChar == 39)
-                     { jjAddStates(14, 15); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 246;
                   break;
                case 246:
-                  if (curChar == 39)
-                     { jjCheckNAddStates(115, 118); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 247;
                   break;
                case 247:
-               case 250:
-                  if (curChar == 39)
-                     { jjCheckNAddTwoStates(248, 251); }
+               case 255:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAdd(248); }
                   break;
                case 248:
-                  if ((0xffffff7fffffffffL & l) != 0L)
-                     { jjCheckNAddStates(115, 118); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(126, 128); }
                   break;
                case 249:
-                  if (curChar == 39)
-                     { jjAddStates(119, 120); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 250;
+                  break;
+               case 250:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 251;
+                  break;
+               case 251:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 252;
                   break;
                case 252:
-                  if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(115, 118); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 253;
+                  break;
+               case 253:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 254;
                   break;
                case 254:
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 255;
                   break;
-               case 255:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 256;
-                  break;
                case 256:
-               case 264:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(257); }
+                  if (curChar == 34)
+                     { jjCheckNAddStates(28, 33); }
                   break;
                case 257:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(115, 118); }
+                  if ((0xfffffffbffffdbffL & l) != 0L)
+                     { jjCheckNAddStates(129, 131); }
                   break;
                case 258:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 259;
-                  break;
-               case 259:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 260;
+                  if (curChar == 34 && kind > 80)
+                     kind = 80;
                   break;
                case 260:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 261;
-                  break;
-               case 261:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 262;
+                  if ((0x8400000000L & l) != 0L)
+                     { jjCheckNAddStates(129, 131); }
                   break;
                case 262:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -1985,63 +1828,61 @@ private int jjMoveNfa_0(int startState, int curPos)
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 264;
                   break;
+               case 264:
+               case 272:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAdd(265); }
+                  break;
                case 265:
-                  if (curChar == 39 && kind > 81)
-                     kind = 81;
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(129, 131); }
                   break;
                case 266:
-                  if (curChar == 39)
-                     jjstateSet[jjnewStateCnt++] = 265;
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 267;
                   break;
                case 267:
-                  if (curChar == 39)
-                     jjstateSet[jjnewStateCnt++] = 246;
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 268;
                   break;
                case 268:
-                  if (curChar == 39)
-                     { jjCheckNAddStates(121, 124); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 269;
                   break;
                case 269:
-               case 272:
-                  if (curChar == 39)
-                     { jjCheckNAddTwoStates(270, 273); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 270;
                   break;
                case 270:
-                  if ((0xffffff7fffffffffL & l) != 0L)
-                     { jjCheckNAddStates(121, 124); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 271;
                   break;
                case 271:
-                  if (curChar == 39)
-                     { jjAddStates(125, 126); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 272;
+                  break;
+               case 273:
+                  if ((0xfffffffbffffdbffL & l) != 0L)
+                     { jjCheckNAddStates(132, 134); }
                   break;
                case 274:
-                  if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(121, 124); }
-                  break;
-               case 276:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 277;
+                  if (curChar == 34)
+                     jjstateSet[jjnewStateCnt++] = 275;
                   break;
                case 277:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 278;
+                  if (curChar == 45)
+                     { jjCheckNAdd(278); }
                   break;
                case 278:
-               case 286:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(279); }
-                  break;
-               case 279:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(121, 124); }
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 84)
+                     kind = 84;
+                  { jjCheckNAddTwoStates(277, 278); }
                   break;
                case 280:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 281;
-                  break;
-               case 281:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 282;
+                  if ((0x8400000000L & l) != 0L)
+                     { jjCheckNAddStates(132, 134); }
                   break;
                case 282:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -2052,77 +1893,83 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 284;
                   break;
                case 284:
+               case 292:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 285;
+                     { jjCheckNAdd(285); }
                   break;
                case 285:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 286;
+                     { jjCheckNAddStates(132, 134); }
+                  break;
+               case 286:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 287;
                   break;
                case 287:
-                  if (curChar == 39)
+                  if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 288;
                   break;
+               case 288:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 289;
+                  break;
+               case 289:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 290;
+                  break;
                case 290:
-                  if (curChar == 45)
-                     { jjCheckNAdd(291); }
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 291;
                   break;
                case 291:
-                  if ((0x3ff000000000000L & l) == 0L)
-                     break;
-                  if (kind > 85)
-                     kind = 85;
-                  { jjCheckNAddTwoStates(290, 291); }
-                  break;
-               case 292:
-                  if (curChar == 39)
-                     jjstateSet[jjnewStateCnt++] = 287;
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 292;
                   break;
                case 293:
                   if (curChar == 39)
-                     jjstateSet[jjnewStateCnt++] = 268;
+                     { jjAddStates(14, 15); }
                   break;
                case 294:
-                  if (curChar == 34)
-                     { jjAddStates(12, 13); }
+                  if (curChar == 39)
+                     { jjCheckNAddStates(135, 138); }
                   break;
                case 295:
-                  if (curChar == 34)
-                     { jjCheckNAddStates(127, 130); }
+               case 298:
+                  if (curChar == 39)
+                     { jjCheckNAddTwoStates(296, 299); }
                   break;
                case 296:
-               case 299:
-                  if (curChar == 34)
-                     { jjCheckNAddTwoStates(297, 300); }
+                  if ((0xffffff7fffffffffL & l) != 0L)
+                     { jjCheckNAddStates(135, 138); }
                   break;
                case 297:
-                  if ((0xfffffffbffffffffL & l) != 0L)
-                     { jjCheckNAddStates(127, 130); }
+                  if (curChar == 39)
+                     { jjAddStates(139, 140); }
                   break;
-               case 298:
-                  if (curChar == 34)
-                     { jjAddStates(131, 132); }
-                  break;
-               case 301:
+               case 300:
                   if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(127, 130); }
+                     { jjCheckNAddStates(135, 138); }
+                  break;
+               case 302:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 303;
                   break;
                case 303:
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 304;
                   break;
                case 304:
+               case 312:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 305;
+                     { jjCheckNAdd(305); }
                   break;
                case 305:
-               case 313:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(306); }
+                     { jjCheckNAddStates(135, 138); }
                   break;
                case 306:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(127, 130); }
+                     jjstateSet[jjnewStateCnt++] = 307;
                   break;
                case 307:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -2144,59 +1991,59 @@ private int jjMoveNfa_0(int startState, int curPos)
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 312;
                   break;
-               case 312:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 313;
+               case 313:
+                  if (curChar == 39 && kind > 81)
+                     kind = 81;
                   break;
                case 314:
-                  if (curChar == 34 && kind > 82)
-                     kind = 82;
+                  if (curChar == 39)
+                     jjstateSet[jjnewStateCnt++] = 313;
                   break;
                case 315:
-                  if (curChar == 34)
-                     jjstateSet[jjnewStateCnt++] = 314;
+                  if (curChar == 39)
+                     jjstateSet[jjnewStateCnt++] = 294;
                   break;
                case 316:
-                  if (curChar == 34)
-                     jjstateSet[jjnewStateCnt++] = 295;
+                  if (curChar == 39)
+                     { jjCheckNAddStates(141, 144); }
                   break;
                case 317:
-                  if (curChar == 34)
-                     { jjCheckNAddStates(133, 136); }
+               case 320:
+                  if (curChar == 39)
+                     { jjCheckNAddTwoStates(318, 321); }
                   break;
                case 318:
-               case 321:
-                  if (curChar == 34)
-                     { jjCheckNAddTwoStates(319, 322); }
+                  if ((0xffffff7fffffffffL & l) != 0L)
+                     { jjCheckNAddStates(141, 144); }
                   break;
                case 319:
-                  if ((0xfffffffbffffffffL & l) != 0L)
-                     { jjCheckNAddStates(133, 136); }
+                  if (curChar == 39)
+                     { jjAddStates(145, 146); }
                   break;
-               case 320:
-                  if (curChar == 34)
-                     { jjAddStates(137, 138); }
-                  break;
-               case 323:
+               case 322:
                   if ((0x8400000000L & l) != 0L)
-                     { jjCheckNAddStates(133, 136); }
+                     { jjCheckNAddStates(141, 144); }
+                  break;
+               case 324:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 325;
                   break;
                case 325:
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 326;
                   break;
                case 326:
+               case 334:
                   if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 327;
+                     { jjCheckNAdd(327); }
                   break;
                case 327:
-               case 335:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAdd(328); }
+                     { jjCheckNAddStates(141, 144); }
                   break;
                case 328:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(133, 136); }
+                     jjstateSet[jjnewStateCnt++] = 329;
                   break;
                case 329:
                   if ((0x3ff000000000000L & l) != 0L)
@@ -2218,130 +2065,289 @@ private int jjMoveNfa_0(int startState, int curPos)
                   if ((0x3ff000000000000L & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 334;
                   break;
-               case 334:
-                  if ((0x3ff000000000000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 335;
+               case 335:
+                  if (curChar == 39)
+                     jjstateSet[jjnewStateCnt++] = 336;
                   break;
-               case 336:
-                  if (curChar == 34)
-                     jjstateSet[jjnewStateCnt++] = 337;
+               case 338:
+                  if (curChar == 45)
+                     { jjCheckNAdd(339); }
                   break;
                case 339:
-                  if (curChar == 45)
-                     { jjCheckNAdd(340); }
+                  if ((0x3ff000000000000L & l) == 0L)
+                     break;
+                  if (kind > 85)
+                     kind = 85;
+                  { jjCheckNAddTwoStates(338, 339); }
                   break;
                case 340:
+                  if (curChar == 39)
+                     jjstateSet[jjnewStateCnt++] = 335;
+                  break;
+               case 341:
+                  if (curChar == 39)
+                     jjstateSet[jjnewStateCnt++] = 316;
+                  break;
+               case 342:
+                  if (curChar == 34)
+                     { jjAddStates(12, 13); }
+                  break;
+               case 343:
+                  if (curChar == 34)
+                     { jjCheckNAddStates(147, 150); }
+                  break;
+               case 344:
+               case 347:
+                  if (curChar == 34)
+                     { jjCheckNAddTwoStates(345, 348); }
+                  break;
+               case 345:
+                  if ((0xfffffffbffffffffL & l) != 0L)
+                     { jjCheckNAddStates(147, 150); }
+                  break;
+               case 346:
+                  if (curChar == 34)
+                     { jjAddStates(151, 152); }
+                  break;
+               case 349:
+                  if ((0x8400000000L & l) != 0L)
+                     { jjCheckNAddStates(147, 150); }
+                  break;
+               case 351:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 352;
+                  break;
+               case 352:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 353;
+                  break;
+               case 353:
+               case 361:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAdd(354); }
+                  break;
+               case 354:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(147, 150); }
+                  break;
+               case 355:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 356;
+                  break;
+               case 356:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 357;
+                  break;
+               case 357:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 358;
+                  break;
+               case 358:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 359;
+                  break;
+               case 359:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 360;
+                  break;
+               case 360:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 361;
+                  break;
+               case 362:
+                  if (curChar == 34 && kind > 82)
+                     kind = 82;
+                  break;
+               case 363:
+                  if (curChar == 34)
+                     jjstateSet[jjnewStateCnt++] = 362;
+                  break;
+               case 364:
+                  if (curChar == 34)
+                     jjstateSet[jjnewStateCnt++] = 343;
+                  break;
+               case 365:
+                  if (curChar == 34)
+                     { jjCheckNAddStates(153, 156); }
+                  break;
+               case 366:
+               case 369:
+                  if (curChar == 34)
+                     { jjCheckNAddTwoStates(367, 370); }
+                  break;
+               case 367:
+                  if ((0xfffffffbffffffffL & l) != 0L)
+                     { jjCheckNAddStates(153, 156); }
+                  break;
+               case 368:
+                  if (curChar == 34)
+                     { jjAddStates(157, 158); }
+                  break;
+               case 371:
+                  if ((0x8400000000L & l) != 0L)
+                     { jjCheckNAddStates(153, 156); }
+                  break;
+               case 373:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 374;
+                  break;
+               case 374:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 375;
+                  break;
+               case 375:
+               case 383:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAdd(376); }
+                  break;
+               case 376:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     { jjCheckNAddStates(153, 156); }
+                  break;
+               case 377:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 378;
+                  break;
+               case 378:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 379;
+                  break;
+               case 379:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 380;
+                  break;
+               case 380:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 381;
+                  break;
+               case 381:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 382;
+                  break;
+               case 382:
+                  if ((0x3ff000000000000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 383;
+                  break;
+               case 384:
+                  if (curChar == 34)
+                     jjstateSet[jjnewStateCnt++] = 385;
+                  break;
+               case 387:
+                  if (curChar == 45)
+                     { jjCheckNAdd(388); }
+                  break;
+               case 388:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 86)
                      kind = 86;
-                  { jjCheckNAddTwoStates(339, 340); }
+                  { jjCheckNAddTwoStates(387, 388); }
                   break;
-               case 341:
+               case 389:
                   if (curChar == 34)
-                     jjstateSet[jjnewStateCnt++] = 336;
+                     jjstateSet[jjnewStateCnt++] = 384;
                   break;
-               case 342:
+               case 390:
                   if (curChar == 34)
-                     jjstateSet[jjnewStateCnt++] = 317;
+                     jjstateSet[jjnewStateCnt++] = 365;
                   break;
-               case 343:
+               case 391:
                   if ((0x280000000000L & l) != 0L)
                      { jjCheckNAddStates(7, 11); }
                   break;
-               case 344:
+               case 392:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 88)
                      kind = 88;
-                  { jjCheckNAdd(344); }
+                  { jjCheckNAdd(392); }
                   break;
-               case 345:
+               case 393:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(345, 346); }
+                     { jjCheckNAddTwoStates(393, 394); }
                   break;
-               case 346:
+               case 394:
                   if (curChar == 46)
-                     { jjCheckNAdd(347); }
+                     { jjCheckNAdd(395); }
                   break;
-               case 347:
+               case 395:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 89)
                      kind = 89;
-                  { jjCheckNAdd(347); }
+                  { jjCheckNAdd(395); }
                   break;
-               case 348:
+               case 396:
                   if (curChar == 46)
-                     { jjCheckNAdd(349); }
+                     { jjCheckNAdd(397); }
                   break;
-               case 349:
+               case 397:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(349, 350); }
+                     { jjCheckNAddTwoStates(397, 398); }
                   break;
-               case 351:
+               case 399:
                   if ((0x280000000000L & l) != 0L)
-                     { jjCheckNAdd(352); }
+                     { jjCheckNAdd(400); }
                   break;
-               case 352:
+               case 400:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 90)
                      kind = 90;
-                  { jjCheckNAdd(352); }
+                  { jjCheckNAdd(400); }
                   break;
-               case 353:
+               case 401:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddStates(139, 142); }
+                     { jjCheckNAddStates(159, 162); }
                   break;
-               case 354:
+               case 402:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(354, 355); }
+                     { jjCheckNAddTwoStates(402, 403); }
                   break;
-               case 355:
+               case 403:
                   if (curChar == 46)
-                     { jjCheckNAddTwoStates(356, 357); }
+                     { jjCheckNAddTwoStates(404, 405); }
                   break;
-               case 356:
+               case 404:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(356, 357); }
+                     { jjCheckNAddTwoStates(404, 405); }
                   break;
-               case 358:
+               case 406:
                   if ((0x280000000000L & l) != 0L)
-                     { jjCheckNAdd(359); }
+                     { jjCheckNAdd(407); }
                   break;
-               case 359:
+               case 407:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 90)
                      kind = 90;
-                  { jjCheckNAdd(359); }
+                  { jjCheckNAdd(407); }
                   break;
-               case 360:
+               case 408:
                   if ((0x3ff000000000000L & l) != 0L)
-                     { jjCheckNAddTwoStates(360, 361); }
+                     { jjCheckNAddTwoStates(408, 409); }
                   break;
-               case 362:
+               case 410:
                   if ((0x280000000000L & l) != 0L)
-                     { jjCheckNAdd(363); }
+                     { jjCheckNAdd(411); }
                   break;
-               case 363:
+               case 411:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 90)
                      kind = 90;
-                  { jjCheckNAdd(363); }
+                  { jjCheckNAdd(411); }
                   break;
-               case 364:
+               case 412:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
                   if (kind > 88)
                      kind = 88;
                   { jjCheckNAddStates(0, 6); }
                   break;
-               case 365:
+               case 413:
                   if (curChar == 46)
-                     { jjCheckNAddTwoStates(347, 349); }
+                     { jjCheckNAddTwoStates(395, 397); }
                   break;
                default : break;
             }
@@ -2356,15 +2362,15 @@ private int jjMoveNfa_0(int startState, int curPos)
             {
                case 0:
                   if ((0x7fffffe07fffffeL & l) != 0L)
-                     { jjCheckNAddStates(143, 148); }
+                     { jjCheckNAddStates(163, 170); }
                   else if (curChar == 64)
-                     { jjCheckNAddStates(149, 154); }
+                     { jjCheckNAddStates(171, 178); }
                   else if (curChar == 95)
-                     jjstateSet[jjnewStateCnt++] = 109;
+                     jjstateSet[jjnewStateCnt++] = 123;
                   else if (curChar == 92)
-                     jjstateSet[jjnewStateCnt++] = 90;
+                     jjstateSet[jjnewStateCnt++] = 104;
                   else if (curChar == 123)
-                     { jjAddStates(155, 156); }
+                     { jjAddStates(179, 180); }
                   break;
                case 1:
                   if (kind > 8)
@@ -2373,7 +2379,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 5:
                   if ((0xc7fffffeafffffffL & l) != 0L)
-                     { jjCheckNAddStates(38, 40); }
+                     { jjCheckNAddStates(40, 42); }
                   break;
                case 6:
                   if (curChar == 92)
@@ -2381,7 +2387,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 7:
                   if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(157, 158); }
+                     { jjAddStates(181, 182); }
                   break;
                case 8:
                   if ((0x7e0000007eL & l) != 0L)
@@ -2398,15 +2404,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 11:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(38, 40); }
+                     { jjCheckNAddStates(40, 42); }
                   break;
                case 14:
                   if (curChar == 123)
-                     { jjCheckNAddStates(44, 46); }
+                     { jjCheckNAddStates(46, 48); }
                   break;
                case 15:
                   if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(44, 46); }
+                     { jjCheckNAddStates(46, 48); }
                   break;
                case 17:
                   if (curChar == 125 && kind > 40)
@@ -2414,15 +2420,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 18:
                   if (curChar == 92)
-                     { jjAddStates(159, 160); }
+                     { jjAddStates(183, 184); }
                   break;
                case 19:
                   if (curChar == 92)
-                     { jjCheckNAddStates(44, 46); }
+                     { jjCheckNAddStates(46, 48); }
                   break;
                case 20:
                   if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(161, 162); }
+                     { jjAddStates(185, 186); }
                   break;
                case 21:
                   if ((0x7e0000007eL & l) != 0L)
@@ -2439,7 +2445,7 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 24:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(44, 46); }
+                     { jjCheckNAddStates(46, 48); }
                   break;
                case 25:
                   if ((0x7e0000007eL & l) != 0L)
@@ -2491,11 +2497,11 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 40:
                   if ((0x7fffffe07fffffeL & l) != 0L)
-                     { jjCheckNAddStates(163, 168); }
+                     { jjCheckNAddStates(187, 194); }
                   break;
                case 41:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(41, 42); }
+                     { jjCheckNAddStates(49, 51); }
                   break;
                case 42:
                   if ((0x7fffffe87fffffeL & l) != 0L)
@@ -2503,31 +2509,23 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 44:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddStates(52, 57); }
+                     { jjCheckNAddStates(56, 62); }
                   break;
                case 45:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddStates(58, 61); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
                case 46:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddStates(41, 43); }
+                     { jjCheckNAddStates(43, 45); }
                   break;
-               case 47:
+               case 49:
                   if (curChar == 92)
-                     { jjAddStates(169, 170); }
-                  break;
-               case 48:
-                  if ((0x4000000080000001L & l) != 0L)
-                     { jjCheckNAddStates(58, 61); }
+                     { jjAddStates(195, 196); }
                   break;
                case 50:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 51;
-                  break;
-               case 51:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(58, 61); }
+                  if ((0x4000000080000001L & l) != 0L)
+                     { jjCheckNAddStates(63, 67); }
                   break;
                case 52:
                   if ((0x7e0000007eL & l) != 0L)
@@ -2535,127 +2533,88 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 53:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(41, 43); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
                case 54:
-                  if ((0x4000000080000001L & l) != 0L)
-                     { jjCheckNAddStates(41, 43); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 55;
+                  break;
+               case 55:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(43, 45); }
                   break;
                case 56:
-                  if (curChar == 92)
-                     jjstateSet[jjnewStateCnt++] = 57;
-                  break;
-               case 57:
                   if ((0x4000000080000001L & l) != 0L)
-                     { jjCheckNAddStates(52, 57); }
+                     { jjCheckNAddStates(43, 45); }
                   break;
                case 59:
-                  if ((0x7e0000007eL & l) != 0L)
+                  if (curChar == 92)
                      jjstateSet[jjnewStateCnt++] = 60;
                   break;
                case 60:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(52, 57); }
-                  break;
-               case 61:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(61, 62); }
+                  if ((0x4000000080000001L & l) != 0L)
+                     { jjCheckNAddStates(56, 62); }
                   break;
                case 62:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 63;
+                  break;
+               case 63:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(56, 62); }
+                  break;
+               case 69:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAdd(63); }
+                     { jjCheckNAddStates(68, 70); }
                   break;
-               case 65:
+               case 70:
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAdd(71); }
+                  break;
+               case 79:
                   if (curChar == 123)
-                     { jjAddStates(155, 156); }
+                     { jjAddStates(179, 180); }
                   break;
-               case 71:
+               case 85:
                   if (curChar == 125 && kind > 41)
                      kind = 41;
                   break;
-               case 74:
-                  if ((0xc7fffffeafffffffL & l) != 0L)
-                     { jjCheckNAddStates(19, 21); }
-                  break;
-               case 75:
-                  if (curChar == 92)
-                     jjstateSet[jjnewStateCnt++] = 76;
-                  break;
-               case 76:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(171, 172); }
-                  break;
-               case 77:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 78;
-                  break;
-               case 78:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 79;
-                  break;
-               case 79:
                case 88:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(80); }
-                  break;
-               case 80:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(19, 21); }
-                  break;
-               case 82:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 83;
-                  break;
-               case 83:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 84;
-                  break;
-               case 84:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 85;
-                  break;
-               case 85:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 86;
-                  break;
-               case 86:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 87;
-                  break;
-               case 87:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 88;
+                  if ((0xc7fffffeafffffffL & l) != 0L)
+                     { jjCheckNAddStates(20, 22); }
                   break;
                case 89:
                   if (curChar == 92)
                      jjstateSet[jjnewStateCnt++] = 90;
                   break;
                case 90:
-                  if ((0x14404410144044L & l) != 0L && kind > 78)
-                     kind = 78;
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(197, 198); }
+                  break;
+               case 91:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 92;
                   break;
                case 92:
-                  if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(77, 79); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 93;
+                  break;
+               case 93:
+               case 102:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAdd(94); }
                   break;
                case 94:
-                  if ((0x108220001082200L & l) == 0L)
-                     break;
-                  if (kind > 92)
-                     kind = 92;
-                  jjstateSet[jjnewStateCnt++] = 94;
-                  break;
-               case 95:
-                  if (curChar == 92)
-                     { jjAddStates(173, 174); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(20, 22); }
                   break;
                case 96:
-                  if ((0x3814400078144000L & l) != 0L)
-                     { jjCheckNAddStates(77, 79); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 97;
                   break;
                case 97:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(175, 176); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 98;
                   break;
                case 98:
                   if ((0x7e0000007eL & l) != 0L)
@@ -2666,153 +2625,119 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 100;
                   break;
                case 100:
-               case 108:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(101); }
+                     jjstateSet[jjnewStateCnt++] = 101;
                   break;
                case 101:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(77, 79); }
-                  break;
-               case 102:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 103;
+                     jjstateSet[jjnewStateCnt++] = 102;
                   break;
                case 103:
-                  if ((0x7e0000007eL & l) != 0L)
+                  if (curChar == 92)
                      jjstateSet[jjnewStateCnt++] = 104;
                   break;
                case 104:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 105;
-                  break;
-               case 105:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 106;
+                  if ((0x14404410144044L & l) != 0L && kind > 78)
+                     kind = 78;
                   break;
                case 106:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 107;
+                  if ((0xffffffffefffffffL & l) != 0L)
+                     { jjCheckNAddStates(85, 87); }
                   break;
-               case 107:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 108;
+               case 108:
+                  if ((0x108220001082200L & l) == 0L)
+                     break;
+                  if (kind > 92)
+                     kind = 92;
+                  jjstateSet[jjnewStateCnt++] = 108;
+                  break;
+               case 109:
+                  if (curChar == 92)
+                     { jjAddStates(199, 200); }
                   break;
                case 110:
+                  if ((0x3814400078144000L & l) != 0L)
+                     { jjCheckNAddStates(85, 87); }
+                  break;
+               case 111:
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(201, 202); }
+                  break;
+               case 112:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 113;
+                  break;
+               case 113:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 114;
+                  break;
+               case 114:
+               case 122:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAdd(115); }
+                  break;
+               case 115:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(85, 87); }
+                  break;
+               case 116:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 117;
+                  break;
+               case 117:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 118;
+                  break;
+               case 118:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 119;
+                  break;
+               case 119:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 120;
+                  break;
+               case 120:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 121;
+                  break;
+               case 121:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 122;
+                  break;
+               case 124:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
                   if (kind > 93)
                      kind = 93;
-                  { jjCheckNAddTwoStates(111, 112); }
+                  { jjCheckNAddStates(90, 92); }
                   break;
-               case 111:
+               case 125:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(111, 112); }
+                     { jjCheckNAddStates(90, 92); }
                   break;
-               case 112:
+               case 126:
                   if ((0x7fffffe87fffffeL & l) != 0L && kind > 93)
                      kind = 93;
                   break;
-               case 113:
-                  if (curChar == 95)
-                     jjstateSet[jjnewStateCnt++] = 109;
-                  break;
-               case 114:
-                  if ((0x7fffffe07fffffeL & l) != 0L)
-                     { jjCheckNAddStates(143, 148); }
-                  break;
-               case 115:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(115, 116); }
-                  break;
-               case 116:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAdd(117); }
-                  break;
-               case 118:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(118, 119); }
-                  break;
-               case 119:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAdd(120); }
-                  break;
-               case 121:
-                  if ((0x7fffffe87fffffeL & l) == 0L)
-                     break;
-                  if (kind > 72)
-                     kind = 72;
-                  { jjCheckNAddStates(84, 87); }
-                  break;
-               case 122:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddStates(84, 87); }
-                  break;
-               case 123:
-                  if ((0x7fffffe87fffffeL & l) != 0L && kind > 72)
-                     kind = 72;
-                  break;
-               case 124:
-                  if (curChar == 92)
-                     { jjAddStates(177, 178); }
-                  break;
-               case 125:
-                  if ((0x4000000080000001L & l) != 0L)
-                     { jjCheckNAddStates(84, 87); }
-                  break;
-               case 127:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 128;
-                  break;
-               case 128:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(84, 87); }
-                  break;
-               case 129:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 130;
-                  break;
-               case 130:
-                  if ((0x7e0000007eL & l) != 0L && kind > 72)
-                     kind = 72;
-                  break;
-               case 131:
-                  if ((0x4000000080000001L & l) != 0L && kind > 72)
-                     kind = 72;
-                  break;
                case 132:
-                  if (curChar == 92)
-                     jjstateSet[jjnewStateCnt++] = 133;
+                  if (curChar == 95)
+                     jjstateSet[jjnewStateCnt++] = 123;
                   break;
                case 133:
-                  if ((0x4000000080000001L & l) == 0L)
-                     break;
-                  if (kind > 72)
-                     kind = 72;
-                  { jjCheckNAddStates(84, 87); }
+                  if ((0x7fffffe07fffffeL & l) != 0L)
+                     { jjCheckNAddStates(163, 170); }
+                  break;
+               case 134:
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAddStates(93, 95); }
                   break;
                case 135:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 136;
-                  break;
-               case 136:
-                  if ((0x7e0000007eL & l) == 0L)
-                     break;
-                  if (kind > 72)
-                     kind = 72;
-                  { jjCheckNAddStates(84, 87); }
-                  break;
-               case 138:
-                  if (curChar == 64)
-                     { jjCheckNAddStates(149, 154); }
-                  break;
-               case 139:
-                  if ((0x7fffffe07fffffeL & l) != 0L)
-                     { jjCheckNAddStates(179, 181); }
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAdd(136); }
                   break;
                case 140:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(140, 141); }
+                     { jjCheckNAddStates(96, 98); }
                   break;
                case 141:
                   if ((0x7fffffe87fffffeL & l) != 0L)
@@ -2821,158 +2746,106 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 143:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 73)
-                     kind = 73;
-                  { jjCheckNAddStates(95, 98); }
+                  if (kind > 72)
+                     kind = 72;
+                  { jjCheckNAddStates(99, 103); }
                   break;
                case 144:
                   if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddStates(95, 98); }
+                     { jjCheckNAddStates(99, 103); }
                   break;
                case 145:
-                  if ((0x7fffffe87fffffeL & l) != 0L && kind > 73)
-                     kind = 73;
+                  if ((0x7fffffe87fffffeL & l) != 0L && kind > 72)
+                     kind = 72;
                   break;
-               case 146:
+               case 148:
                   if (curChar == 92)
-                     { jjAddStates(182, 183); }
-                  break;
-               case 147:
-                  if ((0x4000000080000001L & l) != 0L)
-                     { jjCheckNAddStates(95, 98); }
+                     { jjAddStates(203, 204); }
                   break;
                case 149:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 150;
-                  break;
-               case 150:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(95, 98); }
+                  if ((0x4000000080000001L & l) != 0L)
+                     { jjCheckNAddStates(99, 103); }
                   break;
                case 151:
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 152;
                   break;
                case 152:
-                  if ((0x7e0000007eL & l) != 0L && kind > 73)
-                     kind = 73;
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(99, 103); }
                   break;
                case 153:
-                  if ((0x4000000080000001L & l) != 0L && kind > 73)
-                     kind = 73;
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 154;
                   break;
                case 154:
-                  if (curChar == 92)
-                     jjstateSet[jjnewStateCnt++] = 155;
+                  if ((0x7e0000007eL & l) != 0L && kind > 72)
+                     kind = 72;
                   break;
                case 155:
-                  if ((0x4000000080000001L & l) == 0L)
-                     break;
-                  if (kind > 73)
-                     kind = 73;
-                  { jjCheckNAddStates(95, 98); }
+                  if ((0x4000000080000001L & l) != 0L && kind > 72)
+                     kind = 72;
                   break;
                case 157:
-                  if ((0x7e0000007eL & l) != 0L)
+                  if (curChar == 92)
                      jjstateSet[jjnewStateCnt++] = 158;
                   break;
                case 158:
+                  if ((0x4000000080000001L & l) == 0L)
+                     break;
+                  if (kind > 72)
+                     kind = 72;
+                  { jjCheckNAddStates(99, 103); }
+                  break;
+               case 160:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 161;
+                  break;
+               case 161:
                   if ((0x7e0000007eL & l) == 0L)
+                     break;
+                  if (kind > 72)
+                     kind = 72;
+                  { jjCheckNAddStates(99, 103); }
+                  break;
+               case 171:
+                  if (curChar == 64)
+                     { jjCheckNAddStates(171, 178); }
+                  break;
+               case 172:
+                  if ((0x7fffffe07fffffeL & l) != 0L)
+                     { jjCheckNAddStates(205, 208); }
+                  break;
+               case 173:
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAddStates(106, 108); }
+                  break;
+               case 174:
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAdd(175); }
+                  break;
+               case 176:
+                  if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
                   if (kind > 73)
                      kind = 73;
-                  { jjCheckNAddStates(95, 98); }
-                  break;
-               case 159:
-                  if ((0x7fffffe07fffffeL & l) != 0L)
-                     { jjCheckNAddStates(184, 186); }
-                  break;
-               case 160:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAddTwoStates(160, 161); }
-                  break;
-               case 161:
-                  if ((0x7fffffe87fffffeL & l) != 0L)
-                     { jjCheckNAdd(162); }
-                  break;
-               case 163:
-                  if ((0x10000000100000L & l) != 0L && kind > 75)
-                     kind = 75;
-                  break;
-               case 164:
-                  if ((0x4000000040000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 163;
-                  break;
-               case 165:
-                  if ((0x200000002L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 164;
-                  break;
-               case 166:
-                  if ((0x10000000100000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 165;
-                  break;
-               case 167:
-                  if ((0x8000000080000L & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 166;
-                  break;
-               case 168:
-                  if ((0x7fffffe07fffffeL & l) == 0L)
-                     break;
-                  if (kind > 94)
-                     kind = 94;
-                  { jjCheckNAddTwoStates(168, 169); }
-                  break;
-               case 170:
-                  if ((0x7fffffe07fffffeL & l) == 0L)
-                     break;
-                  if (kind > 94)
-                     kind = 94;
-                  { jjCheckNAddTwoStates(169, 170); }
-                  break;
-               case 172:
-                  if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(103, 105); }
-                  break;
-               case 174:
-                  if (curChar == 92)
-                     { jjAddStates(187, 188); }
-                  break;
-               case 175:
-                  if ((0x14404410144044L & l) != 0L)
-                     { jjCheckNAddStates(103, 105); }
-                  break;
-               case 176:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(189, 190); }
+                  { jjCheckNAddStates(113, 117); }
                   break;
                case 177:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 178;
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAddStates(113, 117); }
                   break;
                case 178:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 179;
-                  break;
-               case 179:
-               case 187:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(180); }
-                  break;
-               case 180:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(103, 105); }
+                  if ((0x7fffffe87fffffeL & l) != 0L && kind > 73)
+                     kind = 73;
                   break;
                case 181:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 182;
+                  if (curChar == 92)
+                     { jjAddStates(209, 210); }
                   break;
                case 182:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 183;
-                  break;
-               case 183:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 184;
+                  if ((0x4000000080000001L & l) != 0L)
+                     { jjCheckNAddStates(113, 117); }
                   break;
                case 184:
                   if ((0x7e0000007eL & l) != 0L)
@@ -2980,267 +2853,235 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 185:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 186;
+                     { jjCheckNAddStates(113, 117); }
                   break;
                case 186:
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 187;
                   break;
+               case 187:
+                  if ((0x7e0000007eL & l) != 0L && kind > 73)
+                     kind = 73;
+                  break;
                case 188:
-                  if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(106, 108); }
+                  if ((0x4000000080000001L & l) != 0L && kind > 73)
+                     kind = 73;
                   break;
                case 190:
-                  if (curChar == 64)
-                     { jjCheckNAdd(191); }
+                  if (curChar == 92)
+                     jjstateSet[jjnewStateCnt++] = 191;
                   break;
                case 191:
-                  if ((0x7fffffe07fffffeL & l) == 0L)
+                  if ((0x4000000080000001L & l) == 0L)
                      break;
-                  if (kind > 83)
-                     kind = 83;
-                  { jjCheckNAddTwoStates(191, 192); }
+                  if (kind > 73)
+                     kind = 73;
+                  { jjCheckNAddStates(113, 117); }
                   break;
                case 193:
-                  if ((0x7fffffe07fffffeL & l) == 0L)
-                     break;
-                  if (kind > 83)
-                     kind = 83;
-                  { jjCheckNAddTwoStates(192, 193); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 194;
                   break;
                case 194:
-                  if (curChar == 92)
-                     { jjAddStates(191, 192); }
-                  break;
-               case 195:
-                  if ((0x14404410144044L & l) != 0L)
-                     { jjCheckNAddStates(106, 108); }
-                  break;
-               case 196:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(193, 194); }
-                  break;
-               case 197:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 198;
-                  break;
-               case 198:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 199;
-                  break;
-               case 199:
-               case 207:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(200); }
-                  break;
-               case 200:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(106, 108); }
-                  break;
-               case 201:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 202;
+                  if ((0x7e0000007eL & l) == 0L)
+                     break;
+                  if (kind > 73)
+                     kind = 73;
+                  { jjCheckNAddStates(113, 117); }
                   break;
                case 202:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 203;
+                  if ((0x7fffffe07fffffeL & l) != 0L)
+                     { jjCheckNAddStates(211, 214); }
                   break;
                case 203:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 204;
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAddStates(120, 122); }
                   break;
                case 204:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 205;
-                  break;
-               case 205:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 206;
-                  break;
-               case 206:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 207;
-                  break;
-               case 209:
-                  if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(109, 111); }
+                  if ((0x7fffffe87fffffeL & l) != 0L)
+                     { jjCheckNAdd(205); }
                   break;
                case 211:
-                  if (curChar == 92)
-                     { jjAddStates(195, 196); }
+                  if ((0x10000000100000L & l) != 0L && kind > 75)
+                     kind = 75;
                   break;
                case 212:
-                  if ((0x14404410144044L & l) != 0L)
-                     { jjCheckNAddStates(109, 111); }
+                  if ((0x4000000040000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 211;
                   break;
                case 213:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(197, 198); }
+                  if ((0x200000002L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 212;
                   break;
                case 214:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 215;
+                  if ((0x10000000100000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 213;
                   break;
                case 215:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 216;
+                  if ((0x8000000080000L & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 214;
                   break;
                case 216:
-               case 224:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(217); }
-                  break;
-               case 217:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(109, 111); }
+                  if ((0x7fffffe07fffffeL & l) == 0L)
+                     break;
+                  if (kind > 94)
+                     kind = 94;
+                  { jjCheckNAddTwoStates(216, 217); }
                   break;
                case 218:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 219;
-                  break;
-               case 219:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 220;
+                  if ((0x7fffffe07fffffeL & l) == 0L)
+                     break;
+                  if (kind > 94)
+                     kind = 94;
+                  { jjCheckNAddTwoStates(217, 218); }
                   break;
                case 220:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 221;
-                  break;
-               case 221:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 222;
+                  if ((0xffffffffefffffffL & l) != 0L)
+                     { jjCheckNAddStates(123, 125); }
                   break;
                case 222:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 223;
+                  if (curChar == 92)
+                     { jjAddStates(215, 216); }
                   break;
                case 223:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 224;
+                  if ((0x14404410144044L & l) != 0L)
+                     { jjCheckNAddStates(123, 125); }
+                  break;
+               case 224:
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(217, 218); }
                   break;
                case 225:
-                  if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(112, 114); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 226;
+                  break;
+               case 226:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 227;
                   break;
                case 227:
-                  if (curChar == 64)
+               case 235:
+                  if ((0x7e0000007eL & l) != 0L)
                      { jjCheckNAdd(228); }
                   break;
                case 228:
-                  if ((0x7fffffe07fffffeL & l) == 0L)
-                     break;
-                  if (kind > 84)
-                     kind = 84;
-                  { jjCheckNAddTwoStates(228, 229); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(123, 125); }
+                  break;
+               case 229:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 230;
                   break;
                case 230:
-                  if ((0x7fffffe07fffffeL & l) == 0L)
-                     break;
-                  if (kind > 84)
-                     kind = 84;
-                  { jjCheckNAddTwoStates(229, 230); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 231;
                   break;
                case 231:
-                  if (curChar == 92)
-                     { jjAddStates(199, 200); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 232;
                   break;
                case 232:
-                  if ((0x14404410144044L & l) != 0L)
-                     { jjCheckNAddStates(112, 114); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 233;
                   break;
                case 233:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(201, 202); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 234;
                   break;
                case 234:
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 235;
                   break;
-               case 235:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 236;
-                  break;
                case 236:
-               case 244:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(237); }
-                  break;
-               case 237:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(112, 114); }
+                  if ((0xffffffffefffffffL & l) != 0L)
+                     { jjCheckNAddStates(126, 128); }
                   break;
                case 238:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 239;
+                  if (curChar == 64)
+                     { jjCheckNAdd(239); }
                   break;
                case 239:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 240;
-                  break;
-               case 240:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 241;
+                  if ((0x7fffffe07fffffeL & l) == 0L)
+                     break;
+                  if (kind > 83)
+                     kind = 83;
+                  { jjCheckNAddTwoStates(239, 240); }
                   break;
                case 241:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 242;
+                  if ((0x7fffffe07fffffeL & l) == 0L)
+                     break;
+                  if (kind > 83)
+                     kind = 83;
+                  { jjCheckNAddTwoStates(240, 241); }
                   break;
                case 242:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 243;
+                  if (curChar == 92)
+                     { jjAddStates(219, 220); }
                   break;
                case 243:
+                  if ((0x14404410144044L & l) != 0L)
+                     { jjCheckNAddStates(126, 128); }
+                  break;
+               case 244:
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(221, 222); }
+                  break;
+               case 245:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 244;
+                     jjstateSet[jjnewStateCnt++] = 246;
+                  break;
+               case 246:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 247;
+                  break;
+               case 247:
+               case 255:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAdd(248); }
                   break;
                case 248:
-                  if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(115, 118); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(126, 128); }
+                  break;
+               case 249:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 250;
+                  break;
+               case 250:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 251;
                   break;
                case 251:
-                  if (curChar == 92)
-                     { jjAddStates(203, 204); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 252;
                   break;
                case 252:
-                  if ((0x14404410144044L & l) != 0L)
-                     { jjCheckNAddStates(115, 118); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 253;
                   break;
                case 253:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(205, 206); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 254;
                   break;
                case 254:
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 255;
                   break;
-               case 255:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 256;
-                  break;
-               case 256:
-               case 264:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(257); }
-                  break;
                case 257:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(115, 118); }
-                  break;
-               case 258:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 259;
+                  if ((0xffffffffefffffffL & l) != 0L)
+                     { jjCheckNAddStates(129, 131); }
                   break;
                case 259:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 260;
+                  if (curChar == 92)
+                     { jjAddStates(223, 224); }
                   break;
                case 260:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 261;
+                  if ((0x14404410144044L & l) != 0L)
+                     { jjCheckNAddStates(129, 131); }
                   break;
                case 261:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 262;
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(225, 226); }
                   break;
                case 262:
                   if ((0x7e0000007eL & l) != 0L)
@@ -3250,46 +3091,72 @@ private int jjMoveNfa_0(int startState, int curPos)
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 264;
                   break;
+               case 264:
+               case 272:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAdd(265); }
+                  break;
+               case 265:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(129, 131); }
+                  break;
+               case 266:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 267;
+                  break;
+               case 267:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 268;
+                  break;
+               case 268:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 269;
+                  break;
+               case 269:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 270;
+                  break;
                case 270:
-                  if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(121, 124); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 271;
+                  break;
+               case 271:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 272;
                   break;
                case 273:
-                  if (curChar == 92)
-                     { jjAddStates(207, 208); }
-                  break;
-               case 274:
-                  if ((0x14404410144044L & l) != 0L)
-                     { jjCheckNAddStates(121, 124); }
+                  if ((0xffffffffefffffffL & l) != 0L)
+                     { jjCheckNAddStates(132, 134); }
                   break;
                case 275:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(209, 210); }
+                  if (curChar == 64)
+                     { jjCheckNAdd(276); }
                   break;
                case 276:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 277;
-                  break;
-               case 277:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 278;
+                  if ((0x7fffffe07fffffeL & l) == 0L)
+                     break;
+                  if (kind > 84)
+                     kind = 84;
+                  { jjCheckNAddTwoStates(276, 277); }
                   break;
                case 278:
-               case 286:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(279); }
+                  if ((0x7fffffe07fffffeL & l) == 0L)
+                     break;
+                  if (kind > 84)
+                     kind = 84;
+                  { jjCheckNAddTwoStates(277, 278); }
                   break;
                case 279:
-                  if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(121, 124); }
+                  if (curChar == 92)
+                     { jjAddStates(227, 228); }
                   break;
                case 280:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 281;
+                  if ((0x14404410144044L & l) != 0L)
+                     { jjCheckNAddStates(132, 134); }
                   break;
                case 281:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 282;
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(229, 230); }
                   break;
                case 282:
                   if ((0x7e0000007eL & l) != 0L)
@@ -3300,63 +3167,74 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 284;
                   break;
                case 284:
+               case 292:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 285;
+                     { jjCheckNAdd(285); }
                   break;
                case 285:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 286;
+                     { jjCheckNAddStates(132, 134); }
+                  break;
+               case 286:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 287;
+                  break;
+               case 287:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 288;
                   break;
                case 288:
-                  if (curChar == 64)
-                     { jjCheckNAdd(289); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 289;
                   break;
                case 289:
-                  if ((0x7fffffe07fffffeL & l) == 0L)
-                     break;
-                  if (kind > 85)
-                     kind = 85;
-                  { jjCheckNAddTwoStates(289, 290); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 290;
+                  break;
+               case 290:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 291;
                   break;
                case 291:
-                  if ((0x7fffffe07fffffeL & l) == 0L)
-                     break;
-                  if (kind > 85)
-                     kind = 85;
-                  { jjCheckNAddTwoStates(290, 291); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 292;
                   break;
-               case 297:
+               case 296:
                   if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(127, 130); }
+                     { jjCheckNAddStates(135, 138); }
+                  break;
+               case 299:
+                  if (curChar == 92)
+                     { jjAddStates(231, 232); }
                   break;
                case 300:
-                  if (curChar == 92)
-                     { jjAddStates(211, 212); }
+                  if ((0x14404410144044L & l) != 0L)
+                     { jjCheckNAddStates(135, 138); }
                   break;
                case 301:
-                  if ((0x14404410144044L & l) != 0L)
-                     { jjCheckNAddStates(127, 130); }
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(233, 234); }
                   break;
                case 302:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(213, 214); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 303;
                   break;
                case 303:
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 304;
                   break;
                case 304:
+               case 312:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 305;
+                     { jjCheckNAdd(305); }
                   break;
                case 305:
-               case 313:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(306); }
+                     { jjCheckNAddStates(135, 138); }
                   break;
                case 306:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(127, 130); }
+                     jjstateSet[jjnewStateCnt++] = 307;
                   break;
                case 307:
                   if ((0x7e0000007eL & l) != 0L)
@@ -3378,42 +3256,42 @@ private int jjMoveNfa_0(int startState, int curPos)
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 312;
                   break;
-               case 312:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 313;
-                  break;
-               case 319:
+               case 318:
                   if ((0xffffffffefffffffL & l) != 0L)
-                     { jjCheckNAddStates(133, 136); }
+                     { jjCheckNAddStates(141, 144); }
+                  break;
+               case 321:
+                  if (curChar == 92)
+                     { jjAddStates(235, 236); }
                   break;
                case 322:
-                  if (curChar == 92)
-                     { jjAddStates(215, 216); }
+                  if ((0x14404410144044L & l) != 0L)
+                     { jjCheckNAddStates(141, 144); }
                   break;
                case 323:
-                  if ((0x14404410144044L & l) != 0L)
-                     { jjCheckNAddStates(133, 136); }
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(237, 238); }
                   break;
                case 324:
-                  if ((0x20000000200000L & l) != 0L)
-                     { jjAddStates(217, 218); }
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 325;
                   break;
                case 325:
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 326;
                   break;
                case 326:
+               case 334:
                   if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 327;
+                     { jjCheckNAdd(327); }
                   break;
                case 327:
-               case 335:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAdd(328); }
+                     { jjCheckNAddStates(141, 144); }
                   break;
                case 328:
                   if ((0x7e0000007eL & l) != 0L)
-                     { jjCheckNAddStates(133, 136); }
+                     jjstateSet[jjnewStateCnt++] = 329;
                   break;
                case 329:
                   if ((0x7e0000007eL & l) != 0L)
@@ -3435,39 +3313,167 @@ private int jjMoveNfa_0(int startState, int curPos)
                   if ((0x7e0000007eL & l) != 0L)
                      jjstateSet[jjnewStateCnt++] = 334;
                   break;
-               case 334:
-                  if ((0x7e0000007eL & l) != 0L)
-                     jjstateSet[jjnewStateCnt++] = 335;
+               case 336:
+                  if (curChar == 64)
+                     { jjCheckNAdd(337); }
                   break;
                case 337:
-                  if (curChar == 64)
-                     { jjCheckNAdd(338); }
-                  break;
-               case 338:
                   if ((0x7fffffe07fffffeL & l) == 0L)
                      break;
-                  if (kind > 86)
-                     kind = 86;
+                  if (kind > 85)
+                     kind = 85;
+                  { jjCheckNAddTwoStates(337, 338); }
+                  break;
+               case 339:
+                  if ((0x7fffffe07fffffeL & l) == 0L)
+                     break;
+                  if (kind > 85)
+                     kind = 85;
                   { jjCheckNAddTwoStates(338, 339); }
                   break;
-               case 340:
+               case 345:
+                  if ((0xffffffffefffffffL & l) != 0L)
+                     { jjCheckNAddStates(147, 150); }
+                  break;
+               case 348:
+                  if (curChar == 92)
+                     { jjAddStates(239, 240); }
+                  break;
+               case 349:
+                  if ((0x14404410144044L & l) != 0L)
+                     { jjCheckNAddStates(147, 150); }
+                  break;
+               case 350:
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(241, 242); }
+                  break;
+               case 351:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 352;
+                  break;
+               case 352:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 353;
+                  break;
+               case 353:
+               case 361:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAdd(354); }
+                  break;
+               case 354:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(147, 150); }
+                  break;
+               case 355:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 356;
+                  break;
+               case 356:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 357;
+                  break;
+               case 357:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 358;
+                  break;
+               case 358:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 359;
+                  break;
+               case 359:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 360;
+                  break;
+               case 360:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 361;
+                  break;
+               case 367:
+                  if ((0xffffffffefffffffL & l) != 0L)
+                     { jjCheckNAddStates(153, 156); }
+                  break;
+               case 370:
+                  if (curChar == 92)
+                     { jjAddStates(243, 244); }
+                  break;
+               case 371:
+                  if ((0x14404410144044L & l) != 0L)
+                     { jjCheckNAddStates(153, 156); }
+                  break;
+               case 372:
+                  if ((0x20000000200000L & l) != 0L)
+                     { jjAddStates(245, 246); }
+                  break;
+               case 373:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 374;
+                  break;
+               case 374:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 375;
+                  break;
+               case 375:
+               case 383:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAdd(376); }
+                  break;
+               case 376:
+                  if ((0x7e0000007eL & l) != 0L)
+                     { jjCheckNAddStates(153, 156); }
+                  break;
+               case 377:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 378;
+                  break;
+               case 378:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 379;
+                  break;
+               case 379:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 380;
+                  break;
+               case 380:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 381;
+                  break;
+               case 381:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 382;
+                  break;
+               case 382:
+                  if ((0x7e0000007eL & l) != 0L)
+                     jjstateSet[jjnewStateCnt++] = 383;
+                  break;
+               case 385:
+                  if (curChar == 64)
+                     { jjCheckNAdd(386); }
+                  break;
+               case 386:
                   if ((0x7fffffe07fffffeL & l) == 0L)
                      break;
                   if (kind > 86)
                      kind = 86;
-                  { jjCheckNAddTwoStates(339, 340); }
+                  { jjCheckNAddTwoStates(386, 387); }
                   break;
-               case 350:
-                  if ((0x2000000020L & l) != 0L)
-                     { jjAddStates(219, 220); }
+               case 388:
+                  if ((0x7fffffe07fffffeL & l) == 0L)
+                     break;
+                  if (kind > 86)
+                     kind = 86;
+                  { jjCheckNAddTwoStates(387, 388); }
                   break;
-               case 357:
+               case 398:
                   if ((0x2000000020L & l) != 0L)
-                     { jjAddStates(221, 222); }
+                     { jjAddStates(247, 248); }
                   break;
-               case 361:
+               case 405:
                   if ((0x2000000020L & l) != 0L)
-                     { jjAddStates(223, 224); }
+                     { jjAddStates(249, 250); }
+                  break;
+               case 409:
+                  if ((0x2000000020L & l) != 0L)
+                     { jjAddStates(251, 252); }
                   break;
                default : break;
             }
@@ -3486,7 +3492,9 @@ private int jjMoveNfa_0(int startState, int curPos)
             {
                case 0:
                   if (jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(143, 148); }
+                     { jjCheckNAddStates(163, 170); }
+                  if (jjCanMove_33(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(253, 254); }
                   break;
                case 1:
                   if (!jjCanMove_0(hiByte, i1, i2, l1, l2))
@@ -3497,19 +3505,19 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 5:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(38, 40); }
+                     { jjAddStates(40, 42); }
                   break;
                case 15:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(44, 46); }
+                     { jjAddStates(46, 48); }
                   break;
                case 40:
                   if (jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(163, 168); }
+                     { jjCheckNAddStates(187, 194); }
                   break;
                case 41:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(41, 42); }
+                     { jjCheckNAddStates(49, 51); }
                   break;
                case 42:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
@@ -3517,85 +3525,153 @@ private int jjMoveNfa_0(int startState, int curPos)
                   break;
                case 44:
                   if (jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(52, 57); }
+                     { jjCheckNAddStates(56, 62); }
                   break;
                case 45:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(58, 61); }
+                     { jjCheckNAddStates(63, 67); }
                   break;
                case 46:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(41, 43); }
+                     { jjCheckNAddStates(43, 45); }
                   break;
-               case 61:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(61, 62); }
+               case 47:
+                  if (jjCanMove_3(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(255, 256); }
                   break;
-               case 62:
+               case 48:
+                  if (jjCanMove_4(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(63, 67); }
+                  break;
+               case 57:
+                  if (jjCanMove_5(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(43, 45); }
+                  break;
+               case 64:
+                  if (jjCanMove_6(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 65;
+                  break;
+               case 65:
+                  if (jjCanMove_7(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(56, 62); }
+                  break;
+               case 66:
+                  if (jjCanMove_8(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(257, 258); }
+                  break;
+               case 67:
+                  if (jjCanMove_9(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(49, 51); }
+                  break;
+               case 68:
+                  if (jjCanMove_10(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(43); }
+                  break;
+               case 69:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAdd(63); }
+                     { jjCheckNAddStates(68, 70); }
+                  break;
+               case 70:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(71); }
+                  break;
+               case 72:
+                  if (jjCanMove_11(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(259, 260); }
+                  break;
+               case 73:
+                  if (jjCanMove_12(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(68, 70); }
                   break;
                case 74:
-                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(19, 21); }
+                  if (jjCanMove_13(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(71); }
                   break;
-               case 92:
-                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(77, 79); }
+               case 75:
+                  if (jjCanMove_14(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(261, 262); }
                   break;
-               case 110:
+               case 76:
+                  if (jjCanMove_15(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(263, 266); }
+                  break;
+               case 77:
+                  if (jjCanMove_16(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(267, 270); }
+                  break;
+               case 88:
+                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(20, 22); }
+                  break;
+               case 106:
+                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(85, 87); }
+                  break;
+               case 124:
                   if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
                      break;
                   if (kind > 93)
                      kind = 93;
-                  { jjCheckNAddTwoStates(111, 112); }
+                  { jjCheckNAddStates(90, 92); }
                   break;
-               case 111:
+               case 125:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(111, 112); }
+                     { jjCheckNAddStates(90, 92); }
                   break;
-               case 112:
+               case 126:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 93)
                      kind = 93;
                   break;
-               case 115:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(115, 116); }
+               case 127:
+                  if (jjCanMove_17(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(271, 272); }
                   break;
-               case 116:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAdd(117); }
+               case 128:
+                  if (jjCanMove_18(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(90, 92); }
                   break;
-               case 118:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(118, 119); }
+               case 129:
+                  if (jjCanMove_19(hiByte, i1, i2, l1, l2) && kind > 93)
+                     kind = 93;
                   break;
-               case 119:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAdd(120); }
+               case 130:
+                  if (jjCanMove_20(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 131;
                   break;
-               case 121:
-                  if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
+               case 131:
+                  if (!jjCanMove_21(hiByte, i1, i2, l1, l2))
                      break;
-                  if (kind > 72)
-                     kind = 72;
-                  { jjCheckNAddStates(84, 87); }
+                  if (kind > 93)
+                     kind = 93;
+                  { jjCheckNAddStates(90, 92); }
                   break;
-               case 122:
+               case 133:
+                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(163, 170); }
+                  break;
+               case 134:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(84, 87); }
+                     { jjCheckNAddStates(93, 95); }
                   break;
-               case 123:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 72)
-                     kind = 72;
+               case 135:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(136); }
+                  break;
+               case 137:
+                  if (jjCanMove_22(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(273, 274); }
+                  break;
+               case 138:
+                  if (jjCanMove_23(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(93, 95); }
                   break;
                case 139:
-                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(179, 181); }
+                  if (jjCanMove_24(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(136); }
                   break;
                case 140:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(140, 141); }
+                     { jjCheckNAddStates(96, 98); }
                   break;
                case 141:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
@@ -3604,61 +3680,198 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 143:
                   if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
                      break;
-                  if (kind > 73)
-                     kind = 73;
-                  { jjCheckNAddStates(95, 98); }
+                  if (kind > 72)
+                     kind = 72;
+                  { jjCheckNAddStates(99, 103); }
                   break;
                case 144:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(95, 98); }
+                     { jjCheckNAddStates(99, 103); }
                   break;
                case 145:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 72)
+                     kind = 72;
+                  break;
+               case 146:
+                  if (jjCanMove_25(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(275, 276); }
+                  break;
+               case 147:
+                  if (jjCanMove_26(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(99, 103); }
+                  break;
+               case 156:
+                  if (jjCanMove_27(hiByte, i1, i2, l1, l2) && kind > 72)
+                     kind = 72;
+                  break;
+               case 162:
+                  if (jjCanMove_28(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 163;
+                  break;
+               case 163:
+                  if (!jjCanMove_29(hiByte, i1, i2, l1, l2))
+                     break;
+                  if (kind > 72)
+                     kind = 72;
+                  { jjCheckNAddStates(99, 103); }
+                  break;
+               case 164:
+                  if (jjCanMove_30(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(277, 278); }
+                  break;
+               case 165:
+                  if (jjCanMove_31(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(96, 98); }
+                  break;
+               case 166:
+                  if (jjCanMove_32(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(142); }
+                  break;
+               case 167:
+                  if (jjCanMove_33(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(253, 254); }
+                  break;
+               case 168:
+                  if (jjCanMove_34(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(279, 282); }
+                  break;
+               case 169:
+                  if (jjCanMove_35(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(283, 286); }
+                  break;
+               case 172:
+                  if (jjCanMove_1(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(205, 208); }
+                  break;
+               case 173:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(106, 108); }
+                  break;
+               case 174:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(175); }
+                  break;
+               case 176:
+                  if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
+                     break;
+                  if (kind > 73)
+                     kind = 73;
+                  { jjCheckNAddStates(113, 117); }
+                  break;
+               case 177:
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(113, 117); }
+                  break;
+               case 178:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 73)
                      kind = 73;
                   break;
-               case 159:
+               case 179:
+                  if (jjCanMove_36(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(287, 288); }
+                  break;
+               case 180:
+                  if (jjCanMove_37(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(113, 117); }
+                  break;
+               case 189:
+                  if (jjCanMove_38(hiByte, i1, i2, l1, l2) && kind > 73)
+                     kind = 73;
+                  break;
+               case 195:
+                  if (jjCanMove_39(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 196;
+                  break;
+               case 196:
+                  if (!jjCanMove_40(hiByte, i1, i2, l1, l2))
+                     break;
+                  if (kind > 73)
+                     kind = 73;
+                  { jjCheckNAddStates(113, 117); }
+                  break;
+               case 197:
+                  if (jjCanMove_41(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(289, 290); }
+                  break;
+               case 198:
+                  if (jjCanMove_42(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(106, 108); }
+                  break;
+               case 199:
+                  if (jjCanMove_43(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(175); }
+                  break;
+               case 200:
+                  if (jjCanMove_44(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 201;
+                  break;
+               case 201:
+                  if (jjCanMove_45(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(205, 208); }
+                  break;
+               case 202:
                   if (jjCanMove_1(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddStates(184, 186); }
+                     { jjCheckNAddStates(211, 214); }
                   break;
-               case 160:
+               case 203:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAddTwoStates(160, 161); }
+                     { jjCheckNAddStates(120, 122); }
                   break;
-               case 161:
+               case 204:
                   if (jjCanMove_2(hiByte, i1, i2, l1, l2))
-                     { jjCheckNAdd(162); }
+                     { jjCheckNAdd(205); }
                   break;
-               case 172:
-                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(103, 105); }
+               case 206:
+                  if (jjCanMove_46(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(291, 292); }
                   break;
-               case 188:
-                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(106, 108); }
+               case 207:
+                  if (jjCanMove_47(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(120, 122); }
+                  break;
+               case 208:
+                  if (jjCanMove_48(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAdd(205); }
                   break;
                case 209:
-                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(109, 111); }
+                  if (jjCanMove_49(hiByte, i1, i2, l1, l2))
+                     jjstateSet[jjnewStateCnt++] = 210;
                   break;
-               case 225:
-                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(112, 114); }
+               case 210:
+                  if (jjCanMove_50(hiByte, i1, i2, l1, l2))
+                     { jjCheckNAddStates(211, 214); }
                   break;
-               case 248:
+               case 220:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(115, 118); }
+                     { jjAddStates(123, 125); }
                   break;
-               case 270:
+               case 236:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(121, 124); }
+                     { jjAddStates(126, 128); }
                   break;
-               case 297:
+               case 257:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(127, 130); }
+                     { jjAddStates(129, 131); }
                   break;
-               case 319:
+               case 273:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
-                     { jjAddStates(133, 136); }
+                     { jjAddStates(132, 134); }
+                  break;
+               case 296:
+                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(135, 138); }
+                  break;
+               case 318:
+                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(141, 144); }
+                  break;
+               case 345:
+                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(147, 150); }
+                  break;
+               case 367:
+                  if (jjCanMove_0(hiByte, i1, i2, l1, l2))
+                     { jjAddStates(153, 156); }
                   break;
                default : if (i1 == 0 || l1 == 0 || i2 == 0 ||  l2 == 0) break; else break;
             }
@@ -3671,7 +3884,7 @@ private int jjMoveNfa_0(int startState, int curPos)
          kind = 0x7fffffff;
       }
       ++curPos;
-      if ((i = jjnewStateCnt) == (startsAt = 366 - (jjnewStateCnt = startsAt)))
+      if ((i = jjnewStateCnt) == (startsAt = 414 - (jjnewStateCnt = startsAt)))
          break;
       try { curChar = input_stream.readChar(); }
       catch(java.io.IOException e) { break; }
@@ -3722,21 +3935,25 @@ private int jjMoveStringLiteralDfa1_1(long active0){
    return 2;
 }
 static final int[] jjnextStates = {
-   344, 345, 346, 354, 355, 360, 361, 344, 345, 346, 348, 353, 316, 342, 267, 293, 
-   121, 132, 134, 74, 75, 81, 3, 4, 40, 64, 209, 210, 225, 226, 231, 211, 
-   172, 173, 188, 189, 194, 174, 5, 6, 12, 13, 14, 32, 15, 16, 18, 41, 
-   42, 44, 56, 58, 45, 46, 13, 14, 47, 55, 45, 46, 47, 49, 61, 62, 
-   44, 56, 58, 13, 14, 32, 67, 68, 71, 69, 70, 72, 71, 92, 93, 95, 
-   115, 116, 118, 119, 122, 123, 124, 126, 127, 129, 140, 141, 143, 154, 156, 144, 
-   145, 146, 148, 149, 151, 160, 161, 172, 173, 174, 188, 189, 194, 209, 210, 211, 
-   225, 226, 231, 247, 248, 249, 251, 250, 266, 269, 270, 271, 273, 272, 292, 296, 
-   297, 298, 300, 299, 315, 318, 319, 320, 322, 321, 341, 354, 355, 360, 361, 115, 
-   116, 117, 118, 119, 120, 139, 142, 159, 162, 167, 168, 66, 67, 8, 33, 19, 
-   20, 21, 25, 41, 42, 43, 61, 62, 63, 48, 54, 77, 82, 96, 97, 98, 
-   102, 125, 131, 140, 141, 142, 147, 153, 160, 161, 162, 175, 176, 177, 181, 195, 
-   196, 197, 201, 212, 213, 214, 218, 232, 233, 234, 238, 252, 253, 254, 258, 274, 
-   275, 276, 280, 301, 302, 303, 307, 323, 324, 325, 329, 351, 352, 358, 359, 362, 
-   363, 
+   392, 393, 394, 402, 403, 408, 409, 392, 393, 394, 396, 401, 364, 390, 315, 341, 
+   143, 157, 159, 162, 88, 89, 95, 3, 4, 40, 75, 78, 257, 258, 273, 274, 
+   279, 259, 220, 221, 236, 237, 242, 222, 5, 6, 12, 13, 14, 32, 15, 16, 
+   18, 41, 42, 66, 44, 59, 61, 64, 45, 46, 13, 14, 47, 49, 58, 45, 
+   46, 47, 49, 51, 69, 70, 72, 44, 59, 61, 64, 13, 14, 32, 81, 82, 
+   85, 83, 84, 86, 85, 106, 107, 109, 124, 130, 125, 126, 127, 134, 135, 137, 
+   140, 141, 164, 144, 145, 146, 148, 150, 151, 153, 173, 174, 197, 176, 190, 192, 
+   195, 177, 178, 179, 181, 183, 184, 186, 203, 204, 206, 220, 221, 222, 236, 237, 
+   242, 257, 258, 259, 273, 274, 279, 295, 296, 297, 299, 298, 314, 317, 318, 319, 
+   321, 320, 340, 344, 345, 346, 348, 347, 363, 366, 367, 368, 370, 369, 389, 402, 
+   403, 408, 409, 134, 135, 136, 140, 141, 142, 164, 137, 172, 200, 175, 202, 209, 
+   205, 215, 216, 80, 81, 8, 33, 19, 20, 21, 25, 41, 42, 43, 69, 70, 
+   71, 72, 66, 50, 56, 91, 96, 110, 111, 112, 116, 149, 155, 173, 174, 175, 
+   197, 182, 188, 203, 204, 205, 206, 223, 224, 225, 229, 243, 244, 245, 249, 260, 
+   261, 262, 266, 280, 281, 282, 286, 300, 301, 302, 306, 322, 323, 324, 328, 349, 
+   350, 351, 355, 371, 372, 373, 377, 399, 400, 406, 407, 410, 411, 168, 169, 48, 
+   57, 67, 68, 73, 74, 76, 77, 41, 42, 43, 66, 69, 70, 71, 72, 128, 
+   129, 138, 139, 147, 156, 165, 166, 134, 135, 136, 137, 140, 141, 142, 164, 180, 
+   189, 198, 199, 207, 208, 
 };
 private static final boolean jjCanMove_0(int hiByte, int i1, int i2, long l1, long l2)
 {
@@ -3798,6 +4015,486 @@ private static final boolean jjCanMove_2(int hiByte, int i1, int i2, long l1, lo
          return false;
    }
 }
+private static final boolean jjCanMove_3(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_4(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_5(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_6(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_7(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_8(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_9(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_10(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_11(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_12(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_13(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_14(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_15(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_16(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_17(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_18(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_19(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_20(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_21(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_22(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_23(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_24(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_25(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_26(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_27(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_28(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_29(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_30(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_31(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_32(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_33(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_34(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_35(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_36(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_37(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_38(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_39(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_40(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_41(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_42(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_43(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_44(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_45(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_46(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_47(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_48(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_49(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec13[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
+private static final boolean jjCanMove_50(int hiByte, int i1, int i2, long l1, long l2)
+{
+   switch(hiByte)
+   {
+      default :
+         if ((jjbitVec14[i1] & l1) != 0L)
+            return true;
+         return false;
+   }
+}
 
 /** Token literal values. */
 public static final String[] jjstrLiteralImages = {
@@ -3809,7 +4506,7 @@ null, null, null, null, null, "\53", "\55", "\174", "\100", "\136", "\56", "\41"
 "\54", "\137", "\73", "\44", "\176", "\46", null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
-null, null, null, };
+null, null, null, null, };
 protected Token jjFillToken()
 {
    final Token t;
@@ -3975,7 +4672,7 @@ private void jjCheckNAddStates(int start, int end)
   {
     int i;
     jjround = 0x80000001;
-    for (i = 366; i-- > 0;)
+    for (i = 414; i-- > 0;)
       jjrounds[i] = 0x80000000;
   }
 
@@ -4007,7 +4704,7 @@ public static final int[] jjnewLexState = {
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
-   -1, -1, -1, -1, -1, -1, -1, 
+   -1, -1, -1, -1, -1, -1, -1, -1, 
 };
 static final long[] jjtoToken = {
    0xffffeffffffff007L, 0x777fcfdfL, 
@@ -4017,8 +4714,8 @@ static final long[] jjtoSkip = {
 };
     protected SimpleCharStream  input_stream;
 
-    private final int[] jjrounds = new int[366];
-    private final int[] jjstateSet = new int[2 * 366];
+    private final int[] jjrounds = new int[414];
+    private final int[] jjstateSet = new int[2 * 414];
 
     
     protected char curChar;

--- a/jena-shex/src/main/java/org/apache/jena/shex/sys/ShexLib.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/sys/ShexLib.java
@@ -32,10 +32,7 @@ import org.apache.jena.riot.system.PrefixMapFactory;
 import org.apache.jena.shex.ShexRecord;
 import org.apache.jena.shex.ShexReport;
 import org.apache.jena.shex.ShexStatus;
-import org.apache.jena.shex.expressions.ShapeExprVisitor;
-import org.apache.jena.shex.expressions.ShapeExprWalker;
-import org.apache.jena.shex.expressions.ShapeExpression;
-import org.apache.jena.shex.expressions.TripleExprVisitor;
+import org.apache.jena.shex.expressions.*;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
@@ -50,19 +47,54 @@ public class ShexLib {
         return uri.substring(idx);
     }
 
-    public static void walk(ShapeExpression shExpr, ShapeExprVisitor beforeVisitor, ShapeExprVisitor afterVisitor) {
-        ShapeExprWalker walker = new ShapeExprWalker(beforeVisitor, afterVisitor, null, null);
+//    public static void walk(ShapeExpression shExpr, ShapeExprVisitor beforeVisitor, ShapeExprVisitor afterVisitor) {
+//        TripleExprVisitor tExprVisitor = new TripleExprVisitor() {
+//            @Override public void visit(TripleConstraint object) {
+//                // One level call of visitor.
+//                //object.getPredicate();
+//                ShapeExpression theShapeExpression = object.getShapeExpression();
+//                if ( theShapeExpression != null )
+//                    theShapeExpression.visit(beforeVisitor);
+//            }
+//        };
+//
+//        ShapeExprWalker walker = new ShapeExprWalker(beforeVisitor, afterVisitor, tExprVisitor, null, null);
+//        shExpr.visit(walker);
+//    }
+
+    public static void walk(ShapeExpression shExpr,
+                             ShapeExprVisitor shapeVisitor,
+                             TripleExprVisitor tripleExpressionVisitor,
+                             NodeConstraintVisitor nodeConstraintVisitor
+                            ) {
+        TripleExprVisitor tExprVisitor = new TripleExprVisitor() {
+            @Override public void visit(TripleConstraint object) {
+                // One level call of visitor.
+                //object.getPredicate();
+                ShapeExpression theShapeExpression = object.getShapeExpression();
+                if ( theShapeExpression != null )
+                    theShapeExpression.visit(shapeVisitor);
+            }
+        };
+        ShapeExprWalker walker = new ShapeExprWalker(shapeVisitor, null,
+                                                     tripleExpressionVisitor, null,
+                                                     nodeConstraintVisitor);
         shExpr.visit(walker);
     }
 
-    public static void walk(ShapeExpression shExpr,
-                            ShapeExprVisitor beforeVisitor, ShapeExprVisitor afterVisitor,
-                            TripleExprVisitor beforeTripleExpressionVisitor, TripleExprVisitor afterTripleExpressionVisitor
-                            ) {
-        ShapeExprWalker walker = new ShapeExprWalker(beforeVisitor, afterVisitor,
-                                                     beforeTripleExpressionVisitor, afterTripleExpressionVisitor);
-        shExpr.visit(walker);
-    }
+
+    // XXX Does this make sense?
+//    private static void walk(ShapeExpression shExpr,
+//                             ShapeExprVisitor beforeVisitor, ShapeExprVisitor afterVisitor,
+//                             //TripleExprVisitor beforeTripleExpressionVisitor, TripleExprVisitor afterTripleExpressionVisitor,
+//                             //NodeConstraint beforeNodeConstraintVisitor, NodeConstraint afterNodeConstraintVisitor
+//                             NodeConstraintVisitor beforeNodeConstraintVisitor, NodeConstraint afterNodeConstraintVisitor
+//                            ) {
+//        ShapeExprWalker walker = new ShapeExprWalker(beforeVisitor, afterVisitor,
+//                                                     beforeTripleExpressionVisitor, afterTripleExpressionVisitor,
+//                                                     beforeNodeConstraintVisitor, afterNodeConstraintVisitor);
+//        shExpr.visit(walker);
+//    }
 
     private static PrefixMap displayPrefixMap = PrefixMapFactory.createForOutput();
     private static NodeFormatter nodeFmtAbbrev = new NodeFormatterTTL(null, displayPrefixMap);

--- a/jena-shex/src/main/java/org/apache/jena/shex/writer/WriterShExC.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/writer/WriterShExC.java
@@ -1,0 +1,466 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.shex.writer;
+
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Consumer;
+
+import org.apache.jena.atlas.io.AWriter;
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.out.NodeFormatter;
+import org.apache.jena.riot.out.NodeFormatterTTL;
+import org.apache.jena.riot.system.RiotLib;
+import org.apache.jena.shex.ShexSchema;
+import org.apache.jena.shex.ShexShape;
+import org.apache.jena.shex.expressions.*;
+import org.apache.jena.shex.sys.SysShex;
+
+/** Print in ShExC format */
+public class WriterShExC {
+
+    public static void print(OutputStream out, ShexSchema schema) {
+        IndentedWriter iOut = new IndentedWriter(out);
+        int row = iOut.getRow();
+        int col = iOut.getCol();
+        WriterShExC.print(iOut, schema);
+        iOut.flush();
+        // Do not close because that closes the underlying stream.
+    }
+
+    public static void print(IndentedWriter out, ShexSchema schema) {
+        boolean hasHeader = false;
+        if ( schema.getBase() != null ) {
+            out.println("BASE   <"+schema.getBase()+">");
+            hasHeader = true;
+        }
+        if ( schema.getPrefixMap() != null && ! schema.getPrefixMap().isEmpty() ) {
+            RiotLib.writePrefixes(out, schema.getPrefixMap(), true);
+            hasHeader = true;
+        }
+        if ( schema.getImports() != null && ! schema.getImports().isEmpty() ) {
+            schema.getImports().forEach(importURI -> out.println("IMPORT <"+importURI+">"));
+            hasHeader = true;
+        }
+        //schema.getSource();
+        // ShexShape start = schema.getStart();
+        boolean printNL = hasHeader;
+        NodeFormatter formatter = new NodeFormatterTTL(schema.getBase(), schema.getPrefixMap());
+
+        // XXX [Print] printNL needs to flow across calls.
+        //PrintCxt cxt = new PrintCxt(out, schema.getBase(), schema.getPrefixMap());
+        schema.getShapes().forEach( shape->print(out, formatter, shape, printNL) );
+    }
+
+    private static void print(IndentedWriter out, NodeFormatter formatter, ShexShape shape, boolean printNL) {
+        if (printNL)
+            out.println();
+        if ( shape.getLabel() != null ) {
+
+            Node n = shape.getLabel();
+            if ( n.equals(SysShex.startNode) )
+                out.print("START=");
+            else
+                formatter.format(out, n);
+            out.print(" ");
+        }
+
+        PrinterShExC shexPrinter = new PrinterShExC(out, formatter);
+        ShapeExpression shapeEx = shape.getShapeExpression();
+        shexPrinter.printShapeExpression(shapeEx);
+    }
+
+    static <X> void printList(IndentedWriter out, List<X> items, String start, String finish, String sep, Consumer<X> action) {
+        if (items.isEmpty())
+            return;
+        if (items.size() == 1 ) {
+            action.accept(items.get(0));
+            return;
+        }
+        if ( start != null ) {
+            out.print(start);
+            out.print(" ");
+        }
+        boolean first = true;
+        for ( X elt : items ) {
+            if ( first ) {
+                first = false;
+            } else {
+                if ( sep != null )
+                    out.print(sep);
+                out.print(" ");
+            }
+            action.accept(elt);
+        }
+        if ( finish != null ) {
+            out.print(" ");
+            out.print(finish);
+        }
+    }
+
+    /** Write a string - basic escaping, no quote escaping. */
+    // XXX [Print] -> ShexParserLib -> ShexRegexStr
+    static void regexStringEsc(AWriter out, String s) {
+        int len = s.length() ;
+        for (int i = 0; i < len; i++) {
+            char c = s.charAt(i);
+            // \\ Escape always possible.
+//                if (c == '\\') {
+//                    out.print('\\') ;
+//                    out.print(c) ;
+//                    continue ;
+//                }
+            switch(c) {
+                case '\n':  out.print("\\n"); continue;
+                case '\t':  out.print("\\t"); continue;
+                case '\r':  out.print("\\r"); continue;
+                case '\f':  out.print("\\f"); continue;
+                case'/':
+//                    case '\\': case '|': case '.' : case'?':
+//                    case'*': case'+': case'(': case')': case'{': case'}': case'$':
+//                    case'-': case'[': case']': case'/':
+                //case '^':
+                    out.print("\\");
+                    out.print(c);
+                    continue;
+                default:
+                    out.print(c);
+            }
+        }
+    }
+
+    private static class PrinterShExC implements ShapeExprVisitor, TripleExprVisitor, NodeConstraintVisitor {
+        final IndentedWriter out;
+        final NodeFormatter formatter;
+
+        public PrinterShExC(IndentedWriter out, NodeFormatter formatter) {
+            this.out = out;
+            this.formatter = formatter;
+        }
+
+        private void printShapeExpression(ShapeExpression shapeExpression) {
+            shapeExpression.visit(this);
+        }
+
+        private void printTripleExpression(TripleExpression tripleExpr) {
+            tripleExpr.visit(this);
+            out.print(" ;");
+        }
+
+        private void printTripleExpressionNoSep(TripleExpression tripleExpr) {
+            tripleExpr.visit(this);
+        }
+
+        private void printNodeConstraint(NodeConstraintComponent ncc) {
+            ncc.visit(this);
+        }
+
+        private void printNode(Node node) {
+            formatter.format(out, node);
+        }
+
+        private boolean inValueSet = false;
+
+        private void printValueSetRange(ValueSetRange vsr) {
+            // [LAYOUT] Gaps.
+            // Need ValueSet object.
+
+            boolean b = inValueSet;
+            if ( !b ) {
+                out.print("[ ");
+                inValueSet = true;
+            }
+
+            out.print(" ");
+            // [LAYOUT]
+            // Need enum.
+            String type = vsr.type();
+            if ( type.equals("unknown") )
+                out.print(".");
+            else
+                out.print(vsr.type());
+            printValueSetItem(vsr.item());
+            if ( vsr.numExclusions() > 0 ) {
+                // [LAYOUT] Which is it?
+                //out.print(" -");
+                vsr.exclusions(vsi->{
+                    out.print(" -");
+                    printValueSetItem(vsi);
+                });
+            }
+
+            if ( !b ) {
+                out.println(" ]");
+                inValueSet = false;
+            }
+        }
+
+        private void printValueSetItem(ValueSetItem item) {
+            if ( item.isEmpty() ) {
+                out.print(".");
+                return;
+            }
+            item.print(out, formatter);
+        }
+
+        @Override
+        public void visit(ShapeExprAND shape) {
+            List<ShapeExpression> shapes = shape.expressions();
+            printList(out, shape.expressions(), null, null, " AND",
+                      x->{
+                          // Avoid flattening S1 AND ( S2 AND S3 )
+                          boolean needParens = ( x instanceof ShapeExprAND || x instanceof ShapeExprOR );
+                          if ( needParens )
+                              out.print("( ");
+                          printShapeExpression(x);
+                          if ( needParens )
+                              out.print(" )");
+                      });
+        }
+
+        @Override
+        public void visit(ShapeExprOR shape) {
+            List<ShapeExpression> shapes = shape.expressions();
+            printList(out, shape.expressions(), null, null, " OR",
+                      x->{
+                          // Avoid flattening S1 OR ( S2 OR S3 )
+                          boolean needParens = ( x instanceof ShapeExprAND || x instanceof ShapeExprOR );
+                          if ( needParens )
+                              out.print("( ");
+                          printShapeExpression(x);
+                          if ( needParens )
+                              out.print(" )");
+                      });
+        }
+
+        @Override
+        public void visit(ShapeExprNOT shape) {
+            out.print("NOT ");
+            ShapeExpression shExpr = shape.subShape();
+            boolean needParens = true;
+
+            if ( shExpr instanceof ShapeExprTripleExpr )
+                needParens = false;
+            else if ( shExpr instanceof ShapeNodeConstraint )
+                needParens = false;
+            else if ( shExpr instanceof ShapeExprAtom )
+                needParens = false;
+
+            if ( needParens ) {
+                out.print("( ");
+            }
+            printShapeExpression(shape.subShape());
+            if ( needParens ) {
+                out.print(" ) ");
+            }
+        }
+
+        @Override
+        public void visit(ShapeExprDot shape) {
+            out.print(". ");
+        }
+
+        @Override
+        public void visit(ShapeExprAtom shape) {
+            final boolean multiLine = false;
+            if ( shape.getShape() == null )
+                return;
+            if ( multiLine ) {
+                out.println("(");
+                out.incIndent();
+                printShapeExpression(shape.getShape());
+                out.decIndent();
+                out.println(")");
+            } else {
+                out.print("( ");
+                out.incIndent();
+                printShapeExpression(shape.getShape());
+                out.decIndent();
+                out.print(" ) ");
+            }
+        }
+
+        @Override
+        public void visit(ShapeExprFalse shape) { out.print("FALSE"); }
+
+        @Override
+        public void visit(ShapeExprNone shape) {
+            out.print("{ }");
+        }
+
+        @Override
+        public void visit(ShapeExprRef shape) {
+            out.print("@");
+            printNode(shape.getRef());
+        }
+
+        @Override
+        public void visit(ShapeExprTrue shape) {
+            out.print(" . ");
+        }
+
+        @Override
+        public void visit(ShapeExprExternal shape) {
+            out.println("EXTERNAL");
+        }
+
+        @Override
+        public void visit(ShapeExprTripleExpr shape) {
+            TripleExpression tripleExpr = shape.getTripleExpr();
+            if ( shape.isClosed() )
+                out.println("CLOSED ");
+            if ( shape.getExtras() != null && ! shape.getExtras().isEmpty() ) {
+                out.println("EXTRA ");
+                shape.getExtras().forEach(n-> { formatter.format(out, n); out.print(" ");});
+            }
+            out.println("{");
+            out.incIndent();
+
+            printTripleExpression(tripleExpr);
+
+            out.decIndent();
+            out.println("}");
+        }
+
+        @Override
+        public void visit(StrRegexConstraint constraint) {
+            out.print("/");
+            //[LAYOUT] Escapes
+            String pattern = constraint.getPattern();
+            regexStringEsc(out, pattern);
+            out.print("/");
+            if ( constraint.getFlagsStr() != null ) {
+                out.print(constraint.getFlagsStr());
+            }
+        }
+
+        @Override
+        public void visit(StrLengthConstraint constraint) {
+            //stringLength       ::=      "LENGTH" | "MINLENGTH" | "MAXLENGTH"
+            out.print(constraint.getLengthType().label().toUpperCase(Locale.ROOT));
+            out.print(" ");
+            out.print(Integer.toString(constraint.getLength()));
+        }
+
+        @Override
+        public void visit(DatatypeConstraint constraint) {
+            formatter.formatURI(out, constraint.getDatatypeURI());
+        }
+
+        @Override
+        public void visit(NodeKindConstraint constraint) {
+            out.print(constraint.getNodeKind().label().toUpperCase(Locale.ROOT));
+        }
+
+        // [30]        numericFacet       ::=      numericRange numericLiteral | numericLength INTEGER
+
+        @Override
+        public void visit(NumLengthConstraint constraint) {
+            // [32]        numericLength      ::=      "TOTALDIGITS" | "FRACTIONDIGITS"
+            out.print(constraint.getLengthType().label().toUpperCase(Locale.ROOT));
+            out.print(" ");
+            out.print(Integer.toString(constraint.getLength()));
+        }
+
+        @Override
+        public void visit(NumRangeConstraint constraint) {
+            // [31]        numericRange       ::=      "MININCLUSIVE" | "MINEXCLUSIVE" | "MAXINCLUSIVE" | "MAXEXCLUSIVE"
+            out.print(constraint.getRangeKind().label().toUpperCase(Locale.ROOT));
+            out.print(" ");
+            printNode(constraint.getValue());
+        }
+
+        @Override
+        public void visit(ValueConstraint constraint) {
+            // [49]        valueSetValue      ::=      iriRange | literalRange | languageRange | exclusion+
+            out.print("[ ");
+            constraint.forEach(valueSetRange->{
+                printValueSetItem(valueSetRange.item());
+                valueSetRange.exclusions(vsItem->{
+                    out.print(" -");
+                    printValueSetItem(vsItem);
+                });
+            });
+            out.print(" ]");
+        }
+
+        @Override public void visit(TripleExprCardinality tripleExpr) {
+            out.incIndent();
+            out.print("( ");
+            printTripleExpressionNoSep(tripleExpr.target());
+            out.print(" )");
+            String x = tripleExpr.cardinalityString();
+            out.print(x);
+            out.decIndent();
+        }
+
+        @Override public void visit(TripleExprEachOf tripleExpr) {
+            printList(out, tripleExpr.expressions(), "(", ")", null, tExpr->{
+                out.incIndent();
+                printTripleExpression(tExpr);
+                out.decIndent();
+            });
+            out.println();
+        }
+        @Override public void visit(TripleExprOneOf tripleExpr) {
+            printList(out, tripleExpr.expressions(), "(", ")", "|", tExpr->{
+                    out.incIndent();
+                    printTripleExpression(tExpr);
+                    out.decIndent();
+               });
+           out.println();
+        }
+
+        @Override public void visit(TripleExprNone tripleExpr) { /* Nothing */ }
+
+        @Override public void visit(TripleExprRef tripleExpr) {
+            out.print("&");
+            printNode(tripleExpr.ref());
+        }
+
+        @Override public void visit(TripleConstraint tripleExpr) {
+            Node predicate = tripleExpr.getPredicate();
+            //formatter.format(w, node);
+            if ( tripleExpr.reverse() )
+                out.print("^");
+            printNode(predicate);
+            out.print(" ");
+            printShapeExpression(tripleExpr.getShapeExpression());
+            String x =  tripleExpr.cardinalityString();
+            if ( x != null && ! x.isEmpty() ) {
+                out.print(" ");
+                out.print(x);
+            }
+        }
+
+        @Override
+        public void visit(ShapeNodeConstraint shape) {
+            if ( shape.getNodeConstraint() != null ) {
+                printList(out, shape.getNodeConstraint().components(), null, null, null,
+                          nc->{
+                              out.incIndent();
+                              printNodeConstraint(nc);
+                              out.decIndent();
+                          });
+            }
+        }
+    }
+}

--- a/jena-shex/src/test/java/org/apache/jena/shex/TestShexPrintShexC.java
+++ b/jena-shex/src/test/java/org/apache/jena/shex/TestShexPrintShexC.java
@@ -18,29 +18,15 @@
 
 package org.apache.jena.shex;
 
+import org.apache.jena.arq.junit.runners.Directories;
+import org.apache.jena.arq.junit.runners.Label;
+import org.apache.jena.shex.runner.RunnerShexSyntax;
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
-    TestShexSyntax.class,
-    TestShexSyntaxBad.class,
-    TestShexValidation.class,
-    TestShexShapeMapSyntax.class,
-    TestShexPrintShexC.class
+@RunWith(RunnerShexSyntax.class)
+@Label("Shex Syntax")
+@Directories({
+    "src/test/files/spec/syntax"
 })
 
-public class TS_Shex {
-
-    // Too later the runners have setup by now.
-//    private static boolean oldValue = false;
-//
-//    @BeforeClass public static void beforeAll() {
-//        oldValue = SysShex.STRICT;
-//        SysShex.STRICT = true;
-//    }
-//
-//    @AfterClass public static void afterAll() {
-//        SysShex.STRICT = oldValue;
-//    }
-}
+public class TestShexPrintShexC {}

--- a/jena-shex/src/test/java/org/apache/jena/shex/runner/AbstractRunnerFiles.java
+++ b/jena-shex/src/test/java/org/apache/jena/shex/runner/AbstractRunnerFiles.java
@@ -47,8 +47,8 @@ public abstract class AbstractRunnerFiles extends ParentRunner<Runner> {
     private List<Runner> children = new ArrayList<>();
 
     // Includes and excludes are filenames with a directory.
-    public AbstractRunnerFiles(Class<? > klass, Function <String, Runnable> maker,
-                               Set<String> includes, Set<String> excludes) throws InitializationError {
+    protected AbstractRunnerFiles(Class<? > klass, Function <String, Runnable> maker,
+                                  Set<String> includes, Set<String> excludes) throws InitializationError {
         super(klass);
         String label = ShexTests.getLabel(klass);
         if ( label == null )

--- a/jena-shex/src/test/java/org/apache/jena/shex/runner/RunnerPrintShex.java
+++ b/jena-shex/src/test/java/org/apache/jena/shex/runner/RunnerPrintShex.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.shex.runner;
+
+import static org.junit.Assert.fail;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.jena.atlas.io.IO;
+import org.apache.jena.atlas.io.IndentedLineBuffer;
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.shex.Shex;
+import org.apache.jena.shex.ShexSchema;
+import org.apache.jena.shex.parser.ShexParseException;
+import org.apache.jena.shex.writer.WriterShExC;
+import org.junit.runners.model.InitializationError;
+
+public class RunnerPrintShex extends org.apache.jena.shex.runner.AbstractRunnerFiles {
+
+    public RunnerPrintShex(Class<? > klass) throws InitializationError {
+        super(klass, RunnerPrintShex::makeShexPrintTest, includes(), excludes());
+    }
+
+    private static Set<String> includes() {
+        Set<String> includes = new HashSet<>();
+        return includes;
+    }
+
+    private static Set<String> excludes() {
+        Set<String> excludes = new HashSet<>();
+
+        // Contains \ud800 (ill-formed surrogate pair)
+        excludes.add("1refbnode_with_spanning_PN_CHARS_BASE1.shex");
+        // Contains \u0d00 (ill-formed surrogate pair)
+        excludes.add("_all.shex");
+        return excludes;
+    }
+
+    private static Runnable makeShexPrintTest(String filename) {
+        return ()->testShexPrint(filename);
+    }
+
+    public static void testShexPrint(String FN) {
+        ShexSchema schema = Shex.readSchema(FN);
+        IndentedLineBuffer out = new IndentedLineBuffer();
+
+        String label = FN;
+        out.println("## Print");
+        WriterShExC.print(out, schema);
+        String s = out.toString();
+
+        ShexSchema schema2;
+        try {
+            schema2 = Shex.schemaFromString(s);
+        } catch (ShexParseException ex) {
+            // Bad syntax in printed output.
+            printFile(FN);
+            System.out.println("-- --");
+            System.out.println(s);
+            System.out.println("** Syntax error ** "+FN);
+            String msg = ex.getMessage();
+            int i = msg.indexOf('\n');
+            if ( i > 0 )
+                msg = msg.substring(0,i);
+            System.out.println("** "+msg);
+            IndentedWriter out2 = IndentedWriter.stdout.clone();
+            out2.setLineNumbers(true);
+            WriterShExC.print(out2, schema);
+            System.out.println("-- --");
+            Shex.printSchema(schema);
+            System.out.println("== ==");
+            throw ex;
+        }
+
+        // bnode isomorphism.
+        boolean equivalent = schema.sameAs(schema2);
+        //if ( !equivalent ) {
+        if ( !equivalent && !s.contains("_:") ) {
+            printFile(FN);
+            System.out.println("** Not same ** "+label);
+            System.out.println(s);
+            System.out.println("-- --");
+            Shex.printSchema(System.out, schema);
+            System.out.println("-- --");
+            Shex.printSchema(System.out, schema2);
+            System.out.println("== ==");
+            fail("ShEx schames not equivalent");
+        }
+    }
+
+    private static void printFile(String FN) {
+        System.out.println("File: "+FN);
+        System.out.print(IO.readWholeFileAsUTF8(FN));
+    }
+
+    private static void printString(String s) {
+        System.out.print(s);
+        if ( ! s.endsWith("\n") )
+            System.out.println();
+        System.out.println("-- --");
+    }
+
+}

--- a/jena-shex/src/test/java/org/apache/jena/shex/runner/RunnerShexBadSyntax.java
+++ b/jena-shex/src/test/java/org/apache/jena/shex/runner/RunnerShexBadSyntax.java
@@ -37,7 +37,7 @@ import org.junit.runners.model.InitializationError;
 public class RunnerShexBadSyntax extends AbstractRunnerFiles {
 
     public RunnerShexBadSyntax(Class<? > klass) throws InitializationError {
-        super(klass, RunnerShexBadSyntax::makeShexSyntaxTest, includes(), excludes());
+        super(klass, RunnerShexBadSyntax::makeShexBadSyntaxTest, includes(), excludes());
     }
 
     private static Set<String> includes() {
@@ -59,7 +59,7 @@ public class RunnerShexBadSyntax extends AbstractRunnerFiles {
         return excludes;
     }
 
-    public static Runnable makeShexSyntaxTest(String filename) {
+    public static Runnable makeShexBadSyntaxTest(String filename) {
         return ()->fileBadSyntax(filename);
     }
 

--- a/jena-shex/src/test/java/org/apache/jena/shex/runner/RunnerShexSyntax.java
+++ b/jena-shex/src/test/java/org/apache/jena/shex/runner/RunnerShexSyntax.java
@@ -33,7 +33,7 @@ import org.junit.runners.model.InitializationError;
 public class RunnerShexSyntax extends AbstractRunnerFiles {
 
     public RunnerShexSyntax(Class<? > klass) throws InitializationError {
-        super(klass, RunnerShexSyntax::makeShexBadSyntaxTest, includes(), excludes());
+        super(klass, RunnerShexSyntax::makeShexSyntaxTest, includes(), excludes());
     }
 
     private static Set<String> includes() {
@@ -52,11 +52,11 @@ public class RunnerShexSyntax extends AbstractRunnerFiles {
         return excludes;
     }
 
-    public static Runnable makeShexBadSyntaxTest(String filename) {
-        return ()->shapesFromFileBadSyntax(filename);
+    public static Runnable makeShexSyntaxTest(String filename) {
+        return ()->shapesFromFileSyntax(filename);
     }
 
-    public static ShexSchema shapesFromFileBadSyntax(String filename) {
+    public static ShexSchema shapesFromFileSyntax(String filename) {
         String str = IO.readWholeFileAsUTF8(filename);
         InputStream input = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
         try {


### PR DESCRIPTION
This prints ShExC and tests by running the syntax test suite.

Whitespace alignment isn't completely consistent, but the output should be correct, ie. parses to the same syntax tree as the original input syntax tree.

Add surrogate pair support to ShExC and SHACL-C.

Unrelated, but GraphSPARQLService was touched and it had its whitespace cleaned up.