### PR TITLE
GH-1468: Improve exclusions due to overlapping dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,10 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -394,6 +398,7 @@
         <groupId>com.github.jsonld-java</groupId>
         <artifactId>jsonld-java</artifactId>
         <version>${ver.jsonldjava}</version>
+
         <exclusions>
           <exclusion>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -407,6 +412,15 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+
           <!-- Exclude so we use our choice of versions -->
           <exclusion>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
GitHub issue resolved #1468

Pull request Description:
Exclude org.slf4j from jsonld-java and lib-thrift.
Exclude org.slf4j from libthrift.

Tested using another project where the dependency resolution via apache-jena-libs causes enforcer plugin alerts when using rule `<dependencyConvergence/>`.

----
By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
