### PR TITLE
GH-1693: Resizeable query editor

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Query.vue
+++ b/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Query.vue
@@ -289,7 +289,7 @@ export default {
           document.getElementById('yasqe'),
           {
             showQueryButton: true,
-            resizeable: false,
+            resizeable: true,
             requestConfig: {
               endpoint: this.$fusekiService.getFusekiUrl(this.currentDatasetUrl)
             },

--- a/jena-fuseki2/jena-fuseki-ui/tests/e2e/specs/query.cy.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/e2e/specs/query.cy.js
@@ -76,4 +76,31 @@ describe('Query', () => {
       .its('response')
       .should('have.property', 'statusCode', 203)
   })
+  it('Can resize the query editor', () => {
+    cy.visit('/#/dataset/skosmos/query')
+    cy
+      .get('div.CodeMirror')
+      .should('be.visible')
+      .invoke('css', 'height')
+      .as('beforeHeight')
+    cy
+      .get('div.resizeChip')
+      .should('exist')
+      .trigger('mousedown', {
+        which: 1, force: true
+      })
+      .trigger('mousemove', { which: 1, force: true, x: 0, y: 50 })
+      .trigger('mouseup', {
+        force: true
+      });
+    cy
+      .get('div.CodeMirror')
+      .invoke('css', 'height')
+      .as('afterHeight')
+    cy.get('@beforeHeight').then(beforeHeight => {
+      cy.get('@afterHeight').then(afterHeight => {
+        expect(afterHeight).to.not.equal(beforeHeight)
+      })
+    })
+  })
 })


### PR DESCRIPTION
GitHub issue resolved #1693

Pull request Description:

a tiny Quality of Live improvement, enable resizeable in the fusekiUI Query editor. That way you can (maybe you still should not!) also view larger queries

test written by @kinow


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
