### PR TITLE
Improve handling of external transactional components

### DIFF
--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/recovery/TestRecovery.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/recovery/TestRecovery.java
@@ -52,8 +52,8 @@ public class TestRecovery {
     private String data;
     private String data1;
     private String data2;
-    private static String loggerLevel; 
-    
+    private static String loggerLevel;
+
     @BeforeClass public static void beforeClass() {
         loggerLevel = LogCtl.getLevel(SysDB.syslog);
         LogCtl.setLevel(SysDB.syslog, "WARNING");
@@ -61,7 +61,7 @@ public class TestRecovery {
     @AfterClass public static void afterClass() {
         LogCtl.setLevel(SysDB.syslog, loggerLevel);
     }
-    
+
     @Before public void before() {
         journal  = dir.getRoot().getAbsolutePath() + "/journal.jrnl";
         data  = dir.getRoot().getAbsolutePath() + "/blob.data";
@@ -94,7 +94,8 @@ public class TestRecovery {
             journal.close();
         }
 
-        TransactionCoordinator coord = new TransactionCoordinator(Location.create(dir.getRoot().getAbsolutePath()));
+        Location location = Location.create(dir.getRoot().getAbsolutePath());
+        TransactionCoordinator coord = TransactionCoordinator.create(location);
         BufferChannel chan = BufferChannelFile.create(data);
         TransBlob tBlob = new TransBlob(cid, chan);
         coord.add(tBlob);

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/TransactionalFactory.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/TransactionalFactory.java
@@ -32,7 +32,7 @@ public class TransactionalFactory {
 
     /** Create, and start, management of a number of {@link TransactionalComponent}s */
     public static Transactional createTransactional(Location location, TransactionalComponent ... elements) {
-        TransactionCoordinator coord = new TransactionCoordinator(location);
+        TransactionCoordinator coord = TransactionCoordinator.create(location);
         return createTransactional(coord, elements);
     }
 

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/ComponentGroup.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/ComponentGroup.java
@@ -39,7 +39,7 @@ public class ComponentGroup {
     public void addAll(Collection<TransactionalComponent> components) {
         components.forEach(this::add);
     }
-    
+
     public void add(TransactionalComponent component) {
         Objects.requireNonNull(component);
         //Log.info(this, "add("+component.getComponentId()+")");
@@ -75,5 +75,7 @@ public class ComponentGroup {
     }
 
     public int size() { return group.size(); }
+
+    public boolean isEmpty() { return group.isEmpty(); }
 }
 

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/ComponentId.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/ComponentId.java
@@ -120,5 +120,11 @@ public class ComponentId {
         return alloc("Local-"+counter, uuid, counter);
     }
 
+    public static ComponentId allocLocal(int id) {
+        counter++;
+        UUID uuid = UUID.randomUUID();
+        byte[] bytes = Bytes.intToBytes(id);
+        return new ComponentId("Local-"+counter, uuid, bytes);
+    }
 }
 

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalComponentExternal.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalComponentExternal.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.dboe.transaction.txn;
+
+/**
+ * Base for transaction components that are added by external sub-systems.
+ */
+public class TransactionalComponentExternal<X> extends TransactionalComponentBase<X> {
+
+    public TransactionalComponentExternal(ComponentId id) {
+        super(id);
+    }
+
+    /**
+     * Don't automatically clear the internal state which allows it to be carried
+     * across switching datasets (e.g. TDB2 compactions).
+     */
+    @Override protected void clearInternal() { }
+}
+

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalComponentLifecycle.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalComponentLifecycle.java
@@ -225,15 +225,6 @@ public abstract class TransactionalComponentLifecycle<X> implements Transactiona
         if ( trackTxn != null )
             trackTxn.remove();
         componentState.remove();
-
-//        java version "1.8.0_31"
-//        Java(TM) SE Runtime Environment (build 1.8.0_31-b13)
-//        Java HotSpot(TM) 64-Bit Server VM (build 25.31-b07, mixed mode)
-//
-//        openjdk version "1.8.0_40-internal"
-//        OpenJDK Runtime Environment (build 1.8.0_40-internal-b09)
-//        OpenJDK 64-Bit Server VM (build 25.40-b13, mixed mode)
-
         // This one is very important else the memory usage grows.  Not clear why.
         // A Transaction has an internal AtomicReference.  Replacing the AtomicReference
         // with a plain member variable slows the growth down greatly.
@@ -253,7 +244,7 @@ public abstract class TransactionalComponentLifecycle<X> implements Transactiona
 
     protected Transaction getTransaction()          { return threadTxn.get(); }
     protected void setTransaction(Transaction txn)  { threadTxn.set(txn); }
-    
+
     private void setTrackTxn(TxnState newState) {
         if ( ! CHECKING ) return;
         trackTxn.set(newState);
@@ -289,12 +280,12 @@ public abstract class TransactionalComponentLifecycle<X> implements Transactiona
      * _complete
      *
      * Promote:
-     * 
+     *
      * _promote
-     * 
+     *
      * and the ReadWrite mode becomes "WRITE".
      * The transaction system manages whether the "promote " is legal,
-     * components do not have to check.  
+     * components do not have to check.
      *
      * Write lifecycle:
      * A write transaction must have a commit() or abort() before end().
@@ -359,7 +350,7 @@ public abstract class TransactionalComponentLifecycle<X> implements Transactiona
             throw new TransactionException("Not in a transaction");
     }
 
-    protected void requireTxn() { 
+    protected void requireTxn() {
         Transaction txn = getTransaction();
         if ( txn == null )
             throw new TransactionException("Not in a transaction");
@@ -372,7 +363,7 @@ public abstract class TransactionalComponentLifecycle<X> implements Transactiona
         txn.requireWriteTxn();
     }
 
-    // Better done 
+    // Better done
 //    protected void ensureWriteTxn() {
 //        Transaction txn = getTransaction();
 //        if ( txn == null )

--- a/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestThreadingTransactions.java
+++ b/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestThreadingTransactions.java
@@ -36,7 +36,7 @@ public class TestThreadingTransactions {
     private TransactionalInteger transInt;
 
     @Before public void init() {
-        TransactionCoordinator coord = new TransactionCoordinator(Location.mem());
+        TransactionCoordinator coord = TransactionCoordinator.create(Location.mem());
         transInt = new TransactionalInteger(coord, InitValue);
         coord.start();
     }

--- a/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestTransactionCoordinatorControl.java
+++ b/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestTransactionCoordinatorControl.java
@@ -46,7 +46,7 @@ public class TestTransactionCoordinatorControl {
     protected Transactional unit;
 
     @Before public void init() {
-        txnMgr = new TransactionCoordinator(Location.mem());
+        txnMgr = TransactionCoordinator.create(Location.mem());
         unit = new TransactionalBase(txnMgr);
         txnMgr.start();
     }

--- a/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestTxnLib2.java
+++ b/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestTxnLib2.java
@@ -37,7 +37,7 @@ public class TestTxnLib2 extends Assert {
     TransactionalInteger integer;
 
     @Before public void setup() {
-        TransactionCoordinator coord = new TransactionCoordinator(Location.mem());
+        TransactionCoordinator coord = TransactionCoordinator.create(Location.mem());
         integer = new TransactionalInteger(coord, InitValue);
         coord.start();
     }

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/DatabaseMgr.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/DatabaseMgr.java
@@ -52,25 +52,26 @@ public class DatabaseMgr {
     }
 
     /**
-     * Compact a datasets which must be a switchable TDB database.
+     * Compact a dataset which must be a switchable TDB database.
      * This is the normal dataset type for on-disk TDB2 databases.
-     *
-     * Deletes old database after successful compaction if `shouldDeleteOld` is `true`.
+     * <p>
+     * Deletes old database after successful compaction if {@code shouldDeleteOld} is {@code true}.
+     * <p>
+     * This is equivalent to a call of {@code compact(container, false)} (do not delete old database).
      *
      * @param container
      *
-     * @deprecated Use `compact(container, false)` instead.
+     * This {@code compact(container, false)} instead.
      */
-    @Deprecated
     public static void compact(DatasetGraph container) {
         compact(container, false);
     }
 
     /**
-     * Compact a datasets which must be a switchable TDB database.
+     * Compact a dataset which must be a switchable TDB database.
      * This is the normal dataset type for on-disk TDB2 databases.
      *
-     * Deletes old database after successful compaction if `shouldDeleteOld` is `true`.
+     * Deletes old database after successful compaction if {@code shouldDeleteOld} is {@code true}.
      *
      * @param container
      * @param shouldDeleteOld

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexDB.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexDB.java
@@ -21,14 +21,14 @@ package org.apache.jena.query.text;
 import java.nio.ByteBuffer;
 
 import org.apache.jena.dboe.transaction.txn.ComponentId;
-import org.apache.jena.dboe.transaction.txn.TransactionalComponentBase;
+import org.apache.jena.dboe.transaction.txn.TransactionalComponentExternal;
 import org.apache.jena.dboe.transaction.txn.TxnId;
 import org.apache.jena.query.ReadWrite;
 
 /**
  * Adapter to put Lucene into DBOE transactions.
  */
-public class TextIndexDB extends TransactionalComponentBase<TextIndexDB.TextState> {
+public class TextIndexDB extends TransactionalComponentExternal<TextIndexDB.TextState> {
 
     private final TextIndex textIndex;
 

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextQueryPF.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextQueryPF.java
@@ -127,13 +127,10 @@ public class TextQueryPF extends PropertyFunctionBase {
 
         Object obj = execCxt.getContext().get(TextQuery.textIndex) ;
 
-        if (obj != null) {
-            try {
-                return (TextIndex)obj ;
-            } catch (ClassCastException ex) {
-                Log.warn(TextQueryPF.class, "Context setting '" + TextQuery.textIndex + "'is not a TextIndex") ;
-            }
-        }
+        if ( obj instanceof TextIndex )
+            return (TextIndex)obj ;
+        if ( obj != null )
+            Log.warn(TextQueryPF.class, "Context setting '" + TextQuery.textIndex + "' is not a TextIndex") ;
 
         if (dsg instanceof DatasetGraphText) {
             DatasetGraphText x = (DatasetGraphText)dsg ;
@@ -154,12 +151,12 @@ public class TextQueryPF extends PropertyFunctionBase {
                 }
             }
         }
-
         return value;
     }
 
     @Override
-    public QueryIterator exec(Binding binding, PropFuncArg argSubject, Node predicate, PropFuncArg argObject,
+    public QueryIterator exec(Binding binding,
+                              PropFuncArg argSubject, Node predicate, PropFuncArg argObject,
                               ExecutionContext execCxt) {
         if (log.isTraceEnabled()) {
             IndentedLineBuffer subjBuff = new IndentedLineBuffer() ;


### PR DESCRIPTION
This is work mentioned in https://github.com/apache/jena/pull/1438#issuecomment-1183087146

The DBOE transaction system allows for transactional components from other sub-systems. An example of this is jena-text, where text index updates are coordinated with the RDF database updates when the database is TDB2.

The previous approach was specific to jena-text. This improves on that by making it a proper feature.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
