### PR TITLE
edit not working on non root gsp-rw endpoint

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/cypress.config.js
+++ b/jena-fuseki2/jena-fuseki-ui/cypress.config.js
@@ -21,11 +21,11 @@ const vitePreprocessor = require('cypress-vite')
 module.exports = defineConfig({
   video: false,
   defaultCommandTimeout: 20000,
-  execTimeout: 15000,
-  taskTimeout: 15000,
-  pageLoadTimeout: 15000,
-  requestTimeout: 7500,
-  responseTimeout: 7500,
+  execTimeout: 30000,
+  taskTimeout: 30000,
+  pageLoadTimeout: 30000,
+  requestTimeout: 10000,
+  responseTimeout: 10000,
 
   e2e: {
     baseUrl: 'http://localhost:' + (process.env.PORT || 8080),
@@ -42,7 +42,11 @@ module.exports = defineConfig({
 
   env: {
     codeCoverage: {
-      exclude: 'cypress/**/*.*',
+      exclude: [
+        'src/services/mock/**/*.*',
+        'cypress/**/*.*',
+        'tests/**/*.*'
+      ],
     },
   },
 })

--- a/jena-fuseki2/jena-fuseki-ui/package.json
+++ b/jena-fuseki2/jena-fuseki-ui/package.json
@@ -10,12 +10,12 @@
     "serve": "vite preview",
     "build": "vite build",
     "test:unit": "vitest run --environment jsdom",
-    "test:e2e": "concurrently --names 'SERVER,CLIENT,TESTS' --prefix-colors 'yellow,blue,green' --success 'first' --kill-others 'yarn run serve:fuseki' 'yarn wait-on http://localhost:${FUSEKI_PORT}/ping && yarn run dev' 'yarn wait-on http-get://localhost:${PORT}/index.html && cypress run ${0}'",
+    "test:e2e": "cross-env FUSEKI_PORT=\"${FUSEKI_PORT:=3030}\" PORT=\"${PORT:=8080}\" concurrently --names 'SERVER,CLIENT,TESTS' --prefix-colors 'yellow,blue,green' --success 'first' --kill-others 'yarn run serve:fuseki' 'yarn wait-on http://localhost:${FUSEKI_PORT}/$/ping && yarn run dev' 'yarn wait-on http-get://localhost:${PORT}/index.html && cypress run $@'",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
-    "coverage:unit": "yarn run test:unit -- --coverage",
+    "coverage:unit": "yarn run test:unit --coverage",
     "coverage:e2e": "cross-env-shell CYPRESS_COVERAGE=true yarn run test:e2e",
     "serve:fuseki": "nodemon src/services/mock/json-server.js",
-    "serve:offline": "cross-env FUSEKI_PORT=\"${FUSEKI_PORT:=3030}\" PORT=\"${PORT:=8080}\" concurrently --names 'SERVER,CLIENT' --prefix-colors 'yellow,blue' --success 'first' --kill-others 'yarn run serve:fuseki' 'yarn wait-on http://localhost:${FUSEKI_PORT}/ping && yarn run dev'"
+    "serve:offline": "cross-env FUSEKI_PORT=\"${FUSEKI_PORT:=3030}\" PORT=\"${PORT:=8080}\" concurrently --names 'SERVER,CLIENT' --prefix-colors 'yellow,blue' --success 'first' --kill-others 'yarn run serve:fuseki' 'yarn wait-on http://localhost:${FUSEKI_PORT}/$/ping && yarn run dev'"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.2.0",

--- a/jena-fuseki2/jena-fuseki-ui/src/services/fuseki.service.js
+++ b/jena-fuseki2/jena-fuseki-ui/src/services/fuseki.service.js
@@ -181,9 +181,31 @@ class FusekiService {
     return results
   }
 
-  async fetchGraph (datasetName, graphName) {
+  /**
+   * Get the data endpoint out of a list of server endpoints.
+   *
+   * For now we are simply returning the first non-empty, but that
+   * may change at some point.
+   *
+   * @private
+   * @param {string[]} serverEndpoints - list of server endpoints in the dataset (can be an empty list).
+   */
+  getDataEndpoint(serverEndpoints) {
+    return serverEndpoints.find(endpoint => endpoint !== '') || ''
+  }
+
+  /**
+   * Fetch a graph.
+   * @param {string} datasetName - Jena dataset name.
+   * @param {string[]} serverEndpoints - list of server endpoints in the dataset (can be an empty list).
+   * @param {string} graphName - name of the graph being accessed.
+   * @return {Promise<AxiosResponse<any>>}
+   */
+  async fetchGraph (datasetName, serverEndpoints, graphName) {
+    const dataEndpoint = this.getDataEndpoint(serverEndpoints)
+    const urlPart = `${datasetName}/${dataEndpoint}`
     return await axios
-      .get(this.getFusekiUrl(`/${datasetName}`), {
+      .get(this.getFusekiUrl(urlPart), {
         params: {
           graph: graphName
         },
@@ -193,9 +215,19 @@ class FusekiService {
       })
   }
 
-  async saveGraph (datasetName, graphName, code) {
+  /**
+   * Save a graph.
+   * @param {string} datasetName - Jena dataset name.
+   * @param {string[]} serverEndpoints - list of server endpoints in the dataset (can be an empty list).
+   * @param {string} graphName - name of the graph being accessed.
+   * @param {string} code - graph content.
+   * @return {Promise<AxiosResponse<any>>}
+   */
+  async saveGraph (datasetName, serverEndpoints, graphName, code) {
+    const dataEndpoint = this.getDataEndpoint(serverEndpoints)
+    const urlPart = `${datasetName}/${dataEndpoint}`
     return await axios
-      .put(this.getFusekiUrl(`/${datasetName}`), code, {
+      .put(this.getFusekiUrl(urlPart), code, {
         params: {
           graph: graphName
         },

--- a/jena-fuseki2/jena-fuseki-ui/src/services/mock/json-server.js
+++ b/jena-fuseki2/jena-fuseki-ui/src/services/mock/json-server.js
@@ -37,6 +37,8 @@ const startTime = new Date()
 
 // Add custom routes before JSON Server router
 
+server.get('/index.html', (req, res) => res.jsonp(''))
+
 // GET SERVER INFO
 server.get('/\\$/server', (req, res) => {
   res.jsonp({
@@ -244,16 +246,19 @@ server.get('/:datasetName/sparql', sparqlCallback)
 server.post('/:datasetName/sparql', sparqlCallback)
 
 // GRAPH
-server.get('/:datasetName', (req, res) => {
-  res
-    .status(200)
-    .set('Content-Type', 'text/turtle')
-    .send(`@prefix :      <https://example.org/book/> .
+const dataContent = `@prefix :      <https://example.org/book/> .
 @prefix dc:    <https://purl.org/dc/elements/1.1/> .
 @prefix ns:    <https://example.org/ns#> .
 @prefix vcard: <https://www.w3.org/2001/vcard-rdf/3.0#> .
 
-:book4  dc:title  "Harry Potter and the Goblet of Fire" .`)
+:book4  dc:title  "Harry Potter and the Goblet of Fire" .`
+
+// This gets called when you count the graphs
+server.get('/:datasetName/data', (req, res) => {
+  res
+    .status(200)
+    .set('Content-Type', 'text/turtle')
+    .send(dataContent)
 })
 
 // PING

--- a/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Edit.vue
+++ b/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Edit.vue
@@ -261,7 +261,11 @@ export default {
       this.loadingGraph = true
       this.selectedGraph = graphName
       try {
-        const result = await this.$fusekiService.fetchGraph(this.datasetName, graphName)
+        const dataEndpoint = this.services['gsp-rw']['srv.endpoints'].find(endpoint => endpoint !== '') || ''
+        const result = await this.$fusekiService.fetchGraph(
+          this.datasetName,
+          this.services['gsp-rw']['srv.endpoints'],
+          graphName)
         this.code = result.data
       } catch (error) {
         displayError(this, error)
@@ -277,7 +281,11 @@ export default {
       if (!this.saveGraphDisabled) {
         this.loadingGraph = true
         try {
-          await this.$fusekiService.saveGraph(this.datasetName, this.selectedGraph, this.content)
+          await this.$fusekiService.saveGraph(
+            this.datasetName,
+            this.services['gsp-rw']['srv.endpoints'],
+            this.selectedGraph,
+            this.content)
           displayNotification(this, `Graph updated for dataset "${this.datasetName}"`)
         } catch (error) {
           displayError(this, error)

--- a/jena-fuseki2/jena-fuseki-ui/tests/e2e/specs/datasets.cy.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/e2e/specs/datasets.cy.js
@@ -22,31 +22,41 @@
  * add new datasets. So we also cover parts of the Manage view.
  */
 describe('datasets', () => {
-  it('Visits datasets page, also the application landing-page', () => {
-    cy.visit('/')
-    cy
-      .contains('Loading')
-      .should('not.exist')
-    cy
-      .get('h2.text-center')
-      .contains('Apache Jena Fuseki')
-    cy
-      .get('tr.jena-table-empty')
-      .contains('No datasets created')
+  describe('without any datasets', () => {
+    before(() => {
+      // Special endpoint that clears the datasets data.
+      cy.request('/tests/reset')
+    })
+    after(() => {
+      // Special endpoint that clears the datasets data.
+      cy.request('/tests/reset')
+    })
+    it('Visits datasets page, also the application landing-page', () => {
+      cy.visit('/')
+      cy
+        .contains('Loading')
+        .should('not.exist')
+      cy
+        .get('h2.text-center')
+        .contains('Apache Jena Fuseki')
+      cy
+        .get('tr.jena-table-empty')
+        .contains('No datasets created')
+    })
+    it('Filters without any data', () => {
+      cy.visit('/')
+      cy
+        .contains('Loading')
+        .should('not.exist')
+      cy
+        .get('#filterInput')
+        .type('pumpkin')
+      cy
+        .get('tr.jena-table-empty-filtered')
+        .contains('No datasets found')
+    })
   })
-  it('Filters without any data', () => {
-    cy.visit('/')
-    cy
-      .contains('Loading')
-      .should('not.exist')
-    cy
-      .get('#filterInput')
-      .type('pumpkin')
-    cy
-      .get('tr.jena-table-empty-filtered')
-      .contains('No datasets found')
-  })
-  describe('After creating new datasets', () => {
+  describe('after creating new datasets', () => {
     before(() => {
       // Special endpoint that clears the datasets data.
       cy.request('/tests/reset')
@@ -78,7 +88,10 @@ describe('datasets', () => {
     })
     it('Edits the graph', () => {
       cy.visit('/#/dataset/a/edit')
-      cy.intercept('/a*').as('getGraph')
+      cy.intercept({
+        method: 'GET',
+        url: '/a/data*'
+      }).as('getGraph')
       cy
         .contains('Loading')
         .should('not.exist')
@@ -117,7 +130,7 @@ describe('datasets', () => {
         .eq(0)
         .find('a')
         .first()
-        .click()
+        .click({ force: true })
       cy.wait('@getGraph')
       cy
         .get('.CodeMirror-code')

--- a/jena-fuseki2/jena-fuseki-ui/tests/e2e/specs/query.cy.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/e2e/specs/query.cy.js
@@ -19,7 +19,7 @@
  * Tests the Query view and YASGUI & family components.
  */
 describe('Query', () => {
-  before(() => {
+  beforeEach(() => {
     // Special endpoint that clears the datasets data.
     cy.request('/tests/reset')
     // Create a sample dataset.
@@ -41,7 +41,7 @@ describe('Query', () => {
           .should('be.visible')
       })
   })
-  after(() => {
+  afterEach(() => {
     // Special endpoint that clears the datasets data.
     cy.request('/tests/reset')
   })

--- a/jena-fuseki2/jena-fuseki-ui/tests/unit/services/fuseki.service.spec.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/unit/services/fuseki.service.spec.js
@@ -283,8 +283,11 @@ describe('FusekiService', () => {
     stub.resolves(Promise.resolve({
       data: 42
     }))
-    const graph = await fusekiService.fetchGraph('jena', 'default')
+    const graph = await fusekiService.fetchGraph('jena', ['dataEndpoint'], 'default')
     expect(stub.called).to.equal(true)
+    const getArgs = stub.getCall(0).args
+    // See https://github.com/apache/jena/pull/1679
+    expect(getArgs[0]).to.equal('/jena/dataEndpoint')
     expect(graph).to.deep.equal({ data: 42 })
     stub.restore()
   })
@@ -293,7 +296,7 @@ describe('FusekiService', () => {
     stub.resolves(Promise.resolve({
       data: 42
     }))
-    const graph = await fusekiService.saveGraph('jena', 'default', 'abc')
+    const graph = await fusekiService.saveGraph('jena', [], 'default', 'abc')
     expect(stub.called).to.equal(true)
     expect(graph).to.deep.equal({ data: 42 })
     stub.restore()
@@ -306,7 +309,7 @@ describe('FusekiService', () => {
     }
     stub.resolves(Promise.reject(error))
     try {
-      await fusekiService.saveGraph('jena', 'default', 'abc')
+      await fusekiService.saveGraph('jena', [], 'default', 'abc')
       expect.fail('Not supposed to get here')
     } catch (error) {
       expect(error.message).to.be.equal('42')

--- a/jena-fuseki2/jena-fuseki-ui/vite.config.js
+++ b/jena-fuseki2/jena-fuseki-ui/vite.config.js
@@ -26,7 +26,12 @@ export default defineConfig({
     vue(),
     istanbul({
       include: "src/*",
-      exclude: ["node_modules"],
+      exclude: [
+        "node_modules",
+        "tests",
+        "coverage",
+        "src/services/mock/*"
+      ],
       extension: [".js", ".jsx", ".ts", ".vue"],
       requireEnv: true,
       cypress: true
@@ -68,6 +73,7 @@ export default defineConfig({
           // or that are requesting /node_modules/ (dev Vite/Vue/JS modules).
           const sendToUI =
             req.method !== 'POST' &&
+            req.url.indexOf('tests/reset') < 0 &&
             (
               (req.hasOwnProperty('originalUrl') && req.originalUrl.includes('node_modules')) ||
               (


### PR DESCRIPTION
GitHub issue resolved #1679

Pull request Description:

I found that the "edit" tab of Fuseki-UI would not allow me to edit my dataset when there is only e.g.

```
fuseki:endpoint [ fuseki:name "data" ; fuseki:operation fuseki:gsp-rw ; ]  ;
```

this patch seems to fix it


----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
