### PR TITLE
incorrect integer cast in scripting.NV

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/scripting/NV.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/scripting/NV.java
@@ -124,7 +124,7 @@ public class NV implements RDFJS {
                         return NodeValue.makeInteger(x);
                     // If is a very large integer (larger than long)?
                     if ( d == Math.floor(d) && Double.isFinite(d) ) {
-                        BigInteger big = new BigInteger(Double.toString(x));
+                        BigInteger big = new BigDecimal(d).toBigInteger();
                         return NodeValue.makeInteger(big);
                     }
                     if ( false ) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/function/scripting/TestNV.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/function/scripting/TestNV.java
@@ -66,7 +66,7 @@ public class TestNV {
         String largeInteger = "1" + "0".repeat(22);
         NodeValue nodeValue = NV.toNodeValue(new BigInteger(largeInteger).doubleValue());
         NV nv = new NV(nodeValue);
-        assertEquals(nv.getValue(), largeInteger);
+        assertEquals(largeInteger, nv.getValue());
         assertTrue("is a number", nv.isNumber());
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/function/scripting/TestNV.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/function/scripting/TestNV.java
@@ -22,7 +22,10 @@ import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.sse.SSE;
 import org.junit.Test;
 
+import java.math.BigInteger;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestNV {
 
@@ -58,7 +61,15 @@ public class TestNV {
         assertEquals(nv.getLabel(), nv.getValue());
         assertEquals("BlankNode", nv.getTermType());
     }
-    
+
+    @Test public void nv_14() {
+        String largeInteger = "1" + "0".repeat(22);
+        NodeValue nodeValue = NV.toNodeValue(new BigInteger(largeInteger).doubleValue());
+        NV nv = new NV(nodeValue);
+        assertEquals(nv.getValue(), largeInteger);
+        assertTrue("is a number", nv.isNumber());
+    }
+
     private void test(String str) {
         NodeValue nv = nv(str);
         Object x = NV.fromNodeValue(nv);


### PR DESCRIPTION
GitHub issue resolved #

Pull request Description: Script Function would crash with number exception when trying to return a big integer from javascript (like 100000000000000000000000000)

as far as I can tell it was also trying to use the wrong variable (x instead of d)



----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
