### PR TITLE
JENA-2333 fix: sort langString first by value then by lang tags

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -734,10 +734,8 @@ public abstract class NodeValue extends ExprNode
                 // Two literals, both with language tags.
                 Node node1 = nv1.asNode() ;
                 Node node2 = nv2.asNode() ;
-                int x = StrUtils.strCompareIgnoreCase(node1.getLiteralLanguage(), node2.getLiteralLanguage()) ;
-
-                if ( x != Expr.CMP_EQUAL )
-                {
+                int x = StrUtils.strCompare(node1.getLiteralLexicalForm(), node2.getLiteralLexicalForm()) ;
+                if ( x != Expr.CMP_EQUAL ) {
                     // Different lang tags
                     if ( ! sortOrderingCompare )
                         raise(new ExprNotComparableException("Can't compare (different languages) "+nv1+" and "+nv2)) ;
@@ -745,11 +743,14 @@ public abstract class NodeValue extends ExprNode
                     return x ;
                 }
 
-                // same lang tag (case insensitive)
-                x = StrUtils.strCompare(node1.getLiteralLexicalForm(), node2.getLiteralLexicalForm()) ;
-                if ( x != Expr.CMP_EQUAL )
+                x = StrUtils.strCompareIgnoreCase(node1.getLiteralLanguage(), node2.getLiteralLanguage()) ;
+                if ( x != Expr.CMP_EQUAL ) {
+                    // Different lang tags
+                    if ( ! sortOrderingCompare )
+                        raise(new ExprNotComparableException("Can't compare (different languages) "+nv1+" and "+nv2)) ;
+                    // Different lang tags - sorting
                     return x ;
-                // Same lexical forms, same lang tag by value
+                }
                 // Try to split by syntactic lang tags.
                 x = StrUtils.strCompare(node1.getLiteralLanguage(), node2.getLiteralLanguage()) ;
                 // Maybe they are the same after all!

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
@@ -1102,6 +1102,26 @@ public class TestNodeValue
         assertFalse(nv1.equals(nv2));
     }
 
+    //Compare value first and then language tag  
+    @Test
+    public void testLangCompareAlways1() {
+        Node n1 = org.apache.jena.graph.NodeFactory.createLiteral("abc", "en");
+        NodeValue nv1 = NodeValue.makeNode(n1);
+        Node n2 = org.apache.jena.graph.NodeFactory.createLiteral("bcd", "ar");
+        NodeValue nv2 = NodeValue.makeNode(n2);
+        assertTrue(NodeValue.compareAlways(nv1, nv2) == -1);
+    }
+    
+    //Language tag comparison ignore case first, then case sensitive 
+    @Test
+    public void testLangCompareAlways2() {
+        Node n1 = org.apache.jena.graph.NodeFactory.createLiteral("abc", "en");
+        NodeValue nv1 = NodeValue.makeNode(n1);
+        Node n2 = org.apache.jena.graph.NodeFactory.createLiteral("abc", "FR");
+        NodeValue nv2 = NodeValue.makeNode(n2);
+        assertTrue(NodeValue.compareAlways(nv1, nv2) == -1);
+    }
+    
     @Test
     public void testEquals1() {
         NodeValue nv1 = NodeValue.makeInteger(1);


### PR DESCRIPTION
Pull request Description:
Pull request to fix  JENA-2333 issue, fixes comparison order for node values with language tags.

----
 - [x] Tests are included.
 - [JIRA Issue](https://issues.apache.org/jira/browse/JENA-2333)
By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
