### PR TITLE
GH-1745: fix plus sharing

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/src/utils/query.js
+++ b/jena-fuseki2/jena-fuseki-ui/src/utils/query.js
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Utility functions for query components and views.
+ *
+ * Useful to separate code that can be easily tested without having to
+ * instantiate a complete component or view.
+ */
+
+import queryString from 'query-string'
+
+/**
+ * Create a shareable link using the value of the SPARQL query in the
+ * YASQE editor and compose a safe link to be used in the browser.
+ *
+ * Based on YASGUI code, but modified to avoid parsing the Vue Route query
+ * hash. Note that we cannot use `document.location.hash` since it could
+ * contain the ?query=... too. Instead, we must use Vue Route path value.
+ *
+ * The query is escaped with the same code as YASGUI.
+ *
+ * @param {string} query
+ * @param {string} path
+ * @return {string}
+ */
+export function createShareableLink (query, path) {
+  return (
+    document.location.protocol +
+    '//' +
+    document.location.host +
+    document.location.pathname +
+    document.location.search +
+    '#' +
+    path +
+    '?' +
+    // Same as YASGUI does, good idea to avoid security problems...
+    queryString.stringify({ query })
+  )
+}

--- a/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Query.vue
+++ b/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Query.vue
@@ -309,9 +309,9 @@ export default {
                 document.location.search +
                 '#' +
                 vm.$route.path +
-                '?query=' +
+                '?' +
                 // Same as YASGUI does, good idea to avoid security problems...
-                queryString.stringify(queryString.parse(yasqe.getValue()))
+                queryString.stringify({'query':yasqe.getValue()})
               )
             }
           }

--- a/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Query.vue
+++ b/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Query.vue
@@ -182,7 +182,7 @@
 import Menu from '@/components/dataset/Menu.vue'
 import Yasqe from '@triply/yasqe'
 import Yasr from '@triply/yasr'
-import queryString from 'query-string'
+import { createShareableLink } from '@/utils/query'
 import { nextTick } from 'vue'
 import currentDatasetMixin from '@/mixins/current-dataset'
 import currentDatasetMixinNavigationGuards from '@/mixins/current-dataset-navigation-guards'
@@ -283,6 +283,11 @@ export default {
             persistenceId: null
           }
         )
+        // Curried function to create shareable links. YASQE expects a function
+        // that accepts only an instance of YASQE.
+        const curriedCreateShareableLink = yasqe => {
+          return createShareableLink(yasqe.getValue(), vm.$route.path)
+        }
         // query editor
         // NOTE: the full screen functionality was removed from YASQE: https://github.com/Triply-Dev/YASGUI.YASQE-deprecated/issues/139#issuecomment-573656137
         vm.yasqe = new Yasqe(
@@ -293,27 +298,7 @@ export default {
             requestConfig: {
               endpoint: this.$fusekiService.getFusekiUrl(this.currentDatasetUrl)
             },
-            /**
-             * Based on YASGUI code, but modified to avoid parsing the Vue Route query
-             * hash. Note that we cannot use `document.location.hash` since it could
-             * contain the ?query=... too. Instead, we must use Vue Route path value.
-             *
-             * @param {Yasqe} yasqe
-             */
-            createShareableLink: function (yasqe) {
-              return (
-                document.location.protocol +
-                '//' +
-                document.location.host +
-                document.location.pathname +
-                document.location.search +
-                '#' +
-                vm.$route.path +
-                '?' +
-                // Same as YASGUI does, good idea to avoid security problems...
-                queryString.stringify({'query':yasqe.getValue()})
-              )
-            }
+            createShareableLink: curriedCreateShareableLink
           }
         )
         vm.yasqe.on('queryResponse', (yasqe, response, duration) => {

--- a/jena-fuseki2/jena-fuseki-ui/tests/unit/components/serverstatus.vue.spec.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/unit/components/serverstatus.vue.spec.js
@@ -33,7 +33,6 @@ describe('ServerStatus', () => {
         mocks: {
           $fusekiService: {
             async getServerStatus () {
-              console.log('Hola!')
               count += 1
               return new ServerStatusModel(true, `OK ${count}`)
             }

--- a/jena-fuseki2/jena-fuseki-ui/tests/unit/utils/query.spec.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/unit/utils/query.spec.js
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest'
+import { createShareableLink } from '@/utils/query'
+
+describe('query', () => {
+  it('creates valid shareable links', () => {
+    // The expected prefix.
+    const prefix = 'https://host:1234/#/query/?query='
+    // The list of tests (parametrized tests). The expected value is the URL-encoded query value.
+    const tests = [
+      {
+        value: '',
+        expected: `${prefix}`
+      },
+      {
+        value: `PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT * WHERE {
+  ?sub ?pred ?obj .
+} LIMIT 10`,
+        expected: `${prefix}PREFIX%20rdf%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23%3E%0APREFIX%20rdfs%3A%20%3Chttp%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23%3E%0ASELECT%20%2A%20WHERE%20%7B%0A%20%20%3Fsub%20%3Fpred%20%3Fobj%20.%0A%7D%20LIMIT%2010`
+      },
+      // See: https://github.com/apache/jena/issues/1745
+      {
+        value: '+++++',
+        expected: `${prefix}%2B%2B%2B%2B%2B`
+      }
+    ]
+    const originalDocument = global.document
+    global.document = {
+      location: {
+        protocol: 'https:',
+        host: 'host:1234',
+        pathname: '/',
+        search: ''
+      }
+    }
+    tests.forEach(test => {
+      expect(createShareableLink(test.value, '/query/')).to.equal(test.expected)
+    })
+    global.document = originalDocument
+  })
+})


### PR DESCRIPTION
GitHub issue resolved #1745

Pull request Description: 

Fix sharing of query string containing `+` with the fuseki yasqe UI

@kinow maybe you can write a test for this?

to test it manually:

- put `+++++` in a query
- click on the share button inside the query editor
- paste that link in a new browser window
- with the bug, the query editor only contains `     ` instead of `+++++`

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
