### PR TITLE
gh-1484: Fix for bulk requests using cache by default

### DIFF
--- a/jena-extras/jena-serviceenhancer/src/main/java/org/apache/jena/sparql/service/enhancer/impl/ChainingServiceExecutorBulkServiceEnhancer.java
+++ b/jena-extras/jena-serviceenhancer/src/main/java/org/apache/jena/sparql/service/enhancer/impl/ChainingServiceExecutorBulkServiceEnhancer.java
@@ -116,7 +116,7 @@ public class ChainingServiceExecutorBulkServiceEnhancer
         boolean enableSpecial = effCacheMode != CacheMode.OFF || enableBulk; // || enableLoopJoin; // || !overrides.isEmpty();
 
         if (enableSpecial) {
-            ChainingServiceExecutorBulkCache exec = new ChainingServiceExecutorBulkCache(bulkSize, cacheMode);
+            ChainingServiceExecutorBulkCache exec = new ChainingServiceExecutorBulkCache(bulkSize, effCacheMode);
             result = exec.createExecution(newOp, input, execCxt, chain);
         } else {
             result = chain.createExecution(newOp, input, execCxt);


### PR DESCRIPTION
GitHub issue resolved #1484

A one liner fix for correctly passing on the effective cache mode.

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
