### PR TITLE
GH-1751: Performance improvement for deltas with many deletions

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/graph/compose/Delta.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/compose/Delta.java
@@ -20,7 +20,6 @@ package org.apache.jena.graph.compose ;
 
 import org.apache.jena.graph.Capabilities ;
 import org.apache.jena.graph.Graph ;
-import org.apache.jena.graph.GraphUtil ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.graph.impl.GraphPlain ;
 import org.apache.jena.graph.impl.SimpleEventManager ;
@@ -101,7 +100,7 @@ public class Delta extends CompositionBase implements Graph
     @Override
     protected ExtendedIterator<Triple> graphBaseFind(Triple t)
     {
-        ExtendedIterator<Triple> iterator = base.find(t).filterDrop(ifIn(GraphUtil.findAll(deletions))).andThen(additions.find(t)) ;
+        ExtendedIterator<Triple> iterator = base.find(t).filterDrop(deletions::contains).andThen(additions.find(t)) ;
         return SimpleEventManager.notifyingRemove( this, iterator ) ;
     }
 


### PR DESCRIPTION
GitHub issue resolved #1751

Pull request Description:
Delta Graphs: Fixed performance issue due to creating a set of all deleted triples in `graphBasedFind(Triple t)` by directly checking membership of the triple in the deletions graph.


----

 - [X] Tests are included.  (Not modified, tests of jena-core still run)
 - [X] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/) (Not modifed)
 - [X] Commits have been squashed to remove intermediate development commit messages. (Just a single commit)
 - [X] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
