### PR TITLE
GH-1387 Improved custom service executor extension system

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryIterator.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryIterator.java
@@ -18,15 +18,13 @@
 
 package org.apache.jena.sparql.engine;
 
-import java.util.Iterator ;
-
-import org.apache.jena.atlas.lib.Closeable ;
+import org.apache.jena.atlas.iterator.IteratorCloseable;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.util.PrintSerializable ;
 
 /** Root of query iterators in ARQ. */
 
-public interface QueryIterator extends Closeable, Iterator<Binding>, PrintSerializable
+public interface QueryIterator extends IteratorCloseable<Binding>, PrintSerializable
 {
     /** Get next binding */
     public Binding nextBinding() ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/OpExecutor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/OpExecutor.java
@@ -45,6 +45,7 @@ import org.apache.jena.sparql.expr.Expr ;
 import org.apache.jena.sparql.expr.ExprList ;
 import org.apache.jena.sparql.procedure.ProcEval ;
 import org.apache.jena.sparql.procedure.Procedure ;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
 
 /**
  * Turn an Op expression into an execution of QueryIterators.
@@ -305,7 +306,7 @@ public class OpExecutor
     }
 
     protected QueryIterator execute(OpService opService, QueryIterator input) {
-        return new QueryIterService(input, opService, execCxt) ;
+        return ServiceExecutorRegistry.exec(input, opService, execCxt);
     }
 
     // Quad form, "GRAPH ?g {}" Flip back to OpGraph.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecution.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecution.java
@@ -19,14 +19,15 @@
 package org.apache.jena.sparql.service;
 
 import org.apache.jena.sparql.engine.QueryIterator;
-import org.apache.jena.sparql.engine.main.iterator.QueryIterService;
 
-/** 
- * Execution of a SERVICE clause in the context of {@link QueryIterService} applying an input binding.
- * @see ServiceExecutorFactory
+/**
+ * Execution of a SERVICE clause in the context of {@link QueryIterService} applying an input binding.s
+ * @see ServiceExecutor
  * @see ServiceExecutorRegistry
- */  
+ *
+ * @deprecated Deprecated in favor of QueryIterators that initialize lazily
+ */
+@Deprecated(since = "4.6.0")
 public interface ServiceExecution {
     public QueryIterator exec();
 }
-

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecutorRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExecutorRegistry.java
@@ -19,18 +19,41 @@
 package org.apache.jena.sparql.service;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
 import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.ARQConstants;
+import org.apache.jena.sparql.algebra.op.OpService;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.service.bulk.ChainingServiceExecutorBulk;
+import org.apache.jena.sparql.service.bulk.ServiceExecutorBulk;
+import org.apache.jena.sparql.service.bulk.ServiceExecutorBulkOverRegistry;
+import org.apache.jena.sparql.service.single.ChainingServiceExecutor;
+import org.apache.jena.sparql.service.single.ChainingServiceExecutorWrapper;
+import org.apache.jena.sparql.service.single.ServiceExecutor;
+import org.apache.jena.sparql.service.single.ServiceExecutorHttp;
 import org.apache.jena.sparql.util.Context;
-import org.apache.jena.sparql.exec.http.*;
 
+/**
+ * Registry for service executors that can be extended with custom ones.
+ * Bulk and single (=non-bulk) executors are maintained in two separate lists.
+ *
+ * Default execution will always start with the bulk list first.
+ * Once that list is exhausted by means of all bulk executors having delegated the request,
+ * then the non-bulk ones will be considered.
+ * There is no need to explicitly register a bulk-to-non-bulk bridge.
+ */
 public class ServiceExecutorRegistry
 {
-    // A list of custom service executors which are tried in the given order
-    List<ServiceExecutorFactory> registry = new ArrayList<>();
+    // A list of bulk service executors which are tried in the given order
+    List<ChainingServiceExecutorBulk> bulkChain = new ArrayList<>();
+
+    // A list of single (non-bulk) service executors which are tried in the given order
+    // This list is only considered after after the bulk registry
+    List<ChainingServiceExecutor> singleChain = new ArrayList<>();
 
     public static ServiceExecutorRegistry standardRegistry()
     {
@@ -38,16 +61,25 @@ public class ServiceExecutorRegistry
         return reg ;
     }
 
-    /** A "call with SPARQL query" service execution factory. */
-    public static ServiceExecutorFactory httpService = (op, opx, binding, execCxt) -> ()->Service.exec(op, execCxt.getContext());
+    /** A "call with SPARQL query" service executor. */
+    public static ServiceExecutor httpService = new ServiceExecutorHttp();
+
+    /** Blindly adds the default executor(s); concretely adds the http executor */
+    public static void initWithDefaults(ServiceExecutorRegistry registry) {
+        registry.add(httpService);
+    }
 
     public static void init() {
         // Initialize if there is no registry already set
-        ServiceExecutorRegistry reg = new ServiceExecutorRegistry() ;
-        reg.add(httpService);
+        ServiceExecutorRegistry reg = new ServiceExecutorRegistry();
+        initWithDefaults(reg);
         set(ARQ.getContext(), reg) ;
     }
 
+    /**
+     * Return the global instance from the ARQ context; create that instance if needed.
+     * Never returns null.
+     */
     public static ServiceExecutorRegistry get()
     {
         // Initialize if there is no registry already set
@@ -61,6 +93,16 @@ public class ServiceExecutorRegistry
         return reg ;
     }
 
+    /** Return the registry from the given context if present; otherwise return the global one */
+    public static ServiceExecutorRegistry chooseRegistry(Context context) {
+        ServiceExecutorRegistry result = ServiceExecutorRegistry.get(context);
+        if (result == null) {
+            result = get();
+        }
+        return result;
+    }
+
+    /** Return the registry from the given context only; null if there is none */
     public static ServiceExecutorRegistry get(Context context)
     {
         if ( context == null )
@@ -76,29 +118,102 @@ public class ServiceExecutorRegistry
     public ServiceExecutorRegistry()
     {}
 
+    /*
+     * Non-bulk API
+     */
+
+    /** Prepend the given service executor as a link to the per-binding chain */
+    public ServiceExecutorRegistry addSingleLink(ChainingServiceExecutor f) {
+        Objects.requireNonNull(f) ;
+        singleChain.add(0, f) ;
+        return this;
+    }
+
+    /** Remove the given service executor from the per-binding chain */
+    public ServiceExecutorRegistry removeSingleLink(ChainingServiceExecutor f) {
+        singleChain.remove(f) ;
+        return this;
+    }
+
+    /** Wraps the given service executor as a chaining one and prepends it
+     *  to the non-bulk chain via {@link #addSingleLink(ChainingServiceExecutor)} */
+    public ServiceExecutorRegistry add(ServiceExecutor f) {
+        Objects.requireNonNull(f) ;
+        return addSingleLink(new ChainingServiceExecutorWrapper(f));
+    }
+
+    /** Remove a given service executor - internally attempts to unwrap every chaining service executor */
+    public ServiceExecutorRegistry remove(ServiceExecutor f) {
+        Iterator<ChainingServiceExecutor> it = singleChain.iterator();
+        while (it.hasNext()) {
+            ChainingServiceExecutor cse = it.next();
+            if (cse instanceof ChainingServiceExecutorWrapper) {
+                ChainingServiceExecutorWrapper wrapper = (ChainingServiceExecutorWrapper)cse;
+                ServiceExecutor delegate = wrapper.getDelegate();
+                if (Objects.equals(delegate, f)) {
+                    it.remove();
+                }
+            }
+        }
+        return this;
+    }
+
+    /** Retrieve the actual list of per-binding executors; allows for re-ordering */
+    public List<ChainingServiceExecutor> getSingleChain() {
+        return singleChain;
+    }
+
+    /*
+     * Bulk API
+     */
+
+    /** Add a chaining bulk executor as a link to the executor chain */
+    public ServiceExecutorRegistry addBulkLink(ChainingServiceExecutorBulk f) {
+        Objects.requireNonNull(f) ;
+        bulkChain.add(0, f) ;
+        return this;
+    }
+
+    /** Remove the given service executor */
+    public ServiceExecutorRegistry removeBulkLink(ChainingServiceExecutorBulk f) {
+        bulkChain.remove(f) ;
+        return this;
+    }
+
+    /** Retrieve the actual list of bulk executors; allows for re-ordering */
+    public List<ChainingServiceExecutorBulk> getBulkChain() {
+        return bulkChain;
+    }
+
+    /*
+     * Utility
+     */
+
     /** Create an independent copy of the registry */
     public ServiceExecutorRegistry copy() {
-    	ServiceExecutorRegistry result = new ServiceExecutorRegistry();
-    	result.getFactories().addAll(getFactories());
-    	return result;
+        ServiceExecutorRegistry result = new ServiceExecutorRegistry();
+        result.getSingleChain().addAll(getSingleChain());
+        result.getBulkChain().addAll(getBulkChain());
+        return result;
     }
 
-    /** Insert a service executor factory. Must not be null. */
-    public ServiceExecutorRegistry add(ServiceExecutorFactory f) {
-        Objects.requireNonNull(f) ;
-        registry.add(0, f) ;
-        return this;
+    /** Return a copy of the registry in the context (if present) or a fresh instance */
+    public ServiceExecutorRegistry copyFrom(Context cxt) {
+        ServiceExecutorRegistry tmp = ServiceExecutorRegistry.get(cxt);
+        ServiceExecutorRegistry result = tmp == null ? new ServiceExecutorRegistry() : tmp.copy();
+        return result;
     }
 
-    /** Remove the given service executor factory. */
-    public ServiceExecutorRegistry remove(ServiceExecutorFactory f) {
-        registry.remove(f) ;
-        return this;
-    }
+    /*
+     * Execution
+     */
 
-    /** Retrieve the actual list of factories; allows for re-ordering */
-    public List<ServiceExecutorFactory> getFactories() {
-        return registry;
+    /** Execute an OpService w.r.t. the execCxt's service executor registry */
+    public static QueryIterator exec(QueryIterator input, OpService opService, ExecutionContext execCxt) {
+        Context cxt = execCxt.getContext();
+        ServiceExecutorRegistry registry = ServiceExecutorRegistry.chooseRegistry(cxt);
+        ServiceExecutorBulk serviceExecutor = new ServiceExecutorBulkOverRegistry(registry);
+        QueryIterator qIter = serviceExecutor.createExecution(opService, input, execCxt);
+        return qIter;
     }
-
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/bulk/ChainingServiceExecutorBulk.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/bulk/ChainingServiceExecutorBulk.java
@@ -16,27 +16,21 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.service;
+package org.apache.jena.sparql.service.bulk;
 
 import org.apache.jena.sparql.algebra.op.OpService;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
-import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.service.single.ChainingServiceExecutor;
-import org.apache.jena.sparql.service.single.ServiceExecutor;
 
-/** Compatibility interface. Consider migrating legacy code to {@link ChainingServiceExecutor} or {@link ServiceExecutor} */
-@Deprecated(since = "4.6.0")
-@FunctionalInterface
-public interface ServiceExecutorFactory
-    extends ServiceExecutor
-{
-    @Override
-    default QueryIterator createExecution(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt) {
-        ServiceExecution svcExec = createExecutor(opExecute, original, binding, execCxt);
-        QueryIterator result = svcExec == null ? null : svcExec.exec();
-        return result;
-    }
-
-    ServiceExecution createExecutor(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt);
+/** Interface for custom service execution extensions that handle
+ *  the iterator over the input bindings themselves */
+public interface ChainingServiceExecutorBulk {
+    /**
+     * If this executor cannot handle the createExecution request then it should delegate
+     * to the chain's @{code createExecution} method and return its result.
+     * In any case, a {@link QueryIterator} needs to be returned.
+     *
+     * @return A non-null {@link QueryIterator} for the execution of the given OpService expression.
+     */
+    public QueryIterator createExecution(OpService opService, QueryIterator input, ExecutionContext execCxt, ServiceExecutorBulk chain);
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/bulk/ServiceExecutorBulk.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/bulk/ServiceExecutorBulk.java
@@ -16,27 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.service;
+package org.apache.jena.sparql.service.bulk;
 
 import org.apache.jena.sparql.algebra.op.OpService;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
-import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.service.single.ChainingServiceExecutor;
-import org.apache.jena.sparql.service.single.ServiceExecutor;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
 
-/** Compatibility interface. Consider migrating legacy code to {@link ChainingServiceExecutor} or {@link ServiceExecutor} */
-@Deprecated(since = "4.6.0")
-@FunctionalInterface
-public interface ServiceExecutorFactory
-    extends ServiceExecutor
-{
-    @Override
-    default QueryIterator createExecution(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt) {
-        ServiceExecution svcExec = createExecutor(opExecute, original, binding, execCxt);
-        QueryIterator result = svcExec == null ? null : svcExec.exec();
-        return result;
-    }
-
-    ServiceExecution createExecutor(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt);
+/**
+ * Interface for abstracting {@link OpService} execution.
+ *
+ * Custom extensions should provide implementations of {@link ChainingServiceExecutorBulk}
+ * and register them with {@link ServiceExecutorRegistry#addBulkLink(ChainingServiceExecutorBulk)}.
+ */
+public interface ServiceExecutorBulk {
+    public QueryIterator createExecution(OpService opService, QueryIterator input, ExecutionContext execCxt);
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/bulk/ServiceExecutorBulkOverRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/bulk/ServiceExecutorBulkOverRegistry.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.service.bulk;
+
+import java.util.List;
+
+import org.apache.jena.query.QueryException;
+import org.apache.jena.sparql.algebra.op.OpService;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
+import org.apache.jena.sparql.service.single.ServiceExecutor;
+import org.apache.jena.sparql.service.single.ServiceExecutorOverRegistry;
+
+/**
+ * Factory for service executions w.r.t. a {@link ServiceExecutorRegistry}.
+ * The {@link #createExecution(OpService, QueryIterator, ExecutionContext)} method
+ * delegates the request to all executors in order of their registration.
+ */
+public class ServiceExecutorBulkOverRegistry
+    implements ServiceExecutorBulk
+{
+    protected ServiceExecutorRegistry registry;
+
+    /** Position in the chain */
+    protected int pos;
+
+    public ServiceExecutorBulkOverRegistry(ServiceExecutorRegistry registry) {
+        this(registry, 0);
+    }
+
+    public ServiceExecutorBulkOverRegistry(ServiceExecutorRegistry registry, int pos) {
+        super();
+        this.registry = registry;
+        this.pos = pos;
+    }
+
+    @Override
+    public QueryIterator createExecution(OpService opService, QueryIterator input, ExecutionContext execCxt) {
+        if (registry == null) {
+            throw new QueryException("No service executor registry configured");
+        }
+
+        QueryIterator result;
+
+        List<ChainingServiceExecutorBulk> factories = registry.getBulkChain();
+        int n = factories.size();
+        if (pos >= n) {
+            // Chain to the single registry
+            ServiceExecutor singleExecutor = new ServiceExecutorOverRegistry(registry);
+            ServiceExecutorBulk bridge = new ServiceExecutorBulkToSingle(singleExecutor);
+            result = bridge.createExecution(opService, input, execCxt);
+
+            // Alternatively we could require for the bridge to be explicitly registered
+            // throw new QueryException("No more elements in service executor chain (pos=" + pos + ", chain size=" + n + ")");
+        } else {
+            ChainingServiceExecutorBulk factory = factories.get(pos);
+            ServiceExecutorBulk next = new ServiceExecutorBulkOverRegistry(registry, pos + 1);
+            result = factory.createExecution(opService, input, execCxt, next);
+        }
+        return result;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ChainingServiceExecutor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ChainingServiceExecutor.java
@@ -16,27 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.service;
+package org.apache.jena.sparql.service.single;
 
 import org.apache.jena.sparql.algebra.op.OpService;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.service.single.ChainingServiceExecutor;
-import org.apache.jena.sparql.service.single.ServiceExecutor;
 
-/** Compatibility interface. Consider migrating legacy code to {@link ChainingServiceExecutor} or {@link ServiceExecutor} */
-@Deprecated(since = "4.6.0")
-@FunctionalInterface
-public interface ServiceExecutorFactory
-    extends ServiceExecutor
-{
-    @Override
-    default QueryIterator createExecution(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt) {
-        ServiceExecution svcExec = createExecutor(opExecute, original, binding, execCxt);
-        QueryIterator result = svcExec == null ? null : svcExec.exec();
-        return result;
-    }
-
-    ServiceExecution createExecutor(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt);
+public interface ChainingServiceExecutor {
+    /**
+     * If this factory cannot handle the execution request then this method should return null.
+     * Otherwise, a {@link QueryIterator} is returned.
+     *
+     * @return A QueryIterator if this factory can handle the request, or null otherwise.
+     */
+    public QueryIterator createExecution(OpService opExecute, OpService opOriginal, Binding binding, ExecutionContext execCxt, ServiceExecutor chain);
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ChainingServiceExecutorWrapper.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ChainingServiceExecutorWrapper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.service.single;
+
+import org.apache.jena.sparql.algebra.op.OpService;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
+
+/**
+ * Turns a ServiceExecutor into a chaining one.
+ * Mainly used by {@link ServiceExecutorRegistry} for wrapping
+ * non-chaining service executors.
+ * If the executor returns null then the next link in the chain will be tried.
+ */
+public class ChainingServiceExecutorWrapper
+    implements ChainingServiceExecutor
+{
+    protected ServiceExecutor executor;
+
+    public ChainingServiceExecutorWrapper(ServiceExecutor executor) {
+        super();
+        this.executor = executor;
+    }
+
+    public ServiceExecutor getDelegate() {
+        return executor;
+    }
+
+    @Override
+    public QueryIterator createExecution(OpService opExecute, OpService opOriginal, Binding binding,
+            ExecutionContext execCxt, ServiceExecutor chain) {
+
+        QueryIterator qIter = executor.createExecution(opExecute, opOriginal, binding, execCxt);
+        QueryIterator result = qIter != null
+                ? qIter
+                : chain.createExecution(opExecute, opOriginal, binding, execCxt);
+
+        return result;
+    }
+
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ServiceExecutor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ServiceExecutor.java
@@ -16,27 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.service;
+package org.apache.jena.sparql.service.single;
 
 import org.apache.jena.sparql.algebra.op.OpService;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.service.single.ChainingServiceExecutor;
-import org.apache.jena.sparql.service.single.ServiceExecutor;
 
-/** Compatibility interface. Consider migrating legacy code to {@link ChainingServiceExecutor} or {@link ServiceExecutor} */
-@Deprecated(since = "4.6.0")
+/**
+ * Interface for handling service execution requests on a per-binding level.
+ */
 @FunctionalInterface
-public interface ServiceExecutorFactory
-    extends ServiceExecutor
-{
-    @Override
-    default QueryIterator createExecution(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt) {
-        ServiceExecution svcExec = createExecutor(opExecute, original, binding, execCxt);
-        QueryIterator result = svcExec == null ? null : svcExec.exec();
-        return result;
-    }
-
-    ServiceExecution createExecutor(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt);
+public interface ServiceExecutor {
+    /**
+     * If this factory cannot handle the execution request then this method should return null.
+     * Otherwise, a {@link QueryIterator} is returned.
+     *
+     * @return A QueryIterator if this factory can handle the request, or null otherwise.
+     */
+    public QueryIterator createExecution(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt);
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ServiceExecutorDecorator.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ServiceExecutorDecorator.java
@@ -16,27 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.service;
+package org.apache.jena.sparql.service.single;
 
 import org.apache.jena.sparql.algebra.op.OpService;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.service.single.ChainingServiceExecutor;
-import org.apache.jena.sparql.service.single.ServiceExecutor;
 
-/** Compatibility interface. Consider migrating legacy code to {@link ChainingServiceExecutor} or {@link ServiceExecutor} */
-@Deprecated(since = "4.6.0")
-@FunctionalInterface
-public interface ServiceExecutorFactory
-    extends ServiceExecutor
+/** Form a service executor from a base service executor and a 'chain' that acts as a decorator */
+public class ServiceExecutorDecorator
+    implements ServiceExecutor
 {
-    @Override
-    default QueryIterator createExecution(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt) {
-        ServiceExecution svcExec = createExecutor(opExecute, original, binding, execCxt);
-        QueryIterator result = svcExec == null ? null : svcExec.exec();
-        return result;
+    protected ServiceExecutor base;
+    protected ChainingServiceExecutor decorator;
+
+    public ServiceExecutorDecorator(ServiceExecutor base, ChainingServiceExecutor decorator) {
+        super();
+        this.base = base;
+        this.decorator = decorator;
     }
 
-    ServiceExecution createExecutor(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt);
+    @Override
+    public QueryIterator createExecution(OpService opExecute, OpService original, Binding binding,
+            ExecutionContext execCxt) {
+        return decorator.createExecution(opExecute, original, binding, execCxt, base);
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ServiceExecutorHttp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ServiceExecutorHttp.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.service.single;
+
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.query.QueryExecException;
+import org.apache.jena.riot.out.NodeFmtLib;
+import org.apache.jena.sparql.algebra.op.OpService;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.iterator.QueryIter;
+import org.apache.jena.sparql.engine.iterator.QueryIterCommonParent;
+import org.apache.jena.sparql.engine.iterator.QueryIterSingleton;
+import org.apache.jena.sparql.exec.http.Service;
+import org.apache.jena.sparql.util.Context;
+
+/** The default HTTP service executor implementation */
+public class ServiceExecutorHttp
+    implements ServiceExecutor
+{
+    @Override
+    public QueryIterator createExecution(OpService opExecute, OpService opOriginal, Binding binding,
+            ExecutionContext execCxt) {
+
+        Context context = execCxt.getContext();
+        if ( context.isFalse(Service.httpServiceAllowed) )
+            throw new QueryExecException("SERVICE not allowed") ;
+        // Old name.
+        if ( context.isFalse(Service.serviceAllowed) )
+            throw new QueryExecException("SERVICE not allowed") ;
+
+        boolean silent = opExecute.getSilent();
+
+        try {
+            QueryIterator qIter = Service.exec(opExecute, context);
+
+            // ---- Execute
+            if ( qIter == null )
+                throw new QueryExecException("No SERVICE handler");
+
+            qIter = QueryIter.makeTracked(qIter, execCxt);
+            // Need to put the outerBinding as parent to every binding of the service call.
+            // There should be no variables in common because of the OpSubstitute.substitute
+            return new QueryIterCommonParent(qIter, binding, execCxt);
+        } catch (RuntimeException ex) {
+            if ( silent ) {
+                Log.warn(this, "SERVICE " + NodeFmtLib.strTTL(opExecute.getService()) + " : " + ex.getMessage());
+                // Return the input
+                return QueryIterSingleton.create(binding, execCxt);
+
+            }
+            throw ex;
+        }
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ServiceExecutorOverRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/single/ServiceExecutorOverRegistry.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.service.single;
+
+import java.util.List;
+
+import org.apache.jena.query.QueryException;
+import org.apache.jena.sparql.algebra.op.OpService;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.iterator.QueryIterRoot;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
+
+/** Abstraction of a registry's single chain as a service executor */
+public class ServiceExecutorOverRegistry
+    implements ServiceExecutor
+{
+    protected ServiceExecutorRegistry registry;
+
+    /** Position in the chain */
+    protected int pos;
+
+    public ServiceExecutorOverRegistry(ServiceExecutorRegistry registry) {
+        this(registry, 0);
+    }
+
+    public ServiceExecutorOverRegistry(ServiceExecutorRegistry registry, int pos) {
+        super();
+        this.registry = registry;
+        this.pos = pos;
+    }
+
+    @Override
+    public QueryIterator createExecution(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt) {
+        List<ChainingServiceExecutor> factories = registry.getSingleChain();
+        int n = factories.size();
+        if (pos >= n) {
+            if (opExecute.getSilent()) {
+                return QueryIterRoot.create(execCxt);
+            } else {
+                throw new QueryException("No more elements in service executor chain (pos=" + pos + ", chain size=" + n + ")");
+            }
+        }
+
+        ChainingServiceExecutor factory = factories.get(pos);
+
+        ServiceExecutor next = new ServiceExecutorOverRegistry(registry, pos + 1);
+        QueryIterator result = factory.createExecution(opExecute, original, binding, execCxt, next);
+
+        return result;
+    }
+}

--- a/jena-integration-tests/src/test/java/org/apache/jena/sparql/exec/http/TestService.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/sparql/exec/http/TestService.java
@@ -46,7 +46,7 @@ import org.apache.jena.sparql.core.DatasetGraphZero;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
-import org.apache.jena.sparql.engine.main.iterator.QueryIterService;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
 import org.apache.jena.sparql.exec.QueryExec;
 import org.apache.jena.sparql.exec.RowSet;
 import org.apache.jena.sparql.sse.SSE;
@@ -108,7 +108,7 @@ public class TestService {
     }
 
     // Remember the initial settings.
-    static String logLevelQueryIterService = LogCtl.getLevel(QueryIterService.class);
+    static String logLevelQueryIterService = LogCtl.getLevel(ServiceExecutorRegistry.class);
     static String logLevelFuseki = LogCtl.getLevel(Fuseki.class);
 
     @BeforeClass public static void beforeClass() {
@@ -185,7 +185,7 @@ public class TestService {
     }
 
     @Test public void service_query_silent_no_service() {
-        logOnlyErrors(QueryIterService.class, ()->{
+        logOnlyErrors(ServiceExecutorRegistry.class, ()->{
             DatasetGraph dsg = env.dsg();
             String queryString = "SELECT * { SERVICE SILENT <"+SERVICE+"JUNK> { VALUES ?X { 1 2 } }} ";
             try ( RDFLink link = RDFLinkFactory.connect(localDataset()) ) {
@@ -201,7 +201,7 @@ public class TestService {
     }
 
     @Test public void service_query_silent_nosite() {
-        logOnlyErrors(QueryIterService.class, ()->{
+        logOnlyErrors(ServiceExecutorRegistry.class, ()->{
             DatasetGraph dsg = env.dsg();
             String queryString = "SELECT * { SERVICE SILENT <http://nosuchsite/> { VALUES ?X { 1 2 } }} ";
             try ( RDFLink link = RDFLinkFactory.connect(localDataset()) ) {

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/service/TestServiceExec.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/service/TestServiceExec.java
@@ -27,7 +27,7 @@ import org.apache.jena.query.*;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
-import org.apache.jena.sparql.engine.main.iterator.QueryIterService;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
 import org.apache.jena.sparql.sse.SSE;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -72,7 +72,7 @@ public class TestServiceExec {
 
     @Test
     public void service_exec_3() {
-        Class<?> logClass = QueryIterService.class;
+        Class<?> logClass = ServiceExecutorRegistry.class;
         String logLevel = LogCtl.getLevel(logClass);
         try {
             LogCtl.setLevel(logClass, "ERROR");


### PR DESCRIPTION
GitHub issue resolved #1387.
This fixes #1399.

Pull request Description: This PR adds the following changes to the custom service executor plugin system:

Improvements:

* **chaining** There is now `ChainingServiceExecutor` which allows for transparently forwarding a request to the next `ChainingServiceExecutor` instance in the registry. This way a custom service executor can modify the request and have it processed by the remainder of the chain.
* **bulk processing** The plugin system introduced with jena 4.5.0 only supports lookups with individual bindings. This PR adds support for plugins that want to process bindings in bulk. The main difference in the APIs is whether the `createExecution` method accepts a single `Binding` or a `QueryIterator`. There is now a `ServiceExecutorRegistryBulk` which by default has an registration that delegates to the non-bulk one.

Breaking changes:

* `ServiceExecutorRegistry.getFactories()` now returns a `List<ChainingServiceExecutor>` because this is its internal storage; previously it was `List<ServiceExecutorFactory>`. I am afraid re-establishing compatibility in this regard would require a completely new registry with a new context attribute.

Deprecations:
* Deprecated `ServiceExecutorFactory` in favor of `ServiceExecutor` (ServiceExecutorFactory extends from the latter). Use of the old code delegates to the new one.
    * In the new code the method that creates a `ServiceExecution` is now called `createExecution` (rather than `createExecutor`)
* ~Deprecated `ServiceExecutorRegistry.add` in favor of `prepend`. Both methods add executors to the beginning of the registry's list so they are considered before the default behavior.~ QueryEngineFactory also uses `add` to prepend; so `add` is consistent with existing naming.
* Legacy add method for `ServiceExecutorFactory` exists and wraps it as a `ChainingServiceExecutor`.
* Legacy remove method for `ServiceExecutorFactory` finds previously wrapped elements..
* Deprecated `ServiceExecution` because it doesn't add anything over `QueryIterator`.

----

 - [x] Javadoc exists and is up-to-data
 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
