### PR TITLE
Allow toggling extended path flattening on

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
@@ -345,9 +345,17 @@ public class ARQ
     /**
      *  Context key controlling whether the main query engine flattens simple paths
      *  (e.g. {@code ?x :p/:q ?z =&gt; ?x :p ?.0 . ?.0 ?q ?z})
-     *  <p>Default is "true"
+     *  <p>Default is "true"</p>
      */
     public static final Symbol optPathFlatten = SystemARQ.allocSymbol("optPathFlatten");
+
+    /**
+     * Context key controlling whether the main query engine does more extensive property path flattening that involves
+     * more in-depth manipulation of the SPARQL algebra. This must be explicitly enabled and is only used if
+     * {@link #optPathFlatten} is also enabled (which it is by default).
+     * <p>Default is {@code false}</p>
+     */
+    public static final Symbol optPathFlattenAlgebra = SystemARQ.allocSymbol("optPathFlattenAlgebra");
 
     /**
      *  Context key controlling whether the main query engine moves filters to the "best" place.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/OptimizerStd.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/OptimizerStd.java
@@ -71,7 +71,11 @@ public class OptimizerStd implements Rewrite
 
         // Convert paths to triple patterns if possible.
         if ( context.isTrueOrUndef(ARQ.optPathFlatten) ) {
-            op = apply("Path flattening", new TransformPathFlattern(), op) ;
+            if (context.isTrue(ARQ.optPathFlattenAlgebra)) {
+                op = apply("Path flattening (algebra)", new TransformPathFlattenAlgebra(), op);
+            } else {
+                op = apply("Path flattening", new TransformPathFlattern(), op);
+            }
             // and merge adjacent BGPs (part 1)
             if ( context.isTrueOrUndef(ARQ.optMergeBGPs) )
                 op = apply("Merge BGPs", new TransformMergeBGPs(), op) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformMergeBGPs.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformMergeBGPs.java
@@ -25,9 +25,12 @@ import org.apache.jena.sparql.algebra.TransformCopy ;
 import org.apache.jena.sparql.algebra.op.OpBGP ;
 import org.apache.jena.sparql.algebra.op.OpJoin ;
 import org.apache.jena.sparql.algebra.op.OpSequence ;
+import org.apache.jena.sparql.algebra.op.OpTriple;
 import org.apache.jena.sparql.core.BasicPattern ;
 
-/** Merge BGPs
+/**
+ * Merge BGPs, additionally merges the special {@link OpTriple} operator which is a BGP of a single triple pattern that
+ * may be introduced by other transforms
  *
  * <ul>
  * <li>(join BGP1 BGP2) {@literal =>} BGP
@@ -106,6 +109,8 @@ public class TransformMergeBGPs extends TransformCopy {
     private static BasicPattern asBGP(Op op) {
         if ( op instanceof OpBGP )
             return ((OpBGP)op).getPattern() ;
+        if ( op instanceof OpTriple)
+            return ((OpTriple)op).asBGP().getPattern();
         return null ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/PathCompiler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/PathCompiler.java
@@ -21,6 +21,8 @@ package org.apache.jena.sparql.path;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.sparql.ARQConstants ;
+import org.apache.jena.sparql.algebra.optimize.TransformPathFlattenAlgebra;
+import org.apache.jena.sparql.algebra.optimize.TransformPathFlattern;
 import org.apache.jena.sparql.core.PathBlock ;
 import org.apache.jena.sparql.core.TriplePath ;
 import org.apache.jena.sparql.core.Var;
@@ -68,9 +70,13 @@ public class PathCompiler
         }
     }
 
-    // ---- Algebra-based transformation.
-    // Does not include "|". Called by TransformPathFlattern.
-    // See TransformPathFlatternStd for union expansion.
+    /**
+     * Algebra-based transformation.
+     * <p>
+     * Does not include "|", this method is called by {@link TransformPathFlattern}. See
+     * {@link TransformPathFlattenAlgebra} for union expansion.
+     * </p>
+     */
     public PathBlock reduce(TriplePath triplePath)
     {
         PathBlock x = new PathBlock() ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformPathFlatten.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformPathFlatten.java
@@ -206,9 +206,58 @@ public class TestTransformPathFlatten {
         test(op1, expected);
     }
 
-    @Test public void pathFlatten_n_to_m_02() {
+    @Test public void pathFlatten_n_to_m_01_algebra() {
         Op op1 = path("?x", ":p{2,}", ":T1");
-        testAlgebra(op1, null);
+        Op expected = op(
+                "(sequence",
+                "  (join",
+                "    (triple ??Q0 :p ??Q1)",
+                "    (triple ??Q1 :p :T1))",
+                "  (path ?x (pathN* :p) ??Q0)",
+                ")"
+        );
+        testAlgebra(op1, expected);
+    }
+
+    @Test public void pathFlatten_n_to_m_01b_algebra() {
+        Op op1 = path("?x", ":p{2,}", ":T1");
+        Op expected = op(
+                "(sequence",
+                "  (bgp",
+                "    (triple ??Q0 :p ??Q1)",
+                "    (triple ??Q1 :p :T1))",
+                "  (path ?x (pathN* :p) ??Q0)",
+                ")"
+        );
+        Context ctx = new Context();
+        ctx.set(ARQ.optPathFlattenAlgebra, true);
+        testOptimise(op1, expected, ctx);
+    }
+
+    @Test public void pathFlatten_n_to_m_02() {
+        Op op1 = path(":T1", ":p{2,}", "?x");
+        Op expected = op(
+                "(sequence",
+                "  (bgp",
+                "    (triple :T1 :p ??P1)",
+                "    (triple ??P1 :p ??P0))",
+                "  (path ??P0 (pathN* :p) ?x)",
+                ")"
+        );
+        test(op1, expected);
+    }
+
+    @Test public void pathFlatten_n_to_m_02_algebra() {
+        Op op1 = path(":T1", ":p{2,}", "?x");
+        Op expected = op(
+                "(sequence",
+                "  (join",
+                "    (triple :T1 :p ??Q1)",
+                "    (triple ??Q1 :p ??Q0))",
+                "  (path ??Q0 (pathN* :p) ?x)",
+                ")"
+        );
+        testAlgebra(op1, expected);
     }
     
     private static Op path(String s, String pathStr, String o) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformPathFlatten.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformPathFlatten.java
@@ -21,7 +21,9 @@ package org.apache.jena.sparql.algebra.optimize;
 import static org.apache.jena.atlas.lib.StrUtils.strjoinNL;
 import static org.junit.Assert.assertEquals;
 
+import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.Transform;
 import org.apache.jena.sparql.algebra.Transformer;
 import org.apache.jena.sparql.algebra.op.OpPath;
 import org.apache.jena.sparql.core.Prologue;
@@ -30,6 +32,7 @@ import org.apache.jena.sparql.path.Path;
 import org.apache.jena.sparql.path.PathCompiler;
 import org.apache.jena.sparql.path.PathParser;
 import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sparql.util.Context;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -49,6 +52,7 @@ public class TestTransformPathFlatten {
     @Before public void before() {
         // Reset the variable allocator. 
         PathCompiler.resetForTest();
+        TransformPathFlattenAlgebra.resetForTest();
     }
     
     @Test public void pathFlatten_00() {
@@ -98,6 +102,114 @@ public class TestTransformPathFlatten {
             ,"   ))");
         test(op1, op2);
     }
+
+    @Test public void pathFlatten_alt_01() {
+        Op op1 = path("?x", ":p1|:p2", ":T1");
+        // Basic flatten does not flatten alternative paths
+        test(op1, op1);
+    }
+
+    @Test public void pathFlatten_alt_02() {
+        Op op1 = path("?x", ":p1|:p2", ":T1");
+        // Extended flatten does flatten alternative paths
+        Op expected = op(
+                "(union",
+                        "  (triple ?x :p1 :T1)",
+                        "  (triple ?x :p2 :T1)",
+                        ")");
+        testAlgebra(op1, expected);
+    }
+
+    @Test public void pathFlatten_alt_03() {
+        Op op1 = path("?x", ":p1|^:p2", ":T1");
+        // Extended flatten does flatten alternative paths
+        Op expected = op(
+                "(union",
+                "  (triple ?x :p1 :T1)",
+                "  (triple :T1 :p2 ?x)",
+                ")");
+        testAlgebra(op1, expected);
+    }
+
+    @Test public void pathFlatten_alt_04() {
+        Op op1 = path("?x", ":p1|:p2|(:p3*)", ":T1");
+        // Extended flatten does flatten alternative paths
+        Op expected = op(
+                "(union",
+                "  (union",
+                "    (triple ?x :p1 :T1)",
+                "    (triple ?x :p2 :T1))",
+                "  (path ?x (path* :p3) :T1)",
+                ")");
+        testAlgebra(op1, expected);
+    }
+
+    @Test public void pathFlatten_alt_05() {
+        Op op1 = path("?x", ":p1|:p2|(:p3{2})", ":T1");
+        // Extended flatten does flatten alternative paths
+        Op expected = op(
+                "(union",
+                "  (union",
+                "    (triple ?x :p1 :T1)",
+                "    (triple ?x :p2 :T1))",
+                "  (join",
+                "    (triple ?x :p3 ??Q0)",
+                "    (triple ??Q0 :p3 :T1))",
+                ")");
+        testAlgebra(op1, expected);
+    }
+
+    @Test public void pathFlatten_alt_05b() {
+        Op op1 = path("?x", ":p1|:p2|(:p3{2})", ":T1");
+        Op expected = op(
+                "(union",
+                "  (union",
+                "    (triple ?x :p1 :T1)",
+                "    (triple ?x :p2 :T1))",
+                "  (bgp",
+                "    (triple ?x :p3 ??Q0)",
+                "    (triple ??Q0 :p3 :T1))",
+                ")"
+        );
+        Context ctx = new Context();
+        ctx.set(ARQ.optPathFlattenAlgebra, true);
+        testOptimise(op1, expected, ctx);
+    }
+
+    @Test public void pathFlatten_reverse_01() {
+        Op op1 = path("?x", "^:p1+", ":T1");
+        Op expected = op(
+                "(path :T1 (path+ :p1) ?x)"
+        );
+
+        test(op1, expected);
+    }
+
+    @Test public void pathFlatten_reverse_algebra_01() {
+        Op op1 = path("?x", "^:p1+", ":T1");
+        Op expected = op(
+                "(path :T1 (path+ :p1) ?x)"
+        );
+        testAlgebra(op1, expected);
+    }
+
+    @Test public void pathFlatten_n_to_m_01() {
+        Op op1 = path("?x", ":p{2,}", ":T1");
+        Op expected = op(
+          "(sequence",
+                 "  (path ??P0 (pathN* :p) :T1)",
+                 "  (bgp",
+                 "    (triple ?x :p ??P1)",
+                 "    (triple ??P1 :p ??P0)",
+                 "))"
+        );
+        test(op1, expected);
+    }
+
+    @Test public void pathFlatten_n_to_m_02() {
+        Op op1 = path("?x", ":p{2,}", ":T1");
+        testAlgebra(op1, null);
+    }
     
     private static Op path(String s, String pathStr, String o) {
         Path path = PathParser.parse(pathStr, prologue);
@@ -112,15 +224,32 @@ public class TestTransformPathFlatten {
     }
     
     private static void test(Op opInput, Op opExpected) {
-        Op op = Transformer.transform(new TransformPathFlattern(), opInput);
+        testPathTransform(opInput, opExpected, new TransformPathFlattern());
+    }
+
+    private static void testPathTransform(Op opInput, Op opExpected, Transform transform) {
+        Op op = Transformer.transform(transform, opInput);
+        verifyTransforms(opInput, opExpected, op);
+    }
+
+    private static void verifyTransforms(Op opInput, Op opExpected, Op opTransformed) {
+        System.out.println(opTransformed.toString(prologue.getPrefixMapping()));
         if ( opExpected == null ) {
-            System.out.print(opInput);
-            System.out.println("  ==>");
-            System.out.print(op);
-            System.out.println();
-            return;
+            // Expect no transformation to be applied so input should be same as transformation output
+            assertEquals(opInput, opTransformed);
+        } else {
+            // Expect transformation to have been applied
+            assertEquals(opExpected, opTransformed);
         }
-        
-        assertEquals(opExpected, op);
+    }
+
+    private static void testAlgebra(Op opInput, Op opExpected) {
+        testPathTransform(opInput, opExpected, new TransformPathFlattenAlgebra());
+    }
+
+    private static void testOptimise(Op opInput, Op opExpected, Context context) {
+        OptimizerStd optimizer = new OptimizerStd(context);
+        Op op = optimizer.rewrite(opInput);
+        verifyTransforms(opInput, opExpected, op);
     }
 }


### PR DESCRIPTION
Intended as a less invasive first step related to #1616

Adds a new ARQ symbol `optPathFlattenExtended` that allows enabling more comprehensive path flattened transform via existing code `TransformPathFlatternStd`.  When enabled this is used in preference to the existing simpler path flattening transform.

This remains disabled by default as it can generate algebra structures that are less performant for the general case.  However users might have use cases that benefit from this so this now allows opting into it without needing deeper modification of ARQs optimiser.


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
