### PR TITLE
GH-1643: Replace commons-fileload

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/pom.xml
+++ b/jena-fuseki2/jena-fuseki-core/pom.xml
@@ -73,11 +73,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
     </dependency>

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
@@ -28,7 +28,8 @@ import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.server.Dispatcher;
 import org.slf4j.Logger;
 
-/** Look at all requests and see if they match a registered dataset name;
+/**
+ * Look at all requests and see if they match a registered dataset name;
  * if they do, pass down to the uber servlet, which can dispatch any request
  * for any service.
  */

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/UploadRDF.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/UploadRDF.java
@@ -199,5 +199,4 @@ public class UploadRDF extends ActionREST {
         }
         return details;
     }
-
 }

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/META-INF/context.xml
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/META-INF/context.xml
@@ -1,0 +1,19 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<Context allowCasualMultipartParsing="true">
+</Context>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
     <ver.commons-codec>1.15</ver.commons-codec>
     <ver.commons-compress>1.22</ver.commons-compress>
     <ver.commons-collections>4.4</ver.commons-collections>
-    <ver.commons-fileupload>1.4</ver.commons-fileupload>
     <ver.dexxcollection>0.7</ver.dexxcollection>
     <ver.micrometer>1.10.2</ver.micrometer>
 
@@ -372,18 +371,6 @@
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-lang3</artifactId>
          <version>${ver.commonslang3}</version>
-       </dependency>
-
-       <dependency>
-         <groupId>commons-fileupload</groupId>
-         <artifactId>commons-fileupload</artifactId>
-         <version>${ver.commons-fileupload}</version>
-         <exclusions>
-           <exclusion>
-             <groupId>javax.servlet</groupId>
-             <artifactId>servlet-api</artifactId>
-           </exclusion>
-         </exclusions>
        </dependency>
 
        <dependency>


### PR DESCRIPTION
GitHub issue resolved #1643

Pull request Description:
See #1643

Tested for Jetty 10.

It uses Servlet API 3.0 which Tomcat has supported since version 7.

This PR removes the `commons-fileupload` dependency which is no longer used. 

https://issues.apache.org/jira/browse/FILEUPLOAD-309

----

 - [x] Tests are included. Existing tests cover usage.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
