### PR TITLE
GH-1477: Improved AsyncParser

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/AsyncParserBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/AsyncParserBuilder.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.atlas.iterator.IteratorCloseable;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.riot.RDFParserBuilder;
+import org.apache.jena.sparql.core.Quad;
+import org.slf4j.Logger;
+
+public class AsyncParserBuilder {
+    /* These following two attributes only exist for javadoc references */
+    private static final int dftChunkSize = AsyncParser.dftChunkSize;
+    private static final int dftQueueSize = AsyncParser.dftQueueSize;
+
+    private int chunkSize;
+    private int queueSize;
+    private boolean daemonMode;
+    private Predicate<EltStreamRDF> prematureDispatch;
+    private List<RDFParserBuilder> sources;
+
+    public AsyncParserBuilder() {
+        this.chunkSize = dftChunkSize;
+        this.queueSize = dftQueueSize;
+        this.daemonMode = true;
+        this.prematureDispatch = null;
+        this.sources = Collections.emptyList();
+    }
+
+    public AsyncParserBuilder(List<RDFParserBuilder> sources) {
+        this();
+        this.sources = List.copyOf(sources);
+    }
+
+    public int getChunkSize() {
+        return chunkSize;
+    }
+
+    /** The chunk size controls the maxmimum number of elements the parser thread transfers at once
+     * to the client iterator's queue. The default value ({@value #dftChunkSize})
+     * is optimized for throughput however it introduces a delay until the first item arrives.
+     * Data can be dispatched prematurely by setting {@link #setPrematureDispatch(Predicate)}.
+     */
+    public AsyncParserBuilder setChunkSize(int chunkSize) {
+        this.chunkSize = chunkSize;
+        return this;
+    }
+
+    public int getQueueSize() {
+        return queueSize;
+    }
+
+    /**
+     * The queue size controls the number of chunks the parser thread can read ahead.
+     * A full queue blocks that thread.
+     * The default value is {@value #dftQueueSize}.
+     */
+    public AsyncParserBuilder setQueueSize(int queueSize) {
+        this.queueSize = queueSize;
+        return this;
+    }
+
+    public boolean isDaemonMode() {
+        return daemonMode;
+    }
+
+    /** Whether the parser thread should run as a daemon thread.
+     * A JVM will terminate as soon as there are no more non-daemon threads. */
+    public AsyncParserBuilder setDaemonMode(boolean daemonMode) {
+        this.daemonMode = daemonMode;
+        return this;
+    }
+
+    /** Set a custom dispatch (flush) policy: When the predicate returns true for an element then that element and
+     * any gathered data is dispatched immediately. Before dispatch a check is made whether parsing has been
+     * (concurrently) aborted. */
+    public AsyncParserBuilder setPrematureDispatch(Predicate<EltStreamRDF> prematureDispatch) {
+        this.prematureDispatch = prematureDispatch;
+        return this;
+    }
+
+    public Predicate<EltStreamRDF> getPrematureDispatch() {
+        return prematureDispatch;
+    }
+
+    public List<RDFParserBuilder> getSources() {
+        return sources;
+    }
+
+    public AsyncParserBuilder setSources(List<RDFParserBuilder> sources) {
+        this.sources = List.copyOf(sources);
+        return this;
+    }
+
+    /** Run an operation on all RDFParserBuilder sources in this builder.
+     * Allows for e.g. configuring prefixes, the error handler or the label-to-node strategy */
+    public AsyncParserBuilder mutateSources(Consumer<RDFParserBuilder> mutator) {
+        for (RDFParserBuilder source : sources) {
+            mutator.accept(source);
+        }
+        return this;
+    }
+
+    private IteratorCloseable<EltStreamRDF> asyncParseElements() {
+        Objects.requireNonNull(sources);
+
+        BlockingQueue<List<EltStreamRDF>> queue = new ArrayBlockingQueue<>(queueSize);
+        Runnable closeAction = AsyncParser.startParserThread(AsyncParser.LOG, sources, queue, chunkSize, prematureDispatch, daemonMode);
+        IteratorCloseable<List<EltStreamRDF>> blocks = AsyncParser.blockingIterator(closeAction, queue, x -> x == AsyncParser.END);
+
+        IteratorCloseable<EltStreamRDF> elements = (IteratorCloseable<EltStreamRDF>)Iter.flatMap(blocks, x->x.iterator());
+        return elements;
+    }
+
+    public IteratorCloseable<Triple> asyncParseTriples() {
+        return Iter.iter(asyncParseElements()).map(AsyncParser.elt2Triple).removeNulls();
+    }
+
+    public IteratorCloseable<Quad> asyncParseQuads() {
+        return Iter.iter(asyncParseElements()).map(AsyncParser.elt2Quad).removeNulls();
+    }
+
+    public Stream<EltStreamRDF> streamElements() {
+        return Iter.asStream(asyncParseElements());
+    }
+
+    public Stream<Triple> streamTriples() {
+        return Iter.asStream(asyncParseTriples());
+    }
+
+    public Stream<Quad> streamQuads() {
+        return Iter.asStream(asyncParseQuads());
+    }
+
+    /** Calling the returned runnable stops parsing.
+     * The sink will see no further data. */
+    public Runnable asyncParseSources(StreamRDF output) {
+        // Async thread
+        Logger LOG1 = AsyncParser.LOG;
+        // Receiver
+        Logger LOG2 = AsyncParser.LOG;
+
+        BlockingQueue<List<EltStreamRDF>> queue = new ArrayBlockingQueue<>(queueSize);
+        Runnable closeAction = AsyncParser.startParserThread(LOG1, sources, queue, chunkSize, prematureDispatch, daemonMode);
+        AsyncParser.receiver(closeAction, LOG2, queue, output);
+
+        return closeAction;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/EltStreamRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/EltStreamRDF.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.apache.jena.graph.Triple;
+import org.apache.jena.riot.out.NodeFmtLib;
+import org.apache.jena.sparql.core.Quad;
+
+/** An item of a StreamRDF, including exceptions. */
+public class EltStreamRDF
+    implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    private final EltStreamRDFType type;
+    private final Triple triple;
+    private final Quad quad;
+    private final String prefix; // Null implies "base".
+    private final String iri;
+    private final Throwable exception;
+
+    /* Prefer static constructors in EltStreamRDF */
+
+    EltStreamRDF(Triple triple) { this(EltStreamRDFType.TRIPLE, triple, null, null, null, null); }
+    EltStreamRDF(Quad quad) { this(EltStreamRDFType.QUAD, null, quad, null, null, null); }
+    EltStreamRDF(String prefix, String iri) { this(EltStreamRDFType.PREFIX, null, null, prefix, iri, null); }
+    EltStreamRDF(String iri) { this(EltStreamRDFType.BASE, null, null, null, iri, null); }
+    EltStreamRDF(Throwable exception) { this(EltStreamRDFType.EXCEPTION, null, null, null, null, exception); }
+
+    EltStreamRDF(EltStreamRDFType eltType, Triple triple, Quad quad, String prefix, String iri, Throwable exception) {
+        this.type = eltType;
+        this.triple = triple;
+        this.quad = quad;
+        this.prefix = prefix;
+        this.iri = iri;
+        this.exception = exception;
+    }
+
+    public boolean   isTriple()    { return EltStreamRDFType.TRIPLE.equals(type); }
+    public Triple    triple()      { return triple; }
+    public boolean   isQuad()      { return EltStreamRDFType.QUAD.equals(type); }
+    public Quad      quad()        { return quad; }
+    public boolean   isPrefix()    { return EltStreamRDFType.PREFIX.equals(type); }
+    public String    prefix()      { return prefix; }
+    public boolean   isBase()      { return EltStreamRDFType.BASE.equals(type); }
+    public String    iri()         { return iri; }
+    public boolean   isException() { return EltStreamRDFType.EXCEPTION.equals(type); }
+    public Throwable exception()   { return exception; }
+
+    public EltStreamRDFType getType() {
+        return type;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, triple, quad, prefix, iri, exception);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        EltStreamRDF other = (EltStreamRDF) obj;
+        return Objects.equals(type, other.type) && Objects.equals(triple, other.triple) &&
+                Objects.equals(quad, other.quad) && Objects.equals(prefix, other.prefix) &&
+                Objects.equals(iri, other.iri) && Objects.equals(exception, other.exception);
+    }
+
+    @Override
+    public String toString() {
+        String str;
+        switch (getType()) {
+        case TRIPLE: str = "triple(" + NodeFmtLib.str(triple()) + ")"; break;
+        case QUAD: str = "quad(" + NodeFmtLib.str(quad()) + ")"; break;
+        case PREFIX: str = "prefix(" + Objects.toString(prefix() + ", " + iri()) + ")"; break;
+        case BASE: str = "base(" + Objects.toString(iri()) + ")"; break;
+        case EXCEPTION: str = "exception(" + Objects.toString(exception()) + ")"; break;
+        default: str = "unknown"; break;
+        }
+        return str;
+    }
+
+    public static EltStreamRDF triple(Triple triple) { return new EltStreamRDF(Objects.requireNonNull(triple)); }
+    public static EltStreamRDF quad(Quad quad) { return new EltStreamRDF(Objects.requireNonNull(quad)); }
+    public static EltStreamRDF base(String iri) { return new EltStreamRDF(Objects.requireNonNull(iri)); }
+    public static EltStreamRDF prefix(String prefix, String iri) { return new EltStreamRDF(Objects.requireNonNull(prefix), Objects.requireNonNull(iri)); }
+    public static EltStreamRDF exception(Throwable exception) { return new EltStreamRDF(Objects.requireNonNull(exception)); }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/EltStreamRDFType.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/EltStreamRDFType.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+/** Payload types of {@link EltStreamRDF} elements */
+public enum EltStreamRDFType {
+    UNKNOWN,
+    TRIPLE,
+    QUAD,
+    PREFIX,
+    BASE,
+    EXCEPTION
+}

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestAsyncParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestAsyncParser.java
@@ -22,14 +22,40 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.apache.jena.atlas.iterator.IteratorCloseable;
+import org.apache.jena.ext.com.google.common.base.Preconditions;
+import org.apache.jena.ext.com.google.common.base.Stopwatch;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.riot.*;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.RDFParserBuilder;
+import org.apache.jena.riot.RiotException;
+import org.apache.jena.riot.RiotNotFoundException;
 import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.sparql.util.IsoMatcher;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestAsyncParser {
@@ -91,4 +117,216 @@ public class TestAsyncParser {
         assertTrue( IsoMatcher.isomorphic(graph1, graph2));
     }
 
+    /** Tests the parser on an infinite amount of data with a failing client.
+     * This should stop the parser. */
+    @Test
+    public void failingSink() {
+        int beforeThreadCount = ManagementFactory.getThreadMXBean().getThreadCount();
+        for (int i = 0; i < 100; ++i) {
+            try (InputStream in = openInfiniteNtStream();
+                    OutputStream out = new FailingOutputStream()) {
+                StreamRDF sink = StreamRDFWriter.getWriterStream(out, RDFFormat.NT);
+                sink.start();
+                // Use small read ahead amount due to the infinite input and always failing sink
+                AsyncParser.of(in, Lang.NT, null).setChunkSize(10).setQueueSize(3).asyncParseSources(sink);
+                sink.finish();
+            } catch (Exception e) {
+                // Expected to fail
+                continue;
+            }
+            throw new RuntimeException("Parsing unexpectedly succeeded");
+        }
+        int afterThreadCount = ManagementFactory.getThreadMXBean().getThreadCount();
+        int threadCountDifference = Math.abs(afterThreadCount - beforeThreadCount);
+        int maxAllowedThreadCountDifference = 5;
+
+        Assert.assertTrue("Cancelling RDF parsing resulted in too many dangling threads ("
+                + threadCountDifference + ")",
+                threadCountDifference <= maxAllowedThreadCountDifference);
+    }
+
+    /** Tests to ensure threads are not piling up when repeatedly canceling parsers */
+    @Test
+    public void repeatedParsingCancellation_1() throws Exception {
+        int beforeThreadCount = ManagementFactory.getThreadMXBean().getThreadCount();
+        for (int i = 0; i < 1000; ++i) {
+            IteratorCloseable<Triple> iter = null;
+            try {
+                iter = AsyncParser.of(DIR+"data.ttl").setDaemonMode(false).asyncParseTriples();
+
+                // Ensure parsing is triggered
+                iter.hasNext();
+            } finally {
+                if (iter != null) {
+                    iter.close();
+                }
+            }
+        }
+        int afterThreadCount = ManagementFactory.getThreadMXBean().getThreadCount();
+        int threadCountDifference = Math.abs(afterThreadCount - beforeThreadCount);
+
+        // Give some room in how much the number of threads may differ
+        // The main point is that the acceptable margin is significantly lower than
+        // the number of started parser threads
+        int maxAllowedThreadCountDifference = 5;
+
+        Assert.assertTrue("Cancelling RDF parsing resulted in too many dangling threads ("
+                + threadCountDifference + ")",
+                threadCountDifference <= maxAllowedThreadCountDifference);
+    }
+
+    /** A test that checks that only a limited number of bytes is read when using a small chunk size*/
+    @Test
+    public void lowLatencyParse() {
+        long expectedLimit = 10;
+        RepeatingReadableByteChannel channel = openInfiniteNtChannel();
+        try (Stream<Triple> s = AsyncParser.of(Channels.newInputStream(channel), Lang.TURTLE, null)
+                .setChunkSize(100).streamTriples().limit(expectedLimit)) {
+            // s.forEach(t -> System.out.println("Triple: " + t));
+            long actualLimit = s.count();
+            Assert.assertEquals(expectedLimit, actualLimit);
+        }
+
+        long pos = channel.position();
+        // The exact number of bytes consumed from the channel when writing the test was 10050 bytes
+        // However to give room for implementation changes the value tested against here is about twice as large
+        Assert.assertTrue("Too many bytes consumed from input stream (" + pos + ")", pos < 20000);
+    }
+
+    /** This test first creates some 'good' data for reference and then appends some 'bad' data in order
+     * to provoke a parse error.
+     * Parsing the bad data should then yield all the good data followed by an error event.
+     * Conversely, errors must not cause loss of any events. */
+    @Test
+    public void testNoEventsAreLost() {
+        // Generate some "good" sample data - good means: no parse errors
+        StringBuilder sb = new StringBuilder();
+        sb.append("PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>");
+        for (int i = 0; i < 4; ++i) {
+            sb.append("<urn:example:s> rdfs:label \"item # " + i + "\" .\n");
+        }
+        String goodInputStr = sb.toString();
+
+        List<EltStreamRDF> expected;
+        try (Stream<EltStreamRDF> s = AsyncParser.of(new ByteArrayInputStream(goodInputStr.getBytes()), Lang.TURTLE, null).streamElements()) {
+            expected = s.collect(Collectors.toList());
+        }
+
+        // Validate parser on the good data
+        int expectedGoodEventCount = 5;
+        Assert.assertEquals(expected.size(), expectedGoodEventCount);
+
+        // Append some bad data
+        String badInputStr = sb.append("parse error").toString();
+
+        // Now test that we get back all the good data plus the error event
+        for (int chunkSize = 1; chunkSize < 10; ++chunkSize) {
+            try (Stream<EltStreamRDF> s = AsyncParser.of(new ByteArrayInputStream(badInputStr.getBytes()), Lang.TURTLE, null)
+                    .setChunkSize(chunkSize)
+                    .streamElements()) {
+                List<EltStreamRDF> actual = s.collect(Collectors.toList());
+                Assert.assertEquals(expectedGoodEventCount + 1, actual.size());
+                Assert.assertEquals(expected, actual.subList(0, expectedGoodEventCount));
+                Assert.assertTrue(actual.get(actual.size() - 1).isException());
+            }
+        }
+    }
+
+    /** Test an AsyncParser setup with a custom dispatch (flush) policy */
+    @Test
+    public void testPrematureDispatch() {
+        final int expectedSize = 10;
+
+        AtomicInteger counter = new AtomicInteger(1);
+        String expectedErrorMsg = "Forced abort";
+        List<EltStreamRDF> actual;
+        try (Stream<EltStreamRDF> stream = AsyncParser.of(openInfiniteNtStream(), Lang.TURTLE, null)
+            .setPrematureDispatch(elt -> {
+                if (counter.getAndIncrement() < expectedSize) {
+                    return true;
+                }
+                throw new RuntimeException(expectedErrorMsg);
+            })
+            .streamElements()
+            .limit(1000)) { // The limit is just a safety net to prevent infinite parsing in case of malfunction
+            actual = stream.collect(Collectors.toList());
+        }
+
+        // Check that only the expected number of elements were dispatched
+        Assert.assertEquals(expectedSize, actual.size());
+
+        // The payload of the last element must be an exception, all others must be triples
+        for (int i = 0; i < expectedSize; ++i) {
+            boolean isLastItem = i + 1 == expectedSize;
+            EltStreamRDF elt = actual.get(i);
+            if (isLastItem) {
+                Assert.assertTrue("Last element expected to be an exception", elt.isException());
+                Assert.assertEquals(expectedErrorMsg, elt.exception().getMessage());
+            } else {
+                Assert.assertTrue("Non-last element expected to be a triple", elt.isTriple());
+            }
+        }
+
+    }
+
+    /** An infinite stream of ntriple data */
+    private static InputStream openInfiniteNtStream() {
+        return Channels.newInputStream(openInfiniteNtChannel());
+    }
+
+    private static RepeatingReadableByteChannel openInfiniteNtChannel() {
+        return new RepeatingReadableByteChannel(
+                "<urn:example:s> <urn:example:p> <urn:example:o> .\n".getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** An always failing output stream */
+    private static class FailingOutputStream
+        extends OutputStream
+    {
+        @Override
+        public void write(int b) throws IOException {
+            throw new IOException("Mocked IO Error");
+        }
+    }
+
+    /** A byte channel that infinitely repeats a given chunk of data */
+    private static class RepeatingReadableByteChannel
+        implements ReadableByteChannel
+    {
+        protected byte[] data;
+        protected boolean isOpen;
+        protected long pos;
+
+        public RepeatingReadableByteChannel(byte[] data) {
+            this(data, 0l);
+        }
+
+        public RepeatingReadableByteChannel(byte[] data, long pos) {
+            super();
+            Objects.requireNonNull(data);
+            Preconditions.checkArgument(data.length > 0, "Provided data array must have at least 1 item");
+            this.data = data;
+            this.pos = pos;
+            this.isOpen = true;
+        }
+        @Override public boolean isOpen() { return isOpen; }
+        @Override public void close() throws IOException { isOpen = false; }
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            int l = data.length;
+            int arrOffset = (int)(pos % l);
+            int n = Math.min(dst.remaining(), l - arrOffset);
+            dst.put(data, arrOffset, n);
+            pos += n;
+            return n;
+        }
+
+        public long position() {
+            return pos;
+        }
+
+        public void position(long pos) {
+            this.pos = pos;
+        }
+    }
 }

--- a/jena-base/src/main/java/org/apache/jena/atlas/iterator/IteratorFlatMap.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/iterator/IteratorFlatMap.java
@@ -23,12 +23,10 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.apache.jena.atlas.lib.Closeable;
-
 /** flatMap iterator.
  * See {@link Stream#flatMap}
  */
-/*package*/ class IteratorFlatMap<IN,OUT> implements Iterator<OUT>, Closeable {
+/*package*/ class IteratorFlatMap<IN,OUT> implements IteratorCloseable<OUT> {
     private boolean         finished = false;
     private Iterator<OUT>   current  = null;
     private Iterator<IN>    input;


### PR DESCRIPTION
GitHub issue resolved #1477

The API changes to AsyncParser are intended to be completely backwards-compatible.
I added a couple of additional tests that check the count of JVM threads and consumed bytes.

Overall the PR is ready for feedback such as whether the proposed changes are acceptable in the first place.

I also tested the integrating of this PR into our Spark setup to do the final real-world testing and and all is green.
I'll do a bit more experiments because it's just too easy to overlook some corner cases when fiddling with async + cancellation, but overall it looks good to me.

An example for a non-trivial setup now looks like:
```java
public class MyHadoopRecordReader {
     //  (Various logic)

    public Stream<Triple> parse(InputStream in) {
        return AsyncParser.of(in, lang, baseIri)
                .mutateSources(parser -> parser
                        .labelToNode(createLabelToNodeAsGivenOrRandom())
                        .resolver(newIRIxResolverAsGiven()))
                .setChunkSize(100)
                .streamTriples();
    }
}
```

----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
