### PR TITLE
GH-1768: Include statement-as-resource cases

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OntResourceImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OntResourceImpl.java
@@ -154,7 +154,7 @@ public class OntResourceImpl
      */
     @Override
     public boolean isOntLanguageTerm() {
-        if (!isAnon()) {
+        if ( isURIResource() ) {
             for ( String KNOWN_LANGUAGE : KNOWN_LANGUAGES )
             {
                 if ( getURI().startsWith( KNOWN_LANGUAGE ) )

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ResourceImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ResourceImpl.java
@@ -115,8 +115,14 @@ public class ResourceImpl extends EnhNode implements Resource {
     }
 
     @Override
-    public Object visitWith( RDFVisitor rv )
-        { return isAnon() ? rv.visitBlank( this, getId() ) : rv.visitURI( this, getURI() ); }
+    public Object visitWith(RDFVisitor rv) {
+        if ( isAnon() )
+            return rv.visitBlank(this, getId());
+        if ( isStmtResource() )
+            return rv.visitStmt(this, getStmtTerm());
+        // if isURIResource()
+        return rv.visitURI(this, getURI());
+    }
 
     @Override
     public Resource asResource()
@@ -127,14 +133,18 @@ public class ResourceImpl extends EnhNode implements Resource {
         { throw new LiteralRequiredException( asNode() ); }
 
     @Override
-    public Resource inModel( Model m )
-        {
-        return
-            getModel() == m ? this
-            : isAnon() ? m.createResource( getId() )
-            : asNode().isConcrete() == false ? (Resource) m.getRDFNode( asNode() )
-            : m.createResource( getURI() );
-        }
+    public Resource inModel( Model m ) {
+        if ( getModel() == m )
+            return this;
+        if ( isAnon() )
+            return m.createResource( getId() );
+        if ( isStmtResource() )
+            return  m.createResource( getStmtTerm() );
+        if ( asNode().isConcrete() == false )
+            return (Resource) m.getRDFNode( asNode() );
+        // if isURIResource()
+        return m.createResource(getURI());
+    }
 
     private static Node fresh( String uri )
         { return uri == null ? NodeFactory.createBlankNode() : NodeFactory.createURI( uri ); }
@@ -160,12 +170,16 @@ public class ResourceImpl extends EnhNode implements Resource {
 
     @Override
     public String getNameSpace() {
-        return isAnon() ? null : node.getNameSpace();
+        if ( ! isURIResource() )
+            return null;
+        return node.getNameSpace();
     }
 
 	@Override
     public String getLocalName() {
-        return isAnon() ? null : node.getLocalName();
+	    if ( ! isURIResource() )
+	        return null;
+	    return node.getLocalName();
     }
 
     @Override


### PR DESCRIPTION
GitHub issue resolved #1768

Pull request Description:
`ResourceImpl.inModel` was not considering all the kinds of RDF term under Resource. It was blank nodes and URIs, now it include statements (for RDF-star quoted triples).

There were a few other places where the introduction of a new term type under `Resource` wasn't being handled either.

----

 - [x] Key commit message starts with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
