### PR TITLE
gh-1393 fix for QueryExecutionAdapter.adapt returning null

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecutionCompat.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecutionCompat.java
@@ -55,7 +55,10 @@ public class QueryExecutionCompat extends QueryExecutionAdapter {
     }
 
     @Override
-    protected QueryExec get() { return qExecHere; }
+    protected QueryExec get() {
+        execution();
+        return qExecHere;
+    }
 
     private void execution() {
         // Delay until used so setTimeout,setInitialBindings work.

--- a/jena-arq/src/test/java/org/apache/jena/sparql/exec/TestExecEnvironment.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/exec/TestExecEnvironment.java
@@ -18,6 +18,10 @@
 
 package org.apache.jena.sparql.exec;
 
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestExecEnvironment {
@@ -29,4 +33,14 @@ public class TestExecEnvironment {
     // RegisterHttpClkient
 
     // RegistryRequestModifier
+
+
+    // https://github.com/apache/jena/issues/1393
+    @Test
+    public void testQueryExecAdapter() {
+        try (QueryExecution qExec = QueryExecutionFactory.create("SELECT * { ?s ?p ?o }", DatasetFactory.empty())) {
+            QueryExec qe  = QueryExecAdapter.adapt(qExec);
+            Assert.assertNotNull(qe);
+        }
+    }
 }


### PR DESCRIPTION
GitHub issue resolved #1393

Fixes an NPE by calling QueryExecutionAdapter.adapt; the underlying QueryExecutionCompat.get() now calls `execute()` to initialize its QueryExec instance.

 - [x] Tests are included.
