### PR TITLE
Allow triggering GitHub Actions via label

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,7 +2,10 @@
 
 name: Apache Jena CI
 # Manual
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
 
 #  push:
 #    branches: [ main ]
@@ -16,6 +19,8 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
+
+    if: ${{ (github.event.action == 'labeled' && github.event.label.name == 'run-actions') || github.event.action != 'labeled' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This allows for the GitHub Actions to be triggered for a PR by adding a run-actions label to that PR.  This then allows project members and/or contributors to have their PRs explicitly tested prior to us merging them.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
