### PR TITLE
GH-1252: Hold up all possible write transactions while compacting.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/mem/DatasetGraphInMemory.java
@@ -65,6 +65,9 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
      * <p>
      * There are changes to be made to several datastructures and this
      * insures that they are made consistently.
+     * <p>
+     * Lock order must be writer lock, system lock.
+     * If a transaction takes the writerLock, it is a writer, and there is only one writer.
      */
     private final ReentrantLock systemLock = new ReentrantLock(true);
 
@@ -144,12 +147,11 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
     public void begin(TxnType txnType) {
         if (isInTransaction())
             throw new JenaTransactionException("Transactions cannot be nested!");
-        transactionType.set(txnType);
         _begin(txnType, TxnType.initial(txnType));
     }
 
     private void _begin(TxnType txnType, ReadWrite readWrite) {
-        // Takes transactionLock
+        // Takes Writer lock first, then system lock.
         startTransaction(txnType, readWrite);
         withLock(systemLock, () ->{
             quadsIndex().begin(readWrite);
@@ -198,7 +200,7 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
     private void _promote(boolean readCommited) {
         // Outside lock.
         if ( ! readCommited && version.get() != generation.get() )  {
-            // This tests for any commited writers since this transaction started.
+            // This tests for any committed writers since this transaction started.
             // This does not catch the case of a currently active writer
             // that has not gone to commit or abort yet.
             // The final test is after we obtain the transactionLock.
@@ -213,9 +215,14 @@ public class DatasetGraphInMemory extends DatasetGraphTriplesQuads implements Tr
                 transactionLock.leaveCriticalSection();
                 throw new JenaTransactionException("Concurrent writer changed the dataset : can't promote") ;
             }
-        // We have the lock and we have promoted!
-        transactionMode(WRITE);
-        _begin(transactionType(), ReadWrite.WRITE) ;
+        // We have the writer lock and we have promoted!
+        withLock(systemLock, ()->{
+            quadsIndex().begin(WRITE);
+            defaultGraph().begin(WRITE);
+            transactionMode(WRITE);
+            if ( readCommited )
+                version.set(generation.get());
+        });
     }
 
     @Override

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TS_DatasetTxnMem.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TS_DatasetTxnMem.java
@@ -24,7 +24,6 @@ import org.junit.runners.Suite.SuiteClasses;
 
 /**
  * Tests for in-memory Dataset and its default implementation.
- *
  */
 @RunWith(Suite.class)
 @SuiteClasses({

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryPromote.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryPromote.java
@@ -21,6 +21,7 @@ package org.apache.jena.sparql.core.mem ;
 import org.apache.jena.sparql.JenaTransactionException ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.transaction.AbstractTestTransPromote ;
+import org.junit.Ignore;
 
 /** Tests for transactions that start read and then promote to write -- TIM */
 public class TestDatasetGraphInMemoryPromote extends AbstractTestTransPromote {
@@ -41,4 +42,11 @@ public class TestDatasetGraphInMemoryPromote extends AbstractTestTransPromote {
     protected Class<JenaTransactionException> getTransactionExceptionClass() {
         return JenaTransactionException.class ;
     }
+
+    // Don't work for TIM.
+    @Override
+    @Ignore public void promote_snapshot_06() {}
+
+    @Override
+    @Ignore public void promote_readCommitted_06() {}
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryPromote.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/mem/TestDatasetGraphInMemoryPromote.java
@@ -21,7 +21,6 @@ package org.apache.jena.sparql.core.mem ;
 import org.apache.jena.sparql.JenaTransactionException ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.transaction.AbstractTestTransPromote ;
-import org.junit.Ignore;
 
 /** Tests for transactions that start read and then promote to write -- TIM */
 public class TestDatasetGraphInMemoryPromote extends AbstractTestTransPromote {
@@ -42,11 +41,4 @@ public class TestDatasetGraphInMemoryPromote extends AbstractTestTransPromote {
     protected Class<JenaTransactionException> getTransactionExceptionClass() {
         return JenaTransactionException.class ;
     }
-
-    // Don't work for TIM.
-    @Override
-    @Ignore public void promote_snapshot_06() {}
-
-    @Override
-    @Ignore public void promote_readCommitted_06() {}
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransPromote.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransPromote.java
@@ -46,10 +46,10 @@ public abstract class AbstractTestTransPromote {
     // Dynamically adjust the loggingso warnings are supressed for this test suite only.
     private final String[] loggerNames;
     private String[] loggerLevelNames;
-    
+
     private boolean stdPromotion ;
     private boolean stdReadCommitted ;
-    
+
     @Before
     public void beforeLoggersNoWarnings() {
         int N = loggerNames.length ;
@@ -74,7 +74,7 @@ public abstract class AbstractTestTransPromote {
     // TDB transactions are in the TDBException hierarchy
     // so can't be JenaTransactionException.
     protected abstract Class<? extends Exception> getTransactionExceptionClass() ;
-    
+
     protected AbstractTestTransPromote(String[] loggerNames) {
         this.loggerNames = loggerNames ;
     }
@@ -94,8 +94,8 @@ public abstract class AbstractTestTransPromote {
 
     @Test public void promote_snapshot_01()         { run_01(TxnType.READ_PROMOTE) ; }
     @Test public void promote_readCommitted_01()    { run_01(TxnType.READ_COMMITTED_PROMOTE) ; }
-    
-    // READ-add
+
+    // read/promote then add
     private void run_01(TxnType txnType) {
         DatasetGraph dsg = create() ;
         dsg.begin(txnType) ;
@@ -103,58 +103,61 @@ public abstract class AbstractTestTransPromote {
         dsg.commit() ;
         dsg.end() ;
     }
-    
+
     @Test public void promote_snapshot_02()         { run_02(TxnType.READ_PROMOTE) ; }
     @Test public void promote_readCommitted_02()    { run_02(TxnType.READ_COMMITTED_PROMOTE) ; }
-    
-    // Previous transaction then READ-add
+
+    // Previous read transaction, then read/promote then add
     private void run_02(TxnType txnType) {
         DatasetGraph dsg = create() ;
-        
+
         dsg.begin(txnType) ;dsg.end() ;
-        
+
         dsg.begin(txnType) ;
         dsg.add(q1) ;
         dsg.commit() ;
         dsg.end() ;
     }
-    
+
     @Test public void promote_snapshot_03()         { run_03(TxnType.READ_PROMOTE) ; }
     @Test public void promote_readCommitted_03()    { run_03(TxnType.READ_COMMITTED_PROMOTE) ; }
 
+    // Previous write transaction, then read/promote then add
     private void run_03(TxnType txnType) {
         DatasetGraph dsg = create() ;
-        
+
         dsg.begin(TxnType.WRITE) ;dsg.commit() ; dsg.end() ;
-        
+
         dsg.begin(txnType) ;
         dsg.add(q1) ;
         dsg.commit() ;
         dsg.end() ;
     }
-    
+
     @Test public void promote_snapshot_04()         { run_04(TxnType.READ_PROMOTE) ; }
     @Test public void promote_readCommitted_04()    { run_04(TxnType.READ_COMMITTED_PROMOTE) ; }
 
+    // Previous aborted write transaction, then read/promote then add
     private void run_04(TxnType txnType) {
         DatasetGraph dsg = create() ;
-        
+
         dsg.begin(ReadWrite.WRITE) ;dsg.abort() ; dsg.end() ;
-        
+
         dsg.begin(txnType) ;
         dsg.add(q1) ;
         dsg.commit() ;
         dsg.end() ;
     }
 
+    // Read/promote, then add, then end-no-commit.
     @Test public void promote_snapshot_05()         { run_05(TxnType.READ_PROMOTE) ; }
     @Test public void promote_readCommitted_05()    { run_05(TxnType.READ_COMMITTED_PROMOTE) ; }
-    
+
     private void run_05(TxnType txnType) {
         DatasetGraph dsg = create() ;
         dsg.begin(txnType) ;
         dsg.add(q1) ;
-        
+
         try {
             dsg.end() ;
             fail("begin(W);end() did not throw an exception");
@@ -163,11 +166,10 @@ public abstract class AbstractTestTransPromote {
         assertCount(0, dsg) ;
     }
 
-    // LOCK UP
-    //@Test public void promote_snapshot_06()         { run_06(TxnMode.READ_PROMOTE) ; }
-    //@Test public void promote_readCommitted_06()    { run_06(TxnMode.READ_COMMITTED_PROMOTE) ; }
-    
-    // Async writer after promotion.
+    @Test public void promote_snapshot_06()         { run_06(TxnType.READ_PROMOTE) ; }
+    @Test public void promote_readCommitted_06()    { run_06(TxnType.READ_COMMITTED_PROMOTE) ; }
+
+    // Async writer during transaction after promotion.
     private void run_06(TxnType txnType) {
         DatasetGraph dsg = create() ;
         AtomicInteger a = new AtomicInteger(0) ;
@@ -197,8 +199,8 @@ public abstract class AbstractTestTransPromote {
 
     @Test public void promote_snapshot_07()         { run_07(TxnType.READ_PROMOTE) ; }
     @Test public void promote_readCommitted_07()    { run_07(TxnType.READ_COMMITTED_PROMOTE) ; }
-    
-    // Async writer after promotion.
+
+    // Async writer after promotion transaction commits.
     private void run_07(TxnType txnType) {
         DatasetGraph dsg = create() ;
         // Start long running reader.
@@ -216,11 +218,11 @@ public abstract class AbstractTestTransPromote {
         dsg.end() ;
         tt.run() ;
     }
-    
+
     @Test public void promote_snapshot_08()         { run_08(TxnType.READ_PROMOTE); }
     @Test public void promote_readCommitted_08()    { run_08(TxnType.READ_COMMITTED_PROMOTE) ; }
-    
-    // Async writer after promotion transaction ends.
+
+    // Async reader after promotion transaction ends.
     private void run_08(TxnType txnType) {
         DatasetGraph dsg = create() ;
         // Start R->W here
@@ -238,7 +240,7 @@ public abstract class AbstractTestTransPromote {
     @SafeVarargs
     private final void expect(Runnable runnable, Class<? extends Exception>...classes) {
         try {
-            runnable.run(); 
+            runnable.run();
             fail("Exception expected") ;
         } catch (Exception e) {
             for ( Class<?> c : classes) {
@@ -254,19 +256,19 @@ public abstract class AbstractTestTransPromote {
 
     @Test
     public void promote_11() { promote_readCommit_txnCommit(TxnType.READ_COMMITTED_PROMOTE, false) ; }
-    
+
     @Test
-    public void promote_12() { 
+    public void promote_12() {
         expect(()->promote_readCommit_txnCommit(TxnType.READ_PROMOTE, true) ,
                getTransactionExceptionClass()) ;
     }
-    
+
     @Test
     public void promote_13() { promote_readCommit_txnCommit(TxnType.READ_PROMOTE, false) ; }
 
     private void promote_readCommit_txnCommit(TxnType txnType, boolean asyncCommit) {
         DatasetGraph dsg = create() ;
-        
+
         ThreadAction tt = asyncCommit?
             ThreadTxn.threadTxnWrite(dsg, () -> dsg.add(q3) ) :
             ThreadTxn.threadTxnWriteAbort(dsg, () -> dsg.add(q3)) ;
@@ -285,21 +287,21 @@ public abstract class AbstractTestTransPromote {
         dsg.end() ;
         //logger2.setLevel(level2);
     }
-    
+
     // Active writer commits -> no promotion.
     @Test
     public void promote_active_writer_1() throws InterruptedException, ExecutionException {
         expect(()->promote_active_writer(true) ,
                getTransactionExceptionClass()) ;
     }
-    
+
     // Active writer aborts -> promotion.
     @Test
     public void promote_active_writer_2() throws InterruptedException, ExecutionException {
         // Active writer aborts -> promotion possible (but not implemented that way).
         promote_active_writer(false) ;
     }
-    
+
     private void promote_active_writer(boolean activeWriterCommit) {
         ExecutorService executor = Executors.newFixedThreadPool(2) ;
         try {
@@ -309,7 +311,7 @@ public abstract class AbstractTestTransPromote {
             executor.shutdown() ;
         }
     }
-    
+
     private void promote_clash_active_writer(ExecutorService executor, boolean activeWriterCommit) {
         Semaphore semaActiveWriterStart     = new Semaphore(0) ;
         Semaphore semaActiveWriterContinue  = new Semaphore(0) ;
@@ -318,7 +320,7 @@ public abstract class AbstractTestTransPromote {
 
         DatasetGraph dsg = create() ;
 
-        // The "active writer". 
+        // The "active writer".
         Callable<Object> activeWriter = ()->{
             dsg.begin(ReadWrite.WRITE) ;
             semaActiveWriterStart.release(1) ;
@@ -335,20 +337,20 @@ public abstract class AbstractTestTransPromote {
         Future<Object> activeWriterFuture = executor.submit(activeWriter) ;
         // Advance "active writer" to (*1), inside a write transaction and waiting.
         // The transaction has been created and started.
-        semaActiveWriterStart.acquireUninterruptibly(); 
+        semaActiveWriterStart.acquireUninterruptibly();
 
         Callable<RuntimeException> attemptedPromote = ()->{
             dsg.begin(TxnType.READ_PROMOTE) ;
             semaPromoteTxnStart.release(1) ;
             // (*2)
             semaPromoteTxnContinue.acquireUninterruptibly();
-            try { 
+            try {
                 // (*3)
                 dsg.add(q1) ;
                 return null ;
             } catch (RuntimeException e) {
                 Class<?> c = getTransactionExceptionClass() ;
-                if ( ! e.getClass().equals(c) ) 
+                if ( ! e.getClass().equals(c) )
                     throw e ;
                 return e ;
             }
@@ -358,37 +360,37 @@ public abstract class AbstractTestTransPromote {
         // Advance "attempted promote" to (*2), inside a read transaction, before attempting a promoting write.
         // The transaction has been created and started.
         semaPromoteTxnStart.acquireUninterruptibly();
-        
+
         // Advance "attempted promote" allowing it to go (*3) where it blocks
         // This may happen at any time - as soon as it does, the "attempted promote" blocks.
         semaPromoteTxnContinue.release(1);
-        // I don't know of a better way to ensure "attempted promote" is blocked. 
-        
+        // I don't know of a better way to ensure "attempted promote" is blocked.
+
         Lib.sleep(100) ;
         // Let the active writer go.
         semaActiveWriterContinue.release(1);
-        
-        try { 
+
+        try {
             // Collect the active writer.
             activeWriterFuture.get();
-            
+
             // (Ideal) and the attempted promotion should advance if the active writer aborts.
             RuntimeException e = attemptedPromoteFuture.get() ;
             if ( e != null )
                 throw e ;
         } catch (InterruptedException | ExecutionException e1) { throw new RuntimeException(e1) ; }
     }
-    
+
     // This would lock up because of a WRITE-WRITE deadly embrace.
     //  @Test(expected=JenaTransactionException.class)
     //  public void promote11() { test2(TxnMode.WRITE); }
-      
+
     @Test
     public void promote_thread_writer_1() { test_thread_writer(TxnType.READ_COMMITTED_PROMOTE); }
-      
+
     @Test(expected=JenaTransactionException.class)
     public void promote_thread_writer_2() { test_thread_writer(TxnType.READ_PROMOTE); }
-    
+
     private void test_thread_writer(TxnType txnType) {
         DatasetGraph dsg = create();
         ThreadAction a = ThreadTxn.threadTxnWrite(dsg, ()->dsg.add(q1));
@@ -402,7 +404,7 @@ public abstract class AbstractTestTransPromote {
         dsg.commit();
         dsg.end();
     }
-    
+
     // With explicit "promote()"
     private void test_promote_thread_writer(TxnType txnType) {
         DatasetGraph dsg = create();
@@ -410,9 +412,9 @@ public abstract class AbstractTestTransPromote {
         dsg.begin(txnType);
         assertEquals(txnType, dsg.transactionType());
         a.run();
-        
+
         boolean b = dsg.promote();
-        
+
         if ( txnType == TxnType.READ_PROMOTE )
             assertFalse(b);
         if ( txnType == TxnType.READ_COMMITTED_PROMOTE )

--- a/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionLifecycle.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/transaction/AbstractTestTransactionLifecycle.java
@@ -38,13 +38,13 @@ import org.apache.jena.sparql.core.Transactional.Promote;
 import org.junit.Test;
 
 /**
- * Dataset transaction lifecycle. 
+ * Dataset transaction lifecycle.
  */
 public abstract class AbstractTestTransactionLifecycle
 {
     protected abstract Dataset create();
-    
-    protected boolean supportsAbort()   { return true; } 
+
+    protected boolean supportsAbort()   { return true; }
     protected boolean supportsPromote() { return true; }
 
     @Test
@@ -101,7 +101,7 @@ public abstract class AbstractTestTransactionLifecycle
         ds.commit();
         assertFalse(ds.isInTransaction());
     }
-    
+
     @Test
     public void transaction_w02() {
         Dataset ds = create();
@@ -162,7 +162,7 @@ public abstract class AbstractTestTransactionLifecycle
 
 //    TxnType.READ_PROMOTE
 //    TxnType.READ_COMMITTED_PROMOTE
-    
+
     @Test
     public void transaction_p01() {
         assumeTrue(supportsPromote());
@@ -176,7 +176,7 @@ public abstract class AbstractTestTransactionLifecycle
         ds.commit();
         ds.end();
     }
-    
+
     @Test
     public void transaction_p02() {
         assumeTrue(supportsPromote());
@@ -191,7 +191,7 @@ public abstract class AbstractTestTransactionLifecycle
         ds.commit();
         ds.end();
     }
-    
+
     @Test
     public void transaction_p03() {
         assumeTrue(supportsPromote());
@@ -235,7 +235,7 @@ public abstract class AbstractTestTransactionLifecycle
         ds.commit();
         ds.end();
     }
-    
+
     @Test
     public void transaction_p06_err() {
         assumeTrue(supportsPromote());
@@ -248,7 +248,7 @@ public abstract class AbstractTestTransactionLifecycle
         assertFalse(b2);
         ds.end();
     }
-    
+
     // JENA-1469
     @Test
     public void transaction_p10() {
@@ -260,8 +260,6 @@ public abstract class AbstractTestTransactionLifecycle
         transaction_promote_write(TxnType.READ_PROMOTE);
     }
 
-    // XXX Refactor the above code.
-    
     // promotion type specified
     private void testPromote(TxnType txnType , Promote promoteMode, boolean succeeds) {
         Dataset ds = create();
@@ -273,58 +271,56 @@ public abstract class AbstractTestTransactionLifecycle
         assertEquals("Try same promote again", b1, b2);
         ds.commit();
         ds.end();
-        
     }
-    
+
     @Test
     public void transaction_promote_write_isolated() {
         assumeTrue(supportsPromote());
         testPromote(TxnType.WRITE, Promote.ISOLATED, true);
     }
-    
+
     @Test
     public void transaction_promote_write_readCommitted() {
         assumeTrue(supportsPromote());
         testPromote(TxnType.WRITE, Promote.READ_COMMITTED, true);
     }
-        
+
     @Test
     public void transaction_promote_read_isolated() {
         assumeTrue(supportsPromote());
         testPromote(TxnType.READ, Promote.ISOLATED, false);
     }
-    
+
     @Test
     public void transaction_promote_read_readCommitted() {
         assumeTrue(supportsPromote());
         testPromote(TxnType.READ, Promote.READ_COMMITTED, false);
     }
-        
+
     @Test
     public void transaction_promote_readPromote_isolated() {
         assumeTrue(supportsPromote());
         testPromote(TxnType.READ_PROMOTE, Promote.ISOLATED, true);
     }
-    
+
     @Test
     public void transaction_promote_readPromote_committed() {
         assumeTrue(supportsPromote());
         testPromote(TxnType.READ_PROMOTE, Promote.READ_COMMITTED, true);
     }
-        
+
     @Test
     public void transaction_promote_readCommitted_isolated() {
         assumeTrue(supportsPromote());
         testPromote(TxnType.READ_COMMITTED_PROMOTE, Promote.ISOLATED, true);
     }
-    
+
     @Test
     public void transaction_promote_readCommitted_readCommitted() {
         assumeTrue(supportsPromote());
         testPromote(TxnType.READ_COMMITTED_PROMOTE, Promote.READ_COMMITTED, true);
     }
-        
-    
+
     @Test
     public void transaction_read_promote() {
         assumeTrue(supportsPromote());
@@ -344,9 +340,9 @@ public abstract class AbstractTestTransactionLifecycle
         ds.end();
         ds.begin(TxnType.WRITE);
         ds.commit();
-        ds.end(); 
+        ds.end();
     }
-    
+
     // Patterns.
     @Test
     public void transaction_pattern_01() {
@@ -378,56 +374,56 @@ public abstract class AbstractTestTransactionLifecycle
         write(ds);
         read2(ds);
     }
-    
+
     // Cycle misalignment.
     // test : commit
     // test : abort
-    // Permit explain .end() - the case of "end" when not sure:  begin...end.end. 
-    
+    // Permit explain .end() - the case of "end" when not sure:  begin...end.end.
+
     @Test(expected=JenaTransactionException.class)
-    public void transaction_err_nontxn_commit_1() { 
+    public void transaction_err_nontxn_commit_1() {
         Dataset ds = create();
         ds.commit();
-    }    
-    
+    }
+
     @Test(expected=JenaTransactionException.class)
-    public void transaction_err_nontxn_commit_2() { 
+    public void transaction_err_nontxn_commit_2() {
         Dataset ds = create();
         ds.begin(TxnType.READ);
         ds.end();
         ds.commit();
-    }    
-    
+    }
+
     @Test(expected=JenaTransactionException.class)
-    public void transaction_err_nontxn_commit_3() { 
+    public void transaction_err_nontxn_commit_3() {
         Dataset ds = create();
         ds.begin(TxnType.WRITE);
         ds.end();
         ds.commit();
-    }    
+    }
 
     @Test(expected=JenaTransactionException.class)
-    public void transaction_err_nontxn_abort_1() { 
+    public void transaction_err_nontxn_abort_1() {
         Dataset ds = create();
         ds.abort();
-    }    
+    }
 
     @Test(expected=JenaTransactionException.class)
-    public void transaction_err_nontxn_abort_2() { 
+    public void transaction_err_nontxn_abort_2() {
         Dataset ds = create();
         ds.begin(TxnType.READ);
         ds.end();
         ds.abort();
-    }    
+    }
 
     @Test(expected=JenaTransactionException.class)
-    public void transaction_err_nontxn_abort_3() { 
+    public void transaction_err_nontxn_abort_3() {
         Dataset ds = create();
         ds.begin(TxnType.WRITE);
         ds.end();
         ds.abort();
-    }    
-    
+    }
+
     @Test
     public void transaction_err_01()    { testBeginBegin(TxnType.WRITE, TxnType.WRITE); }
 
@@ -440,28 +436,28 @@ public abstract class AbstractTestTransactionLifecycle
     @Test
     public void transaction_err_04()    { testBeginBegin(TxnType.READ, TxnType.WRITE); }
 
-    @Test 
+    @Test
     public void transaction_err_05()    { testCommitCommit(TxnType.READ); }
 
-    @Test 
+    @Test
     public void transaction_err_06()    { testCommitCommit(TxnType.WRITE); }
 
-    @Test 
+    @Test
     public void transaction_err_07()    { testCommitAbort(TxnType.READ); }
 
-    @Test 
+    @Test
     public void transaction_err_08()    { testCommitAbort(TxnType.WRITE); }
 
-    @Test 
+    @Test
     public void transaction_err_09()    { testAbortAbort(TxnType.READ); }
 
-    @Test 
+    @Test
     public void transaction_err_10()    { testAbortAbort(TxnType.WRITE); }
 
-    @Test 
+    @Test
     public void transaction_err_11()    { testAbortCommit(TxnType.READ); }
 
-    @Test 
+    @Test
     public void transaction_err_12()    { testAbortCommit(TxnType.WRITE); }
 
     private void read1(Dataset ds) {
@@ -490,7 +486,7 @@ public abstract class AbstractTestTransactionLifecycle
     private static void safeEnd(Dataset ds) {
         try { ds.end(); } catch (JenaTransactionException ex) {}
     }
-    
+
     // Error conditions that should be detected.
 
     private void testBeginBegin(TxnType txnType1, TxnType txnType2) {
@@ -504,7 +500,7 @@ public abstract class AbstractTestTransactionLifecycle
             safeEnd(ds);
         }
     }
-    
+
     private void testCommitCommit(TxnType txnType) {
         Dataset ds = create();
         ds.begin(txnType);
@@ -599,7 +595,7 @@ public abstract class AbstractTestTransactionLifecycle
     public synchronized void transaction_concurrency_reader() throws InterruptedException, ExecutionException, TimeoutException {
         ExecutorService executor = Executors.newCachedThreadPool();
         AtomicLong counter = new AtomicLong(0);
-        
+
         try {
             final Dataset ds = create();
 

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/ThreadLib.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/ThreadLib.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 public class ThreadLib {
 
     private static ExecutorService executor = Executors.newCachedThreadPool();
+    public static ExecutorService getExecutionService() { return executor; }
 
     /**
      * Run asynchronously on another thread; the thread has started

--- a/jena-db/jena-dboe-storage/src/main/java/org/apache/jena/dboe/storage/system/DatasetGraphTxnCtl.java
+++ b/jena-db/jena-dboe-storage/src/main/java/org/apache/jena/dboe/storage/system/DatasetGraphTxnCtl.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.dboe.storage.system;
+
+import java.util.Objects;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.jena.dboe.transaction.txn.TransactionException;
+import org.apache.jena.dboe.transaction.txn.TransactionalSystemControl;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.TxnType;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphWrapper;
+import org.apache.jena.sparql.util.Context;
+
+/**
+ * DatasetGraph wrapper controls entry and exit of transactions.
+ * <ul>
+ * <li>Exclusive access (no transactions active)
+ * <li>Read only database - No possible writers (write and promotable transactions)
+ * </ul>
+ */
+
+public class DatasetGraphTxnCtl extends DatasetGraphWrapper implements TransactionalSystemControl {
+
+    // ---- Controls
+
+    // Multiple state X or single state Y.
+    // Do not confuse with read/write transactions. We need a "one exclusive, or many
+    // other" lock which happens to be called {@code ReadWriteLock}.
+
+    // All transactions need "read" state X through out their lifetime.
+    // The "write" state Y is used for exclusive mode.
+    private ReadWriteLock exclusivitylock = new ReentrantReadWriteLock();
+
+    // Lock to guarantee only readers are present.
+    // Writers and promote transaction need to take a lock on entry.
+    // This is not reentrant.
+    private ReadWriteLock writeableDatabase = new ReentrantReadWriteLock();
+
+    // Better Lock naming?
+    //  MultipleOrSingle (MOS) == MRSW
+    //  MultipleAndSingle (MAS) == MR+SW
+
+    public DatasetGraphTxnCtl(DatasetGraph dsg) {
+        super(dsg);
+    }
+
+    public DatasetGraphTxnCtl(DatasetGraph dsg, Context context) {
+        super(dsg, context);
+    }
+
+    @Override
+    public void begin(TxnType txnType) {
+        Objects.nonNull(txnType);
+        checkNotActive();
+        enterTransaction(txnType, true);
+        super.begin(txnType);
+    }
+
+    final
+    protected void checkNotActive() {
+        if ( isInTransaction() )
+            throw new TransactionException(label("Currently in an active transaction"));
+    }
+
+    private String label(String msg) {
+        // Optional labelling
+        return msg;
+    }
+
+    final
+    protected void checkActive() {
+        // Check no transaction on this thread.
+        if ( ! isInTransaction() )
+            throw new TransactionException(label("Not in an active transaction"));
+    }
+
+    @Override
+    public void begin(ReadWrite readWrite) {
+        Objects.nonNull(readWrite);
+        begin(TxnType.convert(readWrite));
+    }
+
+    /*
+     * Admission policy.
+     * - exclusive mode (no transactions running)
+     * - possibleWriters
+     */
+    private void enterTransaction(TxnType txnType, boolean canBlock) {
+        boolean canBlockWriters = canBlock; // false => "bounce writers mode"
+
+        boolean bExclusive = tryNonExclusiveMode(canBlock);
+        if ( !bExclusive )
+            throw new TransactionException("Can't start transaction at the moment.");
+
+        // Readers never block.
+        // Writers admitted one at a time (provided by TransactionCoordinator presently)
+        // Promotes are readers until they promote.
+        switch(txnType) {
+            case READ :
+                break;
+            case READ_COMMITTED_PROMOTE :
+            case READ_PROMOTE :
+            case WRITE : {
+                startPossibleWriter();
+                break;
+            }
+        }
+    }
+
+    private void exitTransaction(TxnType txnType) {
+        switch(txnType) {
+            case READ :
+                break;
+            case READ_COMMITTED_PROMOTE :
+            case READ_PROMOTE :
+            case WRITE : {
+                finishPossibleWriter();
+                break;
+            }
+        }
+    }
+
+    @Override
+    public void commit() {
+        TxnType txnType = transactionType();
+        super.commit();
+        exitTransaction(txnType);
+    }
+
+    @Override
+    public void abort() {
+        TxnType txnType = transactionType();
+        super.abort();
+        exitTransaction(txnType);
+    }
+
+    @Override
+    public void end() {
+        TxnType txnType = transactionType();
+        super.end();
+        if ( isInTransaction() )
+            exitTransaction(txnType);
+    }
+
+    /**
+     * Block until no writers or promote transactions present are present.
+     */
+    @Override
+    public void startReadOnlyDatabase()  {
+        startReadOnly();
+    }
+
+    /**
+     * Release any waiting potential writers.
+     */
+    @Override
+    public void finishReadOnlyDatabase() {
+        finishReadOnly();
+    }
+
+    // Any writers - WRITE, READ_PROMOTE, READ_COMMITTED_PROMOTE
+    // Writer take this lock (slightly confusingly as a "read" lock)
+    // READ-ONLY operation do no tneed to take this block.
+
+    protected void startReadOnly() {
+        startReadOnly(true);
+    }
+
+    /**
+     * Indicate the database is to be readonly.
+     * Any writer, or potential writer, takes this lock in "multi" mode.
+     * To block, call this method.
+     */
+    protected void startReadOnly(boolean canBlock) {
+        beginSingleMode(writeableDatabase, canBlock);
+    }
+
+    protected void finishReadOnly() {
+        endSingleMode(writeableDatabase);
+    }
+
+    protected void startPossibleWriter() {
+        beginMultiMode(writeableDatabase, true);
+    }
+
+    protected void startPossibleWriter(boolean canBlock) {
+        beginMultiMode(writeableDatabase, canBlock);
+    }
+
+    protected void finishPossibleWriter() {
+        endMultiMode(writeableDatabase);
+    }
+
+    // Lock abstraction.
+    /* Function for enter-leave for two lock types:
+     *    Multiple active threads or exclusive access. (MRSW)
+     *      beginMultiMode, beginSingleMode
+     *    Multiple active threads and one distinguished thread (MR+SW).
+     *      beginSingleGate
+     *
+     * == Multiple active threads or exclusive access. (MRSW)
+     * This uses a ReadWriteLock where "read" is multiple outstanding threads
+     * and "write" is exclusive access.
+     * Used for:
+     *   Exclusivity lock
+     *   No potential writer lock (TxnType.WRITE or PROMOTE).
+     *
+     * The use of R and W for the exclusive access locks are slightly confusing.
+     * It is not related to whether a transaction is R or W.
+     * R means "multiple", W means "exclusive"
+     *
+     * == Multiple active threads and one distinguished thread (MR+SW).
+     * This is a semaphore with one permit taken by the distinguished thread.
+     * The other active threads are not affected.
+     * Use for:
+     *   Multiple ReadWrite==READ and single ReadWrite.WRITE
+     */
+
+    // MRSW - two modes: multiple OR a single thread.
+
+    // -- Exclusivity
+
+    @Override
+    public void startNonExclusiveMode() {
+        boolean b = beginMultiMode(exclusivitylock, true);
+        if ( !b )
+            throw new TransactionException("Can't start transaction at the moment.");
+    }
+
+    @Override
+    public boolean tryNonExclusiveMode(boolean canBlock) {
+        return beginMultiMode(exclusivitylock, canBlock);
+    }
+
+    @Override
+    public void finishNonExclusiveMode() {
+        endMultiMode(exclusivitylock);
+    }
+
+    /**
+     * Enter exclusive mode; block if necessary. There are no active transactions on
+     * return; new transactions will be held up in 'begin'. Return to normal (release
+     * waiting transactions, allow new transactions) with
+     * {@link #finishExclusiveMode}.
+     * <p>
+     * Do not call inside an existing transaction.
+     */
+    @Override
+    public void startExclusiveMode() {
+        startExclusiveMode(true);
+    }
+
+    /**
+     * Enter exclusive mode; block if necessary. There are no active transactions on
+     * return; new transactions will be held up in 'begin'. Return to normal (release
+     * waiting transactions, allow new transactions) with
+     * {@link #finishExclusiveMode}.
+     * <p>
+     * Do not call inside an existing transaction.
+     */
+    private boolean startExclusiveMode(boolean canBlock) {
+        if ( canBlock ) {
+            exclusivitylock.writeLock().lock();
+            return true;
+        }
+        return exclusivitylock.writeLock().tryLock();
+    }
+
+    /**
+     * Try to enter exclusive mode. If return is true, then there are no active
+     * transactions on return and new transactions will be held up in 'begin'. If
+     * false, there were in-progress transactions. Return to normal (release waiting
+     * transactions, allow new transactions) with {@link #finishExclusiveMode}.
+     * <p>
+     * Do not call inside an existing transaction.
+     */
+    @Override
+    public boolean tryExclusiveMode() {
+        return tryExclusiveMode(false);
+    }
+
+    /**
+     * Try to enter exclusive mode. If return is true, then there are no active
+     * transactions on return and new transactions will be held up in 'begin'. If
+     * false, there were in-progress transactions. Return to normal (release waiting
+     * transactions, allow new transactions) with {@link #finishExclusiveMode}.
+     * <p>
+     * Do not call inside an existing transaction.
+     *
+     * @param canBlock Allow the operation block and wait for the exclusive mode
+     *     lock.
+     */
+    @Override
+    public boolean tryExclusiveMode(boolean canBlock) {
+        return startExclusiveMode(canBlock);
+    }
+
+    /**
+     * Return to normal (release waiting transactions, allow new transactions). Must
+     * be paired with an earlier {@link #startExclusiveMode}.
+     */
+    @Override
+    public void finishExclusiveMode() {
+        exclusivitylock.writeLock().unlock();
+    }
+
+    // Lock abstraction.
+    // An MRSW lock has two modes: multiple XOR a single thread.
+    //   Hide names like "read" and "write" in favour of "multi" and "single"
+
+    private final boolean beginMultiMode(ReadWriteLock lock, boolean canBlock) {
+        if ( !canBlock )
+            return lock.readLock().tryLock();
+        lock.readLock().lock();
+        return true;
+    }
+
+    private static void endMultiMode(ReadWriteLock lock) {
+        lock.readLock().unlock();
+    }
+
+    private static boolean beginSingleMode(ReadWriteLock lock, boolean canBlock) {
+        if ( !canBlock )
+            return lock.writeLock().tryLock();
+        lock.writeLock().lock();
+        return true;
+    }
+
+    private static void endSingleMode(ReadWriteLock lock) {
+        lock.writeLock().unlock();
+    }
+}

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/Transaction.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/Transaction.java
@@ -107,14 +107,14 @@ public class Transaction implements TransactionInfo {
         setState(ACTIVE);
     }
 
-    private boolean promoteReadCommitted() {
+    private boolean isPromoteReadCommitted() {
         if ( txnType == TxnType.READ_COMMITTED_PROMOTE ) return true;
         if ( txnType == TxnType.READ_PROMOTE ) return false;
         return false;
     }
 
     public boolean promote() {
-        return promote(promoteReadCommitted());
+        return promote(isPromoteReadCommitted());
     }
 
     public boolean promote(boolean readCommitted) {
@@ -140,7 +140,7 @@ public class Transaction implements TransactionInfo {
     public void notifyUpdate() {
         checkState(ACTIVE);
         if ( mode == ReadWrite.READ ) {
-            promote(promoteReadCommitted());
+            promote(isPromoteReadCommitted());
             mode = ReadWrite.WRITE;
         }
     }

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalBase.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalBase.java
@@ -62,7 +62,7 @@ public class TransactionalBase implements TransactionalSystem {
         if ( trackAttachDetach )
             Log.info(this,  ">> detach");
         checkRunning();
-        // Not if it just commited but before end.
+        // Not if it just committed but before end.
         //checkActive();
         Transaction txn = theTxn.get();
         TransactionCoordinatorState coordinatorState = null;
@@ -127,7 +127,7 @@ public class TransactionalBase implements TransactionalSystem {
 
     @Override
     public final void commit() {
-        checkRunning();
+        checkActive();
         TransactionalSystem.super.commit();
     }
 

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalSystemControl.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalSystemControl.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.dboe.transaction.txn;
+
+/**
+ * Control interface for a transactional system.
+ */
+public interface TransactionalSystemControl {
+
+    // --- Readonly
+    /**
+     * Block write activity - let active potential writers finish while blocking new potential writers.
+     * On exit, there are no active writers or promote transactions.
+     * (Promotes would otherwise become write mode in their lifetime.)
+     */
+    public void startReadOnlyDatabase();
+
+    /**
+     * Release any waiting potential writers.
+     */
+    public void finishReadOnlyDatabase();
+
+    /**
+     * Execute with a read-only database.
+     */
+    public default void execReadOnlyDatabase(Runnable action)  {
+        startReadOnlyDatabase();
+        try {
+            action.run();
+        } finally { finishReadOnlyDatabase(); }
+    }
+
+    // -- Exclusivity
+
+    /**
+     * Enter non-exclusive mode; block if necessary.
+     */
+    public void startNonExclusiveMode();
+
+    /**
+     * Try to enter non-exclusive mode; return true if successful.
+     */
+    public default boolean tryNonExclusiveMode() { return tryNonExclusiveMode(false); }
+
+    /**
+     * Try to enter non-exclusive mode; return true if successful.
+     */
+    public boolean tryNonExclusiveMode(boolean canBlock);
+
+    /**
+     * End non-exclusive mode.
+     */
+    public void finishNonExclusiveMode();
+
+
+    /**
+     * Enter exclusive mode; block if necessary.
+     * There are no active transactions on return; new transactions will be held up in 'begin'.
+     * Return to normal (release waiting transactions, allow new transactions)
+     * with {@link #finishExclusiveMode}.
+     * <p>
+     * Do not call inside an existing transaction.
+     */
+    public void startExclusiveMode();
+
+    /**
+     * Try to enter exclusive mode.
+     * If return is true, then there are no active transactions on return and new transactions will be held up in 'begin'.
+     * If false, there were in-progress transactions.
+     * Return to normal (release waiting transactions, allow new transactions)
+     * with {@link #finishExclusiveMode}.
+     * <p>
+     * Do not call inside an existing transaction.
+     */
+    public default boolean tryExclusiveMode() { return tryExclusiveMode(false); }
+
+    /**
+     * Try to enter exclusive mode.
+     * If return is true, then there are no active transactions on return and new transactions will be held up in 'begin'.
+     * If false, there were in-progress transactions.
+     * Return to normal (release waiting transactions, allow new transactions)
+     * with {@link #finishExclusiveMode}.
+     * <p>
+     * Do not call inside an existing transaction.
+     * @param canBlock Allow the operation block and wait for the exclusive mode lock.
+     */
+    public boolean tryExclusiveMode(boolean canBlock);
+
+    /**
+     * Return to normal (release waiting transactions, allow new transactions).
+     * Must be paired with an earlier {@link #startExclusiveMode}.
+     */
+    public void finishExclusiveMode();
+
+    /**
+     * Execute an action in exclusive mode.  This method can block.
+     * <p>
+     * Equivalent to:
+     * <pre>
+     *   startExclusiveMode();
+     *   try { action.run(); }
+     *   finally { finishExclusiveMode(); }
+     * </pre>
+     *
+     * @param action
+     */
+    public default void execExclusive(Runnable action) {
+        startExclusiveMode();
+        try { action.run(); }
+        finally { finishExclusiveMode(); }
+    }
+}

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/DatabaseOps.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/DatabaseOps.java
@@ -28,14 +28,13 @@ import java.util.zip.GZIPOutputStream;
 import org.apache.jena.atlas.RuntimeIOException;
 import org.apache.jena.atlas.io.IOX;
 import org.apache.jena.atlas.lib.DateTimeUtils;
+import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.atlas.lib.Pair;
 import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.dboe.base.file.Location;
 import org.apache.jena.dboe.sys.IO_DB;
 import org.apache.jena.dboe.sys.Names;
 import org.apache.jena.dboe.transaction.txn.TransactionCoordinator;
-import org.apache.jena.dboe.transaction.txn.TransactionalComponent;
-import org.apache.jena.dboe.transaction.txn.TransactionalSystem;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -211,14 +210,7 @@ public class DatabaseOps {
                 // There are no previous transactions on the old database at this point.
                 Path loc1Path = IO_DB.asPath(loc1);
                 LOG.debug("Deleting old database after successful compaction (old db path='" + loc1Path + "')...");
-
-                try (Stream<Path> walk = Files.walk(loc1Path)){
-                    walk.sorted(Comparator.reverseOrder())
-                        .map(Path::toFile)
-                        .forEach(File::delete);
-                } catch (IOException ex) {
-                    throw IOX.exception(ex);
-                }
+                deleteDatabase(loc1Path);
             }
         }
     }
@@ -233,16 +225,11 @@ public class DatabaseOps {
         }
     }
 
-    // XXX Later - switch in a recording dataset, not block writers, and reply after
-    // switch over before releasing the new dataset to the container.
-    // Maybe copy indexes and switch the DSG over (drop switchable).
-
     /** Copy the latest version from one location to another. */
     private static void compact(DatasetGraphSwitchable container, Location loc1, Location loc2) {
         if ( loc1.isMem() || loc2.isMem() )
             throw new TDBException("Compact involves a memory location: "+loc1+" : "+loc2);
 
-        copyFiles(loc1, loc2);
         StoreConnection srcConn = StoreConnection.connectExisting(loc1);
 
         if ( srcConn == null )
@@ -258,46 +245,74 @@ public class DatabaseOps {
         if ( dsgBase != dsgCurrent )
             throw new TDBException("Inconsistent datasets : "+dsgCurrent.getLocation()+" , "+dsgBase.getLocation());
 
-        TransactionalSystem txnSystem = dsgBase.getTxnSystem();
-        TransactionCoordinator txnMgr = dsgBase.getTxnSystem().getTxnMgr();
+        TransactionCoordinator txnMgr1 = dsgBase.getTxnSystem().getTxnMgr();
 
-        // -- Stop updates.  On exit there are no writers and none will start until switched over.
-        txnMgr.tryBlockWriters();
-        // txnMgr.begin(WRITE, false) will now bounce.
+        // -- Stop updates.
+        // On exit there are no writers and none will start until switched over.
+        // Readers can start on the old database.
 
-        // -- Copy the latest generation.
-        DatasetGraphTDB dsgCompact = StoreConnection.connectCreate(loc2).getDatasetGraphTDB();
-        CopyDSG.copy(dsgBase, dsgCompact);
+        // Block writers on the container (DatasetGraphSwitchable)
+        // while we copy the database to the new location.
+        // These writer wait output the TransactionCoordinator (old and new)
+        // until the switchover has happened.
 
-        TransactionCoordinator txnMgr2 = dsgCompact.getTxnSystem().getTxnMgr();
+        container.execReadOnlyDatabase(()->{
+            // No active writers or promote transactions on the current database.
+            // These are held up on a lock in the switchable container.
 
-        txnMgr2.execExclusive(()->{
-            List<TransactionalComponent> externals = txnMgr.listExternals();
-            if ( ! externals.isEmpty() ) {
-                txnMgr2.modifyConfigDirect(()->externals.forEach(txnMgr2::addExternal));
+            // -- Copy the current state to the new area.
+            copyConfigFiles(loc1, loc2);
+            DatasetGraphTDB dsgCompact = StoreConnection.connectCreate(loc2).getDatasetGraphTDB();
+            CopyDSG.copy(dsgBase, dsgCompact);
+
+            if ( false ) {
+                // DEVELOMENT. FAke a long copy time in state copy.
+                System.err.println("-- Inside compact 1");
+                Lib.sleep(3_000);
+                System.err.println("-- Inside compact 2");
             }
 
-            // -- Switch.
-            // No transactions on either database.
-            if ( ! container.change(dsgCurrent, dsgCompact) ) {
-                Log.warn(DatabaseOps.class, "Inconistent: old datasetgraph not as expected");
-                container.set(dsgCompact);
-            }
+            TransactionCoordinator txnMgr2 = dsgCompact.getTxnSystem().getTxnMgr();
+            // Update TransactionCoordinator and switch over.
+            txnMgr2.execExclusive(()->{
+                // No active transactions in either database.
+                txnMgr2.takeOverFrom(txnMgr1);
 
-            // This switches off the source database. Exclusive mode is not exited.
-            txnMgr.startExclusiveMode();
+                // Copy over external transaction components.
+                txnMgr2.modifyConfigDirect(()-> {
+                    txnMgr1.listExternals().forEach(txnMgr2::addExternal);
+                    // External listeners?
+                    // (the NodeTableCache listener is not external)
+                });
+
+                // No transactions on new database 2 (not exposed yet).
+                // No writers or promote transactions on database 1.
+                // Maybe old readers on database 1.
+                // -- Switch.
+                if ( ! container.change(dsgCurrent, dsgCompact) ) {
+                    Log.warn(DatabaseOps.class, "Inconsistent: old datasetgraph not as expected");
+                    container.set(dsgCompact);
+                }
+                // The compacted database is now active
+            });
+            // New database running.
+            // New transactions go to this database.
+            // Old readers continue on db1.
+
         });
 
-        // New database running.
 
+        // This switches off the source database.
+        // It waits until all transactions (readers) have finished.
+        // This call is not undone.
+        // Database1 is no longer in use.
+        txnMgr1.startExclusiveMode();
         // Clean-up.
-        // txnMgr.finishExclusiveMode();
-        // Don't call : txnMgr.startWriters();
         StoreConnection.release(dsgBase.getLocation());
     }
 
     /** Copy certain configuration files from {@code loc1} to {@code loc2}. */
-    private static void copyFiles(Location loc1, Location loc2) {
+    private static void copyConfigFiles(Location loc1, Location loc2) {
         FileFilter copyFiles  = (pathname)->{
             String fn = pathname.getName();
             if ( fn.equals(Names.TDB_CONFIG_FILE) )


### PR DESCRIPTION
GitHub issue resolved #1252.
This fixes #1457.

Pull request Description:

This is a fix for  #1252 by having writers wait on a lock in the switchable container. Previous, they waited in the transaction coordinator, which is per storage, and changes during compaction. The issue #1252 is a bug when a write starts while compaction is going on. It was blocked (held on a lock) but inside the transaction coordinator for the storage about to be compacted.

#1457 found when some tests were restored.

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
