### PR TITLE
Fix conflict between library and Fuseki logging setup

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
@@ -278,8 +278,10 @@ public class LogCtl {
 
     // ---- log4j2.
 
-    /** The log4j2 configuration file - must be a file or URL, not a classpath java resource */
-    public static final String log4j2ConfigProperty = "log4j.configurationFile";
+    /** The log4j2 configuration file - must be a file or URL, not a classpath java resource. */
+    public static final String log4j2ConfigFileProperty = "log4j2.configurationFile";
+    /** Legacy name for log4j2 configuration file */
+    public static final String log4j2ConfigFilePropertyLegacy = "log4j.configurationFile";
 
     private static final String[] log4j2files = {"log4j2.properties", "log4j2.xml"};
 
@@ -287,12 +289,14 @@ public class LogCtl {
             System.getenv("JENA_LOGLOGGING") != null ||
             System.getProperty("jena.loglogging") != null;
 
-    private static void logLogging(String str) {
+    private static void logLogging(String fmt, Object ... args) {
         if ( LogLogging ) {
-            System.err.print("Fuseki Logging: ");
-            System.err.println(str);
+            System.err.print("Jena Logging: ");
+            System.err.printf(fmt, args);
+            System.err.println();
         }
     }
+
 
 //    private static void logLogging(String fmt, Object ... args) {
 //        if ( LogLogging ) {
@@ -318,13 +322,23 @@ public class LogCtl {
             logLogging("Log4j2: built-in default");
             LogCtlLog4j2.resetLogging(LogCtlLog4j2.log4j2setup);
         } else {
-            logLogging("Ready set: "+log4j2ConfigProperty+"="+System.getProperty(log4j2ConfigProperty));
+            if ( isSetLog4j2property(log4j2ConfigFilePropertyLegacy) )
+                logLogging("Already set: %s=%s", log4j2ConfigFilePropertyLegacy, System.getProperty(log4j2ConfigFilePropertyLegacy));
+            else
+                logLogging("Already set: %s=%s", log4j2ConfigFileProperty, System.getProperty(log4j2ConfigFileProperty));
         }
     }
 
     /* package */ static boolean isSetLog4j2property() {
-        return System.getProperty(log4j2ConfigProperty) != null;
+        // Either name,
+        return isSetLog4j2property(log4j2ConfigFileProperty) ||
+               isSetLog4j2property(log4j2ConfigFilePropertyLegacy);
     }
+
+    private static boolean isSetLog4j2property(String systemProperty) {
+        return System.getProperty(systemProperty) != null;
+    }
+
 
     /** Set log4j, looking for files */
     /*package*/ static void setLog4j2property() {
@@ -333,7 +347,7 @@ public class LogCtl {
         for ( String fn : log4j2files ) {
             File f = new File(fn);
             if ( f.exists() ) {
-                System.setProperty(log4j2ConfigProperty, "file:" + fn);
+                System.setProperty(log4j2ConfigFileProperty, "file:" + fn);
                 return;
             }
         }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.lib.StrUtils;
+import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.atlas.logging.LogCtlLog4j2;
 import org.apache.jena.fuseki.Fuseki;
 
@@ -62,9 +63,9 @@ public class FusekiLogging
         "log4j2.properties"
     };
 
-    private static final boolean LogLogging =
-            System.getenv("FUSEKI_LOGLOGGING") != null ||
-            System.getProperty("fuseki.loglogging") != null;
+    private static final boolean LogLogging = true ;
+//            System.getenv("FUSEKI_LOGLOGGING") != null ||
+//            System.getProperty("fuseki.loglogging") != null;
 
     private static boolean loggingInitialized   = false;
 
@@ -86,7 +87,8 @@ public class FusekiLogging
         setLogging(null);
     }
 
-    public static final String log4j2_configurationFile = "log4j2.configurationFile";
+    public static final String log4j2_configurationFile = LogCtl.log4j2ConfigFileProperty;
+    private static final String log4j2_configurationFileLegacy = LogCtl.log4j2ConfigFilePropertyLegacy;
     // Only used by the webapp.
     public static final String log4j2_web_configuration = "log4jConfiguration";
 
@@ -109,8 +111,8 @@ public class FusekiLogging
         logLogging("Set logging");
 
         // Is there a log4j setup provided?
-        if ( checkSystemProperties("log4j2.configurationFile") ||
-             checkSystemProperties("log4j.configurationFile") ||    // Log4j2 legacy name
+        if ( checkSystemProperties(log4j2_configurationFile) ||
+             checkSystemProperties(log4j2_configurationFileLegacy) ||
              System.getenv("LOG4J_CONFIGURATION_FILE") != null )
         {
             logLogging("External log4j2 setup");
@@ -142,6 +144,11 @@ public class FusekiLogging
 //            }
 
             if ( url != null ) {
+                try ( InputStream inputStream = url.openStream() ) {
+                    String x = IO.readWholeFileAsUTF8(inputStream);
+                    System.err.println(x);
+                } catch (IOException ex) { IO.exception(ex); }
+
                 try ( InputStream inputStream = url.openStream() ) {
                     loadConfiguration(inputStream, resourceName);
                 } catch (IOException ex) { IO.exception(ex); }


### PR DESCRIPTION
Commit daa64b1a81 (2023-03-29) in PR #1818 broke the Fuseki logging setup. The test suite has started printing logging where it used not to. The problem would probably show up for users using embedded Fuseki if this is not fixed.

This PR fixes the problem, and makes the behaviour the same as 4.7.0.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
