### PR TITLE
GH-1617: Cast boolean to derived type of integer

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/CastXSD.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/CastXSD.java
@@ -61,7 +61,7 @@ public class CastXSD {
     public static NodeValue cast(NodeValue nv, XSDDatatype castType) {
         // https://www.w3.org/TR/xpath-functions/#casting
         /*
-            Casting
+          19 Casting
             19.1 Casting from primitive types to primitive types
                 19.1.1 Casting to xs:string and xs:untypedAtomic
                 19.1.2 Casting to numeric types
@@ -153,6 +153,7 @@ public class CastXSD {
     }
 
     private static NodeValue castToNumber(NodeValue nv, XSDDatatype castType) {
+        // xsd:integer is considered to be primitive datatypes.
         if ( castType.equals(XSDDatatype.XSDdecimal) ) {
             // Number to decimal.
             if ( isDouble(nv) || isFloat(nv) ) {
@@ -196,7 +197,12 @@ public class CastXSD {
                 throw exception(nv, castType);
             } else if ( nv.isBoolean() ) {
                 boolean b = nv.getBoolean();
-                return b ? NodeValue.nvONE : NodeValue.nvZERO;
+                // And cast to specific type.
+                if ( castType.equals(XSDDatatype.XSDinteger))
+                    return b ? NodeValue.nvONE : NodeValue.nvZERO;
+                // 19.3.4 Casting across the type hierarchy
+                // Step 3 : Cast the value down to the TT
+                return cast$( ( b ? "1" : "0" ) , castType);
             } else {
                 // Integer derived type -> integer derived type.
                 return castByLex(nv, castType);
@@ -214,6 +220,8 @@ public class CastXSD {
 
     private static NodeValue castToDuration(NodeValue nv, XSDDatatype castType) {
         // Duration cast.
+        //   19.3.1 Casting to derived types
+        //   xsd:dayTimeDuration and xsd:yearMonthDuration are considered to be primitive datatypes
         // yearMonthDuration and TT is xs:dayTimeDuration -> 0.0S
         // xs:dayTimeDuration and TT is yearMonthDuration -> P0M
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestCastXSD.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestCastXSD.java
@@ -76,19 +76,19 @@ public class TestCastXSD {
     @Test public void cast_to_decimal_05()  { testCast      ("xsd:decimal('11e0'^^xsd:double)",     "11.0") ; }
     @Test public void cast_to_decimal_06()  { testCast      ("xsd:decimal('-0.01'^^xsd:double)",    "-0.01") ; }
     @Test public void cast_to_decimal_07()  { testCast      ("xsd:decimal('1'^^xsd:double)",        "'1.0'^^xsd:decimal") ; }
-    
+
     @Test public void cast_to_boolean_01()  { testCast      ("xsd:boolean('1'^^xsd:double)",        "true") ; }
     @Test public void cast_to_boolean_02()  { testCast      ("xsd:boolean('+1.0e5'^^xsd:double)",   "true") ; }
     @Test public void cast_to_boolean_03()  { testCast      ("xsd:boolean('0'^^xsd:float)",         "false") ; }
     @Test public void cast_to_boolean_04()  { testCast      ("xsd:boolean(0.0e0)",                  "false") ; }
     @Test public void cast_to_boolean_05()  { testCast      ("xsd:boolean(-0.0e0)",                 "false") ; }
     @Test public void cast_to_boolean_06()  { testCast      ("xsd:boolean('NaN'^^xsd:float)",       "false") ; }
-    
+
     @Test public void cast_to_boolean_07()  { testCast      ("xsd:boolean(1.0)",                    "true") ; }
     @Test public void cast_to_boolean_08()  { testCast      ("xsd:boolean(0.0)",                    "false") ; }
     @Test public void cast_to_boolean_09()  { testCast      ("xsd:boolean(-1.00)",                  "true") ; }
     @Test public void cast_to_boolean_10()  { testCast      ("xsd:boolean(0)",                      "false") ; }
-    
+
     @Test public void cast_to_boolean_11()  { testCast      ("xsd:boolean('1')",                    "true") ; }
     @Test public void cast_to_boolean_12()  { testCast      ("xsd:boolean('true')",                 "true") ; }
     @Test public void cast_to_boolean_13()  { testCast      ("xsd:boolean('0')",                    "false") ; }
@@ -105,6 +105,7 @@ public class TestCastXSD {
     @Test public void cast_from_boolean_03() { testCast     ("xsd:integer('1'^^xsd:boolean)",            "1" ) ; }
     @Test public void cast_from_boolean_04() { testCast     ("xsd:decimal('false'^^xsd:boolean)",        "0.0" ) ; }
     @Test public void cast_from_boolean_05() { testCast     ("xsd:double('false'^^xsd:boolean)",         "0.0E0" ) ; }
+    @Test public void cast_from_boolean_06() { testCast     ("xsd:int('false'^^xsd:boolean)",            "'0'^^xsd:int" ) ; }
 
     @Test public void cast_to_duration_01()  { testCast     ("xsd:duration('PT10S')",                            "'PT10S'^^xsd:duration") ; }
     @Test public void cast_to_duration_02()  { testCast     ("xsd:duration('P1DT10S'^^xsd:dayTimeDuration)",     "'P1DT10S'^^xsd:duration") ; }


### PR DESCRIPTION
GitHub discussion: #1617

Pull request Description:
When casting xsd:boolean to a derived type of xsd:integer (xsd:int etc), the cast was returning a xsd:integer, not downcasting to  the derived type.

----

 - [x] Tests are included.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
