### PR TITLE
fix a few logging typos

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/AsyncParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/AsyncParser.java
@@ -218,7 +218,7 @@ public class AsyncParser {
             try {
                 queue.put(batch);
             } catch (InterruptedException ex) {
-                FmtLog.error(LOG, "Error: %s", ex.getMessage(), ex);
+                FmtLog.error(LOG, ex, "Error: %s", ex.getMessage());
             }
         };
         EltStreamBatcher batcher = new EltStreamBatcher(destination, chunkSize);
@@ -305,7 +305,7 @@ public class AsyncParser {
                     FmtLog.debug(LOG2, "Receive: Batch : %,d (%,d)", batch.size(), count);
                 dispatch(batch, output);
             } catch (InterruptedException e) {
-                FmtLog.error(LOG2, "Interrupted", e);
+                FmtLog.error(LOG2, e, "Interrupted");
             }
         }
     }

--- a/jena-base/src/main/java/org/apache/jena/base/module/SubsystemRegistryServiceLoader.java
+++ b/jena-base/src/main/java/org/apache/jena/base/module/SubsystemRegistryServiceLoader.java
@@ -61,8 +61,8 @@ public class SubsystemRegistryServiceLoader<T extends SubsystemLifecycle> implem
                     T module = provider.get();
                     this.add(module);
                 } catch (ServiceConfigurationError ex) {
-                    FmtLog.error(LoggerFactory.getLogger(this.getClass()),
-                                 "Error instantiating class %s for %s", provider.type().getName(), moduleClass.getName(), ex);
+                    FmtLog.error(this.getClass(), ex,
+                                 "Error instantiating class %s for %s", provider.type().getName(), moduleClass.getName());
                     throw ex;
                 }
             });


### PR DESCRIPTION
When researching some problems, I came across a couple of bits of logging code that seemed to want to log a stack trace, but put the exception in the string format var-args and the exception was then ignored.