### PR TITLE
Rename package in jena-dboe-index-test

### DIFF
--- a/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/test/TS_Index.java
+++ b/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/test/TS_Index.java
@@ -16,17 +16,15 @@
  * limitations under the License.
  */
 
-package org.apache.jena.dboe.index;
+package org.apache.jena.dboe.index.test;
 
-import org.apache.jena.dboe.base.record.RecordFactory;
-import org.apache.jena.dboe.index.test.AbstractTestIndex;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-public class TestIndexMem extends AbstractTestIndex
-{
-    @Override
-    protected Index makeIndex(int kLen, int vLen) {
-        RecordFactory rf = new RecordFactory(kLen, vLen);
-        return new IndexMap(rf);
-    }
+@RunWith(Suite.class)
+@Suite.SuiteClasses( {
+    TestIndexMem.class
+} )
 
-}
+public class TS_Index
+{ }

--- a/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/test/TestIndexMem.java
+++ b/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/test/TestIndexMem.java
@@ -16,15 +16,19 @@
  * limitations under the License.
  */
 
-package org.apache.jena.dboe.index;
+package org.apache.jena.dboe.index.test;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.apache.jena.dboe.base.record.RecordFactory;
+import org.apache.jena.dboe.index.Index;
+import org.apache.jena.dboe.index.IndexMap;
+import org.apache.jena.dboe.index.testlib.AbstractTestIndex;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
-    TestIndexMem.class
-} )
+public class TestIndexMem extends AbstractTestIndex
+{
+    @Override
+    protected Index makeIndex(int kLen, int vLen) {
+        RecordFactory rf = new RecordFactory(kLen, vLen);
+        return new IndexMap(rf);
+    }
 
-public class TS_Index
-{ }
+}

--- a/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/AbstractTestIndex.java
+++ b/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/AbstractTestIndex.java
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.jena.dboe.index.test;
+package org.apache.jena.dboe.index.testlib;
 
-import static org.apache.jena.dboe.index.test.IndexTestLib.*;
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.*;
 import static org.apache.jena.dboe.test.RecordLib.intToRecord;
 
 import org.apache.jena.dboe.base.record.Record;

--- a/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/AbstractTestRangeIndex.java
+++ b/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/AbstractTestRangeIndex.java
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.jena.dboe.index.test;
+package org.apache.jena.dboe.index.testlib;
 
-import static org.apache.jena.dboe.index.test.IndexTestLib.add;
-import static org.apache.jena.dboe.index.test.IndexTestLib.randTest;
-import static org.apache.jena.dboe.index.test.IndexTestLib.testInsert;
-import static org.apache.jena.dboe.index.test.IndexTestLib.testInsertDelete;
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.add;
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.randTest;
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.testInsert;
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.testInsertDelete;
 import static org.apache.jena.dboe.test.RecordLib.intToRecord;
 import static org.apache.jena.dboe.test.RecordLib.r;
 import static org.apache.jena.dboe.test.RecordLib.toIntList;

--- a/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/IndexMaker.java
+++ b/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/IndexMaker.java
@@ -16,28 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.jena.dboe.index.test;
+package org.apache.jena.dboe.index.testlib;
 
-import org.apache.jena.atlas.lib.RandomLib;
-import org.apache.jena.atlas.test.ExecGenerator;
+import org.apache.jena.dboe.index.Index;
 
-public class IndexTestGenerator implements ExecGenerator
+public interface IndexMaker
 {
-    int maxNumKeys;
-    int maxValue;
-    IndexMaker maker;
-
-    public IndexTestGenerator(IndexMaker maker, int maxValue, int maxNumKeys) {
-        if ( maxValue <= maxNumKeys )
-            throw new IllegalArgumentException("RangeIndexTestGenerator: Max value less than number of keys");
-        this.maker = maker;
-        this.maxValue = maxValue;
-        this.maxNumKeys = maxNumKeys;
-    }
-
-    @Override
-    public void executeOneTest() {
-        int numKeys = RandomLib.random.nextInt(maxNumKeys)+1;
-        IndexTestLib.randTest(maker.makeIndex(), maxValue, numKeys);
-    }
+    Index makeIndex();
+    String getLabel();
 }

--- a/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/IndexTestGenerator.java
+++ b/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/IndexTestGenerator.java
@@ -16,12 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.jena.dboe.index.test;
+package org.apache.jena.dboe.index.testlib;
 
-import org.apache.jena.dboe.index.Index;
+import org.apache.jena.atlas.lib.RandomLib;
+import org.apache.jena.atlas.test.ExecGenerator;
 
-public interface IndexMaker
+public class IndexTestGenerator implements ExecGenerator
 {
-    Index makeIndex();
-    String getLabel();
+    int maxNumKeys;
+    int maxValue;
+    IndexMaker maker;
+
+    public IndexTestGenerator(IndexMaker maker, int maxValue, int maxNumKeys) {
+        if ( maxValue <= maxNumKeys )
+            throw new IllegalArgumentException("RangeIndexTestGenerator: Max value less than number of keys");
+        this.maker = maker;
+        this.maxValue = maxValue;
+        this.maxNumKeys = maxNumKeys;
+    }
+
+    @Override
+    public void executeOneTest() {
+        int numKeys = RandomLib.random.nextInt(maxNumKeys)+1;
+        IndexTestLib.randTest(maker.makeIndex(), maxValue, numKeys);
+    }
 }

--- a/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/IndexTestLib.java
+++ b/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/IndexTestLib.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.dboe.index.test;
+package org.apache.jena.dboe.index.testlib;
 
 import static java.lang.String.format;
 import static org.apache.jena.atlas.lib.ListUtils.asList;

--- a/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/RangeIndexMaker.java
+++ b/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/RangeIndexMaker.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.jena.dboe.index.test;
+package org.apache.jena.dboe.index.testlib;
 
 import org.apache.jena.dboe.index.RangeIndex;
 

--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/BPlusTreeMaker.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/BPlusTreeMaker.java
@@ -20,7 +20,7 @@ package org.apache.jena.dboe.trans.bplustree;
 
 import org.apache.jena.dboe.index.Index;
 import org.apache.jena.dboe.index.RangeIndex;
-import org.apache.jena.dboe.index.test.RangeIndexMaker;
+import org.apache.jena.dboe.index.testlib.RangeIndexMaker;
 import org.apache.jena.dboe.test.RecordLib;
 
 public class BPlusTreeMaker implements RangeIndexMaker

--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPlusTreeIndexNonTxn.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPlusTreeIndexNonTxn.java
@@ -20,7 +20,7 @@ package org.apache.jena.dboe.trans.bplustree;
 
 import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.dboe.base.block.BlockMgr;
-import org.apache.jena.dboe.index.test.AbstractTestIndex;
+import org.apache.jena.dboe.index.testlib.AbstractTestIndex;
 import org.apache.jena.dboe.sys.SystemIndex;
 import org.apache.jena.dboe.test.RecordLib;
 import org.junit.AfterClass;

--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPlusTreeNonTxn.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPlusTreeNonTxn.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.dboe.trans.bplustree;
 
-import static org.apache.jena.dboe.index.test.IndexTestLib.add;
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.add;
 import static org.apache.jena.dboe.test.RecordLib.intToRecord;
 
 import java.util.List;
@@ -26,7 +26,7 @@ import java.util.List;
 import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.dboe.base.block.BlockMgr;
 import org.apache.jena.dboe.base.record.Record;
-import org.apache.jena.dboe.index.test.AbstractTestRangeIndex;
+import org.apache.jena.dboe.index.testlib.AbstractTestRangeIndex;
 import org.apache.jena.dboe.sys.SystemIndex;
 import org.apache.jena.dboe.test.RecordLib;
 import org.junit.AfterClass;

--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPlusTreeTxn.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPlusTreeTxn.java
@@ -19,7 +19,7 @@
 package org.apache.jena.dboe.trans.bplustree;
 
 import org.apache.jena.dboe.base.file.Location;
-import org.apache.jena.dboe.index.test.IndexTestLib;
+import org.apache.jena.dboe.index.testlib.IndexTestLib;
 import org.apache.jena.system.Txn;
 import org.apache.jena.dboe.test.RecordLib;
 import org.apache.jena.dboe.transaction.Transactional;

--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/data/TestTransIndexMem.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/data/TestTransIndexMem.java
@@ -21,7 +21,7 @@ package org.apache.jena.dboe.trans.data;
 import org.apache.jena.dboe.base.record.RecordFactory;
 import org.apache.jena.dboe.index.Index;
 import org.apache.jena.dboe.index.IndexMap;
-import org.apache.jena.dboe.index.test.AbstractTestIndex;
+import org.apache.jena.dboe.index.testlib.AbstractTestIndex;
 
 public class TestTransIndexMem extends AbstractTestIndex
 {

--- a/jena-integration-tests/src/test/java/dboe/CmdTestBPlusTree.java
+++ b/jena-integration-tests/src/test/java/dboe/CmdTestBPlusTree.java
@@ -19,7 +19,7 @@
 package dboe;
 
 import org.apache.jena.dboe.base.file.BlockAccessMem;
-import org.apache.jena.dboe.index.test.IndexTestLib;
+import org.apache.jena.dboe.index.testlib.IndexTestLib;
 import org.apache.jena.dboe.sys.SysDB;
 import org.apache.jena.dboe.sys.SystemIndex;
 import org.apache.jena.dboe.trans.bplustree.BPT;


### PR DESCRIPTION
Pull request Description:

This PR fixes a package overlap issue in jena-dboe-index-test (the framework for testing indexes) that impacts javadoc production in the release build.

Why it has only just shown up is a mystery to me! There has been no changes here for quite some time.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
