### PR TITLE
Clean javadoc for doclint "syntax,html"

### DIFF
--- a/jena-core/pom.xml
+++ b/jena-core/pom.xml
@@ -183,6 +183,7 @@
           <!-- OK for Java17 (compiling to Java11); not OK for Java11
                <doclint>syntax</doclint>
           -->
+          <doclint>none</doclint>
           <author>true</author>
           <version>true</version>
           <show>public</show>

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BinaryDataFileMem.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BinaryDataFileMem.java
@@ -24,7 +24,9 @@ import org.apache.jena.atlas.io.IO;
 /** Implementation of {@link BinaryDataFile} in memory for testing
  * and development use. Raw performance is not an objective.
  *
+ * <ul>
  * <li>This implementation is thread-safe.
+ * </ul>
  */
 public class BinaryDataFileMem implements BinaryDataFile {
 

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BinaryDataFileRandomAccess.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BinaryDataFileRandomAccess.java
@@ -26,8 +26,10 @@ import org.apache.jena.atlas.io.IO;
 
 /** Implementation of {@link BinaryDataFile} using {@link RandomAccessFile}.
  *
+ * <ul>
  * <li>No buffering of reads or writes provided.
  * <li>Not thread-safe.
+ * </ul>
  *
  *  @see BinaryDataFileWriteBuffered
  */

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BinaryDataFileWriteBuffered.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BinaryDataFileWriteBuffered.java
@@ -22,9 +22,11 @@ import org.apache.jena.atlas.RuntimeIOException;
 
 /** Implementation of {@link BinaryDataFile} adding write buffering to another
  * {@link BinaryDataFile} file, such as a {@link BinaryDataFileRandomAccess}.
+ *  <ul>
  *  <li>Thread-safe.
  *  <li>No read buffering provided.
  *  <li>The write buffer is flushed when switching to read.
+ *  </ul>
  */
 
 public class BinaryDataFileWriteBuffered implements BinaryDataFile {
@@ -81,7 +83,7 @@ public class BinaryDataFileWriteBuffered implements BinaryDataFile {
         synchronized(sync) {
             checkOpen();
             long otherLen = other.length();
-            if ( bufferLength > 0) { 
+            if ( bufferLength > 0) {
                 if ( posn >= otherLen ) {
                     long bufLen = posn-otherLen;
                     if ( bufLen < bufferLength ) {

--- a/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalComponent.java
+++ b/jena-db/jena-dboe-transaction/src/main/java/org/apache/jena/dboe/transaction/txn/TransactionalComponent.java
@@ -51,6 +51,7 @@ import java.nio.ByteBuffer;
 * {@link #commitPrepare} and {@link #commitEnd} are not called.
 *<p><br/>
 * Lifecycle of a write transaction:
+* <ul>
 * <li>{@link #begin}
 * <li>{@link #commitPrepare}
 * <li>{@link #commit} or {@link #abort}
@@ -142,7 +143,7 @@ public interface TransactionalComponent
     /** Abort a transaction (undo the effect of a transaction) */
     public void abort(Transaction transaction);
 
-    /** 
+    /**
      * Finalization - the coordinator will not mention the transaction again.
      */
     public void complete(Transaction transaction);

--- a/jena-examples/src/main/java/arq/examples/filter/classify.java
+++ b/jena-examples/src/main/java/arq/examples/filter/classify.java
@@ -35,7 +35,7 @@ import org.apache.jena.sparql.function.FunctionBase1 ;
  *  </pre>
  *  <pre>
  *    FILTER ext:classify(3+?x)
- *  <pre>
+ *  </pre>
  */
 
 public class classify extends FunctionBase1

--- a/jena-extras/jena-commonsrdf/src/main/java/org/apache/jena/commonsrdf/JenaCommonsRDF.java
+++ b/jena-extras/jena-commonsrdf/src/main/java/org/apache/jena/commonsrdf/JenaCommonsRDF.java
@@ -42,9 +42,6 @@ import org.apache.jena.sys.JenaSystem;
  * // provide as a Commons RDF graph
  * org.apache.commons.rdf.api.graph = JenaCommonsRDF.fromJena(jGraph);
  * </pre>
- * <p>
- * <pre>
- * </pre>
  */
 public class JenaCommonsRDF {
     static { JenaSystem.init(); }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -89,7 +89,7 @@ public class UpdateBuilder {
     /**
      * Creates an UpdateBuilder with the prefixes defined in the prolog clause.
      * <b>May modify the contents of the prefix mapping in the prolog handler</b>
-     * 
+     *
      * @param prologClause the default prefixes for this builder.
      */
     public UpdateBuilder(PrologClause<?> prologClause) {
@@ -99,7 +99,7 @@ public class UpdateBuilder {
     /**
      * Creates an UpdateBuilder with the specified PrefixMapping. <b>May modify the
      * contents of the prefix mapping</b>
-     * 
+     *
      * @param pMap the prefix mapping to use.
      */
     public UpdateBuilder(PrefixMapping pMap) {
@@ -109,7 +109,7 @@ public class UpdateBuilder {
 
     /**
      * Convert a collection of QuadHolder to an iterator on Quads.
-     * 
+     *
      * @param holders the Collection of QuadHolder objects
      * @return an iterator over the Quads.
      */
@@ -123,10 +123,10 @@ public class UpdateBuilder {
 
     /**
      * Build the update.
-     * 
+     *
      * <b>Note: the update does not include the prefix statements</b> use
      * buildRequest() or appendTo() methods to include the prefix statements.
-     * 
+     *
      * @return the update.
      */
     public Update build() {
@@ -143,7 +143,7 @@ public class UpdateBuilder {
 
     /**
      * Build as an UpdateRequest with prefix mapping set.
-     * 
+     *
      * @return a new UpdateRequest
      */
     public UpdateRequest buildRequest() {
@@ -154,7 +154,7 @@ public class UpdateBuilder {
 
     /**
      * Appends the new Update to the UpdateRequest.
-     * 
+     *
      * @param req the UpdateRequest to append this Update to.
      * @return the req parameter for chaining.
      */
@@ -232,7 +232,7 @@ public class UpdateBuilder {
 
     /**
      * Make a triple path from the objects.
-     * 
+     *
      * For subject, predicate and objects nodes
      * <ul>
      * <li>Will return Node.ANY if object is null.</li>
@@ -248,7 +248,7 @@ public class UpdateBuilder {
      * <li>Will create a literal representation if the parseNode() fails or for any
      * other object type.</li>
      * </ul>
-     * 
+     *
      * @param s The subject object
      * @param p the predicate object
      * @param o the object object.
@@ -264,11 +264,11 @@ public class UpdateBuilder {
 
     /**
      * Convert the object to a node.
-     * 
+     *
      * Shorthand for AbstractQueryBuilder.makeNode( o, prefixes )
-     * 
+     *
      * @see AbstractQueryBuilder#makeNode(Object)
-     * 
+     *
      * @param o the object to convert to a node.
      * @return the Node.
      */
@@ -278,11 +278,11 @@ public class UpdateBuilder {
 
     /**
      * Convert the object to a node.
-     * 
+     *
      * Shorthand for AbstractQueryBuilder.makeVar( o )
-     * 
+     *
      * @see Converters#makeVar(Object)
-     * 
+     *
      * @param o the object to convert to a var.
      * @return the Var.
      * @deprecated use {@link Converters#makeVar(Object)}
@@ -294,11 +294,11 @@ public class UpdateBuilder {
 
     /**
      * Quote a string.
-     * 
+     *
      * Shorthand for AbstractQueryBuilder.quote( s )
-     * 
+     *
      * @see Converters#quoted(String)
-     * 
+     *
      * @deprecated Use quoted()
      * @param s the string to quote.
      * @return the quoted string.
@@ -311,9 +311,9 @@ public class UpdateBuilder {
 
     /**
      * Add a quad to the insert statement.
-     * 
+     *
      * Arguments are converted to nodes using the makeNode() method.
-     * 
+     *
      * @see #makeNode(Object)
      * @param g the graph
      * @param s the subject
@@ -327,8 +327,8 @@ public class UpdateBuilder {
 
     /**
      * Add a quad to the insert statement.
-     * 
-     * 
+     *
+     *
      * @param quad the quad to add.
      * @return this builder for chaining.
      */
@@ -339,9 +339,9 @@ public class UpdateBuilder {
 
     /**
      * Add a triple to the insert statement.
-     * 
+     *
      * Arguments are converted to nodes using the makeNode() method.
-     * 
+     *
      * @see #makeNode(Object)
      * @param s the subject
      * @param p the predicate
@@ -355,7 +355,7 @@ public class UpdateBuilder {
 
     /**
      * Add a triple to the insert statement.
-     * 
+     *
      * @param t the triple to add.
      * @return this builder for chaining.
      */
@@ -366,9 +366,9 @@ public class UpdateBuilder {
 
     /**
      * Add a triple in a specified graph to the insert statement.
-     * 
+     *
      * The graph object is converted by a call to makeNode().
-     * 
+     *
      * @see #makeNode(Object)
      * @param g the graph for the triple.
      * @param t the triple to add.
@@ -383,7 +383,7 @@ public class UpdateBuilder {
     /**
      * Add all the statements in the model to the insert statement. Uses
      * Quad.defaultGraphNodeGenerated as the graph name.
-     * 
+     *
      * @param model The model to insert.
      * @return this builder for chaining.
      */
@@ -395,7 +395,7 @@ public class UpdateBuilder {
     /**
      * Add all the triples in the model to the insert statement. Uses
      * Quad.defaultGraphNodeGenerated as the graph name.
-     * 
+     *
      * @param collection The triples to insert.
      * @return this builder for chaining.
      * @see Quad#defaultGraphNodeGenerated
@@ -407,7 +407,7 @@ public class UpdateBuilder {
 
     /**
      * Add all the quads in the collection to the insert statement.
-     * 
+     *
      * @param collection The quads to insert.
      * @return this builder for chaining.
      */
@@ -419,7 +419,7 @@ public class UpdateBuilder {
     /**
      * Add all the triples to the insert statement. Uses
      * Quad.defaultGraphNodeGenerated as the graph name.
-     * 
+     *
      * @param iter The iterator of triples to insert.
      * @return this builder for chaining.
      * @see Quad#defaultGraphNodeGenerated
@@ -432,9 +432,9 @@ public class UpdateBuilder {
     /**
      * Add all the statements in the model a specified graph to the insert
      * statement.
-     * 
+     *
      * The graph object is converted by a call to makeNode().
-     * 
+     *
      * @see #makeNode(Object)
      * @param g the graph for the triple.
      * @param model the model to add.
@@ -447,7 +447,7 @@ public class UpdateBuilder {
 
     /**
      * Add triples to the insert statement.
-     * 
+     *
      * @param g the name of the graph to add the triples to.
      * @param collection The triples to insert.
      * @return this builder for chaining.
@@ -459,7 +459,7 @@ public class UpdateBuilder {
 
     /**
      * Add triples to the insert statement.
-     * 
+     *
      * @param g the name of the graph to add the triples to.
      * @param iter The iterator of triples to insert.
      * @return this builder for chaining.
@@ -472,7 +472,7 @@ public class UpdateBuilder {
     /**
      * Add the statements from the where clause in the specified query builder to
      * the insert statement. Uses Quad.defaultGraphNodeGenerated as the graph name.
-     * 
+     *
      * @see #makeNode(Object)
      * @see Quad#defaultGraphNodeGenerated
      * @param queryBuilder The query builder to extract the where clause from.
@@ -486,9 +486,9 @@ public class UpdateBuilder {
     /**
      * Add the statements from the where clause in the specified query builder to
      * the insert statements for the specified graph.
-     * 
+     *
      * The graph object is converted by a call to makeNode().
-     * 
+     *
      * @see #makeNode(Object)
      * @param graph the graph to add the statements to.
      * @param queryBuilder The query builder to extract the where clause from.
@@ -501,9 +501,9 @@ public class UpdateBuilder {
 
     /**
      * Add a quad to the delete statement.
-     * 
+     *
      * Arguments are converted to nodes using the makeNode() method.
-     * 
+     *
      * @see #makeNode(Object)
      * @param g the graph
      * @param s the subject
@@ -517,7 +517,7 @@ public class UpdateBuilder {
 
     /**
      * Add a quad to the delete statement.
-     * 
+     *
      * @param quad the quad to add.
      * @return this builder for chaining.
      */
@@ -528,7 +528,7 @@ public class UpdateBuilder {
 
     /**
      * Add all the quads collection to the delete statement.
-     * 
+     *
      * @param collection The quads to insert.
      * @return this builder for chaining.
      */
@@ -539,9 +539,9 @@ public class UpdateBuilder {
 
     /**
      * Add a triple to the delete statement.
-     * 
+     *
      * Arguments are converted to nodes using the makeNode() method.
-     * 
+     *
      * @see #makeNode(Object)
      * @param s the subject
      * @param p the predicate
@@ -556,7 +556,7 @@ public class UpdateBuilder {
     /**
      * Add a triple to the delete statement. Uses Quad.defaultGraphNodeGenerated as
      * the graph name.
-     * 
+     *
      * @param t the triple to add.
      * @return this builder for chaining.
      * @see Quad#defaultGraphNodeGenerated
@@ -568,9 +568,9 @@ public class UpdateBuilder {
 
     /**
      * Add a triple to the delete statement.
-     * 
+     *
      * The graph object is converted by a call to makeNode().
-     * 
+     *
      * @see #makeNode(Object)
      * @param g the graph for the triple.
      * @param t the triple to add.
@@ -585,7 +585,7 @@ public class UpdateBuilder {
     /**
      * Add all the statements in the model to the delete statement. Uses
      * Quad.defaultGraphNodeGenerated as the graph name.
-     * 
+     *
      * @param model The model to insert.
      * @return this builder for chaining.
      * @see Quad#defaultGraphNodeGenerated
@@ -598,7 +598,7 @@ public class UpdateBuilder {
     /**
      * Add all triples to the delete statement. Uses Quad.defaultGraphNodeGenerated
      * as the graph name.
-     * 
+     *
      * @param collection The collection of triples to insert.
      * @return this builder for chaining.
      * @see Quad#defaultGraphNodeGenerated
@@ -611,7 +611,7 @@ public class UpdateBuilder {
     /**
      * Add all the triples in the iterator to the delete statement. Uses
      * Quad.defaultGraphNodeGenerated as the graph name.
-     * 
+     *
      * @param iter The iterator of triples to insert.
      * @return this builder for chaining.
      * @see Quad#defaultGraphNodeGenerated
@@ -624,9 +624,9 @@ public class UpdateBuilder {
     /**
      * Add all the statements in the model a specified graph to the delete
      * statement.
-     * 
+     *
      * The graph object is converted by a call to makeNode().
-     * 
+     *
      * @see #makeNode(Object)
      * @param g the graph for the triples.
      * @param model the model to add.
@@ -639,7 +639,7 @@ public class UpdateBuilder {
 
     /**
      * Add all the statements in the model to the delete statement.
-     * 
+     *
      * @param g the graph for the triples.
      * @param collection The collection of triples to insert.
      * @return this builder for chaining.
@@ -651,7 +651,7 @@ public class UpdateBuilder {
 
     /**
      * Add all the statements in the model to the delete statement.
-     * 
+     *
      * @param g the graph for the triples.
      * @param iter The iterator of triples to insert.
      * @return this builder for chaining.
@@ -664,7 +664,7 @@ public class UpdateBuilder {
     /**
      * Add the statements from the where clause in the specified query builder to
      * the delete statement. Uses Quad.defaultGraphNodeGenerated as the graph name.
-     * 
+     *
      * @see #makeNode(Object)
      * @see Quad#defaultGraphNodeGenerated
      * @param queryBuilder The query builder to extract the where clause from.
@@ -678,9 +678,9 @@ public class UpdateBuilder {
     /**
      * Add the statements from the where clause in the specified query builder to
      * the delete statements for the specified graph.
-     * 
+     *
      * The graph object is converted by a call to makeNode().
-     * 
+     *
      * @see #makeNode(Object)
      * @param graph the graph to add the statements to.
      * @param queryBuilder The query builder to extract the where clause from.
@@ -693,7 +693,7 @@ public class UpdateBuilder {
 
     /**
      * Add the prefix to the prefix mapping.
-     * 
+     *
      * @param pfx the prefix to add.
      * @param uri the uri for the prefix.
      * @return this builder for chaining
@@ -704,7 +704,7 @@ public class UpdateBuilder {
 
     /**
      * Add the prefix to the prefix mapping.
-     * 
+     *
      * @param pfx the prefix to add.
      * @param uri the uri for the prefix.
      * @return this builder for chaining
@@ -715,7 +715,7 @@ public class UpdateBuilder {
 
     /**
      * Add the prefix to the prefix mapping.
-     * 
+     *
      * @param pfx the prefix to add.
      * @param uri the uri for the prefix.
      * @return this builder for chaining
@@ -727,7 +727,7 @@ public class UpdateBuilder {
 
     /**
      * Add the prefixes to the prefix mapping.
-     * 
+     *
      * @param prefixes the prefixes to add.
      * @return this builder for chaining
      */
@@ -739,7 +739,7 @@ public class UpdateBuilder {
 
     /**
      * Add the prefixes to the prefix mapping.
-     * 
+     *
      * @param prefixes the prefix mapping to add.
      * @return this builder for chaining
      */
@@ -751,7 +751,7 @@ public class UpdateBuilder {
 
     /**
      * Get an ExprFactory that uses the prefixes from this builder.
-     * 
+     *
      * @return the ExpressionFactory.
      */
     public ExprFactory getExprFactory() {
@@ -761,7 +761,7 @@ public class UpdateBuilder {
     /**
      * Set a variable replacement. During build all instances of var in the query
      * will be replaced with value. If value is null the replacement is cleared.
-     * 
+     *
      * @param var The variable to replace
      * @param value The value to replace it with or null to remove the replacement.
      */
@@ -776,10 +776,10 @@ public class UpdateBuilder {
     /**
      * Set a variable replacement. During build all instances of var in the query
      * will be replaced with value. If value is null the replacement is cleared.
-     * 
+     *
      * See {@link #makeVar} for conversion of the var param. See {@link #makeNode}
      * for conversion of the value param.
-     * 
+     *
      * @param var The variable to replace.
      * @param value The value to replace it with or null to remove the replacement.
      */
@@ -803,7 +803,7 @@ public class UpdateBuilder {
 
     /**
      * Add all where attributes from the Where Handler argument.
-     * 
+     *
      * @param whereHandler The Where Handler to copy from.
      */
     public UpdateBuilder addAll(WhereHandler whereHandler) {
@@ -813,7 +813,7 @@ public class UpdateBuilder {
 
     /**
      * Add the triple path to the where clause
-     * 
+     *
      * @param t The triple path to add.
      * @throws IllegalArgumentException If the triple path is not a valid triple
      * path for a where clause.
@@ -825,7 +825,7 @@ public class UpdateBuilder {
 
     /**
      * Add the WhereClause
-     * 
+     *
      * @param whereClause
      * @throws IllegalArgumentException If the triple path is not a valid triple
      * path for a where clause.
@@ -837,7 +837,7 @@ public class UpdateBuilder {
 
     /**
      * Add an optional triple to the where clause
-     * 
+     *
      * @param t The triple path to add.
      * @return The Builder for chaining.
      * @throws IllegalArgumentException If the triple is not a valid triple for a
@@ -850,7 +850,7 @@ public class UpdateBuilder {
 
     /**
      * Add the contents of a where handler as an optional statement.
-     * 
+     *
      * @param whereHandler The where handler to use as the optional statement.
      */
     public UpdateBuilder addOptional(WhereHandler whereHandler) {
@@ -860,7 +860,7 @@ public class UpdateBuilder {
 
     /**
      * Add an expression string as a filter.
-     * 
+     *
      * @param expression The expression string to add.
      * @return The Builder for chaining.
      * @throws ParseException If the expression can not be parsed.
@@ -872,7 +872,7 @@ public class UpdateBuilder {
 
     /**
      * Add a subquery to the where clause.
-     * 
+     *
      * @param subQuery The sub query to add.
      * @return The Builder for chaining.
      */
@@ -883,7 +883,7 @@ public class UpdateBuilder {
 
     /**
      * Add a union to the where clause.
-     * 
+     *
      * @param subQuery The subquery to add as the union.
      * @return The Builder for chaining.
      */
@@ -894,7 +894,7 @@ public class UpdateBuilder {
 
     /**
      * Add a graph to the where clause.
-     * 
+     *
      * @param graph The name of the graph.
      * @param subQuery The where handler that defines the graph.
      */
@@ -905,7 +905,7 @@ public class UpdateBuilder {
 
     /**
      * Add a binding to the where clause.
-     * 
+     *
      * @param expr The expression to bind.
      * @param var The variable to bind it to.
      */
@@ -916,7 +916,7 @@ public class UpdateBuilder {
 
     /**
      * Add a binding to the where clause.
-     * 
+     *
      * @param expression The expression to bind.
      * @param var The variable to bind it to.
      * @throws ParseException
@@ -928,9 +928,9 @@ public class UpdateBuilder {
 
     /**
      * Create a list node from a list of objects as per RDF Collections.
-     * 
+     *
      * http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#collections
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeNode} for conversion of the param values.
      * <p>
      * usage:
@@ -939,8 +939,7 @@ public class UpdateBuilder {
      * <li>addWhere( list( param1, param2, param3, ... ), p, o )</li>
      * <li>addOptional( list( param1, param2, param3, ... ), p, o )</li>
      * </ul>
-     * </p>
-     * 
+     *
      * @param objs the list of objects for the list.
      * @return the first blank node in the list.
      */
@@ -965,7 +964,7 @@ public class UpdateBuilder {
 
     /**
      * Adds a triple to the where clause.
-     * 
+     *
      * @param t The triple path to add
      * @return The Builder for chaining.
      */
@@ -975,7 +974,7 @@ public class UpdateBuilder {
 
     /**
      * Adds a triple to the where clause.
-     * 
+     *
      * @param t The triple to add
      * @return The Builder for chaining.
      */
@@ -985,10 +984,10 @@ public class UpdateBuilder {
 
     /**
      * Adds a triple or triple path to the where clause.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeTriplePath} for conversion of the param
      * values.
-     * 
+     *
      * @param s The subject.
      * @param p The predicate.
      * @param o The object.
@@ -1000,7 +999,7 @@ public class UpdateBuilder {
 
     /**
      * Adds an optional triple to the where clause.
-     * 
+     *
      * @param t The triple to add
      * @return The Builder for chaining.
      */
@@ -1010,7 +1009,7 @@ public class UpdateBuilder {
 
     /**
      * Adds an optional triple as to the where clause.
-     * 
+     *
      * @param t The triple to add
      * @return The Builder for chaining.
      */
@@ -1020,10 +1019,10 @@ public class UpdateBuilder {
 
     /**
      * Adds an optional triple or triple path to the where clause.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeTriplePath} for conversion of the param
      * values.
-     * 
+     *
      * @param s The subject.
      * @param p The predicate.
      * @param o The object.
@@ -1035,7 +1034,7 @@ public class UpdateBuilder {
 
     /**
      * Adds an optional group pattern to the where clause.
-     * 
+     *
      * @param t The select builder to add as an optional pattern
      * @return The Builder for chaining.
      */
@@ -1046,14 +1045,14 @@ public class UpdateBuilder {
 
     /**
      * Adds a filter to the where clause
-     * 
+     *
      * Use ExprFactory or NodeValue static or the AbstractQueryBuilder.makeExpr
      * methods to create the expression.
-     * 
+     *
      * @see ExprFactory
      * @see org.apache.jena.sparql.expr.NodeValue
      * @see AbstractQueryBuilder#makeExpr(String)
-     * 
+     *
      * @param expression the expression to evaluate for the filter.
      * @return @return The Builder for chaining.
      */
@@ -1065,9 +1064,9 @@ public class UpdateBuilder {
     /**
      * Add a graph statement to the query as per
      * http://www.w3.org/TR/2013/REC-sparql11 -query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeNode} for conversion of the graph param.
-     * 
+     *
      * @param graph The iri or variable identifying the graph.
      * @param subQuery The graph to add.
      * @return This builder for chaining.
@@ -1080,7 +1079,7 @@ public class UpdateBuilder {
     /**
      * Add a bind statement to the query *
      * http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * @param expression The expression to bind to the var.
      * @param var The variable to bind to.
      * @return This builder for chaining.
@@ -1093,7 +1092,7 @@ public class UpdateBuilder {
     /**
      * Add a bind statement to the query
      * http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * @param expression The expression to bind to the var.
      * @param var The variable to bind to.
      * @return This builder for chaining.
@@ -1106,9 +1105,9 @@ public class UpdateBuilder {
 
     /**
      * Add a minus clause to the query.
-     * 
+     *
      * https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rMinusGraphPattern
-     * 
+     *
      * @param t The select builder to add as a minus pattern
      * @return this builder for chaining
      */
@@ -1119,8 +1118,8 @@ public class UpdateBuilder {
 
     /**
      * Specify the graph for all inserts and deletes.
-     * 
-     * 
+     *
+     *
      * @see Quad#defaultGraphNodeGenerated
      * @param iri the IRI for the graph to use.
      * @return this builder for chaining.
@@ -1139,7 +1138,7 @@ public class UpdateBuilder {
 
     /**
      * Create a DeleteWhere from the where clause.
-     * 
+     *
      * @return a DeleteWhere update.
      */
     public UpdateDeleteWhere buildDeleteWhere() {
@@ -1149,7 +1148,7 @@ public class UpdateBuilder {
 
     /**
      * Create a DeleteWhere from the where clause.
-     * 
+     *
      * @param queryBuilder the query builder to extract the where clause from.
      * @return a DeleteWhere update.
      */

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/WhereClause.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/WhereClause.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,14 +36,14 @@ import org.apache.jena.sparql.lang.sparql_11.ParseException;
 /**
  * Interface that defines the WhereClause as per
  * http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rWhereClause
- * 
+ *
  * @param <T> The Builder type that the clause is part of.
  */
 public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds a triple to the where clause.
-     * 
+     *
      * @param t The triple path to add
      * @return This Builder for chaining.
      */
@@ -51,7 +51,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds a triple path to the where clause.
-     * 
+     *
      * @param t The triple path to add
      * @return This Builder for chaining.
      */
@@ -59,7 +59,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds a triple to the where clause.
-     * 
+     *
      * @param t The triple to add
      * @return This Builder for chaining.
      */
@@ -67,10 +67,10 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds a triple or triple path to the where clause.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeTriplePath} for conversion of the param
      * values.
-     * 
+     *
      * @param s The subject.
      * @param p The predicate.
      * @param o The object.
@@ -80,7 +80,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds the elements from the whereClause to this where Clause.
-     * 
+     *
      * @param whereClause The whereClause to add to this statement.
      * @return This Builder for chaining.
      */
@@ -88,18 +88,18 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Add a variable or variable and values to the value statement.
-     * 
+     *
      * The first var (or first item in a collection) is converted to a variable
      * using the makeVar strategy. A variable may be added multiple times, doing so
      * will append values to the list of variable values. The order in which
      * variables are added to the values table is preserved.
-     * 
+     *
      * Adding a collection as the var will use the first object in the collection as
      * the var and the remaining objects as values.
-     * 
+     *
      * Values are created using makeNode() strategy except that null values are
      * converted to UNDEF.
-     * 
+     *
      * @param var The variable or collection to add.
      * @return The builder for chaining.
      * @see AbstractQueryBuilder#makeNode(Object)
@@ -109,15 +109,15 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Add a variable and values to the value statement.
-     * 
+     *
      * The var is converted to a variable using the makeVar strategy. A variable may
      * be added multiple times, doing so will append values to the list of variable
      * values. The order in which variables are added to the values table is
      * preserved.
-     * 
+     *
      * Values are created using makeNode() strategy except that null values are
      * converted to UNDEF.
-     * 
+     *
      * @param var The variable to add.
      * @param values The values for the variable
      * @return The builder for chaining.
@@ -128,19 +128,19 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Add a data table to the value statement.
-     * 
+     *
      * Each key in the map is used converted into a variable using the makeVar
      * strategy. The order in which variables are added to the values table is
      * preserved.
-     * 
+     *
      * Variables are added in the iteration order for the map. It may be advisable
      * to use a LinkedHashMap to preserver the insert order.
-     * 
+     *
      * @see java.util.LinkedHashMap
-     * 
+     *
      * Each item in the value collection is converted into a node using makeNode()
      * strategy except that null values are converted to UNDEF.
-     * 
+     *
      * If there are already values in the value statement the data table is adds as
      * follows:
      * <ul>
@@ -153,7 +153,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      * the map additional UNDEF entries are appended to them to account for new rows
      * that are added.</li>
      * </ul>
-     * 
+     *
      * @param dataTable The data table to add.
      * @return The builder for chaining.
      * @see AbstractQueryBuilder#makeNode(Object)
@@ -168,7 +168,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      * variable in the table. Values objects are converted to nodes using the
      * makeNode strategy. Variables will always be in the order added to the values
      * table.
-     * 
+     *
      * @param values the collection of values to add.
      * @return The builder for chaining.
      * @see AbstractQueryBuilder#makeNode(Object)
@@ -182,7 +182,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      * each variable in the table. Values objects are converted to nodes using the
      * makeNode strategy. Variables will always be in the order added to the values
      * table.
-     * 
+     *
      * @param values the collection of values to add.
      * @return The builder for chaining.
      * @see AbstractQueryBuilder#makeNode(Object)
@@ -192,7 +192,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Get an unmodifiable list of vars from the where clause values in the order
      * that they appear in the values table.
-     * 
+     *
      * @return an unmodifiable list of vars.
      */
     public List<Var> getWhereValuesVars();
@@ -200,9 +200,9 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Get an unmodifiable map of vars from the where clause values and their
      * values.
-     * 
+     *
      * Null values are considered as UNDEF values.
-     * 
+     *
      * @return an unmodifiable map of vars and their values.
      */
     public Map<Var, List<Node>> getWhereValuesMap();
@@ -215,7 +215,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds an optional triple to the where clause.
-     * 
+     *
      * @param t The triple to add
      * @return This Builder for chaining.
      */
@@ -223,7 +223,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds an optional triple path to the where clause.
-     * 
+     *
      * @param t The triple path to add
      * @return This Builder for chaining.
      */
@@ -231,7 +231,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds an optional triple as to the where clause.
-     * 
+     *
      * @param t The triple to add
      * @return This Builder for chaining.
      */
@@ -239,10 +239,10 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds an optional triple or triple path to the where clause.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeTriplePath} for conversion of the param
      * values.
-     * 
+     *
      * @param s The subject.
      * @param p The predicate.
      * @param o The object.
@@ -252,7 +252,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds an optional group pattern to the where clause.
-     * 
+     *
      * @param t The select builder to add as an optional pattern
      * @return This Builder for chaining.
      */
@@ -260,7 +260,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds a filter to the where clause
-     * 
+     *
      * @param expression the expression to evaluate for the filter.
      * @return @return This Builder for chaining.
      * @throws ParseException If the expression can not be parsed.
@@ -269,14 +269,14 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Adds a filter to the where clause
-     * 
+     *
      * Use ExprFactory or NodeValue static or the AbstractQueryBuilder.makeExpr
      * methods to create the expression.
-     * 
+     *
      * @see ExprFactory
      * @see org.apache.jena.sparql.expr.NodeValue
      * @see AbstractQueryBuilder#makeExpr(String)
-     * 
+     *
      * @param expression the expression to evaluate for the filter.
      * @return @return This Builder for chaining.
      */
@@ -284,7 +284,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Add a sub query.
-     * 
+     *
      * @param subQuery The subquery as defined by a SelectBuilder.
      * @return This builder for chaining.
      */
@@ -292,7 +292,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Add a union.
-     * 
+     *
      * @param union The union as defined by a SelectBuilder.
      * @return This builder for chaining.
      */
@@ -301,9 +301,9 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Add a graph statement to the query as per
      * http://www.w3.org/TR/2013/REC-sparql11 -query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeNode} for conversion of the graph param.
-     * 
+     *
      * @param graph The iri or variable identifying the graph.
      * @param subQuery The graph to add.
      * @return This builder for chaining.
@@ -313,9 +313,9 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Add a graph statement to the query as per
      * http://www.w3.org/TR/2013/REC-sparql11 -query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeNode} for conversion of the graph param.
-     * 
+     *
      * @param graph The iri or variable identifying the graph.
      * @param triple a single s, p, o triple for the query.
      * @return This builder for chaining.
@@ -325,9 +325,9 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Add a graph statement to the query as per
      * http://www.w3.org/TR/2013/REC-sparql11 -query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeNode} for conversion of the graph param.
-     * 
+     *
      * @param graph The iri or variable identifying the graph.
      * @param subject The subject for the graph query
      * @param predicate The predicate for the graph query.
@@ -339,9 +339,9 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Add a graph statement to the query as per
      * http://www.w3.org/TR/2013/REC-sparql11 -query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeNode} for conversion of the graph param.
-     * 
+     *
      * @param graph The iri or variable identifying the graph.
      * @param triple a single triple for the query.
      * @return This builder for chaining.
@@ -351,9 +351,9 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Add a graph statement to the query as per
      * http://www.w3.org/TR/2013/REC-sparql11 -query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeNode} for conversion of the graph param.
-     * 
+     *
      * @param graph The iri or variable identifying the graph.
      * @param triplePath a single triple path for the query.
      * @return This builder for chaining.
@@ -363,7 +363,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Add a bind statement to the query *
      * http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * @param expression The expression to bind to the var.
      * @param var The variable to bind to.
      * @return This builder for chaining.
@@ -373,7 +373,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Add a bind statement to the query
      * http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rGraphGraphPattern.
-     * 
+     *
      * @param expression The expression to bind to the var.
      * @param var The variable to bind to.
      * @return This builder for chaining.
@@ -383,16 +383,16 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Get the Where handler for this clause.
-     * 
+     *
      * @return The WhereHandler used by this clause.
      */
     public WhereHandler getWhereHandler();
 
     /**
      * Create a list node from a list of objects as per RDF Collections.
-     * 
+     *
      * http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#collections
-     * 
+     *
      * See {@link AbstractQueryBuilder#makeNode} for conversion of the param values.
      * <p>
      * usage:
@@ -401,8 +401,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      * <li>addWhere( list( param1, param2, param3, ... ), p, o )</li>
      * <li>addOptional( list( param1, param2, param3, ... ), p, o )</li>
      * </ul>
-     * </p>
-     * 
+     *
      * @param objs the list of objects for the list.
      * @return the first blank node in the list.
      */
@@ -410,9 +409,9 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
 
     /**
      * Add a minus clause to the query.
-     * 
+     *
      * https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#rMinusGraphPattern
-     * 
+     *
      * @param t The select builder to add as a minus pattern
      * @return this builder for chaining
      */

--- a/jena-extras/jena-serviceenhancer/src/main/java/org/apache/jena/sparql/service/enhancer/claimingcache/Ref.java
+++ b/jena-extras/jena-serviceenhancer/src/main/java/org/apache/jena/sparql/service/enhancer/claimingcache/Ref.java
@@ -34,10 +34,10 @@ import java.util.function.Function;
  *   <li>A reference is <b>closed</b> when {@link #close()} was called; <b>open</b> otherwise.</li>
  *   <li>A reference is <b>alive</b> when it is <b>open</b> and/or any of the child refs acquired from it are still <b>alive</b>.</li>
  *   <li>A reference is <b>released</b> (dead) as soon it is no longer alive. This immediately triggers its release action.</li>
- * <ul>
+ * </ul>
  *
  * Implementation note: At present the alive-check and release action are assumed to run synchronously. As such there
- * is no transition phase ('dying' or 'releasing'). This could be added in the future.</li>
+ * is no transition phase ('dying' or 'releasing'). This could be added in the future.
  *
  * @param <T> The value type stored in this reference.
  */

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiExt.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiExt.java
@@ -27,7 +27,6 @@ import org.apache.jena.fuseki.servlets.ActionService;
 
 /**
  * Operations to extend Fuseki with external code.
- * <p>
  */
 public class FusekiExt {
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/jetty/JettyLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/jetty/JettyLib.java
@@ -38,7 +38,6 @@ import org.eclipse.jetty.util.security.Credential;
 import org.eclipse.jetty.util.security.Password;
 
 /** Helpers for working with Jetty.
- * <p>
  * <h3>SecurityHandler</h3>
  *  <pre>
  *     UserStore userStore = JettyLib.makeUserStore(...);

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/package-info.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/package-info.java
@@ -27,9 +27,7 @@
  * <li><em>Endpoint</em> :: Instance of an operation, toether with its counters.</li>
  * <li><em>DataAccessPointRegistry</em> :: Per server registry of DataAccessPoint</li>
  * </ul>
- * <p>
- * <li><b>Servlets</b>
- * <p>
+ * <b>Servlets</b>
  * <ul>
  * <li><em>FusekiFilter</em> :: Routes requests to Fuseki (handles the dynamic nature dataset naming) by calling ServiceRouter.</li>
  * <li><em>ServiceRouterServlet</em> :: Routes requests to the appropriate service (i.e. implementing servlet).</li>
@@ -38,7 +36,6 @@
  * It implements {@code execCommonWorker} as a lifecycle =&gt; {@code executeAction} =&gt; {@code executeLifecycle} =&gt; {@code validate - perform}
  * <li><em>ServiceRouter</em> :: Routing of request to the cocrete servlet implementations.
  * </ul>
- * <p>
  * <pre>
  * ServiceDispatchServlet &lt; ActionService &lt; ActionBase
  * Services               &lt; ActionService &lt; ActionBase
@@ -48,13 +45,11 @@
  * <p>
  * <b>Registries</b>
  * <p>Located in {@code FusekiRegistries}.
- * <p>
  * <ul>
  * <li><em>ContentTypeToOperation</em>:: Map&lt;content-type, Operation&gt;</li>
  * <li><em>ContentTypeToOperation</em>:: Map&lt;String, Operation&gt;</li>
  * <li><em>Dispatch</em> :: {@literal Map<Operation, ActionService>}</li>
  * </ul>
- * <p>
  */
 
 package org.apache.jena.fuseki;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/CrossOriginFilter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/CrossOriginFilter.java
@@ -107,7 +107,7 @@ import org.slf4j.LoggerFactory;
 * <li><b>chainPreflight</b>, if true preflight requests are chained to their
 * target resource for normal handling (as an OPTION request).  Otherwise the
 * filter will response to the preflight. Default is true.</li>
-* </ul></p>
+* </ul>1
 * <p>A typical configuration could be:
 * <pre>
 * &lt;web-app ...&gt;
@@ -122,7 +122,7 @@ import org.slf4j.LoggerFactory;
 *     &lt;/filter-mapping&gt;
 *     ...
 * &lt;/web-app&gt;
-* </pre></p>
+* </pre>
 */
 public class CrossOriginFilter implements Filter
 {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
@@ -133,11 +133,10 @@ public class HttpAction
      * Initialization after action creation, during lifecycle setup. This is "set
      * once" (in other words, constructor-like but delayed because the information is
      * not yet available at the point we want to create the HttpAction).
-     *
+     * <p>
      * This method sets the action dataset for service requests. Does not apply to "admin" and
      * "ctl" servlets. Setting will replace any existing {@link DataAccessPoint} and
      * {@link DataService}, as the {@link DatasetGraph} of the current HTTP Action.
-     * </p>
      * <p>
      * Once it has updated its members, the HTTP Action will change its transactional
      * state and {@link Transactional} instance according to its base dataset graph.

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -1129,7 +1129,6 @@ public class FusekiServer {
          * Set the number threads used by Jetty. This uses a {@code org.eclipse.jetty.util.thread.QueuedThreadPool} provided by Jetty.
          * <p>
          * Argument order is (minThreads, maxThreads).
-         * <p>
          * <ul>
          * <li>Use (-1,-1) for Jetty "default". The Jetty 9.4 defaults are (min=8,max=200).
          * <li>If (min != -1, max is -1) then the default max is 20.

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -275,7 +275,6 @@ public class JettyServer {
          * Set the number threads used by Jetty. This uses a {@code org.eclipse.jetty.util.thread.QueuedThreadPool} provided by Jetty.
          * <p>
          * Argument order is (minThreads, maxThreads).
-         * <p>
          * <ul>
          * <li>Use (-1,-1) for Jetty "default". The Jetty 9.4 defaults are (min=8,max=200).
          * <li>If (min != -1, max is -1) then the default max is 20.

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/auth/AuthBearerFilter.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/auth/AuthBearerFilter.java
@@ -58,7 +58,8 @@ import org.slf4j.Logger;
  * <li>getting the token from the HTTP request (e.g. from a different HTTP field)</li>
  * <li>handling the challenge case (no authentication provided)</li>
  * <li>handling the case of authentication provided, but it is not "bearer" and bearer is required</li>
- * <p>
+ * </ul>
+ *
  * A more flexible approach for mixing authentication methods is to setup Fuseki with
  * multiple {@code AuthBearerFilter} filters installed in a Fuseki server, with
  * different path specs.

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModule.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModule.java
@@ -77,7 +77,7 @@ public interface FusekiModule extends SubsystemLifecycle {
      * This is the main point for customization of server.
      * <p>
      * It can add and modify the data services being built, and also add servlets and servlet filters.
-     * <p>
+     *
      * @param serverBuilder
      *      The FusekiServer.Builder
      * @param datasetNames

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiEnv.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiEnv.java
@@ -53,7 +53,7 @@ public class FusekiEnv {
         If at server initialization, the MODE is UNSET, then assume WAR setup.
         A WAR file does not have the opportunity to set the mode.
         <p>
-        TEST:  (better to set FUSEKI_HOME, FUSEKI_BASE from the test environment</li>
+        TEST:  (better to set FUSEKI_HOME, FUSEKI_BASE from the test environment
     */
     public enum INIT {
         // Default values of FUSEKI_HOME, and FUSEKI_BASE.

--- a/jena-iri/pom.xml
+++ b/jena-iri/pom.xml
@@ -111,9 +111,11 @@
           </execution>
         </executions>
         <configuration>
-          <!-- OK for Java17 (compiling to Java11); not OK for Java11
+          <!-- 
+               OK for Java17 (compiling to Java11); not OK for Java11
                <doclint>syntax</doclint>
           -->
+          <doclint>none</doclint>
           <version>true</version>
           <show>public</show>
           <quiet>true</quiet>

--- a/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/postprocessing/ResultsPostProcessor.java
+++ b/jena-jdbc/jena-jdbc-core/src/main/java/org/apache/jena/jdbc/postprocessing/ResultsPostProcessor.java
@@ -32,7 +32,7 @@ import org.apache.jena.query.ResultSet ;
  * Interface for results post processors, post processors have the ability to
  * modify the raw SPARQL results or the JDBC results metadata before it is
  * provided for consumption to the caller of the JDBC APIs
- * 
+ *
  */
 public interface ResultsPostProcessor {
 
@@ -43,7 +43,7 @@ public interface ResultsPostProcessor {
      * provides access to all connection configuration parameters except
      * password
      * </p>
-     * 
+     *
      * @param props
      *            Connection properties
      * @throws SQLException
@@ -59,7 +59,7 @@ public interface ResultsPostProcessor {
      * manipulations on the results before they get presented through the JDBC
      * API.
      * </p>
-     * 
+     *
      * @param results
      *            Incoming results
      * @return Processed results
@@ -76,7 +76,7 @@ public interface ResultsPostProcessor {
      * application to do manipulations on the results before they get presented
      * through the JDBC API.
      * </p>
-     * 
+     *
      * @param triples
      *            Incoming results
      * @return Processed results
@@ -92,8 +92,7 @@ public interface ResultsPostProcessor {
      * gets wrapped in a JDBC result set. This allows an application to do
      * manipulations on the results before they get presented through the JDBC
      * API.
-     * <p>
-     * 
+     *
      * @param result
      *            Incoming results
      * @return Processed results
@@ -112,7 +111,7 @@ public interface ResultsPostProcessor {
      * in order to be work better with certain tools or to override the default
      * type mappings that Jena JDBC makes.
      * </p>
-     * 
+     *
      * @param metadata
      *            Calculated metadata
      * @return Processed metadata
@@ -131,7 +130,7 @@ public interface ResultsPostProcessor {
      * column types in order to be work better with certain tools or to override
      * the default type mappings that Jena JDBC makes.
      * </p>
-     * 
+     *
      * @param metadata
      *            Calculated metadata
      * @return Processed metadata
@@ -150,7 +149,7 @@ public interface ResultsPostProcessor {
      * in order to be work better with certain tools or to override the default
      * type mappings that Jena JDBC makes.
      * </p>
-     * 
+     *
      * @param metadata
      *            Calculated metadata
      * @return Processed metadata

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/SecuredAssembler.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/SecuredAssembler.java
@@ -34,26 +34,27 @@ import org.apache.jena.sparql.util.MappingRegistry;
 
 /**
  * Assembler for a secured model.
- * 
+ *
  * <p>
- * The assembler file should include the following <code><pre>
+ * The assembler file should include the following
+    * <pre>
  * &lt;&gt; ja:loadClass    "org.apache.jena.permission.SecuredAssembler" .
  *
  * sec:Model rdfs:subClassOf ja:NamedModel .
  *
  * sec:evaluator rdfs:domain sec:Model ;
  *               rdfs:range sec:Evaluator .
- * </pre></code>
+ * </pre>
  *
  * The model definition should include something like.
  *
- * <code><pre>
+ * <pre>
  * my:secModel a sec:Model ;
  *    sec:baseModel my:baseModel ;
  *    ja:modelName "http://example.com/securedModel" ;
  *    sec:evaluatorFactory "org.apache.jena.permission.MockSecurityEvaluator" ;
  *    .
- * </pre></code>
+ * </pre>
  *
  * Terms used in above example:
  *
@@ -70,7 +71,7 @@ import org.apache.jena.sparql.util.MappingRegistry;
  *
  * <dt>my:baseModel</dt>
  * <dd>a ja:Model (or subclass) defined elsewhere in the assembler file</dd>
- * 
+ *
  * <dt>ja:modelName</dt>
  * <dd>The name of the graph as it will be addressed in the permission
  * environment (see ja:NamedModel examples from Jena)</dd>
@@ -83,7 +84,7 @@ import org.apache.jena.sparql.util.MappingRegistry;
  *
  * or if using an evaluator assembler
  *
- * <code><pre>
+ * <pre>
  * my:secModel a sec:Model ;
  *    sec:baseModel my:baseModel ;
  *    ja:modelName "http://example.com/securedModel" ;
@@ -94,8 +95,7 @@ import org.apache.jena.sparql.util.MappingRegistry;
  *    ex:arg1 "argument 1 for my evaluator constructor" ;
  *    ex:arg2 "argument 2 for my evaluator constructor" ;
  *    .
- *
- * </pre></code>
+ * </pre>
  *
  * Terms used in above example:
  *
@@ -104,7 +104,7 @@ import org.apache.jena.sparql.util.MappingRegistry;
  * <dd>The secured model as referenced in the assembler file.</dd>
  *
  * <dt>sec:Model</dt>
- * <dd>Identifes my:secModel as a secured model</dd>
+ * <dd>Identifies my:secModel as a secured model</dd>
  *
  * <dt>sec:baseModel</dt>
  * <dd>Identifies my:baseModel as the base model we are applying permissions
@@ -112,22 +112,19 @@ import org.apache.jena.sparql.util.MappingRegistry;
  *
  * <dt>my:baseModel</dt>
  * <dd>a ja:Model (or subclass) defined elsewhere in the assembler file</dd>
- * 
+ *
  * <dt>ja:modelName</dt>
  * <dd>The name of the graph as it will be addressed in the permission
  * environment (see ja:NamedModel examples from Jena)</dd>
  *
  * <dt>sec:evaluatorImpl</dt>
  * <dd>Identifies ex:myEvaluator as a SecurityEvaluator defined elsewhere in the
- * assembler file. It must subclass as a sec:Evaluator.</dd></dd>
+ * assembler file. It must subclass as a sec:Evaluator.</dd>
  *
  * <dt>ex:arg1 and ex:arg2</dt>
  * <dd>Arguments as defined by the user defined security evaluator
  * assembler.</dd>
  * </dl>
- *
- * </p>
- *
  */
 public class SecuredAssembler extends ModelAssembler implements AssemblerConstants {
     private static boolean initialized;

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/SecurityEvaluator.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/SecurityEvaluator.java
@@ -45,7 +45,6 @@ import org.apache.jena.shared.AuthenticationRequiredException;
  * as the evaluate methods are called frequently. However, the underlying
  * classes do cache results within a single method check.
  * </p>
- * <p>
  * <dl>
  * <dt>Secured operations</dt>
  * <dd>The security system recognizes and secures each of the CRUD (Create,
@@ -69,7 +68,8 @@ import org.apache.jena.shared.AuthenticationRequiredException;
  * </p>
  * <ul>
  * <li>If the system does not support triple level security the system should
- * always return <code>true</code>.</li> If the system does support triple level
+ * always return <code>true</code>.</li>
+ * <li>If the system does support triple level
  * security and is unable to verify that the user can execute the CRUD action
  * against any arbitrary triple the system should return
  * <code>false</code>.</li>
@@ -82,7 +82,7 @@ import org.apache.jena.shared.AuthenticationRequiredException;
  */
 public interface SecurityEvaluator {
     /**
-     * Identifies a sepcific CRUD actions.
+     * Identifies a specific CRUD actions.
      */
     static enum Action {
         /**
@@ -113,7 +113,7 @@ public interface SecurityEvaluator {
          * <p>
          * The order of the collection is preserved
          * </p>
-         * 
+         *
          * @param actions The actions.
          * @return The set of actions.
          */
@@ -126,7 +126,7 @@ public interface SecurityEvaluator {
          * <p>
          * The order of the collection is preserved
          * </p>
-         * 
+         *
          * @param actions The collection of actions.
          * @return The set of actions.
          */
@@ -141,15 +141,11 @@ public interface SecurityEvaluator {
     /**
      * Indicates a variable in the triple.
      * <p>
-     * </p>
      * This differs from <code>ANY</code> in that the system is asking if there are
      * any prohibitions not if the user may perform. Thus queries with the VARIABLE
      * type node should return <code>true</code> where <code>ANY</code> returns
      * <code>false</code>. In general this type is used in the query to determine if
      * triple level filtering of results must be performed.
-     * <p>
-     * </p>
-     * <p>
      * <dl>
      * <dt><code>(VARIABLE, X, Y )</code></dt>
      * <dd>Asks if there are any prohibitions against the user seeing all subjects
@@ -163,8 +159,6 @@ public interface SecurityEvaluator {
      * </dl>
      * The <code>VARIABLE</code> may occur multiple times and may occur with the
      * <code>ANY</code> node.
-     * </p>
-     * 
      */
     public static final Node VARIABLE = NodeFactory.createBlankNode("urn:jena-permissions:VARIABLE");
 
@@ -173,8 +167,6 @@ public interface SecurityEvaluator {
      * <p>
      * FUTURE is used to check that a blank node may be created in as specific
      * position in a triple.
-     * </p>
-     * <p>
      * <dl>
      * <dt><code>(FUTURE, X, Y )</code></dt>
      * <dd>Asks if there the user may create a blank node that has property X and
@@ -185,7 +177,6 @@ public interface SecurityEvaluator {
      * </dl>
      * The <code>FUTURE</code> may occur multiple times and may occur with the
      * <code>ANY</code> node.
-     * </p>
      */
     public static final Node FUTURE = NodeFactory.createBlankNode("urn:jena-permissions:FUTURE");
 
@@ -226,7 +217,6 @@ public interface SecurityEvaluator {
      * <code>Create</code> actions and is asking if the user may create a blank node
      * in that position in the triple.</li>
      * </ol>
-     * </p>
      *
      * @param principal The principal that is attempting the action.
      *
@@ -265,7 +255,7 @@ public interface SecurityEvaluator {
      * <p>
      * See evaluate( Action, Node, Triple ) for discussion of evaluation strategy.
      * </p>
-     * 
+     *
      * @param actions  The actions to perform.
      * @param graphIRI The IRI of the graph to the action is being taken upon. May
      *                 be <code>ANY</code>.
@@ -356,13 +346,13 @@ public interface SecurityEvaluator {
     /**
      * Returns true if the principal is recognized as an authenticated principal by
      * the underlying authentication mechanism.
-     * 
+     *
      * This is to handle the case where an authentication mechanism returns a
      * non-null object to indicate a non-authenticated principal. (e.g. Shiro).
-     * 
+     *
      * The principal is guaranteed to have been the return value from an earlier
      * getPrincipal() call.
-     * 
+     *
      * @param principal The principal to check.
      * @return true if authenticated, false if not.
      */

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/SecurityEvaluatorAssembler.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/SecurityEvaluatorAssembler.java
@@ -40,8 +40,6 @@ import org.apache.jena.rdf.model.Seq;
  * the arguments. Generally the result of this assembler is passed to a
  * sec:Model construction.
  *
- * @see SecuredAssembler
- *      </p>
  *      <ul>
  *      <li>The evaluator must have one and only one public constructor that
  *      takes the number of arguments specified in the assembler file.</li>
@@ -58,24 +56,25 @@ import org.apache.jena.rdf.model.Seq;
  *      constructor. For example "13"^^xsd:int will be converted to an Integer
  *      with the value of 13.
  *      </p>
- *      The assembler file should include the following <code><pre>
+ *      The assembler file should include the following
+ * <pre>
  * prefix xsd:        &lt;http://www.w3.org/2001/XMLSchema#>
  *
  * &lt;> ja:loadClass    "org.apache.jena.security.SecuredAssembler" .
  *
  * sec:Model rdfs:subClassOf ja:NamedModel .
  *
- * </pre></code>
+ * </pre>
  *
  *      The model definition should include something like.
  *
- *      <code><pre>
+ *      <pre>
  * ex:myEvaluator a sec:Evaluator ;
  *    sec:args [ rdf:_1 "argument 1 for my evaluator constructor" ;
  *               rdf:_2 "13"^^xsd:int ; ];
  *    sec:evaluatorClass "evaluatorClassname";
  *    .
- * </pre></code>
+ * </pre>
  *
  *      Terms used in above example:
  *
@@ -94,14 +93,15 @@ import org.apache.jena.rdf.model.Seq;
  *
  *      <dt>rdf:_2</dt>
  *      <dd>The second argument (an integer in this case</dd>
- * 
+ *
  *      <dt>sec:evaluatorClass</dt>
  *      <dd>The fully qualified name of the SecurityEvaluator class to call.
  *      This class must extend SecurityEvaluator, and must have one and only one
  *      constructor that takes the number of arguments specified in
  *      sec:args</dd>
+ *      </dl>
  *
- *      </p>
+ * @see SecuredAssembler
  *
  */
 public class SecurityEvaluatorAssembler extends AssemblerBase implements Assembler, AssemblerConstants {

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/impl/SecuredItemImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/impl/SecuredItemImpl.java
@@ -31,13 +31,9 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.permissions.SecuredItem;
 import org.apache.jena.permissions.SecurityEvaluator;
 import org.apache.jena.permissions.SecurityEvaluator.Action;
-import org.apache.jena.shared.AddDeniedException;
-import org.apache.jena.shared.AuthenticationRequiredException;
-import org.apache.jena.shared.DeleteDeniedException;
-import org.apache.jena.shared.ReadDeniedException;
-import org.apache.jena.shared.UpdateDeniedException;
+import org.apache.jena.shared.*;
 import org.apache.jena.sparql.expr.Expr;
-import org.apache.jena.sparql.util.NodeUtils;
+import org.apache.jena.sparql.util.NodeCmp;
 import org.apache.jena.util.iterator.ExtendedIterator;
 import org.apache.jena.util.iterator.NullIterator;
 import org.apache.jena.vocabulary.RDF;
@@ -85,7 +81,7 @@ public abstract class SecuredItemImpl implements SecuredItem {
             if (Node.ANY.equals(n2)) {
                 return Expr.CMP_GREATER;
             }
-            return NodeUtils.compareRDFTerms(n1, n2);
+            return NodeCmp.compareRDFTerms(n1, n2);
         }
 
         private int compare(Triple t1, Triple t2) {
@@ -112,7 +108,7 @@ public abstract class SecuredItemImpl implements SecuredItem {
         public int compareTo(final CacheKey other) {
             int retval = this.action.compareTo(other.action);
             if (retval == Expr.CMP_EQUAL) {
-                retval = NodeUtils.compareRDFTerms(this.mNode, other.mNode);
+                retval = NodeCmp.compareRDFTerms(this.mNode, other.mNode);
             }
             if (retval == Expr.CMP_EQUAL) {
                 retval = compare(this.to, other.to);

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredRDFListImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredRDFListImpl.java
@@ -220,7 +220,7 @@ public class SecuredRDFListImpl extends SecuredResourceImpl implements SecuredRD
      * @sec.graph Read - if {@link SecurityEvaluator#isHardReadError()} is true and
      *            the user does not have read access then an empty list is returned.
      * @sec.triple Read for triples containing the returned RDFNodes.
-     * @return List<SecuredRDFNode>
+     * @return List&lt;SecuredRDFNode&gt;
      * @throws AuthenticationRequiredException if user is not authenticated and is
      *                                         required to be.
      */

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/package-info.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/package-info.java
@@ -16,39 +16,32 @@
  * limitations under the License.
  */
 /**
- * JenaSecurity is a SecurityEvaluator interface and a set of dynamic proxies
- * that apply that interface to Jena Graphs, Models, and associated methods and
- * classes.
+ * JenaSecurity is a SecurityEvaluator interface and a set of dynamic proxies that
+ * apply that interface to Jena Graphs, Models, and associated methods and classes.
  * <p>
- * The SecurityEvaluator class must be implemented. This class provides the
- * interface to the authentication results (e.g. <code>getPrincipal()</code>)
- * and the authorization system.
+ * The SecurityEvaluator class must be implemented. This class provides the interface
+ * to the authentication results (e.g. <code>getPrincipal()</code>) and the
+ * authorization system.
  * </p>
- * <p>
  * <ul>
  * <li>Create a SecuredGraph by calling
  * <code>Factory.getInstance( SecurityEvaluator, String, Graph );</code></li>
  * <li>Create a SecuredModel by calling
  * <code>Factory.getInstance( SecurityEvaluator, String, Model )</code></li>
  * <li>It is not recommended that you create a model by calling the Jena
- * <code>ModelFactory.createModelForGraph( SecuredGraph )</code> See Overview
- * for discussion.</li>
+ * <code>ModelFactory.createModelForGraph( SecuredGraph )</code> See Overview for
+ * discussion.</li>
  * </ul>
- * </p>
  * <p>
  * <em>NOTES:</em>
  * <ul>
  * <li>See SecurityEvaluator documentation for description of cascading security
  * checks</li>
- * <li>Secured methods are annotated with:
- *
- * @sec.graph for permissions required on the graph to execute the method.
- * @sec.triple for permissions required on the associated triples (if any) to
- *             execute the method.</li>
- *             <li>It is possible to implement a SecurityEvaluator that does not
- *             enforce security at the triple level. See SecurityEvaluator
- *             documentation for details</li>
- *             </ul>
- *             </p>
+ * <li>Secured methods are annotated with: \@sec.graph for permissions required on
+ * the graph to execute the method. \@sec.triple for permissions required on the
+ * associated triples (if any) to execute the method.</li>
+ * <li>It is possible to implement a SecurityEvaluator that does not enforce security
+ * at the triple level. See SecurityEvaluator documentation for details</li>
+ * </ul>
  */
 package org.apache.jena.permissions;

--- a/jena-permissions/src/main/overview.html
+++ b/jena-permissions/src/main/overview.html
@@ -8,8 +8,6 @@
 		the interface to the authentication results (e.g.
 		<code>getPrincipal()</code>
 		) and the authorization system.
-	</p>
-	<p>
 	<ul>
 		<li>Create a SecuredGraph by calling <code>Factory.getInstance(
 				SecurityEvaluator, String, Graph );</code>
@@ -22,8 +20,6 @@
 			reasons.
 		</li>
 	</ul>
-	</p>
-	<p>
 	<ul>
 		<li>See SecurityEvaluator documentation for description of
 			cascading security checks</li>
@@ -35,7 +31,6 @@
 			enforce security at the triple level. See SecurityEvaluator
 			documentation for details</li>
 	</ul>
-	</p>
 	<h2>
 		Differences Between
 		<code>Graph</code>
@@ -72,12 +67,12 @@
 			graph, and the triple where required, the update is performed as a
 			single event.</li>
 	</ul>
+	<p>
 	This is the well documented case of differences between the two secured
 	model creation methods. For this reason it is recommended that the
 	model be created with the
 	<code>Factory.getInsance()</code>
 	method.
 	</p>
-
 </body>
 </html>

--- a/jena-shex/src/main/java/org/apache/jena/shex/Shex.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/Shex.java
@@ -40,7 +40,6 @@ import org.apache.jena.sys.JenaSystem;
 
 /**
  * <a href="https://shex.io/">ShEx</a>
- * <p>
  *
  * @see ShexValidator
  */

--- a/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeNodeConstraint.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/expressions/ShapeNodeConstraint.java
@@ -30,8 +30,8 @@ import org.apache.jena.shex.sys.ValidationContext;
 ShapeAtom := ( nonLitNodeConstraint ( inlineShapeOrRef )?
              | litNodeConstraint
              | inlineShapeOrRef ( nonLitNodeConstraint )?
-             | <LPAREN> shapeExpression <RPAREN>
-             | <DOT>
+             | &lt;LPAREN&gt; shapeExpression &lt;RPAREN&gt;
+             | &lt;DOT&gt;
              )
 </pre>
 */

--- a/jena-tdb/src/main/java/org/apache/jena/tdb/TDB.java
+++ b/jena-tdb/src/main/java/org/apache/jena/tdb/TDB.java
@@ -105,7 +105,7 @@ public class TDB {
     /**
      * A String enum Symbol that specifies the type of temporary storage for
      * transaction journal write blocks.
-     * <p/>
+     * <p>
      * "mem" = Java heap memory (default) <br>
      * "direct" = Process heap memory <br>
      * "mapped" = Memory mapped temporary file <br>

--- a/pom.xml
+++ b/pom.xml
@@ -990,6 +990,12 @@
                  https://maven.apache.org/guides/mini/guide-reproducible-builds.html
                  See FAQ
             -->
+
+            <!-- Java11 javadoc: "syntax,html" fails on things that aren't wrong
+                 and on unrequested checks such as group "missing".
+                 Java17 has fixed these and behaves as expected:
+                 <doclint>syntax,html</doclint>
+            -->
             <doclint>none</doclint>
 
             <notimestamp>true</notimestamp>


### PR DESCRIPTION
Pull request Description:

This cleans the code so that `<doclint>syntax,html` is clean except: jena-iri and jena-core which ave some large HTML tables which doclint does not like but seem valid, albeit old HTML. 

But.

The top level is set to `<doclint>none` because while Java17 passes, Java11 checks the "missing" category (despite not being asked to) and also rejects `<br/>`.

The Jena release is currently using Java17 compiling for Java11 because the javadoc search fails.

But we ought to ensure that java11 does build Jena as we support Java11.

----
By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
