### PR TITLE
GH-1292: Improve server-side support for auth bearer tokens

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -359,10 +359,10 @@ public class HttpLib {
      * Unclear whether the query string is/isn't included but for SPARQL, while the query
      * may change, the resource is the query service, not a resource named by the
      * uri+query string.
-     *
-     * This makes query-by-GET and query-by-POST work.
+     * <p>
+     * This makes query-by-GET and query-by-POST work the same way.
      */
-    public static String requestTarget(URI uri) {
+    public static String requestTargetServer(URI uri) {
         // RFC7616 -> 7230 5.5
         //   If the request-target is in authority-form or asterisk-form, the
         //   effective request URI's combined path and query component is
@@ -377,6 +377,31 @@ public class HttpLib {
 //        if ( qs == null || qs.isEmpty() )
 //            return path;
 //        return path+"?"+qs;
+    }
+
+    /** Client-side request target - no query string or fragment. */
+    public static String requestTargetClient(URI uri) {
+        // Like endpointURI but string based.
+        String s = uri.toString();
+        if ( uri.getRawQuery() == null && uri.getRawFragment() == null )
+            return s;
+        if ( uri.getRawQuery() != null ) {
+            int idx1 = s.indexOf('?');
+            if ( idx1 > 0 ) {
+                // Normal path.
+                // (this also chops off any fragment, not that there should be one).
+                return s.substring(0, idx1);
+            }
+            // Should not happen. No '?' but getRawQuery != null.
+        }
+        // Shouldn't have a fragment (it is a HTTP request URI but check anyway.
+        if ( uri.getRawFragment() != null ) {
+
+            int idx2 = s.indexOf('#');
+            if ( idx2 > 0 )
+                s = s.substring(0, idx2);
+        }
+        return s;
     }
 
     /** URI, without query string and fragment. */

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthEnv.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthEnv.java
@@ -35,7 +35,7 @@ public class AuthEnv {
     // Challenge setups that are active.
     private Map<String, AuthRequestModifier> authModifiers = new ConcurrentHashMap<>();
     // Token fetcher for bearer authentication
-    private BiFunction<URI, AuthChallenge, String> tokenSupplier = null;
+    private BiFunction<String, AuthChallenge, String> tokenSupplier = null;
 
     private static AuthEnv singleton = new AuthEnv();
     public static AuthEnv get() { return singleton; }
@@ -125,10 +125,12 @@ public class AuthEnv {
      * Base64). It must not contain spaces. Requests will fail when the token becomes
      * out-of-date and the application will need to set a new token.
      * <p>
-     * The string supplied will be used as-is with no further processing. Supply a
-     * null argument to clear any previous token supplier.
+     * The string supplied will be used as-is with no further processing.
+     * <p>
+     * Supply a null argument for the tokenSupplier to clear any previous token
+     * supplier.
      */
-    public void setBearerTokenProvider(BiFunction<URI, AuthChallenge, String> tokenSupplier) {
+    public void setBearerTokenProvider(BiFunction<String, AuthChallenge, String> tokenSupplier) {
         this.tokenSupplier = tokenSupplier;
     }
 
@@ -152,33 +154,17 @@ public class AuthEnv {
     }
 
     /**
-     * Return a bearer auth token to use when responding to a 401 challenge.
-     * The token must be in the form required for the "Authorization" header,
-     * including encoding (e.g. Base64). The string supplied is used as-is
-     * with no further processing.
+     * Return a bearer auth token to use when responding to a 401 challenge. The
+     * token must be in the form required for the "Authorization" header, including
+     * encoding (typically base64 URL encoding with no padding). The string supplied is used
+     * as-is with no further processing.
      * <p>
      * Return null for "no token" in which case a 401 response is passed back to the
      * application.
      */
-    public String getBearerToken(URI uri, AuthChallenge aHeader) {
+    public String getBearerToken(String uri, AuthChallenge aHeader) {
         if ( tokenSupplier == null )
             return null;
         return tokenSupplier.apply(uri, aHeader);
     }
-
-    // Development - do not provide in production systems.
-//    public void state() {
-//        org.apache.jena.atlas.io.IndentedWriter out = org.apache.jena.atlas.io.IndentedWriter.stdout.clone();
-//        out.setFlushOnNewline(true);
-//
-//        out.println("Password Registry");
-//        out.incIndent();
-//        passwordRegistry.registered().forEach(ad->out.println(ad.uri));
-//        out.decIndent();
-//
-//        out.println("Auth Modifiers");
-//        out.incIndent();
-//        authModifiers.forEach((String uriStr, AuthRequestModifier m)->{out.println(uriStr);});
-//        out.decIndent();
-//    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthHeader.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthHeader.java
@@ -37,9 +37,14 @@ import org.apache.jena.riot.system.RiotChars;
  * <ul>
  * Covers:
  * <ul>
- * <li>RFC 7617 - was RFC 2617 - basic authentication
- * <li>RFC 7616 - was RFC 2617 - digest authentication
- * <li>RFC 6750 - Bearer authentication
+ * <li><a href="https://www.rfc-editor.org/rfc/rfc7617.html">RFC 7617</a> - was
+ * <a href="https://www.rfc-editor.org/rfc/rfc7617.html">RFC 617</a> - basic
+ * authentication
+ * <li><a href="https://www.rfc-editor.org/rfc/rfc7616.html">RFC 7616</a> - was
+ * <a href="https://www.rfc-editor.org/rfc/rfc7617.html">RFC 617</a> - digest
+ * authentication
+ * <li><a href="https://www.rfc-editor.org/rfc/rfc6750.html">RFC 6750</a> - Bearer
+ * authentication
  * <li>"Unknown"
  * <ul>
  */
@@ -262,11 +267,24 @@ public class AuthHeader {
         if ( isChallenge() )
             authParams = mapAuthParams();
         else {
-            bearerToken = b64token();
-            if ( bearerToken == null ) {
+            String token = b64token();
+            if ( token == null )
                 unknown = string.substring(startIdx).trim();
-            }
+            else
+                bearerToken = stripPadding(token);
         }
+    }
+
+    // Remove trailing padding characters.
+    private String stripPadding(String token) {
+        int idx = token.length();
+        for (; idx > 0; idx--) {
+            if ( token.charAt(idx-1) != '=' )
+                break;
+        }
+        if ( idx == token.length() )
+            return token;
+        return token.substring(0,idx);
     }
 
     /*
@@ -395,7 +413,7 @@ public class AuthHeader {
     // Bearer "base 64" URL encoding is given as
     // b64token    = 1*( ALPHA / DIGIT /
     //                  "-" / "." / "_" / "~" / "+" / "/" ) *"="
-    // which is token68.
+    // which is token68 with trailing "=".
 
     private String b64token() { return token68(); }
 

--- a/jena-core/src/main/java/org/apache/jena/util/OneToManyMap.java
+++ b/jena-core/src/main/java/org/apache/jena/util/OneToManyMap.java
@@ -30,6 +30,8 @@ import org.apache.jena.util.iterator.NullIterator ;
 /**
  * An extension to a standard map that supports one-to-many mappings: that is, there
  * may be zero, one or many values corresponding to a given key.
+ * <p>
+ * Legacy. old code retained for existing internal use only.
  */
 public class OneToManyMap<From, To> implements Map<From, To>
 {
@@ -56,8 +58,8 @@ public class OneToManyMap<From, To> implements Map<From, To>
      */
     public OneToManyMap() {
     }
-    
-    
+
+
     /**
      * <p>Construct a new one-to-many map whose contents are
      * initialised from the existing map.</p>
@@ -136,8 +138,8 @@ public class OneToManyMap<From, To> implements Map<From, To>
         }
         return false;
     }
-    
-    
+
+
     /**
      * Answer a set of the mappings in this map.  Each member of the set will
      * be a Map.Entry value.
@@ -281,7 +283,7 @@ public class OneToManyMap<From, To> implements Map<From, To>
 
 
     /**
-     * <p>Put all entries from one map into this map. Tests for m being a 
+     * <p>Put all entries from one map into this map. Tests for m being a
      * OneToManyMap, and, if so, copies all of the entries for each key.</p>
      * @param m The map whose contents are to be copied into this map
      */
@@ -337,7 +339,7 @@ public class OneToManyMap<From, To> implements Map<From, To>
      *
      * @param key The key object
      * @param value The value object
-     * @return {@code true} if an entry was removed. 
+     * @return {@code true} if an entry was removed.
      */
     @Override
     public boolean remove( Object key, Object value ) {
@@ -346,7 +348,7 @@ public class OneToManyMap<From, To> implements Map<From, To>
 
         if (entries != null) {
             entries.remove( value );
-            
+
             if (entries.isEmpty()) {
                 m_table.remove( key );
                 return true;
@@ -417,12 +419,12 @@ public class OneToManyMap<From, To> implements Map<From, To>
 
     // Internal implementation methods
     //////////////////////////////////////
-    
-    
-    // Inner classes 
+
+
+    // Inner classes
     //////////////////////////////////////
-    
-    
+
+
     //////////////////////////////////
 
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -851,8 +851,6 @@ public class FusekiServer {
          * Choose the HTTP authentication scheme.
          */
         public Builder auth(AuthScheme authScheme) {
-            if ( authScheme == AuthScheme.BEARER )
-                throw new FusekiConfigException("Bearer authentication not currently supported in the server builder.");
             this.authScheme = authScheme;
             return this;
         }
@@ -1325,7 +1323,7 @@ public class FusekiServer {
 
         /** Do some checking to make sure setup is consistent. */
         private void validate() {
-            if ( ! hasAuthenticationHandler ) {
+            if ( ! hasAuthenticationHandler && authScheme != AuthScheme.BEARER ) {
                 if ( authenticateUser )
                     Fuseki.configLog.warn("Authentication of users required (e.g. 'allowedUsers' is set) but there is no authentication setup (e.g. password file)");
                 if ( hasDataAccessControl )
@@ -1341,8 +1339,8 @@ public class FusekiServer {
                             throw new FusekiConfigException("Authentication scheme set but no password file");
                         break;
                     case BEARER:
-                        if ( bearerVerifiedUser == null )
-                            throw new FusekiConfigException("Bearer authenication set but no function to get the verified user");
+//                        if ( bearerVerifiedUser == null )
+//                            throw new FusekiConfigException("Bearer authentication set but no function to get the verified user");
                         break;
                     case UNKNOWN:
                         throw new FusekiConfigException("Unknown authentication scheme");

--- a/jena-integration-tests/src/test/files/Fuseki/config-bearer.ttl
+++ b/jena-integration-tests/src/test/files/Fuseki/config-bearer.ttl
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used by TestSecurityConfig
+# No server level security, only service level.
+
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+PREFIX access:  <http://jena.apache.org/access#>
+
+[] rdf:type fuseki:Server ;
+   fuseki:services (
+     <#service_tdb2>
+     <#service_plain>
+   ) .
+
+<#service_tdb2> rdf:type fuseki:Service ;
+    rdfs:label                      "Access controlled dataset" ;
+    fuseki:allowedUsers             "user1", "user3";
+    fuseki:name                     "database1" ;
+    fuseki:serviceQuery             "query" ;
+    fuseki:serviceQuery             "sparql" ;
+    fuseki:serviceReadGraphStore    "get" ;
+    fuseki:dataset                  <#dataset1>;
+    .
+
+<#dataset1> rdf:type  ja:MemoryDataset .
+
+<#service_plain> rdf:type fuseki:Service ;
+    rdfs:label                   "Uncontrolled dataset";
+    fuseki:name                  "database2";
+    fuseki:serviceQuery          "query";
+    fuseki:serviceQuery          "sparql";
+    fuseki:serviceReadGraphStore "get" ;
+    fuseki:dataset <#dataset2> ;
+    .
+    
+<#dataset2> rdf:type  ja:MemoryDataset .

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/TS_JenaHttp.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/TS_JenaHttp.java
@@ -31,6 +31,7 @@ import org.junit.runners.Suite;
     , TestAuthBasicRemote.class
     , TestAuthDigestRemote.class
     , TestAuthBearerRemote.class
+    , TestAuthBearerServer.class
 })
 
 public class TS_JenaHttp { }

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/TestAuthBearerRemote.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/TestAuthBearerRemote.java
@@ -43,8 +43,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Bearer authentication is different - it is a framework. We test here with some
- * functionality that checks the JWT "sub" locally.
+ * Bearer authentication is different - it is a framework.
+ * <p>
+ * We test here with some client-side functionality that checks the JWT "sub" locally.
  */
 public class TestAuthBearerRemote {
 
@@ -68,7 +69,7 @@ public class TestAuthBearerRemote {
 
     // Client-side challenge callback.
     private void setBearerAuthProvider(String username) {
-        BiFunction<URI, AuthChallenge, String> testTokenSupplier = (uri, authHeader) -> AuthBearerTestLib.generateTestToken(username);
+        BiFunction<String, AuthChallenge, String> testTokenSupplier = (uri, authHeader) -> AuthBearerTestLib.generateTestToken(username);
         AuthEnv.get().setBearerTokenProvider(testTokenSupplier);
     }
 
@@ -120,7 +121,6 @@ public class TestAuthBearerRemote {
         AuthEnv.get().setBearerTokenProvider(null);
         AuthEnv.get().clearActiveAuthentication();
     }
-
 
 
     // ---- QueryExecHTTP

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/TestAuthBearerServer.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/TestAuthBearerServer.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.http;
+
+import static org.junit.Assert.fail;
+
+import org.apache.jena.atlas.web.AuthScheme;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.auth.AuthBearerFilter;
+import org.apache.jena.http.auth.AuthEnv;
+import org.apache.jena.sparql.exec.http.QueryExecHTTP;
+import org.junit.Test;
+
+/**
+ * Test server side functionality of bearer auth.
+ */
+public class TestAuthBearerServer {
+
+    @Test public void modeBearerAlways() {
+        FusekiServer server = FusekiServer.create()
+                .port(0)
+                .auth(AuthScheme.BEARER)
+                .parseConfigFile("src/test/files/Fuseki/config-bearer.ttl")
+                .addFilter("/*", new AuthBearerFilter(AuthBearerTestLib::subjectFromEncodedJWT))
+                .start();
+        String baseURL = "http://localhost:"+server.getHttpPort()+"/";
+
+        try {
+            String JWT_user1 = AuthBearerTestLib.generateTestToken("user1");
+            String JWT_user2 = AuthBearerTestLib.generateTestToken("noSuchUser");
+            String URL1 = baseURL+"database1";
+            String URL2 = baseURL+"database2";
+
+            // 401
+            AuthEnv.get().setBearerTokenProvider( (uri, challenge)-> uri.equals(URL1) ? JWT_user1 : null);
+            //System.out.println("database1, with user1 token (yes/401)");
+            attempt(URL1, null, true);
+            AuthEnv.get().setBearerTokenProvider( null );
+
+            AuthEnv.get().clearAuthEnv();
+
+            //System.out.println("database1, with user1 token (yes)");
+            attempt(URL1, JWT_user1, true);
+            //System.out.println("database1, with user2 token (no)");
+            attempt(URL1, JWT_user2, false);
+            //System.out.println("database1, without token (no)");
+            attempt(URL1, null, false);
+
+            //System.out.println("database2, with user1 token (yes)");
+            attempt(URL2, JWT_user1, true);
+            //System.out.println("database2, with no token (no)");
+            // fails - bearer required.
+            attempt(URL2, null, false);
+        } finally { server.stop(); }
+    }
+
+    @Test public void modePossibleBearerTesting() {
+        FusekiServer server = FusekiServer.create()
+                .port(0)
+                .auth(AuthScheme.BEARER)
+                .parseConfigFile("src/test/files/Fuseki/config-bearer.ttl")
+                .addFilter("/*", new AuthBearerFilter(AuthBearerTestLib::subjectFromEncodedJWT, false))
+                .start();
+        try {
+            String baseURL = "http://localhost:"+server.getHttpPort()+"/";
+            String JWT_user1 = AuthBearerTestLib.generateTestToken("user1");
+            String JWT_user2 = AuthBearerTestLib.generateTestToken("noSuchUser");
+
+            String URL1 = baseURL+"database1";
+            String URL2 = baseURL+"database2";
+
+            //System.out.println("database1, with user1 token (yes)");
+            attempt(URL1, JWT_user1, true);
+            //System.out.println("database1, with user2 token (no)");
+            attempt(URL1, JWT_user2, false);
+            //System.out.println("database1, without token (no)");
+            attempt(URL1, null, false);
+
+            //System.out.println("database2, with user1 token (yes)");
+            attempt(URL2, JWT_user1, true);
+            //System.out.println("database2, without token (yes)");
+            attempt(URL2, null, true);
+
+        } finally { server.stop(); }
+    }
+
+    private static void attempt(String URL, String JWT, boolean expectedToSucceed) {
+        if ( JWT != null )
+            AuthEnv.get().setBearerToken(URL, JWT);
+
+        try {
+            attempt(URL, expectedToSucceed);
+        } finally {
+            if ( JWT != null )
+                AuthEnv.get().setBearerToken(URL, null);
+        }
+    }
+
+    private static void attempt(String URL, boolean expectedToSucceed) {
+        try {
+            boolean b = QueryExecHTTP.service(URL)
+                    .query("ASK{}")
+                    .ask();
+            if ( ! expectedToSucceed )
+                fail("Expected the operation to be rejected");
+        } catch (RuntimeException ex) {
+            if ( expectedToSucceed )
+                fail("Expected the operation to succeed");
+        }
+    }
+}


### PR DESCRIPTION
A mixture of fixes for problems encountered.

The servlet filter `AuthBearerFilter` is now improved from its previous state of being more for testing usage.

It is not a complete solution to support in Fuseki for bearer authentication. It is slanted towards support for machine-machine interactions. Token validation still has to be provided by the deployment. A Fuseki module could do this.

For example, for OpenID, there is a better solution which is to use the standard Jetty security handler.
