### PR TITLE
Filter shex tests by trait

### DIFF
--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/manifest/Manifest.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/manifest/Manifest.java
@@ -189,7 +189,7 @@ public class Manifest
         }
     }
 
-    private static Resource getResource(Resource r, Property p)
+    public static Resource getResource(Resource r, Property p)
     {
         if ( r == null )
             return null ;

--- a/jena-shex/src/test/java/org/apache/jena/shex/runner/ShexT.java
+++ b/jena-shex/src/test/java/org/apache/jena/shex/runner/ShexT.java
@@ -55,10 +55,12 @@ Also class:
 
     public static final String NS = BASE_URI + "#";
 
+    // Classes
     public final static Resource cValidationTest        = ResourceFactory.createResource(NS + "ValidationTest");
     public final static Resource cValidationFailure     = ResourceFactory.createResource(NS + "ValidationFailure");
     public final static Resource cRepresentationTest    = ResourceFactory.createResource(NS + "RepresentationTest");
 
+    // Properties
     public final static Property shape = ResourceFactory.createProperty(NS + "shape");
     public final static Property data = ResourceFactory.createProperty(NS + "data");
     public final static Property schema = ResourceFactory.createProperty(NS + "schema");
@@ -74,4 +76,63 @@ Also class:
     public final static Property sx_json = ResourceFactory.createProperty(NS_SX + "json");
     public final static Property sx_ttl  = ResourceFactory.createProperty(NS_SX + "ttl");
 
+    // Traits
+    public final static Resource tAbstract    = ResourceFactory.createResource(NS + "Abstract");
+    public final static Resource tAndShapeShapeession    = ResourceFactory.createResource(NS + "AndShapeShapeession");
+    public final static Resource tAndValueExpression    = ResourceFactory.createResource(NS + "AndValueExpression");
+    public final static Resource tAnnotation    = ResourceFactory.createResource(NS + "Annotation");
+    public final static Resource tBacktick    = ResourceFactory.createResource(NS + "Backtick");
+    public final static Resource tBNodeShapeLabel    = ResourceFactory.createResource(NS + "BNodeShapeLabel");
+    public final static Resource tBooleanEquivalence    = ResourceFactory.createResource(NS + "BooleanEquivalence");
+    public final static Resource tClosed    = ResourceFactory.createResource(NS + "Closed");
+    public final static Resource tComparatorFacet    = ResourceFactory.createResource(NS + "ComparatorFacet");
+    public final static Resource tDatatype    = ResourceFactory.createResource(NS + "Datatype");
+    public final static Resource tDatatypedLiteralEquivalence    = ResourceFactory.createResource(NS + "DatatypedLiteralEquivalence");
+    public final static Resource tDotCardinality    = ResourceFactory.createResource(NS + "DotCardinality");
+    public final static Resource tEachOf    = ResourceFactory.createResource(NS + "EachOf");
+    public final static Resource tEmpty    = ResourceFactory.createResource(NS + "Empty");
+    public final static Resource tErrorReport    = ResourceFactory.createResource(NS + "ErrorReport");
+    public final static Resource tExhaustive    = ResourceFactory.createResource(NS + "Exhaustive");
+    public final static Resource tExtends    = ResourceFactory.createResource(NS + "Extends");
+    public final static Resource tExternalSemanticAction    = ResourceFactory.createResource(NS + "ExternalSemanticAction");
+    public final static Resource tExternalShape    = ResourceFactory.createResource(NS + "ExternalShape");
+    public final static Resource tExtra    = ResourceFactory.createResource(NS + "Extra");
+    public final static Resource tFocusConstraint    = ResourceFactory.createResource(NS + "FocusConstraint");
+    public final static Resource tFractionDigitsFacet    = ResourceFactory.createResource(NS + "FractionDigitsFacet");
+    public final static Resource tGreedy    = ResourceFactory.createResource(NS + "Greedy");
+    public final static Resource tImport    = ResourceFactory.createResource(NS + "Import");
+    public final static Resource tInclude    = ResourceFactory.createResource(NS + "Include");
+    public final static Resource tIriEquivalence    = ResourceFactory.createResource(NS + "IriEquivalence");
+    public final static Resource tLanguageTagEquivalence    = ResourceFactory.createResource(NS + "LanguageTagEquivalence");
+    public final static Resource tLengthFacet    = ResourceFactory.createResource(NS + "LengthFacet");
+    public final static Resource tLexicalBNode    = ResourceFactory.createResource(NS + "LexicalBNode");
+    public final static Resource tMissedMatchables    = ResourceFactory.createResource(NS + "MissedMatchables");
+    public final static Resource tMultiExtends    = ResourceFactory.createResource(NS + "MultiExtends");
+    public final static Resource tNodeKind    = ResourceFactory.createResource(NS + "NodeKind");
+    public final static Resource tNonDotCardinality    = ResourceFactory.createResource(NS + "NonDotCardinality");
+    public final static Resource tNotValueExpression    = ResourceFactory.createResource(NS + "NotValueExpression");
+    public final static Resource tNumericEquivalence    = ResourceFactory.createResource(NS + "NumericEquivalence");
+    public final static Resource tOneOf    = ResourceFactory.createResource(NS + "OneOf");
+    public final static Resource tOrderedSemanticActions    = ResourceFactory.createResource(NS + "OrderedSemanticActions");
+    public final static Resource tOrValueExpression    = ResourceFactory.createResource(NS + "OrValueExpression");
+    public final static Resource tOutsideBMP    = ResourceFactory.createResource(NS + "OutsideBMP");
+    public final static Resource tPaternFacet    = ResourceFactory.createResource(NS + "PaternFacet");
+    public final static Resource tRecursiveData    = ResourceFactory.createResource(NS + "RecursiveData");
+    public final static Resource trelativeIRI    = ResourceFactory.createResource(NS + "relativeIRI");
+    public final static Resource tRepeatedGroup    = ResourceFactory.createResource(NS + "RepeatedGroup");
+    public final static Resource tRepeatedOneOf    = ResourceFactory.createResource(NS + "RepeatedOneOf");
+    public final static Resource tSemanticAction    = ResourceFactory.createResource(NS + "SemanticAction");
+    public final static Resource tShapeMap    = ResourceFactory.createResource(NS + "ShapeMap");
+    public final static Resource tShapeReference    = ResourceFactory.createResource(NS + "ShapeReference");
+    public final static Resource tStart    = ResourceFactory.createResource(NS + "Start");
+    public final static Resource tStem    = ResourceFactory.createResource(NS + "Stem");
+    public final static Resource tToldBNode    = ResourceFactory.createResource(NS + "ToldBNode");
+    public final static Resource tTotalDigitsFacet    = ResourceFactory.createResource(NS + "TotalDigitsFacet");
+    public final static Resource tTriplePattern    = ResourceFactory.createResource(NS + "TriplePattern");
+    public final static Resource tUnsatisfiable    = ResourceFactory.createResource(NS + "Unsatisfiable");
+    public final static Resource tValidLexicalForm    = ResourceFactory.createResource(NS + "ValidLexicalForm");
+    public final static Resource tValueReference    = ResourceFactory.createResource(NS + "ValueReference");
+    public final static Resource tValueSet    = ResourceFactory.createResource(NS + "ValueSet");
+    public final static Resource tVapidExtra    = ResourceFactory.createResource(NS + "VapidExtra");
+    public final static Resource tWildcard    = ResourceFactory.createResource(NS + "Wildcard");
 }

--- a/jena-shex/src/test/java/org/apache/jena/shex/runner/ShexValidationTest.java
+++ b/jena-shex/src/test/java/org/apache/jena/shex/runner/ShexValidationTest.java
@@ -24,6 +24,7 @@ import org.apache.jena.arq.junit.manifest.ManifestEntry;
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.lib.IRILib;
 import org.apache.jena.atlas.lib.InternalErrorException;
+import org.apache.jena.atlas.lib.Pair;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.RDFNode;
@@ -31,6 +32,8 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.shex.*;
 import org.apache.jena.shex.sys.ShexLib;
+
+import java.util.List;
 
 /** A Shex validation test. Created by {@link RunnerShexValidation}.  */
 public class ShexValidationTest implements Runnable {
@@ -46,6 +49,8 @@ public class ShexValidationTest implements Runnable {
     private final ShexMap shapeMap;
     private final boolean positiveTest;
     private final boolean verbose = false;
+    private final List<Resource> traits;
+    private List<Pair<Resource,String>> extensionResults;
 
     enum TestType{ ShapeFocus, StartFocus, ShapeMap }
 
@@ -109,6 +114,8 @@ public class ShexValidationTest implements Runnable {
                 : Shex.readShapeMapJson(shapeMapRef);
         this.shapes = Shex.readSchema(schema.getURI(), base);
         this.positiveTest = entry.getTestType().equals(ShexT.cValidationTest);
+        this.traits = ShexTests.extractTraits(entry);
+//        this.extensionResults = entry.extractExtensionResults();
     }
 
     @Override


### PR DESCRIPTION
GitHub issue resolved #1593

Pull request Description:

ShEx validation tests have a (controlled vocabulary) of `traits`. This PR enables excluding tests by traits and uses that for SemAct tests

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
