### PR TITLE
GH-1548: GraphBase.isEmpty() no longer iterates all data.

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/graph/impl/GraphBase.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/impl/GraphBase.java
@@ -317,14 +317,19 @@ public abstract class GraphBase implements GraphWithPerform
 
     /**
      	Answer true iff this graph contains no triples (hidden reification quads do
-        not count). The default implementation is <code>size() == 0</code>, which is
-        fine if <code>size</code> is reasonable efficient. Subclasses may override
+        not count). The default implementation tests whether the iterator returned by
+        {@link #find()} can yield at least one item. Subclasses may override
         if necessary. This method may become final and defined in terms of other
         methods.
     */
     @Override
     public boolean isEmpty()
-        { return size() == 0; }
+        {
+            checkOpen() ;
+            ExtendedIterator<Triple> it = GraphUtil.findAll( this );
+            try { return !it.hasNext(); }
+            finally { it.close(); }
+        }
 
     /**
          Answer true iff this graph is isomorphic to <code>g</code> according to


### PR DESCRIPTION
GitHub issue resolved #1548 

Pull request Description:
Defined GraphBase.isEmpty() in terms of !find().hasNext();

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
