### PR TITLE
GH-1773: Fixes for handling bad URIs consistently.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 public class ARQ
 {
     // Initialization statics must be first in the class to avoid
-    // problems with recursive initialization.  Specifcally,
+    // problems with recursive initialization.  Specifically,
     // initLock being null because elsewhere started the initialization
     // and is calling into the TDB class.
     // The best order is:

--- a/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
@@ -84,6 +84,7 @@ public class RIOT {
             RDFWriterRegistry.init() ;
             ResultSetLang.init();
 
+            MappingRegistry.addPrefixMapping("rdfxml", RDFXML_SYMBOL_BASE) ;
             MappingRegistry.addPrefixMapping("ttl", TURTLE_SYMBOL_BASE) ;
             MappingRegistry.addPrefixMapping("trig", TURTLE_SYMBOL_BASE) ;
 
@@ -125,6 +126,14 @@ public class RIOT {
     // ---- Symbols
 
     private static String TURTLE_SYMBOL_BASE = "http://jena.apache.org/riot/turtle#";
+    private static String RDFXML_SYMBOL_BASE = "http://jena.apache.org/riot/rdfxml#";
+
+    /**
+     * Access to the legacy RDF/XML parser.
+     * @deprecated Do not use! This will be removed.
+     */
+    @Deprecated
+    public static Symbol symRDFXML0 = SystemARQ.allocSymbol(RDFXML_SYMBOL_BASE, "rdfxml0");
 
     /**
      * Printing style. One of "RDF11" or RDF10". Controls {@literal @prefix} vs PREFIX.

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/ReaderRIOTRDFXML0.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/ReaderRIOTRDFXML0.java
@@ -32,10 +32,9 @@ import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.irix.IRIs;
-import org.apache.jena.query.ARQ;
 import org.apache.jena.rdf.model.RDFErrorHandler ;
-import org.apache.jena.rdfxml.xmlinput.* ;
-import org.apache.jena.rdfxml.xmlinput.impl.ARPSaxErrorHandler ;
+import org.apache.jena.rdfxml.xmlinput0.* ;
+import org.apache.jena.rdfxml.xmlinput0.impl.ARPSaxErrorHandler ;
 import org.apache.jena.riot.*;
 import org.apache.jena.riot.system.Checker;
 import org.apache.jena.riot.system.ErrorHandler;
@@ -46,22 +45,24 @@ import org.xml.sax.SAXException ;
 import org.xml.sax.SAXParseException ;
 
 /** RDF/XML.
+ * <p>
+ * <b>LEGACY</b>
+ * <p>
+ * Uses xmlinput0 - uses the version of ARP from jena 4.7.0 before the conversion to IRIx.
  *
  * @see <a href="http://www.w3.org/TR/rdf-syntax-grammar/">http://www.w3.org/TR/rdf-syntax-grammar/</a>
  */
 @SuppressWarnings("deprecation")
-public class ReaderRIOTRDFXML implements ReaderRIOT
+class ReaderRIOTRDFXML0 implements ReaderRIOT
 {
-    public static ReaderRIOTFactory factory = (Lang language, ParserProfile parserProfile) -> {
-        // Ignore the provided ParserProfile
-        // ARP predates RIOT and does many things internally already.
-        String legacySwitch = ARQ.getContext().get(RIOT.symRDFXML0);
-        if ( legacySwitch != null && legacySwitch.equals("true") )
-            return new ReaderRIOTRDFXML0(parserProfile.getErrorHandler());
-        return new ReaderRIOTRDFXML(parserProfile.getErrorHandler());
-    };
+    public static ReaderRIOTFactory factory = (Lang language, ParserProfile parserProfile) ->
+            // Ignore the provided ParserProfile
+            // ARP predates RIOT and does many things internally already.
+            // This includes IRI resolution.
+            new ReaderRIOTRDFXML0(parserProfile.getErrorHandler())
+            ;
 
-    private ARP arp = new ARP() ;
+    private ARP0 arp = new ARP0() ;
 
     private InputStream input = null ;
     private Reader reader = null ;
@@ -72,7 +73,7 @@ public class ReaderRIOTRDFXML implements ReaderRIOT
 
     private Context context;
 
-    public ReaderRIOTRDFXML(ErrorHandler errorHandler) {
+    public ReaderRIOTRDFXML0(ErrorHandler errorHandler) {
         this.errorHandler = errorHandler;
     }
 
@@ -100,8 +101,7 @@ public class ReaderRIOTRDFXML implements ReaderRIOT
     // RDF 1.0 (and RDF/XML) was based on "RDF URI References" which did allow spaces.
 
     // Use with TDB requires this to be "true" - it is set by InitTDB.
-    public static final boolean RiotUniformCompatibility = true ;
-
+    public static boolean RiotUniformCompatibility = true ;
     // Warnings in ARP that should be errors to be compatible with
     // non-XML-based languages.  e.g. language tags should be
     // syntactically valid.

--- a/jena-cmds/src/main/java/riotcmd/ErrorHandlerCLI.java
+++ b/jena-cmds/src/main/java/riotcmd/ErrorHandlerCLI.java
@@ -25,7 +25,7 @@ import org.apache.jena.riot.system.ErrorHandler;
 import org.slf4j.Logger;
 
 /**
- * Error handler for "rio"t command line parsing.
+ * Error handler for "riot" command line parsing.
  */
 class ErrorHandlerCLI implements ErrorHandler {
 

--- a/jena-core/src/main/java/org/apache/jena/irix/IRIProviderJenaIRI.java
+++ b/jena-core/src/main/java/org/apache/jena/irix/IRIProviderJenaIRI.java
@@ -97,6 +97,8 @@ public class IRIProviderJenaIRI implements IRIProvider {
         static private int relFlags = IRIRelativize.SAMEDOCUMENT | IRIRelativize.ABSOLUTE | IRIRelativize.CHILD | IRIRelativize.PARENT;
         @Override
         public IRIx relativize(IRIx other) {
+            if ( jenaIRI.getRawQuery() != null )
+                return null;
             IRIxJena iriOther = (IRIxJena)other;
             IRI iri2 = jenaIRI.relativize(iriOther.jenaIRI, relFlags);
             if ( iri2.equals(iriOther.jenaIRI))

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/ParseException.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/ParseException.java
@@ -36,8 +36,9 @@ public class ParseException extends SAXParseException implements
      */
     private static final long serialVersionUID = -5986976549492477885L;
     final int id;
+    private final String inputName;
 
-    protected ParseException(int id, ARPLocation where, String msg) {
+    public ParseException(int id, ARPLocation where, String msg) {
         this(id, where.inputName, where.endLine, where.endColumn, msg);
     }
 
@@ -46,13 +47,15 @@ public class ParseException extends SAXParseException implements
     }
 
     protected ParseException(int id, String inputName, int endLine, int endColumn, String msg) {
-        super(msg, inputName, null, endLine, endColumn);
+        super(msg, null, null, endLine, endColumn);
         this.id = id;
+        this.inputName = inputName;
     }
 
     protected ParseException(int id, String inputName, int endLine, int endColumn, Exception e) {
-        super(e.getMessage(), inputName, null, endLine, endColumn, e);
+        super(e.getMessage(), null, null, endLine, endColumn, e);
         this.id = id;
+        this.inputName = inputName;
     }
 
     /**
@@ -125,8 +128,6 @@ public class ParseException extends SAXParseException implements
             return idStr + super.getMessage();
     }
 
-
-
     /**
      * Calls e.getMessage() and also accesses line and column information for
      * SAXParseException's.
@@ -142,26 +143,16 @@ public class ParseException extends SAXParseException implements
         if (!(e instanceof SAXParseException))
             return msg;
         SAXParseException sax = (SAXParseException) e;
-        String file = sax.getSystemId();
-        if (file == null)
-            file = sax.getPublicId();
-        String rslt = file == null ? "" : file;
         if (sax.getLineNumber() == -1)
-            return (file != null ? (file + ": ") : "") + msg;
-
-        if (sax.getColumnNumber() == -1) {
-            return rslt + "(line " + sax.getLineNumber() + "): " + msg;
-        }
-        return rslt + "(line " + sax.getLineNumber() + " column " + sax.getColumnNumber()
-                + "): " + msg;
-
+            return msg;
+        if (sax.getColumnNumber() == -1)
+            return "(line " + sax.getLineNumber() + "): " + msg;
+        return "(line " + sax.getLineNumber() + " column " + sax.getColumnNumber()+ "): " + msg;
     }
 
     public boolean isPromoted() {
         return promoteMe;
     }
-
-
 
     /**
      * The  string from
@@ -189,8 +180,6 @@ public class ParseException extends SAXParseException implements
         return null;
     }
 
-
-
     /**
      * The integer code associated with a string from
      * {@link ARPErrorNumbers}.
@@ -206,5 +195,4 @@ public class ParseException extends SAXParseException implements
             return -1;
         }
     }
-
 }

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/RDFXMLReader.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/RDFXMLReader.java
@@ -27,10 +27,7 @@ import java.util.Locale ;
 import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.datatypes.TypeMapper ;
 import org.apache.jena.graph.* ;
-import org.apache.jena.irix.IRIProvider;
-import org.apache.jena.irix.IRIProviderAny;
-import org.apache.jena.irix.IRIs;
-import org.apache.jena.irix.SystemIRIx;
+import org.apache.jena.irix.*;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.RDFErrorHandler ;
 import org.apache.jena.rdf.model.RDFReaderI ;
@@ -193,8 +190,15 @@ public class RDFXMLReader implements RDFReaderI, ARPErrorNumbers {
     private JenaHandler handler;
 
     synchronized private void read(final Graph g, InputSource inputS, String xmlBase, Model m) {
-        if ( xmlBase != null && resolveInitialXmlBase)
-            xmlBase = IRIs.resolve(xmlBase);
+
+        try {
+            if ( xmlBase != null && resolveInitialXmlBase )
+                xmlBase = IRIs.resolve(xmlBase);
+        } catch (IRIException ex) {
+            ParseException parseException = new ParseException(ARPErrorNumbers.EM_ERROR, null, -1, -1, ex.getMessage());
+            errorHandler.error(parseException);
+            throw new JenaException(parseException);
+        }
         try {
             g.getEventManager().notifyEvent(g, GraphEvents.startRead);
             inputS.setSystemId(xmlBase);

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/ARPLocation.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/ARPLocation.java
@@ -30,7 +30,7 @@ public class ARPLocation implements Locator {
     final String publicId;
     public final int endLine;
     public final int endColumn;
-    ARPLocation(Locator locator) {
+    public ARPLocation(Locator locator) {
     	if (locator==null){
     	  inputName = "unknown-source";
     	  publicId = "unknown-source";
@@ -65,5 +65,5 @@ public class ARPLocation implements Locator {
     public String getPublicId() {
         return publicId;
     }
-    
+
 }

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/AbsXMLContext.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/AbsXMLContext.java
@@ -88,6 +88,7 @@ public abstract class AbsXMLContext implements ARPErrorNumbers {
 
     final IRIx resolveAsURI(XMLHandler forErrors, Taint taintMe, String relUri, boolean checkBaseUse)
             throws SAXParseException {
+
         IRIx rslt = uri.resolve(relUri);
 
         if (checkBaseUse)

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/AttributeLexer.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/AttributeLexer.java
@@ -20,7 +20,9 @@ package org.apache.jena.rdfxml.xmlinput.impl;
 
 import java.util.BitSet;
 
+import org.apache.jena.irix.IRIException;
 import org.apache.jena.rdfxml.xmlinput.ARPErrorNumbers ;
+import org.apache.jena.rdfxml.xmlinput.ParseException;
 import org.apache.jena.rdfxml.xmlinput.states.Frame ;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXParseException;
@@ -57,7 +59,7 @@ public class AttributeLexer extends QNameLexer implements ARPErrorNumbers {
     int index;
 
     Attributes att;
-    
+
     AbsXMLContext xml;
 
     public int processSpecials(Taint taintMe, Attributes a) throws SAXParseException {
@@ -83,7 +85,7 @@ public class AttributeLexer extends QNameLexer implements ARPErrorNumbers {
 
             case A_XMLLANG:
                 lang = value();
-              
+
                 break;
             case A_XML_OTHER:
             case A_XMLNS:
@@ -134,7 +136,7 @@ public class AttributeLexer extends QNameLexer implements ARPErrorNumbers {
             if (matched) {
                 done.set(index);
                 count++;
-            } 
+            }
         }
         xml = computeXml(frame.getXMLContext());
         return count;
@@ -147,14 +149,19 @@ public class AttributeLexer extends QNameLexer implements ARPErrorNumbers {
     }
     private AbsXMLContext computeXml(AbsXMLContext in) throws SAXParseException {
         if (base != null) {
+            try {
             in = in.withBase(frame.arp,base);
+            } catch (IRIException ex) {
+                ARPLocation aLoc = new ARPLocation(frame.arp.getLocator());
+                throw new ParseException(EM_ERROR, aLoc, ex.getMessage());
+            }
         }
         if (lang != null)
             in = in.withLang(frame.arp,lang);
         return in;
     }
 
-   
+
 
     @Override
     boolean isInRdfns(Taint taintMe) throws SAXParseException {
@@ -181,12 +188,12 @@ public class AttributeLexer extends QNameLexer implements ARPErrorNumbers {
         case A_BAGID:
             e = ERR_BAD_RDF_ATTRIBUTE;
             break;
-        
+
         }
         frame.warning(taintMe, e, getQName()
                 + " not allowed as attribute"
                 + (e == ERR_BAD_RDF_ATTRIBUTE?".":" here."));
-        
+
     }
 
     @Override
@@ -208,7 +215,7 @@ public class AttributeLexer extends QNameLexer implements ARPErrorNumbers {
     private String value() {
         return att.getValue(index);
     }
-    
+
     /**
         Answer the xml:base value, or null if there wasn't one.
         [Added by kers, in search of xml:base processing]
@@ -228,7 +235,7 @@ public class AttributeLexer extends QNameLexer implements ARPErrorNumbers {
     String getQName() {
         return att.getQName(index);
     }
-    
+
     public boolean done(int i) {
         return done.get(i);
     }

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/RDFXMLParser.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/RDFXMLParser.java
@@ -23,7 +23,9 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UTFDataFormatException;
 
+import org.apache.jena.irix.IRIException;
 import org.apache.jena.rdfxml.xmlinput.FatalParsingErrorException ;
+import org.apache.jena.rdfxml.xmlinput.ParseException;
 import org.apache.jena.rdfxml.xmlinput.SAX2RDF ;
 import org.apache.jena.shared.JenaException;
 import org.apache.jena.util.CharEncoding ;
@@ -92,6 +94,8 @@ public class RDFXMLParser extends XMLHandler {
         initParse(base,"");
         SAX2RDF.installHandlers(saxParser, this);
         initEncodingChecks(input);
+
+        // Catch everything else it is swallowed by
         try {
             saxParser.parse(input);
         }
@@ -100,6 +104,16 @@ public class RDFXMLParser extends XMLHandler {
         }
         catch (IOException e) {
                 generalError(ERR_GENERIC_IO, e);
+        }
+        catch (ParseException ex) {
+            saxParser.getErrorHandler().error(ex);
+            // If error didn't throw an exception.
+            throw ex;
+        }
+        catch (IRIException ex) {
+            // These should have been caught in ARP, turned into an
+            // ARP ParseException with location, if available.
+            throw ex;
         }
         catch (WrappedException wrapped) {
             wrapped.throwMe();

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/URIReference.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/URIReference.java
@@ -24,8 +24,10 @@
 
 package org.apache.jena.rdfxml.xmlinput.impl;
 
+import org.apache.jena.irix.IRIException;
 import org.apache.jena.irix.IRIx;
 import org.apache.jena.rdfxml.xmlinput.ARPErrorNumbers ;
+import org.apache.jena.rdfxml.xmlinput.ParseException;
 import org.apache.jena.rdfxml.xmlinput.states.Frame ;
 import org.xml.sax.SAXParseException;
 
@@ -152,13 +154,18 @@ public class URIReference extends TaintImpl implements AResourceInternal, ARPErr
             throws SAXParseException {
 
         Taint taintMe = new TaintImpl();
-        IRIx iri = ctxt.resolveAsURI(f.arp,taintMe,uri);
-        f.checkEncoding(taintMe,uri);
+        try {
+            IRIx iri = ctxt.resolveAsURI(f.arp,taintMe,uri);
+            f.checkEncoding(taintMe,uri);
 
-        URIReference rslt = new URIReference(iri.toString());
-        if (taintMe.isTainted())
-            rslt.taint();
-        return rslt;
+            URIReference rslt = new URIReference(iri.toString());
+            if (taintMe.isTainted())
+                rslt.taint();
+            return rslt;
+        } catch (IRIException ex) {
+            ARPLocation aLoc = new ARPLocation(f.arp.getLocator());
+            throw new ParseException(EM_ERROR, aLoc, ex.getMessage());
+        }
     }
 
     public static URIReference fromQName(Frame f, String ns, String local)

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/XMLHandler.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput/impl/XMLHandler.java
@@ -80,7 +80,17 @@ public class XMLHandler extends LexicalHandlerImpl implements ARPErrorNumbers,
     @Override
     public void startPrefixMapping(String prefix, String uri)
             throws SAXParseException {
+        try {
         checkNamespaceURI(uri);
+        } catch (IRIException ex) {
+            ARPLocation aLoc;
+            if ( frame instanceof Frame ) {
+                aLoc = new ARPLocation(((Frame)frame).arp.getLocator());
+            } else
+                aLoc = new ARPLocation(null);
+
+            throw new ParseException(EM_ERROR, aLoc, ex.getMessage());
+        }
         handlers.getNamespaceHandler().startPrefixMapping(prefix, uri);
     }
 
@@ -397,21 +407,6 @@ public class XMLHandler extends LexicalHandlerImpl implements ARPErrorNumbers,
                                     + uri
                                     + "> is relative. Such use has been deprecated by the W3C, and may result in RDF interoperability failures. Use an absolute namespace URI.");
                 }
-//                try {
-//                    if (!u.toASCIIString().equals(u.toString()))
-//                        warning(null,
-//                                WARN_BAD_NAMESPACE_URI,
-//                                "Non-ascii characters in a namespace URI may not be completely portable: <"
-//                                        + u.toString()
-//                                        + ">. Resulting RDF URI references are legal.");
-//                } catch (MalformedURLException e) {
-//                    warning(null,
-//                            WARN_BAD_NAMESPACE_URI,
-//                            "Bad namespace URI: <"
-//                                    + u.toString()
-//                                    + ">. " + e.getMessage());
-//              }
-
                 if (uri.startsWith(rdfns) && !uri.equals(rdfns))
                     warning(null,WARN_BAD_RDF_NAMESPACE_URI, "Namespace URI ref <"
                             + uri + "> may not be used in RDF/XML.");

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput0/ARP0.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput0/ARP0.java
@@ -69,9 +69,11 @@ public class ARP0 implements ARPConfig
 
     final private RDFXMLParser arpf;
 
-/** Creates a new RDF Parser.
- * Can parse one file at a time.
- */
+    /** Creates a new RDF Parser.
+     * Can parse one file at a time.
+     * @deprecated Direct access to the RDF/XML parser is planned for removal. Please contact the Jena development community for details.
+     */
+    @Deprecated
     public ARP0()  {
         arpf =  RDFXMLParser.create();
     }

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput0/NTriple.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput0/NTriple.java
@@ -105,7 +105,8 @@ public class NTriple implements ARPErrorNumbers {
 	 * @param eh Can be null.
 	 * @param ap Can be null.
 	 */
-	static public void mainEh(String args[], ErrorHandler eh, ARPEventHandler ap) {
+	@SuppressWarnings("deprecation")
+    static public void mainEh(String args[], ErrorHandler eh, ARPEventHandler ap) {
 		boolean doneOne = false;
 		startMem = -1;
 		andMeToo = ap;
@@ -247,7 +248,7 @@ public class NTriple implements ARPErrorNumbers {
 			switch (opt) {
 				case 'D':
 					final int nStatements = Integer.parseInt(nextArg);
- rt.gc(); rt.gc(); 
+ rt.gc(); rt.gc();
  startMem = (int)(rt.totalMemory()-rt.freeMemory());
 				arp.getHandlers().setStatementHandler(new StatementHandler(){
 int debugC = 0;
@@ -255,7 +256,7 @@ int debugC = 0;
 					@Override
                     public void statement(AResource subj, AResource pred, AResource obj) {
 						statement(null,null,(ALiteral)null);
-						
+
 					}
 
 					@Override
@@ -266,9 +267,9 @@ int debugC = 0;
 							System.out.println("M1: "+ (rt.totalMemory()-rt.freeMemory()-startMem));
 						  rt.gc();
 							System.out.println("M2: " + (rt.totalMemory()-rt.freeMemory()-startMem));
-						} 
+						}
 						if ( debugC == 1 ){
-							rt.gc(); rt.gc(); 
+							rt.gc(); rt.gc();
 							startMem = (int)(rt.totalMemory()-rt.freeMemory());
 						}
 						if (debugC == nStatements) {
@@ -281,10 +282,10 @@ int debugC = 0;
 						  catch (Exception e){
                               // ignore
 						  }
-						  
+
 						}
-							
-						
+
+
 					}
 				});
 				  break;
@@ -313,9 +314,9 @@ int debugC = 0;
                         @Override
                         public void error(SAXParseException exception) { /* ignore */ }
                         @Override
-                        public void fatalError(SAXParseException exception) { /* ignore */ }     
+                        public void fatalError(SAXParseException exception) { /* ignore */ }
                     });
-                    
+
                     arp.setBadStatementHandler(new SH(System.err));
                     break;
 				case 'b' :
@@ -395,7 +396,7 @@ int debugC = 0;
 	@SuppressWarnings("resource")
     static private void process(String surl) {
 		InputStream in = null ;
-		
+
 		URL url;
 		String baseURL;
 
@@ -422,9 +423,9 @@ int debugC = 0;
 			}
 		}
 		process(in, baseURL, surl);
-		try { in.close() ; } catch (IOException ex) {} 
+		try { in.close() ; } catch (IOException ex) {}
 	}
-		
+
 	static private void process(InputStream in, String xmlBasex, String surl) {
 		String xmlBasey = xmlBase == null ? xmlBasex : xmlBase;
 		try {
@@ -525,14 +526,14 @@ int debugC = 0;
 			print("> ");
 		}
 	}
-	
-	
+
+
 	static private Pattern ntripleBnode=Pattern.compile("[a-zA-Y0-9]*");
 	/**
-	 * 
+	 *
 	 * Replace any non-legal char (or Z) with ZNN where NN are the hex codes
 	 * in UTF-8
-	 * @param anonymousID Is something that corresponds to an XMLName 
+	 * @param anonymousID Is something that corresponds to an XMLName
 	 * @return an ascii string that is legal NTriple
 	 */
 	public static String escapeNTriple(String anonymousID) {
@@ -543,9 +544,9 @@ int debugC = 0;
 		StringBuilder rslt = new StringBuilder();
 		int lastNotMatched = 0;
 		while (matcher.find()) {
-			
+
 			String unmatched = anonymousID.substring(lastNotMatched, matcher.start());
-			
+
 			rslt.append(escapeUTF8(unmatched));
 			lastNotMatched = matcher.end();
 			rslt.append(matcher.group());

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput0/XMLLiteralType0.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput0/XMLLiteralType0.java
@@ -89,6 +89,7 @@ public class XMLLiteralType0 extends BaseDatatype implements RDFDatatype {
         // status[1] true once first triple found
         // status[2] the result (good if status[1] and not status[0]).
 
+        @SuppressWarnings("deprecation")
         ARP0 arp = new ARP0();
 
         arp.getHandlers().setErrorHandler(new ErrorHandler(){

--- a/jena-core/src/test/java/org/apache/jena/irix/TestRelative.java
+++ b/jena-core/src/test/java/org/apache/jena/irix/TestRelative.java
@@ -47,7 +47,7 @@ public class TestRelative extends AbstractTestIRIx {
     public void relative_05() { testRelative("https://host:1234/dir/", "http://host:5678/dir/file", null); }
 
     @Test
-    public void relative_06() { testRelative("http://ex/path/?query", "http://ex/path/file", "file"); }
+    public void relative_06() { testRelative("http://ex/path/?query", "http://ex/path/file", null); }
 
     @Test
     public void relative_07() { testRelative("http://ex/path/#frag", "http://ex/path/file", "file"); }

--- a/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput/TestPackage_xmlinput1.java
+++ b/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput/TestPackage_xmlinput1.java
@@ -20,17 +20,16 @@ package org.apache.jena.rdfxml.xmlinput;
 
 import junit.framework.TestSuite;
 
-public class TestPackage_xmlinput extends TestSuite
+public class TestPackage_xmlinput1 extends TestSuite
 {
     static public TestSuite suite()
     {
-        return new TestPackage_xmlinput() ;
-
+        return new TestPackage_xmlinput1() ;
     }
 
-    private TestPackage_xmlinput()
+    private TestPackage_xmlinput1()
     {
-        super("RDF/XML Input") ;
+        super("RDF/XML Input ARP1") ;
         addTest( org.apache.jena.rdfxml.xmlinput.TestURIs.suite());
         addTest( org.apache.jena.rdfxml.xmlinput.TestSuiteWG_NTriples.suite());
         addTest( org.apache.jena.rdfxml.xmlinput.TestSuiteWG_RDFXML.suite());
@@ -42,6 +41,7 @@ public class TestPackage_xmlinput extends TestSuite
         addTest( org.apache.jena.rdfxml.xmlinput.TestsTainting.suite());
         addTest( org.apache.jena.rdfxml.xmlinput.TestsSAX2RDF.suite());
         addTest( org.apache.jena.rdfxml.xmlinput.TestsStAX2Model.suite());
+        addTest( org.apache.jena.rdfxml.xmlinput.TestRDFXML_URI.suite());
     }
 
     private void addTest(String name, TestSuite tc) {

--- a/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput/TestRDFXML_URI.java
+++ b/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput/TestRDFXML_URI.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.rdfxml.xmlinput;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+import junit.framework.JUnit4TestAdapter;
+import org.apache.jena.irix.IRIs;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFErrorHandler;
+import org.apache.jena.shared.JenaException;
+import org.junit.Test;
+
+/** tests of bad URis in RDF/XML. */
+public class TestRDFXML_URI {
+    static public junit.framework.Test suite()
+    {
+        return new JUnit4TestAdapter(TestRDFXML_URI.class) ;
+    }
+
+    private static String DIR = "testing/arp1/uri/";
+
+    // Bad URIs in RDF/XML - various positions.
+    @Test public void bad_uri_1() { test("bad-uri-1.rdf"); }
+    @Test public void bad_uri_2() { test("bad-uri-2.rdf"); }
+    @Test public void bad_uri_3() { test("bad-uri-3.rdf"); }
+    @Test public void bad_uri_4() { test("bad-uri-4.rdf"); }
+
+    // Bad Base URIs in RDF/XML - various ways to set the base
+    @Test
+    public void bad_base_0() {
+        // Passed into the parser by calling code.
+        test("bad-base-0.rdf", "http://example/bad base");
+    }
+
+    @Test public void bad_base_1() { test("bad-base-1.rdf"); }
+    @Test public void bad_base_2() { test("bad-uri-2.rdf"); }
+    @Test public void bad_base_3() { test("bad-uri-3.rdf"); }
+    @Test public void bad_base_4() { test("bad-uri-4.rdf"); }
+
+    private static void test(String file) {
+        String base = IRIs.resolve(file);
+        test(file, base);
+    }
+
+    private static void test(String file, String base) {
+        ErrorHandlerNoPrint eh = new ErrorHandlerNoPrint();
+        try {
+            file = DIR+file;
+            Model m1 = ModelFactory.createDefaultModel();
+            RDFXMLReader xr = new RDFXMLReader(true);
+            xr.setErrorHandler(eh);
+            InputStream in = new FileInputStream(file);
+            xr.read(m1, in, base);
+        } catch (FileNotFoundException ex) {
+            throw new RuntimeException(ex);
+        }
+        catch (JenaException ex) {
+            assertEquals(1, eh.errors);
+            Throwable cause = ex.getCause();
+            assertTrue(cause instanceof ParseException);
+        }
+    }
+
+
+    static class ErrorHandlerNoPrint implements RDFErrorHandler {
+        int warnings = 0;
+        int errors = 0;
+        int fatalErrors = 0;
+
+        @Override
+        public void warning(Exception e) { warnings++; }
+
+        @Override
+        public void error(Exception e) { errors++; }
+
+        @Override
+        public void fatalError(Exception e) { fatalErrors++; }
+    }
+
+}

--- a/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput/TestsARP.java
+++ b/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput/TestsARP.java
@@ -32,9 +32,7 @@ import org.apache.jena.vocabulary.RDF ;
 import org.junit.Assert ;
 import org.slf4j.Logger ;
 import org.slf4j.LoggerFactory ;
-import org.xml.sax.ErrorHandler ;
 import org.xml.sax.SAXException ;
-import org.xml.sax.SAXParseException ;
 
 /** Additional ARP tests */
 @SuppressWarnings("deprecation")
@@ -430,65 +428,6 @@ public class TestsARP extends TestCase implements RDFErrorHandler, ARPErrorNumbe
                    + "]", m.isIsomorphicWith(m1));
         checkExpected();
     }
-
-    // Becomes a IRI error.
-//    public void testBaseTruncation() throws IOException {
-//        Model m = createMemModel();
-//        Model m1 = createMemModel();
-//        RDFReaderI rdr = new RDFXMLReader();
-//        try (FileInputStream fin = new FileInputStream("testing/wg/rdfms-identity-anon-resources/test001.rdf")) {
-//            rdr.setErrorHandler(this);
-//            expected = new int[] { WARN_MALFORMED_URI, WARN_RELATIVE_URI };
-//            rdr.read(m, fin, "ht#tp://jjc3.org/demo.mp3#frag");
-//        }
-////        try (FileInputStream fin = new FileInputStream("testing/wg/rdfms-identity-anon-resources/test001.rdf")) {
-////            rdr.read(m1, fin, "");
-////        }
-//        assertTrue("Bad base URI should have no effect.[" + m1.toString()+ "]",
-//                   m.isIsomorphicWith(m1));
-//        checkExpected();
-//    }
-
-	public void testInterrupt() throws SAXException, IOException {
-	    ARP a = new ARP();
-	    try ( InputStream in = new FileInputStream("testing/wg/miscellaneous/consistent001.rdf") ) {
-	        a.getHandlers().setStatementHandler(new StatementHandler() {
-	            int countDown = 10;
-
-	            @Override
-	            public void statement(AResource subj, AResource pred, AResource obj) {
-	                if (countDown-- == 0)
-	                    Thread.currentThread().interrupt();
-
-	            }
-
-	            @Override
-	            public void statement(AResource subj, AResource pred, ALiteral lit) {
-
-	            }
-	        });
-	        a.getHandlers().setErrorHandler(new ErrorHandler(){
-	            @Override
-	            public void error(SAXParseException exception) throws SAXException {
-	                throw new RuntimeException("Unexpected error", exception);
-	            }
-	            @Override
-	            public void fatalError(SAXParseException exception) throws SAXException {
-	                throw exception;
-	            }
-	            @Override
-	            public void warning(SAXParseException exception) throws SAXException {
-	                throw new RuntimeException("Unexpected warning", exception);
-	            }});
-	        try {
-	            a.load(in);
-	            fail("Thread was not interrupted.");
-	        } catch (InterruptedIOException | SAXParseException e) {
-	        }
-	    }
-	    // System.err.println("Finished "+Thread.interrupted());
-
-	}
 
 	static String RDF_TEXT = "<?xml version=\"1.0\" ?>\n" +
     "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n" +

--- a/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput0/ARPTests2.java
+++ b/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput0/ARPTests2.java
@@ -243,7 +243,8 @@ public class ARPTests2 extends TestCase implements RDFErrorHandler, ARPErrorNumb
 				+ "</rdf:Description> "
 				+ "</rdf:RDF>";
 
-		ARP0 parser = new ARP0();
+		@SuppressWarnings("deprecation")
+        ARP0 parser = new ARP0();
 		ToStringStatementHandler tssh = new ToStringStatementHandler();
 		parser.getHandlers().setStatementHandler(tssh);
 		parser.load(new StringReader(testcase), "http://www.example.com");
@@ -441,7 +442,8 @@ public class ARPTests2 extends TestCase implements RDFErrorHandler, ARPErrorNumb
         checkExpected();
     }
 	public void testInterrupt() throws SAXException, IOException {
-	    ARP0 a = new ARP0();
+	    @SuppressWarnings("deprecation")
+        ARP0 a = new ARP0();
 	    try ( InputStream in = new FileInputStream("testing0/wg/miscellaneous/consistent001.rdf") ) {
 	        a.getHandlers().setStatementHandler(new StatementHandler() {
 	            int countDown = 10;

--- a/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput0/TestErrorMsg.java
+++ b/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput0/TestErrorMsg.java
@@ -63,7 +63,8 @@ public class TestErrorMsg extends TestCase {
 		String regexAbsent)
 		throws IOException {
 		final StringBuffer buf = new StringBuffer();
-		ARP0 arp = new ARP0();
+		@SuppressWarnings("deprecation")
+        ARP0 arp = new ARP0();
 		arp.getHandlers().setErrorHandler(new ErrorHandler() {
 
 			@Override
@@ -99,7 +100,7 @@ public class TestErrorMsg extends TestCase {
 				!Pattern.compile(regexAbsent,Pattern.DOTALL).matcher(contents).find());
 		contents = null;
 	}
-	
+
 	public void testErrMsg01() throws Exception {
 		check("test01",null,"Unusual");
 	}

--- a/jena-core/src/test/java/org/apache/jena/test/TestPackage.java
+++ b/jena-core/src/test/java/org/apache/jena/test/TestPackage.java
@@ -44,7 +44,7 @@ public class TestPackage extends TestCase {
         addTest(ts,  "Model", org.apache.jena.rdf.model.test.TestPackage_model.suite());
         addTest(ts,  "StandardModels", org.apache.jena.rdf.model.test.TestStandardModels.suite() );
         // Currently, "ARP[IRIx]"
-        addTest(ts,  "XML Input", org.apache.jena.rdfxml.xmlinput.TestPackage_xmlinput.suite());
+        addTest(ts,  "XML Input", org.apache.jena.rdfxml.xmlinput.TestPackage_xmlinput1.suite());
         addTest(ts,  "XML Output", org.apache.jena.rdfxml.xmloutput.TestPackage_xmloutput.suite());
         addTest(ts,  "Util", org.apache.jena.util.TestPackage_util.suite());
         addTest(ts,  "Jena iterator", org.apache.jena.util.iterator.test.TestPackage_iter.suite() );

--- a/jena-core/testing/arp1/uri/bad-base-0.rdf
+++ b/jena-core/testing/arp1/uri/bad-base-0.rdf
@@ -1,0 +1,11 @@
+<!-- Bad URI : external base -->
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+         xmlns:ex='http://example/'
+         >
+
+  <rdf:Description rdf:about="x">
+    <ex:p>string</ex:p>
+  </rdf:Description>
+
+</rdf:RDF>

--- a/jena-core/testing/arp1/uri/bad-base-1.rdf
+++ b/jena-core/testing/arp1/uri/bad-base-1.rdf
@@ -1,0 +1,11 @@
+<!-- Bad URI : rdf:RDF xml:base -->
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+         xmlns:ex='http://example/'
+         xml:base='http://host/ bad uri'>
+
+  <rdf:Description rdf:about="x">
+    <ex:p>string</ex:p>
+  </rdf:Description>
+
+</rdf:RDF>

--- a/jena-core/testing/arp1/uri/bad-base-2.rdf
+++ b/jena-core/testing/arp1/uri/bad-base-2.rdf
@@ -1,0 +1,9 @@
+<!-- Bad URI : rdf:Description xml:base-->
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+         xmlns:ex='http://example/'
+         xml:base='http://host/bad uri'>
+  <rdf:Description rdf:about="x" xml:base='http://host/bad uri'>
+    <ex:p>string</ex:p>
+  </rdf:Description>
+</rdf:RDF>

--- a/jena-core/testing/arp1/uri/bad-base-3.rdf
+++ b/jena-core/testing/arp1/uri/bad-base-3.rdf
@@ -1,0 +1,10 @@
+<!-- Bad URI : Stripped class xml:base -->
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+         xmlns:ex='http://example/'>
+
+  <ex:Class  rdf:about="x" xml:base='http://host/bad uri'>
+    <ex:p>string</ex:p>
+  </ex:Class>
+
+</rdf:RDF>

--- a/jena-core/testing/arp1/uri/bad-base-4.rdf
+++ b/jena-core/testing/arp1/uri/bad-base-4.rdf
@@ -1,0 +1,10 @@
+<!-- Bad URI : bad internal base -->
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+         xmlns:ex='http://example/'>
+
+  <rdf:Description rdf:about="x">
+    <ex:p xml:base='http://host/bad uri' rdf:resource='z'/>
+  </rdf:Description>
+
+</rdf:RDF>

--- a/jena-core/testing/arp1/uri/bad-uri-1.rdf
+++ b/jena-core/testing/arp1/uri/bad-uri-1.rdf
@@ -1,0 +1,10 @@
+<!-- Bad URI : namespace -->
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+         xmlns:ex='http://example/bad uri'>
+
+  <rdf:Description rdf:about="x">
+    <ex:p>string</ex:p>
+  </rdf:Description>
+
+</rdf:RDF>

--- a/jena-core/testing/arp1/uri/bad-uri-2.rdf
+++ b/jena-core/testing/arp1/uri/bad-uri-2.rdf
@@ -1,0 +1,10 @@
+<!-- Bad URI : rdf:about -->
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+         xmlns:ex='http://example/'>
+
+  <rdf:Description rdf:about="http://host/bad uri">
+    <ex:p>string</ex:p>
+  </rdf:Description>
+
+</rdf:RDF>

--- a/jena-core/testing/arp1/uri/bad-uri-3.rdf
+++ b/jena-core/testing/arp1/uri/bad-uri-3.rdf
@@ -1,0 +1,10 @@
+<!-- Bad URI : namespace -->
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+         xmlns:ex='http://example/'>
+
+  <rdf:Description rdf:about="x">
+    <ex:p rdf:resource='bad uri'/>
+  </rdf:Description>
+
+</rdf:RDF>

--- a/jena-core/testing/arp1/uri/bad-uri-4.rdf
+++ b/jena-core/testing/arp1/uri/bad-uri-4.rdf
@@ -1,0 +1,10 @@
+<!-- Bad URI : Stripped class rdf:about -->
+
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' 
+         xmlns:ex='http://example/'>
+
+  <ex:Class rdf:about="bad uri">
+    <ex:p rdf:resource='abc'/>
+  </ex:Class>
+
+</rdf:RDF>

--- a/jena-iri/src/main/java/org/apache/jena/iri/ViolationCodes.java
+++ b/jena-iri/src/main/java/org/apache/jena/iri/ViolationCodes.java
@@ -1,7 +1,3 @@
-
-
-
-
  /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -2936,7 +2932,9 @@ This class is not part of the API.
             new ViolationCodeInfo(
                 UNWISE_CHARACTER,
                 "UNWISE_CHARACTER",
-                "The character matches no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, and XML Schema anyURIs.",
+//                "The character matches no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, and XML Schema anyURIs.",
+                // RDF 1.1 - RDF URI References replaced by IRIs.
+                "The character matches no grammar rules of URIs/IRIs.",
                 "<p>The character matches no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, and XML Schema anyURIs.</p>",
                 0|Force.minting,
                 new InSpec[]{
@@ -3642,7 +3640,9 @@ This class is not part of the API.
             new ViolationCodeInfo(
                 WHITESPACE,
                 "WHITESPACE",
-                "A single whitespace character. These match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, and XML Schema anyURIs.",
+//                "A single whitespace character. These match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, and XML Schema anyURIs.",
+                // RDF 1.1 - RDF URI References replaced by IRIs.
+                "A single whitespace character. These match no grammar rules of URIs/IRIs.",
                 "<p>A single whitespace character. These match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, and XML Schema anyURIs.</p>",
                 0,
                 new InSpec[]{
@@ -3676,7 +3676,9 @@ This class is not part of the API.
             new ViolationCodeInfo(
                 DOUBLE_WHITESPACE,
                 "DOUBLE_WHITESPACE",
-                "Either two or more consecutive whitespace characters, or leading or trailing whitespace. These match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, but not XML Schema anyURIs.",
+
+                //"Either two or more consecutive whitespace characters, or leading or trailing whitespace. These match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, but not XML Schema anyURIs.",
+                "Either two or more consecutive whitespace characters, or leading or trailing whitespace. These match no grammar rules of URIs/IRIs.",
                 "<p>Either two or more consecutive whitespace characters, or leading or trailing whitespace. These match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, XML system identifiers, but not XML Schema anyURIs.</p>",
                 0,
                 new InSpec[]{
@@ -3719,7 +3721,8 @@ This class is not part of the API.
             new ViolationCodeInfo(
                 NOT_XML_SCHEMA_WHITESPACE,
                 "NOT_XML_SCHEMA_WHITESPACE",
-                "Whitespace characters match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, and XML system identifiers. However, tab and new line characters, and consecutive space characters cannot occur in XML Schema anyURIs.",
+                //"Whitespace characters match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, and XML system identifiers. However, tab and new line characters, and consecutive space characters cannot occur in XML Schema anyURIs.",
+                "Whitespace characters match no grammar rules of URIs/IRIs.",
                 "<p>Whitespace characters match no grammar rules of URIs/IRIs. These characters are permitted in RDF URI References, and XML system identifiers. However, tab and new line characters, and consecutive space characters cannot occur in XML Schema anyURIs.</p>",
                 0,
                 new InSpec[]{

--- a/jena-iri/src/main/xml/org/apache/jena/iri/impl/violations.xml
+++ b/jena-iri/src/main/xml/org/apache/jena/iri/impl/violations.xml
@@ -1,4 +1,4 @@
-<!--
+fUnwise<!--
    Licensed to the Apache Software Foundation (ASF) under one or more
    contributor license agreements.  See the NOTICE file distributed with
    this work for additional information regarding copyright ownership.
@@ -582,8 +582,10 @@ In addition, octet 0 (0 hex) should NEVER be used, in either unencoded or %-enco
             
 	    <description>
 		    The character matches no grammar rules of URIs/IRIs.
+        <!--
 		    These characters are permitted in RDF URI References,
 		    XML system identifiers, and XML Schema anyURIs.
+        -->
 	    </description>
             
             <comment>Whitespace is dealt with separately.</comment>
@@ -870,8 +872,10 @@ characters or permanently undefined Unicode characters: [#x7F-#x84], [#x86-#x9F]
 	    <description>
 A single whitespace character.
 These match no grammar rules of URIs/IRIs.
+        <!--
 		    These characters are permitted in RDF URI References,
 		    XML system identifiers, and XML Schema anyURIs.
+        -->
 	    </description>
 
 	    <see>IRIFactory#allowUnwiseCharacters</see>

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb/TDB.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb/TDB.java
@@ -30,7 +30,6 @@ import org.apache.jena.query.ARQ ;
 import org.apache.jena.query.Dataset ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.reasoner.InfGraph ;
-import org.apache.jena.riot.lang.ReaderRIOTRDFXML;
 import org.apache.jena.sparql.SystemARQ ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.engine.main.StageBuilder ;
@@ -250,7 +249,6 @@ public class TDB {
             }
             initialized = true ;
             JenaSystem.logLifecycle("TDB1.init - start") ;
-            ReaderRIOTRDFXML.RiotUniformCompatibility = true ;
             EnvTDB.processGlobalSystemProperties() ;
 
             MappingRegistry.addPrefixMapping(SystemTDB.tdbSymbolPrefix,  SystemTDB.symbolNamespace) ;

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/TDB2.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/TDB2.java
@@ -19,7 +19,6 @@
 package org.apache.jena.tdb2;
 
 import org.apache.jena.query.ARQ;
-import org.apache.jena.riot.lang.ReaderRIOTRDFXML;
 import org.apache.jena.sparql.SystemARQ;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sparql.engine.main.StageBuilder;
@@ -127,7 +126,6 @@ public class TDB2 {
                 System.err.println("TDB2.init - start");
 
             SystemTDB.init();
-            ReaderRIOTRDFXML.RiotUniformCompatibility = true;
             EnvTDB.processGlobalSystemProperties();
 
             MappingRegistry.addPrefixMapping(SystemTDB.tdbSymbolPrefix, SystemTDB.symbolNamespace);


### PR DESCRIPTION
Pull request Description:
* Allow access to the original RDFXML parser (xmlinput0) with a context switch.
* Fixes for handling bad URIs consistently in main RDf/XMl parser ("xmlinput" - the intermediate version using IRIx).


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
