### PR TITLE
GH-1803: Keep the old code for byte buffer copy

### DIFF
--- a/jena-tdb1/src/test/java/org/apache/jena/tdb/store/nodetable/TestNodec.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb/store/nodetable/TestNodec.java
@@ -120,7 +120,7 @@ public class TestNodec
         assertEquals(bbLen, x);
         assertEquals(0, bb.position());
 
-        ByteBuffer bb2 = ByteBufferLib.duplicate(bb);
+        ByteBuffer bb2 = ByteBufferLib.copyOf(bb);
         Node n2 = nodec.decode(bb2, null);
         assertEquals(n, n2);
     }


### PR DESCRIPTION
This PR keeps the code (unused) for byte buffer copying that was replaces by #1800.

The original code was originally (a significant number of years ago) faster. Now it isn't, at least on the conventional architectures used for timing #1800. The JVM improves, hardware changes. 

* Add comments in ByteBufferLib
* Rename ByteBufferLib.duplicate as ByteBufferLib.copyOf

----

 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
