### PR TITLE
JENA-2339: Dynamic graph restriction extension

### DIFF
--- a/MOVE_ME_DynamicACL_notes.md
+++ b/MOVE_ME_DynamicACL_notes.md
@@ -1,0 +1,65 @@
+# Proposal: Extension to jena-fuseki-access to support dynamic ACL
+
+## What
+
+`jena-fuseki-access` already offers the means to restrict graph visibility in a dataset on a per-user basis, configurable in Fuseki on startup (or whenever a new dataset is added).
+This proposal:
+
+1. Includes a new "dynamic" visibility restriction such that the set of visible graphs can be chosen on a per-query basis
+2. Has no impact on existing ACL functionality
+3. Defaults to "no graph visibility"
+3. Is designed for intermediate (rather than end-user) applications (see "Why" below.)
+
+## Why
+
+A use-case we're exploring models metadata as many small individual graphs, each with a handful or related subjects and their properties. The aim is to allow our users to query said metadata via SPARQL whilst restricting visibility to a subset of all graphs. The set of users, graphs stored and associated ACLs are dynamic in nature and not a good fit for the current fixed configuration model.
+In our use-case, we can calculate the set of "allowed" graphs at the time a user requests to run a SPARQL query and thus can supply the ACL to Fuseki on a per-query basis.
+
+Since this proposal is generic in nature (and only a small extension to the existing `jena-fuseki-access` module), we'd like to gauge:
+
+1. Is a useful extension that the Jena Community would consider for inclusion in upcoming releases?
+2. Are better ways to support such a feature?
+3. Are there any other concerns/considerations/question beyond what is documented here and in the accompanied PR?
+
+### Alternatives
+
+- Why not implemented this in [Jena Permissions](https://jena.apache.org/documentation/permissions/evaluator.html)? Because right now it can reason about individual graphs/models, not whole datasets. In addition this is expected to not perform as well as Fuseki ACL, which uses TDB hooks. (See also previous discussion [here](https://jena.markmail.org/thread/d44ecdeyn4dnspgx).)
+
+- Why not implement this is a query-rewrite, applying a set of `FROM` clauses to restrict visibility? This would require parsing of the input query (or modification of the generated `Query` object) and from limited testing, a large set of FROM clauses does not perform very well. (See same discussion as in above bullet point.)
+
+## How
+
+### High-level flow
+
+1. The (ACL-enabled) target dataset is assigned a user which enables the new dynamic behaviour, i.e.:
+    ```turtle
+    access:entry ("theUser" <urn:jena:accessGraphsDynamic>) ;
+    ```
+    - **Note**: If there is more than one graph listed, the user behaves like before, i.e. dynamic mode is not enabled.
+
+2. A service/proxy (i.e. something intermediate leveraging Fuseki) receives a SPARQL request and based on it's understanding of users/roles/other calculates the set of visible graphs.
+
+3. The SPARQL query, run as Fuseki user `theUser`, is prefixed with the calculated set of visible graphs (here `graph:one`, `graph:two` and `graph:three`):
+   ```sparql
+   #pragma acl.graphs graph:one|graph:two|graph:three
+   SELECT * WHERE {
+      ...
+   }
+   ```
+    - **Note**: An invalid or missing `#pragma` or one without any graphs specified will result in no graphs being visible.
+    - End-users are of course not meant to be directly authenticating as `theUser` in this dynamic mode.
+    - Why does the proposal read the set of allowed graphs from a preamble/comment in the query rather than either an HTTP header or a URL parameter? Because both of these have fairly low maximum size expectations (by REST servers) such that it's not feasible to store 100s of graph URIs in them.
+
+4. When the query is executed, access is restricted to the previously provided set of graphs
+    - **Note**: The dynamic behaviour only applies to SPARQL queries, not [GSP](https://www.w3.org/TR/sparql11-http-rdf-update). If a GSP request is made, no graphs are visible.
+
+### Technical summary
+
+1. A new `SecurityContext` implementation, `SecurityContextDynamic`, acts as the marker to indicate that the visible graphs should be chosen from the query preamble.
+    - `AssemblerSecurityRegistry` detects this new mode and choose the `SecurityContext` accordingly.
+
+2. When a SPARQL query hits `AccessCtl_SPARQL_QueryDataset`, the raw query string (and thus `#pragma`) are stored in the `HttpAction`'s context.
+
+3. If (based on user) the determined security context is dynamic, the query is parsed to construct a new `SecurityContextView` with the set of chosen graphs.
+
+4. Thereafter execution and ACL guarantees are the same as for pre-existing ACL functionality

--- a/jena-fuseki2/jena-fuseki-access/pom.xml
+++ b/jena-fuseki2/jena-fuseki-access/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-fuseki</artifactId>
     <version>4.6.0-SNAPSHOT</version>
-  </parent> 
+  </parent>
 
   <packaging>jar</packaging>
   
@@ -44,6 +44,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/AssemblerSecurityRegistry.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/AssemblerSecurityRegistry.java
@@ -83,8 +83,13 @@ public class AssemblerSecurityRegistry extends AssemblerBase {
         });
 
         map.keySet().forEach(u->{
-            SecurityContext sCxt = new SecurityContextView(map.get(u));
-            registry.put(u, sCxt);
+            Collection<Node> visibleGraphs = map.get(u);
+            // Dynamic mode is only activated if the marker is the only entry for this user
+            if ( visibleGraphs.size() == 1 && visibleGraphs.contains(SecurityContextDynamic.dynamicAccess)) {
+                registry.put(u, SecurityContext.DYNAMIC);
+            } else {
+                registry.put(u, new SecurityContextView(visibleGraphs));
+            }
         });
 
         return registry;

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContext.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContext.java
@@ -40,6 +40,7 @@ import org.apache.jena.sparql.util.Context;
 public interface SecurityContext {
     public static final SecurityContext NONE = new SecurityContextAllowNone();
     public static final SecurityContext ALL = new SecurityContextAllowAll();
+    public static final SecurityContext DYNAMIC = new SecurityContextDynamic();
     public static SecurityContext ALL_NG(DatasetGraph dsg) {
         Collection<Node> names = Iter.toList(dsg.listGraphNodes());
         //return new SecurityContextAllowNamedGraphs(dsg);

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextDynamic.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/SecurityContextDynamic.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.access;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+
+/** A {@link SecurityContext} that provides no access itself but indicates that the set of visible graphs should be
+ * constructed from a set embedded in the query. Use {@link SecurityContextDynamic#instantiateFromQuery} to create the
+ * query-specific set of graphs to filter.
+ * This context is not meant to be used directly by end users: The initial query has a list of visible graphs prepended
+ * before execution based on use-case specific criteria, with the following format:
+ *
+ * #pragma acl.graphs <graph1>|<graph2>|..|<graphN>
+ *
+ */
+public class SecurityContextDynamic extends SecurityContextAllowNone {
+
+    public static final Node dynamicAccess = NodeFactory.createURI("urn:jena:accessGraphsDynamic");
+
+    public static final String GRAPH_PRAGMA_DELIMITER = "|";
+    private static final Pattern GRAPH_PRAGMA_DELIMITER_PATTERN = Pattern.compile("\\" + GRAPH_PRAGMA_DELIMITER);
+    private static final String GRAPH_PRAGMA_PATTERN_GROUP = "graphs";
+    private static final Pattern GRAPH_PRAGMA_PATTERN = Pattern.compile(
+        "^" +
+        // Leading whitespace
+        "\\s*" +
+        // For simplicity, expect pragma on first non-whitespace line
+        "#pragma acl\\.graphs\\h+(?<" + GRAPH_PRAGMA_PATTERN_GROUP + ">\\S*)\\h*\\v" +
+        // Anything else
+        ".*",
+        Pattern.DOTALL
+    );
+
+    public static SecurityContext forQuery(String queryString) {
+        if ( queryString != null ) {
+            Matcher m = GRAPH_PRAGMA_PATTERN.matcher(queryString);
+            if ( m.matches() ) {
+                String[] graphs = GRAPH_PRAGMA_DELIMITER_PATTERN
+                    .splitAsStream(m.group(GRAPH_PRAGMA_PATTERN_GROUP))
+                    .map(String::trim)
+                    .toArray(String[]::new);
+                if ( graphs.length > 0 ) {
+                    return new SecurityContextView(graphs);
+                }
+            }
+        }
+        /* Note: SecurityContext.ALL is not supported since according to AssemblerSecurityRegistry support for
+         *  urn:jena:accessAllGraphs (*) and urn:jena:accessAllNamedGraphs (**) is unfinished.
+         */
+        return SecurityContext.NONE;
+    }
+}

--- a/jena-fuseki2/jena-fuseki-access/src/test/java/org/apache/jena/fuseki/access/TS_Access.java
+++ b/jena-fuseki2/jena-fuseki-access/src/test/java/org/apache/jena/fuseki/access/TS_Access.java
@@ -27,6 +27,7 @@ import org.junit.runners.Suite;
     // These integration test are in jena-fuseki-main:org.apache.jena.fuseki.main.access
     TestSecurityFilterLocal.class
     , TestSecurityRegistry.class
+    , TestSecurityContextDynamic.class
 })
 
 public class TS_Access {

--- a/jena-fuseki2/jena-fuseki-access/src/test/java/org/apache/jena/fuseki/access/TestSecurityContextDynamic.java
+++ b/jena-fuseki2/jena-fuseki-access/src/test/java/org/apache/jena/fuseki/access/TestSecurityContextDynamic.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.access;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+// Note: JUnit 4 does not support parameterized tests
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Test parsing of assemblers with security aspects */
+@RunWith(JUnitParamsRunner.class)
+public class TestSecurityContextDynamic {
+
+    private static final String ACL_PRAGMA = "#pragma acl.graphs";
+    private static final String ONE_GRAPH_PRAGMA = ACL_PRAGMA + " some:graph";
+
+    @Test
+    @Parameters({
+        // empty
+        "",
+        // other comments before pragma
+        "# Comment\n" + ONE_GRAPH_PRAGMA,
+        // pragma after grammar start
+        "PREFIX ex: http://example.org/\n" + ONE_GRAPH_PRAGMA,
+        // without space delimiter
+        ACL_PRAGMA + "some:graph",
+        // with empty graph list
+        ACL_PRAGMA + " ",
+    })
+    public void forQuery_returns_allow_none_context_when_pragma_not_matched(String preamble) {
+        final String query = "\nSELECT 1 {}";
+
+        SecurityContext sCxt = SecurityContextDynamic.forQuery(preamble + query);
+
+        assertEquals(SecurityContext.NONE, sCxt);
+    }
+
+    @Test
+    @Parameters(method="graphValues")
+    public void forQuery_returns_expected_context_when_pragma_matched(String[] graphs) {
+        final String query = "\nSELECT 1 {}";
+
+        String graphString = String.join(SecurityContextDynamic.GRAPH_PRAGMA_DELIMITER, graphs);
+
+        SecurityContext sCxt = SecurityContextDynamic.forQuery(ACL_PRAGMA + " " + graphString + query);
+
+        assertFalse(sCxt.visableDefaultGraph());
+        assertEquals(graphs.length, sCxt.visibleGraphs().size());
+        assertTrue(sCxt.visibleGraphNames().containsAll(Arrays.asList(graphs)));
+    }
+    private Object[] graphValues() {
+        return new Object[]{
+            new Object[]{new String[]{"graph:one"}},
+            new Object[]{new String[]{"graph:one", "graph:two"}},
+            new Object[]{new String[]{"graph:one", "graph:two", "graph:three"}},
+        };
+    }
+
+}

--- a/jena-fuseki2/jena-fuseki-access/src/test/java/org/apache/jena/fuseki/access/TestSecurityRegistry.java
+++ b/jena-fuseki2/jena-fuseki-access/src/test/java/org/apache/jena/fuseki/access/TestSecurityRegistry.java
@@ -18,7 +18,11 @@
 
 package org.apache.jena.fuseki.access;
 
+import java.util.Collection;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 import org.apache.jena.graph.Node;
@@ -67,6 +71,25 @@ public class TestSecurityRegistry {
             assertEquals(1, sCxt.visibleGraphs().size());
             Node x = sCxt.visibleGraphs().stream().findFirst().get();
             assertEquals(SecurityContext.allGraphs, x);
+        }
+
+        {
+            SecurityContext sCxt = authService.get("user4");
+            assertTrue(sCxt instanceof SecurityContextDynamic);
+            // In dynamic mode, the security context forbids everything
+            assertFalse(sCxt.visableDefaultGraph());
+            assertEquals(0, sCxt.visibleGraphs().size());
+        }
+
+        {
+            SecurityContext sCxt = authService.get("user5");
+            // Use has dynamic mode marker, but other graphs also specified => no dynamic mode
+            assertFalse(sCxt instanceof SecurityContextDynamic);
+            assertFalse(sCxt.visableDefaultGraph());
+            assertEquals(2, sCxt.visibleGraphs().size());
+            Collection<String> graphNames = sCxt.visibleGraphNames();
+            assertTrue(graphNames.contains("http://host/graphname2"));
+            assertTrue(graphNames.contains("urn:jena:accessGraphsDynamic"));
         }
 
         {

--- a/jena-fuseki2/jena-fuseki-access/testing/SecurityRegistry/assem-security-registry-2.ttl
+++ b/jena-fuseki2/jena-fuseki-access/testing/SecurityRegistry/assem-security-registry-2.ttl
@@ -23,12 +23,16 @@ PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
 PREFIX access:  <http://jena.apache.org/access#>
 
 <#securityRegistry> rdf:type access:SecurityRegistry ;
-    ## user1, all named graphs                     
+    ## user1, all named graphs
     access:entry ("user1" "*") ;
     ## user2, all graphs
     access:entry ("user2" "**") ;
     ## user3, all graphs, as named + dft.
     access:entry ("user3" "*" <urn:x-arq:DefaultGraph>) ;
+    ## user4, dynamic mode marker
+    access:entry ("user4" <urn:jena:accessGraphsDynamic>) ;
+    ## user5, dynamic mode marker, but other graphs also specified => no dynamic mode
+    access:entry ("user5" <urn:jena:accessGraphsDynamic> <http://host/graphname2>) ;
     ## any user
     access:entry ("*" <http://host/graphname1> ) ;
     .

--- a/jena-fuseki2/jena-fuseki-main/testing/Access/assem-security-shared.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Access/assem-security-shared.ttl
@@ -55,6 +55,10 @@ PREFIX access:  <http://jena.apache.org/access#>
     access:entry [ access:user "user3" ; access:graphs (<http://host/graphname3> <http://host/graphname4> ) ] ;
     access:entry [ access:user "user3" ; access:graphs <http://host/graphname5> ] ;
     access:entry [ access:user "userZ" ; access:graphs <http://host/graphnameZ> ] ;
+    # "accessGraphsDynamic" as only entry activates dynamic mode
+    access:entry [ access:user "userDyn"; access:graphs <urn:jena:accessGraphsDynamic> ] ;
+    # Dynamic access is NOT enabled since "accessGraphsDynamic" is not the only entry
+    access:entry [ access:user "userNoDyn"; access:graphs (<urn:jena:accessGraphsDynamic> <http://host/graphname3>) ] ;
     .
 ## Dataset 2
 ## No data access control.
@@ -73,4 +77,3 @@ PREFIX access:  <http://jena.apache.org/access#>
     tdb2:location "--mem--" ;
     tdb2:unionDefaultGraph true ;
     .
-

--- a/jena-fuseki2/jena-fuseki-main/testing/Access/assem-security.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Access/assem-security.ttl
@@ -61,6 +61,10 @@ PREFIX access:  <http://jena.apache.org/access#>
     access:entry [ access:user "user3" ; access:graphs (<http://host/graphname3> <http://host/graphname4> ) ] ;
     access:entry [ access:user "user3" ; access:graphs <http://host/graphname5> ] ;
     access:entry [ access:user "userZ" ; access:graphs <http://host/graphnameZ> ] ;
+    # "accessGraphsDynamic" as only entry activates dynamic mode
+    access:entry [ access:user "userDyn"; access:graphs <urn:jena:accessGraphsDynamic> ] ;
+    # Dynamic access is NOT enabled since "accessGraphsDynamic" is not the only entry
+    access:entry [ access:user "userNoDyn"; access:graphs (<urn:jena:accessGraphsDynamic> <http://host/graphname3>) ] ;
     .
 
 ## Dataset 2
@@ -78,4 +82,3 @@ PREFIX access:  <http://jena.apache.org/access#>
 <#tdb_dataset> rdf:type      tdb2:DatasetTDB2 ;
     tdb2:location "--mem--" ;
     .
-    


### PR DESCRIPTION
Jira issue: https://issues.apache.org/jira/browse/JENA-2339

**Pull request Description**:

Extend `jena-fuseki-access` to support dynamic graph visibility choice at query time. The details of the what/why/how I've put in a [separate document](https://github.com/vtermanis/jena/blob/dynamic-graph-restriction-extension/MOVE_ME_DynamicACL_notes.md) (simply due to the amount of information).

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
    - Not yet - would like to hear whether the extension is likely to be accepted in some form
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)
    - I've left a separate "to remove" commit with just a markdown page detailing the what/why/how which can be removed later.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).

**Edit**: Please note: I'm on leave until 24/07 so I won't be able to respond to feedback/questions until then.