### PR TITLE
JENA-2342: Only consider group variables

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpVars.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpVars.java
@@ -16,28 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.algebra ;
+package org.apache.jena.sparql.algebra;
 
-import static org.apache.jena.sparql.core.Vars.addVar ;
+import static org.apache.jena.sparql.core.Vars.addVar;
 
-import java.util.* ;
+import java.util.*;
 
-import org.apache.jena.atlas.lib.SetUtils ;
-import org.apache.jena.atlas.lib.tuple.Tuple ;
-import org.apache.jena.atlas.lib.tuple.TupleFactory ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.graph.Triple ;
+import org.apache.jena.atlas.lib.SetUtils;
+import org.apache.jena.atlas.lib.tuple.Tuple;
+import org.apache.jena.atlas.lib.tuple.TupleFactory;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.algebra.OpWalker.OpWalkerVisitor;
-//import org.apache.jena.sparql.algebra.walker.WalkerVisitor ;
-import org.apache.jena.sparql.algebra.op.* ;
+//import org.apache.jena.sparql.algebra.walker.WalkerVisitor;
+import org.apache.jena.sparql.algebra.op.*;
 //import org.apache.jena.sparql.algebra.walker.WalkerVisitorVisible;
-import org.apache.jena.sparql.core.BasicPattern ;
-import org.apache.jena.sparql.core.Var ;
+import org.apache.jena.sparql.core.BasicPattern;
+import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.ExprAggregator;
-import org.apache.jena.sparql.expr.ExprVars ;
-import org.apache.jena.sparql.pfunction.PropFuncArg ;
-import org.apache.jena.sparql.util.VarUtils ;
+import org.apache.jena.sparql.expr.ExprVars;
+import org.apache.jena.sparql.pfunction.PropFuncArg;
+import org.apache.jena.sparql.util.VarUtils;
 
 /** Get vars for a pattern */
 
@@ -46,50 +46,50 @@ public class OpVars
     // Choose the default collector - LinkedHashSet is predictable and
     // keeps the "found" order
     private static Set<Var> collector() {
-        return new LinkedHashSet<>() ;
+        return new LinkedHashSet<>();
     }
 
     public static Set<Var> visibleVars(Op op) {
-        Set<Var> acc = collector() ;
-        visibleVars(op, acc) ;
-        return acc ;
+        Set<Var> acc = collector();
+        visibleVars(op, acc);
+        return acc;
     }
 
     public static void visibleVars(Op op, Set<Var> acc) {
-        OpVarsPattern visitor = new OpVarsPattern(acc, true) ;
+        OpVarsPattern visitor = new OpVarsPattern(acc, true);
         // Does not work yet for new walker.
-        OpWalker.walk(new OpWalkerVisitorVisible(visitor, acc), op) ;
+        OpWalker.walk(new OpWalkerVisitorVisible(visitor, acc), op);
     }
 
     /** The set of variables that will be in every solution of this Op */
     public static Set<Var> fixedVars(Op op) {
-        Set<Var> acc = collector() ;
-        fixedVars(op, acc) ;
-        return acc ;
+        Set<Var> acc = collector();
+        fixedVars(op, acc);
+        return acc;
     }
 
     public static void fixedVars(Op op, Set<Var> acc) {
-        OpVarsPattern visitor = new OpVarsPattern(acc, true) ;
-        OpWalker.walk(new OpWalkerVisitorFixed(visitor, acc), op) ;
+        OpVarsPattern visitor = new OpVarsPattern(acc, true);
+        OpWalker.walk(new OpWalkerVisitorFixed(visitor, acc), op);
     }
 
     public static Tuple<Set<Var>> mentionedVarsByPosition(Op op) {
-        Set<Var> graphAcc = collector() ;
-        Set<Var> subjAcc = collector() ;
-        Set<Var> predAcc = collector() ;
-        Set<Var> objAcc = collector() ;
-        Set<Var> unknownAcc = collector() ;
+        Set<Var> graphAcc = collector();
+        Set<Var> subjAcc = collector();
+        Set<Var> predAcc = collector();
+        Set<Var> objAcc = collector();
+        Set<Var> unknownAcc = collector();
         OpVarsPatternWithPositions visitor = new OpVarsPatternWithPositions(graphAcc, subjAcc, predAcc, objAcc, unknownAcc, false);
         OpWalker.walk(op, visitor);
         return TupleFactory.tuple(graphAcc, subjAcc, predAcc, objAcc, unknownAcc);
     }
 
     public static Tuple<Set<Var>> mentionedVarsByPosition(Op... ops) {
-        Set<Var> graphAcc = collector() ;
-        Set<Var> subjAcc = collector() ;
-        Set<Var> predAcc = collector() ;
-        Set<Var> objAcc = collector() ;
-        Set<Var> unknownAcc = collector() ;
+        Set<Var> graphAcc = collector();
+        Set<Var> subjAcc = collector();
+        Set<Var> predAcc = collector();
+        Set<Var> objAcc = collector();
+        Set<Var> unknownAcc = collector();
         OpVarsPatternWithPositions visitor = new OpVarsPatternWithPositions(graphAcc, subjAcc, predAcc, objAcc, unknownAcc, false);
         for (Op op : ops)
             OpWalker.walk(op, visitor);
@@ -98,15 +98,15 @@ public class OpVars
 
     // All mentioned variables regardless of scope/visibility.
     public static Collection<Var> mentionedVars(Op op) {
-        Set<Var> acc = collector() ;
-        mentionedVars(op, acc) ;
-        return acc ;
+        Set<Var> acc = collector();
+        mentionedVars(op, acc);
+        return acc;
     }
 
     // All mentioned variables regardless of scope/visibility.
     public static void mentionedVars(Op op, Set<Var> acc) {
-        OpVarsMentioned visitor = new OpVarsMentioned(acc) ;
-        OpWalker.walk(op, visitor) ;
+        OpVarsMentioned visitor = new OpVarsMentioned(acc);
+        OpWalker.walk(op, visitor);
     }
 
     private static void accVarsFromGroup(Collection<Var> acc, OpGroup opGroup) {
@@ -127,39 +127,39 @@ public class OpVars
      */
     private static class OpWalkerVisitorVisible extends OpWalkerVisitor
     {
-        private final Collection<Var> acc ;
+        private final Collection<Var> acc;
 
         public OpWalkerVisitorVisible(OpVarsPattern visitor, Collection<Var> acc) {
-            super(visitor) ;
-            this.acc = acc ;
+            super(visitor);
+            this.acc = acc;
         }
 
         @Override
         public void visit(OpProject op) {
-            before(op) ;
+            before(op);
             // Skip Project subop.
-            acc.addAll(op.getVars()) ;
-            after(op) ;
+            acc.addAll(op.getVars());
+            after(op);
         }
 
         @Override
         public void visit(OpMinus op) {
-            before(op) ;
+            before(op);
             if (op.getLeft() != null)
-                op.getLeft().visit(this) ;
+                op.getLeft().visit(this);
             // Skip right.
-            // if ( op.getRight() != null ) op.getRight().visit(this) ;
+            // if ( op.getRight() != null ) op.getRight().visit(this);
             if (visitor != null)
-                op.visit(visitor) ;
-            after(op) ;
+                op.visit(visitor);
+            after(op);
         }
 
         @Override public void visit(OpGroup op) {
             // Do not walk inside the group
-            before(op) ;
+            before(op);
             if (visitor != null)
-                op.visit(visitor) ;
-            after(op) ;
+                op.visit(visitor);
+            after(op);
         }
     }
 
@@ -167,12 +167,12 @@ public class OpVars
     // OPTIONAL (2 forms) and UNION are the interesting cases.
     private static class OpWalkerVisitorFixed extends OpWalkerVisitor
     {
-        private final Collection<Var> acc ;
+        private final Collection<Var> acc;
 
         public OpWalkerVisitorFixed(OpVarsPattern visitor, Collection<Var> acc) {
-            //super(visitor, null, null, null) ;
+            //super(visitor, null, null, null);
             super(visitor);
-            this.acc = acc ;
+            this.acc = acc;
         }
 
         @Override
@@ -187,79 +187,78 @@ public class OpVars
 
         @Override
         public void visit(OpUnion x) {
-            Set<Var> left = fixedVars(x.getLeft()) ;
-            Set<Var> right = fixedVars(x.getRight()) ;
-            Set<Var> r = SetUtils.intersection(left,  right) ;
-            acc.addAll(r) ;
+            Set<Var> left = fixedVars(x.getLeft());
+            Set<Var> right = fixedVars(x.getRight());
+            Set<Var> r = SetUtils.intersection(left,  right);
+            acc.addAll(r);
         }
 
         @Override
         public void visit(OpProject op) {
-            before(op) ;
+            before(op);
             // Skip Project subop.
-            acc.addAll(op.getVars()) ;
-            after(op) ;
+            acc.addAll(op.getVars());
+            after(op);
         }
 
         @Override
         public void visit(OpMinus op) {
-            before(op) ;
+            before(op);
             if (op.getLeft() != null)
-                op.getLeft().visit(this) ;
+                op.getLeft().visit(this);
             // Skip right.
-            // if ( op.getRight() != null ) op.getRight().visit(this) ;
+            // if ( op.getRight() != null ) op.getRight().visit(this);
 //            if (opVisitor != null)
-//                op.visit(opVisitor) ;
+//                op.visit(opVisitor);
             if (visitor != null)
-                op.visit(visitor) ;
-            after(op) ;
+                op.visit(visitor);
+            after(op);
         }
 
         @Override public void visit(OpGroup op) {
             // Do not walk inside the group
-            before(op) ;
+            before(op);
             if (visitor != null)
-                op.visit(visitor) ;
-            after(op) ;
+                op.visit(visitor);
+            after(op);
         }
     }
 
-    /** Collect variables.
-     * What to collect from is controlled by the walker e.g.
-     * OpWalkerVisitorFixed, OpWalkerVisitorVisible
-     * and for OpVarsMentioned, the full geenral walker.
+    /**
+     * Collect variables. What to collect from is controlled by the walker e.g.
+     * OpWalkerVisitorFixed, OpWalkerVisitorVisible and for OpVarsMentioned, the full
+     * geenral walker.
      */
-    private static class OpVarsPattern extends OpVisitorBase
-    {
+    private static class OpVarsPattern extends OpVisitorBase {
         // The possibly-set-vars
-        protected Set<Var> acc ;
-        final boolean      visibleOnly ;
+        protected Set<Var> acc;
+        final boolean visibleOnly;
 
         OpVarsPattern(Set<Var> acc, boolean visibleOnly) {
-            this.acc = acc ;
-            this.visibleOnly = visibleOnly ;
+            this.acc = acc;
+            this.visibleOnly = visibleOnly;
         }
 
         @Override
         public void visit(OpBGP opBGP) {
-            VarUtils.addVars(acc, opBGP.getPattern()) ;
+            VarUtils.addVars(acc, opBGP.getPattern());
         }
 
         @Override
         public void visit(OpPath opPath) {
-            addVar(acc, opPath.getTriplePath().getSubject()) ;
-            addVar(acc, opPath.getTriplePath().getObject()) ;
+            addVar(acc, opPath.getTriplePath().getSubject());
+            addVar(acc, opPath.getTriplePath().getObject());
         }
 
         @Override
         public void visit(OpQuadPattern quadPattern) {
-            addVar(acc, quadPattern.getGraphNode()) ;
-            VarUtils.addVars(acc, quadPattern.getBasicPattern()) ;
+            addVar(acc, quadPattern.getGraphNode());
+            VarUtils.addVars(acc, quadPattern.getBasicPattern());
         }
 
         @Override
         public void visit(OpQuadBlock quadBlock) {
-            VarUtils.addVars(acc, quadBlock.getPattern()) ;
+            VarUtils.addVars(acc, quadBlock.getPattern());
         }
 
         @Override
@@ -274,20 +273,20 @@ public class OpVars
 
         @Override
         public void visit(OpGraph opGraph) {
-            addVar(acc, opGraph.getNode()) ;
+            addVar(acc, opGraph.getNode());
         }
 
         @Override
         public void visit(OpDatasetNames dsNames) {
-            addVar(acc, dsNames.getGraphNode()) ;
+            addVar(acc, dsNames.getGraphNode());
         }
 
         @Override
         public void visit(OpTable opTable) {
             // Only the variables with values in the tables (When building,
             // undefs didn't get into bindings so no variable mentioned)
-            Table t = opTable.getTable() ;
-            acc.addAll(t.getVars()) ;
+            Table t = opTable.getTable();
+            acc.addAll(t.getVars());
         }
 
         @Override
@@ -297,86 +296,86 @@ public class OpVars
             // The visibleOnly/clear is simply to be as general as possible.
             // visible: OpWalkerVisitorFixed, OpWalkerVisitorVisible,
             // all (visibleOnly==false) for OpVarsMentioned
-            if (visibleOnly)
-                acc.clear() ;
-            acc.addAll(opProject.getVars()) ;
+            if ( visibleOnly )
+                acc.clear();
+            acc.addAll(opProject.getVars());
         }
 
         @Override
         public void visit(OpAssign opAssign) {
-            acc.addAll(opAssign.getVarExprList().getVars()) ;
+            acc.addAll(opAssign.getVarExprList().getVars());
         }
 
         @Override
         public void visit(OpExtend opExtend) {
-            acc.addAll(opExtend.getVarExprList().getVars()) ;
+            acc.addAll(opExtend.getVarExprList().getVars());
         }
 
         @Override
         public void visit(OpPropFunc opPropFunc) {
-            PropFuncArg.addVars(acc, opPropFunc.getSubjectArgs()) ;
-            PropFuncArg.addVars(acc, opPropFunc.getObjectArgs()) ;
+            PropFuncArg.addVars(acc, opPropFunc.getSubjectArgs());
+            PropFuncArg.addVars(acc, opPropFunc.getObjectArgs());
         }
 
         @Override
         public void visit(OpProcedure opProc) {
-            ExprVars.varsMentioned(acc, opProc.getArgs()) ;
+            ExprVars.varsMentioned(acc, opProc.getArgs());
         }
 
         @Override
         public void visit(OpExt opExt) {
-            // OpWalkerVisitor is taking care of calling opExt.effectiveOp().visit(this)
+            // OpWalkerVisitor is taking care of calling
+            // opExt.effectiveOp().visit(this)
         }
 
-        @Override public void visit(OpGroup opGroup) {
+        @Override
+        public void visit(OpGroup opGroup) {
             accVarsFromGroup(acc, opGroup);
 
         }
 
     }
 
-    private static class OpVarsPatternWithPositions extends OpVisitorBase
-    {
+    private static class OpVarsPatternWithPositions extends OpVisitorBase {
         // The possibly-set-vars
-        protected Set<Var> graphAcc, subjAcc, predAcc, objAcc, unknownAcc ;
-        final boolean      visibleOnly ;
+        protected Set<Var> graphAcc, subjAcc, predAcc, objAcc, unknownAcc;
+        final boolean visibleOnly;
 
-        OpVarsPatternWithPositions(Set<Var> graphAcc,
-                                   Set<Var> subjAcc, Set<Var> predAcc, Set<Var> objAcc,
-                                   Set<Var> unknownAcc, boolean visibleOnly) {
+        OpVarsPatternWithPositions(Set<Var> graphAcc, Set<Var> subjAcc, Set<Var> predAcc, Set<Var> objAcc, Set<Var> unknownAcc,
+                                   boolean visibleOnly) {
             this.graphAcc = graphAcc;
             this.subjAcc = subjAcc;
             this.predAcc = predAcc;
             this.objAcc = objAcc;
             this.unknownAcc = unknownAcc;
-            this.visibleOnly = visibleOnly ;
+            this.visibleOnly = visibleOnly;
         }
 
         @Override
         public void visit(OpBGP opBGP) {
-            vars(opBGP.getPattern()) ;
+            vars(opBGP.getPattern());
         }
 
         @Override
         public void visit(OpPath opPath) {
-            addVar(subjAcc, opPath.getTriplePath().getSubject()) ;
-            addVar(objAcc, opPath.getTriplePath().getObject()) ;
+            addVar(subjAcc, opPath.getTriplePath().getSubject());
+            addVar(objAcc, opPath.getTriplePath().getObject());
         }
 
         @Override
         public void visit(OpQuadPattern quadPattern) {
-            addVar(graphAcc, quadPattern.getGraphNode()) ;
-            vars(quadPattern.getBasicPattern()) ;
+            addVar(graphAcc, quadPattern.getGraphNode());
+            vars(quadPattern.getBasicPattern());
         }
 
         @Override
         public void visit(OpGraph opGraph) {
-            addVar(graphAcc, opGraph.getNode()) ;
+            addVar(graphAcc, opGraph.getNode());
         }
 
         @Override
         public void visit(OpDatasetNames dsNames) {
-            addVar(graphAcc, dsNames.getGraphNode()) ;
+            addVar(graphAcc, dsNames.getGraphNode());
         }
 
         @Override
@@ -384,9 +383,9 @@ public class OpVars
             // Only the variables with values in the tables
             // (When building, undefs didn't get into bindings so no variable
             // mentioned)
-            Table t = opTable.getTable() ;
+            Table t = opTable.getTable();
             // Treat as unknown position
-            unknownAcc.addAll(t.getVars()) ;
+            unknownAcc.addAll(t.getVars());
         }
 
         @Override
@@ -406,14 +405,14 @@ public class OpVars
         }
 
         private void merge(List<Var> vs) {
-            if (visibleOnly) {
+            if ( visibleOnly ) {
                 clear(graphAcc, vs);
                 clear(subjAcc, vs);
                 clear(predAcc, vs);
                 clear(objAcc, vs);
             }
-            for (Var v : vs) {
-                if (!graphAcc.contains(v) && !subjAcc.contains(v) && !predAcc.contains(v) && !objAcc.contains(v)) {
+            for ( Var v : vs ) {
+                if ( !graphAcc.contains(v) && !subjAcc.contains(v) && !predAcc.contains(v) && !objAcc.contains(v) ) {
                     addVar(unknownAcc, v);
                 }
             }
@@ -422,28 +421,28 @@ public class OpVars
         @Override
         public void visit(OpAssign opAssign) {
             // Unknown position
-            unknownAcc.addAll(opAssign.getVarExprList().getVars()) ;
+            unknownAcc.addAll(opAssign.getVarExprList().getVars());
         }
 
         @Override
         public void visit(OpExtend opExtend) {
             // Unknown position
-            unknownAcc.addAll(opExtend.getVarExprList().getVars()) ;
+            unknownAcc.addAll(opExtend.getVarExprList().getVars());
         }
 
         @Override
         public void visit(OpPropFunc opPropFunc) {
-            addvars(subjAcc, opPropFunc.getSubjectArgs()) ;
-            addvars(objAcc, opPropFunc.getObjectArgs()) ;
+            addvars(subjAcc, opPropFunc.getSubjectArgs());
+            addvars(objAcc, opPropFunc.getObjectArgs());
         }
 
         private void addvars(Set<Var> acc, PropFuncArg pfArg) {
-            if (pfArg.isNode()) {
-                addVar(acc, pfArg.getArg()) ;
-                return ;
+            if ( pfArg.isNode() ) {
+                addVar(acc, pfArg.getArg());
+                return;
             }
-            for (Node n : pfArg.getArgList())
-                addVar(acc, n) ;
+            for ( Node n : pfArg.getArgList() )
+                addVar(acc, n);
         }
 
         @Override
@@ -452,8 +451,7 @@ public class OpVars
         }
 
         private void vars(BasicPattern bp) {
-            for (Triple t : bp.getList())
-            {
+            for ( Triple t : bp.getList() ) {
                 addVar(subjAcc, t.getSubject());
                 addVar(predAcc, t.getPredicate());
                 addVar(objAcc, t.getObject());
@@ -462,32 +460,30 @@ public class OpVars
 
         private void clear(Set<Var> acc, List<Var> visible) {
             List<Var> toRemove = new ArrayList<>();
-            for (Var found : acc)
-            {
-                if (!visible.contains(found)) {
+            for ( Var found : acc ) {
+                if ( !visible.contains(found) ) {
                     toRemove.add(found);
                 }
             }
-            for (Var v : toRemove) {
+            for ( Var v : toRemove ) {
                 acc.remove(v);
             }
         }
     }
 
-    private static class OpVarsMentioned extends OpVarsPattern
-    {
+    private static class OpVarsMentioned extends OpVarsPattern {
         OpVarsMentioned(Set<Var> acc) {
-            super(acc, false) ;
+            super(acc, false);
         }
 
         @Override
         public void visit(OpFilter opFilter) {
-            ExprVars.varsMentioned(acc, opFilter.getExprs()) ;
+            ExprVars.varsMentioned(acc, opFilter.getExprs());
         }
 
         @Override
         public void visit(OpOrder opOrder) {
-            ExprVars.varsMentioned(acc, opOrder.getConditions()) ;
+            ExprVars.varsMentioned(acc, opOrder.getConditions());
         }
 
         @Override
@@ -502,7 +498,7 @@ public class OpVars
 
         // The expression side of (extend) and (assign)
         private void visitExtendAssign(OpExtendAssign op) {
-            op.getVarExprList().forEachExpr((v,e)->ExprVars.varsMentioned(acc, e));
+            op.getVarExprList().forEachExpr((v, e) -> ExprVars.varsMentioned(acc, e));
         }
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpWalker.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpWalker.java
@@ -55,7 +55,7 @@ public class OpWalker
     
     public static void walk(OpWalkerVisitor walkerVisitor, Op op)
     {
-        // Stil needed for OpWalkerVisitorVisible, OpWalkerVisitorFixed
+        // Still needed for OpWalkerVisitorVisible, OpWalkerVisitorFixed
         op.visit(walkerVisitor) ;
     }
     

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpWalker.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpWalker.java
@@ -18,9 +18,9 @@
 
 package org.apache.jena.sparql.algebra;
 
-import java.util.Iterator ;
+import java.util.Iterator;
 
-import org.apache.jena.sparql.algebra.op.* ;
+import org.apache.jena.sparql.algebra.op.*;
 
 /** Apply a visitor to the whole structure of Ops, recursively.
  *  Visit sub Op before the current level
@@ -30,121 +30,118 @@ public class OpWalker
 {
     // Predates org.apache.jena.sparql.algebra.walker.Walker
     // Need to convert but OpVars depends on OpWalkerVisitorFixed, OpWalkerVisitorVisible
-    
+
     /* OpVars::
      public static void visibleVars(Op op, Set<Var> acc) {
-        OpVarsPattern visitor = new OpVarsPattern(acc, true) ;
+        OpVarsPattern visitor = new OpVarsPattern(acc, true);
         // Does not work.
         //new WalkerVisitorVisible(visitor, null, null, null).walk(op);
-        //OpWalker.walk(new OpWalkerVisitorVisible(visitor, acc), op) ;
+        //OpWalker.walk(new OpWalkerVisitorVisible(visitor, acc), op);
     }
      */
-    
+
     // **** Replace with org.apache.jena.sparql.algebra.walker.Walker
-    public static void walk(Op op, OpVisitor visitor)
-    {
+    public static void walk(Op op, OpVisitor visitor) {
         // new walker :: this works
         // Walker.walk(op, visitor);
-        walk(new OpWalkerVisitor(visitor, null, null), op) ;
+        walk(new OpWalkerVisitor(visitor, null, null), op);
     }
-    
-//    public static void walk(Op op, OpVisitor visitor, OpVisitor beforeVisitor, OpVisitor afterVisitor)
-//    {
-//        walk(new OpWalkerVisitor(visitor, beforeVisitor, afterVisitor), op) ;
+
+//    public static void walk(Op op, OpVisitor visitor, OpVisitor beforeVisitor, OpVisitor afterVisitor) {
+//        walk(new OpWalkerVisitor(visitor, beforeVisitor, afterVisitor), op);
 //    }
-    
-    public static void walk(OpWalkerVisitor walkerVisitor, Op op)
-    {
+
+    public static void walk(OpWalkerVisitor walkerVisitor, Op op) {
         // Still needed for OpWalkerVisitorVisible, OpWalkerVisitorFixed
-        op.visit(walkerVisitor) ;
+        op.visit(walkerVisitor);
     }
-    
+
     protected static class OpWalkerVisitor extends OpVisitorByType {
-        private final OpVisitor   beforeVisitor ;
-        private final OpVisitor   afterVisitor ;
-        protected final OpVisitor visitor ;
+        private final OpVisitor   beforeVisitor;
+        private final OpVisitor   afterVisitor;
+        protected final OpVisitor visitor;
 
         public OpWalkerVisitor(OpVisitor visitor, OpVisitor beforeVisitor, OpVisitor afterVisitor) {
-            this.visitor = visitor ;
-            this.beforeVisitor = beforeVisitor ;
-            this.afterVisitor = afterVisitor ;
+            this.visitor = visitor;
+            this.beforeVisitor = beforeVisitor;
+            this.afterVisitor = afterVisitor;
         }
 
         public OpWalkerVisitor(OpVisitor visitor) {
-            this(visitor, null, null) ;
+            this(visitor, null, null);
         }
 
         protected final void before(Op op) {
             if ( beforeVisitor != null )
-                op.visit(beforeVisitor) ;
+                op.visit(beforeVisitor);
         }
 
         protected final void after(Op op) {
             if ( afterVisitor != null )
-                op.visit(afterVisitor) ;
+                op.visit(afterVisitor);
         }
 
         @Override
         protected void visit0(Op0 op) {
-            before(op) ;
+            before(op);
             if ( visitor != null )
-                op.visit(visitor) ;
-            after(op) ;
+                op.visit(visitor);
+            after(op);
         }
 
         @Override
         protected void visit1(Op1 op) {
-            before(op) ;
+            before(op);
             if ( op.getSubOp() != null )
-                op.getSubOp().visit(this) ;
+                op.getSubOp().visit(this);
             if ( visitor != null )
-                op.visit(visitor) ;
-            after(op) ;
+                op.visit(visitor);
+            after(op);
         }
 
         @Override
         protected void visitFilter(OpFilter op) {
-            visit1(op) ;
+            visit1(op);
         }
 
         @Override
         protected void visitLeftJoin(OpLeftJoin op) {
-            visit2(op) ;
+            visit2(op);
         }
 
         @Override
         protected void visit2(Op2 op) {
-            before(op) ;
+            before(op);
             if ( op.getLeft() != null )
-                op.getLeft().visit(this) ;
+                op.getLeft().visit(this);
             if ( op.getRight() != null )
-                op.getRight().visit(this) ;
+                op.getRight().visit(this);
             if ( visitor != null )
-                op.visit(visitor) ;
-            after(op) ;
+                op.visit(visitor);
+            after(op);
         }
 
         @Override
         protected void visitN(OpN op) {
-            before(op) ;
+            before(op);
             for (Iterator<Op> iter = op.iterator(); iter.hasNext();) {
-                Op sub = iter.next() ;
-                sub.visit(this) ;
+                Op sub = iter.next();
+                sub.visit(this);
             }
             if ( visitor != null )
-                op.visit(visitor) ;
-            after(op) ;
+                op.visit(visitor);
+            after(op);
         }
 
         @Override
         protected void visitExt(OpExt op) {
-            before(op) ;
+            before(op);
             if ( op.effectiveOp() != null )
                 // Walk the effective op, if present.
                 op.effectiveOp().visit(this);
             if ( visitor != null )
-                op.visit(visitor) ;
-            after(op) ;
+                op.visit(visitor);
+            after(op);
         }
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterImplicitJoin.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterImplicitJoin.java
@@ -41,7 +41,7 @@ import org.apache.jena.sparql.expr.* ;
  * Optimizer for transforming implicit joins. These covers queries like the
  * following:
  * </p>
- * 
+ *
  * <pre>
  * SELECT *
  * WHERE
@@ -57,7 +57,7 @@ import org.apache.jena.sparql.expr.* ;
  * would otherwise be required to evaluate. The optimization where applicable
  * results in a query of the following form:
  * </p>
- * 
+ *
  * <pre>
  * SELECT *
  * WHERE
@@ -139,13 +139,13 @@ public class TransformFilterImplicitJoin extends TransformCopy {
             op = OpFilter.filterBy(exprs, op);
             return op;
         }
-        
+
         // Special case : filter is over a union where one/both sides are always false
         if (testSpecialCaseUnion(subOp, joins)) {
         	// This will attempt to eliminate the sides that are always false
         	op = processSpecialCaseUnion(subOp, joins);
-        	
-        	// In the case where both sides were invalid we'll have a table empty 
+
+        	// In the case where both sides were invalid we'll have a table empty
         	// operator at this point and can return immediately
         	if (op instanceof OpTable) return op;
         }
@@ -286,7 +286,7 @@ public class TransformFilterImplicitJoin extends TransformCopy {
             Op2 op2 = (Op2) op;
             return safeToTransform(joins, varsEquality, op2.getLeft()) && safeToTransform(joins, varsEquality, op2.getRight());
         }
-        
+
         if (op instanceof OpUnion) {
         	// True only if for any pairs that affect the pattern both variables occur
         	Set<Var> fixedVars = OpVars.fixedVars(op);
@@ -392,13 +392,13 @@ public class TransformFilterImplicitJoin extends TransformCopy {
         }
         return isTableUnit(op);
     }
-    
+
     private static boolean testSpecialCaseUnion(Op op, List<Pair<Var, Var>> joins) {
     	if (op instanceof OpUnion) {
     		OpUnion union = (OpUnion) op;
     		Set<Var> leftVars = OpVars.visibleVars(union.getLeft());
     		Set<Var> rightVars = OpVars.visibleVars(union.getRight());
-    		
+
     		// Is a special case if there is any implicit join where only one of the variables mentioned in an
     		// implicit join is present on one side of the union
     		for (Pair<Var, Var> p : joins) {
@@ -449,14 +449,14 @@ public class TransformFilterImplicitJoin extends TransformCopy {
         }
         return false;
     }
-    
+
     private static Op processSpecialCaseUnion(Op op, List<Pair<Var, Var>> joins) {
     	if (op instanceof OpUnion) {
     		OpUnion union = (OpUnion) op;
-    		
+
     		Set<Var> leftVars = OpVars.visibleVars(union.getLeft());
     		Set<Var> rightVars = OpVars.visibleVars(union.getRight());
-    		
+
     		// Is a special case if there is any implicit join where only one of the variables mentioned in an
     		// implicit join is present on one side of the union
     		boolean leftEmpty = false, rightEmpty = false;
@@ -464,7 +464,7 @@ public class TransformFilterImplicitJoin extends TransformCopy {
     			if (leftEmpty || !leftVars.contains(p.getLeft()) || !leftVars.contains(p.getRight())) leftEmpty = true;
     			if (rightEmpty || !rightVars.contains(p.getLeft()) || !rightVars.contains(p.getRight())) rightEmpty = true;
     		}
-    		
+
     		// If both sides of the union guarantee to produce errors then just replace the whole thing with table empty
     		if (leftEmpty && rightEmpty) return OpTable.empty();
     		if (leftEmpty) return union.getRight();

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformImplicitLeftJoin.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformImplicitLeftJoin.java
@@ -41,7 +41,7 @@ import org.apache.jena.sparql.expr.* ;
  * Optimizer for transforming implicit joins. These covers queries like the
  * following:
  * </p>
- * 
+ *
  * <pre>
  * SELECT *
  * WHERE
@@ -60,7 +60,7 @@ import org.apache.jena.sparql.expr.* ;
  * would otherwise be required to evaluate. The optimization where applicable
  * results in a query of the following form:
  * </p>
- * 
+ *
  * <pre>
  * SELECT *
  * WHERE
@@ -107,10 +107,10 @@ public class TransformImplicitLeftJoin extends TransformCopy {
     private static Op apply(OpLeftJoin opLeftJoin, Op left, Op right) {
         // This handles arbitrarily nested && conditions
         ExprList orig = ExprList.splitConjunction(opLeftJoin.getExprs());
-        
+
         // Extract optimizable conditions?
         Pair<List<Pair<Var, Var>>, ExprList> p = preprocessFilterImplicitJoin(left, right, orig);
-        
+
         // Were there any optimizable conditions?
         if (p == null || p.getLeft().size() == 0)
             return null;
@@ -245,7 +245,6 @@ public class TransformImplicitLeftJoin extends TransformCopy {
         if (e instanceof E_Equals) {
             // Is a safe equals for this optimization?
             Tuple<Set<Var>> varsByPosition = OpVars.mentionedVarsByPosition(opLeft, opRight);
-
             if (!isSafeEquals(varsByPosition, left.asVar(), right.asVar()))
                 return null;
         }
@@ -330,7 +329,7 @@ public class TransformImplicitLeftJoin extends TransformCopy {
             Op2 op2 = (Op2) op;
             return safeToTransform(joins, varsEquality, op2.getLeft()) && safeToTransform(joins, varsEquality, op2.getRight());
         }
-        
+
         if (op instanceof OpUnion) {
         	// True only if for any pairs that affect the pattern both variables occur
         	Set<Var> fixedVars = OpVars.fixedVars(op);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/VarExprList.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/VarExprList.java
@@ -64,6 +64,7 @@ public class VarExprList
 
     /** Call the action for each (variable, expression) defined.
      *  Not called when there is no expression, just a variable.
+     *  (c.f. {@link #forEachVarExpr}).
      *  Not order preserving.
      */
     public void forEachExpr(BiConsumer<Var, Expr> action) {
@@ -72,7 +73,8 @@ public class VarExprList
 
     /** Call the action for each variable, in order.
      *  The expression may be null.
-     *  Not called when there is no expression, just a variable.
+     *  Called when there is no expression, just a variable
+     *  (c.f. {@link #forEachExpr}).
      */
     public void forEachVarExpr(BiConsumer<Var, Expr> action) {
         //*  See {@link #forEach}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/VarExprList.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/VarExprList.java
@@ -18,104 +18,110 @@
 
 package org.apache.jena.sparql.core;
 
-import java.util.* ;
-import java.util.function.BiConsumer ;
-import java.util.function.Consumer ;
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
-import org.apache.jena.graph.Node ;
-import org.apache.jena.sparql.ARQInternalErrorException ;
-import org.apache.jena.sparql.engine.binding.Binding ;
-import org.apache.jena.sparql.expr.Expr ;
-import org.apache.jena.sparql.expr.ExprEvalException ;
-import org.apache.jena.sparql.expr.NodeValue ;
-import org.apache.jena.sparql.function.FunctionEnv ;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprEvalException;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.function.FunctionEnv;
 
-public class VarExprList
-{
-    private List<Var> vars  ;
-    private LinkedHashMap<Var, Expr> exprs  ;   // Preserve order.
+public class VarExprList {
+    private List<Var> vars;
+    private LinkedHashMap<Var, Expr> exprs;   // Preserve order.
 
-    public VarExprList(List<Var> vars)
-    {
-        this.vars = new ArrayList<>(vars) ;
-        this.exprs = new LinkedHashMap<>() ;
+    public VarExprList(List<Var> vars) {
+        this.vars = new ArrayList<>(vars);
+        this.exprs = new LinkedHashMap<>();
     }
 
-    public VarExprList(VarExprList other)
-    {
-        this.vars = new ArrayList<>(other.vars) ;
-        this.exprs = new LinkedHashMap<>(other.exprs) ;
+    public VarExprList(VarExprList other) {
+        this.vars = new ArrayList<>(other.vars);
+        this.exprs = new LinkedHashMap<>(other.exprs);
     }
 
-    public VarExprList()
-    {
-        this.vars = new ArrayList<>() ;
-        this.exprs = new LinkedHashMap<>() ;
+    public VarExprList() {
+        this.vars = new ArrayList<>();
+        this.exprs = new LinkedHashMap<>();
     }
 
-    public VarExprList(Var var, Expr expr)
-    {
-        this() ;
-        add(var, expr) ;
+    public VarExprList(Var var, Expr expr) {
+        this();
+        add(var, expr);
     }
 
-    public List<Var> getVars()          { return vars ; }
-    public Map<Var, Expr> getExprs()    { return exprs ; }
+    public List<Var> getVars() {
+        return vars;
+    }
 
-    /** Call the action for each (variable, expression) defined.
-     *  Not called when there is no expression, just a variable.
-     *  (c.f. {@link #forEachVarExpr}).
-     *  Not order preserving.
+    public Map<Var, Expr> getExprs() {
+        return exprs;
+    }
+
+    /**
+     * Call the action for each (variable, expression) defined.
+     * Not called when there is no expression, just a variable.
+     * (c.f. {@link #forEachVarExpr}). Not order preserving.
      */
     public void forEachExpr(BiConsumer<Var, Expr> action) {
         exprs.forEach(action);
     }
 
-    /** Call the action for each variable, in order.
-     *  The expression may be null.
-     *  Called when there is no expression, just a variable
-     *  (c.f. {@link #forEachExpr}).
+    /**
+     * Call the action for each variable, in order.
+     * The expression may be null.
+     * Called when there is no expression, just a variable (c.f.
+     * {@link #forEachExpr}).
      */
     public void forEachVarExpr(BiConsumer<Var, Expr> action) {
-        //*  See {@link #forEach}
+        // * See {@link #forEach}
         getVars().forEach((v) -> {
             // Maybe null.
-            Expr e = exprs.get(v) ;
+            Expr e = exprs.get(v);
             action.accept(v, e);
-        }) ;
+        });
     }
 
     /** Call the action for each variable, in order. */
     public void forEachVar(Consumer<Var> action) {
         getVars().forEach((v) -> {
             action.accept(v);
-        }) ;
+        });
     }
 
-    public boolean contains(Var var) { return vars.contains(var) ; }
-    public boolean hasExpr(Var var) { return exprs.containsKey(var) ; }
+    public boolean contains(Var var) {
+        return vars.contains(var);
+    }
 
-    public Expr getExpr(Var var) { return exprs.get(var) ; }
+    public boolean hasExpr(Var var) {
+        return exprs.containsKey(var);
+    }
 
-    public Node get(Var var, Binding binding, FunctionEnv funcEnv)
-    {
-        Expr expr = exprs.get(var) ;
+    public Expr getExpr(Var var) {
+        return exprs.get(var);
+    }
+
+    public Node get(Var var, Binding binding, FunctionEnv funcEnv) {
+        Expr expr = exprs.get(var);
         if ( expr == null )
-            return binding.get(var) ;
+            return binding.get(var);
 
         try {
-            NodeValue nv = expr.eval(binding, funcEnv) ;
+            NodeValue nv = expr.eval(binding, funcEnv);
             if ( nv == null )
-                return null ;
-            return nv.asNode() ;
+                return null;
+            return nv.asNode();
         } catch (ExprEvalException ex)
-        //{ Log.warn(this, "Eval failure "+expr+": "+ex.getMessage()) ; }
-        { }
-        return null ;
+        // { Log.warn(this, "Eval failure "+expr+": "+ex.getMessage()) ; }
+        {}
+        return null;
     }
 
-    public void add(Var var)
-    {
+    public void add(Var var) {
         // Checking here controls whether duplicate variables are allowed.
         // Duplicates with expressions are not allowed (add(Var, Expr))
         // See ARQ.allowDuplicateSelectColumns
@@ -123,37 +129,33 @@ public class VarExprList
         // Every should work either way round if this is enabled.
         // Checking is done in Query for adding result vars, and group vars.
         // if ( vars.contains(var) )
-            vars.add(var) ;
+        vars.add(var);
     }
 
-    public void add(Var var, Expr expr)
-    {
-        if ( expr == null )
-        {
-            add(var) ;
-            return ;
+    public void add(Var var, Expr expr) {
+        if ( expr == null ) {
+            add(var);
+            return;
         }
 
         if ( var == null )
-            throw new ARQInternalErrorException("Attempt to add a named expression with a null variable") ;
+            throw new ARQInternalErrorException("Attempt to add a named expression with a null variable");
         if ( exprs.containsKey(var) )
-            throw new ARQInternalErrorException("Attempt to assign an expression again") ;
-        add(var) ;
-        exprs.put(var, expr) ;
+            throw new ARQInternalErrorException("Attempt to assign an expression again");
+        add(var);
+        exprs.put(var, expr);
     }
 
-    public void addAll(VarExprList other)
-    {
-        for ( Var v : other.vars )
-        {
-            Expr e = other.getExpr( v );
-            add( v, e );
+    public void addAll(VarExprList other) {
+        for ( Var v : other.vars ) {
+            Expr e = other.getExpr(v);
+            add(v, e);
         }
     }
 
     public void remove(Var var) {
-        vars.remove(var) ;
-        exprs.remove(var) ;
+        vars.remove(var);
+        exprs.remove(var);
     }
 
     public void clear() {
@@ -161,29 +163,32 @@ public class VarExprList
         exprs.clear();
     }
 
-    public int size() { return vars.size() ; }
-    public boolean isEmpty() { return vars.isEmpty() ; }
+    public int size() {
+        return vars.size();
+    }
 
-    @Override
-    public int hashCode()
-    {
-        int x = vars.hashCode() ^ exprs.hashCode() ;
-        return x ;
+    public boolean isEmpty() {
+        return vars.isEmpty();
     }
 
     @Override
-    public boolean equals(Object other)
-    {
-        if ( this == other) return true ;
-        if ( ! ( other instanceof VarExprList ) )
-            return false ;
-        VarExprList x = (VarExprList)other ;
-        return Objects.equals(vars, x.vars) && Objects.equals(exprs, x.exprs) ;
+    public int hashCode() {
+        int x = vars.hashCode() ^ exprs.hashCode();
+        return x;
     }
 
     @Override
-    public String toString()
-    {
-        return vars.toString() + " // "+exprs.toString();
+    public boolean equals(Object other) {
+        if ( this == other )
+            return true;
+        if ( !(other instanceof VarExprList) )
+            return false;
+        VarExprList x = (VarExprList)other;
+        return Objects.equals(vars, x.vars) && Objects.equals(exprs, x.exprs);
+    }
+
+    @Override
+    public String toString() {
+        return vars.toString() + " // " + exprs.toString();
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprAggregator.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprAggregator.java
@@ -20,16 +20,16 @@ package org.apache.jena.sparql.expr;
 
 import java.util.Objects;
 
-import org.apache.jena.atlas.lib.Lib ;
-import org.apache.jena.atlas.logging.Log ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.sparql.ARQInternalErrorException ;
-import org.apache.jena.sparql.core.Var ;
-import org.apache.jena.sparql.engine.binding.Binding ;
-import org.apache.jena.sparql.expr.aggregate.Aggregator ;
-import org.apache.jena.sparql.function.FunctionEnv ;
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.expr.aggregate.Aggregator;
+import org.apache.jena.sparql.function.FunctionEnv;
 import org.apache.jena.sparql.graph.NodeTransform;
-import org.apache.jena.sparql.serializer.SerializationContext ;
+import org.apache.jena.sparql.serializer.SerializationContext;
 
 /** Group aggregation functions calculated a value during grouping and
  *  placed in the output binding.  This class is relationship of
@@ -39,107 +39,114 @@ import org.apache.jena.sparql.serializer.SerializationContext ;
 
 public class ExprAggregator extends ExprNode
 {
-    protected Aggregator aggregator ;
-    protected Var var ;
-    protected ExprVar exprVar = null ;
+    protected Aggregator aggregator;
+    protected Var var;
+    protected ExprVar exprVar = null;
 
-    public ExprAggregator(Var v, Aggregator agg)          { _setVar(v) ; aggregator = agg ; }
-    public Var getVar()                                 { return var ; }
+    public ExprAggregator(Var v, Aggregator agg) {
+        _setVar(v);
+        aggregator = agg;
+    }
+
+    public Var getVar() {
+        return var;
+    }
 
     public void setVar(Var v)
     {
         if (this.var != null)
-            throw new ARQInternalErrorException(Lib.className(this)+ ": Attempt to set variable to " + v + " when already set as " + this.var) ;
+            throw new ARQInternalErrorException(Lib.className(this)+ ": Attempt to set variable to " + v + " when already set as " + this.var);
         if (v == null)
-            throw new ARQInternalErrorException(Lib.className(this)+ ": Attempt to set variable to null") ;
-        _setVar(v) ;
+            throw new ARQInternalErrorException(Lib.className(this)+ ": Attempt to set variable to null");
+        _setVar(v);
     }
 
     private void _setVar(Var v)
     {
-        this.var = v ;
-        this.exprVar = new ExprVar(var) ;
+        this.var = v;
+        this.exprVar = new ExprVar(var);
     }
 
-    public Aggregator getAggregator()   { return aggregator ; }
+    public Aggregator getAggregator()   { return aggregator; }
 
     @Override
     public int hashCode()
     {
-        int x = aggregator.hashCode() ;
+        int x = aggregator.hashCode();
         if ( var != null )
-            x ^= var.hashCode() ;
-        return x ;
+            x ^= var.hashCode();
+        return x;
     }
 
     @Override
     public boolean equals(Expr other, boolean bySyntax) {
-        if ( other == null ) return false ;
-        if ( this == other ) return true ;
+        if ( other == null ) return false;
+        if ( this == other ) return true;
         if ( ! ( other instanceof ExprAggregator ) )
-            return false ;
-        ExprAggregator agg = (ExprAggregator)other ;
+            return false;
+        ExprAggregator agg = (ExprAggregator)other;
         if ( ! Objects.equals(var, agg.var) )
-            return false ;
-        return Objects.equals(aggregator, agg.aggregator) ;
+            return false;
+        return Objects.equals(aggregator, agg.aggregator);
     }
 
     // Ensure no confusion - in an old design, an ExprAggregator was a subclass of ExprVar.
     @Override
     public ExprVar getExprVar()
-    { throw new ARQInternalErrorException() ; }
+    { throw new ARQInternalErrorException(); }
 
     @Override
     public Var asVar()
-    { throw new ARQInternalErrorException() ; }
+    { throw new ARQInternalErrorException(); }
 
-    public ExprVar getAggVar() { return exprVar ; }
+    public ExprVar getAggVar() { return exprVar; }
 
     // As an expression suitable for outputting the calculation.
     public String asSparqlExpr(SerializationContext sCxt)
-    { return aggregator.asSparqlExpr(sCxt) ; }
+    { return aggregator.asSparqlExpr(sCxt); }
 
     @Override
     public ExprAggregator copySubstitute(Binding binding)
     {
-        Var v = var ;
-        Aggregator agg = aggregator ;
-        return new ExprAggregator(v, agg) ;
+        Var v = var;
+        Aggregator agg = aggregator;
+        return new ExprAggregator(v, agg);
     }
 
     @Override
     public ExprAggregator applyNodeTransform(NodeTransform transform)
     {
         // Can't rewrite this to a non-variable.
-        Node node = transform.apply(var) ;
+        Node node = transform.apply(var);
         if ( ! Var.isVar(node) )
         {
-            Log.warn(this, "Attempt to convert an aggregation variable to a non-variable: ignored") ;
-            node = var ;
+            Log.warn(this, "Attempt to convert an aggregation variable to a non-variable: ignored");
+            node = var;
         }
 
-        Var v = (Var)node ;
-        Aggregator agg = aggregator.copyTransform(transform) ;
-        return new ExprAggregator(Var.alloc(node), agg) ;
+        Var v = (Var)node;
+        Aggregator agg = aggregator.copyTransform(transform);
+        return new ExprAggregator(Var.alloc(node), agg);
     }
 
     @Override
-    public String toString()
-    { return "(AGG "+
+    public String toString() {
+        return "(AGG "+
                 (var==null?"<>":"?"+var.getVarName())+
-                " "+aggregator.toString()+")"; }
+                " "+aggregator.toString()+")";
+    }
 
-    public Expr copy(Var v)  { return new ExprAggregator(v, aggregator.copy(aggregator.getExprList())) ; }
+    public Expr copy(Var v)  { return new ExprAggregator(v, aggregator.copy(aggregator.getExprList())); }
 
     @Override
     public NodeValue eval(Binding binding, FunctionEnv env)
     {
-       return ExprVar.eval(var, binding, env) ;
+       return ExprVar.eval(var, binding, env);
     }
 
-    public Expr apply(ExprTransform transform)  { return transform.transform(this) ; }
+    public Expr apply(ExprTransform transform)  { return transform.transform(this); }
 
     @Override
     public void visit(ExprVisitor visitor)
-    { visitor.visit(this) ; }
+    { visitor.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprAggregator.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprAggregator.java
@@ -31,14 +31,13 @@ import org.apache.jena.sparql.function.FunctionEnv;
 import org.apache.jena.sparql.graph.NodeTransform;
 import org.apache.jena.sparql.serializer.SerializationContext;
 
-/** Group aggregation functions calculated a value during grouping and
- *  placed in the output binding.  This class is relationship of
- *  an aggregation expression and that variable.  Evaluation returns
- *  the variable's bound value.
+/**
+ * Group aggregation functions calculated a value during grouping and placed in the
+ * output binding. This class is relationship of an aggregation expression and that
+ * variable. Evaluation returns the variable's bound value.
  */
 
-public class ExprAggregator extends ExprNode
-{
+public class ExprAggregator extends ExprNode {
     protected Aggregator aggregator;
     protected Var var;
     protected ExprVar exprVar = null;
@@ -52,26 +51,26 @@ public class ExprAggregator extends ExprNode
         return var;
     }
 
-    public void setVar(Var v)
-    {
-        if (this.var != null)
-            throw new ARQInternalErrorException(Lib.className(this)+ ": Attempt to set variable to " + v + " when already set as " + this.var);
-        if (v == null)
-            throw new ARQInternalErrorException(Lib.className(this)+ ": Attempt to set variable to null");
+    public void setVar(Var v) {
+        if ( this.var != null )
+            throw new ARQInternalErrorException(Lib.className(this) + ": Attempt to set variable to " + v + " when already set as "
+                                                + this.var);
+        if ( v == null )
+            throw new ARQInternalErrorException(Lib.className(this) + ": Attempt to set variable to null");
         _setVar(v);
     }
 
-    private void _setVar(Var v)
-    {
+    private void _setVar(Var v) {
         this.var = v;
         this.exprVar = new ExprVar(var);
     }
 
-    public Aggregator getAggregator()   { return aggregator; }
+    public Aggregator getAggregator() {
+        return aggregator;
+    }
 
     @Override
-    public int hashCode()
-    {
+    public int hashCode() {
         int x = aggregator.hashCode();
         if ( var != null )
             x ^= var.hashCode();
@@ -80,46 +79,51 @@ public class ExprAggregator extends ExprNode
 
     @Override
     public boolean equals(Expr other, boolean bySyntax) {
-        if ( other == null ) return false;
-        if ( this == other ) return true;
-        if ( ! ( other instanceof ExprAggregator ) )
+        if ( other == null )
+            return false;
+        if ( this == other )
+            return true;
+        if ( !(other instanceof ExprAggregator) )
             return false;
         ExprAggregator agg = (ExprAggregator)other;
-        if ( ! Objects.equals(var, agg.var) )
+        if ( !Objects.equals(var, agg.var) )
             return false;
         return Objects.equals(aggregator, agg.aggregator);
     }
 
-    // Ensure no confusion - in an old design, an ExprAggregator was a subclass of ExprVar.
+    // Ensure no confusion - in an old design, an ExprAggregator was a subclass of
+    // ExprVar.
     @Override
-    public ExprVar getExprVar()
-    { throw new ARQInternalErrorException(); }
+    public ExprVar getExprVar() {
+        throw new ARQInternalErrorException();
+    }
 
     @Override
-    public Var asVar()
-    { throw new ARQInternalErrorException(); }
+    public Var asVar() {
+        throw new ARQInternalErrorException();
+    }
 
-    public ExprVar getAggVar() { return exprVar; }
+    public ExprVar getAggVar() {
+        return exprVar;
+    }
 
     // As an expression suitable for outputting the calculation.
-    public String asSparqlExpr(SerializationContext sCxt)
-    { return aggregator.asSparqlExpr(sCxt); }
+    public String asSparqlExpr(SerializationContext sCxt) {
+        return aggregator.asSparqlExpr(sCxt);
+    }
 
     @Override
-    public ExprAggregator copySubstitute(Binding binding)
-    {
+    public ExprAggregator copySubstitute(Binding binding) {
         Var v = var;
         Aggregator agg = aggregator;
         return new ExprAggregator(v, agg);
     }
 
     @Override
-    public ExprAggregator applyNodeTransform(NodeTransform transform)
-    {
+    public ExprAggregator applyNodeTransform(NodeTransform transform) {
         // Can't rewrite this to a non-variable.
         Node node = transform.apply(var);
-        if ( ! Var.isVar(node) )
-        {
+        if ( !Var.isVar(node) ) {
             Log.warn(this, "Attempt to convert an aggregation variable to a non-variable: ignored");
             node = var;
         }
@@ -131,22 +135,24 @@ public class ExprAggregator extends ExprNode
 
     @Override
     public String toString() {
-        return "(AGG "+
-                (var==null?"<>":"?"+var.getVarName())+
-                " "+aggregator.toString()+")";
+        return "(AGG " + (var == null ? "<>" : "?" + var.getVarName()) + " " + aggregator.toString() + ")";
     }
 
-    public Expr copy(Var v)  { return new ExprAggregator(v, aggregator.copy(aggregator.getExprList())); }
-
-    @Override
-    public NodeValue eval(Binding binding, FunctionEnv env)
-    {
-       return ExprVar.eval(var, binding, env);
+    public Expr copy(Var v) {
+        return new ExprAggregator(v, aggregator.copy(aggregator.getExprList()));
     }
 
-    public Expr apply(ExprTransform transform)  { return transform.transform(this); }
+    @Override
+    public NodeValue eval(Binding binding, FunctionEnv env) {
+        return ExprVar.eval(var, binding, env);
+    }
+
+    public Expr apply(ExprTransform transform) {
+        return transform.transform(this);
+    }
 
     @Override
-    public void visit(ExprVisitor visitor)
-    { visitor.visit(this); }
+    public void visit(ExprVisitor visitor) {
+        visitor.visit(this);
+    }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestOpVars.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestOpVars.java
@@ -25,47 +25,68 @@ import java.util.Collection ;
 import java.util.HashSet ;
 import java.util.List ;
 
+import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.junit.Test ;
 
 public class TestOpVars
 {
-    @Test public void opvars_01() { visible("(bgp (?s :p ?o))", "s", "o") ; }
-    @Test public void opvars_02() { visible("(leftjoin (bgp (?s :p ?o)) (bgp (?s1 :p ?o1)) )", "s1", "o1", "s", "o") ; }
-    @Test public void opvars_03() { visible("(leftjoin (bgp (?s :p ?o)) (bgp (?s :p ?o)) )", "s", "o") ; }
-    
-    @Test public void opvars_04() { visible("(project (?s) (bgp(?s :p ?o)))", "s") ; }
-    @Test public void opvars_05() { visible("(minus (bgp (?s :p ?o)) (bgp (?s1 :p ?o1)) )", "s", "o") ; }
-    @Test public void opvars_06() { visible("(join (project (?x) (bgp(?x :p ?z)))  (bgp(?s :p 1)) )", "x", "s") ; }
-    @Test public void opvars_07() { visible("(triple ?s :p ?o)", "s", "o") ; }
-    @Test public void opvars_08() { visible("(quad :g ?s :p ?o)", "s", "o") ; }
-    
-    @Test public void opvars_10() { fixed("(bgp (?s :p ?o))", "s", "o") ; }
-    @Test public void opvars_11() { fixed("(leftjoin (bgp (?s :p ?o)) (bgp (?s1 :p ?o1)) )", "s", "o") ; }
-    @Test public void opvars_12() { fixed("(leftjoin (bgp (?s :p ?o)) (bgp (?s :p ?o)) )", "s", "o") ; }
-    
-    @Test public void opvars_13() { fixed("(union (bgp (?s :p ?o1)) (bgp (?s :p ?o2)) )", "s") ; }
-    @Test public void opvars_14() { fixed("(minus (bgp (?s :p ?o)) (bgp (?s1 :p ?o1)) )", "s", "o") ; }
-    @Test public void opvars_15() { fixed("(join (project (?x) (bgp(?x :p ?z)))  (bgp(?s :p 1)) )", "x", "s") ; }
-    @Test public void opvars_16() { fixed("(triple ?s :p ?o)", "s", "o") ; }
-    @Test public void opvars_17() { fixed("(quad :g ?s :p ?o)", "s", "o") ; }
-    
-    
+    @Test public void opvars_visible_1() { visible("(bgp (?s :p ?o))", "s", "o") ; }
+    @Test public void opvars_visible_2() { visible("(leftjoin (bgp (?s :p ?o)) (bgp (?s1 :p ?o1)) )", "s1", "o1", "s", "o") ; }
+    @Test public void opvars_visible_3() { visible("(leftjoin (bgp (?s :p ?o)) (bgp (?s :p ?o)) )", "s", "o") ; }
+
+    @Test public void opvars_visible_4() { visible("(project (?s) (bgp(?s :p ?o)))", "s") ; }
+    @Test public void opvars_visible_5() { visible("(minus (bgp (?s :p ?o)) (bgp (?s1 :p ?o1)) )", "s", "o") ; }
+    @Test public void opvars_visible_6() { visible("(join (project (?x) (bgp(?x :p ?z)))  (bgp(?s :p 1)) )", "x", "s") ; }
+    @Test public void opvars_visible_7() { visible("(triple ?s :p ?o)", "s", "o") ; }
+    @Test public void opvars_visible_8() { visible("(quad :g ?s :p ?o)", "s", "o") ; }
+
+    @Test public void opvars_visible_9() {
+        // JENA-2342
+        String s = StrUtils.strjoinNL(
+                                      "(group (?id) ((?.0 (count ?v1)) (?.1 (count ?v2)))",
+                                      "        (table (vars ?id ?v1 ?v2)",
+                                      "          (row [?id 'A'] [?v1 'B'] [?v2 'C'])",
+                                      "        ))"
+                                      );
+        visible(s, "id", ".0", ".1") ;
+    }
+
+    @Test public void opvars_fixed_1() { fixed("(bgp (?s :p ?o))", "s", "o") ; }
+    @Test public void opvars_fixed_2() { fixed("(leftjoin (bgp (?s :p ?o)) (bgp (?s1 :p ?o1)) )", "s", "o") ; }
+    @Test public void opvars_fixed_3() { fixed("(leftjoin (bgp (?s :p ?o)) (bgp (?s :p ?o)) )", "s", "o") ; }
+
+    @Test public void opvars_fixed_4() { fixed("(union (bgp (?s :p ?o1)) (bgp (?s :p ?o2)) )", "s") ; }
+    @Test public void opvars_fixed_5() { fixed("(minus (bgp (?s :p ?o)) (bgp (?s1 :p ?o1)) )", "s", "o") ; }
+    @Test public void opvars_fixed_6() { fixed("(join (project (?x) (bgp(?x :p ?z)))  (bgp(?s :p 1)) )", "x", "s") ; }
+    @Test public void opvars_fixed_7() { fixed("(triple ?s :p ?o)", "s", "o") ; }
+    @Test public void opvars_fixed_8() { fixed("(quad :g ?s :p ?o)", "s", "o") ; }
+    @Test public void opvars_fixed_9() {
+        // JENA-2342
+        String s = StrUtils.strjoinNL(
+                                      "(group (?id) ((?.0 (count ?v1)) (?.1 (count ?v2)))",
+                                      "        (table (vars ?id ?v1 ?v2)",
+                                      "          (row [?id 'A'] [?v1 'B'] [?v2 'C'])",
+                                      "        ))"
+                                      );
+        fixed(s, "id", ".0", ".1") ;
+    }
+
     private static void visible(String string, String... vars)
     {
         Op op = SSE.parseOp(string) ;
         Collection<Var> c = OpVars.visibleVars(op) ;
         check(vars, c) ;
     }
-    
+
     private static void fixed(String string, String... vars)
     {
         Op op = SSE.parseOp(string) ;
         Collection<Var> c = OpVars.fixedVars(op) ;
         check(vars, c) ;
     }
-    
+
 
     private static void check(String[] varsExpected, Collection<Var> varsFound)
     {
@@ -75,7 +96,7 @@ public class TestOpVars
             Var v = Var.alloc(varsExpected[i]) ;
             vars[i] = v ;
         }
-        
+
         List<Var> varList = Arrays.asList(vars) ;
         HashSet<Var> varSet = new HashSet<>() ;
         varSet.addAll(varList) ;


### PR DESCRIPTION
Pull request Description:

Fix for JENA-2342: Processing groups was not considering that a group hides the variables of the inner pattern unless they are grouping variables and also that grouping can introduce variables via aggregation.

----

 - [x] Tests are included.
 - [NA] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

