### PR TITLE
fix(sec): upgrade org.apache.shiro:shiro-web to 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <ver.lucene>9.4.2</ver.lucene>
 
     <ver.jetty>10.0.13</ver.jetty>
-    <ver.shiro>1.10.1</ver.shiro>
+    <ver.shiro>1.11.0</ver.shiro>
 
     <ver.protobuf>3.21.12</ver.protobuf>
     <ver.libthrift>0.17.0</ver.libthrift>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.shiro:shiro-web 1.10.1
- [CVE-2023-22602](https://www.oscs1024.com/hd/CVE-2023-22602)


### What did I do？
Upgrade org.apache.shiro:shiro-web from 1.10.1 to 1.11.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS