### PR TITLE
Silence integration tests

### DIFF
--- a/jena-integration-tests/src/test/java/org/apache/jena/sparql/exec/http/TestService.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/sparql/exec/http/TestService.java
@@ -46,9 +46,10 @@ import org.apache.jena.sparql.core.DatasetGraphZero;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
-import org.apache.jena.sparql.service.ServiceExecutorRegistry;
 import org.apache.jena.sparql.exec.QueryExec;
 import org.apache.jena.sparql.exec.RowSet;
+import org.apache.jena.sparql.service.ServiceExecutorRegistry;
+import org.apache.jena.sparql.service.single.ServiceExecutorHttp;
 import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.sparql.syntax.Element;
 import org.apache.jena.sparql.syntax.ElementGroup;
@@ -185,7 +186,7 @@ public class TestService {
     }
 
     @Test public void service_query_silent_no_service() {
-        logOnlyErrors(ServiceExecutorRegistry.class, ()->{
+        logOnlyErrors(ServiceExecutorHttp.class, ()->{
             DatasetGraph dsg = env.dsg();
             String queryString = "SELECT * { SERVICE SILENT <"+SERVICE+"JUNK> { VALUES ?X { 1 2 } }} ";
             try ( RDFLink link = RDFLinkFactory.connect(localDataset()) ) {
@@ -201,7 +202,7 @@ public class TestService {
     }
 
     @Test public void service_query_silent_nosite() {
-        logOnlyErrors(ServiceExecutorRegistry.class, ()->{
+        logOnlyErrors(ServiceExecutorHttp.class, ()->{
             DatasetGraph dsg = env.dsg();
             String queryString = "SELECT * { SERVICE SILENT <http://nosuchsite/> { VALUES ?X { 1 2 } }} ";
             try ( RDFLink link = RDFLinkFactory.connect(localDataset()) ) {

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/service/TestServiceExec.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/service/TestServiceExec.java
@@ -27,7 +27,7 @@ import org.apache.jena.query.*;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
-import org.apache.jena.sparql.service.ServiceExecutorRegistry;
+import org.apache.jena.sparql.service.single.ServiceExecutorHttp;
 import org.apache.jena.sparql.sse.SSE;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -72,7 +72,7 @@ public class TestServiceExec {
 
     @Test
     public void service_exec_3() {
-        Class<?> logClass = ServiceExecutorRegistry.class;
+        Class<?> logClass = ServiceExecutorHttp.class;
         String logLevel = LogCtl.getLevel(logClass);
         try {
             LogCtl.setLevel(logClass, "ERROR");

--- a/jena-integration-tests/src/test/resources/log4j2.properties
+++ b/jena-integration-tests/src/test/resources/log4j2.properties
@@ -46,6 +46,9 @@ logger.fuseki-admin.level = WARN
 logger.jetty.name  = org.eclipse.jetty
 logger.jetty.level = WARN
 
+logger.geosparql-registry.name = org.apache.jena.geosparql.implementation.registry.SRSRegistry
+logger.geosparql-registry.level = ERROR
+
 # May be useful to turn up to DEBUG if debugging HTTP communication issues
 logger.apache-http.name   = org.apache.http
 logger.apache-http.level  = WARN


### PR DESCRIPTION
Make the integration tests run without warning outputs.

The Release Manager does not detailed knowledge of each and every component in jena,. Expected logging should be suppressed so that a correct test run has no output.

----
By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
