### PR TITLE
Follow redirect (jena-core legacy)

### DIFF
--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestReaders.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestReaders.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,7 +35,7 @@ public class TestReaders extends AbstractModelTestBase
     public TestReaders(final TestingModelFactory modelFactory, final String name) {
         super(modelFactory, name) ;
     }
-	
+
     public TestReaders() {
         this(new TestPackage.PlainModelFactory(), "TestReaders") ;
     }
@@ -47,7 +47,7 @@ public class TestReaders extends AbstractModelTestBase
         final RDFReaderI reader = model.getReader("N-TRIPLE") ;
         Assert.assertNotNull(reader) ;
     }
-	
+
     public void testReadLocalNTriple() {
         model.read(getInputStream("TestReaders.nt"), "", "N-TRIPLE") ;
         Assert.assertEquals("Wrong size model", 5, model.size()) ;
@@ -61,7 +61,7 @@ public class TestReaders extends AbstractModelTestBase
 
     public void testReadRemoteNTriple() {
         try {
-            model.read("http://www.w3.org/2000/10/rdf-tests/rdfcore/" + "rdf-containers-syntax-vs-schema/test001.nt",
+            model.read("https://www.w3.org/2000/10/rdf-tests/rdfcore/" + "rdf-containers-syntax-vs-schema/test001.nt",
                        "N-TRIPLE") ;
         }
         catch (final JenaException jx) {
@@ -76,7 +76,7 @@ public class TestReaders extends AbstractModelTestBase
 
     public void testReadRemoteRDF() {
         try {
-            model.read("http://www.w3.org/2000/10/rdf-tests/rdfcore/" + "rdf-containers-syntax-vs-schema/test001.rdf") ;
+            model.read("https://www.w3.org/2000/10/rdf-tests/rdfcore/" + "rdf-containers-syntax-vs-schema/test001.rdf") ;
         }
         catch (final JenaException jx) {
             if ( (jx.getCause() instanceof NoRouteToHostException) || (jx.getCause() instanceof UnknownHostException)


### PR DESCRIPTION
A test that used to work, has started failing. Same code (same commit!) as a few days ago.

The RDF/XML reader code for "read URL" is not following redirects : either this is a java change or W3C change.

This PR:

1. Changes the test URL to "https".
2. Implement following redirects (because they code got written as part of diagnosing the problem).
