### PR TITLE
JENA-2153: Write pretty JSON-LD 1.1

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFFormat.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFFormat.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 public class RDFFormat {
     /** Pretty printing variant */
     public static final RDFFormatVariant PRETTY         = new RDFFormatVariant("pretty") ;
+    /** Plain printing variant */
+    public static final RDFFormatVariant PLAIN          = new RDFFormatVariant("plain") ;
     /**
      * Print in blocks, typically all triples with the same subject in an
      * incoming triple/quad stream
@@ -85,12 +87,14 @@ public class RDFFormat {
 
     // ---- JSONLD 1.1 / Titanium
 
+    /** JSON LD 1.1 - multi-line JSON - prefixes and native types. */
+    public static RDFFormat             JSONLD11_PRETTY  = new RDFFormat(Lang.JSONLD11, RDFFormat.PRETTY);
     /** JSON LD 1.1 - multi-line JSON */
     public static RDFFormat             JSONLD11_PLAIN  = new RDFFormat(Lang.JSONLD11, RDFFormat.PLAIN);
     /** JSON LD 1.1 - single-line JSON */
     public static RDFFormat             JSONLD11_FLAT   = new RDFFormat(Lang.JSONLD11, RDFFormat.FLAT);
     /** JSON LD 1.1 default form - multi-line JSON */
-    public static RDFFormat             JSONLD11        = JSONLD11_PLAIN;
+    public static RDFFormat             JSONLD11        = JSONLD11_PRETTY;
 
     // ---- JSONLD 1.0 / jsonld-java
 
@@ -123,7 +127,7 @@ public class RDFFormat {
         public boolean isFrame() { return isFormat(JSONLD_FORMAT.FRAME); }
     }
 
-    // variants for the JsonLD outputs.
+    // Variants for the JsonLD 1.0 outputs.
     // because of the pre-existing JSONLD_PRETTY and JSONLD_FLAT,
     // we're more or less obliged to create all of these
     // Assumes jsonld-java.
@@ -137,27 +141,67 @@ public class RDFFormat {
     private static final RDFFormatVariant FRAME_PRETTY       = new JSONLDVariant("frame pretty", true, JSONLDVariant.JSONLD_FORMAT.FRAME) ;
     private static final RDFFormatVariant FRAME_FLAT         = new JSONLDVariant("frame flat", false, JSONLDVariant.JSONLD_FORMAT.FRAME) ;
 
-    public static final RDFFormat        JSONLD_EXPAND_PRETTY   = new RDFFormat(Lang.JSONLD10, EXPAND_PRETTY) ;
-    public static final RDFFormat        JSONLD_EXPAND_FLAT     = new RDFFormat(Lang.JSONLD10, EXPAND_FLAT) ;
-    public static final RDFFormat        JSONLD_COMPACT_PRETTY  = new RDFFormat(Lang.JSONLD10, COMPACT_PRETTY) ;
-    public static final RDFFormat        JSONLD_COMPACT_FLAT    = new RDFFormat(Lang.JSONLD10, COMPACT_FLAT) ;
-    public static final RDFFormat        JSONLD_FLATTEN_PRETTY  = new RDFFormat(Lang.JSONLD10, FLATTEN_PRETTY) ;
-    public static final RDFFormat        JSONLD_FLATTEN_FLAT    = new RDFFormat(Lang.JSONLD10, FLATTEN_FLAT) ;
-    public static final RDFFormat        JSONLD_FRAME_PRETTY    = new RDFFormat(Lang.JSONLD10, FRAME_PRETTY) ;
-    public static final RDFFormat        JSONLD_FRAME_FLAT      = new RDFFormat(Lang.JSONLD10, FRAME_FLAT) ;
+    public static final RDFFormat        JSONLD10_EXPAND_PRETTY   = new RDFFormat(Lang.JSONLD10, EXPAND_PRETTY) ;
+    public static final RDFFormat        JSONLD10_EXPAND_FLAT     = new RDFFormat(Lang.JSONLD10, EXPAND_FLAT) ;
+    public static final RDFFormat        JSONLD10_COMPACT_PRETTY  = new RDFFormat(Lang.JSONLD10, COMPACT_PRETTY) ;
+    public static final RDFFormat        JSONLD10_COMPACT_FLAT    = new RDFFormat(Lang.JSONLD10, COMPACT_FLAT) ;
+    public static final RDFFormat        JSONLD10_FLATTEN_PRETTY  = new RDFFormat(Lang.JSONLD10, FLATTEN_PRETTY) ;
+    public static final RDFFormat        JSONLD10_FLATTEN_FLAT    = new RDFFormat(Lang.JSONLD10, FLATTEN_FLAT) ;
+    public static final RDFFormat        JSONLD10_FRAME_PRETTY    = new RDFFormat(Lang.JSONLD10, FRAME_PRETTY) ;
+    public static final RDFFormat        JSONLD10_FRAME_FLAT      = new RDFFormat(Lang.JSONLD10, FRAME_FLAT) ;
 
-    // redefine following ones in a way that preserve what they were doing in previous version
-    public static final RDFFormat        JSONLD10       = JSONLD_COMPACT_PRETTY ;
-    public static final RDFFormat        JSONLD_PRETTY  = JSONLD_COMPACT_PRETTY ;
-    public static final RDFFormat        JSONLD         = JSONLD_COMPACT_PRETTY ;
-    public static final RDFFormat        JSONLD_FLAT    = JSONLD_COMPACT_FLAT ;
+    /** Use {@link #JSONLD10_EXPAND_PRETTY} */
+    @Deprecated
+    public static final RDFFormat        JSONLD_EXPAND_PRETTY   = JSONLD10_EXPAND_PRETTY;
+
+    /** Use {@link #JSONLD10_EXPAND_FLAT} */
+    @Deprecated
+    public static final RDFFormat        JSONLD_EXPAND_FLAT     = JSONLD10_EXPAND_FLAT;
+
+    /** Use {@link #JSONLD10_COMPACT_PRETTY} */
+    @Deprecated
+    public static final RDFFormat        JSONLD_COMPACT_PRETTY  = JSONLD10_COMPACT_PRETTY;
+
+    /** Use {@link #JSONLD10_COMPACT_FLAT} */
+    @Deprecated
+    public static final RDFFormat        JSONLD_COMPACT_FLAT    = JSONLD10_COMPACT_FLAT;
+
+    /** Use {@link #JSONLD10_FLATTEN_PRETTY} */
+    @Deprecated
+    public static final RDFFormat        JSONLD_FLATTEN_PRETTY  = JSONLD10_FLATTEN_PRETTY;
+
+    /** Use {@link #JSONLD10_FLATTEN_FLAT} */
+    @Deprecated
+    public static final RDFFormat        JSONLD_FLATTEN_FLAT    = JSONLD10_FLATTEN_FLAT;
+
+    /** Use {@link #JSONLD10_FRAME_PRETTY} */
+    @Deprecated
+    public static final RDFFormat        JSONLD_FRAME_PRETTY    = JSONLD10_FRAME_PRETTY;
+
+    /** Use {@link #JSONLD10_FRAME_FLAT} */
+    @Deprecated
+    public static final RDFFormat        JSONLD_FRAME_FLAT      = JSONLD10_FRAME_FLAT;
+
+    public static final RDFFormat        JSONLD10        = JSONLD10_COMPACT_PRETTY ;
+    public static final RDFFormat        JSONLD10_PRETTY = JSONLD10_COMPACT_PRETTY ;
+    public static final RDFFormat        JSONLD10_FLAT   = JSONLD10_COMPACT_FLAT ;
+
+    // JSON-LD 1.0
+//    public static final RDFFormat        JSONLD_PRETTY  = new RDFFormat(Lang.JSONLD, JSONLD10.getVariant());
+//    public static final RDFFormat        JSONLD_PLAIN   = new RDFFormat(Lang.JSONLD, JSONLD10.getVariant());
+//    public static final RDFFormat        JSONLD         = JSONLD_PRETTY;
+//    public static final RDFFormat        JSONLD_FLAT    = new RDFFormat(Lang.JSONLD, JSONLD10_EXPAND_FLAT.getVariant());
+
+    // JSON-LD 1.1
+    public static final RDFFormat        JSONLD_PRETTY  = new RDFFormat(Lang.JSONLD, PRETTY);
+    public static final RDFFormat        JSONLD_PLAIN   = new RDFFormat(Lang.JSONLD, PLAIN);
+    public static final RDFFormat        JSONLD         = JSONLD_PRETTY;
+    public static final RDFFormat        JSONLD_FLAT    = new RDFFormat(Lang.JSONLD, FLAT);
 
     /** RDF/XML ABBREV variant */
-    public static final RDFFormatVariant ABBREV         = new RDFFormatVariant("pretty") ;
-    /** Basic RDF/XML variant */
-    public static final RDFFormatVariant PLAIN          = new RDFFormatVariant("plain") ;
+    public static final RDFFormatVariant ABBREV         = PRETTY;
 
-    public static final RDFFormat        RDFXML_PRETTY  = new RDFFormat(Lang.RDFXML, ABBREV) ;
+    public static final RDFFormat        RDFXML_PRETTY  = new RDFFormat(Lang.RDFXML, PRETTY) ;
     public static final RDFFormat        RDFXML_ABBREV  = RDFXML_PRETTY ;
     public static final RDFFormat        RDFXML         = RDFXML_PRETTY ;
     public static final RDFFormat        RDFXML_PLAIN   = new RDFFormat(Lang.RDFXML, PLAIN) ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
@@ -45,19 +45,23 @@ public class RDFWriterRegistry
     // Let the serializer deal with the character issues.
     // UTF-8 is universal - but UTF-8 is not the default in Java ("platform encoding" is).
 
+    // System defaults for JSON-LD writing in init$().
+    // Also - settings in RDFFormat.
+
     private static Map<RDFFormat, WriterGraphRIOTFactory> registryGraph     = new HashMap<>() ;
     private static Map<RDFFormat, WriterDatasetRIOTFactory> registryDataset = new HashMap<>() ;
     private static Map<Lang, RDFFormat> langToFormat                        = new HashMap<>() ;
 
     static { JenaSystem.init() ; }
 
-    // Writing a graph
-    static WriterGraphRIOTFactory wgfactory = new WriterGraphRIOTFactory() {
-        @Override
-        public WriterGraphRIOT create(RDFFormat serialization)
-        {
-            // Built-ins
+    // WriterDatasetRIOTFactory as graph writer.
+    private static WriterDatasetRIOTFactory wdsfactoryAsGraph = createWriterDatasetFactory();
+    private static WriterDatasetRIOTFactory wdsfactoryForGraph() { return wdsfactoryAsGraph; }
 
+    // Graph writers : if none, use a dataset writer
+    private static WriterGraphRIOTFactory createWriterGraphFactory() {
+        return (RDFFormat serialization) -> {
+            // Built-ins
             if ( Objects.equals(RDFFormat.TURTLE_PRETTY, serialization) )
                 return new TurtleWriter() ;
             if ( Objects.equals(RDFFormat.TURTLE_BLOCKS, serialization) )
@@ -77,48 +81,60 @@ public class RDFWriterRegistry
             if ( Objects.equals(RDFFormat.RDFXML_PLAIN, serialization) )
                 return new RDFXMLPlainWriter() ;
 
-            WriterDatasetRIOT dsw = wdsfactory.create(serialization) ;
+            WriterDatasetRIOT dsw = wdsfactoryForGraph().create(serialization) ;
             if ( dsw != null )
                 return RiotLib.adapter(dsw) ;
+            return null;
+        };
+    }
+
+    // Dataset writers.
+    private static WriterDatasetRIOTFactory createWriterDatasetFactory() {
+        return (RDFFormat serialization) -> {
+            if ( Objects.equals(RDFFormat.TRIG_PRETTY, serialization) )
+                return new TriGWriter() ;
+            if ( Objects.equals(RDFFormat.TRIG_BLOCKS, serialization) )
+                return new TriGWriterBlocks() ;
+            if ( Objects.equals(RDFFormat.TRIG_FLAT, serialization) )
+                return new TriGWriterFlat() ;
+            if ( Objects.equals(RDFFormat.NQUADS_UTF8, serialization) )
+                return new NQuadsWriter() ;
+            if ( Objects.equals(RDFFormat.NQUADS_ASCII, serialization) )
+                return new NQuadsWriter(CharSpace.ASCII) ;
+            if ( Objects.equals(RDFFormat.RDFNULL, serialization) )
+                return NullWriter.factory.create(RDFFormat.RDFNULL) ;
             return null ;
-    }} ;
-
-    // Writing a dataset
-    static WriterDatasetRIOTFactory wdsfactory = (RDFFormat serialization) -> {
-        if ( Objects.equals(RDFFormat.TRIG_PRETTY, serialization) )
-            return new TriGWriter() ;
-        if ( Objects.equals(RDFFormat.TRIG_BLOCKS, serialization) )
-            return new TriGWriterBlocks() ;
-        if ( Objects.equals(RDFFormat.TRIG_FLAT, serialization) )
-            return new TriGWriterFlat() ;
-        if ( Objects.equals(RDFFormat.NQUADS_UTF8, serialization) )
-            return new NQuadsWriter() ;
-        if ( Objects.equals(RDFFormat.NQUADS_ASCII, serialization) )
-            return new NQuadsWriter(CharSpace.ASCII) ;
-        if ( Objects.equals(RDFFormat.RDFNULL, serialization) )
-            return NullWriter.factory.create(RDFFormat.RDFNULL) ;
-        return null ;
-    } ;
-
-    private static WriterDatasetRIOTFactory wdsJsonldFactory10 = syntaxForm -> new JsonLD10Writer(syntaxForm);
-    private static WriterGraphRIOTFactory wgJsonldFactory10    = syntaxForm -> RiotLib.adapter(new JsonLD10Writer(syntaxForm));
-
-    private static WriterDatasetRIOTFactory wdsJsonldFactory11 = syntaxForm -> new JsonLD11Writer(syntaxForm);
-    private static WriterGraphRIOTFactory wgJsonldFactory11    = syntaxForm -> RiotLib.adapter(new JsonLD11Writer(syntaxForm));
-
-    private static WriterGraphRIOTFactory wgProtoFactory       = syntaxForm -> new WriterGraphProtobuf(syntaxForm);
-    private static WriterDatasetRIOTFactory wdsProtoFactory    = syntaxForm -> new WriterDatasetProtobuf(syntaxForm);
-
-    private static WriterGraphRIOTFactory wgThriftFactory      = syntaxForm -> new WriterGraphThrift(syntaxForm);
-    private static WriterDatasetRIOTFactory wdsThriftFactory   = syntaxForm -> new WriterDatasetThrift(syntaxForm);
-
-    private static WriterGraphRIOTFactory wgTriXFactory        = syntaxForm -> new WriterTriX();
-    private static WriterDatasetRIOTFactory wdsTriXFactory     = syntaxForm -> new WriterTriX() ;
+        } ;
+    }
 
     public static void init() {}
     static { init$() ; }
     private static void init$()
     {
+        WriterGraphRIOTFactory wgfactory = createWriterGraphFactory();
+        WriterDatasetRIOTFactory wdsfactory = createWriterDatasetFactory();
+
+        // Safer here than as statics due to class initialization ordering effects.
+        WriterDatasetRIOTFactory wdsJsonldFactory10 = syntaxForm -> new JsonLD10Writer(syntaxForm);
+        WriterGraphRIOTFactory wgJsonldFactory10    = syntaxForm -> RiotLib.adapter(new JsonLD10Writer(syntaxForm));
+        WriterDatasetRIOTFactory wdsJsonldFactory11 = syntaxForm -> new JsonLD11Writer(syntaxForm);
+        WriterGraphRIOTFactory wgJsonldFactory11    = syntaxForm -> RiotLib.adapter(new JsonLD11Writer(syntaxForm));
+        WriterGraphRIOTFactory wgProtoFactory       = syntaxForm -> new WriterGraphProtobuf(syntaxForm);
+        WriterDatasetRIOTFactory wdsProtoFactory    = syntaxForm -> new WriterDatasetProtobuf(syntaxForm);
+        WriterGraphRIOTFactory wgThriftFactory      = syntaxForm -> new WriterGraphThrift(syntaxForm);
+        WriterDatasetRIOTFactory wdsThriftFactory   = syntaxForm -> new WriterDatasetThrift(syntaxForm);
+        WriterGraphRIOTFactory wgTriXFactory        = syntaxForm -> new WriterTriX();
+        WriterDatasetRIOTFactory wdsTriXFactory     = syntaxForm -> new WriterTriX() ;
+
+        // ==== System defaults for JSON-LD writing.
+        // ** Coordinate with RDFFormat definitions of JSONLD RDFFormats:
+        //    JSONLD_PRETTY, JSONLD_PLAIN, JSONLD,JSONLD_FLAT
+
+        WriterGraphRIOTFactory jsonldWriterGraphDefault      = wgJsonldFactory11;
+        WriterDatasetRIOTFactory jsonldWriterDatasetDefault  = wdsJsonldFactory11;
+
+        // -----------------------
+
         //  Language to format.
         register(Lang.TURTLE,      RDFFormat.TURTLE) ;
         register(Lang.N3,          RDFFormat.TURTLE) ;
@@ -126,7 +142,7 @@ public class RDFWriterRegistry
         register(Lang.RDFXML,      RDFFormat.RDFXML) ;
 
         register(Lang.JSONLD,      RDFFormat.JSONLD) ;
-        register(Lang.JSONLD10,    RDFFormat.JSONLD) ;  // Default writing is JSON-LD 1.0
+        register(Lang.JSONLD10,    RDFFormat.JSONLD10) ;
         register(Lang.JSONLD11,    RDFFormat.JSONLD11) ;
         register(Lang.RDFJSON,     RDFFormat.RDFJSON) ;
 
@@ -149,22 +165,45 @@ public class RDFWriterRegistry
         register(RDFFormat.NTRIPLES_ASCII, wgfactory) ;
 
         // JSON-LD 1.0
-        register(RDFFormat.JSONLD,                      wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_FLAT,                 wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_PRETTY,               wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_COMPACT_PRETTY,       wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_FLATTEN_PRETTY,       wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_EXPAND_PRETTY,        wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_FRAME_PRETTY,         wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_COMPACT_FLAT,         wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_FLATTEN_FLAT,         wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_EXPAND_FLAT,          wgJsonldFactory10) ;
-        register(RDFFormat.JSONLD_FRAME_FLAT,           wgJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_COMPACT_PRETTY,     wgJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_FLATTEN_PRETTY,     wgJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_EXPAND_PRETTY,      wgJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_FRAME_PRETTY,       wgJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_COMPACT_FLAT,       wgJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_FLATTEN_FLAT,       wgJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_EXPAND_FLAT,        wgJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_FRAME_FLAT,         wgJsonldFactory10) ;
+
+        register(RDFFormat.JSONLD10_COMPACT_PRETTY,     wdsJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_FLATTEN_PRETTY,     wdsJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_EXPAND_PRETTY,      wdsJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_FRAME_PRETTY,       wdsJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_COMPACT_FLAT,       wdsJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_FLATTEN_FLAT,       wdsJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_EXPAND_FLAT,        wdsJsonldFactory10) ;
+        register(RDFFormat.JSONLD10_FRAME_FLAT,         wdsJsonldFactory10) ;
 
         // JSON-LD 1.1
         register(RDFFormat.JSONLD11,                    wgJsonldFactory11) ;
+        register(RDFFormat.JSONLD11_PRETTY,             wgJsonldFactory11) ;
         register(RDFFormat.JSONLD11_PLAIN,              wgJsonldFactory11) ;
         register(RDFFormat.JSONLD11_FLAT,               wgJsonldFactory11) ;
+
+        register(RDFFormat.JSONLD11,                    wdsJsonldFactory11) ;
+        register(RDFFormat.JSONLD11_PRETTY,             wdsJsonldFactory11) ;
+        register(RDFFormat.JSONLD11_PLAIN,              wdsJsonldFactory11) ;
+        register(RDFFormat.JSONLD11_FLAT,               wdsJsonldFactory11) ;
+
+        // JSON-LD System defaults.
+        register(RDFFormat.JSONLD,                      jsonldWriterGraphDefault) ;
+        register(RDFFormat.JSONLD_PRETTY,               jsonldWriterGraphDefault) ;
+        register(RDFFormat.JSONLD_PLAIN,                jsonldWriterGraphDefault) ;
+        register(RDFFormat.JSONLD_FLAT,                 jsonldWriterGraphDefault) ;
+
+        register(RDFFormat.JSONLD,                      jsonldWriterDatasetDefault) ;
+        register(RDFFormat.JSONLD_PRETTY,               jsonldWriterDatasetDefault) ;
+        register(RDFFormat.JSONLD_PLAIN,                jsonldWriterDatasetDefault) ;
+        register(RDFFormat.JSONLD_FLAT,                 jsonldWriterDatasetDefault) ;
 
         register(RDFFormat.RDFJSON,        wgfactory) ;
 
@@ -196,26 +235,6 @@ public class RDFWriterRegistry
         register(RDFFormat.NQUADS,         wdsfactory) ;
         register(RDFFormat.NQUADS_ASCII,   wdsfactory) ;
         register(RDFFormat.RDFNULL,        wdsfactory) ;
-
-        // JSON-LD 1.0
-        register(RDFFormat.JSONLD,                      wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD10,                    wdsJsonldFactory10) ;
-
-        register(RDFFormat.JSONLD_FLAT,                 wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD_PRETTY,               wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD_COMPACT_PRETTY,       wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD_FLATTEN_PRETTY,       wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD_EXPAND_PRETTY,        wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD_FRAME_PRETTY,         wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD_COMPACT_FLAT,         wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD_FLATTEN_FLAT,         wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD_EXPAND_FLAT,          wdsJsonldFactory10) ;
-        register(RDFFormat.JSONLD_FRAME_FLAT,           wdsJsonldFactory10) ;
-
-        // JSON-LD 1.1
-        register(RDFFormat.JSONLD11,                    wdsJsonldFactory11) ;
-        register(RDFFormat.JSONLD11_PLAIN,              wdsJsonldFactory11) ;
-        register(RDFFormat.JSONLD11_FLAT,               wdsJsonldFactory11) ;
 
         register(RDFFormat.RDF_PROTO,           wdsProtoFactory) ;
         register(RDFFormat.RDF_PROTO_VALUES,    wdsProtoFactory) ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/SysRIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/SysRIOT.java
@@ -119,53 +119,54 @@ public class SysRIOT
 
 
     private static Boolean isJSONLD11 = null;
-    private static ReaderRIOTFactory readerFactoryDft = null;
-    private static ReaderRIOTFactory readerFactoryJSON10;
-    private static ReaderRIOTFactory readerFactoryJSON11;
+    private static ReaderRIOTFactory readerFactoryJsonldDft = null;
+    private static ReaderRIOTFactory readerFactoryJsonld10;
+    private static ReaderRIOTFactory readerFactoryJsonld11;
 
     /**
      * <p>
      * Flip between JSON-LD 1.0 and JSON-LD 1.1 as the default parser for JSON-LD
      * ({@code Lang.JSONLD}). Both are available as {@code Lang.JSONLD10} and
      * {@code Lang.JSONLD11} respectively.
-     * This function control the setting of content type
+     * </p><p>
+     * This function controls the setting of content type
      * "application/ld+json" and {@code Lang.JSONLD} for input (parsing).
      * </p><p>
      * <em>This function is not a permanent API.</em>
      * </p><p>
-     * The default output is currently fixed as JSON-LD 1.0. A specific version can be obtained by choosing the versioned language name.
+     * The default output is currently fixed as JSON-LD 1.1.
+     * A specific version can be obtained by choosing the versioned language name,
+     * {@code Lang.JSONLD10} or {@code Lang.JSONLD11}.
      * </p><p>
      * Apache Jena uses
-     * <a href="https://github.com/jsonld-java/jsonld-java">jsonld-java</a> for
-     * JSON-LD 1.0 and <a href="https://github.com/filip26/titanium-json-ld">Titanium</a>
-     * for JSON-LD 1.1.
+     * <a href="https://github.com/jsonld-java/jsonld-java">jsonld-java</a> for JSON-LD 1.0
+     * and
+     * <a href="https://github.com/filip26/titanium-json-ld">Titanium</a> for JSON-LD 1.1.
      * </p><p>We are grateful to each of communities for the work in implementing and maintaining these projects.
      * </p>
-     * Contribute to <a href="https://issues.apache.org/jira/browse/JENA-2153">JENA-2153<a/> to
-     * improve the JSON-LD 1.1 output.
-     * <p>
+     *
      * @param version   A string that is either "1.1" or "1.0" or "" (reset to system installation default)
      */
     public static void setDefaultJSONLD(String version) {
         Objects.requireNonNull(version, "Argument 'version' must be \"1.1\", \"1.0\" or \"\" (empty string)");
 
-        if ( readerFactoryDft == null ) {
-            readerFactoryDft = RDFParserRegistry.getFactory(Lang.JSONLD);
-            readerFactoryJSON10 = RDFParserRegistry.getFactory(Lang.JSONLD10);
-            readerFactoryJSON11 = RDFParserRegistry.getFactory(Lang.JSONLD11);
+        if ( readerFactoryJsonldDft == null ) {
+            readerFactoryJsonldDft = RDFParserRegistry.getFactory(Lang.JSONLD);
+            readerFactoryJsonld10  = RDFParserRegistry.getFactory(Lang.JSONLD10);
+            readerFactoryJsonld11  = RDFParserRegistry.getFactory(Lang.JSONLD11);
         }
         switch (version) {
             case "":
-                RDFParserRegistry.registerLangTriples(Lang.JSONLD, readerFactoryDft);
-                RDFParserRegistry.registerLangQuads(Lang.JSONLD, readerFactoryDft);
+                RDFParserRegistry.registerLangTriples(Lang.JSONLD, readerFactoryJsonldDft);
+                RDFParserRegistry.registerLangQuads(Lang.JSONLD, readerFactoryJsonldDft);
                 return;
             case "1.1":
-                RDFParserRegistry.registerLangTriples(Lang.JSONLD, readerFactoryJSON11);
-                RDFParserRegistry.registerLangQuads(Lang.JSONLD, readerFactoryJSON11);
+                RDFParserRegistry.registerLangTriples(Lang.JSONLD, readerFactoryJsonld11);
+                RDFParserRegistry.registerLangQuads(Lang.JSONLD, readerFactoryJsonld11);
                 return;
             case "1.0":
-                RDFParserRegistry.registerLangTriples(Lang.JSONLD, readerFactoryJSON10);
-                RDFParserRegistry.registerLangQuads(Lang.JSONLD, readerFactoryJSON10);
+                RDFParserRegistry.registerLangTriples(Lang.JSONLD, readerFactoryJsonld10);
+                RDFParserRegistry.registerLangQuads(Lang.JSONLD, readerFactoryJsonld10);
                 return;
             default:
                 Log.warn(SysRIOT.class, "Version string not recognized: '"+version+"'");

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/TurtleJCC.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/TurtleJCC.java
@@ -24,19 +24,19 @@ public class TurtleJCC {
 
     // Must be a different content type.
     // Must be a different file extension.
-    public static Lang lang = LangBuilder.create("TurtleJavaCC", "text/turtle-jcc")
+    public static Lang TTLJCC = LangBuilder.create("TurtleJavaCC", "text/turtle-jcc")
                                         .addAltNames("ttljcc")
                                         .addFileExtensions("ttljcc")
                                         .build();
     public static ReaderRIOTFactory factory = (lang, profile) -> new TurtleJavaccReaderRIOT(profile) ;
 
     public static void register() {
-        RDFLanguages.register(lang);
-        RDFParserRegistry.registerLangTriples(lang, factory);
+        RDFLanguages.register(TTLJCC);
+        RDFParserRegistry.registerLangTriples(TTLJCC, factory);
     }
 
     public static void unregister() {
-        RDFParserRegistry.removeRegistration(lang);
-        RDFLanguages.unregister(lang);
+        RDFParserRegistry.removeRegistration(TTLJCC);
+        RDFLanguages.unregister(TTLJCC);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/JenaRDF2JSONLD10.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/JenaRDF2JSONLD10.java
@@ -33,7 +33,7 @@ import com.github.jsonldjava.core.JsonLdError ;
 import com.github.jsonldjava.core.RDFDataset ;
 
 /** Convert from JSON-LD syntax to JSON-LD internal representation of a dataset, using Jena Quads/Nodes etc */
-class JenaRDF2JSONLD implements com.github.jsonldjava.core.RDFParser {
+class JenaRDF2JSONLD10 implements com.github.jsonldjava.core.RDFParser {
     NodeToLabel labels = SyntaxLabels.createNodeToLabel() ;
 
     @Override
@@ -87,7 +87,7 @@ class JenaRDF2JSONLD implements com.github.jsonldjava.core.RDFParser {
             }
         }                
         else
-            Log.warn(JenaRDF2JSONLD.class, "unknown") ;
+            Log.warn(JenaRDF2JSONLD10.class, "unknown") ;
         return result ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/JsonLD10Writer.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/JsonLD10Writer.java
@@ -197,7 +197,7 @@ public class JsonLD10Writer extends WriterDatasetRIOTBase
 
         // with this, we cannot call the json-ld fromRDF method that assumes no duplicates in RDFDataset
         // Object obj = JsonLdProcessor.fromRDF(dataset, opts, new JenaRDF2JSONLD()) ;
-        final RDFDataset jsonldDataset = (new JenaRDF2JSONLD()).parse(dataset);
+        final RDFDataset jsonldDataset = (new JenaRDF2JSONLD10()).parse(dataset);
         Object obj = (new JsonLdApi(opts)).fromRDF(jsonldDataset, true); // true because we know that we don't have any duplicate in jsonldDataset
 
         if (variant.isExpand()) {

--- a/jena-arq/src/test/java/org/apache/jena/rdf_star/TestTurtleStarParse.java
+++ b/jena-arq/src/test/java/org/apache/jena/rdf_star/TestTurtleStarParse.java
@@ -70,7 +70,7 @@ public class TestTurtleStarParse {
         string = "PREFIX : <http://example/>\n"+string;
 
         Lang lang1 = Lang.TURTLE;
-        Lang lang2 = TurtleJCC.lang;
+        Lang lang2 = TurtleJCC.TTLJCC;
         Lang lang = lang1;
 
         RDFParser.fromString(string).lang(lang).errorHandler(silent).parse(sink);

--- a/jena-arq/src/test/java/org/apache/jena/riot/TS_RiotGeneral.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TS_RiotGeneral.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.riot;
 
-import org.apache.jena.riot.writer.TestJsonLDWriter;
+import org.apache.jena.riot.writer.TestJsonLD10Writer;
 import org.junit.runner.RunWith ;
 import org.junit.runners.Suite ;
 import org.junit.runners.Suite.SuiteClasses ;
@@ -42,7 +42,7 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestTurtleWriterPretty.class
 
     , TestJsonLDReader.class
-    , TestJsonLDWriter.class
+    , TestJsonLD10Writer.class
 })
 
 public class TS_RiotGeneral

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 
 public class TestJsonLDReader {
 
-    // These tests fail under java11 (but not java17)
+    // These tests fail under some java11 (but not java17)
     // for RIOT default JSON-LD 1.1 because Titanium contacts schema.org
     // with java.net.http/HTTP2 (default version setting)
     // which fails.
@@ -47,7 +47,7 @@ public class TestJsonLDReader {
     @Test
     public final void simpleReadTest() throws IOException {
         String jsonld = someSchemaDotOrgJsonld();
-        Dataset ds = jsonld2dataset(jsonld, null);
+        Dataset ds = jsonld2dataset(jsonld, null, Lang.JSONLD);
         assertJohnDoeIsOK(ds.getDefaultModel());
     }
 
@@ -64,7 +64,7 @@ public class TestJsonLDReader {
         jenaCtx.setJsonLDContext(schemaOrgResolvedContext());
 
         // read the jsonld, replacing its "@context"
-        Dataset ds = jsonld2dataset(jsonld, jenaCtx);
+        Dataset ds = jsonld2dataset(jsonld, jenaCtx, Lang.JSONLD);
 
         // check ds is correct
         assertJohnDoeIsOK(ds.getDefaultModel());
@@ -85,7 +85,8 @@ public class TestJsonLDReader {
         jenaCtx.setOptions(options);
 
         // read the jsonld, replacing its "@context"
-        Dataset ds = jsonld2dataset(jsonld, jenaCtx);
+        // Uses JsonLdOptions which is specific to jsonld-java (1.0).
+        Dataset ds = jsonld2dataset(jsonld, jenaCtx, Lang.JSONLD10);
 
         // check ds is correct
         assertJohnDoeIsOK(ds.getDefaultModel());
@@ -96,12 +97,12 @@ public class TestJsonLDReader {
      * @return a new Dataset
      * @throws IOException
      */
-    private Dataset jsonld2dataset(String jsonld, Context jenaCtx) throws IOException {
+    private Dataset jsonld2dataset(String jsonld, Context jenaCtx, Lang lang) throws IOException {
         Dataset ds = DatasetFactory.create();
         RDFParser.create()
             .fromString(jsonld)
             .errorHandler(ErrorHandlerFactory.errorHandlerNoLogging)
-            .lang(Lang.JSONLD)
+            .lang(lang)
             .context(jenaCtx)
             .parse(ds.asDatasetGraph());
         return ds;

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestJsonLDReadWrite.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestJsonLDReadWrite.java
@@ -152,7 +152,7 @@ public class TestJsonLDReadWrite
 
         for ( String prefix : namespaces.keySet() ) {
             if ( !prefix.isEmpty() )
-                Assert.assertEquals("Model does contain expected namespace " + prefix + ": <" + namespaces.get(prefix) + ">",
+                Assert.assertEquals("Model does not contain expected namespace " + prefix + ": <" + namespaces.get(prefix) + ">",
                                     namespaces.get(prefix), m.getNsPrefixURI(prefix));
         }
     }

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestJsonLD10Writer.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestJsonLD10Writer.java
@@ -47,7 +47,7 @@ import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Test;
 
-public class TestJsonLDWriter {
+public class TestJsonLD10Writer {
 
     /**
      * Checks that JSON-LD RDFFormats supposed to be pretty are pretty
@@ -61,20 +61,20 @@ public class TestJsonLDWriter {
 
         // pretty is pretty
 
-        s = toString(m, RDFFormat.JSONLD_EXPAND_PRETTY, null);
+        s = toString(m, RDFFormat.JSONLD10_EXPAND_PRETTY, null);
         assertTrue(s.trim().contains("\n"));
-        s = toString(m, RDFFormat.JSONLD_COMPACT_PRETTY, null);
+        s = toString(m, RDFFormat.JSONLD10_COMPACT_PRETTY, null);
         assertTrue(s.trim().contains("\n"));
-        s = toString(m, RDFFormat.JSONLD_FLATTEN_PRETTY, null);
+        s = toString(m, RDFFormat.JSONLD10_FLATTEN_PRETTY, null);
         assertTrue(s.trim().contains("\n"));
 
         // and flat is flat
 
-        s = toString(m, RDFFormat.JSONLD_EXPAND_FLAT, null);
+        s = toString(m, RDFFormat.JSONLD10_EXPAND_FLAT, null);
         assertFalse(s.trim().contains("\n"));
-        s = toString(m, RDFFormat.JSONLD_COMPACT_FLAT, null);
+        s = toString(m, RDFFormat.JSONLD10_COMPACT_FLAT, null);
         assertFalse(s.trim().contains("\n"));
-        s = toString(m, RDFFormat.JSONLD_FLATTEN_FLAT, null);
+        s = toString(m, RDFFormat.JSONLD10_FLATTEN_FLAT, null);
         assertFalse(s.trim().contains("\n"));
         assertFalse(s.trim().contains("\n"));
         // JSON_LD FRAME case not tested here, but in testFrames
@@ -91,20 +91,20 @@ public class TestJsonLDWriter {
 
         // there's no "@context" in expand
 
-        s = toString(m, RDFFormat.JSONLD_EXPAND_PRETTY, null);
+        s = toString(m, RDFFormat.JSONLD10_EXPAND_PRETTY, null);
         assertFalse(s.contains("@context"));
-        s = toString(m, RDFFormat.JSONLD_EXPAND_FLAT, null);
+        s = toString(m, RDFFormat.JSONLD10_EXPAND_FLAT, null);
         assertFalse(s.contains("@context"));
 
         // there's an "@context" in compact and flatten
 
-        s = toString(m, RDFFormat.JSONLD_COMPACT_PRETTY, null);
+        s = toString(m, RDFFormat.JSONLD10_COMPACT_PRETTY, null);
         assertTrue(s.contains("@context"));
-        s = toString(m, RDFFormat.JSONLD_COMPACT_FLAT, null);
+        s = toString(m, RDFFormat.JSONLD10_COMPACT_FLAT, null);
         assertTrue(s.contains("@context"));
-        s = toString(m, RDFFormat.JSONLD_FLATTEN_PRETTY, null);
+        s = toString(m, RDFFormat.JSONLD10_FLATTEN_PRETTY, null);
         assertTrue(s.contains("@context"));
-        s = toString(m, RDFFormat.JSONLD_FLATTEN_FLAT, null);
+        s = toString(m, RDFFormat.JSONLD10_FLATTEN_FLAT, null);
         assertTrue(s.contains("@context"));
     }
 
@@ -140,7 +140,7 @@ public class TestJsonLDWriter {
         String ns = "http://www.a.com/foo/";
         Model m = simpleModel(ns);
         m.setNsPrefix("", ns);
-        String jsonld = toString(m, RDFFormat.JSONLD_COMPACT_PRETTY, null);
+        String jsonld = toString(m, RDFFormat.JSONLD10_COMPACT_PRETTY, null);
         assertFalse(jsonld.contains("\"\""));
         Model m2 = parse(jsonld);
         assertTrue(m2.isIsomorphicWith(m));
@@ -158,7 +158,7 @@ public class TestJsonLDWriter {
         Model m = simpleModel(ns);
         m.setNsPrefix("ex", ns);
 
-        String s1 = toString(m, RDFFormat.JSONLD_COMPACT_FLAT, null);
+        String s1 = toString(m, RDFFormat.JSONLD10_COMPACT_FLAT, null);
         // there's a prefix in m, and we find it in the output
         String prefixStringInResult = "\"ex\":\"" + ns + "\"";
         assertTrue(s1.contains(prefixStringInResult));
@@ -179,7 +179,7 @@ public class TestJsonLDWriter {
 
         // remove the prefix from m
         m.removeNsPrefix("ex");
-        String s2 = toString(m, RDFFormat.JSONLD_COMPACT_PRETTY, null);
+        String s2 = toString(m, RDFFormat.JSONLD10_COMPACT_PRETTY, null);
         // model wo prefix -> no more prefix string in result:
         assertFalse(s2.contains(prefixStringInResult));
 
@@ -187,7 +187,7 @@ public class TestJsonLDWriter {
         JsonLDWriteContext jenaCtx = new JsonLDWriteContext();
         jenaCtx.setJsonLDContext(js);
 
-        String s3 = toString(m, RDFFormat.JSONLD_COMPACT_FLAT, jenaCtx);
+        String s3 = toString(m, RDFFormat.JSONLD10_COMPACT_FLAT, jenaCtx);
 
         assertTrue(s3.length() == s1.length());
         assertTrue(s3.contains(prefixStringInResult));
@@ -199,7 +199,7 @@ public class TestJsonLDWriter {
         js = "{\"@context\":" + js + "}";
         jenaCtx.setJsonLDContext(js);
 
-        String s4 = toString(m, RDFFormat.JSONLD_COMPACT_FLAT, jenaCtx);
+        String s4 = toString(m, RDFFormat.JSONLD10_COMPACT_FLAT, jenaCtx);
 
         assertTrue(s4.length() == s1.length());
         assertTrue(s4.contains(prefixStringInResult));
@@ -217,7 +217,7 @@ public class TestJsonLDWriter {
         Model m = simpleModel(ns);
         m.setNsPrefix("ex", ns);
 
-        String s1 = toString(m, RDFFormat.JSONLD_COMPACT_FLAT, null);
+        String s1 = toString(m, RDFFormat.JSONLD10_COMPACT_FLAT, null);
         // there's a prefix in m, and we find it in the output
         String prefixStringInResult = "\"ex\":\"" + ns + "\"";
         assertTrue(s1.contains(prefixStringInResult));
@@ -229,14 +229,14 @@ public class TestJsonLDWriter {
 
         // remove the prefix from m
         m.removeNsPrefix("ex");
-        String s2 = toString(m, RDFFormat.JSONLD_COMPACT_PRETTY, null);
+        String s2 = toString(m, RDFFormat.JSONLD10_COMPACT_PRETTY, null);
         // model wo prefix -> no more prefix string in result:
         assertFalse(s2.contains(prefixStringInResult));
 
         // the model wo prefix, output as jsonld using a context that defines the prefix
         Context jenaCtx = new Context();
         jenaCtx.set(JsonLD10Writer.JSONLD_CONTEXT, ctx);
-        String s3 = toString(m, RDFFormat.JSONLD_COMPACT_FLAT, jenaCtx);
+        String s3 = toString(m, RDFFormat.JSONLD10_COMPACT_FLAT, jenaCtx);
 
         assertTrue(s3.length() == s1.length());
         assertTrue(s3.contains(prefixStringInResult));
@@ -287,7 +287,7 @@ public class TestJsonLDWriter {
         JsonLDWriteContext jenaCtx = new JsonLDWriteContext();
         jenaCtx.setJsonLDContextSubstitution((new JsonString(ns)).toString());
         String jsonld;
-        jsonld = toString(m, RDFFormat.JSONLD_COMPACT_FLAT, jenaCtx);
+        jsonld = toString(m, RDFFormat.JSONLD10_COMPACT_FLAT, jenaCtx);
         String c = "\"@context\":\"http://schema.org/\"";
         assertTrue(jsonld.contains(c));
 
@@ -295,7 +295,7 @@ public class TestJsonLDWriter {
 
         String ctx = "{\"jobTitle\":{\"@id\":\"http://ex.com/jobTitle\"},\"url\":{\"@id\":\"http://ex.com/url\"},\"name\":{\"@id\":\"http://ex.com/name\"}}";
         jenaCtx.setJsonLDContextSubstitution(ctx);
-        jsonld = toString(m, RDFFormat.JSONLD_COMPACT_FLAT, jenaCtx);
+        jsonld = toString(m, RDFFormat.JSONLD10_COMPACT_FLAT, jenaCtx);
         assertTrue(jsonld.contains("http://ex.com/name"));
     }
 
@@ -326,7 +326,7 @@ public class TestJsonLDWriter {
 
         frame.put("@type", ns +"Person");
         jenaCtx.set(JsonLD10Writer.JSONLD_FRAME, frame.toString());
-        String jsonld = toString(m, RDFFormat.JSONLD_FRAME_PRETTY, jenaCtx);
+        String jsonld = toString(m, RDFFormat.JSONLD10_FRAME_PRETTY, jenaCtx);
 
         Model m2 = parse(jsonld);
         // 2 subjects with a type in m2
@@ -341,7 +341,7 @@ public class TestJsonLDWriter {
         frame = new JsonObject();
         frame.put("http://schema.org/jobTitle", new JsonObject());
         jenaCtx.set(JsonLD10Writer.JSONLD_FRAME, JsonUtils.fromString(frame.toString()));
-        jsonld = toString(m, RDFFormat.JSONLD_FRAME_FLAT, jenaCtx);
+        jsonld = toString(m, RDFFormat.JSONLD10_FRAME_FLAT, jenaCtx);
         m2 = parse(jsonld);
         // 1 subject with a type in m2
         assertTrue(m2.listStatements((Resource) null, RDF.type, (RDFNode) null).toList().size() == 1);
@@ -364,7 +364,7 @@ public class TestJsonLDWriter {
         m.add(s, m.createProperty(ns + "pfloat"), m.createTypedLiteral((float) 1789.14));
         m.add(s, m.createProperty(ns + "pstring"), m.createTypedLiteral("a TypedLiteral atring"));
 
-        String jsonld = toString(m, RDFFormat.JSONLD_FLAT, null);
+        String jsonld = toString(m, RDFFormat.JSONLD10_FLAT, null);
 
         // without following line in JsonLDWriter, the test fails
         // if (! isLangString(o) && ! isSimpleString(o) )
@@ -384,7 +384,7 @@ public class TestJsonLDWriter {
         m.add(s, m.createProperty(ns1 + "name"), "schema.org name");
         m.add(s, m.createProperty(ns2 + "name"), "ex.com name");
 
-        String jsonld = toString(m, RDFFormat.JSONLD, null);
+        String jsonld = toString(m, RDFFormat.JSONLD10, null);
 
         // in one case, we have "name" : "xxx", and the other "http://.../name" : "yyy"
         assertTrue(jsonld.contains("\"name\" : \""));
@@ -392,7 +392,7 @@ public class TestJsonLDWriter {
 
         m.setNsPrefix("ns1", ns1);
         m.setNsPrefix("ns2", "http://ex.com/");
-        jsonld = toString(m, RDFFormat.JSONLD, null);
+        jsonld = toString(m, RDFFormat.JSONLD10, null);
         // we get either:
         /*
       "name" : "ex.com name",
@@ -418,7 +418,7 @@ public class TestJsonLDWriter {
 
         // our default uses true for compactArrays
 
-        String jsonld = toString(m, RDFFormat.JSONLD, null);
+        String jsonld = toString(m, RDFFormat.JSONLD10, null);
 
         // compactArrays is true -> no "@graph"
         assertFalse(jsonld.contains("@graph"));
@@ -434,7 +434,7 @@ public class TestJsonLDWriter {
 
         jenaCtx.setOptions(opts);
 
-        jsonld = toString(m, RDFFormat.JSONLD, jenaCtx);
+        jsonld = toString(m, RDFFormat.JSONLD10, jenaCtx);
 
         // compactArrays is false -> a "@graph" node
         assertTrue(jsonld.contains("@graph"));
@@ -461,7 +461,7 @@ public class TestJsonLDWriter {
         m.add(s, m.createProperty(ns + "knows"), s2);
 
         m.setNsPrefix("", ns);
-        String jsonld = toString(m, RDFFormat.JSONLD, null);
+        String jsonld = toString(m, RDFFormat.JSONLD10, null);
         assertTrue(jsonld.contains("@vocab"));
     }
 
@@ -488,8 +488,8 @@ public class TestJsonLDWriter {
         Context jenaContext = null;
 
         // the JSON-LD API object. It's a map
-        Map<String, Object> map = (Map<String, Object>) JsonLD10Writer.toJsonLDJavaAPI((RDFFormat.JSONLDVariant)RDFFormat.JSONLD.getVariant()
-                , g, pm, base, jenaContext);
+        RDFFormat.JSONLDVariant variant = (RDFFormat.JSONLDVariant)(RDFFormat.JSONLD10.getVariant());
+        Map<String, Object> map = (Map<String, Object>) JsonLD10Writer.toJsonLDJavaAPI(variant, g, pm, base, jenaContext);
 
         // get the @context:
         Map<String, Object> ctx = (Map<String, Object>) map.get("@context");
@@ -518,7 +518,6 @@ public class TestJsonLDWriter {
         // JsonUtils.writePrettyPrint(new PrintWriter(System.out), map) ;
     }
 
-
     //
     // some utilities
     //
@@ -539,13 +538,13 @@ public class TestJsonLDWriter {
     }
 
     private static RDFFormat[] JSON_LD_FORMATS = {
-            RDFFormat.JSONLD_COMPACT_PRETTY,
-            RDFFormat.JSONLD_FLATTEN_PRETTY,
-            RDFFormat.JSONLD_EXPAND_PRETTY,
-            RDFFormat.JSONLD_FRAME_PRETTY,
-            RDFFormat.JSONLD_COMPACT_FLAT,
-            RDFFormat.JSONLD_FLATTEN_FLAT,
-            RDFFormat.JSONLD_EXPAND_FLAT,
-            RDFFormat.JSONLD_FRAME_FLAT,
+            RDFFormat.JSONLD10_COMPACT_PRETTY,
+            RDFFormat.JSONLD10_FLATTEN_PRETTY,
+            RDFFormat.JSONLD10_EXPAND_PRETTY,
+            RDFFormat.JSONLD10_FRAME_PRETTY,
+            RDFFormat.JSONLD10_COMPACT_FLAT,
+            RDFFormat.JSONLD10_FLATTEN_FLAT,
+            RDFFormat.JSONLD10_EXPAND_FLAT,
+            RDFFormat.JSONLD10_FRAME_FLAT,
     };
 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRiotWriterGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRiotWriterGraph.java
@@ -19,6 +19,7 @@
 package org.apache.jena.riot.writer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -40,6 +41,7 @@ public class TestRiotWriterGraph extends AbstractWriterTest
     @Parameters(name = "{index}: {0}")
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][] {
+
             { RDFFormat.RDFNULL }
 
             , { RDFFormat.NTRIPLES_UTF8 }
@@ -52,12 +54,21 @@ public class TestRiotWriterGraph extends AbstractWriterTest
             , { RDFFormat.RDFXML }
             , { RDFFormat.RDFXML_PRETTY }
             , { RDFFormat.RDFXML_PLAIN }
+
             , { RDFFormat.JSONLD }
             , { RDFFormat.JSONLD_PRETTY }
             , { RDFFormat.JSONLD_FLAT }
+
+            , { RDFFormat.JSONLD10 }
+            , { RDFFormat.JSONLD10_PRETTY }
+            , { RDFFormat.JSONLD10_FLAT }
+
+            , { RDFFormat.JSONLD11 }
+            , { RDFFormat.JSONLD11_PRETTY }
+            , { RDFFormat.JSONLD11_FLAT }
+
             , { RDFFormat.RDFJSON }
 
-            // graph in quad formats.
             , { RDFFormat.TRIG }
             , { RDFFormat.TRIG_PRETTY }
             , { RDFFormat.TRIG_BLOCKS }
@@ -124,6 +135,7 @@ public class TestRiotWriterGraph extends AbstractWriterTest
         Lang lang = format.getLang();
 
         WriterGraphRIOT rs = RDFWriterRegistry.getWriterGraphFactory(format).create(format);
+        assertNotNull(rs);
         assertEquals(lang, rs.getLang());
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/jena-examples/src/main/java/arq/examples/riot/Ex_WriteJsonLD.java
+++ b/jena-examples/src/main/java/arq/examples/riot/Ex_WriteJsonLD.java
@@ -21,7 +21,6 @@ package arq.examples.riot;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.StringReader;
 
 import com.github.jsonldjava.core.DocumentLoader;
 import com.github.jsonldjava.core.JsonLdOptions;
@@ -30,16 +29,16 @@ import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.riot.JsonLDWriteContext;
-import org.apache.jena.riot.RDFDataMgr;
-import org.apache.jena.riot.RDFFormat;
-import org.apache.jena.riot.RDFWriter;
+import org.apache.jena.riot.*;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.util.Context;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 
-/** Example writing as JSON-LD */
+/**
+ * Example writing as JSON-LD using jsonlkd-java (JSON-LD 1.0)
+ * sNote the use of "JSONLD10"
+  */
 public class Ex_WriteJsonLD
 {
     public static void main(String[] args) {
@@ -63,18 +62,18 @@ public class Ex_WriteJsonLD
 
         // to get a default output: just do like for any other lang
         System.out.println("--- DEFAULT ---");
-        m.write(System.out, "JSON-LD");
+        RDFWriter.source(m).lang(Lang.JSONLD10).output(System.out);
 
-        // same thing, using the more modern RDFDataMgr, and specifying the RDFFormat
+        // same thing, using RDFDataMgr, and specifying the RDFFormat
         System.out.println("\n--- DEFAULT ---");
-        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD);
+        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD10);
 
         // output can be pretty (with line breaks), or not
         System.out.println("\n--- DEFAULT, PRETTY (same as above, BTW) ---");
-        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD_PRETTY);
+        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD10_PRETTY);
 
         System.out.println("\n--- DEFAULT, FLAT ---");
-        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD_FLAT);
+        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD10_FLAT);
 
         // all these default outputs use the JsonLD "Compact" format
         // (note the "@context" node in the output)
@@ -86,21 +85,21 @@ public class Ex_WriteJsonLD
         m.setNsPrefix("ex", "http://www.ex.com/");
         m.setNsPrefix("sh", "https://schema.org/");
         System.out.println("\n--- DEFAULT, model including prefix mappings ---");
-        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD_PRETTY);
+        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD10_PRETTY);
 
         // Besides "Compact", JSON-LD defines the following kinds of outputs: expanded, flattened, and framed
         // For each of them, there is a dedicated RDFFormat -- actually, 2 of them (one pretty, one flat)
-        // As previously seen, RDFFormat.JSONLD is just an alias of RDFFormat.JSONLD_COMPACT_PRETYY
+        // As previously seen, RDFFormat.JSONLD is just an alias of RDFFormat.JSONLD10_COMPACT_PRETYY
         // Let's try the other ones:
 
         // Expand is the fastest one
         // no @context in it
         System.out.println("\n--- EXPAND ---");
-        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD_EXPAND_PRETTY);
+        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD10_EXPAND_PRETTY);
 
         // flatten has an @context node
         System.out.println("\n--- FLATTEN ---");
-        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD_FLATTEN_PRETTY);
+        RDFDataMgr.write(System.out, m, RDFFormat.JSONLD10_FLATTEN_PRETTY);
 
         // framed requires some more parameters to run, we'll get back to it later
     }
@@ -129,7 +128,7 @@ public class Ex_WriteJsonLD
         // (remember, "Context" here is not to be confused with "@context" in JSON-LD,
         // see {@link #write(DatasetGraph, RDFFormat, Context)})
         System.out.println("\n--- COMPACT with a null Context: same result as default ---");
-        write(g, RDFFormat.JSONLD_COMPACT_PRETTY, null);
+        write(g, RDFFormat.JSONLD10_COMPACT_PRETTY, null);
 
         // A Context is just a way to pass implementation-specific parameters as named values
         // to a given general interface (the WriterDatasetRIOT, in this case).
@@ -140,7 +139,7 @@ public class Ex_WriteJsonLD
         // so, the way to proceed is:
         // JsonLDWriteContext ctx = new JsonLDWriteContext();
         // ctx.setSomething(...)
-        // write(g, RDFFormat.JSONLD_COMPACT_PRETTY, ctx);
+        // write(g, RDFFormat.JSONLD10_COMPACT_PRETTY, ctx);
 
         // let's see now what can be customized with the JsonLDWriteContext object
 
@@ -183,7 +182,7 @@ public class Ex_WriteJsonLD
         String atContextAsJson = "{\"@vocab\":\"http://schema.org/\"}";
         ctx.setJsonLDContext(atContextAsJson);
         System.out.println("\n--- COMPACT using a Context that defines @vocab ---");
-        write(g, RDFFormat.JSONLD_COMPACT_PRETTY, ctx);
+        write(g, RDFFormat.JSONLD10_COMPACT_PRETTY, ctx);
     }
 
     /**
@@ -201,17 +200,17 @@ public class Ex_WriteJsonLD
         DatasetGraph g = DatasetFactory.wrap(m).asDatasetGraph();
         JsonLDWriteContext ctx = new JsonLDWriteContext();
 
-        // The following works with Uris returning JSON-LD or Uris returning an Alternate document location that is JSON-LD
-        // https://www.w3.org/TR/json-ld11/#alternate-document-location
-        // NOTE: This example will download the "@context" from the passed URL before processing the output, which can be slow.
+//        // The following works with Uris returning JSON-LD or Uris returning an Alternate document location that is JSON-LD
+//        // https://www.w3.org/TR/json-ld11/#alternate-document-location
+//        // NOTE: This example will download the "@context" from the passed URL before processing the output, which can be slow.
         ctx.setJsonLDContext("\"http://schema.org/\"");
         System.out.println("\n--- Setting the context to a URI, WRONG WAY: it's slow, and the output is not JSON-LD. Sorry about that. ---");
-        write(g, RDFFormat.JSONLD_COMPACT_PRETTY, ctx);
+        write(g, RDFFormat.JSONLD10_COMPACT_PRETTY, ctx);
 
         // Alternatively, if we know beforehand the resolved context, we can use the DocumentLoader as follows (much more performant):
         DocumentLoader dl = new DocumentLoader();
-        String resolvedContext = "\"@context\": {\"name\":{\"@id\":\"http://schema.org/name\"},\"Person\": {\"@id\": \"http://schema.org/Person\"}}";
-        dl.addInjectedDoc("http://schema.org", resolvedContext);
+        String resolvedContext = "{\"@context\": {\"name\":{\"@id\":\"http://schema.org/name\"},\"Person\": {\"@id\": \"http://schema.org/Person\"}}}";
+        dl.addInjectedDoc("https://schema.org/", resolvedContext);
         JsonLdOptions options = new JsonLdOptions();
         options.setDocumentLoader(dl);
         ctx.setOptions(options);
@@ -219,14 +218,14 @@ public class Ex_WriteJsonLD
         // Alternatively, we could just pass "null" as context and let jena compute it (as the model only uses schema.org vocab)
         // After that, we can substitute the output "@context" from Jena by whatever we want, in this case the URL http://schema.org/
         ctx.setJsonLDContext(null);
-        ctx.setJsonLDContextSubstitution("\"http://schema.org/\"");
+        ctx.setJsonLDContextSubstitution("\"https://schema.org/\"");
 
         // To summarize:
         // - ctx.setJsonLDContext allows to define the @context used to produce the output in compacted/frame/flatten algorithms
         // - ctx.setOptions allows to define the Json-LD options and override the remote context URI resolutions (using DocumentLoader)
         // - ctx.setJsonLDContextSubstitution allows to override the output value of the "@context" after the compaction/frame/flattening algorithms have already been executed
         System.out.println("\n--- COMPACT with @context replaced by schema.org URI ---");
-        write(g, RDFFormat.JSONLD_COMPACT_PRETTY, ctx);
+        write(g, RDFFormat.JSONLD10_COMPACT_PRETTY, ctx);
 
         // Final note: BEWARE when replacing the context:
         // if you let some things undefined, the output will be json, not jsonld
@@ -265,7 +264,7 @@ public class Ex_WriteJsonLD
         String frame = "{\"@type\" : \"http://schema.org/Person\"}";
         ctx.setFrame(frame);
         System.out.println("\n--- Using frame to select resources to be output: only output persons ---");
-        write(g, RDFFormat.JSONLD_FRAME_PRETTY, ctx);
+        write(g, RDFFormat.JSONLD10_FRAME_PRETTY, ctx);
     }
 
     /**
@@ -282,7 +281,7 @@ public class Ex_WriteJsonLD
         ctx.setOptions(opts);
         opts.setCompactArrays(false); // default is true
         System.out.println("\n--- COMPACT with CompactArrays false: there is an @graph node");
-        write(g, RDFFormat.JSONLD_COMPACT_PRETTY, ctx);
+        write(g, RDFFormat.JSONLD10_COMPACT_PRETTY, ctx);
     }
 
     /**
@@ -295,7 +294,7 @@ public class Ex_WriteJsonLD
      * and we pass a "Context" object (not to be confused with the "@context" in JSON-LD) as argument to its write method
      *
      * @param out
-     * @param f RDFFormat of the output, eg. RDFFormat.JSONLD_COMPACT_PRETTY
+     * @param f RDFFormat of the output, eg. RDFFormat.JSONLD10_COMPACT_PRETTY
      * @param g the data that we want to output as JSON-LD
      * @param ctx the object that allows to control the writing process (a set of parameters)
      */
@@ -317,7 +316,7 @@ public class Ex_WriteJsonLD
     // following 2 methods: if you want to test
     // that everything is OK in a roundtrip: model -> jsonld -> model
     // something like:
-    // String jsonld = write2String(g, RDFFormat.JSONLD_COMPACT_PRETTY, ctx);
+    // String jsonld = write2String(g, RDFFormat.JSONLD10_COMPACT_PRETTY, ctx);
     // Model m2 = parse(jsonld);
     // System.out.println("ISO : " + m.isIsomorphicWith(m2));
 
@@ -331,10 +330,9 @@ public class Ex_WriteJsonLD
     }
 
     /** Parse a jsonld string into a Model */
-    private Model parse(String jsonld) {
+    private Model parse(String jsonldStr) {
         Model m = ModelFactory.createDefaultModel();
-        StringReader reader = new StringReader(jsonld);
-        m.read(reader, null, "JSON-LD");
+        RDFParser.fromString(jsonldStr).lang(Lang.JSONLD10).parse(m);
         return m;
     }
 


### PR DESCRIPTION
This is preparation for Jena to default to JSON-LD 1.1.

* Add a JSON-LD 1.1 (slightly) pretty writer.
* Refactor to make switching between JSON-LD 1.0 and JSON-LD 1.1 just a matter of change constants (separate contents for reading and writing).

