### PR TITLE
Automatically enable Javascript ES6 with Nashorn

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/scripting/ScriptFunction.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/scripting/ScriptFunction.java
@@ -43,6 +43,10 @@ public class ScriptFunction extends FunctionBase {
 
     static {
         System.setProperty("polyglot.engine.WarnInterpreterOnly", "false");
+        // Enable es6 in Nashorn
+        if (System.getProperty("nashorn.args") == null) {
+            System.setProperty("nashorn.args", "--language=es6");
+        }
     }
 
     private static void checkScriptingEnabled() {


### PR DESCRIPTION
GitHub issue resolved #

Pull request Description:

Suggestion to automatically enable EcmaScript 6 when using Nashorn JS Engine (e.g. for Licence reasons)

Note: Graal enables ES12 already by default

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
