### PR TITLE
Add alternative java to more commands

### DIFF
--- a/apache-jena/bin/jena
+++ b/apache-jena/bin/jena
@@ -63,6 +63,25 @@ if [ -L "${JENA_HOME}" ]; then
   export JENA_HOME
 fi
 
+if [ -z "$JAVA" ]
+then
+    if [ -z "$JAVA_HOME" ]
+    then
+	JAVA="$(which java)"
+    else
+        JAVA="$JAVA_HOME/bin/java"
+    fi
+fi
+
+if [ -z "$JAVA" ]
+then
+    (
+	echo "Cannot find a Java JDK."
+	echo "Please set either set JAVA or JAVA_HOME and put java (>=Java 11) in your PATH."
+    ) 1>&2
+  exit 1
+fi
+
 # ---- Setup
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
@@ -89,7 +108,7 @@ fi
 ## ---- Determine the command.
 case "$#" in
     0)
-	V="$(java -cp "$JENA_CP" jena.version)"
+	V="$("$JAVA" -cp "$JENA_CP" jena.version)"
 	echo "Jena version : $V"
 	echo "Jena home    : $JENA_HOME"
 	exit
@@ -98,4 +117,4 @@ case "$#" in
     *) CMD="$1" ; shift ;;
 esac
 
-java $JVM_ARGS $LOGGING -cp "$JENA_CP" "$CMD" "$@" 
+"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" "$CMD" "$@"

--- a/apache-jena/bin/xload-data
+++ b/apache-jena/bin/xload-data
@@ -63,6 +63,25 @@ if [ -L "${JENA_HOME}" ]; then
   echo "Resolved symbolic links for JENA_HOME to $JENA_HOME"
 fi
 
+if [ -z "$JAVA" ]
+then
+    if [ -z "$JAVA_HOME" ]
+    then
+	JAVA="$(which java)"
+    else
+        JAVA="$JAVA_HOME/bin/java"
+    fi
+fi
+
+if [ -z "$JAVA" ]
+then
+    (
+	echo "Cannot find a Java JDK."
+	echo "Please set either set JAVA or JAVA_HOME and put java (>=Java 11) in your PATH."
+    ) 1>&2
+  exit 1
+fi
+
 if [ -e "${LOADER_SCRIPTS}/xload-common" ]; then
   # Can source common functions
   source "${LOADER_SCRIPTS}/xload-common"
@@ -283,7 +302,7 @@ DATA_QUADS="$LOC/data-quads.tmp"
 debug "Triples text files is $DATA_TRIPLES"
 debug "Quads text file is $DATA_QUADS"
 
-java $JVM_ARGS -cp "$JENA_CP" "$PKG".CmdNodeTableBuilder \
+"$JAVA" $JVM_ARGS -cp "$JENA_CP" "$PKG".CmdNodeTableBuilder \
     "--loc=$LOC" "--triples=$DATA_TRIPLES" "--quads=$DATA_QUADS" -- "${FILES[@]}"
 
 info "Data Load Phase Completed"

--- a/apache-jena/bin/xload-index
+++ b/apache-jena/bin/xload-index
@@ -63,6 +63,25 @@ if [ -L "${JENA_HOME}" ]; then
   echo "Resolved symbolic links for JENA_HOME to $JENA_HOME"
 fi
 
+if [ -z "$JAVA" ]
+then
+    if [ -z "$JAVA_HOME" ]
+    then
+	JAVA="$(which java)"
+    else
+        JAVA="$JAVA_HOME/bin/java"
+    fi
+fi
+
+if [ -z "$JAVA" ]
+then
+    (
+	echo "Cannot find a Java JDK."
+	echo "Please set either set JAVA or JAVA_HOME and put java (>=Java 11) in your PATH."
+    ) 1>&2
+  exit 1
+fi
+
 if [ -e "${LOADER_SCRIPTS}/xload-common" ]; then
   # Can source common functions
   source "${LOADER_SCRIPTS}/xload-common"
@@ -365,7 +384,7 @@ generate_index()
     info "Build $IDX"
     rm -f "$LOC/$IDX.dat"
     rm -f "$LOC/$IDX.idn"
-    java $JVM_ARGS -cp "$JENA_CP" "$PKG".CmdIndexBuild "$LOC" "$IDX" "$WORK"
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" "$PKG".CmdIndexBuild "$LOC" "$IDX" "$WORK"
     info "Build $IDX Completed"
 
     # Remove work file unless keeping


### PR DESCRIPTION
In #1185 the option to set the used java installation was added to most commands. For some commands this is still missing. Therefore we have added the missing ones.