### PR TITLE
Log test failure in test:e2e but not fail whole build

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/pom.xml
+++ b/jena-fuseki2/jena-fuseki-ui/pom.xml
@@ -109,6 +109,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <testFailureIgnore>true</testFailureIgnore>
                             <environmentVariables>
                                 <PORT>${org.apache.jena.fuseki.ui.port}</PORT>
                                 <FUSEKI_PORT>${org.apache.jena.fuseki.port}</FUSEKI_PORT>


### PR DESCRIPTION
Temporary fix so the build overall does not fail is the e2e test fail.

e2e tests fail on CI with no X server. The failure is very noticeably logged.



----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
