### PR TITLE
GH-1713: Use ARQ timezone for adjust

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDDuration.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDDuration.java
@@ -26,7 +26,7 @@ import org.apache.jena.sparql.expr.Expr;
 import javax.xml.datatype.DatatypeConstants.Field;
 
 /**
- * Functions relating to XSD durations (F&O 3.1), using
+ * Functions relating to XSD durations (F&amp;O 3.1), using
  * {@code javax.xml.datatype.Duration}
  */
 public class XSDDuration {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -1676,19 +1676,7 @@ public class XSDFuncOp
     // minutes are used for the timezone in XMLGregorianCalendar
     private static final int implicitTimezoneMinutes() { return 0; }
 
-    // Server-local timezone
-    //    private static NodeValue serverTimezone() {
-    //    }
-    //
-    //    /**
-    //     * Calculate the server current local timezone in minutes
-    //     */
-    //    private static int localTimezoneOffsetMinutes() {
-    //        return TimeZone.getDefault().getOffset(new Date().getTime())/(1000*60);
-    //    }
-
     /**
-     *
      * <a href="https://www.w3.org/TR/xpath-functions-3/#func-implicit-timezone">Implciit Timezone</a>
      * // https://www.w3.org/TR/xpath-functions-3/#comp.datetime
      */

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestFunctions.java
@@ -74,7 +74,9 @@ public class TestFunctions
     @Test public void exprSprintf_21() { test_exprSprintf_tz_exact("2005-10-14T12:09:43+00:00") ; }
     // Timezone +11:00 can be a day behind
     @Test public void exprSprintf_22() { test_exprSprintf_tz_exact("2005-10-14T10:09:43+11:00") ; }
+
     private static void test_exprSprintf_tz_exact(String nodeStr) {
+        // JVM default timezone.
         String exprStr = "afn:sprintf('%1$tm %1$te,%1$tY', "+NodeValue.makeDateTime(nodeStr).toString()+")" ;
         Expr expr = ExprUtils.parse(exprStr) ;
         NodeValue r = expr.eval(null, LibTestExpr.createTest()) ;
@@ -89,7 +91,7 @@ public class TestFunctions
         } catch (ParseException e) {
             assertFalse("Cannot parse the input date string. Message:"+e.getMessage(),false);
         }
-        // print the date based on the current timeZone.
+        // print the date based on the JVM timezone.
         SimpleDateFormat stdFormatOut = new SimpleDateFormat("MM dd,yyyy");
         stdFormatOut.setTimeZone(TimeZone.getDefault());
         String outDate = stdFormatOut.format(dtDate);

--- a/jena-arq/src/test/java/org/apache/jena/sparql/function/library/TestFnFunctionsDateTimeDuration.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/function/library/TestFnFunctionsDateTimeDuration.java
@@ -20,15 +20,13 @@ package org.apache.jena.sparql.function.library;
 import static org.apache.jena.sparql.expr.LibTestExpr.test;
 import static org.junit.Assert.fail;
 
-import java.util.Date;
-import java.util.TimeZone;
-
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprEvalException;
 import org.apache.jena.sparql.expr.LibTestExpr;
 import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp;
 import org.apache.jena.sparql.util.ExprUtils;
 import org.apache.jena.sys.JenaSystem ;
 import org.junit.Test ;
@@ -142,13 +140,13 @@ public class TestFnFunctionsDateTimeDuration {
     @Test public void exprAdjustDatetimeToTz_01(){
         test(
             "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00'^^xsd:dateTime)",
-            "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00'^^xsd:dateTime,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+            "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00'^^xsd:dateTime,"+getTimezoneDurationString()+")");
     }
 
     @Test public void exprAdjustDatetimeToTz_02(){
         test(
             "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00-07:00'^^xsd:dateTime)",
-            "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00-07:00'^^xsd:dateTime,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+            "fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00-07:00'^^xsd:dateTime,"+getTimezoneDurationString()+")");
     }
 
     @Test public void exprAdjustDatetimeToTz_03() { test("fn:adjust-dateTime-to-timezone('2002-03-07T10:00:00'^^xsd:dateTime,'-PT10H'^^xsd:dayTimeDuration)",NodeValue.makeDateTime("2002-03-07T10:00:00-10:00"));}
@@ -166,13 +164,13 @@ public class TestFnFunctionsDateTimeDuration {
     @Test public void exprAdjustDateToTz_01(){
         test(
             "fn:adjust-date-to-timezone('2002-03-07'^^xsd:date)",
-            "fn:adjust-date-to-timezone('2002-03-07'^^xsd:date,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+            "fn:adjust-date-to-timezone('2002-03-07'^^xsd:date,"+getTimezoneDurationString()+")");
     }
 
     @Test public void exprAdjustDateToTz_02(){
         test(
             "fn:adjust-date-to-timezone('2002-03-07-07:00'^^xsd:date)",
-            "fn:adjust-date-to-timezone('2002-03-07-07:00'^^xsd:date,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+            "fn:adjust-date-to-timezone('2002-03-07-07:00'^^xsd:date,"+getTimezoneDurationString()+")");
     }
 
     @Test public void exprAdjustDateToTz_03() { test("fn:adjust-date-to-timezone('2002-03-07'^^xsd:date,'-PT10H'^^xsd:dayTimeDuration)",NodeValue.makeDate("2002-03-07-10:00"));}
@@ -186,13 +184,13 @@ public class TestFnFunctionsDateTimeDuration {
     @Test public void exprAdjustTimeToTz_01(){
         test(
             "fn:adjust-time-to-timezone('10:00:00'^^xsd:time)",
-            "fn:adjust-time-to-timezone('10:00:00'^^xsd:time,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+            "fn:adjust-time-to-timezone('10:00:00'^^xsd:time,"+getTimezoneDurationString()+")");
     }
 
     @Test public void exprAdjustTimeToTz_02(){
         test(
             "fn:adjust-time-to-timezone('10:00:00-07:00'^^xsd:time)",
-            "fn:adjust-time-to-timezone('10:00:00-07:00'^^xsd:time,'"+getDynamicDurationString()+"'^^xsd:dayTimeDuration)");
+            "fn:adjust-time-to-timezone('10:00:00-07:00'^^xsd:time,"+getTimezoneDurationString()+")");
     }
 
     @Test public void exprAdjustTimeToTz_03() { test("fn:adjust-time-to-timezone('10:00:00'^^xsd:time,'-PT10H'^^xsd:dayTimeDuration)",NodeValue.makeNode("10:00:00-10:00",XSDDatatype.XSDtime));}
@@ -208,14 +206,9 @@ public class TestFnFunctionsDateTimeDuration {
 
     @Test public void localTimezone_1() { test("fn:implicit-timezone()", nv->nv.isDayTimeDuration()); }
 
-    private String getDynamicDurationString(){
-        int tzOffset = TimeZone.getDefault().getOffset(new Date().getTime()) / (1000*60);
-        String off = "PT"+Math.abs(tzOffset)+"M";
-        if(tzOffset < 0)
-            off = "-"+off;
-        return off;
+    /** Return syntax for the timezone as a day-time duration */
+    private String getTimezoneDurationString(){
+        // Timezone for ARQ is not the JVM timezone.
+        return XSDFuncOp.implicitTimezone().asQuotedString();
     }
-
-
-
 }


### PR DESCRIPTION
Pull request Description:
Another use of the JVM default timezone. This time in `TestFnFunctionsDateTimeDuration`.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
