### PR TITLE
configurable yasgui prefix and query

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/src/services/fuseki.service.js
+++ b/jena-fuseki2/jena-fuseki-ui/src/services/fuseki.service.js
@@ -22,6 +22,39 @@ import { BUS } from '@/events'
 
 const DATASET_SIZE_QUERY_1 = 'select (count(*) as ?count) {?s ?p ?o}'
 const DATASET_SIZE_QUERY_2 = 'select ?g (count(*) as ?count) {graph ?g {?s ?p ?o}} group by ?g'
+const CONF_DATASET_NAME = 'yasgui-config'
+const CONF_EXAMPLE_QUERIES_QUERY = `PREFIX conf: <https://yasgui.triply.cc/config#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
+PREFIX list: <http://jena.apache.org/ARQ/list#>
+JSON {
+ "text": ?text,
+ "value": ?value
+} WHERE {
+  ?root sd:endpoint "/@DATASET_NAME@/" .
+  ?root conf:exampleQueries ?list .
+  ?list list:index (?idx ?ex) .
+  ?ex rdfs:label ?text .
+  ?ex conf:query ?value .
+}
+ORDER BY ?idx`
+const CONF_PREFIXES_QUERY = `PREFIX conf: <https://yasgui.triply.cc/config#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
+PREFIX sd: <http://www.w3.org/ns/sparql-service-description#>
+PREFIX list: <http://jena.apache.org/ARQ/list#>
+JSON {
+ "text": ?text,
+ "uri": ?uri
+} WHERE {
+  ?root sd:endpoint "/@DATASET_NAME@/" .
+  ?root conf:prefixes ?list .
+  ?list list:index (?idx ?ex) .
+  ?ex rdfs:label ?text .
+  ?ex conf:uri ?uri .
+}
+ORDER BY ?idx`
 
 class FusekiService {
   /**
@@ -207,6 +240,28 @@ class FusekiService {
       .catch(error => {
         throw new Error(error.response.data)
       })
+  }
+
+  async getYasguiExampleQueries (datasetName) {
+    return await axios
+      .get(this.getFusekiUrl(`/${CONF_DATASET_NAME}`), {
+        params: {
+          query: CONF_EXAMPLE_QUERIES_QUERY.replaceAll("@DATASET_NAME@", datasetName)
+        }
+      })
+  }
+
+  async getYasguiPrefixes (datasetName) {
+    return await axios
+      .get(this.getFusekiUrl(`/${CONF_DATASET_NAME}`), {
+        params: {
+          query: CONF_PREFIXES_QUERY.replaceAll("@DATASET_NAME@", datasetName)
+        }
+      })
+  }
+
+  getYasguiConfigDsName () {
+    return CONF_DATASET_NAME
   }
 }
 

--- a/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Query.vue
+++ b/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Query.vue
@@ -345,9 +345,21 @@ export default {
     datasetUrl: function (val, oldVal) {
       this.currentDatasetUrl = val
     },
-    currentDatasetUrl: function (val, oldVal) {
+    currentDatasetUrl: async function (val, oldVal) {
       if (this.yasqe) {
         this.yasqe.options.requestConfig.endpoint = this.$fusekiService.getFusekiUrl(val)
+      }
+      if (this.serverData.datasets.find((ds) => ds['ds.name'] === `/${this.$fusekiService.getYasguiConfigDsName()}`)) {
+        const [queries_res, prefixes_res] = await Promise.all([
+          this.$fusekiService.getYasguiExampleQueries(this.datasetName),
+          this.$fusekiService.getYasguiPrefixes(this.datasetName)
+        ])
+        if (queries_res.data.length !== 0) {
+          this.queries.splice(0, Infinity, ...queries_res.data)
+        }
+        if (prefixes_res.data.length !== 0) {
+          this.prefixes.splice(0, Infinity, ...prefixes_res.data)
+        }
       }
     },
     contentTypeSelect: function (val, oldVal) {


### PR DESCRIPTION
GitHub issue resolved #1680

Pull request Description:

fusekiUI will look for a dataset named yasgui-config to load Example Queries and Prefixes based on the current dataset name


----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
