### PR TITLE
Add wait-on with concurrently, and simplify packages…

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/README.md
+++ b/jena-fuseki2/jena-fuseki-ui/README.md
@@ -32,3 +32,13 @@ YASGUI and Axios.
   - Starts a fake Fuseki backend with responses saves from a real instance. Used to test the UI without the backend, and for e2e tests.
 - `serve:offline`
   - Runs both the serve:offline and the serve scripts to serve the UI offline.
+
+For every command above that starts Vite (default port `8080`) or Fuseki (default port `3030`), you
+can customize the ports used. For example:
+
+```bash
+FUSEKI_PORT=9999 yarn run serve:fuseki
+PORT=1313 FUSEKI_PORT=9999 yarn run serve:offline
+FUSEKI_PORT=3031 PORT=8081 yarn run test:e2e
+...
+```

--- a/jena-fuseki2/jena-fuseki-ui/cypress.config.js
+++ b/jena-fuseki2/jena-fuseki-ui/cypress.config.js
@@ -28,7 +28,7 @@ module.exports = defineConfig({
   responseTimeout: 7500,
 
   e2e: {
-    baseUrl: 'http://localhost:8080/',
+    baseUrl: 'http://localhost:' + (process.env.PORT || 8080),
     setupNodeEvents (on, config) {
       on('file:preprocessor', vitePreprocessor())
       return require('./tests/e2e/plugins/index.js')(on, config)

--- a/jena-fuseki2/jena-fuseki-ui/package.json
+++ b/jena-fuseki2/jena-fuseki-ui/package.json
@@ -7,15 +7,15 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "vite",
-    "serve": "vite preview --port 8080",
+    "serve": "vite preview",
     "build": "vite build",
     "test:unit": "vitest run --environment jsdom",
-    "test:e2e": "bash -c 'concurrently --names \"SERVER,TESTS\" --prefix-colors \"yellow,blue\" --success \"first\" --kill-others \"yarn run serve:offline\" \"cross-env CYPRESS_COVERAGE=false cypress run ${0}\"'",
+    "test:e2e": "concurrently --names 'SERVER,CLIENT,TESTS' --prefix-colors 'yellow,blue,green' --success 'first' --kill-others 'yarn run serve:fuseki' 'yarn wait-on http://localhost:${FUSEKI_PORT}/ping && yarn run dev' 'yarn wait-on http-get://localhost:${PORT}/index.html && cypress run ${0}'",
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
-    "coverage:unit": "vitest run --environment jsdom --coverage",
-    "coverage:e2e": "bash -c 'concurrently --names \"SERVER,TESTS\" --prefix-colors \"yellow,blue\" --success \"first\" --kill-others \"yarn run serve:offline\" \"cross-env CYPRESS_COVERAGE=true cypress run ${0}\"'",
+    "coverage:unit": "yarn run test:unit -- --coverage",
+    "coverage:e2e": "cross-env-shell CYPRESS_COVERAGE=true yarn run test:e2e",
     "serve:fuseki": "nodemon src/services/mock/json-server.js",
-    "serve:offline": "concurrently --names 'SERVER,CLIENT' --prefix-colors 'yellow,blue' --success \"first\" --kill-others 'yarn run serve:fuseki' 'yarn run dev'"
+    "serve:offline": "cross-env FUSEKI_PORT=\"${FUSEKI_PORT:=3030}\" PORT=\"${PORT:=8080}\" concurrently --names 'SERVER,CLIENT' --prefix-colors 'yellow,blue' --success 'first' --kill-others 'yarn run serve:fuseki' 'yarn wait-on http://localhost:${FUSEKI_PORT}/ping && yarn run dev'"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
@@ -42,7 +42,7 @@
     "@vue/compiler-sfc": "^3.2.39",
     "@vue/eslint-config-standard": "^8.0.1",
     "@vue/test-utils": "^2.0.2",
-    "concurrently": "^7.4.0",
+    "concurrently": "^7.6.0",
     "cross-env": "^7.0.3",
     "cypress": "^12.1.0",
     "cypress-vite": "^1.3.0",
@@ -61,7 +61,8 @@
     "sinon": "^14.0.0",
     "vite": "^4.0.4",
     "vite-plugin-istanbul": "^4.0.0",
-    "vitest": "^0.27.1"
+    "vitest": "^0.27.1",
+    "wait-on": "^7.0.1"
   },
   "overrides": {
     "terser": "^5.14.2",

--- a/jena-fuseki2/jena-fuseki-ui/pom.xml
+++ b/jena-fuseki2/jena-fuseki-ui/pom.xml
@@ -109,16 +109,11 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
-                          <!--
-                               An unstable test. 
-                               https://github.com/apache/jena/issues/1644 
-                          -->
-                            <testFailureIgnore>true</testFailureIgnore>
                             <environmentVariables>
                                 <PORT>${org.apache.jena.fuseki.ui.port}</PORT>
                                 <FUSEKI_PORT>${org.apache.jena.fuseki.port}</FUSEKI_PORT>
                             </environmentVariables>
-                            <arguments>run test:e2e -- --headless --browser chrome</arguments>
+                            <arguments>run test:e2e</arguments>
                         </configuration>
                     </execution>
                 </executions>

--- a/jena-fuseki2/jena-fuseki-ui/vite.config.js
+++ b/jena-fuseki2/jena-fuseki-ui/vite.config.js
@@ -49,7 +49,8 @@ export default defineConfig({
     sourcemap: 'inline',
   },
   server: {
-    port: 8080,
+    // Default, can be overridden by `--port 1234` in package.json
+    port: process.env.PORT || 8080,
     // The proxy is used for the `dev` target, for e2e tests, rapid development in the IDE, etc.
     proxy: {
       '/': {

--- a/jena-fuseki2/jena-fuseki-ui/yarn.lock
+++ b/jena-fuseki2/jena-fuseki-ui/yarn.lock
@@ -431,6 +431,18 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.3.tgz#633e2998d11f7d4ed41f0d5ea461a22ec9b9d034"
   integrity sha512-KCPHi9QemVXGMrfuwf3nNnNo129resAIQWut9QTAMXmXqL2ErABC6ohd2yY5Ipq0CLWNbKHk8TMdTXL/Zf3ZhA==
 
+"@hapi/hoek@^9.0.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.3.0.tgz#8368869dcb735be2e7f5cb7647de78e167a251fb"
+  integrity sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==
+
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -531,6 +543,23 @@
   version "2.11.6"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
+
+"@sideway/address@^4.1.3":
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"
+  integrity sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.1.tgz#80fcbcbaf7ce031e0ef2dd29b1bfc7c3f583611f"
+  integrity sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.6"
@@ -1511,7 +1540,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-concurrently@^7.4.0:
+concurrently@^7.6.0:
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-7.6.0.tgz#531a6f5f30cf616f355a4afb8f8fcb2bba65a49a"
   integrity sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==
@@ -3287,6 +3316,17 @@ jju@^1.1.0:
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
 
+joi@^17.7.0:
+  version "17.7.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.7.0.tgz#591a33b1fe1aca2bc27f290bcad9b9c1c570a6b3"
+  integrity sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
+
 jquery@>=1.7, jquery@^3.5.0:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.3.tgz#23ed2ffed8a19e048814f13391a19afcdba160e6"
@@ -3739,7 +3779,7 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
@@ -4476,7 +4516,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^7.0.0, rxjs@^7.5.1:
+rxjs@^7.0.0, rxjs@^7.5.1, rxjs@^7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
   integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
@@ -5284,6 +5324,17 @@ w3c-xmlserializer@^4.0.0:
   integrity sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==
   dependencies:
     xml-name-validator "^4.0.0"
+
+wait-on@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-7.0.1.tgz#5cff9f8427e94f4deacbc2762e6b0a489b19eae9"
+  integrity sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==
+  dependencies:
+    axios "^0.27.2"
+    joi "^17.7.0"
+    lodash "^4.17.21"
+    minimist "^1.2.7"
+    rxjs "^7.8.0"
 
 webidl-conversions@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
….json scripts. Add docs.

GitHub issue resolved #1644

Pull request Description:

@afs, I re-read the Cypress docs and found [this page](https://docs.cypress.io/guides/continuous-integration/introduction) talking about CI and Cypress, where they mention ways to control the order of initialization of a service like our Fuseki. I replaced `concurrently` by `start-server-and-test`, since otherwise we would have to bring `wait-on` as an extra dependency.

To review this, someone (able to reproduce the issue linked :grimacing: ) would have to run it a few times to confirm it's gone, and that everything works OK. I got the impression that `start-server-and-test` runs the Cypress tests faster than `concurrently`, but I could be wrong.

----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
