### PR TITLE
Ignore external DTDs

### DIFF
--- a/jena-arq/src/test/java/org/apache/jena/system/TS_System.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TS_System.java
@@ -30,6 +30,7 @@ import org.junit.runners.Suite ;
     , TestTxn.class
     , TestTxnThread.class
     , TestJenaTitanium.class
+    , TestReadXML.class
     , TestRDFStarTranslation.class
 })
 

--- a/jena-arq/src/test/java/org/apache/jena/system/TestReadXML.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestReadXML.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.system;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.stream.XMLInputFactory;
+
+import org.apache.jena.query.ResultSetFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.util.JenaXMLInput;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+public class TestReadXML {
+
+    // SAX
+    @Test public void sax_setup() {
+        try {
+            XMLReader xmlReader = JenaXMLInput.createXMLReader();
+            assertFalse(xmlReader.getFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd"));
+            assertFalse(xmlReader.getFeature("http://xml.org/sax/features/external-general-entities"));
+            assertFalse(xmlReader.getFeature("http://xml.org/sax/features/external-parameter-entities"));
+            // Allows for in-document entities.
+            assertFalse(xmlReader.getFeature("http://apache.org/xml/features/disallow-doctype-decl"));
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // SAX : When allowing DTDs in RDF/XML, and ignoring external ones.
+    @Test public void rdfxml_dtd_http_migration() {
+        // DTD http does not exist, no error because it was ignored
+        Model model = ModelFactory.createDefaultModel();
+        model.read("file:testing/xml/rdfxml-dtd-http.rdf");
+    }
+
+    // SAX : When allowing DTDs in RDF/XML, and ignoring external ones.
+    @Test public void rdfxml_dtd_file_migration() {
+        // DTD http does not exist, no error because it was ignored
+        Model model = ModelFactory.createDefaultModel();
+        model.read("file:testing/xml/rdfxml-dtd-file.rdf");
+    }
+
+    // StAX - best available option is ignore DTDs
+    // srx =  SPARQL results XML
+    @Test public void stax_setup() {
+        XMLInputFactory xf = XMLInputFactory.newInstance() ;
+        JenaXMLInput.initXMLInputFactory(xf);
+        assertEquals(Boolean.FALSE, xf.getProperty(XMLInputFactory.SUPPORT_DTD));
+        assertEquals(null, xf.getProperty(XMLConstants.ACCESS_EXTERNAL_DTD));
+        assertEquals(Boolean.FALSE,xf.getProperty("javax.xml.stream.isSupportingExternalEntities"));
+    }
+
+    @Test public void srx_dtd_http() {
+        ResultSetFactory.load("file:testing/xml/srx-dtd-http.srx");
+    }
+
+    @Test public void srx_dtd_file() {
+        ResultSetFactory.load("file:testing/xml/srx-dtd-file.srx");
+    }
+
+    // TriX uses StAX
+    @Test public void trix_dtd_http() {
+        Model model = ModelFactory.createDefaultModel();
+        model.read("file:testing/xml/trix-dtd-http.trix");
+    }
+
+    @Test public void trix_dtd_file() {
+        Model model = ModelFactory.createDefaultModel();
+        model.read("file:testing/xml/trix-dtd-file.trix");
+    }
+}

--- a/jena-arq/testing/xml/rdfxml-dtd-file.rdf
+++ b/jena-arq/testing/xml/rdfxml-dtd-file.rdf
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE foo SYSTEM "no-such-localfile">
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+</rdf:RDF>

--- a/jena-arq/testing/xml/rdfxml-dtd-http.rdf
+++ b/jena-arq/testing/xml/rdfxml-dtd-http.rdf
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE foo SYSTEM "http://localhost:70000/no-such">
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+</rdf:RDF>

--- a/jena-arq/testing/xml/srx-dtd-file.srx
+++ b/jena-arq/testing/xml/srx-dtd-file.srx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE foo SYSTEM "no-such-localfile">
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="x"/>
+  </head>
+  <results>
+    <result>
+      <binding name="x">
+        <literal>ABC</literal>
+      </binding>
+    </result>
+  </results>
+</sparql>

--- a/jena-arq/testing/xml/srx-dtd-http.srx
+++ b/jena-arq/testing/xml/srx-dtd-http.srx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE foo SYSTEM "http://localhost:70000/no-such">
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="x"/>
+  </head>
+  <results>
+    <result>
+      <binding name="x">
+        <literal>ABC</literal>
+      </binding>
+    </result>
+  </results>
+</sparql>

--- a/jena-arq/testing/xml/trix-dtd-file.trix
+++ b/jena-arq/testing/xml/trix-dtd-file.trix
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE foo SYSTEM "no-such-localfile">
+<trix xmlns="http://www.w3.org/2004/03/trix/trix-1/">
+</trix>

--- a/jena-arq/testing/xml/trix-dtd-http.trix
+++ b/jena-arq/testing/xml/trix-dtd-http.trix
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE foo SYSTEM "http://localhost:70000/no-such">
+<trix xmlns="http://www.w3.org/2004/03/trix/trix-1/">
+</trix>

--- a/jena-cmds/testing/cmd/sg-test-config.rdf
+++ b/jena-cmds/testing/cmd/sg-test-config.rdf
@@ -1,23 +1,15 @@
 <?xml version='1.0'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY jena    'http://jena.hpl.hp.com/'>
-
-    <!ENTITY rdf     'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs    'http://www.w3.org/2000/01/rdf-schema#'>
-    <!ENTITY owl     'http://www.w3.org/2002/07/owl#'>
-    <!ENTITY xsd     'http://www.w3.org/2001/XMLSchema#'>
-    <!ENTITY base    '&jena;2003/04/schemagen'>
-    <!ENTITY sgen    '&base;#'>
-]>
-
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:owl="http://www.w3.org/2002/07/owl#"
-  xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:sgen="http://jena.hpl.hp.com/2003/04/schemagen#">
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" 
+         xmlns:sgen="http://jena.hpl.hp.com/2003/04/schemagen#">
 
   <sgen:Config>
     <!-- specifies that the source document uses OWL -->
-    <sgen:owl rdf:datatype="&xsd;boolean">true</sgen:owl>
+    <sgen:owl rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</sgen:owl>
     <!-- specifies that we want the generated vocab to use OntClass, OntProperty, etc, not Resource and Property -->
-    <sgen:ontology rdf:datatype="&xsd;boolean">true</sgen:ontology>
+    <sgen:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</sgen:ontology>
   </sgen:Config>
 </rdf:RDF>

--- a/jena-core/src/main/java/org/apache/jena/util/JenaXMLInput.java
+++ b/jena-core/src/main/java/org/apache/jena/util/JenaXMLInput.java
@@ -40,8 +40,6 @@ import org.xml.sax.XMLReader;
  * External DTD and entity processing is disabled to prevent
  * <a href="https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing">XXE Processing</a>
  * problems.
- * <p>
- * DTDs are, by default, not processed. These may be enabled with {@link #allowLocalDTDs}.
  */
 public class JenaXMLInput {
 
@@ -49,30 +47,17 @@ public class JenaXMLInput {
     // RDFXMLParser
     private static SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
 
-    /**
-     * Whether to allow DTD processing. This applies to reading RDF/XML
-     * and SPARQL XML Results - these formats do not need DTD processing
-     * to be read into Jena.
-     * <p>
-     * External DTDs are always prohibited.
-     * <p>
-     * The default configuration is to not process DTDs.
-     * An application may enable local DTD processing if necessary.
-     *
-     * @deprecated The ability to enable local DTDs processing will be removed.
-     */
-    @Deprecated
-    public static boolean allowLocalDTDs = true;
-
     public static XMLReader createXMLReader() throws ParserConfigurationException, SAXException {
             SAXParser saxParser = saxParserFactory.newSAXParser();
             XMLReader xmlreader = saxParser.getXMLReader();
 
-            if ( !allowLocalDTDs ) {
-                // XXE : disable all DTD processing.
-                // Effect: RiotException if a DTD is found.
-                xmlreader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            }
+            // XXE : disable all DTD processing.
+            // Effect: RiotException if a DTD is found.
+            // However, OWL WG test files, and others, have internal entity
+            // declarations in internal DTD subset ("the "[ ]"in a DOCTYPE).
+            // xmlreader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            // instead, silently ignore external DTDs.
+
             // Always disable remote DTDs (silently ignore if DTDs are allowed at all)
             xmlreader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             // and ignore external entities (silently ignore)
@@ -125,7 +110,7 @@ public class JenaXMLInput {
 //    // ---- SAXBuilder
 //    public static SAXBuilder newSAXBuilder() throws ParserConfigurationException {
 //        SAXBuilder builder = new SAXBuilder();
-//        builder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
+//        //builder.setFeature("http://apache.org/xml/features/disallow-doctype-decl",true);
 //        builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false;)
 //        builder.setFeature("http://xml.org/sax/features/external-general-entities", false);
 //        builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);

--- a/jena-core/src/main/resources/ont-policy.rdf
+++ b/jena-core/src/main/resources/ont-policy.rdf
@@ -16,21 +16,11 @@
    limitations under the License.
 -->
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY jena    'http://jena.hpl.hp.com/schemas/'>
-
-    <!ENTITY rdf     'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs    'http://www.w3.org/2000/01/rdf-schema#'>
-    <!ENTITY xsd     'http://www.w3.org/2001/XMLSchema#'>
-    <!ENTITY base    '&jena;2003/03/ont-manager'>
-    <!ENTITY ont     '&base;#'>
-]>
-
 <rdf:RDF
-  xmlns:rdf ="&rdf;"
-  xmlns:rdfs="&rdfs;"
-  xmlns     ="&ont;"
-  xml:base  ="&base;"
+  xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xml:base  ="http://jena.hpl.hp.com/schemas/2003/03/ont-manager"
+  xmlns     ="http://jena.hpl.hp.com/schemas/2003/03/ont-manager#"
 >
 
 <!--
@@ -42,8 +32,8 @@
 
 <DocumentManagerPolicy>
     <!-- policy for controlling the document manager's behaviour -->
-    <processImports rdf:datatype="&xsd;boolean">true</processImports>
-    <cacheModels    rdf:datatype="&xsd;boolean">true</cacheModels>
+    <processImports rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</processImports>
+    <cacheModels    rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</cacheModels>
 </DocumentManagerPolicy>
 
 
@@ -53,7 +43,7 @@
     <!-- uncomment the following line to re-direct attempts to http get the file
     <altURL    rdf:resource="file:vocabularies/owl.owl" /-->
     <language  rdf:resource="http://www.w3.org/2002/07/owl" />
-    <prefix    rdf:datatype="&xsd;string">owl</prefix>
+    <prefix    rdf:datatype="http://www.w3.org/2001/XMLSchema#string">owl</prefix>
 </OntologySpec>
 
 <OntologySpec>
@@ -62,7 +52,7 @@
     <!-- uncomment the following line to re-direct attempts to http get the file
     <altURL    rdf:resource="file:vocabularies/rdf-schema.rdf" /-->
     <language  rdf:resource="http://www.w3.org/2000/01/rdf-schema" />
-    <prefix    rdf:datatype="&xsd;string">rdfs</prefix>
+    <prefix    rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rdfs</prefix>
 </OntologySpec>
 
 <!-- Removed as a default entry from Jena 2.6 onwards
@@ -72,7 +62,7 @@
     <!- - uncomment the following line to re-direct attempts to http get the file
     <altURL    rdf:resource="file:vocabularies/daml+oil.daml" /- ->
     <language  rdf:resource="http://www.daml.org/2001/03/daml+oil" />
-    <prefix    rdf:datatype="&xsd;string">daml</prefix>
+    <prefix    rdf:datatype="http://www.w3.org/2001/XMLSchema#string">daml</prefix>
 </OntologySpec>
 -->
 

--- a/jena-core/src/test/resources/ont-policy-test.rdf
+++ b/jena-core/src/test/resources/ont-policy-test.rdf
@@ -1,20 +1,10 @@
 <?xml version='1.0'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY jena    'http://jena.hpl.hp.com/schemas/'>
-
-    <!ENTITY rdf     'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs    'http://www.w3.org/2000/01/rdf-schema#'>
-    <!ENTITY xsd     'http://www.w3.org/2001/XMLSchema#'>
-    <!ENTITY base    '&jena;2003/03/ont-manager'>
-    <!ENTITY ont     '&base;#'>
-]>
-
 <rdf:RDF
-  xmlns:rdf ="&rdf;"
-  xmlns:rdfs="&rdfs;"
-  xmlns     ="&ont;"
-  xml:base  ="&base;"
+  xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xml:base  ="http://jena.hpl.hp.com/schemas/2003/03/ont-manager"
+  xmlns     ="http://jena.hpl.hp.com/schemas/2003/03/ont-manager#"
 >
 
 <!--
@@ -26,8 +16,8 @@
 
 <DocumentManagerPolicy>
     <!-- policy for controlling the document manager's behaviour -->
-    <processImports rdf:datatype="&xsd;boolean">true</processImports>
-    <cacheModels    rdf:datatype="&xsd;boolean">true</cacheModels>
+    <processImports rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</processImports>
+    <cacheModels    rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</cacheModels>
 </DocumentManagerPolicy>
 
 
@@ -36,7 +26,7 @@
     <publicURI rdf:resource="http://www.w3.org/2002/07/owl" />
     <altURL    rdf:resource="file:vocabularies/owl.owl" />
     <language  rdf:resource="http://www.w3.org/2002/07/owl#" />
-    <prefix    rdf:datatype="&xsd;string">owl</prefix>
+    <prefix    rdf:datatype="http://www.w3.org/2001/XMLSchema#string">owl</prefix>
 </OntologySpec>
 
 <OntologySpec>
@@ -44,14 +34,14 @@
     <publicURI rdf:resource="http://www.w3.org/2000/01/rdf-schema" />
     <altURL    rdf:resource="file:vocabularies/rdf-schema.rdf" />
     <language  rdf:resource="http://www.w3.org/2000/01/rdf-schema#" />
-    <prefix    rdf:datatype="&xsd;string">rdfs</prefix>
+    <prefix    rdf:datatype="http://www.w3.org/2001/XMLSchema#string">rdfs</prefix>
 </OntologySpec>
 
 <OntologySpec>
     <publicURI rdf:resource="http://www.daml.org/2001/03/daml+oil" />
     <altURL    rdf:resource="file:vocabularies/daml+oil.daml" />
     <language  rdf:resource="http://www.daml.org/2001/03/daml+oil#" />
-    <prefix    rdf:datatype="&xsd;string">daml</prefix>
+    <prefix    rdf:datatype="http://www.w3.org/2001/XMLSchema#string">daml</prefix>
 </OntologySpec>
 
 

--- a/jena-core/src/test/resources/ontology/list0.rdf
+++ b/jena-core/src/test/resources/ontology/list0.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/src/test/resources/ontology/list1.rdf
+++ b/jena-core/src/test/resources/ontology/list1.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/src/test/resources/ontology/list2.rdf
+++ b/jena-core/src/test/resources/ontology/list2.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/src/test/resources/ontology/list3.rdf
+++ b/jena-core/src/test/resources/ontology/list3.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/src/test/resources/ontology/list4.rdf
+++ b/jena-core/src/test/resources/ontology/list4.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/src/test/resources/ontology/list5.rdf
+++ b/jena-core/src/test/resources/ontology/list5.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/testing/ontology/list0.rdf
+++ b/jena-core/testing/ontology/list0.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/testing/ontology/list1.rdf
+++ b/jena-core/testing/ontology/list1.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/testing/ontology/list2.rdf
+++ b/jena-core/testing/ontology/list2.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/testing/ontology/list3.rdf
+++ b/jena-core/testing/ontology/list3.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/testing/ontology/list4.rdf
+++ b/jena-core/testing/ontology/list4.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/testing/ontology/list5.rdf
+++ b/jena-core/testing/ontology/list5.rdf
@@ -1,13 +1,8 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <rdf:RDF
-    xmlns:rdf   ="&rdf;"
-    xmlns:rdfs  ="&rdfs;"
+    xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xml:base    ="uri:urn:x-rdf:test"
     xmlns       ="uri:urn:x-rdf:test#"
 >

--- a/jena-core/testing/ontology/relativenames.rdf
+++ b/jena-core/testing/ontology/relativenames.rdf
@@ -1,10 +1,5 @@
 <?xml version='1.0' encoding='ISO-8859-1'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY rdf   'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs  'http://www.w3.org/2000/01/rdf-schema#'>
-]>
-
 <!-- Note: no xml:base -->
 <!-- we pretend document is being served from http://jena.hpl.hp.com/testing/ontology/relativenames -->
 

--- a/jena-core/testing/ontology/testImport5/ont-policy.rdf
+++ b/jena-core/testing/ontology/testImport5/ont-policy.rdf
@@ -1,18 +1,9 @@
 <?xml version='1.0'?>
 
-<!DOCTYPE rdf:RDF [
-    <!ENTITY jena    'http://jena.hpl.hp.com/schemas/'>
-
-    <!ENTITY rdf     'http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
-    <!ENTITY rdfs    'http://www.w3.org/2000/01/rdf-schema#'>
-    <!ENTITY xsd     'http://www.w3.org/2000/10/XMLSchema#'>
-    <!ENTITY ont     '&jena;2003/03/ont-manager#'>
-]>
-
 <rdf:RDF
-  xmlns:rdf ="&rdf;"
-  xmlns:rdfs="&rdfs;"
-  xmlns     ="&ont;"
+  xmlns:rdf ="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns     ="http://jena.hpl.hp.com/schemas/2003/03/ont-manager#"
 >
 
 <!--


### PR DESCRIPTION
RDF/XML does not use them (SAX).

SPARQL XML Results don't use them (StAX) and inline entities are unknown.
