### PR TITLE
[GH-1661] Fix javadocs links

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/ontology/OntClass.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/OntClass.java
@@ -406,7 +406,7 @@ public interface OntClass
      * of a class</em>, by looking at the domains of the properties in this
      * class's model, and matching them to this class. A full description of
      * the frame-like view of a class may be found in:
-     * <a href="//how-to/rdf-frames.html">RDF frames how-to</a>
+     * <a href="/documentation/notes/rdf-frames.html">RDF frames how-to</a>
      * for full details.<p>
      * Note that many cases of determining whether a
      * property is associated with a class depends on RDFS or OWL reasoning.

--- a/jena-core/src/main/java/org/apache/jena/ontology/OntProperty.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/OntProperty.java
@@ -560,7 +560,7 @@ public interface OntProperty
      * that each returned class has this property as one of its
      * properties in {@link OntClass#listDeclaredProperties()}. This
      * simulates a frame-like view of properties and classes; for more
-     * details see the <a href="../../../../../../how-to/rdf-frames.html">
+     * details see the <a href="/documentation/notes/rdf-frames.html">
      * RDF frames how-to</a>.</p>
      * @return An iterator of the classes having this property as one
      * of their declared properties
@@ -572,7 +572,7 @@ public interface OntProperty
      * that each returned class has this property as one of its
      * properties in {@link OntClass#listDeclaredProperties(boolean)}. This
      * simulates a frame-like view of properties and classes; for more
-     * details see the <a href="../../../../../../how-to/rdf-frames.html">
+     * details see the <a href="/documentation/notes/rdf-frames.html">
      * RDF frames how-to</a>.</p>
      * @param direct If true, use only <em>direct</em> associations between classes
      * and properties

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OntPropertyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OntPropertyImpl.java
@@ -787,7 +787,7 @@ public class OntPropertyImpl
      * that each returned class has this property as one of its
      * properties in {@link OntClass#listDeclaredProperties()}. This
      * simulates a frame-like view of properties and classes; for more
-     * details see the <a href="../../../../../../how-to/rdf-frames.html">
+     * details see the <a href=/documentation/notes/rdf-frames.html">
      * RDF frames howto</a>.</p>
      * @return An iterator of the classes having this property as one
      * of their declared properties
@@ -802,7 +802,7 @@ public class OntPropertyImpl
      * that each returned class has this property as one of its
      * properties in {@link OntClass#listDeclaredProperties(boolean)}. This
      * simulates a frame-like view of properties and classes; for more
-     * details see the <a href="../../../../../../how-to/rdf-frames.html">
+     * details see the <a href="/documentation/notes/rdf-frames.html">
      * RDF frames howto</a>.</p>
      * @param direct If true, use only <em>direct</em> associations between classes
      * and properties


### PR DESCRIPTION
GitHub issue resolved #1661

Pull request Description:

I was adding a new `../`, replacing `how-tos` by `notes`... when I found in another place javadocs being linked with the `/path/to/file.html` link.

Applied that to the places the user reported in the mailing list, then did a quick search with Eclipse and replaced the other ones I could find :+1: 

----

 - [ ] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
