### PR TITLE
Add command argument modules to Fuseki Main from a Fuseki modules

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpOp.java
@@ -22,6 +22,8 @@ import static org.apache.jena.http.HttpLib.*;
 import static org.apache.jena.http.Push.PATCH;
 import static org.apache.jena.http.Push.POST;
 import static org.apache.jena.http.Push.PUT;
+import static org.apache.jena.riot.web.HttpNames.METHOD_HEAD;
+import static org.apache.jena.riot.web.HttpNames.METHOD_OPTIONS;
 
 import java.io.InputStream;
 import java.net.Authenticator;
@@ -231,7 +233,11 @@ public class HttpOp {
      * @see BodyPublishers#ofString
      */
     public static void httpPost(HttpClient httpClient, String url, String contentType, BodyPublisher body) {
-        httpPushData(httpClient, POST, url, contentType, body);
+        execHttpPost(httpClient, url, contentType, body);
+    }
+
+    private static void execHttpPost(HttpClient httpClient, String url, String contentType, BodyPublisher body) {
+        execPushData(httpClient, POST, url, contentType, body);
     }
 
     // ---- POST stream response.
@@ -316,7 +322,7 @@ public class HttpOp {
      * @see BodyPublishers#ofString
      */
     public static void httpPut(HttpClient httpClient, String url, String contentType, BodyPublisher body) {
-        httpPushData(httpClient, PUT, url, contentType, body);
+        execPushData(httpClient, PUT, url, contentType, body);
     }
 
     // ---- PATCH
@@ -335,11 +341,11 @@ public class HttpOp {
      * @see BodyPublishers#ofString
      */
     public static void httpPatch(HttpClient httpClient, String url, String contentType, BodyPublisher body) {
-        httpPushData(httpClient, PATCH, url, contentType, body);
+        execPushData(httpClient, PATCH, url, contentType, body);
     }
 
     /** Push data. POST, PUT, PATCH request with no response body data. */
-    private static void httpPushData(HttpClient httpClient, Push style, String url, String contentType, BodyPublisher body) {
+    private static void execPushData(HttpClient httpClient, Push style, String url, String contentType, BodyPublisher body) {
         HttpLib.httpPushData(httpClient, style, url, setContentTypeHeader(contentType), body);
     }
 
@@ -373,7 +379,7 @@ public class HttpOp {
     public static String httpOptions(HttpClient httpClient, String url) {
         // Need to access the response headers
         HttpRequest.Builder builder =
-                HttpLib.requestBuilderFor(url).uri(toRequestURI(url)).method(HttpNames.METHOD_OPTIONS, BodyPublishers.noBody());
+                HttpLib.requestBuilderFor(url).uri(toRequestURI(url)).method(METHOD_OPTIONS, BodyPublishers.noBody());
         HttpRequest request = builder.build();
         HttpResponse<InputStream> response = execute(httpClient, request);
         String allowValue = HttpLib.responseHeader(response, HttpNames.hAllow);
@@ -417,7 +423,7 @@ public class HttpOp {
      */
     public static String httpHead(HttpClient httpClient, String url, String acceptHeader) {
         HttpRequest.Builder builder =
-                HttpLib.requestBuilderFor(url).uri(toRequestURI(url)).method(HttpNames.METHOD_HEAD, BodyPublishers.noBody());
+                HttpLib.requestBuilderFor(url).uri(toRequestURI(url)).method(METHOD_HEAD, BodyPublishers.noBody());
         HttpLib.acceptHeader(builder, acceptHeader);
         HttpRequest request = builder.build();
         HttpResponse<InputStream> response = execute(httpClient, request);

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthHeader.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthHeader.java
@@ -49,6 +49,7 @@ import org.apache.jena.riot.system.RiotChars;
  * </ul>
  */
 public class AuthHeader {
+    // Update for RFC 9112
     /* RFC 7235 header:
      *    WWW-Authenticate:
      *    Authorization:

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/BlankNodeAllocatorFixedSeedHash.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/BlankNodeAllocatorFixedSeedHash.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 /**
  * A variant of {@link BlankNodeAllocatorHash} where a fixed seed is used so
  * repeated runs produce identical allocations
- * 
+ *
  */
 public class BlankNodeAllocatorFixedSeedHash extends BlankNodeAllocatorHash {
 
@@ -51,7 +51,7 @@ public class BlankNodeAllocatorFixedSeedHash extends BlankNodeAllocatorHash {
     @Override
     protected UUID freshSeed() {
         // NB - The parent constructor calls reset() so we have to provide a
-        // fake value here temorarily which we then replace with the user
+        // fake value here temporarily which we then replace with the user
         // specified seed by calling reset() again in our own constructor
         return this.seed == null ? UUID.randomUUID() : this.seed;
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/other/G.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/other/G.java
@@ -461,7 +461,7 @@ public class G {
     }
 
     /**
-     * List all the nodes of type, including node of sub-classes.
+     * List all the nodes of type, including nodes of sub-classes.
      */
     public static List<Node> listNodesOfTypeRDFS(Graph graph, Node type) {
         Objects.requireNonNull(graph, "graph");

--- a/jena-arq/src/main/java/org/apache/jena/riot/out/NodeFmtLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/out/NodeFmtLib.java
@@ -197,7 +197,7 @@ public class NodeFmtLib
     // Strict N-triples only allows [A-Za-z][A-Za-z0-9]
     static char encodeMarkerChar = 'X';
 
-    // These two form a pair to convert bNode labels to a safe (i.e. legal N-triples form) and back agains.
+    // These two form a pair to convert bNode labels to a safe (i.e. legal N-triples form) and back again.
 
     // Encoding is:
     // 1 - Add a Letter

--- a/jena-arq/src/main/java/org/apache/jena/riot/web/HttpNames.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/web/HttpNames.java
@@ -60,14 +60,25 @@ public class HttpNames
     public static final String paramGraph           = "graph" ;
     public static final String paramGraphDefault    = "default" ;
 
+    // Special names for GSP targets (use in ?graph=)
+    public static final String graphTargetDefault   = "default" ;
+    public static final String graphTargetUnion     = "union" ;
+
+    public static final String paramUpdate          = "update" ;
+    public static final String paramRequest         = "request" ;
+    public static final String paramUsingGraphURI        = "using-graph-uri" ;
+    public static final String paramUsingNamedGraphURI   = "using-named-graph-uri" ;
+
+    // SPARQL parameter names
     public static final String paramQuery           = "query" ;
     public static final String paramQueryRef        = "query-ref" ;
     public static final String paramDefaultGraphURI = "default-graph-uri" ;
     public static final String paramNamedGraphURI   = "named-graph-uri" ;
     public static final String paramTarget          = "target" ;
 
-
+    // Jena parameter names (SPARQL protocol extensions)
     public static final String paramStyleSheet      = "stylesheet" ;
+    public static final String paramLang            = "lang" ;
     public static final String paramAccept          = "accept" ;
     public static final String paramOutput1         = "output" ;
     public static final String paramOutput2         = "format" ;        // Alternative name
@@ -75,11 +86,6 @@ public class HttpNames
     public static final String paramCallback        = "callback" ;
     public static final String paramForceAccept     = "force-accept" ;  // Force the accept header at the last moment
     public static final String paramTimeout         = "timeout" ;
-
-    public static final String paramUpdate          = "update" ;
-    public static final String paramRequest         = "request" ;
-    public static final String paramUsingGraphURI        = "using-graph-uri" ;
-    public static final String paramUsingNamedGraphURI   = "using-named-graph-uri" ;
 
     public static final String METHOD_DELETE        = "DELETE";
     public static final String METHOD_HEAD          = "HEAD";
@@ -93,8 +99,4 @@ public class HttpNames
 
     public static final String HEADER_IFMODSINCE    = "If-Modified-Since";
     public static final String HEADER_LASTMOD       = "Last-Modified";
-
-    // Special names for GSP targets (use in ?graph=)
-    public static final String graphTargetDefault   = "default" ;
-    public static final String graphTargetUnion     = "union" ;
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
@@ -46,7 +46,6 @@ public class InMemDatasetAssembler extends DatasetAssembler {
         return DatasetAssemblerVocab.tMemoryDataset ;
     }
 
-
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {
         // Old name : bypass.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/HttpParams.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/HttpParams.java
@@ -18,35 +18,37 @@
 
 package org.apache.jena.sparql.engine.http;
 
+import org.apache.jena.riot.web.HttpNames;
+
 /** Constants related to SPARQL over HTTP */
 
 public class HttpParams
 {
     /** Parameter for the SPARQL query string */
-    public static final String pQuery               = "query" ;
-    
+    public static final String pQuery               = HttpNames.paramQuery;
+
     /** Parameter for the SPARQL update string */
-    public static final String pUpdate              = "update" ;
-    
+    public static final String pUpdate              = HttpNames.paramUpdate;
+
 //    /** Parameter for a URI pointing to a SPARQL query in a document */
 //    public static final String pQueryUri       = "query-uri" ;
-    
+
     /** Parameter for a URI identifying the default graph (or one of the graphs) for SPARQL queries */
-    public static final String pDefaultGraph        = "default-graph-uri" ;
-    
+    public static final String pDefaultGraph        = HttpNames.paramDefaultGraphURI;
+
     /** Parameter for a URI identifying the named graph (or one of the graphs) for SPARQL queries */
-    public static final String pNamedGraph          = "named-graph-uri" ;
-    
+    public static final String pNamedGraph          = HttpNames.paramNamedGraphURI;
+
     /** Parameter for a URI identifying the default graph (or one of the graphs) for SPARQL updates */
-    public static final String pUsingGraph          = "using-graph-uri" ;
-    
+    public static final String pUsingGraph          = HttpNames.paramUsingGraphURI ;
+
     /** Parameter for a URI identifying the named graph (or one of the graphs) for SPARQL updates */
-    public static final String pUsingNamedGraph     = "using-named-graph-uri" ;
-    
+    public static final String pUsingNamedGraph     = HttpNames.paramUsingNamedGraphURI ;
+
     // ----------------- Non-SPARQL parameters
 
-    public static final String pStylesheet      = "stylesheet" ;
+    public static final String pStylesheet      = HttpNames.paramStyleSheet;
 
     /** Parameter for query language URI */
-    public static final String pQueryLang      = "lang" ;
+    public static final String pQueryLang      = HttpNames.paramLang ;
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/Service.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/Service.java
@@ -269,7 +269,7 @@ public class Service {
             if ( "GET".equalsIgnoreCase(str) )
                 return QuerySendMode.asGetAlways;
             try {
-                // "asGetWithLimitForm", "asGetWithLimitBody", "asGetAlways", "asPostForm", "asPost"
+                // "asGetAlways", "asGetWithLimitForm", "asGetWithLimitBody", "asGetAlways", "asPostForm", "asPost"
                 return QuerySendMode.valueOf((String) querySendMode);
             } catch (IllegalArgumentException ex) {
                 throw new QueryExecException("Failed to interpret '"+querySendMode+"' as a query send mode");

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI.java
@@ -30,7 +30,7 @@ import org.apache.jena.sparql.serializer.SerializationContext;
 import org.apache.jena.sparql.sse.Tags;
 
 /**
- * IRI(expr), oen argument, SPARQL standard form.
+ * IRI(expr), one argument, SPARQL standard form.
  * The function URI(expr) is the same, but under a different name as a
  * subclass.
  * <p>

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI2.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI2.java
@@ -29,7 +29,8 @@ import org.apache.jena.sparql.serializer.SerializationContext;
 import org.apache.jena.sparql.sse.Tags;
 
 /**
- * IRI(base, expr). Two arguemnt SPARQl extension. The function URI(expr) is the same, but under a different name as a
+ * IRI(base, expr). Two argument SPARQL extension.
+ * The function URI(base, expr) is the same, but under a different name as a
  * subclass.
  * <p>
  * As an ARQ extension, {@code IRI(base, relative)} resolves the relative

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_URI2.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_URI2.java
@@ -22,8 +22,8 @@ import org.apache.jena.sparql.serializer.SerializationContext;
 import org.apache.jena.sparql.sse.Tags;
 
 /**
- * This class is an alternative name for {@linkplain E_IRI}.
- * See the javadoc for {@linkplain E_IRI}.
+ * This class is an alternative name for {@linkplain E_IRI2}.
+ * See the javadoc for {@linkplain E_IRI2}.
  */
 public class E_URI2 extends E_IRI2 {
     private static final String sparqlPrintName = "URI";

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/graph/GraphUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/graph/GraphUtils.java
@@ -39,6 +39,11 @@ import org.apache.jena.vocabulary.RDF ;
 
 public class GraphUtils {
 
+    // Only used by DatasetDescriptionAssembler
+    // (and DatasetDescriptionAssembler itself is unused)
+    /**
+     * Get all the literals for a resource-property.
+     */
     public static List<String> multiValueString(Resource r, Property p) {
         List<RDFNode> nodes = multiValue(r, p) ;
         List<String> values = new ArrayList<>() ;

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/Arg.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/Arg.java
@@ -23,15 +23,15 @@ import java.util.List;
 
 public class Arg
 {
-    String name;
-    String value;                                      // Last seen
-    List<String> values = new ArrayList<>();     // All seen
+    private String name;
+    private String value;                                // Last seen
+    private List<String> values = new ArrayList<>();     // All seen
 
-    Arg() { name = null; value = null; }
+    /*package*/ Arg() { name = null; value = null; }
 
-    public Arg(String _name) { this(); setName(_name); }
+    /*package*/ Arg(String _name) { this(); setName(_name); }
 
-    Arg(String _name, String _value) { this(); setName(_name); setValue(_value); }
+    /*package*/ Arg(String _name, String _value) { this(); setName(_name); setValue(_value); }
 
     void setName(String n) { name = n; }
 
@@ -44,8 +44,7 @@ public class Arg
 
     public boolean hasValue() { return value != null; }
 
-    public boolean matches(ArgDecl decl)
-    {
+    public boolean matches(ArgDecl decl) {
         return decl.getNames().contains(name);
     }
 

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/ArgProc.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/ArgProc.java
@@ -18,9 +18,7 @@
 
 package org.apache.jena.cmd;
 
-
-public interface ArgProc {
-
+interface ArgProc {
     void startArgs();
     void finishArgs();
     void arg(String arg, int i);

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/CmdException.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/CmdException.java
@@ -24,7 +24,7 @@ package org.apache.jena.cmd;
 
 public class CmdException extends RuntimeException
 {
-    public CmdException()                             { super() ; }
-    public CmdException(String msg)                   { super(msg) ; }
-    public CmdException(String msg, Throwable cause)  { super(msg, cause) ; }
+    public CmdException()                             { super(); }
+    public CmdException(String msg)                   { super(msg); }
+    public CmdException(String msg, Throwable cause)  { super(msg, cause); }
 }

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/CmdGeneral.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/CmdGeneral.java
@@ -41,10 +41,10 @@ public abstract class CmdGeneral extends CmdArgModule
         argModule.registerWith(this);
     }
 
-    protected boolean isVerbose() { return modGeneral.verbose ; }
-    protected boolean isQuiet()   { return modGeneral.quiet ; }
-    protected boolean isDebug()   { return modGeneral.debug ; }
-    protected boolean help()      { return modGeneral.help ; }
+    protected boolean isVerbose() { return modGeneral.verbose; }
+    protected boolean isQuiet()   { return modGeneral.quiet; }
+    protected boolean isDebug()   { return modGeneral.debug; }
+    protected boolean help()      { return modGeneral.help; }
 
     final public void printHelp() {
         usage();
@@ -60,7 +60,7 @@ public abstract class CmdGeneral extends CmdArgModule
     private Usage usage = new Usage();
     protected String cmdName = null;
     protected abstract String getSummary();
-    public void usage() { usage(System.err) ; }
+    public void usage() { usage(System.err); }
 
     public void usage(PrintStream pStr) {
         IndentedWriter out = new IndentedWriter(pStr);
@@ -73,5 +73,5 @@ public abstract class CmdGeneral extends CmdArgModule
         getUsage().addUsage(argName, msg);
     }
 
-    public Usage getUsage() { return usage ; }
+    public Usage getUsage() { return usage; }
 }

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/CmdLineArgs.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/CmdLineArgs.java
@@ -32,9 +32,9 @@ public class CmdLineArgs extends CommandLineBase {
     }
 
     private boolean processedArgs = false;
-    protected Map<String, ArgDecl> argMap = new HashMap<>() ;   // Map from string name to ArgDecl
-    protected Map<String, Arg> args = new HashMap<>() ;         // Name to Arg
-    protected List<String> positionals = new ArrayList<>() ;    // Positional arguments as strings.
+    protected Map<String, ArgDecl> argMap = new HashMap<>();   // Map from string name to ArgDecl
+    protected Map<String, Arg> args = new HashMap<>();         // Name to Arg
+    protected List<String> positionals = new ArrayList<>();    // Positional arguments as strings.
 
     public void process() throws IllegalArgumentException
     {
@@ -129,10 +129,10 @@ public class CmdLineArgs extends CommandLineBase {
     // ---- Indirection
 
     static final String DefaultIndirectMarker = "@";
-    public boolean matchesIndirect(String s) { return matchesIndirect(s, DefaultIndirectMarker) ; }
-    public boolean matchesIndirect(String s, String marker) { return s.startsWith(marker) ; }
+    public boolean matchesIndirect(String s) { return matchesIndirect(s, DefaultIndirectMarker); }
+    public boolean matchesIndirect(String s, String marker) { return s.startsWith(marker); }
 
-    public String indirect(String s) { return indirect(s, DefaultIndirectMarker) ; }
+    public String indirect(String s) { return indirect(s, DefaultIndirectMarker); }
 
     public String indirect(String s, String marker) {
         if ( !matchesIndirect(s, marker) )
@@ -148,26 +148,26 @@ public class CmdLineArgs extends CommandLineBase {
 
     /** Test whether an argument was seen. */
 
-    public boolean contains(ArgDecl argDecl)    { return getArg(argDecl) != null ; }
+    public boolean contains(ArgDecl argDecl)    { return getArg(argDecl) != null; }
 
     /** Test whether an argument was seen. */
 
-    public boolean contains(String s)           { return getArg(s) != null ; }
+    public boolean contains(String s)           { return getArg(s) != null; }
 
     /** Test whether an argument was seen more than once */
-    public boolean containsMultiple(String s)   { return getValues(s).size() > 1 ; }
+    public boolean containsMultiple(String s)   { return getValues(s).size() > 1; }
 
     /** Test whether an argument was seen more than once */
-    public boolean containsMultiple(ArgDecl argDecl) { return getValues(argDecl).size() > 1 ; }
+    public boolean containsMultiple(ArgDecl argDecl) { return getValues(argDecl).size() > 1; }
 
-    public boolean hasArgs() { return args.size() > 0 ; }
+    public boolean hasArgs() { return args.size() > 0; }
 
     /** Test whether the command line had a particular argument
      *
      * @param argName
      * @return this object
      */
-    public boolean hasArg(String argName) { return getArg(argName) != null ; }
+    public boolean hasArg(String argName) { return getArg(argName) != null; }
 
     /** Test whether the command line had a particular argument
      *
@@ -175,7 +175,7 @@ public class CmdLineArgs extends CommandLineBase {
      * @return true or false
      */
 
-    public boolean hasArg(ArgDecl argDecl) { return getArg(argDecl) != null ; }
+    public boolean hasArg(ArgDecl argDecl) { return getArg(argDecl) != null; }
 
 
     /** Get the argument associated with the argument declaration.
@@ -186,10 +186,8 @@ public class CmdLineArgs extends CommandLineBase {
 
     public Arg getArg(ArgDecl argDecl) {
         Arg arg = null;
-        for ( Arg a : args.values() )
-        {
-            if ( argDecl.matches( a ) )
-            {
+        for ( Arg a : args.values() ) {
+            if ( argDecl.matches(a) ) {
                 arg = a;
             }
         }
@@ -208,7 +206,10 @@ public class CmdLineArgs extends CommandLineBase {
 
     /**
      * Returns the value (a string) for an argument with a value -
-     * returns null for no argument and no value.
+     * returns null for no use of the argument and for an argument with no value
+     * ({@code ArgDecl(false}}).
+     * These two cases can be distinguished with {@link #contains(ArgDecl)}.
+     *
      * @param argDecl
      * @return String
      */
@@ -323,15 +324,13 @@ public class CmdLineArgs extends CommandLineBase {
             return super.toString();
         String str = "";
         String sep = "";
-        for ( String k : args.keySet() )
-        {
-            Arg a = args.get( k );
+        for ( String k : args.keySet() ) {
+            Arg a = args.get(k);
             str = str + sep + a;
             sep = " ";
         }
         sep = " -- ";
-        for ( String v : positionals )
-        {
+        for ( String v : positionals ) {
             str = str + sep + v;
             sep = " ";
         }

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/CmdMain.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/CmdMain.java
@@ -32,7 +32,7 @@ public abstract class CmdMain extends CmdLineArgs
 {
     // Do this very early so it happens before anything else
     // gets a chance to create a logger.
-    static { LogCtl.setLogging() ; }
+    static { LogCtl.setLogging(); }
 
     public CmdMain(String[] args) {
         super(args);
@@ -40,21 +40,21 @@ public abstract class CmdMain extends CmdLineArgs
 
     /** Run command - exit on failure */
     public void mainRun()
-    { mainRun(false, true) ; }
+    { mainRun(false, true); }
 
     /** Run command - choose whether to exit on failure */
     public void mainRun(boolean exitOnFailure)
-    { mainRun(exitOnFailure, true) ; }
+    { mainRun(exitOnFailure, true); }
 
     /** Run command - exit on success or failure */
     public void mainAndExit()
-    { mainRun(true, true) ; }
+    { mainRun(true, true); }
 
     /** Run command */
     public int mainRun(boolean exitOnSuccess, boolean exitOnFailure)
     {
-        try { mainMethod() ; }
-        catch (TerminationException ex) { System.exit(ex.getCode()) ; }
+        try { mainMethod(); }
+        catch (TerminationException ex) { System.exit(ex.getCode()); }
         catch (IllegalArgumentException ex)
         {
             ex.printStackTrace(System.err);
@@ -89,7 +89,7 @@ public abstract class CmdMain extends CmdLineArgs
 
     protected abstract void exec();
     protected abstract String getCommandName();
-    public void cmdError(String msg) { cmdError(msg, true) ;}
+    public void cmdError(String msg) { cmdError(msg, true);}
 
     public void cmdError(String msg, boolean exit) {
         System.err.println(msg);

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/Invoke.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/Invoke.java
@@ -20,10 +20,12 @@ package org.apache.jena.cmd;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-/** Helper code to invoke a main method buy reflection
- *  This means command can be invoked from this module even
- *  if their implementation resides in a module later
- *  in the build sequence.
+
+/**
+ * Helper code to invoke a main method by reflection.
+ * <p>
+ * This means the command can be invoked from this module even if the implementation
+ * resides in a module not on the classpath at build time.
  */
 public class Invoke {
     public static void invokeCmd(String className, String[] args) {

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/ModBase.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/ModBase.java
@@ -19,5 +19,4 @@
 package org.apache.jena.cmd;
 
 public abstract class ModBase implements ArgModuleGeneral
-{
-}
+{}

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/ModGeneral.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/ModGeneral.java
@@ -22,8 +22,8 @@ public class ModGeneral extends ModBase
 {
     private Runnable helpFunction = null;
     public ModGeneral(Runnable helpFunction) { this.helpFunction = helpFunction ; }
-    
-    // Could be turned into a module but these are convenient as inherited flags 
+
+    // Could be turned into a module but these are convenient as inherited flags
     private final ArgDecl argDeclHelp        = new ArgDecl(false, "help", "h");
     private final ArgDecl argDeclVerbose     = new ArgDecl(false, "v", "verbose");
     private final ArgDecl argDeclQuiet       = new ArgDecl(false, "q", "quiet");
@@ -33,9 +33,9 @@ public class ModGeneral extends ModBase
     protected boolean quiet = false;
     public boolean debug = false;
     protected boolean help = false;
+
     @Override
-    public void registerWith(CmdGeneral cmdLine)
-    {
+    public void registerWith(CmdGeneral cmdLine) {
         cmdLine.getUsage().startCategory("General");
         cmdLine.add(argDeclVerbose, "-v   --verbose", "Verbose");
         cmdLine.add(argDeclQuiet, "-q   --quiet", "Run with minimal output");
@@ -44,10 +44,9 @@ public class ModGeneral extends ModBase
     }
 
     @Override
-    public void processArgs(CmdArgModule cmdLine)
-    {
+    public void processArgs(CmdArgModule cmdLine) {
         verbose = cmdLine.contains(argDeclVerbose) || cmdLine.contains(argDeclDebug);
-        quiet   = cmdLine.contains(argDeclQuiet);
+        quiet = cmdLine.contains(argDeclQuiet);
         help = cmdLine.contains(argDeclHelp);
         if ( help )
             helpFunction.run();

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/ModVersion.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/ModVersion.java
@@ -26,38 +26,38 @@ public class ModVersion extends ModBase
     protected boolean version = false;
     protected boolean printAndExit = false;
     private Version versionMgr = new Version();
-    public ModVersion(boolean printAndExit)
-    {
+
+    public ModVersion(boolean printAndExit) {
         this.printAndExit = printAndExit;
     }
-    
-    public void addClass(Class<?> c) { versionMgr.addClass(c) ; }
-    
+
+    public void addClass(Class<? > c) {
+        versionMgr.addClass(c);
+    }
+
     @Override
-    public void registerWith(CmdGeneral cmdLine)
-    {
+    public void registerWith(CmdGeneral cmdLine) {
         cmdLine.add(versionDecl, "--version", "Version information");
     }
 
     @Override
-    public void processArgs(CmdArgModule cmdLine)
-    {
+    public void processArgs(CmdArgModule cmdLine) {
         if ( cmdLine.contains(versionDecl) )
             version = true;
-        // The --version flag causes us to print and exit. 
+        // The --version flag causes us to print and exit.
         if ( version && printAndExit )
             printVersionAndExit();
     }
 
-    public boolean getVersionFlag() { return version ; }
-    
-    public void printVersion()
-    {
+    public boolean getVersionFlag() {
+        return version;
+    }
+
+    public void printVersion() {
         versionMgr.print(IndentedWriter.stdout);
-    }  
-     
-    public void printVersionAndExit()
-    {
+    }
+
+    public void printVersionAndExit() {
         printVersion();
         System.exit(0);
     }

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/TerminationException.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/TerminationException.java
@@ -23,10 +23,9 @@ package org.apache.jena.cmd;
  * Exception used to indicate that the command should end now. Use instead of
  * System.exit so that a wrapper can catch (else a command server will exit wrongly).
  */
-
 public class TerminationException extends CmdException
 {
     public int returnCode;
-    public TerminationException(int rc) { super() ; this.returnCode = rc ; }
-    public int getCode() { return returnCode ; }
+    public TerminationException(int rc) { super(); this.returnCode = rc; }
+    public int getCode() { return returnCode; }
 }

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/Usage.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/Usage.java
@@ -20,79 +20,73 @@ package org.apache.jena.cmd;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.ext.com.google.common.collect.Lists;
 public class Usage
 {
-    class Category
-    {
+    public static class Category {
         String desc;
         List<Entry> entries = new ArrayList<>();
-        Category(String desc) { this.desc = desc ; }
+        Category(String desc) {
+            this.desc = desc;
+        }
     }
-    
-   class Entry
-   { String arg; String msg;
-     Entry(String arg, String msg) { this.arg = arg ; this.msg = msg ; }
-   }
-   
-   List<Category> categories = new ArrayList<>();
-   public Usage()
-   {
+
+    private static class Entry {
+        String arg;
+        String msg;
+        Entry(String arg, String msg) {
+            this.arg = arg;
+            this.msg = msg;
+        }
+    }
+
+   private List<Category> categories = new ArrayList<>();
+
+   public Usage() {
        // Start with an unnamed category
        startCategory(null);
    }
-   
-   public void startCategory(String desc) 
-   {
+
+   public void startCategory(String desc) {
        categories.add(new Category(desc));
    }
-   
-   public void addUsage(String argName, String msg)
-   {
+
+   public void addUsage(String argName, String msg) {
        current().entries.add(new Entry(argName, msg));
    }
-   
-   
-   public void output(PrintStream out)
-   {
+
+   public void output(PrintStream out) {
        output(new IndentedWriter(out));
    }
-   
-   public void output(IndentedWriter out)
-   {
+
+   public void output(IndentedWriter out) {
        int INDENT1 = 2;
        int INDENT2 = 4;
        out.incIndent(INDENT1);
-       List<Category> categories2 = new ArrayList<>(categories);
-       Collections.reverse(categories2);
-       for ( Category c : categories2 )
-       {
-           if ( c.desc != null )
-           {
-               out.println( c.desc );
+
+       for ( Category c : Lists.reverse(categories) ) {
+           if ( c.desc != null ) {
+               out.println(c.desc);
            }
-           out.incIndent( INDENT2 );
-           for ( final Entry e : c.entries )
-           {
-               out.print( e.arg );
-               if ( e.msg != null )
-               {
-                   out.pad( 20 );
-                   out.print( "   " );
-                   out.print( e.msg );
+           out.incIndent(INDENT2);
+           for ( final Entry e : c.entries ) {
+               out.print(e.arg);
+               if ( e.msg != null ) {
+                   out.pad(20);
+                   out.print("   ");
+                   out.print(e.msg);
                }
                out.println();
            }
-           out.decIndent( INDENT2 );
+           out.decIndent(INDENT2);
        }
        out.decIndent(INDENT1);
        out.flush();
    }
-   
-   private Category current()
-   {
-       return categories.get(categories.size()-1);
+
+   private Category current() {
+       return categories.get(categories.size() - 1);
    }
 }

--- a/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/NodeIdType.java
+++ b/jena-db/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/NodeIdType.java
@@ -20,6 +20,8 @@ package org.apache.jena.tdb2.store;
 
 import static org.apache.jena.tdb2.store.NodeIdType.TYPES.*;
 
+import org.apache.jena.tdb2.store.value.DoubleNode62;
+
 /** Constants for NodeIds.
  * Note that "PTR" is special - it uses the high bit only set to zero.
  * Note that "XSD_DOUBLE" is special - it sets the high bit (value/ptr)
@@ -71,7 +73,7 @@ public enum NodeIdType {
      * <ul>
      * <li>PTR : high bit zero, everything else written with a high bit one (done in {@link NodeIdFactory#encode}
      * <li>T_DOUBLE : Special case: next bit one.  01?? ???? i.e. 11?? on disk (value bit, double bit).
-     *    This leaves 62 bits for encoding doubles in the future.
+     *    This leaves 62 bits for encoding a double (See {@link DoubleNode62}).
      * <li>Otherwise, a number in the low byte of the constant, high bits "10".
      * </ul>
      * The {@code T_*} constants do not include the high bit.
@@ -110,6 +112,7 @@ public enum NodeIdType {
         // Never stored : bits 1011 0000 so as not to look like a double.
         public static final int T_SPECIAL = enc(0x30);
         public static final int T_INVALID = enc(0x31);
+
         public static final int T_EXTENSION = enc(0x3F);
 
         // Encode/decode of the type value.

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/fuseki/run.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/fuseki/run.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fuseki;
+
+/**
+ * Run FusekiMain.
+ */
+public class run {
+    // This class must not depend on any Jena code (it would trigger
+    // early logging initialization) except FusekiLogging.setLogging.
+    //static { FusekiLogging.setLogging(); }
+
+    public static void main (String... args) {
+        // This does FusekiLogging.setLogging
+        org.apache.jena.fuseki.main.cmds.FusekiMainCmd.main(args);
+    }
+}

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/auth/AuthBearerFilter.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/auth/AuthBearerFilter.java
@@ -217,7 +217,7 @@ public class AuthBearerFilter implements Filter {
 
     /**
      * Create a AuthHeader
-     * Usually, this reads the "Authenticate" and parses it (RFC 7230)
+     * Usually, this reads the "Authenticate" and parses it (RFC 7230, RFC 9112)
      * ... although AWS Cognito is different.
      * The header to access is controlled by {@link #getHttpAuthField(HttpServletRequest)}
      * and the value of the header is passed as {@code authHeaderValue}.

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -23,6 +23,7 @@ import static arq.cmdline.ModAssembler.assemblerDescDecl;
 import java.net.BindException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 import arq.cmdline.CmdARQ;
@@ -32,6 +33,7 @@ import org.apache.jena.atlas.lib.FileOps;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.jena.atlas.web.AuthScheme;
 import org.apache.jena.cmd.ArgDecl;
+import org.apache.jena.cmd.ArgModuleGeneral;
 import org.apache.jena.cmd.CmdException;
 import org.apache.jena.cmd.TerminationException;
 import org.apache.jena.fuseki.Fuseki;
@@ -107,6 +109,10 @@ public class FusekiMain extends CmdARQ {
     private static ArgDecl  argSparqler     = new ArgDecl(ArgDecl.HasValue, "sparqler");
 
     private static ArgDecl  argValidators   = new ArgDecl(ArgDecl.NoValue,  "validators");
+
+    private static List<ArgModuleGeneral> additionalArgs = new ArrayList<>();
+    public static void addArgModule(ArgModuleGeneral argModule) { additionalArgs.add(argModule); }
+
     // private static ModLocation modLocation = new ModLocation();
     private static ModDatasetAssembler modDataset      = new ModDatasetAssembler();
 
@@ -134,6 +140,9 @@ public class FusekiMain extends CmdARQ {
             TransactionManager.QueueBatchSize = TransactionManager.QueueBatchSize / 2;
 
         getUsage().startCategory("Fuseki Main");
+
+        additionalArgs.forEach(aMod->super.addModule(aMod));
+
         // Control the order!
         add(argMem, "--mem",
             "Create an in-memory, non-persistent dataset for the server");
@@ -146,7 +155,7 @@ public class FusekiMain extends CmdARQ {
         add(argMemTDB, "--memTDB",
             "Create an in-memory, non-persistent dataset using TDB (testing only)");
 //            add(argEmpty, "--empty",
-//                "Run with no datasets and services (validators only)");
+//                "Run with no datasets and services");
         add(argRDFS, "--rdfs=FILE",
             "Apply RDFS on top of the dataset");
         add(argConfig, "--config=FILE",

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,8 @@
     <ver.commonscsv>1.9.0</ver.commonscsv>
     <ver.commons-codec>1.15</ver.commons-codec>
     <ver.commons-compress>1.21</ver.commons-compress>
+    <ver.commons-collections>4.4</ver.commons-collections>
+    <ver.commons-fileupload>1.4</ver.commons-fileupload>
     <ver.dexxcollection>0.7</ver.dexxcollection>
     <ver.micrometer>1.9.3</ver.micrometer>
 
@@ -371,7 +373,7 @@
        <dependency>
          <groupId>commons-fileupload</groupId>
          <artifactId>commons-fileupload</artifactId>
-         <version>1.4</version>
+         <version>${ver.commons-fileupload}</version>
          <exclusions>
            <exclusion>
              <groupId>javax.servlet</groupId>
@@ -383,7 +385,7 @@
        <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-collections4</artifactId>
-         <version>4.4</version>
+         <version>${ver.commons-collections}</version>
        </dependency>
        
        <!-- supports persistent data structures -->


### PR DESCRIPTION
GitHub issue resolved #1522 

Pull request Description:

Allow plugin code to add argument modules to the Fuseki command line.

Includes various clean-up that got done while on this branch.

----

 - [ ] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
