### PR TITLE
GH-1272 E_IRI now takes base IRI of UpdateRequest into account

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/ARQConstants.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/ARQConstants.java
@@ -204,8 +204,17 @@ public class ARQConstants
 
     /** Context key for the query for the current query execution
      * (may be null if was not created from a query string )
+     *
+     * No longer used; use sysCurrentStatement instead.
      */
+    @Deprecated
     public static final Symbol sysCurrentQuery          = Symbol.create(systemVarNS+"query") ;
+
+    /** Context key for the current statement execution (Query or UpdateRequest)
+     * Prologue is the common base class
+     */
+    public static final Symbol sysCurrentStatement      = Symbol.create(systemVarNS+"statement") ;
+
 
     /** Context key for the OpExecutor to be used */
     public static final Symbol sysOpExecutorFactory     = Symbol.create(systemVarNS+"opExecutorFactory") ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryEngineBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryEngineBase.java
@@ -29,6 +29,7 @@ import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.core.DatasetDescription;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DynamicDatasets;
+import org.apache.jena.sparql.core.Prologue;
 import org.apache.jena.sparql.core.Substitute;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.binding.BindingRoot;
@@ -166,7 +167,12 @@ public abstract class QueryEngineBase implements OpEval, Closeable
         queryEngineInfo.incQueryCount();
         queryEngineInfo.setLastQueryExecAt();
         //queryEngineInfo.setLastQueryExecTime(-1);
-        queryEngineInfo.setLastQueryString((Query)context.get(ARQConstants.sysCurrentQuery));
+
+        // Only set the last query string if the current statement is a Query (rather than an UpdateRequest)
+        Prologue stmt = (Prologue)context.get(ARQConstants.sysCurrentStatement);
+        Query query = stmt instanceof Query ? (Query)stmt : null;
+        queryEngineInfo.setLastQueryString(query);
+
         queryEngineInfo.setLastOp(op);
         return eval(op, dsg, binding, context);
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDataset.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDataset.java
@@ -115,7 +115,7 @@ public class QueryExecDataset implements QueryExec
     private void init() {
         Context.setCurrentDateTime(context);
         if ( query != null )
-            context.put(ARQConstants.sysCurrentQuery, query);
+            context.put(ARQConstants.sysCurrentStatement, query);
     }
 
     private static long asMillis(long duration, TimeUnit timeUnit) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDatasetBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDatasetBuilder.java
@@ -239,8 +239,6 @@ public class QueryExecDatasetBuilder implements QueryExecMod, QueryExecBuilder {
 
         if ( dataset != null )
             cxt.set(ARQConstants.sysCurrentDataset, DatasetFactory.wrap(dataset));
-        if ( queryActual != null )
-            cxt.set(ARQConstants.sysCurrentQuery, queryActual);
 
         QueryExec qExec = new QueryExecDataset(queryActual, queryStringActual, dataset, cxt, qeFactory,
                                                initialTimeout, initialTimeoutUnit,

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecDatasetBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecDatasetBuilder.java
@@ -170,6 +170,13 @@ public class UpdateExecDatasetBuilder implements UpdateExecBuilder {
     }
 
     private void add(UpdateRequest request) {
+        // Limitation: Only the prologue of the first request that gets added takes effect
+        // For details see https://github.com/apache/jena/issues/1272
+        if (updateRequest.getOperations().isEmpty()) {
+            updateRequest.setBase(request.getBase());
+            updateRequest.setPrefixMapping(request.getPrefixMapping());
+        }
+
         request.getOperations().forEach(this::add);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI.java
@@ -18,9 +18,9 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.query.Query ;
 import org.apache.jena.sparql.ARQConstants ;
 import org.apache.jena.sparql.ARQInternalErrorException ;
+import org.apache.jena.sparql.core.Prologue;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions ;
 import org.apache.jena.sparql.function.FunctionEnv ;
 import org.apache.jena.sparql.sse.Tags ;
@@ -38,21 +38,21 @@ public class E_IRI extends ExprFunction1
     {
         super(expr, altSymbol) ;
     }
-    
+
     // Use the hook to get the env.
     @Override
     public NodeValue eval(NodeValue v, FunctionEnv env)
-    { 
+    {
         String baseIRI = null ;
         if ( env.getContext() != null )
         {
-            Query query = (Query)env.getContext().get(ARQConstants.sysCurrentQuery) ;
-            if ( query != null )
-                baseIRI = query.getBaseURI() ;
+            Prologue stmt = (Prologue)env.getContext().get(ARQConstants.sysCurrentStatement) ;
+            if ( stmt != null )
+                baseIRI = stmt.getBaseURI() ;
         }
         return NodeFunctions.iri(v, baseIRI) ;
     }
-    
+
     @Override
     public Expr copy(Expr expr) { return new E_IRI(expr) ; }
 
@@ -60,5 +60,5 @@ public class E_IRI extends ExprFunction1
     public NodeValue eval(NodeValue v)
     {
         throw new ARQInternalErrorException("Should not be called") ;
-    } 
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/mgt/QueryEngineInfo.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/mgt/QueryEngineInfo.java
@@ -29,16 +29,16 @@ public class QueryEngineInfo implements QueryEngineInfoMBean
     // Has to be careful about concurrency.
     // It is possible that the count may be momentarily wrong
     // (reading longs is not atomic).
-    
+
     private AtomicLong count = new AtomicLong(0) ;
     @Override
     public long getQueryCount()                 { return count.get() ; }
     public void incQueryCount()                 { count.incrementAndGet() ; }
-    
+
     Query query = null ;
     @Override
     public String getLastQueryString()
-    { 
+    {
         Query q = query ;    // Get once.
         if ( q != null ) return q.toString() ;
         // Sometimes an alegra expression is executited without a query.
@@ -63,6 +63,6 @@ public class QueryEngineInfo implements QueryEngineInfoMBean
 //    private long lastExecTime ;
 //    public long getLastQueryExecTime()          { return lastExecTime ; }
 //    public void setLastQueryExecTime(long timeMillis)   { lastExecTime = timeMillis ; }
-    
-    
+
+
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorBase.java
@@ -19,6 +19,7 @@
 package org.apache.jena.sparql.modify;
 
 import org.apache.jena.atlas.iterator.Iter ;
+import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.util.Context ;
@@ -36,10 +37,10 @@ public class UpdateProcessorBase implements UpdateProcessor
     protected final UpdateEngineFactory factory ;
     protected final Context context ;
 
-    public UpdateProcessorBase(UpdateRequest request, 
-                               DatasetGraph datasetGraph, 
+    public UpdateProcessorBase(UpdateRequest request,
+                               DatasetGraph datasetGraph,
                                Binding inputBinding,
-                               Context context, 
+                               Context context,
                                UpdateEngineFactory factory)
     {
         this.request = request ;
@@ -48,13 +49,14 @@ public class UpdateProcessorBase implements UpdateProcessor
         this.context = context;
         Context.setCurrentDateTime(this.context) ;
         this.factory = factory ;
+        this.context.set(ARQConstants.sysCurrentStatement, request);
     }
 
     @Override
     public void execute() {
         UpdateEngine uProc = factory.create(datasetGraph, inputBinding, context);
         uProc.startRequest();
-        
+
         try {
             UpdateSink sink = uProc.getUpdateSink();
             Iter.sendToSink(request.iterator(), sink);     // Will call close on sink if there are no exceptions


### PR DESCRIPTION
See #1272 for discussion on possible issues/limitations 

- Renamed ARQConstants.sysCurrentQuery to ARQConstants.sysCurrentStatement
- QueryExecDatasetBuilder no longer redundantly sets the current statement
- UpdateProcessorBase now sets the current statement
- Added a workaround to set the prologue in UpdateExecDatasetBuilder (see discussion)
- Added test case to TestUpdateOperations