### PR TITLE
Fixes for running tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
     - name: Build with Maven
-      run: mvn -B --file pom.xml -Dmaven.javadoc.skip=true verify
+      run: mvn -B --file pom.xml -Dmaven.javadoc.skip=true install

--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -26,4 +26,4 @@ jobs:
         java-version: '17'
 
     - name: Build with Maven
-      run: mvn -B --file pom.xml -Dmaven.javadoc.skip=true verify
+      run: mvn -B --file pom.xml -Dmaven.javadoc.skip=true install

--- a/.github/workflows/maven_windows.yml
+++ b/.github/workflows/maven_windows.yml
@@ -32,5 +32,5 @@ jobs:
 
     - name: Build with Maven for windows-latest
       # If Windows and java 11, then MJAVADOC-586 / JDK issue.
-      run: bash -c "mvn -B --file pom.xml -Dmaven.javadoc.skip=true verify"
+      run: bash -c "mvn -B --file pom.xml -Dmaven.javadoc.skip=true install"
       working-directory: c:\jena

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/MainTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/MainTest.java
@@ -65,7 +65,9 @@ public class MainTest {
 
     @AfterClass
     public static void tearDownClass() {
-        SERVER.shutdown();
+        try {
+            SERVER.shutdown();
+        } catch (Throwable th) {}
     }
 
     @Before

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDB2Test.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDB2Test.java
@@ -69,7 +69,9 @@ public class TDB2Test {
 
     @AfterClass
     public static void tearDownClass() {
-        SERVER.shutdown();
+        try {
+            SERVER.shutdown();
+        } catch (Throwable th) {}
     }
 
     @Before

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDBTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDBTest.java
@@ -69,7 +69,9 @@ public class TDBTest {
 
     @AfterClass
     public static void tearDownClass() {
-        SERVER.shutdown();
+        try {
+            SERVER.shutdown();
+        } catch (Throwable th) {}
     }
 
     @Before

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestAdminAPI.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestAdminAPI.java
@@ -34,7 +34,6 @@ import org.apache.jena.query.QueryExecution;
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.apache.jena.sparql.exec.http.Params;
 import org.apache.jena.web.HttpSC;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /** More tests of the admin functionality
@@ -46,10 +45,9 @@ public class TestAdminAPI extends AbstractFusekiWebappTest {
         testAddDelete("db_mem", "mem", false);
     }
 
-    @Ignore  // Not stable on github actions.
     @Test public void add_delete_api_2() throws Exception {
         // Deleted mmap files on Windows does not go away until the JVM exits.
-        if ( Sys.isWindows )
+        if ( org.apache.jena.tdb.sys.SystemTDB.isWindows )
             return;
         testAddDelete("db_tdb", "tdb", true);
     }

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/InitGeoSPARQL.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/InitGeoSPARQL.java
@@ -35,6 +35,10 @@ public class InitGeoSPARQL implements JenaSubsystemLifecycle {
 
     @Override
     public void start() {
+        init();
+    }
+
+    public static void init() {
         if ( initialized )
             return ;
         synchronized (initLock) {

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb/sys/ProcessUtils.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb/sys/ProcessUtils.java
@@ -25,8 +25,6 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.jena.base.Sys;
-
 public class ProcessUtils {
 
     private static int myPid = -1;
@@ -34,11 +32,11 @@ public class ProcessUtils {
     /**
      * Tries to get the PID of the current process caching it for future calls
      * since it won't change throughout the life of the process
-     *
+     * 
      * @param fallback
      *            Fallback PID to return if unable to determine the PID i.e. an
      *            error code to return
-     *
+     * 
      * @return PID of current process or provided {@code fallback} if unable to
      *         determine PID
      */
@@ -76,7 +74,7 @@ public class ProcessUtils {
 
     /**
      * Determines whether a given PID is alive
-     *
+     * 
      * @param pid
      *            PID
      * @return True if the given PID is alive or unknown, false if it is dead
@@ -112,7 +110,7 @@ public class ProcessUtils {
      * negative (i.e. invalid) PIDs as alive because of the format in which the
      * command line process monitor application for the system returns errors
      * for invalid PIDs
-     *
+     * 
      * @return True if a negative PID is treated as alive on this platform or we
      *         cannot determine liveness for PIDs on this platform, false
      *         otherwise
@@ -123,7 +121,7 @@ public class ProcessUtils {
 
     /**
      * Gets process information based on the given PID string
-     *
+     * 
      * @param pidStr
      *            PID string
      * @return Output of running the OSes appropriate command line task info
@@ -134,7 +132,7 @@ public class ProcessUtils {
      */
     private static List<String> getProcessInfo(String pidStr) throws IOException {
         Process p;
-        if (Sys.isWindows) {
+        if (SystemTDB.isWindows) {
             // Use the Windows tasklist utility
             ProcessBuilder builder = new ProcessBuilder("tasklist", "/FI", "PID eq " + pidStr);
             builder.redirectErrorStream(true);

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb/sys/SystemTDB.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb/sys/SystemTDB.java
@@ -26,7 +26,6 @@ import java.util.Properties ;
 import org.apache.jena.atlas.io.IO ;
 import org.apache.jena.atlas.lib.PropertyUtils ;
 import org.apache.jena.atlas.logging.Log ;
-import org.apache.jena.base.Sys;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderLib ;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation ;
@@ -316,9 +315,18 @@ public class SystemTDB
 
     // --------
 
-    /** @deprecated Use {@link Sys#isWindows} */
-    @Deprecated
-    public static final boolean isWindows = Sys.isWindows;
+    public static final boolean isWindows = determineIfWindows() ;	// Memory mapped files behave differently.
+
+    //Or look in File.listRoots.
+    //Alternative method:
+    //  http://stackoverflow.com/questions/1293533/name-of-the-operating-system-in-java-not-os-name
+
+    private static boolean determineIfWindows() {
+    	String s = System.getProperty("os.name") ;
+    	if ( s == null )
+    		return false ;
+    	return s.startsWith("Windows ") ;
+	}
 
     private static boolean determineIf64Bit()
     {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb/ConfigTest.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb/ConfigTest.java
@@ -19,7 +19,7 @@
 package org.apache.jena.tdb;
 
 import org.apache.jena.atlas.lib.FileOps ;
-import org.apache.jena.base.Sys;
+import org.apache.jena.tdb.sys.SystemTDB ;
 
 public class ConfigTest
 {
@@ -27,7 +27,7 @@ public class ConfigTest
     // Place under target
     private static final String testingDir = "target/tdb-testing" ;
     private static final String testingDirDB = "target/tdb-testing/DB" ;
-    static boolean nonDeleteableMMapFiles = Sys.isWindows ;
+    static boolean nonDeleteableMMapFiles = SystemTDB.isWindows ;
 
     static boolean initialized = false ;
 


### PR DESCRIPTION
Pull request Description:

The key revert:
[Revert "Use Sys.isWindows"](https://github.com/apache/jena/commit/c0cdb5a51f2a2883e511649837de5ba4db797007) 

Update works to use Java 17 (compiling for java11); also do a local install, not just verify
[Workflows to use Java17](https://github.com/apache/jena/commit/e877fa2c95ba9f01fc9d7f89114377ea8d6f8ac8)

jena-fuseki-geosparql test fix.:
[Test tear down to ignore server shutdown exceptions](https://github.com/apache/jena/commit/5a4e0a0bd5645038a6f8c8d3c0ebeb89df9e3163)

Code tidy - done as part of getting geoSPARQL sorted (wasn't necessary but done now):
[Static init() function](https://github.com/apache/jena/commit/1481936f05595ae6422e5c0160d6e52e63dd81b0)


----


By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
