### PR TITLE
calculate ungrounded path starting set lazily

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIter.java
@@ -20,11 +20,13 @@ package org.apache.jena.sparql.engine.iterator;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import org.apache.jena.atlas.io.IndentedWriter ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.engine.ExecutionContext ;
 import org.apache.jena.sparql.engine.QueryIterator ;
+import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.serializer.SerializationContext ;
 
 /**
@@ -66,6 +68,15 @@ public abstract class QueryIter extends QueryIteratorBase
 
     public static QueryIterator map(QueryIterator qIter, Map<Var, Var> varMapping) {
         return new QueryIteratorMapped(qIter, varMapping);
+    }
+
+    /** flatmap.
+     * The mapper may return null to signal "no iterator for this binding"
+     */
+    public static QueryIter flatMap(QueryIterator input, Function<Binding, QueryIterator> mapper, ExecutionContext execCxt) {
+        return new QueryIterRepeatApply(input, execCxt) {
+            @Override protected QueryIterator nextStage(Binding binding) { return mapper.apply(binding); }
+        };
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterExtendByVar.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterExtendByVar.java
@@ -20,6 +20,7 @@ package org.apache.jena.sparql.engine.iterator;
 
 import java.util.Iterator ;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.sparql.ARQInternalErrorException ;
 import org.apache.jena.sparql.core.Var ;
@@ -28,7 +29,7 @@ import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.engine.binding.BindingFactory ;
 
 /**
- * Yield new bindings, with a fixed parent, with values from an iterator. 
+ * Yield new bindings, with a fixed parent, with values from an iterator.
  */
 public class QueryIterExtendByVar extends QueryIter
 {
@@ -36,10 +37,10 @@ public class QueryIterExtendByVar extends QueryIter
     private Binding binding ;
     private Var var ;
     private Iterator<Node> members ;
-    
+
     public QueryIterExtendByVar(Binding binding, Var var, Iterator<Node> members, ExecutionContext execCxt) {
         super(execCxt);
-        if ( true ) { // Assume not too costly.
+        if ( true ) {
             if ( binding.contains(var) )
                 throw new ARQInternalErrorException("Var " + var + " already set in " + binding);
         }
@@ -61,7 +62,9 @@ public class QueryIterExtendByVar extends QueryIter
     }
 
     @Override
-    protected void closeIterator() {}
+    protected void closeIterator() {
+        Iter.close(members);
+    }
 
     @Override
     protected void requestCancel() {}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterRepeatApply.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterRepeatApply.java
@@ -34,8 +34,8 @@ public abstract class QueryIterRepeatApply extends QueryIter1 {
     private QueryIterator currentStage;
     private volatile boolean cancelRequested = false;
 
-    public QueryIterRepeatApply(QueryIterator input, ExecutionContext context) {
-        super(input, context);
+    public QueryIterRepeatApply(QueryIterator input, ExecutionContext execCxt) {
+        super(input, execCxt);
         this.currentStage = null;
 
         if ( input == null ) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/PathLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/PathLib.java
@@ -22,6 +22,7 @@ import java.util.ArrayList ;
 import java.util.Iterator ;
 import java.util.List ;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.apache.jena.atlas.iterator.Iter ;
@@ -41,9 +42,7 @@ import org.apache.jena.sparql.engine.ExecutionContext ;
 import org.apache.jena.sparql.engine.QueryIterator ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.engine.binding.BindingFactory ;
-import org.apache.jena.sparql.engine.iterator.QueryIterConcat ;
-import org.apache.jena.sparql.engine.iterator.QueryIterPlainWrapper ;
-import org.apache.jena.sparql.engine.iterator.QueryIterYieldN ;
+import org.apache.jena.sparql.engine.iterator.*;
 import org.apache.jena.sparql.mgt.Explain ;
 import org.apache.jena.sparql.path.eval.PathEval ;
 import org.apache.jena.sparql.pfunction.PropertyFunctionFactory ;
@@ -78,7 +77,7 @@ public class PathLib
         op = flush(bp, op);
         return op;
     }
-    
+
     static private Op flush(BasicPattern bp, Op op) {
         if ( bp == null || bp.isEmpty() )
             return op;
@@ -104,14 +103,14 @@ public class PathLib
             Path path = new P_Link(triplePath.getPredicate());
             triplePath = new TriplePath(triplePath.getSubject(), path, triplePath.getObject());
         }
-        
-        return execTriplePath(binding, 
+
+        return execTriplePath(binding,
                               triplePath.getSubject(),
                               triplePath.getPath(),
                               triplePath.getObject(),
                               execCxt) ;
     }
-    
+
     public static QueryIterator execTriplePath(Binding binding, Node s, Path path, Node o, ExecutionContext execCxt) {
         Explain.explain(s, path, o, execCxt.getContext()) ;
         s = Var.lookup(binding, s) ;
@@ -143,13 +142,13 @@ public class PathLib
         }
         return evalGroundedOneEnd(binding, iter, endNode, execCxt);
     }
-    
+
     private static QueryIterator evalGroundedOneEnd(Binding binding, Iterator<Node> iter, Node endNode, ExecutionContext execCxt) {
         List<Binding> results = new ArrayList<>() ;
-        
+
         if (! Var.isVar(endNode))
-            throw new ARQInternalErrorException("Non-variable endnode in _execTriplePath") ;
-        
+            throw new ARQInternalErrorException("Non-variable endNode in evalGroundedOneEnd") ;
+
         Var var = Var.alloc(endNode) ;
         // Assign.
         for (; iter.hasNext();) {
@@ -160,68 +159,59 @@ public class PathLib
     }
 
     // Subject and object are nodes.
-    private static QueryIterator evalGroundedPath(Binding binding, 
+    private static QueryIterator evalGroundedPath(Binding binding,
                                                   Graph graph, Node subject, Path path, Node object,
                                                   ExecutionContext execCxt) {
         Iterator<Node> iter = PathEval.eval(graph, subject, path, execCxt.getContext()) ;
         // Now count the number of matches.
-        
+
         int count = 0 ;
         for ( ; iter.hasNext() ; ) {
             Node n = iter.next() ;
             if ( n.sameValueAs(object) )
                 count++ ;
         }
-        
+
         return new QueryIterYieldN(count, binding, execCxt) ;
     }
 
-    // Brute force evaluation of a TriplePath where neither subject nor object are bound 
+    // Brute force evaluation of a TriplePath where neither subject nor object are bound
     private static QueryIterator execUngroundedPath(Binding binding, Graph graph, Var sVar, Path path, Var oVar, ExecutionContext execCxt) {
         // Starting points.
         Iterator<Node> iter = determineUngroundedStartingSet(graph, path, execCxt) ;
-        QueryIterConcat qIterCat = new QueryIterConcat(execCxt) ;
-        
-        for ( ; iter.hasNext() ; )
-        {
-            Node n = iter.next() ;
-            Binding b2 = BindingFactory.binding(binding, sVar, n) ;
-            Iterator<Node> pathIter = PathEval.eval(graph, n, path, execCxt.getContext()) ;
-            QueryIterator qIter = evalGroundedOneEnd(b2, pathIter, oVar, execCxt) ;
-            qIterCat.add(qIter) ;
-        }
-        return qIterCat ;
+        QueryIterator input = new QueryIterExtendByVar(binding, sVar, iter, execCxt);
+        Function<Binding, QueryIterator> mapper = b -> {
+            Iterator<Node> pathIter = PathEval.eval(graph, b.get(sVar), path, execCxt.getContext());
+            QueryIterator qIter = evalGroundedOneEnd(b, pathIter, oVar, execCxt);
+            return qIter;
+        };
+        return QueryIter.flatMap(input, mapper, execCxt);
     }
-    
+
     private static QueryIterator execUngroundedPathSameVar(Binding binding, Graph graph, Var var, Path path, ExecutionContext execCxt) {
         // Try each end, ungrounded.
-        // Slightly more efficient would be to add a per-engine to do this.
         Iterator<Node> iter = determineUngroundedStartingSet(graph, path, execCxt) ;
-        QueryIterConcat qIterCat = new QueryIterConcat(execCxt) ;
-        
-        for ( ; iter.hasNext() ; )
-        {
-            Node n = iter.next() ;
-            Binding b2 = BindingFactory.binding(binding, var, n) ;
-            int x = existsPath(graph, n, path, n, execCxt) ;
-            if ( x > 0 )
-            {
-                QueryIterator qIter = new QueryIterYieldN(x, b2, execCxt) ;
-                qIterCat.add(qIter) ;
-            }
-        }
-        return qIterCat ; 
+        QueryIterator input = new QueryIterExtendByVar(binding, var, iter, execCxt);
+        Function<Binding, QueryIterator> mapper = b -> {
+            Node n = b.get(var);
+            int x = existsPath(graph, n, path, n, execCxt);
+            if (x <= 0)
+                return null;
+            Binding b2 = BindingFactory.binding(binding, var, n);
+            return new QueryIterYieldN(x, b2, execCxt);
+        };
+        return QueryIter.flatMap(input, mapper, execCxt);
     }
-    
+
     private static Iterator<Node> determineUngroundedStartingSet(Graph graph, Path path, ExecutionContext execCxt) {
         // Find a better set of seed values than "everything"
         //    (:p+) and (^:p)+
-        //  :p* need everything because it is always the case that "<x> :p* <x>" 
+        //  :p* need everything because it is always the case that "<x> :p* <x>"
         if ( path instanceof P_OneOrMore1 || path instanceof P_OneOrMoreN ) {
             Path subPath = ((P_Path1)path).getSubPath() ;
             if ( subPath instanceof P_Link ) {
                 // :predicate+
-                // If a property functions, 
+                // If a property functions,
                 P_Link link = (P_Link)subPath ;
                 if ( ! isPropertyFunction(link.getNode(), execCxt.getContext()) ) {
                     Iterator<Triple> sIter = graph.find(null, link.getNode(), null) ;
@@ -244,7 +234,7 @@ public class PathLib
         // No idea - everything.
         return GraphUtils.allNodes(graph) ;
     }
-    
+
     private static boolean isPropertyFunction(Node node, Context context) {
         if ( ! node.isURI() )
             return false ;
@@ -255,10 +245,10 @@ public class PathLib
         if ( ! subject.isConcrete() || !object.isConcrete() )
             throw new ARQInternalErrorException("Non concrete node for existsPath evaluation") ;
         Iterator<Node> iter = PathEval.eval(graph, subject, path, execCxt.getContext()) ;
-        Predicate<Node> filter = node -> Objects.equals(node,  object); 
+        Predicate<Node> filter = node -> Objects.equals(node,  object);
         // See if we got to the node we're interested in finishing at.
         iter = Iter.filter(iter, filter) ;
-        long x = Iter.count(iter) ; 
+        long x = Iter.count(iter) ;
         return (int)x ;
     }
 }


### PR DESCRIPTION
Issue improved: GH-1614

- the GraphUtils.allNodes used in the worst case determineUngroundedStartingSet was previously computing the contents of the whole data set. this has two drawbacks, (1) not lazy (2) not easy to abort, i.e queryTimeout was not respected

  changed it to Iter.distinct (unfortunately that means in worst case it will still require to load everything into memory)

- the `PathLib.execUngroundedPath` and `execUngroundedPathSameVar` were both consuming the iterator fully while creating new QueryIterConcats. Drawbacks are the same as above, additionally LIMIT could not be pushed down. Changed it to be lazy instead


co-authored with @LorenzBuehmann

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
