### PR TITLE
jena-fuseki-access - Propagate request/service context

### DIFF
--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/AccessCtl_SPARQL_QueryDataset.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/AccessCtl_SPARQL_QueryDataset.java
@@ -122,8 +122,7 @@ public class AccessCtl_SPARQL_QueryDataset extends SPARQL_QueryDataset {
 
         SecurityContext sCxt = DataAccessLib.getSecurityContext(action, dsg, requestUser);
         // A QueryExecution for controlled access
-        QueryExecution qExec = sCxt.createQueryExecution(query, target);
+        QueryExecution qExec = sCxt.createQueryExecution(action, query, target);
         return qExec;
     }
 }
-

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextAllowAll.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextAllowAll.java
@@ -24,7 +24,6 @@ import java.util.function.Predicate;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 
@@ -41,11 +40,6 @@ public class SecurityContextAllowAll implements SecurityContext {
 
     @Override
     public boolean visableDefaultGraph() { return true; }
-
-    @Override
-    public QueryExecution createQueryExecution(Query query, DatasetGraph dsg) {
-        return QueryExecutionFactory.create(query, dsg);
-    }
 
     /**
      * Quad filter to reflect the security policy of this {@link SecurityContextAllowAll}. It is

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextAllowNamedGraphs.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextAllowNamedGraphs.java
@@ -23,8 +23,6 @@ import java.util.function.Predicate;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 
@@ -41,12 +39,6 @@ public class SecurityContextAllowNamedGraphs implements SecurityContext {
 
     @Override
     public boolean visableDefaultGraph() { return true; }
-
-    @Override
-    public QueryExecution createQueryExecution(Query query, DatasetGraph dsg) {
-
-        return QueryExecutionFactory.create(query, dsg);
-    }
 
     /**
      * Quad filter to reflect the security policy of this {@link SecurityContextAllowNamedGraphs}. It is

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextAllowNone.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextAllowNone.java
@@ -23,9 +23,7 @@ import java.util.Collections;
 import java.util.function.Predicate;
 
 import org.apache.jena.graph.Node;
-import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphSink;
 import org.apache.jena.sparql.core.Quad;
@@ -42,11 +40,6 @@ public class SecurityContextAllowNone implements SecurityContext {
 
     @Override
     public boolean visableDefaultGraph() { return false; }
-
-    @Override
-    public QueryExecution createQueryExecution(Query query, DatasetGraph dsg) {
-        return QueryExecutionFactory.create(query, DatasetGraphSink.create());
-    }
 
     @Override
     public Predicate<Quad> predicateQuad() { return q -> false; }

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextAllowNone.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextAllowNone.java
@@ -22,8 +22,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Predicate;
 
+import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.graph.Node;
+import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphSink;
 import org.apache.jena.sparql.core.Quad;
@@ -40,6 +43,11 @@ public class SecurityContextAllowNone implements SecurityContext {
 
     @Override
     public boolean visableDefaultGraph() { return false; }
+
+    @Override
+    public QueryExecution createQueryExecution(HttpAction action, Query query, DatasetGraph dsg) {
+        return SecurityContext.super.createQueryExecution(action, query, DatasetGraphSink.create());
+    }
 
     @Override
     public Predicate<Quad> predicateQuad() { return q -> false; }

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextView.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextView.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.function.Predicate;
 
+import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
@@ -31,6 +32,9 @@ import org.apache.jena.query.QueryExecutionFactory;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.exec.QueryExecDatasetBuilder;
+import org.apache.jena.sparql.exec.QueryExecutionAdapter;
 import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.NodeUtils;
 import org.apache.jena.tdb.TDBFactory;
@@ -87,20 +91,20 @@ public class SecurityContextView implements SecurityContext {
     }
 
     @Override
-    public QueryExecution createQueryExecution(String queryString, DatasetGraph dsg) {
-        return createQueryExecution(QueryFactory.create(queryString), dsg);
+    public QueryExecution createQueryExecution(HttpAction action, String queryString, DatasetGraph dsg) {
+        return createQueryExecution(action, QueryFactory.create(queryString), dsg);
     }
 
     @Override
-    public QueryExecution createQueryExecution(Query query, DatasetGraph dsg) {
+    public QueryExecution createQueryExecution(HttpAction action, Query query, DatasetGraph dsg) {
         if ( isAccessControlledTDB(dsg) ) {
-            QueryExecution qExec = QueryExecutionFactory.create(query, dsg);
+            QueryExecution qExec = SecurityContext.super.createQueryExecution(action, query, dsg);
             filterTDB(dsg, qExec);
             return qExec;
         }
         // Not TDB - do by selecting graphs.
         DatasetGraph dsgA = DataAccessCtl.filteredDataset(dsg, this);
-        return QueryExecutionFactory.create(query, dsgA);
+        return SecurityContext.super.createQueryExecution(action, query, dsgA);
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
@@ -319,7 +319,7 @@ public abstract class SPARQLQueryProcessor extends ActionService
      * Set the timeouts. The context timeout, which is the system settings, provides
      * an upper bound to setting by protocol ?timeout.
      */
-    private static void setTimeouts(QueryExecDatasetBuilder builder, HttpAction action) {
+    public static void setTimeouts(QueryExecDatasetBuilder builder, HttpAction action) {
         // Protocol settings.
         long protocolInitialTimeout = -1;
         long protocolOverallTimeout = -1;


### PR DESCRIPTION
### What
Process request/service context in `AccessControlledDataset` the same way as is done in (parent) query processor, i.e. honour the server => dataset => endpoint context value priority order.

### Why
Standard SPARQL queries honour the context of the endpoint ([see docs](https://jena.apache.org/documentation/fuseki2/fuseki-config-endpoint.html)) as well as setting of reuqest-specific timeout via the `timeout` URL parameter. These two features allow one to:
- Override context values specified at server and/or dataset level (e.g. disable access to text indexing or change the default timeout for the endpoint)
- Specify per-request timeouts

(See bottom of summary of example. See also [mailing list thread](https://markmail.org/message/n7tcbi3ihfzlvbdv#query:+page:1+mid:2mvx45a2avki4tvc+state:results).)

### How
- Use `QueryExec` to create the `QueryExecution` instead of `QueryExecutionFactory` (the latter does not consider `HTTPActions`'s context)
- Use same `timeout` parameter logic for pre-request timeouts as in base SPARQL query processor

---

**Note**: I am not convinced that the way I've updated `AccessControlledDataset` (and promoted a helper method from `SPARQLQueryProcessor.java` to public) is the right way to go. But I can confirm that the following use-case works:

1. Define a dataset `DS1` with `jena:text` indexing enabled
2. Define a dataset `DS2`, with `AccessControlledDataset` wrapping `DS1`. (The access actual rules are irrelevant here.)
3. Define service `A` exposing a query endpoint for `DS1`, with extended context: `ja:context [ ja:cxtName "http://jena.apache.org/text#index" ; ja:cxtValue false ] ;`
4. Define service `B` the same as `A`, but for `DS2`

Current behaviour (pre-patch):
- `jena:text` is exposed only with query endpoint of `B`. SPARQL queries against `A` do not match text-indexed properties.

Expected behaviour (post patch):
- Neither `A` nor `B` match text-indexed properties