### PR TITLE
[GH-1622] Make the Jena Fuseki UI and Vue ports dynamic for the e2e tests

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/package.json
+++ b/jena-fuseki2/jena-fuseki-ui/package.json
@@ -13,7 +13,7 @@
     "lint": "vue-cli-service lint",
     "coverage:e2e": "bash -c 'concurrently --names \"SERVER,TESTS\" --prefix-colors \"yellow,blue\" --success \"first\" --kill-others \"yarn run serve:fuseki\" \"nyc vue-cli-service test:e2e ${0}\"'",
     "coverage:unit": "nyc vue-cli-service test:unit",
-    "serve:fuseki": "nodemon src/services/mock/json-server.js src/services/mock/db.json",
+    "serve:fuseki": "nodemon src/services/mock/json-server.js",
     "serve:offline": "concurrently --names 'SERVER,CLIENT' --prefix-colors 'yellow,blue' --success \"first\" --kill-others 'yarn run serve:fuseki' 'yarn run serve'"
   },
   "dependencies": {

--- a/jena-fuseki2/jena-fuseki-ui/pom.xml
+++ b/jena-fuseki2/jena-fuseki-ui/pom.xml
@@ -37,6 +37,28 @@
 
     <build>
         <plugins>
+            <!-- Allocate two network ports for Jena Fuseki UI and for Jena Fuseki -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>reserve-network-port</id>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <portNames>
+                                <portName>org.apache.jena.fuseki.port</portName>
+                                <portName>org.apache.jena.fuseki.ui.port</portName>
+                            </portNames>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Run Yarn to build and run tests -->
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
@@ -87,6 +109,10 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <environmentVariables>
+                                <PORT>${org.apache.jena.fuseki.ui.port}</PORT>
+                                <FUSEKI_PORT>${org.apache.jena.fuseki.port}</FUSEKI_PORT>
+                            </environmentVariables>
                             <arguments>run test:e2e -- --headless --browser chrome</arguments>
                         </configuration>
                     </execution>

--- a/jena-fuseki2/jena-fuseki-ui/src/services/mock/json-server.js
+++ b/jena-fuseki2/jena-fuseki-ui/src/services/mock/json-server.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-const PORT = 3030
+const PORT = process.env.FUSEKI_PORT || 3030
 
 const data = {}
 

--- a/jena-fuseki2/jena-fuseki-ui/vue.config.js
+++ b/jena-fuseki2/jena-fuseki-ui/vue.config.js
@@ -74,7 +74,7 @@ module.exports = {
   devServer: {
     proxy: {
       '/': {
-        target: 'http://localhost:3030',
+        target: `http://localhost:${process.env.FUSEKI_PORT || 3030}`,
         ws: true,
         changeOrigin: true
       }


### PR DESCRIPTION
GitHub issue resolved #1622 

Pull request Description:

The `PORT` env var is used by Vue dev server. I only defined a new env var `FUSEKI_PORT`. The default values are the same, `8080` and `3030`.

In `pom.xml` for the Jena Fuseki UI module a Maven plug-in is used to allocate two network ports (it will search two free) and define Maven properties. In the Maven Frontend plug-in, these environment variables are then used to define `PORT` and `FUSEKI_PORT`.

I tested by starting `python3 -m http.server 3030` in one terminal, `watch -n 2 netstat -tlnp` in another, and then running `mvn test` in the Jena Fuseki UI module folder.

![Screenshot from 2022-11-19 19-39-05](https://user-images.githubusercontent.com/304786/202866835-0dbf8bc1-fe4e-4892-b75d-2259815430ab.png)

![Screenshot from 2022-11-19 19-38-18](https://user-images.githubusercontent.com/304786/202866840-ef603c67-9823-48b0-ad5a-89cf761e46dc.png)

![Screenshot from 2022-11-19 19-38-37](https://user-images.githubusercontent.com/304786/202866842-b5c6d359-e51c-4549-ac9a-f284d093f7c2.png)


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
