### PR TITLE
Rework Fuseki configuration information logging

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/Registry.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/Registry.java
@@ -18,26 +18,26 @@
 
 package org.apache.jena.atlas.lib;
 
-import java.util.Collection ;
-import java.util.Map ;
-import java.util.concurrent.ConcurrentHashMap ;
-import java.util.function.BiConsumer ;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 
 public class Registry<K,T>
 {
-    protected Map<K, T> registry = new ConcurrentHashMap<>() ;
-    
+    protected Map<K, T> registry = new ConcurrentHashMap<>();
+
     public Registry() {}
-    
-    public void put(K key, T value)     { registry.put(key, value) ; }
-    public T get(K key)                 { return registry.get(key) ; }
-    public boolean isRegistered(K key)  { return registry.containsKey(key) ; }
-    public void remove(K key)           { registry.remove(key) ; } 
-    public Collection<K> keys()         { return registry.keySet() ; }
-    public int size()                   { return registry.size() ; }
-    public boolean isEmpty()            { return registry.isEmpty() ; }
-    public void clear()                 { registry.clear() ; }
+
+    public void put(K key, T value)     { registry.put(key, value); }
+    public T get(K key)                 { return registry.get(key); }
+    public boolean isRegistered(K key)  { return registry.containsKey(key); }
+    public void remove(K key)           { registry.remove(key); }
+    public Collection<K> keys()         { return registry.keySet(); }
+    public int size()                   { return registry.size(); }
+    public boolean isEmpty()            { return registry.isEmpty(); }
+    public void clear()                 { registry.clear(); }
     public void forEach(BiConsumer<K, T> action) {
-        registry.forEach(action); 
+        registry.forEach(action);
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -205,7 +205,12 @@ public class Fuseki {
     }
 
     public static boolean getVerbose(ServletContext cxt) {
-        return (Boolean)cxt.getAttribute(attrVerbose);
+        Object x = cxt.getAttribute(attrVerbose);
+        if ( x == null )
+            return false;
+        if ( x instanceof Boolean )
+            return (Boolean)x;
+        throw new FusekiException("attrVerbose: unknown object class: "+x.getClass().getName());
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/PlatformInfo.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/PlatformInfo.java
@@ -32,23 +32,18 @@ public class PlatformInfo {
         long freeMem = Runtime.getRuntime().freeMemory();
         long usedMem = totalMem - freeMem;
         Function<Long, String> f = PlatformInfo::strNum2;
-
         System.out.printf("max=%s  total=%s  used=%s  free=%s\n", f.apply(maxMem), f.apply(totalMem), f.apply(usedMem), f.apply(freeMem));
     }
 
-    /** Essential information about the runtime environment. */
-    public static void logDetails(Logger log) {
-        logDetails(log, "  ");
+    /** System details section */
+    public static void logDetailsSystem(Logger log) {
+        log.info("System");
+        logDetailsSystemPlain(log);
     }
 
-    /**
-     * Essential information about the runtime environment
-     * @param log
-     * @param prefix String to add at the start of the log message.
-     */
-    public static void logDetails(Logger log, String prefix) {
-        if ( prefix == null )
-            prefix = "";
+    /** System details, no section header */
+    public static void logDetailsSystemPlain(Logger log) {
+        String prefix = "  ";
         long maxMem = Runtime.getRuntime().maxMemory();
         long totalMem = Runtime.getRuntime().totalMemory();
         long freeMem = Runtime.getRuntime().freeMemory();
@@ -64,12 +59,10 @@ public class PlatformInfo {
             FmtLog.info(log, "%sPID:    %s", prefix, pid);
     }
 
-    public static void logDetailsVerbose(Logger log) {
-        logDetailsVerbose(log, "  ");
-    }
-
-    public static void logDetailsVerbose(Logger log, String prefix) {
-        logDetails(log);
+    /** JVM details section. */
+    public static void logDetailsJVM(Logger log) {
+        String prefix = "  ";
+        log.info("Java");
         logOne(log, prefix, "java.vendor");
         logOne(log, prefix, "java.home");
         logOne(log, prefix, "java.runtime.version");
@@ -79,38 +72,21 @@ public class PlatformInfo {
         logOne(log, prefix, "user.timezone");
         logOne(log, prefix, "user.country");
         logOne(log, prefix, "user.dir");
-        //logOne(log, "file.encoding");
+        //logOne(log, prefix, "file.encoding");
     }
 
     private static void logOne(Logger log, String prefix, String property) {
+        if ( prefix == null )
+            prefix = "";
         FmtLog.info(log, "%s%-20s = %s", prefix, property, System.getProperty(property));
     }
 
-//    /** Create a human-friendly string for a number based on Kilo/Mega/Giga/Tera (powers of 2) */
-//    public static String strNumMixed(long x) {
-//        // https://en.wikipedia.org/wiki/Kibibyte
-//        if ( x < 1024 )
-//            return Long.toString(x);
-//        if ( x < 1024*1024 )
-//            return String.format("%.1fK", x/1024.0);
-//        if ( x < 1024*1024*1024 )
-//            return String.format("%.1fM", x/(1024.0*1024));
-//        if ( x < 1024L*1024*1024*1024 )
-//            return String.format("%.1fG", x/(1024.0*1024*1024));
-//        return String.format("%.1fT", x/(1024.0*1024*1024*1024));
-//    }
-
     private static long getProcessId() {
-        // Java9
-        //long pid = ProcessHandle.current().getPid();
-        try {
-            String x = java.lang.management.ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
-            return Long.parseLong(x);
-        } catch (NumberFormatException ex) { return -1; }
+        return ProcessHandle.current().pid();
     }
 
     /** Create a human-friendly string for a number based on Kilo/Mega/Giga/Tera (powers of 10) */
-    public static String strNum10(long x) {
+    private static String strNum10(long x) {
         if ( x < 1_000 )
             return Long.toString(x);
         if ( x < 1_000_000 )
@@ -123,7 +99,7 @@ public class PlatformInfo {
     }
 
     /** Create a human-friendly string for a number based on Kibi/Mebi/Gibi/Tebi (powers of 2) */
-    public static String strNum2(long x) {
+    private static String strNum2(long x) {
         // https://en.wikipedia.org/wiki/Kibibyte
         if ( x < 1024 )
             return Long.toString(x);

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiMainInfo.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiMainInfo.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.main;
+
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.fuseki.server.FusekiCoreInfo;
+import org.slf4j.Logger;
+
+public class FusekiMainInfo {
+
+    /** Details of the code version. */
+    public static void logCode(Logger log) {
+        FusekiCoreInfo.logCode(log);
+    }
+
+    /** Log server details. */
+    public static void logServer(Logger log, FusekiServer server, boolean verbose) {
+        FusekiMainInfo.logServerConnections(log, server);
+        FusekiMainInfo.logServerDatasets(log, server, verbose);
+        if ( server.getStaticContentDir() != null )
+            FmtLog.info(log,  "Static files: %s", server.getStaticContentDir());
+    }
+
+    /** Log details about the code version */
+    public static void logServerCode(Logger log) {
+        FusekiCoreInfo.logCode(log);
+    }
+
+    /** The the server connection setup */
+    public static void logServerConnections(Logger log, FusekiServer server) {
+        int httpsPort = server.getHttpsPort();
+        int httpPort = server.getHttpPort();
+        if ( httpsPort > 0 && httpPort > 0 )
+            log.info("Ports: http="+httpPort+" https="+httpsPort);
+        else if ( httpsPort <= 0 )
+            log.info("Port: http="+httpPort);
+        else if ( httpPort <= 0 )
+            log.info("Port: https="+httpsPort);
+    }
+
+    /** Log information about datasets in this server */
+    public static void logServerDatasets(Logger log, FusekiServer server, boolean longForm) {
+        FusekiCoreInfo.logDataAccessPointRegistry(log, server.getDataAccessPointRegistry(), longForm);
+    }
+}

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -39,7 +39,6 @@ import org.apache.jena.atlas.lib.FileOps;
 import org.apache.jena.atlas.lib.IRILib;
 import org.apache.jena.atlas.lib.Pair;
 import org.apache.jena.atlas.lib.Registry;
-import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.jena.atlas.web.AuthScheme;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiConfigException;
@@ -116,7 +115,6 @@ public class FusekiServer {
     /**
      * Construct a Fuseki server from command line arguments.
      * The return server has not been started.
-     *
      */
     static public FusekiServer construct(String... args) {
         return FusekiMain.build(args);
@@ -251,25 +249,36 @@ public class FusekiServer {
         return server;
     }
 
-    /** Get the {@link ServletContext} used for Fuseki processing.
+    /**
+     * Get the {@link ServletContext} used for Fuseki processing.
      * Adding new servlets is possible with care.
      */
     public ServletContext getServletContext() {
         return servletContext;
     }
 
-    /** Get the {@link DataAccessPointRegistry}.
+    /**
+     * Get the {@link DataAccessPointRegistry}.
      * This method is intended for inspecting the registry.
      */
     public DataAccessPointRegistry getDataAccessPointRegistry() {
         return DataAccessPointRegistry.get(getServletContext());
     }
 
-    /** Get the {@link OperationRegistry}.
+    /**
+     * Get the {@link OperationRegistry}.
      * This method is intended for inspecting the registry.
      */
     public OperationRegistry getOperationRegistry() {
         return OperationRegistry.get(getServletContext());
+    }
+
+    /**
+     * Return the filename to the static content area.
+     * Returns null if there is no such area.
+     */
+    public String getStaticContentDir() {
+        return staticContentDir;
     }
 
     /**
@@ -351,24 +360,6 @@ public class FusekiServer {
     public void join() {
         try { server.join(); }
         catch (Exception e) { throw new FusekiException(e); }
-    }
-
-    /** Log server details. */
-    public void logServer() {
-        Logger log = Fuseki.serverLog;
-        DataAccessPointRegistry dapRegistery = getDataAccessPointRegistry();
-        FusekiInfo.server(log);
-        if ( httpsPort > 0 && httpPort > 0 )
-            log.info("Ports: http="+httpPort+" https="+httpsPort);
-        else if ( httpsPort <= 0 )
-            log.info("Port: http="+getHttpPort());
-        else if ( httpPort <= 0 )
-            log.info("Port: https="+getHttpsPort());
-        boolean verbose = Fuseki.getVerbose(getServletContext());
-        FusekiInfo.logDataAccessPointRegistry(log, dapRegistery, verbose );
-        if ( staticContentDir != null )
-            FmtLog.info(log,  "Static files: %s", staticContentDir);
-
     }
 
     /** FusekiServer.Builder */

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -38,10 +38,11 @@ import org.apache.jena.cmd.CmdException;
 import org.apache.jena.cmd.TerminationException;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiException;
+import org.apache.jena.fuseki.main.FusekiMainInfo;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.server.DataAccessPoint;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
-import org.apache.jena.fuseki.server.FusekiInfo;
+import org.apache.jena.fuseki.server.FusekiCoreInfo;
 import org.apache.jena.fuseki.servlets.SPARQL_QueryGeneral;
 import org.apache.jena.fuseki.validation.DataValidator;
 import org.apache.jena.fuseki.validation.IRIValidator;
@@ -183,7 +184,7 @@ public class FusekiMain extends CmdARQ {
             "Add a general SPARQL endpoint (without a dataset) at /PATH");
 
         add(argAuth, "--auth=[basic|digest]",
-            "Run the server using basic or digest authentication (dft: digest).");
+            "Run the server using basic or digest authentication");
         add(argHttps, "--https=CONF",
             "https certificate access details. JSON file { \"cert\":FILE , \"passwd\"; SECRET } ");
         add(argHttpsPort, "--httpsPort=NUM",
@@ -480,7 +481,7 @@ public class FusekiMain extends CmdARQ {
     protected void exec() {
         try {
             FusekiServer server = buildServer(serverConfig);
-            info(server);
+            infoCmd(server);
             try {
                 server.start();
             } catch (FusekiException ex) {
@@ -582,15 +583,15 @@ public class FusekiMain extends CmdARQ {
         return builder.build();
     }
 
-    private void info(FusekiServer server) {
+    /** Information from the command line setup */
+    private void infoCmd(FusekiServer server) {
         if ( super.isQuiet() )
             return;
 
         Logger log = Fuseki.serverLog;
 
-        FusekiInfo.server(log);
+        FusekiMainInfo.logServerCode(log);
 
-        DataAccessPointRegistry dapRegistry = DataAccessPointRegistry.get(server.getServletContext());
         if ( serverConfig.empty ) {
             FmtLog.info(log, "No SPARQL datasets services");
         } else {
@@ -598,6 +599,7 @@ public class FusekiMain extends CmdARQ {
                 log.error("No dataset path nor server configuration file");
         }
 
+        DataAccessPointRegistry dapRegistry = DataAccessPointRegistry.get(server.getServletContext());
         if ( serverConfig.datasetPath != null ) {
             if ( dapRegistry.size() != 1 )
                 log.error("Expected only one dataset in the DataAccessPointRegistry");
@@ -611,8 +613,8 @@ public class FusekiMain extends CmdARQ {
         boolean verbose = serverConfig.verboseLogging;
 
         if ( ! super.isQuiet() )
-            FusekiInfo.logServerSetup(log, verbose, dapRegistry,
-                                      datasetPath, datasetDescription, serverConfigFile, staticFiles);
+            FusekiCoreInfo.logServerCmdSetup(log, verbose, dapRegistry,
+                                             datasetPath, datasetDescription, serverConfigFile, staticFiles);
     }
 
     @Override

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
@@ -22,9 +22,10 @@ import org.apache.jena.atlas.web.AuthScheme;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.sparql.core.DatasetGraph;
 
-/** Setup details (command line, config file) from command line processing.
- *  This is built by {@link FusekiMain#exec}.
- *  This is processed by {@link FusekiMain#buildServer}.
+/**
+ * Setup details (command line, config file) from command line processing.
+ * This is built by {@link FusekiMain#exec}.
+ * This is processed by {@link FusekiMain#buildServer}.
  */
 class ServerConfig {
     /** Server port. This is the http port when both http and https are active. */

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
@@ -30,7 +30,7 @@ import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.jetty.FusekiErrorHandler;
 import org.apache.jena.fuseki.jetty.JettyServerConfig;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
-import org.apache.jena.fuseki.server.FusekiInfo;
+import org.apache.jena.fuseki.server.FusekiCoreInfo;
 import org.apache.jena.fuseki.webapp.FusekiEnv;
 import org.eclipse.jetty.security.*;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
@@ -108,7 +108,7 @@ public class JettyFusekiWebapp {
      */
     public void start() {
 
-        FusekiInfo.server(serverLog);
+        FusekiCoreInfo.logCode(serverLog);
         // This does not get anything usefully for Jetty as we use it.
         // String jettyVersion = org.eclipse.jetty.server.Server.getVersion();
         // serverLog.info(format("Jetty %s",jettyVersion));

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerListener.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerListener.java
@@ -27,7 +27,7 @@ import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.cmd.FusekiArgs;
 import org.apache.jena.fuseki.metrics.MetricsProviderRegistry;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
-import org.apache.jena.fuseki.server.FusekiInfo;
+import org.apache.jena.fuseki.server.FusekiCoreInfo;
 import org.apache.jena.fuseki.server.OperationRegistry;
 import org.slf4j.Logger;
 
@@ -110,8 +110,6 @@ public class FusekiServerListener implements ServletContextListener {
         if ( initialSetup.quiet )
             return;
 
-
-
         info(initialSetup.datasetPath,
              initialSetup.datasetDescription,
              initialSetup.fusekiServerConfigFile,
@@ -124,13 +122,8 @@ public class FusekiServerListener implements ServletContextListener {
                             String serverConfigFile,
                             DataAccessPointRegistry dapRegistry) {
         Logger log = Fuseki.serverLog;
-        // Done earlier to get it before config output
-//        String version = Fuseki.VERSION;
-//        String buildDate = Fuseki.BUILD_DATE;
-//        FusekiInfo.logServer(log, Fuseki.NAME, version, buildDate);
-
-        FusekiInfo.logServerSetup(log, initialSetup.verbose,
-                                  dapRegistry,
-                                  datasetPath, datasetDescription, serverConfigFile, null);
+        FusekiCoreInfo.logServerCmdSetup(log, initialSetup.verbose,
+                                         dapRegistry,
+                                         datasetPath, datasetDescription, serverConfigFile, null);
     }
 }


### PR DESCRIPTION
This is a small step to disentangling the Fuseki Main and Fuseki webapp java code.

The logging code used to print the server details used at the start of running a Fuseki server is now split into functions an application using Fuseki in embedded mode can use.

There are logging functions in library classes :
* PlatformInfo -- OS and Java details.
* FusekiCoreInfo -- dataset registry, common command line information
* FusekiMainInfo -- FusekiServer setup.
* FusekiServerListener (used by the webapp file packaging).

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
