### PR TITLE
fix for custom builtins not being used when parsing rules

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/Rule.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/Rule.java
@@ -510,7 +510,7 @@ public class Rule implements ClauseEntry {
             InputStream in = FileManager.getInternal().open(uri);
             if (in == null) throw new RulesetNotFoundException( uri );
             br = FileUtils.asBufferedUTF8( in );
-            return parseRules( Rule.rulesParserFromReader( br ) );
+            return parseRules( Rule.rulesParserFromReader( br, registry ) );
         } finally {
             if (br != null) try { br.close(); } catch (IOException e2) {}
         }

--- a/jena-core/testing/reasoners/bugs/custom-builtins.rules
+++ b/jena-core/testing/reasoners/bugs/custom-builtins.rules
@@ -1,0 +1,4 @@
+@prefix ex: <https://example.com/>
+
+# rule uses a custom builtin
+ruleWithBuiltin: (?s ?p ?o) -> customBuiltin(?s, ?p, ?o) .

--- a/jena-core/testing/reasoners/rules/include-test-not-found.rules
+++ b/jena-core/testing/reasoners/rules/include-test-not-found.rules
@@ -1,0 +1,8 @@
+# Test file used to check @import redirection
+@prefix p1: <http://jena.hpl.hp.com/newprefix#>
+
+-> (p1:A p1:p p1:foo).
+
+@include <file:testing/reasoners/includeAlt.rules>.
+
+ 

--- a/jena-core/testing/reasoners/rules/ruleset1.rules
+++ b/jena-core/testing/reasoners/rules/ruleset1.rules
@@ -1,0 +1,3 @@
+# Used to test inclusion of multiple rule sets
+
+rule1: -> (eg:a rdf:type eg:C) .

--- a/jena-core/testing/reasoners/rules/ruleset2.rules
+++ b/jena-core/testing/reasoners/rules/ruleset2.rules
@@ -1,0 +1,3 @@
+# Used to test inclusion of multiple rule sets
+
+rule2: -> (eg:a rdf:type eg:D) .


### PR DESCRIPTION
`Rule.rulesFromURL(String, BuiltinRegistry)` does not pass the `BuiltinRegistry` argument to `Rule.rulesParserFromReader()`. This means that a user-specified builtin registry cannot be used with rules that are loaded using `rulesFromURL()`. This seems like a bug, so I can create a corresponding GitHub or JIRA issue, but wanted to first present this pull request. This is a simple one-line fix to pass `registry` into `rulesParserFromReader()`, along with some additional unit tests and a minor reorganization for some of the `.rules` files.

If you checkout just the `TestRuleLoader.java` unit test file from this PR, you can see that the `load_from_file_with_custom_builtins()` test fails. After adding the change to `Rule.java`, the test passes.