### PR TITLE
jena-geosparql - Add assembler option to disable spatial index

### DIFF
--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/assembler/GeoAssembler.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/assembler/GeoAssembler.java
@@ -117,6 +117,11 @@ public class GeoAssembler extends DatasetAssembler {
         if (root.hasProperty(pSpatialIndexFile) )
             spatialIndexFilename = GraphUtils.getStringValue(root, pSpatialIndexFile);
 
+        // Spatial Index enabled.
+        boolean spatialIndexEnabled = true;
+        if (root.hasProperty(pSpatialIndexEnabled) )
+        spatialIndexEnabled = getBooleanValue(root, pSpatialIndexEnabled);
+
         // ---- Build
 
         Dataset dataset = DatasetFactory.wrap(base);
@@ -148,7 +153,7 @@ public class GeoAssembler extends DatasetAssembler {
             GeoSPARQLConfig.setupNoIndex(queryRewrite);
         }
 
-        prepareSpatialExtension(dataset, spatialIndexFilename);
+        prepareSpatialExtension(dataset, spatialIndexEnabled, spatialIndexFilename);
         return base;
     }
 
@@ -165,13 +170,13 @@ public class GeoAssembler extends DatasetAssembler {
         return integerList;
     }
 
-    private static void prepareSpatialExtension(Dataset dataset, String spatialIndex){
+    private static void prepareSpatialExtension(Dataset dataset, boolean spatialIndexEnabled, String spatialIndex){
         boolean isEmpty = dataset.calculate(()->dataset.isEmpty());
-        if ( isEmpty && spatialIndex != null ) {
+        if ( isEmpty && spatialIndexEnabled && spatialIndex != null ) {
             LOG.warn("Dataset empty. Spatial Index not constructed. Server will require restarting after adding data and any updates to build Spatial Index.");
             return;
         }
-        if ( isEmpty )
+        if ( isEmpty || !spatialIndexEnabled )
             // Nothing to do.
             return;
 

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/assembler/VocabGeoSPARQL.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/assembler/VocabGeoSPARQL.java
@@ -73,6 +73,9 @@ public class VocabGeoSPARQL {
     // "File to load or store the spatial index. Default to " + SPATIAL_INDEX_FILE + " in TDB folder if using TDB and not set. Otherwise spatial index is not stored.
     public static final Property pSpatialIndexFile = property("spatialIndexFile");
 
+    // Whether to load/generate the spatial index at all (defaults to True). With this off, the value of spatialIndexFile will be ignored.
+    public static final Property pSpatialIndexEnabled = property("spatialIndexEnabled");
+
     // Dataset
     public static final Property pDataset = property("dataset");
 }


### PR DESCRIPTION
The [Spatial Index](https://jena.apache.org/documentation/geosparql/#spatial-index) is [generated on server startup](https://github.com/vtermanis/jena/blob/be6a377751ce585785700b2c6c3d6a9eb8e33aa3/jena-geosparql/src/main/java/org/apache/jena/geosparql/assembler/GeoAssembler.java#L183-L199) and, as per design, thereafter cannot be updated (until the next Fuseki restart).

Currently there are two options for the Spatial Index in assembler configuration:
1. `geosparql:spatialIndexFile` set => Index loaded from / generated + written to disk on startup
2. `geosparql:spatialIndexFile` unset => Index generated in memory

For a read + write dataset, said index is not very useful (in that startup time is wasted to re-generate the index which then is out-of-date after the next write op). This proposal adds a a new assembler option, `geosparql:spatialIndexEnabled` (defaulting to `true`) so that there now is a third mode:

3. `geosparql:spatialIndexEnabled` set to `false` => `geosparql:spatialIndexFile` is ignored and no index is loaded or generated
