### PR TITLE
JENA-2182: Pass builder into FusekiModule.configured()

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -1198,7 +1198,7 @@ public class FusekiServer {
             DataAccessPointRegistry dapRegistry = buildStart();
 
             // FusekiModule call - inspect the DataAccessPointRegistry.
-            FusekiModuleStep.configured(dapRegistry, configModel);
+            FusekiModuleStep.configured(this, dapRegistry, configModel);
 
             buildSecurity(dapRegistry);
             try {

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModule.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModule.java
@@ -46,7 +46,7 @@ import org.apache.jena.rdf.model.Model;
  * <li>{@linkplain #serverBeforeStarting(FusekiServer)} -- called before {@code server.start} happens.</li>
  * <li>{@linkplain #serverAfterStarting(FusekiServer)} -- called after {@code server.start} happens.</li>
  * <li>{@linkplain #serverStopped(FusekiServer)} -- call after {@code server.stop}, but only if a clean shutdown happens.
- *     Servers may simply exit without shutdown phase.
+ *     Servers may simply exit without a shutdown phase.
  *     The JVM may exit or be killed without clean shutdown.
  *     Modules must not rely on a call to {@code serverStopped} happening.</li>
  * <li>{@linkplain #stop} -- modules finishes. Unlikely to be called in practice. There is no guarantee of a clean shutdown.
@@ -54,7 +54,7 @@ import org.apache.jena.rdf.model.Model;
  */
 public interface FusekiModule extends SubsystemLifecycle {
     /**
-     * Display name id to identify this module.
+     * Display name to identify this module.
      * <p>
      * Modules are loaded once by the service loader.
      * <p>
@@ -70,7 +70,7 @@ public interface FusekiModule extends SubsystemLifecycle {
 
     /**
      * Called at the start of "build" step. The builder has been set according to the
-     * configuration of API calls and paring configuration files. No build actions have been carried out yet.
+     * configuration of API calls and parsing configuration files. No build actions have been carried out yet.
      * The module can make further FusekiServer.{@link Builder} calls.
      * The "configModel" parameter is set if a configuration file was used otherwise it is null.
      * <p>
@@ -95,7 +95,7 @@ public interface FusekiModule extends SubsystemLifecycle {
       *    dapRegistry.accessPoints().forEach(accessPoint{@literal ->}configDataAccessPoint(accessPoint, configModel));
       * </pre>
       */
-    public default void configured(DataAccessPointRegistry dapRegistry, Model configModel) {
+    public default void configured(FusekiServer.Builder serverBuilder, DataAccessPointRegistry dapRegistry, Model configModel) {
         dapRegistry.accessPoints().forEach(accessPoint->configDataAccessPoint(accessPoint, configModel));
     }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModuleStep.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModuleStep.java
@@ -39,8 +39,8 @@ public class FusekiModuleStep {
      * The DataAccessPointRegistry that will be used to build the server.
      *
      */
-    public static void configured(DataAccessPointRegistry dapRegistry, Model configModel) {
-        FusekiModules.forEachModule(module -> module.configured(dapRegistry, configModel));
+    public static void configured(FusekiServer.Builder serverBuilder, DataAccessPointRegistry dapRegistry, Model configModel) {
+        FusekiModules.forEachModule(module -> module.configured(serverBuilder, dapRegistry, configModel));
     }
 
     /**


### PR DESCRIPTION
Pull request Description:

Pass the FusekiServer builder into `FusekiModule.configured()`.

It was an oversight not to pass it in.

`configured` is called after the DataAccessPoint registry is built and before the server is built.

 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
