### PR TITLE
Enabled 'decompressConcatenated' for bzip2 to prevent partial reads of input

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IO.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IO.java
@@ -90,7 +90,7 @@ public class IO
         switch ( ext ) {
             case "":        return in;
             case ext_gz:    return new GZIPInputStream(in);
-            case ext_bz2:   return new BZip2CompressorInputStream(in);
+            case ext_bz2:   return new BZip2CompressorInputStream(in, true);
             case ext_sz:    return new SnappyCompressorInputStream(in);
         }
         return in;


### PR DESCRIPTION
We just noticed missing data after loading a bzip2 file and realized that the flag was not set which caused the file to only be read partially.