### PR TITLE
GH-1749: Replacing webpack chunks by Vite rollup

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/cypress.config.js
+++ b/jena-fuseki2/jena-fuseki-ui/cypress.config.js
@@ -16,7 +16,8 @@
  */
 
 const { defineConfig } = require('cypress')
-const vitePreprocessor = require('cypress-vite')
+const vitePreprocessor = require('./tests/e2e/support/vite-preprocessor')
+const path = require('path')
 
 module.exports = defineConfig({
   video: false,
@@ -30,7 +31,13 @@ module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:' + (process.env.PORT || 8080),
     setupNodeEvents (on, config) {
-      on('file:preprocessor', vitePreprocessor())
+      // For test coverage
+      require('@cypress/code-coverage/task')(on, config)
+
+      on(
+        'file:preprocessor',
+        vitePreprocessor(path.resolve(__dirname, 'vite.config.js'))
+      )
       return require('./tests/e2e/plugins/index.js')(on, config)
     },
     specPattern: 'tests/e2e/specs/**/*.cy.{js,jsx,ts,tsx}',
@@ -39,7 +46,10 @@ module.exports = defineConfig({
     videosFolder: 'tests/e2e/videos',
     supportFile: 'tests/e2e/support/index.js',
   },
-
+  components: {
+    framework: 'vue',
+    bundler: 'vite'
+  },
   env: {
     codeCoverage: {
       exclude: [

--- a/jena-fuseki2/jena-fuseki-ui/src/router/index.js
+++ b/jena-fuseki2/jena-fuseki-ui/src/router/index.js
@@ -28,7 +28,7 @@ const routes = [
   {
     path: '/dataset/:datasetName/query',
     name: 'DatasetQuery',
-    component: () => import(/* webpackChunkName: "datasetQuery" */ '../views/dataset/Query.vue'),
+    component: () => import('../views/dataset/Query.vue'),
     props: true
   },
   {
@@ -36,46 +36,46 @@ const routes = [
     //            query parameter, e.g. /#/dataset/abc/query?query=SELECT...
     path: '/dataset/:datasetName/query*',
     name: 'DatasetQueryParameters',
-    component: () => import(/* webpackChunkName: "datasetQuery" */ '../views/dataset/Query.vue'),
+    component: () => import('../views/dataset/Query.vue'),
     props: true
   },
   {
     path: '/dataset/:datasetName/upload',
     name: 'DatasetUpload',
-    component: () => import(/* webpackChunkName: "datasetUpload" */ '../views/dataset/Upload.vue'),
+    component: () => import('../views/dataset/Upload.vue'),
     props: true
   },
   {
     path: '/dataset/:datasetName/edit',
     name: 'DatasetEdit',
-    component: () => import(/* webpackChunkName: "datasetEdit" */ '../views/dataset/Edit.vue'),
+    component: () => import('../views/dataset/Edit.vue'),
     props: true
   },
   {
     path: '/dataset/:datasetName/info',
     name: 'DatasetInfo',
-    component: () => import(/* webpackChunkName: "datasetInfo" */ '../views/dataset/Info.vue'),
+    component: () => import('../views/dataset/Info.vue'),
     props: true
   },
   {
     path: '/manage',
     name: 'ManageDatasets',
-    component: () => import(/* webpackChunkName: "manageDatasets" */ '../views/manage/ExistingDatasets.vue')
+    component: () => import('../views/manage/ExistingDatasets.vue')
   },
   {
     path: '/manage/new',
     name: 'NewDataset',
-    component: () => import(/* webpackChunkName: "newDataset" */ '../views/manage/NewDataset.vue')
+    component: () => import('../views/manage/NewDataset.vue')
   },
   {
     path: '/manage/tasks',
     name: 'Tasks',
-    component: () => import(/* webpackChunkName: "tasks" */ '../views/manage/Tasks.vue')
+    component: () => import('../views/manage/Tasks.vue')
   },
   {
     path: '/documentation',
     name: 'Help',
-    component: () => import(/* webpackChunkName: "documentation" */ '../views/Help.vue')
+    component: () => import('../views/Help.vue')
   },
   {
     path: '/:pathMatch(.*)*',

--- a/jena-fuseki2/jena-fuseki-ui/tests/e2e/support/index.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/e2e/support/index.js
@@ -30,7 +30,7 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
-import '@cypress/code-coverage/support'
+// import '@cypress/code-coverage/support'
 
 // Import commands.js using ES2015 syntax:
 import './commands'

--- a/jena-fuseki2/jena-fuseki-ui/tests/e2e/support/vite-preprocessor.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/e2e/support/vite-preprocessor.js
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path')
+const vite = require('vite')
+
+function vitePreprocessor (userConfigPath) {
+  return async (file) => {
+    const { filePath, outputPath } = file
+    const fileName = path.basename(outputPath)
+    const filenameWithoutExtension = path.basename(
+      outputPath,
+      path.extname(outputPath)
+    )
+
+    const defaultConfig = vite.defineConfig({
+      logLevel: 'warn',
+      define: {
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      },
+      build: {
+        emptyOutDir: false,
+        minify: false,
+        outDir: path.dirname(outputPath),
+        sourcemap: true,
+        write: true,
+        rollupOptions: {
+          output: {
+            inlineDynamicImports: false
+          }
+        },
+        lib: {
+          entry: filePath,
+          fileName: () => fileName,
+          formats: ['es'],
+          name: filenameWithoutExtension
+        }
+      }
+    })
+
+    await vite.build({
+      configFile: userConfigPath,
+      ...defaultConfig
+    })
+
+    return outputPath
+  }
+}
+
+module.exports = vitePreprocessor

--- a/jena-fuseki2/jena-fuseki-ui/vite.config.js
+++ b/jena-fuseki2/jena-fuseki-ui/vite.config.js
@@ -52,6 +52,28 @@ export default defineConfig({
     outDir: 'target/webapp',
     assetsDir: 'static',
     sourcemap: 'inline',
+    // https://router.vuejs.org/guide/advanced/lazy-loading.html
+    rollupOptions: {
+      // https://rollupjs.org/guide/en/#outputmanualchunks
+      output: {
+        manualChunks: {
+          queryDataset: [
+            'src/views/manage/ExistingDatasets.vue',
+            'src/views/dataset/Query.vue'
+          ],
+          manageDataset: [
+            'src/views/manage/NewDataset.vue',
+            'src/views/dataset/Upload.vue',
+            'src/views/dataset/Edit.vue',
+            'src/views/dataset/Info.vue'
+          ],
+          other: [
+            'src/views/manage/Tasks.vue',
+            'src/views/Help.vue'
+          ]
+        }
+      }
+    }
   },
   server: {
     // Default, can be overridden by `--port 1234` in package.json


### PR DESCRIPTION
GitHub issue resolved #1749

Pull request Description:

The [vue docs for layz loading routes](https://router.vuejs.org/guide/advanced/lazy-loading.html) shows an example of webpack and vite for dynamic lazy imports of routes.

We had webpack before moving to Vite, but we did not update this part. This shouldn't be breaking anything, but could be related to #1749.

It will be marked as a draft until we can figure out if this fixes #1749 or not, or otherwise add another commit with the fix for that issue here.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
