### PR TITLE
deprecate ShexMap to migrate to ShapeMap

### DIFF
--- a/jena-cmds/src/main/java/shex/shex_validate.java
+++ b/jena-cmds/src/main/java/shex/shex_validate.java
@@ -137,7 +137,7 @@ public class shex_validate extends CmdGeneral {
 //        }
 
         if ( mapfile != null ) {
-            ShexMap map;
+            ShapeMap map;
             try {
                 map = Shex.readShapeMap(mapfile);
             } catch (ShexException ex) {

--- a/jena-examples/src/main/java/shex/examples/Shex01_validateGraph.java
+++ b/jena-examples/src/main/java/shex/examples/Shex01_validateGraph.java
@@ -41,7 +41,7 @@ public class Shex01_validateGraph {
 
         // Shapes map.
         System.out.println("Read shapes map");
-        ShexMap shapeMap = Shex.readShapeMap(SHAPES_MAP);
+        ShapeMap shapeMap = Shex.readShapeMap(SHAPES_MAP);
 
         // ShexReport
         System.out.println("Validate");

--- a/jena-examples/src/main/java/shex/examples/Shex02_validateNode.java
+++ b/jena-examples/src/main/java/shex/examples/Shex02_validateNode.java
@@ -43,7 +43,7 @@ public class Shex02_validateNode {
 
         // Shapes map.
         System.out.println("Read shapes map");
-        ShexMap shapeMap = Shex.readShapeMap(SHAPES_MAP);
+        ShapeMap shapeMap = Shex.readShapeMap(SHAPES_MAP);
 
         Node data1 = NodeFactory.createURI("http://example/x");
         Node data2 = NodeFactory.createURI("http://example/s");

--- a/jena-examples/src/main/java/shex/examples/Shex03_validate.java
+++ b/jena-examples/src/main/java/shex/examples/Shex03_validate.java
@@ -47,12 +47,12 @@ public class Shex03_validate {
         Triple instancesOfFoo = Triple.create(Shex.FOCUS, RDF.type.asNode(), myClass);
         Node shape1 = NodeFactory.createURI("http://example/shapes#shape1");
 
-        ShexMap shapeMap = ShexMap.newBuilder()
+        ShapeMap shapeMap = ShapeMap.newBuilder()
                 .add(instancesOfFoo, shape1)
                 .build();
 
         // Equivalent helper for map with one ShapeMap entry
-        ShexMap shapeMapAlt = ShexMap.record(instancesOfFoo, shape1);
+        ShapeMap shapeMapAlt = ShapeMap.record(instancesOfFoo, shape1);
 
         // Validate
         System.out.println();

--- a/jena-shex/src/main/java/org/apache/jena/shex/ShapeMap.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/ShapeMap.java
@@ -26,38 +26,35 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 
 /**
- * DEPRECATED - please use ShapeMap (e.g. ShapeMap.create()) instead.
+ * <a href="https://shexspec.github.io/shape-map/">ShEx shape map</a> used for both
+ * targeting validation and reporting violations.
  */
-@Deprecated
-public class ShexMap {
+public class ShapeMap extends ShexMap {
 
-    protected final List<ShexRecord> associations;
-
-    public static ShexMap create(List<ShexRecord> associations) {
+    public static ShapeMap create(List<ShexRecord> associations) {
         associations = new ArrayList<>(associations);
-        return new ShexMap(associations);
+        return new ShapeMap(associations);
     }
 
-    protected ShexMap(List<ShexRecord> associations) {
-        this.associations = associations;
+    private ShapeMap(List<ShexRecord> associations) {
+        super(associations); // TODO next version: remove super() and replace with:
+        // this.associations = associations;
     }
 
-    public List<ShexRecord> entries() {
-        return Collections.unmodifiableList(associations);
+    // TODO next version: mv ShexMap `List<ShexRecord> entries()` here
+
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
-    public static ShapeMap.Builder newBuilder() {
-        return new ShapeMap.Builder();
+    public static ShapeMap record(Node focus, Node shapeRef) {
+        return new Builder().add(focus, shapeRef).build();
     }
 
-    public static ShexMap record(Node focus, Node shapeRef) {
-        return new ShapeMap.Builder().add(focus, shapeRef).build();
+    public static ShapeMap record(Triple pattern, Node shapeRef) {
+        return new Builder().add(pattern, shapeRef).build();
     }
 
-    public static ShexMap record(Triple pattern, Node shapeRef) {
-        return new ShapeMap.Builder().add(pattern, shapeRef).build();
-    }
-    /*
     public static class Builder {
 
         private List<ShexRecord> records = new ArrayList<>();
@@ -85,5 +82,4 @@ public class ShexMap {
             return map;
         }
     }
-    */
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/Shex.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/Shex.java
@@ -183,7 +183,7 @@ public class Shex {
      * @param filename
      * @return ShexShapeMap
      */
-    public static ShexMap readShapeMap(String filename) {
+    public static ShapeMap readShapeMap(String filename) {
         return readShapeMap(filename, IRILib.filenameToIRI(filename));
     }
 
@@ -193,7 +193,7 @@ public class Shex {
      * @param baseURI
      * @return ShexShapeMap
      */
-    public static ShexMap readShapeMap(String filename, String baseURI) {
+    public static ShapeMap readShapeMap(String filename, String baseURI) {
         InputStream input = IO.openFile(filename);
         return readShapeMap(input, baseURI);
     }
@@ -204,7 +204,7 @@ public class Shex {
      * @param baseURI
      * @return ShexShapeMap
      */
-    public static ShexMap readShapeMap(InputStream input, String baseURI) {
+    public static ShapeMap readShapeMap(InputStream input, String baseURI) {
         return ShExC.parseShapeMap(input, baseURI);
     }
 
@@ -214,12 +214,12 @@ public class Shex {
      * @param baseURI
      * @return ShexShapeMap
      */
-    public static ShexMap shapeMapFromString(String inputStr, String baseURI) {
+    public static ShapeMap shapeMapFromString(String inputStr, String baseURI) {
         return ShExC.parseShapeMap(new StringReader(inputStr), baseURI);
     }
 
-    /** Read a {@link ShexMap} from a file or URL. */
-    public static ShexMap readShapeMapJson(String filenameOrURL) {
+    /** Read a {@link ShapeMap} from a file or URL. */
+    public static ShapeMap readShapeMapJson(String filenameOrURL) {
         TypedInputStream in = RDFDataMgr.open(filenameOrURL);
         return readShapeMapJson(in.getInputStream());
     }
@@ -229,7 +229,7 @@ public class Shex {
      * @param input
      * @return ShexShapeMap
      */
-    public static ShexMap readShapeMapJson(InputStream input) {
+    public static ShapeMap readShapeMapJson(InputStream input) {
         return ShExJ.readShapeMapJson(input);
     }
 }

--- a/jena-shex/src/main/java/org/apache/jena/shex/ShexMapBuilder.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/ShexMapBuilder.java
@@ -28,17 +28,17 @@ public class ShexMapBuilder {
 
     private List<ShexRecord> records = new ArrayList<>();
 
-    public static ShexMap record(Node focus, Node shapeRef) {
+    public static ShapeMap record(Node focus, Node shapeRef) {
         return new ShexMapBuilder().add(focus, shapeRef).build();
     }
 
-    public static ShexMap record(Triple pattern, Node shapeRef) {
+    public static ShapeMap record(Triple pattern, Node shapeRef) {
         return new ShexMapBuilder().add(pattern, shapeRef).build();
     }
 
     public ShexMapBuilder() {}
 
-    public ShexMapBuilder(ShexMap base) {
+    public ShexMapBuilder(ShapeMap base) {
         base.entries().forEach(records::add);
     }
 
@@ -52,9 +52,9 @@ public class ShexMapBuilder {
         return this;
     }
 
-    public ShexMap build() {
+    public ShapeMap build() {
         // Copies argument.
-        ShexMap map = ShexMap.create(records);
+        ShapeMap map = ShapeMap.create(records);
         records.clear();
         return map;
     }

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/ParserShExC.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/ParserShExC.java
@@ -36,7 +36,7 @@ import org.apache.jena.irix.IRIs;
 import org.apache.jena.riot.RiotException;
 import org.apache.jena.riot.lang.extra.LangParserBase;
 import org.apache.jena.riot.lang.extra.LangParserLib;
-import org.apache.jena.shex.ShexMap;
+import org.apache.jena.shex.ShapeMap;
 import org.apache.jena.shex.ShexRecord;
 import org.apache.jena.shex.ShexSchema;
 import org.apache.jena.shex.ShexShape;
@@ -837,8 +837,8 @@ public class ParserShExC extends LangParserBase {
 
     public void parseShapeMapStart() {}
 
-    public ShexMap parseShapeMapFinish() {
-        return ShexMap.create(associations);
+    public ShapeMap parseShapeMapFinish() {
+        return ShapeMap.create(associations);
     }
 
     protected Triple createTriple(Node s, Node p, Node o, int line, int column) {

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/ShExC.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/ShExC.java
@@ -31,7 +31,7 @@ import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.irix.IRIxResolver;
 import org.apache.jena.riot.system.*;
 import org.apache.jena.shex.ShexShape;
-import org.apache.jena.shex.ShexMap;
+import org.apache.jena.shex.ShapeMap;
 import org.apache.jena.shex.ShexSchema;
 import org.apache.jena.shex.expressions.*;
 import org.apache.jena.shex.parser.javacc.ParseException;
@@ -115,7 +115,7 @@ public class ShExC {
      * @param filename
      * @return ShexShapeMap
      */
-    public static ShexMap parseShapeMap(String filename) {
+    public static ShapeMap parseShapeMap(String filename) {
         return parseShapeMap(filename, IRILib.filenameToIRI(filename));
     }
 
@@ -125,7 +125,7 @@ public class ShExC {
      * @param baseURI
      * @return ShexShapeMap
      */
-    public static ShexMap parseShapeMap(String filename, String baseURI) {
+    public static ShapeMap parseShapeMap(String filename, String baseURI) {
         InputStream input = IO.openFile(filename);
         return parseShapeMap(input, baseURI);
     }
@@ -136,7 +136,7 @@ public class ShExC {
      * @param baseURI
      * @return ShexShapeMap
      */
-    public static ShexMap parseShapeMap(InputStream input, String baseURI) {
+    public static ShapeMap parseShapeMap(InputStream input, String baseURI) {
         try ( Reader r = setReader(input) ) {
             ShExJavacc parser = new ShExJavacc(r);
             return parseShapeMap$(parser, baseURI, null);
@@ -152,7 +152,7 @@ public class ShExC {
      * @param baseURI
      * @return ShexShapeMap
      */
-    public static ShexMap parseShapeMap(StringReader input, String baseURI) {
+    public static ShapeMap parseShapeMap(StringReader input, String baseURI) {
         ShExJavacc parser = new ShExJavacc(input);
         return parseShapeMap$(parser, baseURI, null);
     }
@@ -255,7 +255,7 @@ public class ShExC {
         }
     }
 
-    private static ShexMap parseShapeMap$(ShExJavacc parser, String baseURI, Context context) {
+    private static ShapeMap parseShapeMap$(ShExJavacc parser, String baseURI, Context context) {
         ParserProfile profile = new ParserProfileStd(RiotLib.factoryRDF(),
                                                      ErrorHandlerFactory.errorHandlerStd,
                                                      IRIxResolver.create(baseURI).build(),
@@ -268,7 +268,7 @@ public class ShExC {
         try {
             parser.parseShapeMapStart();
             parser.UnitShapeMap();
-            ShexMap map = parser.parseShapeMapFinish();
+            ShapeMap map = parser.parseShapeMapFinish();
             return map;
         } catch (ParseException ex) {
             throw new ShexParseException(ex.getMessage(), ex.currentToken.beginLine, ex.currentToken.beginColumn);

--- a/jena-shex/src/main/java/org/apache/jena/shex/parser/ShExJ.java
+++ b/jena-shex/src/main/java/org/apache/jena/shex/parser/ShExJ.java
@@ -31,7 +31,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.shex.ShexException;
 import org.apache.jena.shex.ShexRecord;
-import org.apache.jena.shex.ShexMap;
+import org.apache.jena.shex.ShapeMap;
 
 /** Shape Expressions : JSON syntax */
 public class ShExJ {
@@ -40,7 +40,7 @@ public class ShExJ {
      * @param input
      * @return ShexShapeMap
      */
-    public static ShexMap readShapeMapJson(InputStream input) {
+    public static ShapeMap readShapeMapJson(InputStream input) {
         if ( input instanceof BufferedInputStream )
             input = new BufferedInputStream(input, 128*1024);
         JsonValue x = JSON.parseAny(input);
@@ -52,7 +52,7 @@ public class ShExJ {
             ShexRecord a = parseShapeMapEntry(j.getAsObject());
             associations.add(a);
         });
-        return ShexMap.create(associations);
+        return ShapeMap.create(associations);
     }
 
     private static ShexRecord parseShapeMapEntry(JsonObject obj) {


### PR DESCRIPTION
per http://shex.io/shape-map/#shapemap-structure

(ShExMap is a different concept.)

GitHub issue resolved #

Pull request Description:
The ShEx `ShapeMap` concept was expressed in a `ShexMap` class. This PR migrates to `ShapeMap`
1. `ShapeMap` extends `ShexMap`.
2. `ShexMap` continues to hold members and member accessors.
3. `ShexMap`'s `.create()` and `Builder` functions return `ShapeMap` and `ShapeMap.Builder`.
4. deprecate `ShexMap`.

In order to verify that tests pass using either ShexMap or ShapeMap, PRs in this test use ShexMap. The next PR migrates tests to ShapeMap.

Are there any docs to fix or will javadoc comments suffice?

This PR obviates #1580

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
