### PR TITLE
GH-1551: IRI with tab - don't return null after error

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizerText.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizerText.java
@@ -527,7 +527,7 @@ public final class TokenizerText implements Tokenizer
                     // Probably a corrupt file so treat as fatal.
                     fatal("Bad character in IRI (bad character: '<'): <%s[<]...>", stringBuilder.toString()); return null;
                 case TAB:
-                    error("Bad character in IRI (Tab character): <%s[tab]...>", stringBuilder.toString()); return null;
+                    error("Bad character in IRI (tab character): <%s[tab]...>", stringBuilder.toString()); break;
                 case '{': case '}': case '"': case '|': case '^': case '`' :
                     if ( ! VeryVeryLaxIRI )
                         warning("Illegal character in IRI (codepoint 0x%02X, '%c'): <%s[%c]...>", ch, (char)ch, stringBuilder.toString(), (char)ch);

--- a/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizer.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizer.java
@@ -1044,6 +1044,13 @@ public class TestTokenizer {
         // and no escaped characters for blank node labels.
     }
 
+    @Test(expected=RiotException.class)
+    public void tokenIRI_tab() {
+        // Raw tab in a IRI string. Illegal - this is an error.
+        Tokenizer tokenizer = tokenizer("<http://example/invalid/iri/with_\t_tab>") ;
+        testNextToken(tokenizer, TokenType.IRI) ;
+    }
+
     private static Token testExpectWarning(String input, TokenType expectedTokenType, int warningCount) {
         PeekReader r = PeekReader.readString(input);
         return testExpectWarning(r, expectedTokenType, warningCount);


### PR DESCRIPTION
GitHub issue resolved #1551

Pull request Description:
After signalling an error because of a tab character, execute break not, "return null".

----

 - [x] Tests are included.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
