### PR TITLE
GH-1499: Release non-exclusive mode at the end of transaction.

### DIFF
--- a/jena-db/jena-dboe-storage/src/main/java/org/apache/jena/dboe/storage/system/DatasetGraphTxnCtl.java
+++ b/jena-db/jena-dboe-storage/src/main/java/org/apache/jena/dboe/storage/system/DatasetGraphTxnCtl.java
@@ -137,6 +137,7 @@ public class DatasetGraphTxnCtl extends DatasetGraphWrapper implements Transacti
                 break;
             }
         }
+        finishNonExclusiveMode();
     }
 
     @Override


### PR DESCRIPTION
GitHub issue resolved #1499

Pull request Description:

Exit non-exclusive mode properly. (Non-exclusive mode is normal mode for transactions, exclusive mode is used during compaction to switch storage databases.)

----

 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
