### PR TITLE
Don't write StoreParams label (for previous versions)

### DIFF
--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsCodec.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsCodec.java
@@ -86,8 +86,9 @@ public class StoreParamsCodec {
         JsonBuilder builder = new JsonBuilder();
         builder.startObject("StoreParams");    // "StoreParams" is an internal alignment marker - not in the JSON.
 
-        if ( params.label != null )
-            encode(builder, key(fLabel),                params.getLabel());
+        //Don't include label - otherwise previous versions can't read the database.
+//        if ( params.label != null )
+//            encode(builder, key(fLabel),                params.getLabel());
 
         encode(builder, key(fFileMode),                 params.getFileMode().name());
         encode(builder, key(fBlockSize),                params.getBlockSize());
@@ -129,7 +130,9 @@ public class StoreParamsCodec {
         for ( String key : json.keys() ) {
             String short_key = unkey(key);
             switch(short_key) {
+                // Optional (4.7.0 onwards)
                 case fLabel :                  builder.label(getString(json, key));                        break ;
+                // Expected.
                 case fFileMode :               builder.fileMode(FileMode.valueOf(getString(json, key)));   break ;
                 case fBlockSize:               builder.blockSize(getInt(json, key));                       break ;
                 case fBlockReadCacheSize:      builder.blockReadCacheSize(getInt(json, key));              break ;


### PR DESCRIPTION
This is a fix to commit #db23fbed 

The changes meant 4.6.1 and before could not read a 4.7.0 created database (i.e create-new, read-old failed).


