### PR TITLE
Add maven default goal to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -818,6 +818,7 @@
   </dependencyManagement>
 
   <build>
+    <defaultGoal>clean test install</defaultGoal>
     <!-- Run the enforcer plugin automatically at compile time -->
     <plugins>
       <plugin>


### PR DESCRIPTION
Small `pom.xml` change to add some default goals to Maven. Every time I sync the code I run `mvn clean test install -Pdev`, but sometimes I mess up part of the command… so with this `mvn -Pdev` is enough. WDYT?

Thanks

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
