### PR TITLE
GH-1676: Helper methods for registered language retrieval

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserRegistry.java
@@ -22,6 +22,7 @@ import static org.apache.jena.riot.Lang.*;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -170,6 +171,16 @@ public class RDFParserRegistry
 
     /** return true if the language is registered with the quads parser factories */
     public static boolean isQuads(Lang lang)   { return langQuads.contains(lang); }
+
+    /** Return registered triple languages. */
+    public static Set<Lang> registeredLangTriples() {
+        return Collections.unmodifiableCollection(langTriples);
+    }
+
+    /** Return registered quad languages. */
+    public static Set<Lang> registeredLangQuads() {
+        return Collections.unmodifiableCollection(langQuads);
+    }
 
     // Parsers and factories.
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/resultset/ResultSetReaderRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/resultset/ResultSetReaderRegistry.java
@@ -22,6 +22,7 @@ import static org.apache.jena.riot.resultset.ResultSetLang.*;
 
 import java.io.InputStream ;
 import java.io.Reader ;
+import java.util.Collections;
 import java.util.HashMap ;
 import java.util.Map ;
 import java.util.Objects ;
@@ -76,6 +77,11 @@ public class ResultSetReaderRegistry {
         register(RS_None,     factory) ;
         register(RS_Thrift,   factory) ;
         register(RS_Protobuf, factory) ;
+    }
+    
+    /** Return registered result set languages. */
+    public static Set<Lang> registered() {
+        return Collections.unmodifiableCollection(registry.keySet());
     }
 
     private static class ResultSetReaderAdapter implements ResultSetReader {


### PR DESCRIPTION
GitHub issue resolved #1676

New registry methods that return registered triple/quad/result set languages.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
