### PR TITLE
Skip javadoc production locally

### DIFF
--- a/jena-db/jena-dboe-index-test/pom.xml
+++ b/jena-db/jena-dboe-index-test/pom.xml
@@ -50,6 +50,17 @@
       <scope>compile</scope>
     </dependency>
 
+    <!--
+        Fix necessary for java11 (not java17)
+        when building javadoc.
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>[2.1,)</version>
+      <scope>compile</scope>
+    </dependency>
+    -->
+
   </dependencies>
 
   <build>
@@ -83,6 +94,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <!--
+              java11 issue - 
+              For generating javadoc, the javadoc tool needs org.hamcrest:hamcrest
+              in scope compile in this module.
+              Either skip javadoc or (despite junit using hamcrest-core)
+              use the dependency commented out up-file.
+          -->
+          <skip>true</skip>
+        </configuration>
       </plugin>
 
     </plugins>


### PR DESCRIPTION
This fixes the javadoc production problem by skipping javadoc in `jena-dboe-index-test`.

The problem is that the javadoc tool fails with the error below, for Java11, not java17.
```
com.sun.tools.javac.code.Symbol$CompletionFailure: class file for org.hamcrest.Matcher not found
```

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
