### PR TITLE
GH-1498 Prologue.setPrefix now simply delegates to PrefixMapping

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/Prologue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/Prologue.java
@@ -113,14 +113,6 @@ public class Prologue
     public void setPrefix(String prefix, String expansion)
     {
         try {
-            // Removal may involve regeneration of the reverse mapping
-            // so only do if needed.
-            String oldExpansion = prefixMap.getNsPrefixURI(prefix) ;
-            if ( Objects.equals(oldExpansion, expansion) )
-                return ;
-            if ( oldExpansion != null )
-                prefixMap.removeNsPrefix(prefix) ;
-
             prefixMap.setNsPrefix(prefix, expansion) ;
         } catch (PrefixMapping.IllegalPrefixException ex)
         {


### PR DESCRIPTION
GitHub issue resolved #1498 

Pull request Description: Removed a few lines of seemingly redundant logic from Prologue that implementations of PrefixMapping will handle anyway.