### PR TITLE
Use a skip scan based iterator for listing graph names in TDB2 (GH-1639)

### DIFF
--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPTreeDistinctKeyPrefixIterator.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPTreeDistinctKeyPrefixIterator.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.dboe.trans.bplustree;
+
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.atlas.lib.InternalErrorException;
+import org.apache.jena.dboe.base.record.Record;
+import org.apache.jena.dboe.trans.bplustree.AccessPath.AccessStep;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * Iterator over records that only provides records which are distinct with respect to a prefix of their key
+ */
+class BPTreeDistinctKeyPrefixIterator implements Iterator<Record> {
+    static Logger log = LoggerFactory.getLogger(BPTreeDistinctKeyPrefixIterator.class);
+
+    public static Iterator<Record> create(BPTreeNode node, int keyPrefixLength) {
+        return new BPTreeDistinctKeyPrefixIterator(node, keyPrefixLength);
+    }
+
+    // Convert path to a stack of iterators
+    private final Deque<Iterator<BPTreePage>> stack = new ArrayDeque<>();
+    private Iterator<Record> current;
+    private Record slot = null, minRecord, maxRecord;
+    private byte[] lastPrefix = null;
+    private boolean finished = false;
+
+    private final int keyPrefixLength;
+
+    BPTreeDistinctKeyPrefixIterator(BPTreeNode node, int keyPrefixLength) {
+        if (keyPrefixLength < 1) {
+            throw new IllegalArgumentException("keyPrefixLength must be >= 1");
+        }
+        this.keyPrefixLength = keyPrefixLength;
+        this.minRecord = node.minRecord();
+        this.maxRecord = node.maxRecord();
+        BPTreeRecords r = loadStack(node);
+        current = getRecordsIterator(r);
+    }
+
+    @Override
+    public boolean hasNext() {
+        if (finished) {
+            return false;
+        }
+        if (slot != null) {
+            return true;
+        }
+        while (true) {
+            if (current == null) {
+                end();
+                return false;
+            }
+
+            if (current.hasNext()) {
+                Record next = current.next();
+                if (lastPrefix == null) {
+                    return populateSlot(next);
+                } else if (Arrays.compare(this.lastPrefix, 0, this.keyPrefixLength, next.getKey(), 0,
+                                          this.keyPrefixLength) == 0) {
+                    // Same key prefix as the last record we yielded so continue scanning
+                    continue;
+                } else {
+                    return populateSlot(next);
+                }
+            } else {
+                current = moveOnCurrent();
+            }
+        }
+    }
+
+    private boolean populateSlot(Record next) {
+        slot = next;
+        lastPrefix = next.getKey();
+        return true;
+    }
+
+    // Move across the head of the stack until empty - then move next level.
+    private Iterator<Record> moveOnCurrent() {
+        Iterator<BPTreePage> iter = null;
+        while (!stack.isEmpty()) {
+            iter = stack.peek();
+            if (iter.hasNext()) {
+                break;
+            }
+            stack.pop();
+        }
+
+        if (iter == null || !iter.hasNext()) {
+            return null;
+        }
+        BPTreePage p = iter.next();
+        BPTreeRecords r;
+        if (p instanceof BPTreeNode) {
+            BPTreeNode n = ((BPTreeNode) p);
+            // Check whether this entire subtree has the same key prefix, if so we can just return a singleton
+            // iterator for this entire subtree and skip further recursion
+            Record subtreeMin = n.minRecord();
+            Record subtreeMax = n.maxRecord();
+            if (Arrays.compare(subtreeMin.getKey(), 0, this.keyPrefixLength, subtreeMax.getKey(), 0,
+                               this.keyPrefixLength) == 0) {
+                return Iter.singleton(subtreeMin);
+            }
+            r = loadStack(n);
+        } else {
+            r = (BPTreeRecords) p;
+        }
+        return getRecordsIterator(r);
+    }
+
+    // ---- Places we touch blocks.
+
+    protected Iterator<Record> getRecordsIterator(BPTreeRecords records) {
+        records.bpTree.startReadBlkMgr();
+        Iterator<Record> iter;
+        if (!records.hasAnyKeys()) {
+            return Iter.nullIterator();
+        }
+        // Check whether we need to scan the whole page or can process it by skipping or singleton yield
+        Record lowRecord = records.getLowRecord();
+        if (Arrays.compare(lowRecord.getKey(), 0, this.keyPrefixLength, records.getHighRecord().getKey(),
+                           0, this.keyPrefixLength) == 0) {
+            // If the low and high keys for this page have the same prefix then just return a singleton iterator
+            iter = Iter.singleton(lowRecord);
+        } else {
+            // Otherwise need to scan the whole page
+            iter = records.getRecordBuffer().iterator();
+            records.bpTree.finishReadBlkMgr();
+        }
+        return iter;
+    }
+
+    private BPTreeRecords loadStack(BPTreeNode node) {
+        AccessPath path = new AccessPath(null);
+        node.bpTree.startReadBlkMgr();
+
+        node.internalMinRecord(path);
+        List<AccessStep> steps = path.getPath();
+        for (AccessStep step : steps) {
+            BPTreeNode n = step.node;
+            Iterator<BPTreePage> it = n.iterator(this.minRecord, this.maxRecord);
+            if (it == null || !it.hasNext()) {
+                continue;
+            }
+            BPTreePage p = it.next();
+            stack.push(it);
+        }
+        BPTreePage p = steps.get(steps.size() - 1).page;
+        if (!(p instanceof BPTreeRecords)) {
+            throw new InternalErrorException("Last path step not to a records block");
+        }
+        node.bpTree.finishReadBlkMgr();
+        return (BPTreeRecords) p;
+    }
+
+    // ----
+
+    private void end() {
+        finished = true;
+        current = null;
+    }
+
+    // ----
+
+    public void close() {
+        if (!finished) {
+            end();
+        }
+    }
+
+    @Override
+    public Record next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        Record r = slot;
+        if (r == null) {
+            throw new InternalErrorException("Null slot after hasNext is true");
+        }
+        slot = null;
+        return r;
+    }
+}

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPlusTree.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPlusTree.java
@@ -318,6 +318,14 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         //return iterator(fromRec, toRec, RecordFactory.mapperRecord);
     }
 
+    public Iterator<Record> distinctByKeyPrefix(int keyPrefixLength) {
+        startReadBlkMgr();
+        BPTreeNode root = getRootRead();
+        releaseRootRead(root);
+        finishReadBlkMgr();
+        return BPTreeDistinctKeyPrefixIterator.create(root, keyPrefixLength);
+    }
+
     /*
     @Override
     public <X> Iterator<X> iterator(Record minRec, Record maxRec, RecordMapper<X> mapper) {

--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPTreeDistinctKeys.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPTreeDistinctKeys.java
@@ -80,17 +80,24 @@ public class TestBPTreeDistinctKeys extends TestBPTreeModes {
         this.treeOrder = treeOrder;
 
         // Generate random data
+        // We generate a random selection of keys such that those keys will always have the same 1 byte prefix by
+        // limiting the range of our randomly generated numbers to up to the first key that would not have an empty 1st
+        // byte
         Random random = new Random();
         randomData = new ArrayList<>();
         int maxKey = (int) Math.pow(2, 24);
         while (randomData.size() < this.randomSize) {
             int x = random.nextInt(maxKey);
+            // Need to ensure that every random key generated is unique since the B+Tree will not permit duplicate
+            // keys
             if (!randomData.contains(x)) {
                 randomData.add(x);
             }
         }
 
-        // Sort out random data into the order we expect it back out
+        // Sort out random data into the order we expect to retrieve it back out for our test assertions
+        // Intentionally keeping the random data in the randomly generated order thus we're also exercising the B+Tree
+        // being populated in a random order as part of these tests
         expectedData = new ArrayList<>(randomData);
         Collections.sort(expectedData);
     }
@@ -258,8 +265,8 @@ public class TestBPTreeDistinctKeys extends TestBPTreeModes {
             bpt.insert(factory.create(Bytes.packInt(key)));
         }
 
-        // Find only the keys with a unique 2 byte prefix, since we already ensured with our data generation that the
-        // first byte is always identical only need to use the 2nd byte as the key here
+        // Find only the first keys with a unique 2 byte prefix, since we already ensured with our data generation that
+        // the first byte is always identical only need to use the 2nd byte as the key here
         Map<Byte, Integer> relevantKeys = new HashMap<>();
         for (int key : expectedData) {
             byte[] keyBytes = Bytes.packInt(key);
@@ -281,7 +288,7 @@ public class TestBPTreeDistinctKeys extends TestBPTreeModes {
             bpt.insert(factory.create(Bytes.packInt(key)));
         }
 
-        // Find only the keys with a unique 3 byte prefix
+        // Find only the first keys with each unique 3 byte prefix
         Map<Record, Integer> relevantKeys = new HashMap<>();
         for (int key : expectedData) {
             byte[] keyBytes = Bytes.packInt(key);

--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPTreeDistinctKeys.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPTreeDistinctKeys.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.dboe.trans.bplustree;
+
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.atlas.lib.Bytes;
+import org.apache.jena.dboe.base.record.Record;
+import org.apache.jena.dboe.base.record.RecordFactory;
+import org.apache.jena.dboe.test.RecordLib;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.*;
+import java.util.*;
+
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.testInsert;
+import static org.apache.jena.dboe.test.RecordLib.TestRecordLength;
+import static org.apache.jena.dboe.test.RecordLib.toIntList;
+
+@RunWith(Parameterized.class)
+public class TestBPTreeDistinctKeys extends TestBPTreeModes {
+    public static final byte[] DISTINCT_KEYS = new byte[] {
+            0x00,
+            0x04,
+            0x08,
+            0x0F,
+            0x40,
+            (byte) 0x80,
+            (byte) 0xF0,
+            (byte) 0xFF
+    };
+
+    public static final int[] RANDOM_SIZES = new int[] {
+            10, 100, 1_000, 5_000, 10_000
+    };
+
+    public static final int[] TREE_ORDERS = new int[] { 2, 4 };
+
+    @Parameterized.Parameters(name = "Random Size={0}, Tree Order={1}, Node dup={2}, Record dup={3}")
+    public static Collection<Object[]> data() {
+        List<Object[]> parameters = new ArrayList<>();
+        boolean[] modes = new boolean[] { true, false };
+        for (int size : RANDOM_SIZES) {
+            for (int order : TREE_ORDERS) {
+                for (boolean nodeDup : modes) {
+                    for (boolean recordDup : modes) {
+                        parameters.add(new Object[] { size, order, nodeDup, recordDup });
+                    }
+                }
+            }
+        }
+        return parameters;
+    }
+
+    int randomSize, treeOrder;
+    List<Integer> randomData;
+    List<Integer> expectedData;
+
+    public TestBPTreeDistinctKeys(int randomSize, int treeOrder, boolean nodeMode, boolean recordsMode) {
+        super(nodeMode, recordsMode);
+        this.randomSize = randomSize;
+        this.treeOrder = treeOrder;
+
+        // Generate random data
+        Random random = new Random();
+        randomData = new ArrayList<>();
+        int maxKey = (int) Math.pow(2, 24);
+        while (randomData.size() < this.randomSize) {
+            int x = random.nextInt(maxKey);
+            if (!randomData.contains(x)) {
+                randomData.add(x);
+            }
+        }
+
+        // Sort out random data into the order we expect it back out
+        expectedData = new ArrayList<>(randomData);
+        Collections.sort(expectedData);
+    }
+
+    private static List<Integer> populateKeys(BPlusTree bpt, byte[] keys, int keyPosition) {
+        RecordFactory factory = bpt.getParams().recordFactory;
+        List<Integer> expected = new ArrayList<>();
+        for (byte key : keys) {
+            byte[] actualKey = new byte[TestRecordLength];
+            for (int i = 0; i < TestRecordLength; i++) {
+                actualKey[i] = keyPosition == i ? key : 0;
+            }
+            Record r = factory.create(actualKey);
+            bpt.insert(r);
+            expected.add(Bytes.getInt(r.getKey()));
+        }
+        return expected;
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void bptree_distinct_by_key_bad_01() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(0);
+        Assert.assertFalse(iter.hasNext());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void bptree_distinct_by_key_bad_02() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(6);
+        Assert.assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void bptree_distinct_by_key_01() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(1);
+        Assert.assertFalse(iter.hasNext());
+    }
+
+    @Test
+    public void bptree_distinct_by_key_02() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        int[] keys = new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        testInsert(bpt, keys);
+        // Given a single byte prefix all the above keys have a prefix of 0 so only the first key
+        // should be returned
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(1);
+        List<Integer> actual = toIntList(iter);
+        List<Integer> expected = toIntList(1);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void bptree_distinct_by_key_03() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        int[] keys = new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        testInsert(bpt, keys);
+        // Given a prefix of the whole record length all keys are distinct
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(RecordLib.TestRecordLength);
+        List<Integer> actual = toIntList(iter);
+        List<Integer> expected = toIntList(keys);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void bptree_distinct_by_key_04() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        // Keys chosen so that the first byte of the key will be different for each record
+        int[] keys = new int[] { 0, 536870912, 1073741284, 1610612736 };
+        List<Integer> expected = toIntList(keys);
+        testInsert(bpt, keys);
+        Iterator<Record> all = bpt.iterator();
+        assertEquals(expected, toIntList(all));
+
+        // Given a 1 byte prefix each key is distinct
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(1);
+        List<Integer> actual = toIntList(iter);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void bptree_distinct_by_key_05() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        // Same keys as 04 BUT add a few additional keys that are close to them such that their prefixes
+        // are the same
+        int[] keys = new int[] { 0, 1, 2, 3, 4, 536870912, 536870913, 1073741284, 1073741285, 1610612736, 1610612737 };
+        testInsert(bpt, keys);
+        // Given a 1 byte prefix there are 4 distinct keys based on that prefix
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(1);
+        List<Integer> actual = toIntList(iter);
+        List<Integer> expected = toIntList(0, 536870912, 1073741284, 1610612736);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void bptree_distinct_by_key_06() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        // Create a selection of keys with distinct prefixes
+        List<Integer> expected = populateKeys(bpt, DISTINCT_KEYS, 0);
+
+        // Given a 1 byte prefix all keys are distinct
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(1);
+        List<Integer> actual = toIntList(iter);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void bptree_distinct_by_key_07() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        // Create a selection of keys with distinct prefixes
+        List<Integer> expected = populateKeys(bpt, DISTINCT_KEYS, 1);
+
+        // Given a 1 byte prefix all keys are non-distinct so only get first key back
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(1);
+        List<Integer> actual = toIntList(iter);
+        assertEquals(toIntList(Bytes.getInt(new byte[] { 0, DISTINCT_KEYS[0], 0, 0 })), actual);
+
+        // Given a 2 byte prefix all keys are distinct so get all keys back
+        iter = bpt.distinctByKeyPrefix(2);
+        actual = toIntList(iter);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void bptree_distinct_by_key_08() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+
+        // Fill with a range of keys that will be non-distinct when using a 1 byte prefix
+        RecordFactory factory = bpt.getParams().recordFactory;
+        List<Integer> expected = new ArrayList<>();
+        int maxKey = (int) Math.pow(2, 24);
+        for (int i = 1; i < maxKey; i *= 2) {
+            bpt.insert(factory.create(Bytes.packInt(i)));
+            expected.add(i);
+        }
+        // Given a prefix of 1 byte only the first key is distinct
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(1);
+        List<Integer> actual = toIntList(iter);
+        assertEquals(toIntList(1), actual);
+
+        // Given a prefix of the whole record length every key should be returned
+        actual = toIntList(bpt.distinctByKeyPrefix(TestRecordLength));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void bptree_distinct_by_key_09() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        RecordFactory factory = bpt.getRecordFactory();
+        for (int key : randomData) {
+            bpt.insert(factory.create(Bytes.packInt(key)));
+        }
+
+        // Given a prefix of the whole record length every key should be returned
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(TestRecordLength);
+        verifyAllRecordsReturned(bpt, iter, expectedData);
+    }
+
+    @Test
+    public void bptree_distinct_by_key_10() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        RecordFactory factory = bpt.getRecordFactory();
+        for (int key : randomData) {
+            bpt.insert(factory.create(Bytes.packInt(key)));
+        }
+
+        // Find only the keys with a unique 2 byte prefix, since we already ensured with our data generation that the
+        // first byte is always identical only need to use the 2nd byte as the key here
+        Map<Byte, Integer> relevantKeys = new HashMap<>();
+        for (int key : expectedData) {
+            byte[] keyBytes = Bytes.packInt(key);
+            relevantKeys.computeIfAbsent(keyBytes[1], p -> key);
+        }
+        List<Integer> expected = new ArrayList<>(relevantKeys.values());
+        Collections.sort(expected);
+
+        // Given a prefix of 2 bytes only the first keys with that prefix should be returned
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(2);
+        verifyAllRecordsReturned(bpt, iter, expected);
+    }
+
+    @Test
+    public void bptree_distinct_by_key_11() {
+        BPlusTree bpt = makeRangeIndex(this.treeOrder, 0);
+        RecordFactory factory = bpt.getRecordFactory();
+        for (int key : randomData) {
+            bpt.insert(factory.create(Bytes.packInt(key)));
+        }
+
+        // Find only the keys with a unique 3 byte prefix
+        Map<Record, Integer> relevantKeys = new HashMap<>();
+        for (int key : expectedData) {
+            byte[] keyBytes = Bytes.packInt(key);
+            Record record = new Record(new byte[] { keyBytes[0], keyBytes[1], keyBytes[2]}, new byte[0]);
+            relevantKeys.computeIfAbsent(record, p -> key);
+        }
+        List<Integer> expected = new ArrayList<>(relevantKeys.values());
+        Collections.sort(expected);
+
+        // Given a prefix of 3 bytes only the first keys with that prefix should be returned
+        Iterator<Record> iter = bpt.distinctByKeyPrefix(3);
+        verifyAllRecordsReturned(bpt, iter, expected);
+    }
+
+    private void verifyAllRecordsReturned(BPlusTree bpt, Iterator<Record> iter, List<Integer> expected) {
+        List<Integer> actual = toIntList(iter);
+        for (int i = 0; i < expected.size(); i++) {
+            if (i >= actual.size()) {
+                dumpOnFailure(bpt, null);
+                Assert.fail("Missing key at Index " + i + ", expected " + expected.get(i));
+            }
+            if ((int) actual.get(i) != expected.get(i)) {
+                dumpOnFailure(bpt, bpt.getRecordFactory().create(Bytes.packInt(expected.get(i))));
+                Assert.fail("Actual key at Index " + i + " is incorrect (" + actual.get(
+                        i) + "), expected " + expected.get(i));
+            }
+        }
+        assertEquals(expected, actual);
+    }
+
+    private void dumpOnFailure(BPlusTree bpt, Record record) {
+        File treeDump = new File("target/bptree-dump-order-" + this.treeOrder + "-random-" + this.randomSize + ".txt");
+        File insertDump = new File(
+                "target/bptree-data-insertion-order-" + this.treeOrder + "-random-" + this.randomSize + ".txt");
+        try (OutputStream output = new FileOutputStream(treeDump)) {
+            bpt.dump(new IndentedWriter(output));
+            System.out.println("Tree dump written to " + treeDump.getAbsolutePath());
+            if (record != null) {
+                System.out.println("Missing Record is: " + record);
+            }
+            try (BufferedWriter insertOutput = new BufferedWriter(new FileWriter(insertDump))) {
+                for (int key : this.randomData) {
+                    insertOutput.write(Integer.toString(key));
+                    insertOutput.write('\n');
+                }
+            }
+            System.out.println("Data Insertion dump is written to " + insertDump.getAbsolutePath());
+        } catch (Throwable t) {
+            // Ignore errors trying to dump debug output
+        }
+    }
+
+}

--- a/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPTreeModes.java
+++ b/jena-db/jena-dboe-trans-data/src/test/java/org/apache/jena/dboe/trans/bplustree/TestBPTreeModes.java
@@ -18,9 +18,6 @@
 
 package org.apache.jena.dboe.trans.bplustree;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -29,12 +26,16 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 /** Run the B+Tree algorithm tests but for each combination of explicit
  * write-in-place / always copy modes.
  */
 @RunWith(Parameterized.class)
 public class TestBPTreeModes extends TestBPlusTreeNonTxn
 {
+
     @Parameters(name="Node dup={0}, Record dup={1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb/store/DatasetGraphTDB.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb/store/DatasetGraphTDB.java
@@ -48,7 +48,7 @@ import org.apache.jena.tdb.transaction.DatasetGraphTxn ;
  * <p>
  *  See also:
  *  <ul>
- *  <li>{@link DatasetGraphTxn} &ndash; the sublclass that provides a single transaction</li>
+ *  <li>{@link DatasetGraphTxn} &ndash; the subclass that provides a single transaction</li>
  *  <li>{@link DatasetGraphTransaction} &ndash; class that provides the application with the right DatasetGraphTDB (base or transaction).</li>
  *  </ul>
  */

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/SolverLibTDB.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/SolverLibTDB.java
@@ -161,7 +161,7 @@ public class SolverLibTDB
 
         // Select a graph based index for use, if a suitable one is available
         // We select twice here because if there is an index of a specific type we can do additional optimisation, but
-        // a graph based index allows for some optimisation regardless
+        // a graph based index allows for some optimisation regardless of the underlying index type
         TupleIndexRecord idxRecord = ntt.getTupleTable().selectIndex("G", TupleIndexRecord.class);
         TupleIndex idx = ntt.getTupleTable().selectIndex("G");
 
@@ -187,7 +187,8 @@ public class SolverLibTDB
         } else {
             // Fall back to a find all which will use the most appropriate index available
             // Need full distinct calculation as no guarantee that the index is ordered with respect to the graph name
-            // Memory usage will scale with number of distinct graph names though this is a
+            // Memory usage will scale with number of distinct graph names though this is likely to be relatively
+            // modest so generally not a problem
             iter1 = ntt.findAll();
             distinctMode = GraphNamesDistinctMode.FULL;
         }

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/SolverLibTDB.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/SolverLibTDB.java
@@ -27,6 +27,7 @@ import java.util.function.Predicate;
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.tuple.Tuple;
 import org.apache.jena.atlas.lib.tuple.TupleFactory;
+import org.apache.jena.dboe.trans.bplustree.BPlusTree;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.ExecutionContext;
@@ -40,10 +41,11 @@ import org.apache.jena.sparql.engine.iterator.QueryIterNullIterator;
 import org.apache.jena.tdb2.lib.NodeLib;
 import org.apache.jena.tdb2.store.DatasetGraphTDB;
 import org.apache.jena.tdb2.store.NodeId;
+import org.apache.jena.tdb2.store.NodeIdFactory;
 import org.apache.jena.tdb2.store.nodetable.NodeTable;
 import org.apache.jena.tdb2.store.nodetupletable.NodeTupleTable;
 import org.apache.jena.tdb2.store.tupletable.TupleIndex;
-import org.apache.jena.tdb2.store.tupletable.TupleTable;
+import org.apache.jena.tdb2.store.tupletable.TupleIndexRecord;
 import org.apache.jena.tdb2.sys.TDBInternal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,24 +147,49 @@ public class SolverLibTDB
 
     private static Tuple<NodeId> TupleANY = TupleFactory.create4(NodeId.NodeIdAny, NodeId.NodeIdAny, NodeId.NodeIdAny, NodeId.NodeIdAny);
 
+    private enum GraphNamesDistinctMode {
+        NONE,
+        ADJACENT,
+        FULL;
+    }
+
     /** Find all the graph names in the quads table. */
     static QueryIterator graphNames(DatasetGraphTDB ds, Node graphNode, QueryIterator input,
                                     Predicate<Tuple<NodeId>> filter, ExecutionContext execCxt) {
         List<Abortable> killList = new ArrayList<>();
         NodeTupleTable ntt = ds.getQuadTable().getNodeTupleTable();
 
-        TupleIndex idx = findGraphIndex(ntt.getTupleTable(), "G");
+        // Select a graph based index for use, if a suitable one is available
+        // We select twice here because if there is an index of a specific type we can do additional optimisation, but
+        // a graph based index allows for some optimisation regardless
+        TupleIndexRecord idxRecord = ntt.getTupleTable().selectIndex("G", TupleIndexRecord.class);
+        TupleIndex idx = ntt.getTupleTable().selectIndex("G");
 
-        boolean needDistinct;
+        GraphNamesDistinctMode distinctMode;
         Iterator<Tuple<NodeId>> iter1;
 
-        if ( idx == null ) {
-            iter1 = ntt.findAll();
-            needDistinct = true;
-        }
-        else {
+        if (idxRecord != null && idxRecord.getRangeIndex() instanceof BPlusTree) {
+            // Have a B+Tree based graph index so can use our distinct by key prefix iterator to optimise evaluation
+            // This iterator already guarantees the graph names returned are distinct so no further distinct calculation
+            // is needed
+            // Need to pad the yielded tuple with placeholders to create a tuple of the right length so the subsequent
+            // filtering (if any) applies correctly
+            BPlusTree bpt = (BPlusTree) (idxRecord).getRangeIndex();
+            iter1 = Iter.iter(bpt.distinctByKeyPrefix(NodeId.SIZE))
+                        .map(r -> TupleFactory.create4(NodeIdFactory.get(r.getKey(), 0), NodeId.NodeIdAny, NodeId.NodeIdAny, NodeId.NodeIdAny));
+            distinctMode =  GraphNamesDistinctMode.NONE;
+        } else if (idx != null) {
+            // Have a generic Graph based index, can at least optimise slightly by only needing distinct adjacent as we
+            // know the same Graph Names will be stored in a sequence within the index. This also keeps memory footprint
+            // for the distinct constant to a single Graph Name
             iter1 = idx.find(TupleANY);
-            needDistinct = false;
+            distinctMode = GraphNamesDistinctMode.ADJACENT;
+        } else {
+            // Fall back to a find all which will use the most appropriate index available
+            // Need full distinct calculation as no guarantee that the index is ordered with respect to the graph name
+            // Memory usage will scale with number of distinct graph names though this is a
+            iter1 = ntt.findAll();
+            distinctMode = GraphNamesDistinctMode.FULL;
         }
 
         if ( filter != null )
@@ -172,7 +199,20 @@ public class SolverLibTDB
         // Project is cheap - don't brother wrapping iter1
         iter2 = makeAbortable(iter2, killList);
 
-        Iterator<NodeId> iter3 = (needDistinct) ? Iter.distinct(iter2) : Iter.distinctAdjacent(iter2);
+        // Apply the necessary distinct calculation (if any)
+        Iterator<NodeId> iter3;
+        switch (distinctMode) {
+            case FULL:
+                iter3 = Iter.distinct(iter2);
+                break;
+            case ADJACENT:
+                iter3 = Iter.distinctAdjacent(iter2);
+                break;
+            case NONE:
+            default:
+                iter3 = iter2;
+                break;
+        }
         iter3 = makeAbortable(iter3, killList);
 
         Iterator<Node> iter4 = NodeLib.nodes(ds.getQuadTable().getNodeTupleTable().getNodeTable(), iter3);
@@ -180,17 +220,6 @@ public class SolverLibTDB
         final Var var = Var.alloc(graphNode);
         Iterator<Binding> iterBinding = Iter.map(iter4, node -> BindingFactory.binding(var, node));
         return new QueryIterAbortable(iterBinding, killList, input, execCxt);
-    }
-
-    private static TupleIndex findGraphIndex(TupleTable tupleTable, String indexPrefix) {
-        TupleIndex[] indexes = tupleTable.getIndexes();
-        for ( int i = 0 ; i < indexes.length ; i++ ) {
-            TupleIndex idx = indexes[i];
-            String n = idx.getName();
-            if ( n.startsWith(indexPrefix) )
-                return idx;
-        }
-        return null;
     }
 
     static Set<NodeId> convertToNodeIds(Collection<Node> nodes, DatasetGraphTDB dataset)

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/DatasetGraphTDB.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/DatasetGraphTDB.java
@@ -18,14 +18,18 @@
 
 package org.apache.jena.tdb2.store;
 
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.tuple.Tuple;
 import org.apache.jena.dboe.base.file.Location;
+import org.apache.jena.dboe.base.record.Record;
 import org.apache.jena.dboe.storage.StoragePrefixes;
 import org.apache.jena.dboe.storage.system.DatasetGraphStorage;
+import org.apache.jena.dboe.trans.bplustree.BPlusTree;
 import org.apache.jena.dboe.transaction.txn.TransactionalSystem;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
@@ -34,7 +38,10 @@ import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation;
 import org.apache.jena.tdb2.TDBException;
 import org.apache.jena.tdb2.lib.NodeLib;
 import org.apache.jena.tdb2.params.StoreParams;
+import org.apache.jena.tdb2.store.nodetable.NodeTable;
 import org.apache.jena.tdb2.store.nodetupletable.NodeTupleTable;
+import org.apache.jena.tdb2.store.tupletable.TupleIndex;
+import org.apache.jena.tdb2.store.tupletable.TupleIndexRecord;
 
 final
 public class DatasetGraphTDB extends DatasetGraphStorage
@@ -137,9 +144,24 @@ public class DatasetGraphTDB extends DatasetGraphStorage
     public Iterator<Node> listGraphNodes() {
         checkNotClosed();
         NodeTupleTable quads = getQuadTable().getNodeTupleTable();
+
+        TupleIndexRecord graphIndex = null;
+        for (TupleIndex index : quads.getTupleTable().getIndexes()) {
+            if (StringUtils.startsWith(index.getName(), "G") && index instanceof TupleIndexRecord)
+                graphIndex = (TupleIndexRecord) index;
+        }
+
+        if (graphIndex != null && graphIndex.getRangeIndex() instanceof BPlusTree) {
+            BPlusTree bpt = (BPlusTree) graphIndex.getRangeIndex();
+            Iterator<NodeId> distinctGraphNodeIds
+                    = Iter.iter(bpt.distinctByKeyPrefix(NodeId.SIZE)).map(r -> NodeIdFactory.get(r.getKey(), 0));
+            return NodeLib.nodes(quads.getNodeTable(), distinctGraphNodeIds);
+        }
+
         Iterator<Tuple<NodeId>> x = quads.findAll();
         // If we are using a Graph based index i.e. Graph is the first part of the record then we can use a more
         // efficient distinct implementation that only needs to remember the most recently seen graph name
+        // findAll() always uses the first index for the tuple table hence the assumption in the following test
         boolean usingGraphBasedIndex = StringUtils.startsWith(quads.getTupleTable().getIndex(0).getName(), "G");
         Iterator<NodeId> graphNodeIds = Iter.iter(x).map(t -> t.get(0));
         Iterator<NodeId> distinctGraphNodeIds
@@ -155,5 +177,62 @@ public class DatasetGraphTDB extends DatasetGraphStorage
         else
             // Includes Node.ANY and union graph
             return getQuadTable().getNodeTupleTable();
+    }
+
+    private static class DistinctKeyPrefixIterator implements Iterator<Node> {
+        private final BPlusTree bpt;
+        private final NodeTable nodeTable;
+        private Iterator<Record> records = null;
+        private byte[] lastKey = null;
+        private Record next = null;
+
+        public DistinctKeyPrefixIterator(BPlusTree bpt, NodeTable nodeTable) {
+            this.bpt = bpt;
+            this.nodeTable = nodeTable;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (this.records == null) {
+                this.records = this.bpt.iterator();
+            }
+            return this.next != null || this.moveToNext();
+        }
+
+        private boolean moveToNext() {
+            // Try to find the next record whose key prefix differs from the previously seen prefix
+            while (this.records.hasNext()) {
+                Record r = this.records.next();
+                byte[] currentKey = r.getKey();
+                if (this.lastKey == null) {
+                    // First time we've been called so just return the first record
+                    this.next = r;
+                    this.lastKey = currentKey;
+                    return true;
+                } else if (Arrays.compare(this.lastKey, 0, NodeId.SIZE, currentKey, 0, NodeId.SIZE) == 0) {
+                    // If the current record key prefix is the same as the last record key prefix we yielded then skip
+                    // this record
+                    continue;
+                } else {
+                    // Otherwise this is a different key prefix therefore we can yield this next
+                    this.next = r;
+                    this.lastKey = currentKey;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public Node next() {
+            if (this.next == null) {
+                if (!this.moveToNext()) throw new NoSuchElementException();
+            }
+            Record r = this.next;
+            this.next = null;
+            NodeId id = NodeIdFactory.get(r.getKey(), 0);
+            return nodeTable.getNodeForNodeId(id);
+        }
     }
 }

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/tupletable/TupleTable.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/tupletable/TupleTable.java
@@ -201,6 +201,44 @@ public class TupleTable implements Sync, Closeable
     /** Get i'th index */
     public TupleIndex getIndex(int i)                   { return indexes[i]; }
 
+    /**
+     * Selects an index that starts with the given prefix, used for internal execution optimisations that need to ensure
+     * they are accessing an index organised in a specific way.
+     * <p>
+     * If an optimisation needs access to a specific index type to function then it should use the
+     * {@link #selectIndex(String, Class)} overload providing the desired index implementation type.
+     * </p>
+     *
+     * @param prefix Index prefix
+     * @return Tuple Index, or {@code null} if no such index exists
+     */
+    public TupleIndex selectIndex(String prefix) {
+        return this.selectIndex(prefix, TupleIndex.class);
+    }
+
+    /**
+     * Selects an index that starts with the given prefix and is of the given implementation class.
+     * <p>
+     * Used for internal execution optimisation that need to access specific index types in specific ways.
+     * </p>
+     *
+     * @param prefix     Index Prefix
+     * @param indexType  Index implementation class
+     * @return Index, or {@code null} if no such index of the correct type exists
+     * @param <T> Index type
+     */
+    public <T extends TupleIndex> T selectIndex(String prefix, Class<T> indexType) {
+        if (indexes == null)
+            return null;
+        for ( int i = 0 ; i < indexes.length ; i++ ) {
+            TupleIndex idx = indexes[i];
+            String n = idx.getName();
+            if ( n.startsWith(prefix) && indexType.isAssignableFrom(idx.getClass()) )
+                return indexType.cast(idx);
+        }
+        return null;
+    }
+
     /** Get all indexes - for code that manipulates internal structures directly - use with care */
     public TupleIndex[] getIndexes()                    { return indexes; }
 

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/store/tupletable/TestTupleTable.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/store/tupletable/TestTupleTable.java
@@ -30,6 +30,7 @@ import org.apache.jena.atlas.lib.tuple.Tuple;
 import org.apache.jena.dboe.base.record.RecordFactory;
 import org.apache.jena.tdb2.store.NodeId;
 import org.apache.jena.tdb2.sys.SystemTDB;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestTupleTable
@@ -147,6 +148,41 @@ public class TestTupleTable
 
         Tuple<NodeId> e1 = x.get(0);
         assertEquals(tuple(n1, n2, n3) , e1);
+    }
+
+    @Test public void selectIndex1() {
+        TupleTable table = create();
+
+        // With no index type constraint should return an index for S, P and O but not G as test table doesn't have that
+        // index
+        TupleIndex byS = table.selectIndex("S");
+        Assert.assertNotNull(byS);
+        TupleIndex byP = table.selectIndex("P");
+        Assert.assertNotNull(byP);
+        TupleIndex byO = table.selectIndex("O");
+        Assert.assertNotNull(byO);
+        TupleIndex byG = table.selectIndex("G");
+        Assert.assertNull(byG);
+
+        // We're using TupleIndexRecord as the index type so this should select indexes for everything but G
+        TupleIndexRecord recordByS = table.selectIndex("S", TupleIndexRecord.class);
+        Assert.assertNotNull(recordByS);
+        TupleIndexRecord recordByP = table.selectIndex("P", TupleIndexRecord.class);
+        Assert.assertNotNull(recordByP);
+        TupleIndexRecord recordByO = table.selectIndex("O", TupleIndexRecord.class);
+        Assert.assertNotNull(recordByO);
+        TupleIndexRecord recordByG = table.selectIndex("G", TupleIndexRecord.class);
+        Assert.assertNull(recordByG);
+
+        // Using the wrong type constraint should select no index for anything
+        TupleIndexWrapper wrapperByS = table.selectIndex("S", TupleIndexWrapper.class);
+        Assert.assertNull(wrapperByS);
+        TupleIndexWrapper wrapperByP = table.selectIndex("P", TupleIndexWrapper.class);
+        Assert.assertNull(wrapperByP);
+        TupleIndexWrapper wrapperByO = table.selectIndex("O", TupleIndexWrapper.class);
+        Assert.assertNull(wrapperByO);
+        TupleIndexWrapper wrapperByG = table.selectIndex("G", TupleIndexWrapper.class);
+        Assert.assertNull(wrapperByG);
     }
 
 }


### PR DESCRIPTION
Adds a new `BPTreeDistinctKeyPrefixIterator` that allows iterating only records which are considered distinct based on a portion of their key.  It is effectively a skip scan based iterator that can avoid reading portions of the B+Tree where all records share the same key prefix.  This is used to improve performance of `DatasetGraphTDB.listGraphNodes()` and `SolverLibTDB.graphNames()`, in some cases dramatically so.

Used a couple of different test scenarios with calling `listGraphNodes()`:

- 100k named graphs comprising a total of 125 million quads
   - On 4.6.1 this takes an average of 21,480 milliseconds
   - With this patch this is reduced to 18,235 milliseconds
- 10 named graphs comprising a total of 177 million quads
   - On 4.6.1 this takes an average of 27,856 milliseconds 
   - With the previous patches (#1641 and #1642) this was reduced to an average of 25,185 milliseconds
   - With this new patch this is reduced to around 5 milliseconds 😄 

This resolves #1639