### PR TITLE
GH-1419: fix DatasetGraphMap#clear 

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphMap.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphMap.java
@@ -178,6 +178,12 @@ public class DatasetGraphMap extends DatasetGraphTriplesQuads
         return g;
     }
 
+    @Override
+    public void clear() {
+        super.clear();
+        graphs.clear();
+    }
+
     /** Called from getGraph when a nonexistent graph is asked for.
      * Return null for "nothing created as a graph".
      * Sub classes can reimplement this.

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphTests.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphTests.java
@@ -328,6 +328,23 @@ public abstract class AbstractDatasetGraphTests
         assertFalse(dsg.containsGraph(gn)) ;
     }
 
+    @Test public void clear_02() {
+        DatasetGraph dsg = emptyDataset();
+        dsg.add(SSE.parseQuad("(quad _ <a0> <b0> <b0>)"));
+        dsg.add(SSE.parseQuad("(quad <g1> <a1> <b1> <b1>)"));
+        dsg.add(SSE.parseQuad("(quad <g2> <a2> <b2> <b2>)"));
+
+        assertEquals(2, dsg.size());
+        assertEquals(1, dsg.getDefaultGraph().size());
+        assertFalse(dsg.isEmpty());
+
+        dsg.clear();
+
+        assertEquals(0, dsg.size());
+        assertEquals(0, dsg.getDefaultGraph().size());
+        assertTrue(dsg.isEmpty());
+    }
+
     @Test public void graph_clear_1() {
         DatasetGraph dsg = emptyDataset() ;
         if ( ! dsg.supportsTransactions() )

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/DatasetGraphSimpleMem.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/DatasetGraphSimpleMem.java
@@ -72,6 +72,10 @@ public class DatasetGraphSimpleMem extends DatasetGraphTriplesQuads implements T
         int size() {
             return store.size();
         }
+
+        void clear() {
+            store.clear();
+        }
     }
 
     public DatasetGraphSimpleMem() {}
@@ -168,7 +172,7 @@ public class DatasetGraphSimpleMem extends DatasetGraphTriplesQuads implements T
         protected ExtendedIterator<Triple> graphBaseFind(Triple m) {
             List<Triple> results = new ArrayList<>();
             for ( Triple t : triples )
-                if ( t.matches(m.getMatchSubject(), m.getMatchPredicate(), m.getMatchObject()) )
+                if ( m.matches(t.getMatchSubject(), t.getMatchPredicate(), t.getMatchObject()) )
                     results.add(t);
             return WrappedIterator.create(results.iterator());
         }
@@ -212,6 +216,17 @@ public class DatasetGraphSimpleMem extends DatasetGraphTriplesQuads implements T
     @Override
     public Graph getGraph(Node graphNode) {
         return new GraphNamed(graphNode);
+    }
+
+    @Override
+    public void clear() {
+        triples.clear();
+        quads.clear();
+    }
+
+    @Override
+    public long size() {
+        return graphNodes().size();
     }
 
     @Override

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TS_Core.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TS_Core.java
@@ -30,6 +30,7 @@ import org.junit.runners.Suite ;
     , TestDynamicDatasetMem.class
     , TestDatasetGraphsRegular.class
     , TestDatasetGraphLink.class
+    , TestDatasetGraphMap.class
     , TestDatasetGraphCopyAdd.class
     , TestDatasetGraphViewGraphs.class
     , TestGraphView.class

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetGraphMap.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestDatasetGraphMap.java
@@ -1,0 +1,9 @@
+package org.apache.jena.sparql.core;
+
+public class TestDatasetGraphMap extends AbstractDatasetGraphTests {
+
+    @Override
+    protected DatasetGraph emptyDataset() {
+        return new DatasetGraphMap();
+    }
+}


### PR DESCRIPTION
GitHub issue resolved #1419 

Pull request Description:

- fix `DatasetGraphMap#clear`
- fix `DatasetGraphSimpleMem` (from tests): methods clear, def-graph#find
- add tests


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
