### PR TITLE
Fix broken header

### DIFF
--- a/jena-examples/src/main/java/arq/examples/riot/ExRIOT_RDFXML_WriteProperties.java
+++ b/jena-examples/src/main/java/arq/examples/riot/ExRIOT_RDFXML_WriteProperties.java
@@ -1,5 +1,6 @@
 /*
- * or more contributor license agreements.  See the NOTICE fil
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the


### PR DESCRIPTION
The license header of `ExRIOT_RDFXML_WriteProperties.java` was broken.
