### PR TITLE
Remove checkboxes for operating system information.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -19,19 +19,20 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: Also tell us, what did you expect to happen?
+      description: What did you expect to happen?
       placeholder: Tell us what happened.
     validations:
       required: true
-  - type: checkboxes
-    id: operating-systems
-    attributes:
-      label: Which environment is running?
-      options:
-        - label: macOS
-        - label: Windows
-        - label: Linux
-        - label: other
+##   (2022-06) Github treats checkboxes as "tasks"
+##   - type: checkboxes
+##     id: operating-systems
+##     attributes:
+##       label: Which environment is running?
+##       options:
+##         - label: macOS
+##         - label: Windows
+##         - label: Linux
+##         - label: other
   - type: textarea
     id: output
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,7 +14,7 @@ body:
   - type: textarea
     id: suggestion
     attributes:
-      label: Suggestion
+      label: Feature
       placeholder: Tell us about the suggestion.
     validations:
       required: true


### PR DESCRIPTION
`type: checkboxes` in a GH template becomes a task list.

Remove the checkboxes for the environment operating systems for now.

See https://github.com/github-community/community/discussions/5197 about this behaviour of GH templates.

----
By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
