### PR TITLE
Javadoc : source=11

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/atlas/json/io/parserjavacc/javacc/JavaCharStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/atlas/json/io/parserjavacc/javacc/JavaCharStream.java
@@ -30,7 +30,7 @@ public
 class JavaCharStream
 {
   /** Whether parser is static. */
-  
+
 @SuppressWarnings("all")
 public static final boolean staticFlag = false;
 
@@ -82,7 +82,7 @@ public static final boolean staticFlag = false;
   }
 
 /* Position in buffer. */
-  
+
 @SuppressWarnings("all")
 public int bufpos = -1;
   int bufsize;
@@ -107,10 +107,10 @@ public int bufpos = -1;
   protected int tabSize = 1;
   protected boolean trackLineColumn = true;
 
-  
+
 @SuppressWarnings("all")
 public void setTabSize(int i) { tabSize = i; }
-  
+
 @SuppressWarnings("all")
 public int getTabSize() { return tabSize; }
 
@@ -202,7 +202,7 @@ public int getTabSize() { return tabSize; }
   }
 
 /* @return starting character for token. */
-  
+
 @SuppressWarnings("all")
 public char BeginToken() throws java.io.IOException
   {
@@ -284,7 +284,7 @@ public char BeginToken() throws java.io.IOException
   }
 
 /* Read a character. */
-  
+
 @SuppressWarnings("all")
 public char readChar() throws java.io.IOException
   {
@@ -384,7 +384,7 @@ public char readChar() throws java.io.IOException
    * @see #getEndColumn
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getColumn() {
     return bufcolumn[bufpos];
@@ -396,7 +396,7 @@ public int getColumn() {
    * @return the line number.
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getLine() {
     return bufline[bufpos];
@@ -405,7 +405,7 @@ public int getLine() {
 /** Get end column.
  * @return the end column or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndColumn() {
     return bufcolumn[bufpos];
@@ -414,7 +414,7 @@ public int getEndColumn() {
 /** Get end line.
  * @return the end line number or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndLine() {
     return bufline[bufpos];
@@ -422,21 +422,21 @@ public int getEndLine() {
 
 /** Get the beginning column.
  * @return column of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginColumn() {
     return bufcolumn[tokenBegin];
   }
 
 /** @return line number of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginLine() {
     return bufline[tokenBegin];
   }
 
 /** Retreat. */
-  
+
 @SuppressWarnings("all")
 public void backup(int amount) {
 
@@ -451,7 +451,7 @@ public void backup(int amount) {
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -472,7 +472,7 @@ public JavaCharStream(java.io.Reader dstream,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -482,16 +482,15 @@ public JavaCharStream(java.io.Reader dstream,
 
 /** Constructor.
  * @param dstream the underlying data source.
- * @param startline line number of the first character of the stream, mostly for error messages.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream)
   {
     this(dstream, 1, 1, 4096);
   }
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -514,7 +513,7 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -523,14 +522,14 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream)
   {
     ReInit(dstream, 1, 1, 4096);
   }
 /** Constructor. */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -544,7 +543,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -557,9 +556,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
                         int startcolumn) throws java.io.UnsupportedEncodingException
@@ -572,7 +571,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
                         int startcolumn)
@@ -583,9 +582,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
 /** Constructor.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -595,7 +594,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.
   /** Constructor.
    * @param dstream the underlying data source.
    */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream)
   {
@@ -609,7 +608,7 @@ public JavaCharStream(java.io.InputStream dstream)
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -623,7 +622,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -635,9 +634,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
                      int startcolumn) throws java.io.UnsupportedEncodingException
@@ -649,7 +648,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
                      int startcolumn)
@@ -659,9 +658,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
 /** Reinitialise.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -671,7 +670,7 @@ public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.
 /** Reinitialise.
  * @param dstream the underlying data source.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream)
   {
@@ -680,7 +679,7 @@ public void ReInit(java.io.InputStream dstream)
 
   /** Get the token timage.
    * @return token image as String */
-  
+
 @SuppressWarnings("all")
 public String GetImage()
   {
@@ -694,7 +693,7 @@ public String GetImage()
   /** Get the suffix as an array of characters.
    * @param len the length of the array to return.
    * @return suffix */
-  
+
 @SuppressWarnings("all")
 public char[] GetSuffix(int len)
   {
@@ -713,7 +712,7 @@ public char[] GetSuffix(int len)
   }
 
   /** Set buffers back to null when finished. */
-  
+
 @SuppressWarnings("all")
 public void Done()
   {
@@ -729,7 +728,7 @@ public void Done()
    * @param newLine the new line number.
    * @param newCol the new column number.
    */
-  
+
 @SuppressWarnings("all")
 public void adjustBeginLineColumn(int newLine, int newCol)
   {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_11/JavaCharStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_11/JavaCharStream.java
@@ -13,7 +13,7 @@ public
 class JavaCharStream
 {
   /** Whether parser is static. */
-  
+
 @SuppressWarnings("all")
 public static final boolean staticFlag = false;
 
@@ -65,7 +65,7 @@ public static final boolean staticFlag = false;
   }
 
 /* Position in buffer. */
-  
+
 @SuppressWarnings("all")
 public int bufpos = -1;
   int bufsize;
@@ -90,10 +90,10 @@ public int bufpos = -1;
   protected int tabSize = 1;
   protected boolean trackLineColumn = true;
 
-  
+
 @SuppressWarnings("all")
 public void setTabSize(int i) { tabSize = i; }
-  
+
 @SuppressWarnings("all")
 public int getTabSize() { return tabSize; }
 
@@ -185,7 +185,7 @@ public int getTabSize() { return tabSize; }
   }
 
 /* @return starting character for token. */
-  
+
 @SuppressWarnings("all")
 public char BeginToken() throws java.io.IOException
   {
@@ -267,7 +267,7 @@ public char BeginToken() throws java.io.IOException
   }
 
 /* Read a character. */
-  
+
 @SuppressWarnings("all")
 public char readChar() throws java.io.IOException
   {
@@ -367,7 +367,7 @@ public char readChar() throws java.io.IOException
    * @see #getEndColumn
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getColumn() {
     return bufcolumn[bufpos];
@@ -379,7 +379,7 @@ public int getColumn() {
    * @return the line number.
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getLine() {
     return bufline[bufpos];
@@ -388,7 +388,7 @@ public int getLine() {
 /** Get end column.
  * @return the end column or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndColumn() {
     return bufcolumn[bufpos];
@@ -397,7 +397,7 @@ public int getEndColumn() {
 /** Get end line.
  * @return the end line number or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndLine() {
     return bufline[bufpos];
@@ -405,21 +405,21 @@ public int getEndLine() {
 
 /** Get the beginning column.
  * @return column of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginColumn() {
     return bufcolumn[tokenBegin];
   }
 
 /** @return line number of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginLine() {
     return bufline[tokenBegin];
   }
 
 /** Retreat. */
-  
+
 @SuppressWarnings("all")
 public void backup(int amount) {
 
@@ -434,7 +434,7 @@ public void backup(int amount) {
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -455,7 +455,7 @@ public JavaCharStream(java.io.Reader dstream,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -465,16 +465,15 @@ public JavaCharStream(java.io.Reader dstream,
 
 /** Constructor.
  * @param dstream the underlying data source.
- * @param startline line number of the first character of the stream, mostly for error messages.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream)
   {
     this(dstream, 1, 1, 4096);
   }
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -497,7 +496,7 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -506,14 +505,14 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream)
   {
     ReInit(dstream, 1, 1, 4096);
   }
 /** Constructor. */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -527,7 +526,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -540,9 +539,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
                         int startcolumn) throws java.io.UnsupportedEncodingException
@@ -555,7 +554,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
                         int startcolumn)
@@ -566,9 +565,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
 /** Constructor.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -578,7 +577,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.
   /** Constructor.
    * @param dstream the underlying data source.
    */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream)
   {
@@ -592,7 +591,7 @@ public JavaCharStream(java.io.InputStream dstream)
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -606,7 +605,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -618,9 +617,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
                      int startcolumn) throws java.io.UnsupportedEncodingException
@@ -632,7 +631,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
                      int startcolumn)
@@ -642,9 +641,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
 /** Reinitialise.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -654,7 +653,7 @@ public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.
 /** Reinitialise.
  * @param dstream the underlying data source.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream)
   {
@@ -663,7 +662,7 @@ public void ReInit(java.io.InputStream dstream)
 
   /** Get the token timage.
    * @return token image as String */
-  
+
 @SuppressWarnings("all")
 public String GetImage()
   {
@@ -677,7 +676,7 @@ public String GetImage()
   /** Get the suffix as an array of characters.
    * @param len the length of the array to return.
    * @return suffix */
-  
+
 @SuppressWarnings("all")
 public char[] GetSuffix(int len)
   {
@@ -696,7 +695,7 @@ public char[] GetSuffix(int len)
   }
 
   /** Set buffers back to null when finished. */
-  
+
 @SuppressWarnings("all")
 public void Done()
   {
@@ -712,7 +711,7 @@ public void Done()
    * @param newLine the new line number.
    * @param newCol the new column number.
    */
-  
+
 @SuppressWarnings("all")
 public void adjustBeginLineColumn(int newLine, int newCol)
   {

--- a/jena-core/src/main/java/org/apache/jena/ttl/turtle/parser/JavaCharStream.java
+++ b/jena-core/src/main/java/org/apache/jena/ttl/turtle/parser/JavaCharStream.java
@@ -31,7 +31,7 @@ public
 class JavaCharStream
 {
   /** Whether parser is static. */
-  
+
 @SuppressWarnings("all")
 public static final boolean staticFlag = false;
 
@@ -83,7 +83,7 @@ public static final boolean staticFlag = false;
   }
 
 /* Position in buffer. */
-  
+
 @SuppressWarnings("all")
 public int bufpos = -1;
   int bufsize;
@@ -108,10 +108,10 @@ public int bufpos = -1;
   protected int tabSize = 1;
   protected boolean trackLineColumn = true;
 
-  
+
 @SuppressWarnings("all")
 public void setTabSize(int i) { tabSize = i; }
-  
+
 @SuppressWarnings("all")
 public int getTabSize() { return tabSize; }
 
@@ -203,7 +203,7 @@ public int getTabSize() { return tabSize; }
   }
 
 /* @return starting character for token. */
-  
+
 @SuppressWarnings("all")
 public char BeginToken() throws java.io.IOException
   {
@@ -285,7 +285,7 @@ public char BeginToken() throws java.io.IOException
   }
 
 /* Read a character. */
-  
+
 @SuppressWarnings("all")
 public char readChar() throws java.io.IOException
   {
@@ -385,7 +385,7 @@ public char readChar() throws java.io.IOException
    * @see #getEndColumn
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getColumn() {
     return bufcolumn[bufpos];
@@ -397,7 +397,7 @@ public int getColumn() {
    * @return the line number.
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getLine() {
     return bufline[bufpos];
@@ -406,7 +406,7 @@ public int getLine() {
 /** Get end column.
  * @return the end column or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndColumn() {
     return bufcolumn[bufpos];
@@ -415,7 +415,7 @@ public int getEndColumn() {
 /** Get end line.
  * @return the end line number or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndLine() {
     return bufline[bufpos];
@@ -423,21 +423,21 @@ public int getEndLine() {
 
 /** Get the beginning column.
  * @return column of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginColumn() {
     return bufcolumn[tokenBegin];
   }
 
 /** @return line number of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginLine() {
     return bufline[tokenBegin];
   }
 
 /** Retreat. */
-  
+
 @SuppressWarnings("all")
 public void backup(int amount) {
 
@@ -452,7 +452,7 @@ public void backup(int amount) {
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -473,7 +473,7 @@ public JavaCharStream(java.io.Reader dstream,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -483,16 +483,15 @@ public JavaCharStream(java.io.Reader dstream,
 
 /** Constructor.
  * @param dstream the underlying data source.
- * @param startline line number of the first character of the stream, mostly for error messages.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream)
   {
     this(dstream, 1, 1, 4096);
   }
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -515,7 +514,7 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -524,14 +523,14 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream)
   {
     ReInit(dstream, 1, 1, 4096);
   }
 /** Constructor. */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -545,7 +544,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -560,7 +559,7 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
                         int startcolumn) throws java.io.UnsupportedEncodingException
@@ -573,7 +572,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
                         int startcolumn)
@@ -586,7 +585,7 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -596,7 +595,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.
   /** Constructor.
    * @param dstream the underlying data source.
    */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream)
   {
@@ -610,7 +609,7 @@ public JavaCharStream(java.io.InputStream dstream)
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -624,7 +623,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -638,7 +637,7 @@ public void ReInit(java.io.InputStream dstream, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
                      int startcolumn) throws java.io.UnsupportedEncodingException
@@ -650,7 +649,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
                      int startcolumn)
@@ -662,7 +661,7 @@ public void ReInit(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -672,7 +671,7 @@ public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.
 /** Reinitialise.
  * @param dstream the underlying data source.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream)
   {
@@ -681,7 +680,7 @@ public void ReInit(java.io.InputStream dstream)
 
   /** Get the token timage.
    * @return token image as String */
-  
+
 @SuppressWarnings("all")
 public String GetImage()
   {
@@ -695,7 +694,7 @@ public String GetImage()
   /** Get the suffix as an array of characters.
    * @param len the length of the array to return.
    * @return suffix */
-  
+
 @SuppressWarnings("all")
 public char[] GetSuffix(int len)
   {
@@ -714,7 +713,7 @@ public char[] GetSuffix(int len)
   }
 
   /** Set buffers back to null when finished. */
-  
+
 @SuppressWarnings("all")
 public void Done()
   {
@@ -730,7 +729,7 @@ public void Done()
    * @param newLine the new line number.
    * @param newCol the new column number.
    */
-  
+
 @SuppressWarnings("all")
 public void adjustBeginLineColumn(int newLine, int newCol)
   {

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
@@ -1054,7 +1054,7 @@ public class UpdateBuilder {
      * @see AbstractQueryBuilder#makeExpr(String)
      *
      * @param expression the expression to evaluate for the filter.
-     * @return @return The Builder for chaining.
+     * @return The Builder for chaining.
      */
     public UpdateBuilder addFilter(Expr expression) {
         whereProcessor.addFilter(expression);

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/WhereClause.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/WhereClause.java
@@ -262,7 +262,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      * Adds a filter to the where clause
      *
      * @param expression the expression to evaluate for the filter.
-     * @return @return This Builder for chaining.
+     * @return This Builder for chaining.
      * @throws ParseException If the expression can not be parsed.
      */
     public T addFilter(String expression) throws ParseException;
@@ -278,7 +278,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      * @see AbstractQueryBuilder#makeExpr(String)
      *
      * @param expression the expression to evaluate for the filter.
-     * @return @return This Builder for chaining.
+     * @return This Builder for chaining.
      */
     public T addFilter(Expr expression);
 

--- a/pom.xml
+++ b/pom.xml
@@ -994,7 +994,7 @@
             <!-- Java11 javadoc: "syntax,html" fails on things that aren't wrong
                  and on unrequested checks such as group "missing".
                  Java17 has fixed these and behaves as expected:
-                 <doclint>syntax,html</doclint>
+                 <doclint>syntax,html,reference</doclint>
             -->
             <doclint>none</doclint>
 

--- a/pom.xml
+++ b/pom.xml
@@ -970,35 +970,25 @@
             </execution>
           </executions>
           <configuration>
-            <!-- Fixes for Javadoc when building for Java11.
-                 (1) Fix for:
-                 Named / unnamed modules error/warning
-                 (2) Fix for:
-                 [ERROR] error: the unnamed module reads package PKG from both A and B
-
-                 Modules impacted:
-                   jena-geosparql
-                   jena-jdbc
-            -->
+            <!-- Fixes for Javadoc when building with Java11 -->
             <detectJavaApiLink>false</detectJavaApiLink>
-            <source>8</source>
+            <source>${java.version}</source>
 
             <!-- To allow the build to keep going despite javadoc problems:
                  <failOnError>false</failOnError>
             -->
             <!-- For producible builds
                  https://maven.apache.org/guides/mini/guide-reproducible-builds.html
-                 See FAQ
             -->
+            <notimestamp>true</notimestamp>
 
-            <!-- Java11 javadoc: "syntax,html" fails on things that aren't wrong
-                 and on unrequested checks such as group "missing".
+            <!-- Java11 javadoc: "syntax,html" fails on things that aren't 
+                 wrong and applies unrequested checks such as group "missing".
                  Java17 has fixed these and behaves as expected:
                  <doclint>syntax,html,reference</doclint>
             -->
             <doclint>none</doclint>
 
-            <notimestamp>true</notimestamp>
             <quiet>true</quiet>
             <version>true</version>
             <show>public</show>


### PR DESCRIPTION
Follow on from #1486  (Javadoc cleaning to get the build working for Java11, not cross-compiled)

Pull request Description:

This PR has fixes and settings so the javadoc:javadoc goal can be source=11.
Otherwise, we have an implicit restriction that the source code must be Java8 syntax. The case that bit me was private methods interfaces.

doclint is still set to "none" but with Java17 running maven, the setting "<doclint>syntax,html,reference" work.

There are still some warnings like:
```
[WARNING] javadoc: warning - The code being documented uses packages in the unnamed module, but the packages defined in https://jena.apache.org/documentation/javadoc/rdfconnection/ are in named modules.
```
but they don't stop the build and seem to bee Java17 to make them go away.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
