### PR TITLE
GH-1535: set ARQ exec log level through system property

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
@@ -664,6 +664,9 @@ public class ARQ
         context.set(enablePropertyFunctions,       true) ;
         context.set(regexImpl,                     javaRegex) ;
 
+        final InfoLevel infoLevel = InfoLevel.get(System.getProperty("org.apache.jena.arq.exec.log.level"));
+        context.set(ARQ.symLogExec, infoLevel) ;
+
         return context ;
     }
 


### PR DESCRIPTION
GitHub issue resolved #1535

Pull request Description:

ARQ reads the system property `org.apache.jena.arq.exec.log.level` and sets the exec log level accordingly.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [X] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
