### PR TITLE
GH-1686: fix recursive delete on macos for service enhancer TestServiceEnhancerDatasetAssembler test

### DIFF
--- a/jena-extras/jena-serviceenhancer/src/test/java/org/apache/jena/sparql/service/enhancer/assembler/TestServiceEnhancerDatasetAssembler.java
+++ b/jena-extras/jena-serviceenhancer/src/test/java/org/apache/jena/sparql/service/enhancer/assembler/TestServiceEnhancerDatasetAssembler.java
@@ -18,12 +18,13 @@
 
 package org.apache.jena.sparql.service.enhancer.assembler;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 
-import org.apache.jena.ext.com.google.common.io.MoreFiles;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.QueryExecException;
@@ -171,7 +172,10 @@ public class TestServiceEnhancerDatasetAssembler
 
             Assert.assertEquals(4, actualRowCount);
         } finally {
-            MoreFiles.deleteRecursively(tdb2TmpFolder);
+            Files.walk(tdb2TmpFolder)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
         }
     }
 }


### PR DESCRIPTION
GH-1686: fix recursive delete on macos for service enhancer TestServiceEnhancerDatasetAssembler test

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>

GitHub issue resolved #1686 

Pull request Description: Modifies post-test cleanup with recursive temp dir delete using standard Java NIO2 code.



----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [X] Commits have been squashed to remove intermediate development commit messages.
 - [X] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
