### PR TITLE
GH-1292: Support for bearer auth

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -95,6 +95,18 @@ public class HttpLib {
     }
 
     /**
+     * Calculate bearer auth header value.
+     * The token supplied is expected to already be in base 64.
+     * Use with header "Authorization" (constant {@link HttpNames#hAuthorization}).
+     */
+    public static String bearerAuth(String tokenBase64) {
+        Objects.requireNonNull(tokenBase64);
+        if ( tokenBase64.indexOf(' ') >= 0 )
+            throw new IllegalArgumentException("Base64 token contains a space");
+        return "Bearer " + tokenBase64;
+    }
+
+    /**
      * Get the InputStream from an HttpResponse, handling possible compression settings.
      * The application must consume or close the {@code InputStream} (see {@link #finish(InputStream)}).
      * Closing the InputStream may close the HTTP connection.
@@ -308,13 +320,8 @@ public class HttpLib {
 
     // Terminology:
     // RFC 2616:   Request-Line   = Method SP Request-URI SP HTTP-Version CRLF
-
     // RFC 7320:   request-line   = method SP request-target SP HTTP-version CRLF
     // https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.1
-
-    // request-target:
-    // https://datatracker.ietf.org/doc/html/rfc7230#section-5.3
-    // When it is for the origin server ==> absolute-path [ "?" query ]
 
     // EndpointURI: URL for a service, no query string.
 
@@ -328,7 +335,7 @@ public class HttpLib {
     }
 
     /**
-     * Return a string (assumed to be a URI) without query string or fragment.
+     * Return a string (assumed to be an absolute URI) without query string or fragment.
      */
     public static String endpoint(String uriStr) {
         int idx1 = uriStr.indexOf('?');

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthCredentials.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthCredentials.java
@@ -38,7 +38,7 @@ public class AuthCredentials {
 
     public void put(AuthDomain location, PasswordRecord pwRecord) {
         // Checks.
-        URI uri = location.uri;
+        URI uri = location.getURI();
         if ( uri.getRawQuery() != null || uri.getRawFragment() != null )
             throw new HttpException("Endpoint URI must not have query string or fragment: "+uri);
         authRegistry.put(location, pwRecord);
@@ -46,7 +46,7 @@ public class AuthCredentials {
     }
 
     public boolean contains(AuthDomain location) {
-        return prefixes.contains(location.uri.toString());
+        return prefixes.contains(location.getURI().toString());
     }
 
     public List<AuthDomain> registered() {
@@ -58,9 +58,9 @@ public class AuthCredentials {
         if ( pwRecord != null )
             return pwRecord;
 
-        prefixes.partialSearch(location.uri.toString());
+        prefixes.partialSearch(location.getURI().toString());
 
-        AuthDomain match = prefixes.longestMatch(location.uri.toString());
+        AuthDomain match = prefixes.longestMatch(location.getURI().toString());
         if ( match == null )
             return null;
         if ( match.getRealm() != null ) {
@@ -71,7 +71,7 @@ public class AuthCredentials {
     }
 
     public void remove(AuthDomain location) {
-        prefixes.remove(location.uri.toString());
+        prefixes.remove(location.getURI().toString());
         authRegistry.remove(location);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthDomain.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthDomain.java
@@ -21,18 +21,21 @@ package org.apache.jena.http.auth;
 import java.net.URI;
 import java.util.Objects;
 
-/** URI and optional realm, as a value-equality pair. */
+/** URI, and optional realm, as a value-equality pair. */
 public class AuthDomain {
-    URI uri;
-    // May be null;
+    private URI uri;
     private String realm;
+    public static final String noRealm = "";
 
     public AuthDomain(URI uri) {
         this(uri, null);
     }
 
-    public AuthDomain(URI uri, String realm) {
+    private AuthDomain(URI uri, String realm) {
+        Objects.requireNonNull(uri);
         this.uri = uri;
+        if ( realm == null )
+            realm = noRealm;
         this.realm = realm;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthException.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthException.java
@@ -18,12 +18,14 @@
 
 package org.apache.jena.http.auth;
 
-public class AuthStringException extends RuntimeException {
-    public AuthStringException() {
+import org.apache.jena.shared.JenaException;
+
+public class AuthException extends JenaException {
+    public AuthException() {
         super();
     }
 
-    public AuthStringException(String msg) {
+    public AuthException(String msg) {
         super(msg);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/DigestLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/DigestLib.java
@@ -93,16 +93,15 @@ class DigestLib {
      * Function to modify a {@link java.net.http.HttpRequest.Builder} for digest authentication.
      * One instance of this function is used for each digest session.
      */
-    public static AuthRequestModifier buildDigest(AuthChallenge aHeader, String user, String password, String method, String requestTarget) {
+    public static AuthRequestModifier digestAuthModifier(AuthChallenge aHeader, String user, String password, String method, String requestTarget) {
         String clientNonce = DigestLib.generateNonce();
         AtomicLong ncCounter = new AtomicLong(0);
-        return req->{
+        return request->{
             // Bump nc
             String nc = String.format("%08X", ncCounter.getAndIncrement());
-            String responseField =
-                    DigestLib.calcDigestChallengeResponse(aHeader, user, password,
-                                                          method, requestTarget,
-                                                          clientNonce, nc, "auth");
+            String responseField = calcDigestChallengeResponse(aHeader, user, password,
+                                                               method, requestTarget,
+                                                               clientNonce, nc, "auth");
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append("Digest ");
             field(stringBuilder, true, "username", user, true);
@@ -116,8 +115,8 @@ class DigestLib {
             field(stringBuilder, false, "opaque", aHeader.opaque, true);
             String x = stringBuilder.toString();
             // setHeader - replace previous
-            req.setHeader(HttpNames.hAuthorization , x);
-            return req;
+            request.setHeader(HttpNames.hAuthorization , x);
+            return request;
         };
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/PasswordRecord.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/PasswordRecord.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 public class PasswordRecord {
     private String username;
     private String password;
+
     public PasswordRecord(String username, String password) {
         super();
         this.username = username;

--- a/jena-arq/src/test/java/org/apache/jena/http/auth/TestAuthHeaderParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/http/auth/TestAuthHeaderParser.java
@@ -29,17 +29,17 @@ import org.junit.Test;
 
 public class TestAuthHeaderParser {
 
-    private static AuthHeaderParser parse(String input) {
-        return AuthHeaderParser.parse(input);
+    private static AuthHeader parse(String input) {
+        return AuthHeader.parse(input);
     }
 
     @Test public void parse_empty() {
-        AuthHeaderParser auth = parse("");
+        AuthHeader auth = parse("");
         assertNull(auth.getAuthScheme());
     }
 
     @Test public void parse_basic_01() {
-        AuthHeaderParser auth = parse("Basic       BASE64");
+        AuthHeader auth = parse("Basic       BASE64");
         assertEquals(AuthScheme.BASIC, auth.getAuthScheme());
         assertTrue(auth.isBasicAuth());
         assertFalse(auth.isDigestAuth());
@@ -49,7 +49,7 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_basic_02() {
-        AuthHeaderParser auth = parse("Basic dGVzdDoxMjPCow==");
+        AuthHeader auth = parse("Basic dGVzdDoxMjPCow==");
         assertEquals(AuthScheme.BASIC, auth.getAuthScheme());
         assertTrue(auth.isBasicAuth());
         assertFalse(auth.isDigestAuth());
@@ -64,7 +64,7 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_basic_03() {
-        AuthHeaderParser auth = parse("Basic realm = hades");
+        AuthHeader auth = parse("Basic realm = hades");
         assertTrue(auth.isBasicAuth());
         assertFalse(auth.isDigestAuth());
         Map<String, String> map = auth.getAuthParams();
@@ -74,7 +74,7 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_basic_04() {
-        AuthHeaderParser auth = parse("Basic realm=hades");
+        AuthHeader auth = parse("Basic realm=hades");
         assertTrue(auth.isBasicAuth());
         assertFalse(auth.isDigestAuth());
         Map<String, String> map = auth.getAuthParams();
@@ -85,7 +85,7 @@ public class TestAuthHeaderParser {
 
     // fn5+fjp/f38K is "~~~~:\x7F\x7F\x7F"
     @Test public void parse_basic_05() {
-        AuthHeaderParser auth = parse("Basic fn5+fjp/f38K");
+        AuthHeader auth = parse("Basic fn5+fjp/f38K");
         assertTrue(auth.isBasicAuth());
         assertFalse(auth.isDigestAuth());
         Map<String, String> map = auth.getAuthParams();
@@ -94,7 +94,7 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_basic_bad_01() {
-        AuthHeaderParser auth = parse("Basic {}ABCD");  // Not base64
+        AuthHeader auth = parse("Basic {}ABCD");  // Not base64
         assertTrue(auth.isBasicAuth());
         Map<String, String> map = auth.getAuthParams();
         assertNull(map);
@@ -102,21 +102,21 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_bad_01() {
-        AuthHeaderParser auth = parse("Basic realm =");
+        AuthHeader auth = parse("Basic realm =");
         assertTrue(auth.isBasicAuth());
         assertNull(auth.getAuthParams());
         assertNull(auth.getBasicUserPassword());
     }
 
     @Test public void parse_bad_02() {
-        AuthHeaderParser auth = parse("Basic ");
+        AuthHeader auth = parse("Basic ");
         assertTrue(auth.isBasicAuth());
         assertNull(auth.getAuthParams());
         assertNull(auth.getBasicUserPassword());
     }
 
     @Test public void parse_digest_01() {
-        AuthHeaderParser auth = parse("Digest realm = hades");
+        AuthHeader auth = parse("Digest realm = hades");
         assertTrue(auth.isDigestAuth());
         assertFalse(auth.isBasicAuth());
         assertEquals(AuthScheme.DIGEST, auth.getAuthScheme());
@@ -128,7 +128,7 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_digest_02() {
-        AuthHeaderParser auth = parse("Digest a=b C=\"def\", xyz=\"rst uvw\"");
+        AuthHeader auth = parse("Digest a=b C=\"def\", xyz=\"rst uvw\"");
         assertTrue(auth.isDigestAuth());
         assertFalse(auth.isBasicAuth());
         assertEquals(AuthScheme.DIGEST, auth.getAuthScheme());
@@ -143,7 +143,7 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_digest_bad_01() {
-        AuthHeaderParser auth = parse("Digest a=b c=");
+        AuthHeader auth = parse("Digest a=b c=");
         assertTrue(auth.isDigestAuth());
         assertFalse(auth.isBasicAuth());
         assertEquals(AuthScheme.DIGEST, auth.getAuthScheme());
@@ -153,7 +153,7 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_digest_bad_02() {
-        AuthHeaderParser auth = parse("Digest c=\"");
+        AuthHeader auth = parse("Digest c=\"");
         assertTrue(auth.isDigestAuth());
         assertFalse(auth.isBasicAuth());
         assertEquals(AuthScheme.DIGEST, auth.getAuthScheme());
@@ -164,7 +164,7 @@ public class TestAuthHeaderParser {
 
     @Test public void parse_bearer_01() {
         // Credentials
-        AuthHeaderParser auth = parse("Bearer AAAA");
+        AuthHeader auth = parse("Bearer AAAA");
         assertTrue(auth.isBearerAuth());
         assertFalse(auth.isDigestAuth());
         assertFalse(auth.isBasicAuth());
@@ -175,7 +175,7 @@ public class TestAuthHeaderParser {
 
     @Test public void parse_bearer_02() {
         // Challenge
-        AuthHeaderParser auth = parse("Bearer realm = hades");
+        AuthHeader auth = parse("Bearer realm = hades");
         assertNull(auth.getBearerToken());
         Map<String, String> map = auth.getAuthParams();
         assertNotNull(map);
@@ -184,7 +184,7 @@ public class TestAuthHeaderParser {
 
     @Test public void parse_bearer_03() {
         // Challenge
-        AuthHeaderParser auth = parse("Bearer realm=hades");
+        AuthHeader auth = parse("Bearer realm=hades");
         assertNull(auth.getBearerToken());
         Map<String, String> map = auth.getAuthParams();
         assertNotNull(map);
@@ -192,7 +192,7 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_bearer_bad_01() {
-        AuthHeaderParser auth = parse("Bearer ");
+        AuthHeader auth = parse("Bearer ");
         assertTrue(auth.isBearerAuth());
         assertNull(auth.getBearerToken());
         Map<String, String> map = auth.getAuthParams();
@@ -200,20 +200,20 @@ public class TestAuthHeaderParser {
     }
 
     @Test public void parse_bearer_bad_03() {
-        AuthHeaderParser auth = parse("Bearer abcd()"); // Not base64
+        AuthHeader auth = parse("Bearer abcd()"); // Not base64
         assertTrue(auth.isBearerAuth());
         assertNull(auth.getBearerToken());
     }
 
     @Test public void parse_unknown_01() {
         // scheme, param
-        AuthHeaderParser auth = parse("Unknown abcd");
+        AuthHeader auth = parse("Unknown abcd");
         assertEquals(AuthScheme.UNKNOWN, auth.getAuthScheme());
         assertEquals("abcd", auth.getUnknown());
     }
 
     @Test public void parse_unknown_02() {
-        AuthHeaderParser auth = parse("UnKnOwN a=b");
+        AuthHeader auth = parse("UnKnOwN a=b");
         assertEquals(AuthScheme.UNKNOWN, auth.getAuthScheme());
         assertEquals("UnKnOwN", auth.getAuthSchemeStr());
         assertEquals("a=b", auth.getUnknown());

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionExecLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionExecLib.java
@@ -56,7 +56,6 @@ public class ActionExecLib {
         // Need a way to set verbose logging on a per servlet and per request basis.
         HttpAction action = new HttpAction(id, log, category, request, response);
         if ( dap != null ) {
-            // TODO remove setRequest?
             DataService dataService = dap.getDataService();
             action.setRequest(dap, dataService);
         }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/auth/AuthBearerFilter.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/auth/AuthBearerFilter.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.main.auth;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.servlets.ServletOps;
+import org.apache.jena.http.auth.AuthHeader;
+import org.apache.jena.riot.web.HttpNames;
+import org.apache.jena.web.HttpSC;
+import org.slf4j.Logger;
+
+/**
+ * Process an "Authorization: Bearer" header.
+ * If present, extract as JWT
+ */
+public class AuthBearerFilter implements Filter {
+    private static Logger log = Fuseki.serverLog;
+    private final Function<String, String> verifiedUser;
+
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+//    public AuthBearerFilter() {
+//        this(null);
+//    }
+
+    public AuthBearerFilter(Function<String, String> verifiedUser) {
+        this.verifiedUser = verifiedUser;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+        throws IOException, ServletException {
+        HttpServletRequest withUser;
+        try {
+            HttpServletRequest request = (HttpServletRequest)servletRequest;
+            HttpServletResponse response = (HttpServletResponse)servletResponse;
+            withUser = request;
+
+            // Authorization: required.
+            String auth = request.getHeader(HttpNames.hAuthorization);
+            if ( auth == null ) {
+                // No auth header - reject and ask for Authorization:
+                response.setHeader(HttpNames.hWWWAuthenticate, "Bearer");   // No realm, no scope.
+                response.sendError(HttpSC.UNAUTHORIZED_401);
+                return;
+            }
+
+            AuthHeader authParser = AuthHeader.parse(auth);
+            String bearerToken = authParser.getBearerToken();
+            String x = authParser.getUnknown();
+
+            switch(authParser.getAuthScheme()) {
+                case BEARER : {
+                    if ( bearerToken == null ) {
+                        log.warn("Not a legal bearer token: "+authParser.getAuthArgs());
+                        response.sendError(HttpSC.BAD_REQUEST_400);
+                        return;
+                    }
+                    if ( verifiedUser == null ) {
+                        // No function to verify the token and extract the user.
+                        response.sendError(HttpSC.BAD_REQUEST_400);
+                        return;
+                    }
+                    String user = verifiedUser.apply(bearerToken);
+                    if ( user == null ) {
+                        response.sendError(HttpSC.FORBIDDEN_403);
+                        return;
+                    }
+                    withUser = new HttpServletRequestWithPrincipal(request, user);
+                    break;
+                }
+                case UNKNOWN :
+                    break;
+                case BASIC :
+                case DIGEST :
+                default :
+                    break;
+            }
+        } catch (Throwable ex) {
+            log.info("Filter: unexpected exception: "+ex.getMessage(),ex);
+            ServletOps.error(500);
+            return;
+        }
+        // Continue.
+        chain.doFilter(withUser, servletResponse);
+    }
+
+    /** Add a value for "getUserPrincipal" */
+    private static class HttpServletRequestWithPrincipal extends HttpServletRequestWrapper {
+
+        final String user ;
+        HttpServletRequestWithPrincipal(HttpServletRequest req, String user) {
+            super(req);
+            this.user = user;
+        }
+
+        @Override public java.security.Principal getUserPrincipal() {
+            return new java.security.Principal() {
+                @Override public String getName() { return user; }
+            };
+        }
+    }
+
+    @Override
+    public void destroy() {}
+
+}

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -172,7 +172,7 @@ public class FusekiMain extends CmdARQ {
         add(argGeneralQuerySvc, "--general=PATH",
             "Add a general SPARQL endpoint (without a dataset) at /PATH");
 
-        add(argAuth, "--auth=[basic|Digest]",
+        add(argAuth, "--auth=[basic|digest]",
             "Run the server using basic or digest authentication (dft: digest).");
         add(argHttps, "--https=CONF",
             "https certificate access details. JSON file { \"cert\":FILE , \"passwd\"; SECRET } ");

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/HttpLoggerFilter.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/HttpLoggerFilter.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.main.sys;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.servlets.ActionLib;
+import org.apache.jena.riot.web.HttpNames;
+import org.slf4j.Logger;
+
+/**
+ * Standalone request-response logger.
+ * Use with Fuseki main addFilter
+ *
+ */
+public class HttpLoggerFilter implements Filter {
+    private static final Logger log = Fuseki.serverLog;
+    private static final boolean verbose = true;
+
+    private static final AtomicLong counter =new AtomicLong(0);
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain) throws IOException, ServletException {
+        // See also ActionExecLib
+        String id = "{"+counter.incrementAndGet()+"}";
+        logRequest(id, servletRequest);
+        chain.doFilter(servletRequest, servletResponse);
+        logResponse(id, servletResponse);
+    }
+
+    private void logRequest(String id, ServletRequest servletRequest) {
+        try {
+            HttpServletRequest request = (HttpServletRequest)servletRequest;
+            String url = ActionLib.wholeRequestURL(request);
+            String method = request.getMethod();
+            FmtLog.info(log, "%s %s %s", id, method, url);
+
+            if ( verbose ) {
+                Enumeration<String> en = request.getHeaderNames();
+                if ( en != null ) {
+                    for (; en.hasMoreElements();) {
+                        String h = en.nextElement();
+                        Enumeration<String> vals = request.getHeaders(h);
+                        if ( !vals.hasMoreElements() )
+                            FmtLog.info(log, "%s    => %s", id, h+":");
+                        else {
+                            for (; vals.hasMoreElements();)
+                                FmtLog.info(log, "%s    => %-20s %s", id, h+":", vals.nextElement());
+                        }
+                    }
+                }
+            }
+        } catch (Throwable ex) {
+            log.info("Filter (log request): unexpected exception: "+ex.getMessage(),ex);
+        }
+    }
+
+    private void logResponse(String id, ServletResponse servletResponse) {
+        try {
+            HttpServletResponse response = (HttpServletResponse)servletResponse;
+            if ( verbose ) {
+                String responseContentType = response.getHeader(HttpNames.hContentType);
+                String responseContentLength = response.getHeader(HttpNames.hContentLength);
+
+                if ( responseContentType != null )
+                    FmtLog.info(log, "%s    <= %-20s %s", id, HttpNames.hContentType+":", responseContentType);
+                if ( responseContentLength != null )
+                    FmtLog.info(log, "%s    <= %-20s %d", id, HttpNames.hContentLength+":", responseContentLength);
+
+                for (String headerName : response.getHeaderNames() ) {
+                    // Skip already printed.
+                    if ( headerName.equalsIgnoreCase(HttpNames.hContentType) )
+                        continue;
+                    if ( headerName.equalsIgnoreCase(HttpNames.hContentLength))
+                        continue;
+                    String headerValue = response.getHeader(headerName);
+                    FmtLog.info(log, "%s    <= %-20s %s", id, headerName+":", headerValue);
+                }
+            }
+            FmtLog.info(log, "%s %s", id, response.getStatus());
+
+        } catch (Throwable ex) {
+            log.info("Filter (log response: unexpected exception: "+ex.getMessage(),ex);
+        }
+    }
+}

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/AbstractTestAuthRemote.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/AbstractTestAuthRemote.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.http;
+
+import static org.apache.jena.fuseki.test.HttpTest.expect401;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.URI;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.http.auth.AuthEnv;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.exec.http.GSP;
+import org.apache.jena.sparql.exec.http.QueryExecHTTP;
+import org.junit.Test;
+
+/**
+ * Covers the AuthEnv/Lib challenge response code
+ * for basic and digest authentication.
+ */
+public abstract class AbstractTestAuthRemote {
+
+    protected abstract String endpoint() ;
+    protected abstract URI endpointURI();
+    protected abstract String user();
+    protected abstract String password();
+
+    // ---- QueryExecHTTP
+
+    @Test
+    public void auth_qe_no_auth() {
+        expect401(()->{
+            try ( QueryExec qexec = QueryExecHTTP.newBuilder()
+                    .endpoint(endpoint())
+                    .queryString("ASK{}")
+                    .build()) {
+                qexec.ask();
+            }
+        });
+    }
+
+    @Test
+    public void auth_qe_good_registered() {
+        // Digest auth is not provided by java.net.http.
+        // Digest only works via AuthEnv.
+        AuthEnv.get().registerUsernamePassword(endpointURI(), user(), password());
+
+        try ( QueryExec qexec = QueryExecHTTP.newBuilder()
+                //.httpClient(hc)
+                .endpoint(endpoint())
+                .queryString("ASK{}")
+                .build()) {
+            qexec.ask();
+        }
+    }
+
+    @Test
+    public void auth_qe_good_registered_query() {
+        // Digest only works via AuthEnv.
+        AuthEnv.get().registerUsernamePassword(endpointURI(), user(), password());
+        // This has a query string with newlines.
+        // Issue: https://github.com/apache/jena/issues/1318
+        Query query = QueryFactory.create("ASK{}");
+        try ( QueryExec qexec = QueryExecHTTP.newBuilder()
+                //.httpClient(hc)
+                .endpoint(endpoint())
+                .query(query)
+                .build()) {
+            qexec.ask();
+        }
+    }
+
+    @Test
+    public void auth_qe_bad_registered() {
+        expect401(()->{
+            AuthEnv.get().registerUsernamePassword(endpointURI(), "wrong-user", password());
+            try ( QueryExec qexec = QueryExecHTTP.newBuilder()
+                    .endpoint(endpoint())
+                    .queryString("ASK{}")
+                    .build()) {
+                qexec.ask();
+            }
+        });
+    }
+
+    // ---- GSP
+
+    @Test
+    public void auth_gsp_no_auth() {
+        expect401(()->{
+            GSP.service(endpoint()).defaultGraph().GET();
+        });
+    }
+
+    @Test
+    public void auth_gsp_good_registered() {
+        AuthEnv.get().registerUsernamePassword(endpointURI(), user(), password());
+        Graph graph = GSP.service(endpoint()).defaultGraph().GET();
+        assertNotNull(graph);
+    }
+
+    @Test
+    public void auth_gsp_bad_registered() {
+        AuthEnv.get().registerUsernamePassword(endpointURI(), "wrong-user", password());
+        expect401(()->{
+            GSP.service(endpoint()).defaultGraph().GET();
+        });
+    }
+
+}

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/AuthBearerTestLib.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/AuthBearerTestLib.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.http;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Objects;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.http.auth.AuthEnv;
+import org.apache.jena.http.auth.AuthRequestModifier;
+import org.apache.jena.riot.web.HttpNames;
+import org.slf4j.Logger;
+
+public class AuthBearerTestLib {
+
+    private static Logger log = Fuseki.serverLog;
+    private static java.util.Base64.Encoder encoder = Base64.getUrlEncoder();
+    private static java.util.Base64.Decoder decoder = Base64.getUrlDecoder();
+
+    /**
+     * Extract the "sub" field from an encoded JWT, or return null.
+     * This method does not verify the token.
+     */
+    public static String subjectFromEncodedJWT(String token) {
+        try {
+            String[] parts = token.split("\\.");
+            if ( parts.length != 3 ) {
+                log.warn("Bad token: '"+token+"'");
+                return null;
+            }
+            byte[] jsonBytes = decoder.decode(parts[1]);
+            String jsonStr = new String(jsonBytes, StandardCharsets.UTF_8);
+            JsonObject obj = new Gson().fromJson(jsonStr, JsonObject.class);
+            JsonElement field = obj.get("sub");
+            if ( field == null ) {
+                log.warn("Bad token: no \"sub\" '"+jsonStr+"'");
+                return null;
+            }
+            if ( ! field.isJsonPrimitive() ) {
+                log.warn("Bad token: \"sub\" is not a string'"+jsonStr+"'");
+            }
+            String subject = field.getAsString();
+            return subject;
+        } catch (IllegalArgumentException|JsonSyntaxException ex) {
+            return null;
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+
+    /** Test token */
+    public static String generateTestToken(String user) {
+        Objects.requireNonNull(user);
+        String header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}".trim();
+        String body = "{ \"iss\": \"SELF\", \"exp\": \"never\", \"sub\": \"SUBJECT\" }".trim().replace("SUBJECT", user);
+        String token = enc64(header)+"."+enc64(body)+"."+enc64("HASH");
+        return token;
+    }
+
+    private static String enc64(String x) {
+        byte[] bytes = x.getBytes(StandardCharsets.UTF_8);
+        byte[] encoded = encoder.encode(bytes);
+        return new String(encoded, StandardCharsets.UTF_8);
+    }
+
+    public static void addAuthModifierBearerToken(String endpoint, String token) {
+        AuthRequestModifier requestModifier = builder->builder.setHeader(HttpNames.hAuthorization, "Bearer "+token);
+        AuthEnv.get().registerAuthModifier(endpoint, requestModifier);
+    }
+}

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/TS_JenaHttp.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/TS_JenaHttp.java
@@ -28,7 +28,9 @@ import org.junit.runners.Suite;
     , TestHttpRDF.class
     , TestAsyncHttpRDF.class
     , TestAuthRemote.class
+    , TestAuthBasicRemote.class
     , TestAuthDigestRemote.class
+    , TestAuthBearerRemote.class
 })
 
 public class TS_JenaHttp { }

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/TestAuthBasicRemote.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/TestAuthBasicRemote.java
@@ -35,13 +35,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-/**
- * Digest authentication.
- * Digest auth is not provided by java.net.http,
- * so {@code Authenticator} on the {@code HttpClient} does not work.
- * Jena has to implement it itself (in AuthLib).
- */
-public class TestAuthDigestRemote extends AbstractTestAuthRemote {
+public class TestAuthBasicRemote extends AbstractTestAuthRemote {
     private static String user = "user";
     private static String password = "password";
 
@@ -79,11 +73,12 @@ public class TestAuthDigestRemote extends AbstractTestAuthRemote {
         FusekiServer.Builder builder = FusekiServer.create()
             .port(0)
             .enablePing(true)
-            .auth(AuthScheme.DIGEST)
+            .auth(AuthScheme.BASIC)
             .add(dsName, dsg);
+        // Instead of a password file.
         if ( user != null ) {
             UserStore userStore = JettyLib.makeUserStore(user, password);
-            SecurityHandler sh = JettyLib.makeSecurityHandler("TripleStore",  userStore, AuthScheme.DIGEST);
+            SecurityHandler sh = JettyLib.makeSecurityHandler("TripleStore",  userStore, AuthScheme.BASIC);
             builder.securityHandler(sh)
                    .serverAuthPolicy(Auth.policyAllowSpecific(user));
         }

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/TestAuthBearerRemote.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/TestAuthBearerRemote.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.http;
+
+import static org.apache.jena.fuseki.test.HttpTest.expect401;
+import static org.apache.jena.fuseki.test.HttpTest.expect403;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.URI;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.auth.AuthBearerFilter;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.http.auth.AuthChallenge;
+import org.apache.jena.http.auth.AuthEnv;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.exec.http.GSP;
+import org.apache.jena.sparql.exec.http.QueryExecHTTP;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Bearer authentication is different - it is a framework. We test here with some
+ * functionality that checks the JWT "sub" locally.
+ */
+public class TestAuthBearerRemote {
+
+    private static String user = "user";
+
+    private static FusekiServer server = null;
+    private static String dsEndpoint;
+    private static URI dsEndpointURI;
+
+    protected String endpoint() {
+        return dsEndpoint;
+    }
+
+    protected URI endpointURI() {
+        return dsEndpointURI;
+    }
+
+    @BeforeClass public static void beforeClass() {
+        server = server("/ds", DatasetGraphFactory.createTxnMem());
+    }
+
+    // Client-side challenge callback.
+    private void setBearerAuthProvider(String username) {
+        BiFunction<URI, AuthChallenge, String> testTokenSupplier = (uri, authHeader) -> AuthBearerTestLib.generateTestToken(username);
+        AuthEnv.get().setBearerTokenProvider(testTokenSupplier);
+    }
+
+    // Client-side provide token ahead of time.
+    private void addBearerAuthToken(String requestTarget, String username) {
+        String token = AuthBearerTestLib.generateTestToken(username);
+        AuthEnv.get().setBearerToken(requestTarget, token);
+    }
+
+    private static FusekiServer server(String dsName, DatasetGraph dsg) {
+        // Server verified user function.
+        Function<String, String> verifiedUser = token -> {
+            String u = AuthBearerTestLib.subjectFromEncodedJWT(token);
+            if ( u == null )
+                return null;
+            if ( user.equals(u) )
+                return user;
+            return null;
+        };
+
+        FusekiServer server = FusekiServer.create()
+            .port(0)
+            .enablePing(true)
+            //.auth(AuthScheme.BEARER)
+            .addFilter("/*", new AuthBearerFilter(verifiedUser))
+            .add(dsName, dsg)
+            .build();
+        server.start();
+        dsEndpoint = "http://localhost:"+server.getHttpPort()+"/ds";
+        dsEndpointURI = URI.create(dsEndpoint);
+        return server;
+    }
+
+    @AfterClass public static void afterClass() {
+        dsEndpoint = null;
+        dsEndpointURI = null;
+        if ( server == null )
+            return;
+        try {
+            server.stop();
+            server = null;
+        } catch (Throwable th) {
+            Log.warn(TestAuthBearerRemote.class, "Exception in test suite shutdown", th);
+        }
+    }
+
+    @After public void afterTest() {
+        // Clear bearer auth.
+        AuthEnv.get().setBearerTokenProvider(null);
+        AuthEnv.get().clearActiveAuthentication();
+    }
+
+
+
+    // ---- QueryExecHTTP
+
+    @Test
+    public void auth_qe_no_auth() {
+        expect401(()->{
+            try ( QueryExec qexec = QueryExecHTTP.newBuilder()
+                    .endpoint(endpoint())
+                    .queryString("ASK{}")
+                    .build()) {
+                qexec.ask();
+            }
+        });
+    }
+
+    @Test
+    public void auth_qe_good_challenge_handler() {
+        // 401 challenge handler.
+        setBearerAuthProvider(user);
+        try ( QueryExec qexec = QueryExecHTTP.newBuilder()
+                .endpoint(endpoint())
+                .queryString("ASK{}")
+                .build()) {
+            qexec.ask();
+        }
+    }
+
+    @Test
+    public void auth_qe_good_bearer_request() {
+        // Register token to use.
+        addBearerAuthToken(endpoint(), user);
+        try ( QueryExec qexec = QueryExecHTTP.newBuilder()
+                .endpoint(endpoint())
+                .queryString("ASK{}")
+                .build()) {
+            qexec.ask();
+        }
+    }
+
+    @Test
+    public void auth_qe_bad_bearer_request() {
+        addBearerAuthToken(endpoint(), "wrong-user");
+
+        expect403(()->{
+            try ( QueryExec qexec = QueryExecHTTP.newBuilder()
+                    .endpoint(endpoint())
+                    .queryString("ASK{}")
+                    .build()) {
+                qexec.ask();
+            }
+        });
+    }
+
+    @Test
+    public void auth_qe_bad_registered() {
+        setBearerAuthProvider("wrong-user");
+        expect403(()->{
+            try ( QueryExec qexec = QueryExecHTTP.newBuilder()
+                    .endpoint(endpoint())
+                    .queryString("ASK{}")
+                    .build()) {
+                qexec.ask();
+            }
+        });
+    }
+
+    // ---- GSP
+
+    @Test
+    public void auth_gsp_no_auth() {
+        expect401(()->{
+            GSP.service(endpoint()).defaultGraph().GET();
+        });
+    }
+
+    @Test
+    public void auth_gsp_good_registered() {
+        setBearerAuthProvider("user");
+        Graph graph = GSP.service(endpoint()).defaultGraph().GET();
+        assertNotNull(graph);
+    }
+
+    @Test
+    public void auth_gsp_bad_registered() {
+        expect401(()->{
+            GSP.service(endpoint()).defaultGraph().GET();
+        });
+    }
+}

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/conn/EnvTest.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/conn/EnvTest.java
@@ -120,7 +120,6 @@ public class EnvTest {
             .port(0)
             .verbose(verbose)
             .enablePing(true)
-            .auth(AuthScheme.BASIC)
             .addServlet(data, holder)
             .add(dsName, dsg);
         if ( user != null ) {

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/LibSec.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/LibSec.java
@@ -49,7 +49,7 @@ public class LibSec {
         // Prefix
         URI urix = URI.create(urlStr);
         //String requestTarget = HttpLib.requestTarget(urix);
-        AuthDomain domain = new AuthDomain(urix, null);
+        AuthDomain domain = new AuthDomain(urix);
         try {
             AuthEnv.get().registerUsernamePassword(urix, auth.user, auth.password);
             try ( RDFConnection conn = RDFConnectionRemote.newBuilder().destination(urlStr).build() ) {


### PR DESCRIPTION
This resolves GH-1292.

The PR covers mainly client-side with a thin interface for responding to bearer auth 401 challenges. The application must a function to provide the token. There is little a standard library can do. The server side has some preparation work but again there has to be custom code somewhere to validate tokens in the deployment environment. This is probaly better done with a Fuseki module - cusomt code for Fuseki main as released.