### PR TITLE
Added copy() method to ServiceExecutorRegistry

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecutorRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecutorRegistry.java
@@ -76,6 +76,12 @@ public class ServiceExecutorRegistry
     public ServiceExecutorRegistry()
     {}
 
+    /** Create an independent copy of the registry */
+    public ServiceExecutorRegistry copy() {
+    	ServiceExecutorRegistry result = new ServiceExecutorRegistry();
+    	result.getFactories().addAll(getFactories());
+    	return result;
+    }
 
     /** Insert a service executor factory. Must not be null. */
     public ServiceExecutorRegistry add(ServiceExecutorFactory f) {


### PR DESCRIPTION
This PR adds a copy() method to ServiceExecutorRegistry in order to ease setting up local copies.
The copy method is mentioned in the jena-site PR https://github.com/apache/jena-site/pull/103