### PR TITLE
Use JUnit TemproraryFolder in backup test

### DIFF
--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/sys/TestDatabaseOps.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/sys/TestDatabaseOps.java
@@ -22,48 +22,51 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.atlas.lib.FileOps;
 import org.apache.jena.dboe.base.file.Location;
-import org.apache.jena.dboe.sys.IO_DB;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.system.Txn;
-import org.apache.jena.tdb2.ConfigTest;
 import org.apache.jena.tdb2.DatabaseMgr;
 import org.junit.After;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /** Test DatabaseOp - the compaction tests are in {@link TestDatabaseCompact}. */
 public class TestDatabaseOps
 {
-    private Location dir = null;
-
     static Quad quad1 = SSE.parseQuad("(_ <s> <p> 1)");
     static Quad quad2 = SSE.parseQuad("(_ _:a <p> 2)");
     static Triple triple1 = quad1.asTriple();
     static Triple triple2 = quad2.asTriple();
     static Triple triple3 = SSE.parseTriple("(<s> <q> 3)");
 
-    @Before
-    public void before() {
-        String DIR = ConfigTest.getCleanDir();
-        FileOps.ensureDir(DIR);
-        FileOps.clearAll(DIR);
-        dir = Location.create(DIR);
+    private static final String testingDirBackup = "target/tdb-testing/Backup";
+    private static final File testingDirBackupFile = new File(testingDirBackup);
+    static {
+        FileOps.ensureDir("target");
+        FileOps.ensureDir("target/tdb-testing");
+        FileOps.ensureDir(testingDirBackup);
     }
 
     @After
     public void after() {
         TDBInternal.reset();
-        FileUtils.deleteQuietly(IO_DB.asFile(dir));
+        FileUtils.deleteQuietly(testingDirBackupFile);
     }
 
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder(testingDirBackupFile);
+
     @Test public void backup_1() {
+        Location dir = Location.create(folder.getRoot().getPath());
         DatasetGraph dsg = DatabaseMgr.connectDatasetGraph(dir);
         Txn.executeWrite(dsg, ()-> {
             dsg.add(quad2);
@@ -79,5 +82,4 @@ public class TestDatabaseOps
         String file2 = DatabaseMgr.backup(dsg);
         assertNotEquals(file1, file2);
     }
-
 }


### PR DESCRIPTION
The test `TestDatabaseOps.backup_1` is unreliable, failing in a way that suggests it isn't getting a clean directory in the run. 9it sees more triples than the test can possibly create). This is intermittent and seems to only occur on ASF Jenkins (a heavily loaded build service).

This PR reworks the test to use JUnit `TemporaryDirectory`.

There is no way to test this except to try it in the build and wait!

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
