### PR TITLE
GH-1688 Fix possible incomplete results with service enhaner caching + bulk

### DIFF
--- a/jena-extras/jena-serviceenhancer/src/main/java/org/apache/jena/sparql/service/enhancer/impl/OpServiceInfo.java
+++ b/jena-extras/jena-serviceenhancer/src/main/java/org/apache/jena/sparql/service/enhancer/impl/OpServiceInfo.java
@@ -93,7 +93,7 @@ public class OpServiceInfo {
 
         // Handling of a null supOp - can that happen?
         Set<Var> visibleSubOpVars = OpVars.visibleVars(baseSubOp);
-        this.visibleSubOpVarsScopedToNorm = VarScopeUtils.normalizeVarScopesGlobal(visibleSubOpVars);
+        this.visibleSubOpVarsScopedToNorm = VarScopeUtils.normalizeVarScopes(visibleSubOpVars);
 
         this.normedQuery = OpAsQuery.asQuery(normedQueryOp);
 


### PR DESCRIPTION
GitHub issue resolved #1688

Pull request Description: Fixes registration of an empty iterator in case a cache hit reveals an empty result set.

----

 - [x] Tests are included.
 - ~~[ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)~~
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
