### PR TITLE
Require source=8 for jena-querybuilder

### DIFF
--- a/jena-extras/jena-querybuilder/pom.xml
+++ b/jena-extras/jena-querybuilder/pom.xml
@@ -110,6 +110,27 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <detectJavaApiLink>false</detectJavaApiLink>
+          <source>8</source>
+          <doclint>none</doclint>
+          <notimestamp>true</notimestamp>
+          <quiet>true</quiet>
+          <version>true</version>
+          <show>public</show>
+          <encoding>UTF-8</encoding>
+
+          <windowtitle>${project.name} ${project.version}</windowtitle>
+          <doctitle>${project.name} ${project.version}</doctitle>
+          <bottom>Licensed under the Apache License, Version 2.0</bottom>
+
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Javadoc in jena-querybuilder triggers issues with modules in some builds cases.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
