### PR TITLE
Fix for auth test: clear auth env

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthEnv.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthEnv.java
@@ -19,6 +19,7 @@
 package org.apache.jena.http.auth;
 
 import java.net.URI;
+import java.net.http.HttpRequest;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
@@ -87,7 +88,7 @@ public class AuthEnv {
      * Add authentication, if in the authModifiers registry. That is, add the right
      * headers, and for digest, calculate the new digest string.
      */
-    public java.net.http.HttpRequest.Builder addAuth(java.net.http.HttpRequest.Builder requestBuilder, String uri) {
+    public HttpRequest.Builder addAuth(HttpRequest.Builder requestBuilder, String uri) {
         if ( authModifiers.isEmpty() )
             return requestBuilder;
         // Convert to the key for authentication handlers.
@@ -167,4 +168,20 @@ public class AuthEnv {
             return null;
         return tokenSupplier.apply(uri, aHeader);
     }
+
+ // Development - do not provide in production systems.
+//  public void state() {
+//      org.apache.jena.atlas.io.IndentedWriter out = org.apache.jena.atlas.io.IndentedWriter.stdout.clone();
+//      out.setFlushOnNewline(true);
+//
+//      out.println("Password Registry");
+//      out.incIndent();
+//      passwordRegistry.registered().forEach(ad->out.println(ad.uri));
+//      out.decIndent();
+//
+//      out.println("Auth Modifiers");
+//      out.incIndent();
+//      authModifiers.forEach((String uriStr, AuthRequestModifier m)->{out.println(uriStr);});
+//      out.decIndent();
+//  }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestAuthQuery_JDK.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestAuthQuery_JDK.java
@@ -65,21 +65,23 @@ public class TestAuthQuery_JDK extends AbstractTestAuth_JDK {
             Assert.assertTrue(qe.execAsk());
         } finally {
             AuthEnv.get().unregisterUsernamePassword(uri);
-            //AuthEnv.get().clearAuthRequestModifiers();
         }
     }
 
     @Test
     public void query_authenv_02_prefix_good() {
         QueryExecutionHTTP qe = QueryExecutionHTTP.create().endpoint(databaseURL()).query("ASK { }").build();
-        // Dataset URL.
+        // Server URL - a prefix.
         String dsURL = serverURL;
         URI uri = URI.create(dsURL);
         AuthEnv.get().registerUsernamePassword(uri, "allowed", "password");
         try {
             Assert.assertTrue(qe.execAsk());
         } finally {
+            // Does not clear authModifier because it is by prefix.
             AuthEnv.get().unregisterUsernamePassword(uri);
+            // ... so do a complete clear.
+            AuthEnv.get().clearAuthEnv();
         }
     }
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestWebappAuthQuery_JDK.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestWebappAuthQuery_JDK.java
@@ -64,14 +64,12 @@ public class TestWebappAuthQuery_JDK extends AbstractTestWebappAuth_JDK {
             Assert.assertTrue(qe.execAsk());
         } finally {
             AuthEnv.get().unregisterUsernamePassword(uri);
-            //AuthEnv.get().clearAuthRequestModifiers();
         }
     }
 
     @Test
     public void query_authenv_02_prefix_good() {
         QueryExecutionHTTP qe = QueryExecutionHTTP.create().endpoint(authServiceQuery).query("ASK { }").build();
-        // Dataset URL.
         String dsURL = "http://localhost:"+authPort+authDatasetPath;
         URI uri = URI.create(dsURL);
         AuthEnv.get().registerUsernamePassword(uri, "allowed", "password");
@@ -79,6 +77,8 @@ public class TestWebappAuthQuery_JDK extends AbstractTestWebappAuth_JDK {
             Assert.assertTrue(qe.execAsk());
         } finally {
             AuthEnv.get().unregisterUsernamePassword(uri);
+            // Currently necessary because it is a prefix registration of the password.
+            AuthEnv.get().clearAuthEnv();
         }
     }
 


### PR DESCRIPTION
Unregistering password does not account for authModifiers that were created due to a prefix match for the password registration.