### PR TITLE
GH-1432: Fix for adding text data after TDB2 compaction

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/GSP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/GSP.java
@@ -142,7 +142,7 @@ public class GSP extends StoreProtocol<GSP> {
     }
 
     final protected void validateGraphOperation() {
-        Objects.requireNonNull(serviceEndpoint);
+        Objects.requireNonNull("Service Endpoint", serviceEndpoint);
         if ( ! defaultGraph && graphName == null )
             throw exception("Need either default graph or a graph name");
     }
@@ -314,49 +314,35 @@ public class GSP extends StoreProtocol<GSP> {
     }
 
     // Expose access for subclasses. "final" to ensure that this class controls constraints and expectations.
-    // Only valid when the request has correctly been setup.
+    // Only valid when the request has been correctly setup.
 
     final protected String graphName()           { return graphName; }
     final protected boolean isDefaultGraph()     { return graphName == null; }
     final protected boolean isGraphOperation()   { return defaultGraph || graphName != null; }
 
-    
-
-    
-
-    //    /**
-    //     * Delete a graph.
-    //     * <p>
-    //     * Synonym for {@link #DELETE()}.
-    //     */
-    //    public void deleteGraph() {
-    //        // Synonym
-    //        DELETE();
-    //    }
-    
-        private String graphRequestURL() {
-            return HttpLib.requestURL(serviceEndpoint, queryStringForGraph(graphName));
-        }
+    private String graphRequestURL() {
+        return HttpLib.requestURL(serviceEndpoint, queryStringForGraph(graphName));
+    }
 
     final protected void internalDataset() {
-            // Set as dataset request.
-            // Checking is done by validateDatasetOperation.
-            // The dataset operations have "Dataset" in the name, so less point having
-            // required dataset(). We can't use GET() because the return type
-            // would be "Graph or DatasetGraph"
-            // Reconsider if graph synonyms provided.
-            this.datasetGraph = true;
-        }
+        // Set as dataset request.
+        // Checking is done by validateDatasetOperation.
+        // The dataset operations have "Dataset" in the name, so less point having
+        // required dataset(). We can't use GET() because the return type
+        // would be "Graph or DatasetGraph"
+        // Reconsider if graph synonyms provided.
+        this.datasetGraph = true;
+    }
 
     final protected void validateDatasetOperation() {
-            Objects.requireNonNull(serviceEndpoint);
-            if ( defaultGraph )
-                throw exception("Default graph specified for dataset operation");
-            if ( graphName != null )
-                throw exception("A graph name specified for dataset operation");
-            if ( ! datasetGraph )
-                throw exception("Dataset request not specified for dataset operation");
-        }
+        Objects.requireNonNull("Service Endpoint", serviceEndpoint);
+        if ( defaultGraph )
+            throw exception("Default graph specified for dataset operation");
+        if ( graphName != null )
+            throw exception("A graph name specified for dataset operation");
+        if ( ! datasetGraph )
+            throw exception("Dataset request not specified for dataset operation");
+    }
 
     // Redirect
     /** @deprecated Use {@link DSP#GET()} */

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
@@ -145,7 +145,6 @@ public class IOX {
         }
     }
 
-
     public static void deleteAll(String start) {
         deleteAll(Paths.get(start));
     }
@@ -155,6 +154,8 @@ public class IOX {
      * Walks down the tree and deletes directories on the way backup.
      */
     public static void deleteAll(Path start) {
+        if ( ! Files.exists(start) )
+            return;
         try {
             Files.walkFileTree(start, new SimpleFileVisitor<Path>() {
                 @Override

--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
@@ -362,4 +362,15 @@ public class LogCtl {
             throw new AtlasException(ex);
         }
     }
+
+    /** Execute with a given logging level. */
+    public static void withLevel(Logger logger, String execLevel, Runnable action) {
+        String currentLevel = getLevel(logger);
+        try {
+            setLevel(logger, execLevel);
+            action.run();
+        } finally {
+            setLevel(logger, currentLevel);
+        }
+    }
 }

--- a/jena-integration-tests/pom.xml
+++ b/jena-integration-tests/pom.xml
@@ -106,6 +106,12 @@
       <version>4.6.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
+    </dependency>  
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-text</artifactId>
+      <version>4.6.0-SNAPSHOT</version>
     </dependency>
 
     <!-- The test artifacts to go with apache-jena-libs -->

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/TC_Integration.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/TC_Integration.java
@@ -27,6 +27,7 @@ import org.apache.jena.test.integration.TS_Integration;
 import org.apache.jena.test.rdfconnection.TS_RDFConnectionIntegration;
 import org.apache.jena.test.rdflink.TS_RDFLinkIntegration;
 import org.apache.jena.test.service.TS_SPARQLService;
+import org.apache.jena.test.text.TestTextTDB2Compact;
 import org.apache.jena.test.txn.TS_TranactionIntegration;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -44,6 +45,7 @@ import org.junit.runners.Suite;
     , TestRemoteEndToEnd.class
     , TS_SPARQLService.class
     , TS_GeoSPARQL.class
+    , TestTextTDB2Compact.class
 })
 
 public class TC_Integration { }

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/TC_Integration.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/TC_Integration.java
@@ -20,12 +20,12 @@ package org.apache.jena.test;
 
 import org.apache.jena.geosparql.TS_GeoSPARQL;
 import org.apache.jena.http.TS_JenaHttp;
-import org.apache.jena.integration.TS_RDFLinkIntegration;
 import org.apache.jena.sparql.exec.http.TS_SparqlExecHttp;
 import org.apache.jena.test.assembler.TS_Assembler;
 import org.apache.jena.test.general.TestRemoteEndToEnd;
 import org.apache.jena.test.integration.TS_Integration;
 import org.apache.jena.test.rdfconnection.TS_RDFConnectionIntegration;
+import org.apache.jena.test.rdflink.TS_RDFLinkIntegration;
 import org.apache.jena.test.service.TS_SPARQLService;
 import org.apache.jena.test.txn.TS_TranactionIntegration;
 import org.junit.runner.RunWith;

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/integration/TestDatasetPrefixes.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/integration/TestDatasetPrefixes.java
@@ -56,7 +56,6 @@ import org.junit.runners.Parameterized.Parameters;
  * See {@code AbstractTestPrefixMap} for tests of prefix maps in general.
  */
 
-
 @FixMethodOrder(MethodSorters.JVM)
 @RunWith(Parameterized.class)
 public class TestDatasetPrefixes {

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TS_RDFLinkIntegration.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TS_RDFLinkIntegration.java
@@ -16,24 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.jena.integration;
+package org.apache.jena.test.rdflink;
 
-import org.apache.jena.rdfconnection.Isolation;
-import org.apache.jena.rdflink.AbstractTestRDFLink;
-import org.apache.jena.rdflink.RDFLink;
-import org.apache.jena.rdflink.RDFLinkFactory;
-import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.tdb2.DatabaseMgr;
+import org.junit.runner.RunWith ;
+import org.junit.runners.Suite ;
 
-public class TestRDFLinkLocalTDB2 extends AbstractTestRDFLink {
+@RunWith(Suite.class)
+@Suite.SuiteClasses( {
+    // Done in the module
+    //    TestRDFLinkLocalTxnMem
+    //    TestRDFLinkLocalMRSW
 
-    @Override
-    protected boolean supportsAbort() { return true ; }
+    // Addition tests added here.
+    TestRDFLinkLocalTDB.class,
+    TestRDFLinkLocalTDB2.class,
+    TestRDFLinkHTTP.class,
+    TestRDFLinkFuseki.class,
+    TestRDFLinkFusekiBinary.class
+})
 
-    @Override
-    protected RDFLink link() {
-        DatasetGraph dsg = DatabaseMgr.createDatasetGraph() ;
-        return RDFLinkFactory.connect(dsg, Isolation.COPY) ;
-    }
-}
-
+public class TS_RDFLinkIntegration {}

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkFuseki.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkFuseki.java
@@ -16,23 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.jena.integration;
+package org.apache.jena.test.rdflink;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
+import org.apache.jena.rdflink.RDFLink;
+import org.apache.jena.rdflink.RDFLinkFactory;
+import org.apache.jena.rdflink.RDFLinkFuseki;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
-    // Done in the module
-    //    TestRDFLinkLocalTxnMem
-    //    TestRDFLinkLocalMRSW
+public class TestRDFLinkFuseki extends TestRDFLinkHTTP {
+    @Override
+    protected RDFLink link() {
+        return RDFLinkFactory.connectFuseki("http://localhost:"+PORT+"/ds");
+    }
 
-    // Addition tests added here.
-    TestRDFLinkLocalTDB.class,
-    TestRDFLinkLocalTDB2.class,
-    TestRDFLinkHTTP.class,
-    TestRDFLinkFuseki.class,
-    TestRDFLinkFusekiBinary.class
-})
+    @Override
+    protected boolean defaultToCheckQueries() { return false; }
 
-public class TS_RDFLinkIntegration {}
+    @Override
+    protected RDFLink link(boolean parseCheckSPARQL) {
+        return RDFLinkFuseki.service("http://localhost:"+PORT+"/ds").parseCheckSPARQL(parseCheckSPARQL).build();
+    }
+}

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkFusekiBinary.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkFusekiBinary.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.integration;
+package org.apache.jena.test.rdflink;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkHTTP.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkHTTP.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.integration;
+package org.apache.jena.test.rdflink;
 
 import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.fuseki.Fuseki ;

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkLocalTDB.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkLocalTDB.java
@@ -16,23 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.jena.integration;
+package org.apache.jena.test.rdflink;
 
+import org.apache.jena.rdfconnection.Isolation;
+import org.apache.jena.rdflink.AbstractTestRDFLink;
 import org.apache.jena.rdflink.RDFLink;
 import org.apache.jena.rdflink.RDFLinkFactory;
-import org.apache.jena.rdflink.RDFLinkFuseki;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.tdb.TDBFactory ;
 
-public class TestRDFLinkFuseki extends TestRDFLinkHTTP {
+public class TestRDFLinkLocalTDB extends AbstractTestRDFLink {
+
+    @Override
+    protected boolean supportsAbort() { return true ; }
+
     @Override
     protected RDFLink link() {
-        return RDFLinkFactory.connectFuseki("http://localhost:"+PORT+"/ds");
-    }
-
-    @Override
-    protected boolean defaultToCheckQueries() { return false; }
-
-    @Override
-    protected RDFLink link(boolean parseCheckSPARQL) {
-        return RDFLinkFuseki.service("http://localhost:"+PORT+"/ds").parseCheckSPARQL(parseCheckSPARQL).build();
+        DatasetGraph dsg = TDBFactory.createDatasetGraph() ;
+        return RDFLinkFactory.connect(dsg, Isolation.COPY) ;
     }
 }
+

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkLocalTDB2.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkLocalTDB2.java
@@ -16,23 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.jena.integration;
+package org.apache.jena.test.rdflink;
 
 import org.apache.jena.rdfconnection.Isolation;
 import org.apache.jena.rdflink.AbstractTestRDFLink;
 import org.apache.jena.rdflink.RDFLink;
 import org.apache.jena.rdflink.RDFLinkFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.tdb.TDBFactory ;
+import org.apache.jena.tdb2.DatabaseMgr;
 
-public class TestRDFLinkLocalTDB extends AbstractTestRDFLink {
+public class TestRDFLinkLocalTDB2 extends AbstractTestRDFLink {
 
     @Override
     protected boolean supportsAbort() { return true ; }
 
     @Override
     protected RDFLink link() {
-        DatasetGraph dsg = TDBFactory.createDatasetGraph() ;
+        DatasetGraph dsg = DatabaseMgr.createDatasetGraph() ;
         return RDFLinkFactory.connect(dsg, Isolation.COPY) ;
     }
 }

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/text/TestTextTDB2Compact.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/text/TestTextTDB2Compact.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.test.text;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.atlas.io.IOX;
+import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.atlas.logging.LogCtl;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.http.HttpOp;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.exec.RowSet;
+import org.apache.jena.sparql.exec.http.GSP;
+import org.apache.jena.sys.JenaSystem;
+import org.junit.Test;
+
+/** A test of running TDB2 compaction on the storage of a text dataset. */
+public class TestTextTDB2Compact {
+    static { JenaSystem.init(); }
+
+    @Test
+    public void tdb2CompactText() {
+        LogCtl.withLevel(Fuseki.compactLog, "WARN", ()->execTdb2CompactText());
+    }
+
+    private static void execTdb2CompactText() {
+        // GH-1432
+        // Input files.
+        String DIR = "testing/TextIndex";
+        // Target
+        String DB = "target/text_tdb2";
+
+        // Ensure a clean setup.
+        IOX.deleteAll(DB);
+        FileOps.ensureDir(DB);
+
+        FusekiServer server =
+                FusekiServer.create()
+                    .port(0)
+                    .parseConfigFile(DIR+"/conf-tdb2-text.ttl")
+                    .enableCompact(true)
+                    .start();
+        try {
+            String serverURL = "http://localhost:"+server.getHttpPort();
+            HttpOp.httpPost(serverURL+"/$/compact/fedora");
+            Lib.sleep(50);
+            // Load data after compact
+            GSP.service(serverURL+"/fedora").defaultGraph().POST(DIR+"/D1.ttl");
+            RowSet rs = QueryExec.service(serverURL+"/fedora")
+                                 .query("PREFIX text:    <http://jena.apache.org/text#> SELECT * { ?x text:query 'Title' }")
+                                 .build()
+                                 .select();
+            assertTrue(rs.hasNext());
+        } finally {
+            server.stop();
+        }
+    }
+}

--- a/jena-integration-tests/testing/TextIndex/D1.ttl
+++ b/jena-integration-tests/testing/TextIndex/D1.ttl
@@ -1,0 +1,10 @@
+PREFIX :        <http://example/> 
+
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh:      <http://www.w3.org/ns/shacl#>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+
+:x1 dc:title "Title 1" .

--- a/jena-integration-tests/testing/TextIndex/D2.ttl
+++ b/jena-integration-tests/testing/TextIndex/D2.ttl
@@ -1,0 +1,11 @@
+PREFIX :        <http://example/> 
+
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh:      <http://www.w3.org/ns/shacl#>
+PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+PREFIX dc:      <http://purl.org/dc/elements/1.1/>
+
+#:x2 dc:title "Title text for x2" .
+:x2 dc:title "Title 2" .

--- a/jena-integration-tests/testing/TextIndex/conf-tdb2-text.ttl
+++ b/jena-integration-tests/testing/TextIndex/conf-tdb2-text.ttl
@@ -1,0 +1,44 @@
+@prefix :       <http://base/#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+@prefix ja:     <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb2:   <http://jena.apache.org/2016/tdb#> .
+@prefix text:   <http://jena.apache.org/text#> .
+@prefix dc:     <http://purl.org/dc/elements/1.1/> .
+@prefix ibron:  <http://surf.nl/ibron/item/2020/07/> .
+
+:service_tdb_all  rdf:type fuseki:Service ;
+    fuseki:name            "fedora" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-r ;  ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; ] ; 
+    fuseki:endpoint [ fuseki:operation fuseki:upload ; ] ; 
+    fuseki:dataset                :text_dataset ;
+    .
+
+:text_dataset rdf:type text:TextDataset ;
+    text:dataset :tdb_dataset_readwrite ;
+    text:index <#lucene> ;
+    .
+
+:tdb_dataset_readwrite rdf:type       tdb2:DatasetTDB2 ;
+    tdb2:location  "target/text_tdb2/db2" .
+
+<#lucene> a text:TextIndexLucene ;
+    text:directory "target/text_tdb2/lucene";
+    text:storeValues true ;
+    text:entityMap <#entity-map> ;
+    .
+
+<#entity-map> a text:EntityMap ;
+    text:entityField "uri" ;
+    text:defaultField "text" ;  ## Must be defined in the text:map
+    text:uidField "uid" ;
+    text:langField "lang" ;
+    text:map (
+         [ text:field "text" ; text:predicate dc:title ]
+         )
+     .
+     

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextDocProducerTriples.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextDocProducerTriples.java
@@ -31,6 +31,7 @@ public class TextDocProducerTriples implements TextDocProducer {
     // Have to have a ThreadLocal here to keep track of whether or not we are in a transaction,
     // therefore whether or not we have to do autocommit
     private final ThreadLocal<Boolean> inTransaction = new ThreadLocal<Boolean>() {
+
         @Override
         protected Boolean initialValue() {
             return Boolean.FALSE ;
@@ -63,7 +64,6 @@ public class TextDocProducerTriples implements TextDocProducer {
              qaction != TextQuadAction.DELETE )
             return ;
 
-
         Entity entity = TextQueryFuncs.entityFromQuad(defn, g, s, p, o) ;
         // Null means does not match defn
         if ( entity != null ) {
@@ -71,17 +71,15 @@ public class TextDocProducerTriples implements TextDocProducer {
                 indexer.addEntity(entity);
 
                 // Auto commit the entity if we aren't in a transaction
-                if (!inTransaction.get()) {
+                if (!inTransaction.get())
                     indexer.commit();
-                }
             }
             else if (qaction == TextQuadAction.DELETE) {
                 indexer.deleteEntity(entity);
 
                 // Auto commit the entity if we aren't in a transaction
-                if (!inTransaction.get()) {
+                if (!inTransaction.get())
                     indexer.commit();
-                }
             }
         }
     }

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexDB.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexDB.java
@@ -25,7 +25,7 @@ import org.apache.jena.dboe.transaction.txn.TransactionalComponentBase;
 import org.apache.jena.dboe.transaction.txn.TxnId;
 import org.apache.jena.query.ReadWrite;
 
-/** 
+/**
  * Adapter to put Lucene into DBOE transactions.
  */
 public class TextIndexDB extends TransactionalComponentBase<TextIndexDB.TextState> {
@@ -41,10 +41,9 @@ public class TextIndexDB extends TransactionalComponentBase<TextIndexDB.TextStat
 
     @Override
     protected TextState _begin(ReadWrite readWrite, TxnId txnId) {
-        // Need to MRSW?
         return new TextState();
     }
-    
+
 //    @Override
 //    protected TextState _promote(TxnId txnId, TextState oldState) {
 //        return null;
@@ -75,5 +74,5 @@ public class TextIndexDB extends TransactionalComponentBase<TextIndexDB.TextStat
 //
 //    @Override
 //    protected void _shutdown() {}
-    
+
 }


### PR DESCRIPTION
GitHub issue resolved #1432

Pull request Description:

jena-text integrates with TDB2 by adding a `TransactionalComponent` and becoming part of the TDB/DBOW transaction system.

The bug is that the added `TransactionalComponent` is in the storage database, not the switchable database. The storage database is rewritten and rebuilt by a compaction and the added component gets lost.


----

 - [x] Tests are included.
 - [N/A] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
