### PR TITLE
SPARQL 1.2 language grammar (quoted triples)

### DIFF
--- a/apache-jena/bat/arq.bat
+++ b/apache-jena/bat/arq.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.arq %*
 exit /B

--- a/apache-jena/bat/infer.bat
+++ b/apache-jena/bat/infer.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" riotcmd.infer %*
 exit /B

--- a/apache-jena/bat/iri.bat
+++ b/apache-jena/bat/iri.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.iri %*
 exit /B

--- a/apache-jena/bat/jena_version.bat
+++ b/apache-jena/bat/jena_version.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" jena.version %*
 exit /B

--- a/apache-jena/bat/juuid.bat
+++ b/apache-jena/bat/juuid.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.juuid %*
 exit /B

--- a/apache-jena/bat/nquads.bat
+++ b/apache-jena/bat/nquads.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" riotcmd.nquads %*
 exit /B

--- a/apache-jena/bat/ntriples.bat
+++ b/apache-jena/bat/ntriples.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" riotcmd.ntriples %*
 exit /B

--- a/apache-jena/bat/qparse.bat
+++ b/apache-jena/bat/qparse.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.qparse %*
 exit /B

--- a/apache-jena/bat/rdfcat.bat
+++ b/apache-jena/bat/rdfcat.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" jena.rdfcat %*
 exit /B

--- a/apache-jena/bat/rdfcompare.bat
+++ b/apache-jena/bat/rdfcompare.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" jena.rdfcompare %*
 exit /B

--- a/apache-jena/bat/rdfcopy.bat
+++ b/apache-jena/bat/rdfcopy.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" jena.rdfcopy %*
 exit /B

--- a/apache-jena/bat/rdfdiff.bat
+++ b/apache-jena/bat/rdfdiff.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.rdfdiff %*
 exit /B

--- a/apache-jena/bat/rdfparse.bat
+++ b/apache-jena/bat/rdfparse.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" jena.rdfparse %*
 exit /B

--- a/apache-jena/bat/rdfpatch.bat
+++ b/apache-jena/bat/rdfpatch.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" rdfpatch.rdfpatch %*
 exit /B

--- a/apache-jena/bat/rdfxml.bat
+++ b/apache-jena/bat/rdfxml.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" riotcmd.rdfxml %*
 exit /B

--- a/apache-jena/bat/riot.bat
+++ b/apache-jena/bat/riot.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" riotcmd.riot %*
 exit /B

--- a/apache-jena/bat/rset.bat
+++ b/apache-jena/bat/rset.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.rset %*
 exit /B

--- a/apache-jena/bat/rsparql.bat
+++ b/apache-jena/bat/rsparql.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.rsparql %*
 exit /B

--- a/apache-jena/bat/rupdate.bat
+++ b/apache-jena/bat/rupdate.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.rupdate %*
 exit /B

--- a/apache-jena/bat/schemagen.bat
+++ b/apache-jena/bat/schemagen.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" jena.schemagen %*
 exit /B

--- a/apache-jena/bat/shacl.bat
+++ b/apache-jena/bat/shacl.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" shacl.shacl %*
 exit /B

--- a/apache-jena/bat/shex.bat
+++ b/apache-jena/bat/shex.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" shex.shex %*
 exit /B

--- a/apache-jena/bat/sparql.bat
+++ b/apache-jena/bat/sparql.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.sparql %*
 exit /B

--- a/apache-jena/bat/tdb2_tdbbackup.bat
+++ b/apache-jena/bat/tdb2_tdbbackup.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb2.tdbbackup %*
 exit /B

--- a/apache-jena/bat/tdb2_tdbcompact.bat
+++ b/apache-jena/bat/tdb2_tdbcompact.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb2.tdbcompact %*
 exit /B

--- a/apache-jena/bat/tdb2_tdbdump.bat
+++ b/apache-jena/bat/tdb2_tdbdump.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb2.tdbdump %*
 exit /B

--- a/apache-jena/bat/tdb2_tdbloader.bat
+++ b/apache-jena/bat/tdb2_tdbloader.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb2.tdbloader %*
 exit /B

--- a/apache-jena/bat/tdb2_tdbquery.bat
+++ b/apache-jena/bat/tdb2_tdbquery.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb2.tdbquery %*
 exit /B

--- a/apache-jena/bat/tdb2_tdbstats.bat
+++ b/apache-jena/bat/tdb2_tdbstats.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb2.tdbstats %*
 exit /B

--- a/apache-jena/bat/tdb2_tdbupdate.bat
+++ b/apache-jena/bat/tdb2_tdbupdate.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb2.tdbupdate %*
 exit /B

--- a/apache-jena/bat/tdbbackup.bat
+++ b/apache-jena/bat/tdbbackup.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb.tdbbackup %*
 exit /B

--- a/apache-jena/bat/tdbdump.bat
+++ b/apache-jena/bat/tdbdump.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb.tdbdump %*
 exit /B

--- a/apache-jena/bat/tdbloader.bat
+++ b/apache-jena/bat/tdbloader.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb.tdbloader %*
 exit /B

--- a/apache-jena/bat/tdbquery.bat
+++ b/apache-jena/bat/tdbquery.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb.tdbquery %*
 exit /B

--- a/apache-jena/bat/tdbstats.bat
+++ b/apache-jena/bat/tdbstats.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb.tdbstats %*
 exit /B

--- a/apache-jena/bat/tdbupdate.bat
+++ b/apache-jena/bat/tdbupdate.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" tdb.tdbupdate %*
 exit /B

--- a/apache-jena/bat/trig.bat
+++ b/apache-jena/bat/trig.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" riotcmd.trig %*
 exit /B

--- a/apache-jena/bat/turtle.bat
+++ b/apache-jena/bat/turtle.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" riotcmd.turtle %*
 exit /B

--- a/apache-jena/bat/uparse.bat
+++ b/apache-jena/bat/uparse.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.uparse %*
 exit /B

--- a/apache-jena/bat/update.bat
+++ b/apache-jena/bat/update.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.update %*
 exit /B

--- a/apache-jena/bat/utf8.bat
+++ b/apache-jena/bat/utf8.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" riotcmd.utf8 %*
 exit /B

--- a/apache-jena/bat/wwwdec.bat
+++ b/apache-jena/bat/wwwdec.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.wwwdec %*
 exit /B

--- a/apache-jena/bat/wwwenc.bat
+++ b/apache-jena/bat/wwwenc.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" arq.wwwenc %*
 exit /B

--- a/apache-jena/bin/arq
+++ b/apache-jena/bin/arq
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.arq "$@" 

--- a/apache-jena/bin/infer
+++ b/apache-jena/bin/infer
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.infer "$@" 

--- a/apache-jena/bin/iri
+++ b/apache-jena/bin/iri
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.iri "$@" 

--- a/apache-jena/bin/jena.version
+++ b/apache-jena/bin/jena.version
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.version "$@" 

--- a/apache-jena/bin/juuid
+++ b/apache-jena/bin/juuid
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.juuid "$@" 

--- a/apache-jena/bin/nquads
+++ b/apache-jena/bin/nquads
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.nquads "$@" 

--- a/apache-jena/bin/ntriples
+++ b/apache-jena/bin/ntriples
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.ntriples "$@" 

--- a/apache-jena/bin/qparse
+++ b/apache-jena/bin/qparse
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.qparse "$@" 

--- a/apache-jena/bin/rdfcat
+++ b/apache-jena/bin/rdfcat
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.rdfcat "$@" 

--- a/apache-jena/bin/rdfcompare
+++ b/apache-jena/bin/rdfcompare
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.rdfcompare "$@" 

--- a/apache-jena/bin/rdfcopy
+++ b/apache-jena/bin/rdfcopy
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.rdfcopy "$@" 

--- a/apache-jena/bin/rdfdiff
+++ b/apache-jena/bin/rdfdiff
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.rdfdiff "$@" 

--- a/apache-jena/bin/rdfparse
+++ b/apache-jena/bin/rdfparse
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.rdfparse "$@" 

--- a/apache-jena/bin/rdfpatch
+++ b/apache-jena/bin/rdfpatch
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" rdfpatch.rdfpatch "$@" 

--- a/apache-jena/bin/rdfxml
+++ b/apache-jena/bin/rdfxml
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.rdfxml "$@" 

--- a/apache-jena/bin/riot
+++ b/apache-jena/bin/riot
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.riot "$@" 

--- a/apache-jena/bin/rset
+++ b/apache-jena/bin/rset
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.rset "$@" 

--- a/apache-jena/bin/rsparql
+++ b/apache-jena/bin/rsparql
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.rsparql "$@" 

--- a/apache-jena/bin/rupdate
+++ b/apache-jena/bin/rupdate
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.rupdate "$@" 

--- a/apache-jena/bin/schemagen
+++ b/apache-jena/bin/schemagen
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.schemagen "$@" 

--- a/apache-jena/bin/shacl
+++ b/apache-jena/bin/shacl
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" shacl.shacl "$@" 

--- a/apache-jena/bin/shex
+++ b/apache-jena/bin/shex
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" shex.shex "$@" 

--- a/apache-jena/bin/sparql
+++ b/apache-jena/bin/sparql
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.sparql "$@" 

--- a/apache-jena/bin/tdb2.tdbbackup
+++ b/apache-jena/bin/tdb2.tdbbackup
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbbackup "$@" 

--- a/apache-jena/bin/tdb2.tdbcompact
+++ b/apache-jena/bin/tdb2.tdbcompact
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbcompact "$@" 

--- a/apache-jena/bin/tdb2.tdbdump
+++ b/apache-jena/bin/tdb2.tdbdump
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbdump "$@" 

--- a/apache-jena/bin/tdb2.tdbloader
+++ b/apache-jena/bin/tdb2.tdbloader
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbloader "$@" 

--- a/apache-jena/bin/tdb2.tdbquery
+++ b/apache-jena/bin/tdb2.tdbquery
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbquery "$@" 

--- a/apache-jena/bin/tdb2.tdbstats
+++ b/apache-jena/bin/tdb2.tdbstats
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbstats "$@" 

--- a/apache-jena/bin/tdb2.tdbupdate
+++ b/apache-jena/bin/tdb2.tdbupdate
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbupdate "$@" 

--- a/apache-jena/bin/tdbbackup
+++ b/apache-jena/bin/tdbbackup
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbbackup "$@" 

--- a/apache-jena/bin/tdbdump
+++ b/apache-jena/bin/tdbdump
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbdump "$@" 

--- a/apache-jena/bin/tdbloader
+++ b/apache-jena/bin/tdbloader
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbloader "$@" 

--- a/apache-jena/bin/tdbquery
+++ b/apache-jena/bin/tdbquery
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbquery "$@" 

--- a/apache-jena/bin/tdbstats
+++ b/apache-jena/bin/tdbstats
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbstats "$@" 

--- a/apache-jena/bin/tdbupdate
+++ b/apache-jena/bin/tdbupdate
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbupdate "$@" 

--- a/apache-jena/bin/trig
+++ b/apache-jena/bin/trig
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.trig "$@" 

--- a/apache-jena/bin/turtle
+++ b/apache-jena/bin/turtle
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.turtle "$@" 

--- a/apache-jena/bin/uparse
+++ b/apache-jena/bin/uparse
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.uparse "$@" 

--- a/apache-jena/bin/update
+++ b/apache-jena/bin/update
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.update "$@" 

--- a/apache-jena/bin/utf8
+++ b/apache-jena/bin/utf8
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.utf8 "$@" 

--- a/apache-jena/bin/wwwdec
+++ b/apache-jena/bin/wwwdec
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.wwwdec "$@" 

--- a/apache-jena/bin/wwwenc
+++ b/apache-jena/bin/wwwenc
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -103,6 +104,12 @@ then
 elif [ -n "$TMP" ]
 then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
+fi
+
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
 "$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.wwwenc "$@" 

--- a/apache-jena/template.bat
+++ b/apache-jena/template.bat
@@ -13,6 +13,10 @@ exit /B
 set JENA_CP=%JENA_HOME%\lib\*;
 set LOGGING=file:%JENA_HOME%/log4j2.properties
 
+if "%CLASSPATH%" == "" goto :noExtra
+set JENA_CP="%JENA_CP%:%CLASSPATH%"
+:noExtra
+
 @rem JVM_ARGS comes from the environment.
 java %JVM_ARGS% -Dlog4j.configurationFile="%LOGGING%" -cp "%JENA_CP%" JENA_CMD %*
 exit /B

--- a/apache-jena/template.bin
+++ b/apache-jena/template.bin
@@ -87,6 +87,7 @@ fi
 # JVM_ARGS : don't set here but it can be set in the environment.
 # Expand JENA_HOME but literal *
 JENA_CP="$JENA_HOME"'/lib/*'
+
 LOGGING="${LOGGING:--Dlog4j.configurationFile=file:$JENA_HOME/log4j2.properties}"
 
 # Platform specific fixup
@@ -105,4 +106,10 @@ then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP:$CLASSPATH" JENA_CMD "$@" 
+## Append any custom classpath
+if [ -n "$CLASSPATH" ]
+then
+    JENA_CP="$JENA_CP:$CLASSPATH"
+fi
+
+"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" JENA_CMD "$@" 

--- a/jena-arq/Grammar/Final/jj2html_11
+++ b/jena-arq/Grammar/Final/jj2html_11
@@ -320,7 +320,7 @@ if ( !$TABLE )
 sub readFile
 {
     my $f = $_[0] ;
-    open(F, "$f") || die "$!"; 
+    open(F, "$f") || die "$f: $!"; 
     my $s = <F> ;
     return $s ;
 }

--- a/jena-arq/Grammar/Notes
+++ b/jena-arq/Grammar/Notes
@@ -7,12 +7,15 @@ main.jj - Template for SPARQL and ARQ
     cpp input to produce sparql.jj or arq.jj
 
 sparql_11.jj - The SPARQL working group syntax
-    This should be exactly the grammar in the SPARQL rec.
+    This should be exactly the grammar in the SPARQL 1.1 rec.
     Generates org.apache.jena.query.parser.sparql_11.SPARQLParser
+
+sparql_12.jj - The RDF Star working group syntax
+    This should be exactly the grammar in the SPARQL 1.2 rec.
+    Generates org.apache.jena.query.parser.sparql_12.SPARQLParser
 
 arq.jj - The native query language of the query engine
     Generates org.apache.jena.query.parser.arq.ARQParser
-
 
 sparql_10-final.jj - SPARQL 1.0, but updated to match internal chnages in ARQ.
     This should produce the grammar in the SPARQ 1.0/DAWG rec.
@@ -31,7 +34,7 @@ Note this runs cpp over main.jj to produce arq.jj or sparql.jj
 
 ==== Making the HTML
 
-sparql_N.txt is produced by "grammar", used to make HTML.
+sparql_N.txt is produced by "grammar", and is used to make HTML.
 We don't use jjdoc to produce HTML but instead get jjdoc to produce
 its text form and process that, toegther with a hand-managed
 token.txt file.
@@ -41,6 +44,6 @@ token.txt file.
 Run "jj2tokens sparql_11.jj > tokens.txt" to get a first pass at a tokens file.
 Manually tidy, noting which to inline
 
-Produce HTML suiatble for inclusion in the SPARQL recomendations.
+Produce HTML suitable for inclusion in the SPARQL recomendations.
 Includes some hand-craft tidying up. 
   jj2html arq.txt tokens.txt 

--- a/jena-arq/Grammar/Turtle/turtle
+++ b/jena-arq/Grammar/Turtle/turtle
@@ -26,6 +26,9 @@ javacc -OUTPUT_DIRECTORY=$DIR -JDK_VERSION=1.8 "$FILE"
 RC=$?
 [ "$RC" = 0 ] || exit $RC
 
+## echo "---- Create text form"
+## jjdoc -TEXT=true -OUTPUT_FILE=${FILE%%.jj}.txt "${FILE}"
+ 
 echo "---- Fixing Java warnings in TokenMgrError"
 F="$DIR/TokenMgrError.java"
 if [ -e "$F" ]

--- a/jena-arq/Grammar/Turtle/turtle.jj
+++ b/jena-arq/Grammar/Turtle/turtle.jj
@@ -142,7 +142,7 @@ void Annotation(Node s, Node p, Node o) : {}
 {
   (
     <L_ANN>
-      { Node x = createTripleTerm(s, p, o, token.beginLine, token.beginColumn); }
+      { Node x = createQuotedTriple(s, p, o, token.beginLine, token.beginColumn); }
       PredicateObjectList(x)
     <R_ANN>
   )?
@@ -164,7 +164,7 @@ Node Subject() : { Node s; String iri ; }
   |
     s = Collection()
   |
-    s = EmbTriple()
+    s = QuotedTriple()
   )
   { return s ; }
 }
@@ -185,40 +185,39 @@ Node Object(): { Node o ; String iri; }
   | o = Collection()
   | o = BlankNodePropertyList()
   | o = Literal()
-  | o = EmbTriple()
+  | o = QuotedTriple()
   )
   { return o; }
 }
 
-Node EmbSubject(): { Node o ; String iri; }
+Node QuotedTripleSubject(): { Node o ; String iri; }
 {
   ( iri = iri() { o = createURI(iri, token.beginLine, token.beginColumn) ; }
   | o = BlankNode()
-  | o = EmbTriple()
+  | o = QuotedTriple()
   )
   { return o; }
 }
 
-Node EmbObject(): { Node o ; String iri; }
+Node QuotedTripleObject(): { Node o ; String iri; }
 {
   ( iri = iri() { o = createURI(iri, token.beginLine, token.beginColumn) ; }
   | o = BlankNode()
   | o = Literal()
-  | o = EmbTriple()
+  | o = QuotedTriple()
   )
   { return o ; } 
 }
 
 // The syntax for RDF-star <<>>
-Node EmbTriple() : { Node s , p , o ; Token t ; }
+Node QuotedTriple() : { Node s , p , o ; Token t ; }
 {
   t = <LT2>
-    { int beginLine = t.beginLine; int beginColumn = t.beginColumn; t = null; }
-  s = EmbSubject()
+  s = QuotedTripleSubject()
   p = Verb()
-  o = EmbObject()
+  o = QuotedTripleObject()
   <GT2>
-  { Node n = createTripleTerm(s, p, o, beginLine, beginColumn);
+  { Node n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn);
     return n;
   }
 }

--- a/jena-arq/Grammar/arq.jj
+++ b/jena-arq/Grammar/arq.jj
@@ -729,13 +729,12 @@ void InlineDataFull() : { Var v ; Node n ; Token t ; int beginLine; int beginCol
 }
 Node DataBlockValue() : { Node n ; String iri ; }
 {
-  n = TripleTermData() { return n ; }
-|
   iri = iri() { return createNode(iri) ; }
 | n = RDFLiteral() { return n ; }
 | n = NumericLiteral() { return n ; }
 | n = BooleanLiteral() { return n ; }
 | <UNDEF> { return null ; }
+| n = QuotedTripleData() { return n ; }
 }
 Element Assignment() : { Var v ; Expr expr ; }
 {
@@ -1163,7 +1162,7 @@ void AnnotationPath(TripleCollector acc, Node s, Node p, Path path, Node o) : {}
   (
     <L_ANN>
       { Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
-        Node x = createTripleTerm(s, pAnn, o, token.beginLine, token.beginColumn);
+        Node x = createQuotedTriple(s, pAnn, o, token.beginLine, token.beginColumn);
       }
       PropertyListPathNotEmpty(x, acc)
     <R_ANN>
@@ -1174,7 +1173,7 @@ void Annotation(TripleCollector acc, Node s, Node p, Path path, Node o) : { }
   (
     <L_ANN>
       { Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
-        Node x = createTripleTerm(s, p, o, token.beginLine, token.beginColumn);
+        Node x = createQuotedTriple(s, p, o, token.beginLine, token.beginColumn);
       }
       PropertyListNotEmpty(x, acc)
     <R_ANN>
@@ -1192,31 +1191,36 @@ Node GraphNodePath(TripleCollectorMark acc) : { Node n ; }
  |
   n = TriplesNodePath(acc) { return n ; }
 }
-Node VarOrTerm() : { Node n = null ; }
+Node VarOrTerm() : { Node n = null ; String iri ; }
 {
-  ( n = TripleTerm()
-  | n = Var()
-  | n = GraphTerm()
-  )
+  ( n = Var()
+  | iri = iri() { return createNode(iri) ; }
+  | n = RDFLiteral() { return n ; }
+  | n = NumericLiteral() { return n ; }
+  | n = BooleanLiteral() { return n ; }
+  | n = BlankNode() { return n ; }
+  | <NIL> { return nRDFnil ; }
+  | n = QuotedTriple()
+)
   { return n ; }
 }
-Node TripleTerm() : { Node n = null ; Token t ; Node s , p , o ; }
+Node QuotedTriple() : { Node n = null ; Token t ; Node s , p , o ; }
 {
   t = <LT2>
   s = VarOrTerm()
   p = Verb()
   o = VarOrTerm()
-  { n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn); }
+  { n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn); }
   <GT2>
   { return n; }
 }
-Node TripleTermData() : { Node n = null ; Token t ; String iri ; Node s , p , o ; }
+Node QuotedTripleData() : { Node n = null ; Token t ; String iri ; Node s , p , o ; }
 {
   t = <LT2>
   ( s = DataValueTerm() )
   ( iri = iri() { p = createNode(iri) ; } | <KW_A> { p = nRDFtype ; } )
   ( o = DataValueTerm() )
-  { n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn); }
+  { n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn); }
   <GT2>
   { return n; }
 }
@@ -1226,7 +1230,7 @@ Node DataValueTerm() : { Node n = null ; String iri ; Node s , p , o ; }
 | n = RDFLiteral() { return n ; }
 | n = NumericLiteral() { return n ; }
 | n = BooleanLiteral() { return n ; }
-| n = TripleTermData() { return n ; }
+| n = QuotedTripleData() { return n ; }
 }
 Node VarOrIri() : {Node n = null ; String iri ; }
 {
@@ -1242,15 +1246,6 @@ Var Var() : { Token t ;}
 {
     ( t = <VAR1> | t = <VAR2> )
     { return createVariable(t.image, t.beginLine, t.beginColumn) ; }
-}
-Node GraphTerm() : { Node n ; String iri ; }
-{
-  iri = iri() { return createNode(iri) ; }
-| n = RDFLiteral() { return n ; }
-| n = NumericLiteral() { return n ; }
-| n = BooleanLiteral() { return n ; }
-| n = BlankNode() { return n ; }
-| <NIL> { return nRDFnil ; }
 }
 Expr Expression() : { Expr expr ; }
 {
@@ -1373,7 +1368,7 @@ Expr PrimaryExpression() : { Expr expr ; Node n ; }
   | n = NumericLiteral() { return asExpr(n) ; }
   | n = BooleanLiteral() { return asExpr(n) ; }
   | n = Var() { return asExpr(n) ; }
-  | n = ExprTripleTerm() { return asExpr(n) ; }
+  | n = ExprQuotedTriple() { return asExpr(n) ; }
   )
 }
 Node ExprVarOrTerm() : { Node n; String s;}
@@ -1383,16 +1378,16 @@ Node ExprVarOrTerm() : { Node n; String s;}
   | n = NumericLiteral()
   | n = BooleanLiteral()
   | n = Var()
-  | n = ExprTripleTerm()
+  | n = ExprQuotedTriple()
   )
   { return n; }
 }
-Node ExprTripleTerm() : { Token t ; Node s,p,o,n; }
+Node ExprQuotedTriple() : { Token t ; Node s,p,o,n; }
 { t = <LT2>
   s = ExprVarOrTerm()
   p = Verb()
   o = ExprVarOrTerm()
-  { n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn); }
+  { n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn); }
   <GT2>
   { return n; }
 }
@@ -1504,7 +1499,7 @@ Expr BuiltInCall() : { Expr expr ;
     expr = RegexExpression() { return expr ; }
   | expr = ExistsFunc() { return expr ; }
   | expr = NotExistsFunc() { return expr ; }
-  | <IS_TRIPLE> <LPAREN> expr = Expression() <RPAREN>
+| <IS_TRIPLE> <LPAREN> expr = Expression() <RPAREN>
     { return new E_IsTriple(expr) ; }
   | <TRIPLE> <LPAREN> expr1 = Expression() <COMMA> expr2 = Expression() <COMMA> expr3 = Expression() <RPAREN>
     { return new E_TripleFn(expr1, expr2, expr3) ; }
@@ -1789,12 +1784,12 @@ TOKEN [IGNORE_CASE] :
 | < BIND: "bind" >
 | < SERVICE: "service" >
 | < LET: "LET" >
+| < LATERAL: "LATERAL" >
 | < TRIPLE: "TRIPLE" >
 | < IS_TRIPLE: "isTRIPLE" >
 | < SUBJECT: "SUBJECT" >
 | < PREDICATE: "PREDICATE" >
 | < OBJECT: "OBJECT" >
-| < LATERAL: "LATERAL" >
 | < EXISTS: "exists" >
 | < NOT: "not" >
 | < AS: "as" >

--- a/jena-arq/Grammar/grammar
+++ b/jena-arq/Grammar/grammar
@@ -35,7 +35,7 @@ function grammar
     (cd "$DIR" ; rm -f TokenMgrError.java ParseException.java Token.java JavaCharStream.java )
 
     echo "---- Process grammar -- $1"
-    javacc -OUTPUT_DIRECTORY=$DIR  -JDK_VERSION=1.7 "${FILE}"
+    javacc -OUTPUT_DIRECTORY=$DIR  -JDK_VERSION=1.8 "${FILE}"
     RC=$?
 
     [ "$RC" = 0 ] || return

--- a/jena-arq/Grammar/jj2html
+++ b/jena-arq/Grammar/jj2html
@@ -70,8 +70,7 @@ $tokens =~ s!\r!!g ;
 # Grammar rules
 # Direct from "jjdoc -TEXT=true"
 
-for $g (@g)
-{
+for $g (@g) {
     ($rulename, $rulebody) = split(/:=/,$g) ;
 
     $rulename =~ s!^\s*!! ;
@@ -79,23 +78,12 @@ for $g (@g)
 
     $rulebody =~ s!^\s*!! ;
     $rulebody =~ s!\s*$!! ;
+
     
     # Remove outer brackets
 #    $rulebody =~ s!^\((.*)\)$!$1! ;
 
-    # Remove <> around tokens in grammar.
-    ## Now done very late (as &lt;&gt;) in fixups.
-    ## $rulebody =~ s/\<(\w+)\>/$1/g ;
-    # Leave in - so tokens distinguished from rules
-
     next if $rulename eq '' ;
-    #next if $rulebody eq '' ;
-
-    # Skip the root rule.
-    next if ( $rulename eq 'CompilationUnit' ) ;
-
-    $rulebody = 'Perl 5 regular expression'
-	if ( $rulename eq 'PatternLiteral' ) ;
 
     push @rules, $rulename ;
     warn "Duplicate rule (grammar): $rulename\n" if defined($ruleMap{$rulename}) ;
@@ -104,7 +92,6 @@ for $g (@g)
 ##     print "----------\n" ;
 ##     print $rulename,"\n" ;
 ##     print $rulebody,"\n" ;
-
 }
 
 
@@ -117,53 +104,36 @@ $tokens =~ s/^\n// ;
 
 @t = split(/\n(?=\<|\[)/, $tokens) ;
 
-for $t (@t)
-{
+for $t (@t) {
     ($tokenname,$tokenbody) = split(/::=/, $t) ;
     $tokenname =~ s!^\s*!! ;
     $tokenname =~ s!\s*$!! ;
-
-##     # remove <> around tokens
-## Do very late as a formatting fix up.
-##     $tokenname =~ s/^\<// ;
-##     $tokenname =~ s/\>$// ;
-
     $tokenname =~ s/#// ;
-    
+
     $tokenbody =~ s!^\s*!! ;
     $tokenbody =~ s!\s*$!! ;
-    
-    # <> round tokens
-    # Remove at last minute.
-
-    # Remove outer ()
-    # $tokenbody =~ s!^\((.*)\)$!$1! ;
 
     # Inline?
-    if ( $tokenname =~ /^\[\<\w*\>\]/ )
-    {
+    if ( $tokenname =~ /^\[\<\w*\>\]/ ) {
 	warn "Duplicate inline (token): $tokenname\n" if defined($inline{$tokenname}) ;
 	$tokenname =~ s/^\[//g ;
 	$tokenname =~ s/\]$//g ;
 	$tokenbody =~ s/"/'/g ; # '" -- But not literal " -- how?
         $tokenbody =~ s/\<\>\'\{\}/\<\>\"\{\}/ ; # '" IRI fixup
-
 	$inline{$tokenname} = $tokenbody ;
 
 	#print "INLINE: ",$tokenname," => ",$tokenbody,"\n" ;
-    }
-    else
-    {
+    } else {
 	push @rules, $tokenname ;
 	warn "Duplicate rule (token): $tokenname\n" if defined($tokenMap{$tokenname}) ;
 	$ruleMap{$tokenname} = $tokenbody ; 
     }
+    
 }
 
 # Table
 
-if ( ! $TABLE )
-{
+if ( ! $TABLE ) {
     print "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" ;
     print "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"\n" ;
     print "    \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n" ;
@@ -194,15 +164,17 @@ EOF
      print "<body>\n";
 
     print "\n" ;
-}
+} ## End TABLE
 
-print "<div class=\"grammarTable\">\n" ;
-print "  <table><tbody>\n" ;
+$indent = "        ";
+## $indent = "";
+
+print $indent,"<div class=\"grammarTable\">\n" ;
+print $indent,"  <table><tbody>\n" ;
 
 $ruleNum = 0 ;
 
-for $r (@rules)
-{
+for $r (@rules) {
     $DEBUG = 0 ;
     $ruleNum++ ;
     $rulename = $r ;
@@ -211,45 +183,35 @@ for $r (@rules)
 
 ##    $DEBUG = 1 if ( $rulename =~ /Prolog/ ) ;
 
-    $rb = $rulebody ;
 
-    if ( $DEBUG )
-    {
+    if ( $DEBUG ) {
 	print STDERR "\n" ;
 	print STDERR "Rule: $rulename\n" ; 
 	print STDERR "Body: $rulebody\n" ; 
     }
 
-    ## Do before '||' substitution
-    # Not perfect - some fixups later.
-    #$rb =~ s%\|%\<br/\>\|%g ;
-
+    $ruleBodyStr = $rulebody ;
     # Escape HTML chars before adding markup.
-    $rb = esc($rb) ;
+    $ruleBodyStr = esc($ruleBodyStr) ;
     
     # Inlines
-    for $k (keys %inline)
-    {
-	$s = span('token', $inline{$k}) ;
+    for $k (keys %inline) {
+	$s = '<span class="token">' . esc($inline{$k}) . '</span>' ;
 	$k = esc($k) ;
 	# Assumes escaped <> round tokens.
 	$k = quotemeta $k ;
-	$rb =~ s/$k/$s/g ;
-
+	$ruleBodyStr =~ s/$k/$s/g ;
     }
 
-    if ( $DEBUG )
-    {
+    if ( $DEBUG ) {
 	print STDERR "After inlining\n" ;
-	print STDERR $rb,"\n" ; ; 
+	print STDERR $ruleBodyStr,"\n" ; ; 
     }
-
 
     # Add hrefs - issue if one is a substring of another \W helps.
 
-    for $k (keys %ruleMap)
-    {
-	$s = href("r-".$k,$k) ;
+    for $k (keys %ruleMap) {
+	$s = '<a href="#r' . sane($k) . '">' . esc($k) . '</a>' ;
 
 	$k = esc($k) ;
 	$k = quotemeta $k ;
@@ -260,73 +222,75 @@ for $r (@rules)
 ## 	}
 
 
-	$rb =~ s/(?=\W)(\s*)$k(\s*)(?=\W)/$1$s$2/g ;
-	$rb =~ s/^$k(\s*)(?=\W)/$s$1/g ;
-	$rb =~ s/(?=\W)(\s*)$k$/$1$s/g ;
-	$rb =~ s/^$k$/$s/g ;
+	$ruleBodyStr =~ s/(?=\W)(\s*)$k(\s*)(?=\W)/$1$s$2/g ;
+	$ruleBodyStr =~ s/^$k(\s*)(?=\W)/$s$1/g ;
+	$ruleBodyStr =~ s/(?=\W)(\s*)$k$/$1$s/g ;
+	$ruleBodyStr =~ s/^$k$/$s/g ;
     }
     
-    if ( $DEBUG )
-    {
+    if ( $DEBUG ) {
 	print STDERR "After hrefs\n" ;
-	print STDERR $rb,"\n" ; ; 
+	print STDERR $ruleBodyStr,"\n" ; ; 
     }
 
     #exit if $ruleNum > 2 ;
 
-    $rn = anchor("r-".$rulename, $rulename) ;
-    $rn = fixupHead($rn) ;
+    $ruleId = sane("r".$rulename) ;
 
-    if($rulename eq 'IRIREF') 
-    {
-	print "  </tbody></table>\n" ;
-	print "</div>\n" ;
-	print "<p>Productions for terminals:</p>\n" ;
-	print "<div class=\"grammarTable\">\n" ;
-	print "  <table><tbody>\n" ;
+    if($rulename eq 'IRIREF') {
+	print $indent,"  </tbody></table>\n" ;
+	print $indent,"</div>\n" ;
+	print $indent,"<p>Productions for terminals:</p>\n" ;
+	print $indent,"<div class=\"grammarTable\">\n" ;
+	print $indent,"  <table><tbody>\n" ;
     }
 
-
     print "\n" ;
-    print "<tr valign=\"baseline\">\n" ;
+    $indentRule = "              ";
+    ##$indentRule = "";
+    print $indentRule,"<tr style=\"vertical-align: baseline\">\n";
+    
     $rlabel = '[' . $ruleNum .  ']&nbsp;&nbsp;' ;
 
-    print "  <td>",code('gRuleLabel', $rlabel),"</td>\n" ;
+    print $indentRule,"  <td><code>",$rlabel,"</code></td>\n" ;
 
-    #print "  <td>",span('gRuleHead', $rn),"</td>\n" ;
-    print "  <td>",code('gRuleHead',$rn),"</td>\n" ;
-
-    print "  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>\n" ;
+    $rn = $rulename;
+    $rn =~ s!^<!!; 
+    $rn =~ s!>$!!; 
     
-    $rb = fixupRule($rulename, $rb) ;
-    print "  <td>",code('gRuleBody',$rb),"</td>\n" ;
+    print $indentRule,
+	'  <td><code><span class="doc-ref" id="',$ruleId,'">',
+	esc($rn),
+	'</span></code></td>',"\n";
+    
+    print $indentRule,"  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>\n" ;
+    
+    $ruleBodyStr = fixupRule($rulename, $ruleBodyStr) ;
+    print $indentRule,"  <td>",code('gRuleBody',$ruleBodyStr),"</td>\n" ;
 
-    print "</tr>\n" ;
+    print $indentRule,"</tr>\n" ;
 
 #    $rule{$rulename, $rulebody) ;
 #    print $rulename , "\n" ;
 }
 
-print "  </tbody></table>\n" ;
-print "</div>\n" ;
+print $indent,"  </tbody></table>\n" ;
+print $indent,"</div>\n" ;
 
-if ( !$TABLE )
-{
+if ( !$TABLE ) {
     print "\n" ;
     print "</body>\n" ;
     print "</html>\n" ;
 }
 
-sub readFile
-{
+sub readFile {
     my $f = $_[0] ;
     open(F, "$f") || die "$f: $!"; 
     my $s = <F> ;
     return $s ;
 }
 
-sub esc
-{
+sub esc {
     my $s = $_[0] ;
     $s =~ s/&/&amp;/g ; 
     $s =~ s/</&lt;/g ; 
@@ -334,78 +298,31 @@ sub esc
     return $s ;
 }
 
-sub span
-{
-    my $c = $_[0] ;
-    my $t = $_[1] ;
-    $t = esc($t) ;
-    my $s = '<span class="' . $c . '">' . $t . '</span>' ;
-    return $s ;
-}
-
-sub href
-{
-    my $a = $_[0] ;
-    my $t = $_[1] ;
-    $a = sane($a) ;
-    $t = esc($t) ;
-    my $s = '<a href="#' . $a . '">' . $t . '</a>' ;
-    return $s ;
-}
-
-sub anchor
-{
-    my $a = $_[0] ;
-    my $t = $_[1] ;
-    $a = sane($a) ;
-    $t = esc($t) ;
-    my $s = '<a id="' . $a . '" name="' . $a . '">' . $t . '</a>' ;
-    return $s ;
-}
-
-sub sane
-{
+sub sane {
    my $a = $_[0] ;
    $a =~ s/\W//g ;
    return $a ;
 }
 
-sub code
-{
+sub code {
     my $c = $_[0] ;
     my $t = $_[1] ;
     return '<code class="' . $c . '">' . $t . '</code>' ;
 }
 
-sub fixupHead
-{
+sub fixupHead {
     my $head = $_[0] ;
     # Remove <> around tokens.
     $head =~ s/&lt;(\w+)&gt;/$1/g ;
     return $head ;
 }
 
-sub fixupRule
-{
+sub fixupRule {
     my $head = $_[0] ;
     my $body = $_[1] ;
 
     # Remove unnecessary ()
     $body =~ s/\(\s*([^()| ]*) \)/$1/g ;
-
-##     if ( $body =~ m!\(\s+(\<a[^>]*\>[^<>]*\</a\>)\s+\)! )
-##     {
-## 	$b = $body ;
-## 	print "================================\n" ;
-## 	print STDERR "$b\n" ;
-## 	print STDERR "--------\n" ;
-## 	$b =~ s!\(\s+(\<a[^>]*\>[^<>]*\</a\>)\s+\)!$1!g ;
-## 	$b =~ s!\(\s+(\<span[^>]*\>[^<>]*\</span\>)\s+\)!$1!g ;
-## 	print STDERR "$b\n" ;
-## 	print STDERR "=====\n" ;
-## 	print STDERR "\n" ;
-##     }
-
 
     # Remove outer matching () where there are no inner ()
     $body =~ s/^\(\s+([^\(]*)\s+\)$/$1/ ;
@@ -451,13 +368,13 @@ sub fixupRule
 	$body =~ s%\<br/\>\| *\<a href="#rNIL"\>NIL\</a\>%\| \<a href="#rNIL"\>NIL\</a\>%g ;
     }
 
-    if ( $head eq "RelationalExpression" ||
-	 $head eq "AdditiveExpression" ||
-	 $head eq "MultiplicativeExpression" ||
-	 $head eq "ConditionalOrExpression")
-    {
-	$body =~ s%\*\(%<br/>\(% ;
-    }
+##     if ( $head eq "RelationalExpression" ||
+## 	 $head eq "AdditiveExpression" ||
+## 	 $head eq "MultiplicativeExpression" ||
+## 	 $head eq "ConditionalOrExpression")
+##     {
+## 	$body =~ s%\*\(%<br/>\(% ;
+##     }
 
     # These failed the outer () test because they have nested () in them
     if (  $head eq "QueryPattern" ||

--- a/jena-arq/Grammar/main.jj
+++ b/jena-arq/Grammar/main.jj
@@ -21,7 +21,6 @@
 // (Run through cpp -P -C first)
 #endif
 
-
 #if !defined(ARQ) && !defined(SPARQL_12)
 #error Please define one of ARQ and SPARQL_12
 #endif
@@ -42,14 +41,12 @@
 #define PACKAGE     lang.sparql_12
 #define CLASS       SPARQLParser12
 #define PARSERBASE  SPARQLParser12Base
-#define UPDATE
 #endif
 
 #ifdef ARQ
 #define PACKAGE     lang.arq
 #define CLASS       ARQParser
 #define PARSERBASE  ARQParserBase
-#define UPDATE
 #endif
 
 options
@@ -100,11 +97,10 @@ import org.apache.jena.sparql.syntax.* ;
 import org.apache.jena.sparql.expr.* ;
 import org.apache.jena.sparql.path.* ;
 import org.apache.jena.sparql.expr.aggregate.* ;
-#ifdef  UPDATE
 import org.apache.jena.sparql.expr.aggregate.lib.* ;
 import org.apache.jena.update.* ;
 import org.apache.jena.sparql.modify.request.* ;
-#endif
+
 #ifdef ARQ
 import org.apache.jena.sparql.core.Quad ;
 import java.util.List;
@@ -125,7 +121,9 @@ PARSER_END(CLASS)
 // Query only entry point
 void QueryUnit(): { }
 {
+#ifdef ARQ
   ByteOrderMark()
+#endif
   { startQuery() ; }
   Query() <EOF>
   { finishQuery() ; }
@@ -142,21 +140,23 @@ void Query() : { }
   ValuesClause()
 }
 
-#ifdef UPDATE
 void UpdateUnit() : {}
 {
+#ifdef ARQ
   ByteOrderMark()
+#endif
   { startUpdateRequest() ; }
   Update()
   <EOF>
   { finishUpdateRequest() ; }
 }
-#endif
 
+#ifdef ARQ
 void ByteOrderMark() : {}
 {
    (<BOM>)?
 }
+#endif
 
 void Prologue() : {}
 {
@@ -245,6 +245,7 @@ void SelectClause() : {  Var v ; Expr expr ; Node n ; }
 }
 
 #ifdef ARQ
+// Allows quads
 void ConstructQuery() : { Template t ; 
                           QuadAcc acc = new QuadAcc() ; }
 {
@@ -263,7 +264,7 @@ void ConstructQuery() : { Template t ;
     <WHERE>
     // Should have been "ConstructTemplate()"
     <LBRACE>  
-    ConstructQuads(acc)
+    ConstructQuads(acc) // Quads
     <RBRACE>
     SolutionModifier()
     { 
@@ -276,7 +277,6 @@ void ConstructQuery() : { Template t ;
  )
 }
 #else
-// Complete compatibility - this differs from the above at "new Template"
 void ConstructQuery() : { Template t ; 
                           TripleCollectorBGP acc = new TripleCollectorBGP() ; }
 {
@@ -295,7 +295,7 @@ void ConstructQuery() : { Template t ;
     <WHERE>
     // Should have been "ConstructTemplate()"
     <LBRACE>  
-    (TriplesTemplate(acc))?
+    (TriplesTemplate(acc))? // triples
     <RBRACE>
     SolutionModifier()
     { 
@@ -513,10 +513,6 @@ void ValuesClause() : { Token t ; }
     { finishValuesClause(t.beginLine, t.beginColumn) ; }
   )?
 }
-
-#ifdef UPDATE
-// SPARQL Update + transitional extensions for SPARQL/Update (the W3C submission)
-// Update only entry point
 
 #ifdef ARQ
 void Update() : { }
@@ -816,8 +812,6 @@ void TriplesTemplate(TripleCollector acc) : { }
 #endif
 }
 
-#endif
-
 // ---- General Graph Pattern 
 
 Element GroupGraphPattern() : { Element el = null ; Token t ; }
@@ -1022,15 +1016,13 @@ void InlineDataFull() : { Var v ; Node n ; Token t ; int beginLine; int beginCol
 
 Node DataBlockValue() : { Node n ; String iri ; }
 {
-#ifdef ARQ
-  n = TripleTermData()      { return n ; }
-|
-#endif
   iri = iri()           { return createNode(iri) ; }
 | n = RDFLiteral()      { return n ; }
 | n = NumericLiteral()  { return n ; }
 | n = BooleanLiteral()  { return n ; }
 | <UNDEF>               { return null ; }
+| n = QuotedTripleData()      { return n ; }
+
 }
 
 #ifdef ARQ
@@ -1261,9 +1253,7 @@ void Object(Node s, Node p, Path path, TripleCollector acc): { Node o ; }
   { ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ; }
   o = GraphNode(tempAcc) 
   { insert(tempAcc, mark, s, p, path, o) ;  insert(acc, tempAcc) ; }
-#ifdef ARQ  
   Annotation(acc, s, p, path, o)
-#endif
 }
 
 // -------- BGPs with paths.
@@ -1333,9 +1323,7 @@ void ObjectPath(Node s, Node p, Path path, TripleCollector acc): { Node o ; }
   { ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ; }
   o = GraphNodePath(tempAcc) 
   { insert(tempAcc, mark, s, p, path, o) ;  insert(acc, tempAcc) ; }
-#ifdef ARQ
   AnnotationPath(acc, s, p, path, o)
-#endif
 }
 
 // End paths stuff.
@@ -1624,14 +1612,13 @@ Node CollectionPath(TripleCollectorMark acc) :
      return listHead ; }
 }
 
-#ifdef ARQ
 // RDF-star Annotation Syntax
 void AnnotationPath(TripleCollector acc, Node s, Node p, Path path, Node o) : {}
 {
   (
     <L_ANN>
       { Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
-        Node x = createTripleTerm(s, pAnn, o, token.beginLine, token.beginColumn);
+        Node x = createQuotedTriple(s, pAnn, o, token.beginLine, token.beginColumn);
       }
       PropertyListPathNotEmpty(x, acc)
     <R_ANN>
@@ -1645,13 +1632,12 @@ void Annotation(TripleCollector acc, Node s, Node p, Path path, Node o) : { }
   (
     <L_ANN>
       { Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
-        Node x = createTripleTerm(s, p, o, token.beginLine, token.beginColumn);
+        Node x = createQuotedTriple(s, p, o, token.beginLine, token.beginColumn);
       }
       PropertyListNotEmpty(x, acc)
     <R_ANN>
   )?
 }
-#endif
 
 // -------- Nodes in a graph pattern or template
 
@@ -1669,42 +1655,39 @@ Node GraphNodePath(TripleCollectorMark acc) : { Node n ; }
   n = TriplesNodePath(acc) { return n ; }
 }
 
-#ifdef SPARQL_12
-Node VarOrTerm() : {Node n = null ; }
+Node VarOrTerm() : { Node n = null ; String iri ; }
 {
-  ( n = Var() | n = GraphTerm() )
-  { return n ; }
-}
-#endif
-#ifdef ARQ
-// RDF-star Triple as term.
-Node VarOrTerm() : { Node n = null ; }
-{
-  ( n = TripleTerm()
-  | n = Var()
-  | n = GraphTerm()
-  )
+  ( n = Var()
+  | iri = iri()           { return createNode(iri) ; }
+  | n = RDFLiteral()      { return n ; }
+  | n = NumericLiteral()  { return n ; }
+  | n = BooleanLiteral()  { return n ; }
+  | n = BlankNode()       { return n ; }
+  //  <LPAREN> <RPAREN>     { return nRDFnil ; }
+  | <NIL>  { return nRDFnil ; }
+  | n = QuotedTriple()
+)
   { return n ; }
 }
 
-Node TripleTerm() :  { Node n = null ; Token t ; Node s , p , o ; }
+Node QuotedTriple() :  { Node n = null ; Token t ; Node s , p , o ; }
 {
   t = <LT2>
   s = VarOrTerm()
   p = Verb()
   o = VarOrTerm()
-  { n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn); }
+  { n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn); }
   <GT2>
   { return n; }
 }
 
-Node TripleTermData() :  { Node n = null ; Token t ; String iri ; Node s , p , o ; }
+Node QuotedTripleData() :  { Node n = null ; Token t ; String iri ; Node s , p , o ; }
 {
   t = <LT2>
   ( s = DataValueTerm() )
   ( iri = iri() { p = createNode(iri) ; } | <KW_A> { p = nRDFtype ; } )
   ( o = DataValueTerm() )
-  { n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn); }
+  { n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn); }
   <GT2>
   { return n; }
 }
@@ -1715,10 +1698,8 @@ Node DataValueTerm() : {  Node n = null ; String iri ; Node s , p , o ; }
 | n = RDFLiteral()      { return n ; }
 | n = NumericLiteral()  { return n ; }
 | n = BooleanLiteral()  { return n ; }
-| n = TripleTermData()  { return n ; }
+| n = QuotedTripleData()  { return n ; }
 }
-
-#endif
 
 // e.g. Property (if no bNodes) + DESCRIBE
 Node VarOrIri() : {Node n = null ; String iri ; }
@@ -1728,27 +1709,18 @@ Node VarOrIri() : {Node n = null ; String iri ; }
 }
 
 // e.g. INSERT DATA { GRAPH ... }
+#ifdef ARQ
 Node VarOrBlankNodeOrIri() : {Node n = null ; String iri ; }
 {
   ( n = Var() | n = BlankNode() | iri = iri() { n = createNode(iri) ; } )
   { return n ; }
 }
+#endif
 
 Var Var() : { Token t ;}
 {
     ( t = <VAR1> | t = <VAR2> )
     { return createVariable(t.image, t.beginLine, t.beginColumn) ; }
-}
-
-Node GraphTerm() : { Node n ; String iri ; }
-{
-  iri = iri()        { return createNode(iri) ; }
-| n = RDFLiteral()      { return n ; }
-| n = NumericLiteral()  { return n ; }
-| n = BooleanLiteral()  { return n ; }
-| n = BlankNode()       { return n ; }   
-  //  <LPAREN> <RPAREN>     { return nRDFnil ; }
-| <NIL>  { return nRDFnil ; }
 }
 
 // -------- Constraint syntax
@@ -1879,22 +1851,6 @@ Expr UnaryExpression() : { Expr expr ; }
   | expr = PrimaryExpression() { return expr ; }
 }
 
-#ifndef ARQ
-Expr PrimaryExpression() : { Expr expr ; Node n ; }
-{
-  ( expr = BrackettedExpression() { return expr ; }
-  | expr = BuiltInCall() { return expr ; }  
-  | expr = iriOrFunction()  { return expr ; }
-// NOT  | n = VarOrTerm()           { return asExpr(n) ; }
-// Because of iriOrFunction 
-  | n = RDFLiteral()      { return asExpr(n) ; }
-  | n = NumericLiteral()  { return asExpr(n) ; }
-  | n = BooleanLiteral()  { return asExpr(n) ; }
-  | n = Var()             { return asExpr(n) ; }
-  )
-}
-#endif
-#ifdef ARQ
 Expr PrimaryExpression() : { Expr expr ; Node n ; }
 {
   ( expr = BrackettedExpression() { return expr ; }
@@ -1907,7 +1863,8 @@ Expr PrimaryExpression() : { Expr expr ; Node n ; }
   | n = NumericLiteral()  { return asExpr(n) ; }
   | n = BooleanLiteral()  { return asExpr(n) ; }
   | n = Var()             { return asExpr(n) ; }
-  | n = ExprTripleTerm()  { return asExpr(n) ; }
+  | n = ExprQuotedTriple()  { return asExpr(n) ; }
+
 // and not SPARQL 12
 // needs checking.
 // Use this for ?var(args)
@@ -1922,22 +1879,20 @@ Node ExprVarOrTerm() : { Node n; String s;}
   | n = NumericLiteral()
   | n = BooleanLiteral()
   | n = Var()
-  | n = ExprTripleTerm()
+  | n = ExprQuotedTriple()
   )
   { return n; }
 }
 
-// Embedded triple in expressions
-Node ExprTripleTerm() : { Token t ; Node s,p,o,n; }
+Node ExprQuotedTriple() : { Token t ; Node s,p,o,n; }
 { t = <LT2>
   s = ExprVarOrTerm()
   p = Verb()
   o = ExprVarOrTerm()
-  { n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn); }
+  { n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn); }
   <GT2>
   { return n; }
 }
-#endif
 
 Expr BrackettedExpression() : { Expr expr ; }
 {
@@ -2128,8 +2083,8 @@ Expr BuiltInCall() : { Expr expr ;
   | expr = ExistsFunc()      { return expr ; }
 
   | expr = NotExistsFunc()   { return expr ; }
-#if ARQ
-  | <IS_TRIPLE>  <LPAREN> expr = Expression() <RPAREN>
+
+| <IS_TRIPLE>  <LPAREN> expr = Expression() <RPAREN>
     { return new E_IsTriple(expr) ; }
 
   | <TRIPLE>  <LPAREN> expr1 = Expression() <COMMA> expr2 = Expression() <COMMA> expr3 = Expression() <RPAREN>
@@ -2143,7 +2098,6 @@ Expr BuiltInCall() : { Expr expr ;
 
   | <OBJECT>  <LPAREN> expr = Expression() <RPAREN>
     { return new E_TripleObject(expr) ; }
-#endif
 }
 
 Expr RegexExpression() :
@@ -2468,8 +2422,10 @@ TOKEN: {
 |
   // Whitespace or comment.
   <#WSC: <WS> | <SINGLE_LINE_COMMENT> >
+#ifdef ARQ
 |
   <BOM:    "\uFEFF">
+#endif
 }
 
 // Main tokens */
@@ -2542,16 +2498,17 @@ TOKEN [IGNORE_CASE] :
 
 #ifdef ARQ
 |  < LET:         "LET" >
+|  < LATERAL:     "LATERAL" >
+#endif
+
 |  < TRIPLE:      "TRIPLE" >
 |  < IS_TRIPLE:   "isTRIPLE" >
 |  < SUBJECT:     "SUBJECT" >
 |  < PREDICATE:   "PREDICATE" >
 |  < OBJECT:      "OBJECT" >
-|  < LATERAL:     "LATERAL" >
-#endif
+
 |  < EXISTS:      "exists" >
 |  < NOT:         "not" >
-//|  < UNSAID:      "unsaid" >
 |  < AS:          "as" >
 |  < GROUP:       "group" >
 |  < HAVING:      "having" >
@@ -2659,7 +2616,6 @@ TOKEN [IGNORE_CASE] :
 |  < FALSE:       "false" >
 }
 
-#if defined(UPDATE)
 // SPARQL/Update parts.
 
 TOKEN [IGNORE_CASE] :
@@ -2693,7 +2649,6 @@ TOKEN [IGNORE_CASE] :
 //| < COMMIT:      "commit" >
 //| < ABORT:       "abort" >
 }
-#endif
 
 // -------------------------------------------------
 
@@ -2779,12 +2734,10 @@ TOKEN :
 | < LE:      "<=" >    // Maybe: | "=>" >
 | < GE:      ">=" >    // Maybe: | "=<" >
 
-#ifdef ARQ
 | < GT2:     ">>" >
 | < LT2:     "<<" >
 | <L_ANN:    "{|" >
 | <R_ANN:    "|}" >
-#endif
 
 | < BANG:    "!" >
 | < TILDE:   "~" >

--- a/jena-arq/Grammar/sparql2html
+++ b/jena-arq/Grammar/sparql2html
@@ -4,7 +4,10 @@ echo "Grammar to X.html, fragments file to Y.html"
 ##jj2html 'sparql_11.txt' 'tokens.txt' > X11.html
 ##grammarExtracts < X11.html > Y11.html
 
-jj2html 'arq.txt' 'tokens.txt' > X.html
-grammarExtracts < X.html > Y.html
+jj2html 'sparql_12.txt' 'tokens.txt' > X12.html
+grammarExtracts < X12.html > Y12.html
+
+## jj2html 'arq_12.txt' 'tokens.txt' > X.html
+## grammarExtracts < X.html > Y.html
 
 echo "Check X and Y for IRI_REF because \" became '"

--- a/jena-arq/Grammar/sparql_12.jj
+++ b/jena-arq/Grammar/sparql_12.jj
@@ -39,7 +39,6 @@ public class SPARQLParser12 extends SPARQLParser12Base
 PARSER_END(SPARQLParser12)
 void QueryUnit(): { }
 {
-  ByteOrderMark()
   { startQuery() ; }
   Query() <EOF>
   { finishQuery() ; }
@@ -53,15 +52,10 @@ void Query() : { }
 }
 void UpdateUnit() : {}
 {
-  ByteOrderMark()
   { startUpdateRequest() ; }
   Update()
   <EOF>
   { finishUpdateRequest() ; }
-}
-void ByteOrderMark() : {}
-{
-   (<BOM>)?
 }
 void Prologue() : {}
 {
@@ -645,6 +639,7 @@ Node DataBlockValue() : { Node n ; String iri ; }
 | n = NumericLiteral() { return n ; }
 | n = BooleanLiteral() { return n ; }
 | <UNDEF> { return null ; }
+| n = QuotedTripleData() { return n ; }
 }
 Element MinusGraphPattern() : { Element el ; }
 {
@@ -784,6 +779,7 @@ void Object(Node s, Node p, Path path, TripleCollector acc): { Node o ; }
   { ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ; }
   o = GraphNode(tempAcc)
   { insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ; }
+  Annotation(acc, s, p, path, o)
 }
 void TriplesSameSubjectPath(TripleCollector acc) : { Node s ; }
 {
@@ -835,6 +831,7 @@ void ObjectPath(Node s, Node p, Path path, TripleCollector acc): { Node o ; }
   { ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ; }
   o = GraphNodePath(tempAcc)
   { insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ; }
+  AnnotationPath(acc, s, p, path, o)
 }
 Path Path() : { Path p ; }
 {
@@ -995,6 +992,28 @@ Node CollectionPath(TripleCollectorMark acc) :
        insert(acc, lastCell, nRDFrest, nRDFnil) ;
      return listHead ; }
 }
+void AnnotationPath(TripleCollector acc, Node s, Node p, Path path, Node o) : {}
+{
+  (
+    <L_ANN>
+      { Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
+        Node x = createQuotedTriple(s, pAnn, o, token.beginLine, token.beginColumn);
+      }
+      PropertyListPathNotEmpty(x, acc)
+    <R_ANN>
+  )?
+}
+void Annotation(TripleCollector acc, Node s, Node p, Path path, Node o) : { }
+{
+  (
+    <L_ANN>
+      { Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
+        Node x = createQuotedTriple(s, p, o, token.beginLine, token.beginColumn);
+      }
+      PropertyListNotEmpty(x, acc)
+    <R_ANN>
+  )?
+}
 Node GraphNode(TripleCollectorMark acc) : { Node n ; }
 {
   n = VarOrTerm() { return n ; }
@@ -1007,34 +1026,56 @@ Node GraphNodePath(TripleCollectorMark acc) : { Node n ; }
  |
   n = TriplesNodePath(acc) { return n ; }
 }
-Node VarOrTerm() : {Node n = null ; }
+Node VarOrTerm() : { Node n = null ; String iri ; }
 {
-  ( n = Var() | n = GraphTerm() )
+  ( n = Var()
+  | iri = iri() { return createNode(iri) ; }
+  | n = RDFLiteral() { return n ; }
+  | n = NumericLiteral() { return n ; }
+  | n = BooleanLiteral() { return n ; }
+  | n = BlankNode() { return n ; }
+  | <NIL> { return nRDFnil ; }
+  | n = QuotedTriple()
+)
   { return n ; }
+}
+Node QuotedTriple() : { Node n = null ; Token t ; Node s , p , o ; }
+{
+  t = <LT2>
+  s = VarOrTerm()
+  p = Verb()
+  o = VarOrTerm()
+  { n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn); }
+  <GT2>
+  { return n; }
+}
+Node QuotedTripleData() : { Node n = null ; Token t ; String iri ; Node s , p , o ; }
+{
+  t = <LT2>
+  ( s = DataValueTerm() )
+  ( iri = iri() { p = createNode(iri) ; } | <KW_A> { p = nRDFtype ; } )
+  ( o = DataValueTerm() )
+  { n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn); }
+  <GT2>
+  { return n; }
+}
+Node DataValueTerm() : { Node n = null ; String iri ; Node s , p , o ; }
+{
+  iri = iri() { return createNode(iri) ; }
+| n = RDFLiteral() { return n ; }
+| n = NumericLiteral() { return n ; }
+| n = BooleanLiteral() { return n ; }
+| n = QuotedTripleData() { return n ; }
 }
 Node VarOrIri() : {Node n = null ; String iri ; }
 {
   ( n = Var() | iri = iri() { n = createNode(iri) ; } )
   { return n ; }
 }
-Node VarOrBlankNodeOrIri() : {Node n = null ; String iri ; }
-{
-  ( n = Var() | n = BlankNode() | iri = iri() { n = createNode(iri) ; } )
-  { return n ; }
-}
 Var Var() : { Token t ;}
 {
     ( t = <VAR1> | t = <VAR2> )
     { return createVariable(t.image, t.beginLine, t.beginColumn) ; }
-}
-Node GraphTerm() : { Node n ; String iri ; }
-{
-  iri = iri() { return createNode(iri) ; }
-| n = RDFLiteral() { return n ; }
-| n = NumericLiteral() { return n ; }
-| n = BooleanLiteral() { return n ; }
-| n = BlankNode() { return n ; }
-| <NIL> { return nRDFnil ; }
 }
 Expr Expression() : { Expr expr ; }
 {
@@ -1153,7 +1194,28 @@ Expr PrimaryExpression() : { Expr expr ; Node n ; }
   | n = NumericLiteral() { return asExpr(n) ; }
   | n = BooleanLiteral() { return asExpr(n) ; }
   | n = Var() { return asExpr(n) ; }
+  | n = ExprQuotedTriple() { return asExpr(n) ; }
   )
+}
+Node ExprVarOrTerm() : { Node n; String s;}
+{
+  ( s = iri() { n = createNode(s); }
+  | n = RDFLiteral()
+  | n = NumericLiteral()
+  | n = BooleanLiteral()
+  | n = Var()
+  | n = ExprQuotedTriple()
+  )
+  { return n; }
+}
+Node ExprQuotedTriple() : { Token t ; Node s,p,o,n; }
+{ t = <LT2>
+  s = ExprVarOrTerm()
+  p = Verb()
+  o = ExprVarOrTerm()
+  { n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn); }
+  <GT2>
+  { return n; }
 }
 Expr BrackettedExpression() : { Expr expr ; }
 {
@@ -1250,6 +1312,16 @@ Expr BuiltInCall() : { Expr expr ;
     expr = RegexExpression() { return expr ; }
   | expr = ExistsFunc() { return expr ; }
   | expr = NotExistsFunc() { return expr ; }
+| <IS_TRIPLE> <LPAREN> expr = Expression() <RPAREN>
+    { return new E_IsTriple(expr) ; }
+  | <TRIPLE> <LPAREN> expr1 = Expression() <COMMA> expr2 = Expression() <COMMA> expr3 = Expression() <RPAREN>
+    { return new E_TripleFn(expr1, expr2, expr3) ; }
+  | <SUBJECT> <LPAREN> expr = Expression() <RPAREN>
+    { return new E_TripleSubject(expr) ; }
+  | <PREDICATE> <LPAREN> expr = Expression() <RPAREN>
+    { return new E_TriplePredicate(expr) ; }
+  | <OBJECT> <LPAREN> expr = Expression() <RPAREN>
+    { return new E_TripleObject(expr) ; }
 }
 Expr RegexExpression() :
 { Expr expr ; Expr patExpr = null ; Expr flagsExpr = null ; }
@@ -1447,8 +1519,6 @@ TOKEN: {
   <#WS: " " | "\t" | "\n" | "\r" | "\f">
 |
   <#WSC: <WS> | <SINGLE_LINE_COMMENT> >
-|
-  <BOM: "\uFEFF">
 }
 TOKEN:
 {
@@ -1495,6 +1565,11 @@ TOKEN [IGNORE_CASE] :
 | < MINUS_P: "minus" >
 | < BIND: "bind" >
 | < SERVICE: "service" >
+| < TRIPLE: "TRIPLE" >
+| < IS_TRIPLE: "isTRIPLE" >
+| < SUBJECT: "SUBJECT" >
+| < PREDICATE: "PREDICATE" >
+| < OBJECT: "OBJECT" >
 | < EXISTS: "exists" >
 | < NOT: "not" >
 | < AS: "as" >
@@ -1654,6 +1729,10 @@ TOKEN :
 | < LT: "<" >
 | < LE: "<=" >
 | < GE: ">=" >
+| < GT2: ">>" >
+| < LT2: "<<" >
+| <L_ANN: "{|" >
+| <R_ANN: "|}" >
 | < BANG: "!" >
 | < TILDE: "~" >
 | < COLON: ":" >

--- a/jena-arq/Grammar/sparql_12.txt
+++ b/jena-arq/Grammar/sparql_12.txt
@@ -16,7 +16,6 @@ TOKENS
 <DEFAULT> TOKEN : {
 <#WS: " " | "\t" | "\n" | "\r" | "\f">
 | <#WSC: <WS> | <SINGLE_LINE_COMMENT>>
-| <BOM: "\ufeff">
 }
 
 <DEFAULT> TOKEN : {
@@ -62,6 +61,11 @@ TOKENS
 | <MINUS_P: "minus">
 | <BIND: "bind">
 | <SERVICE: "service">
+| <TRIPLE: "TRIPLE">
+| <IS_TRIPLE: "isTRIPLE">
+| <SUBJECT: "SUBJECT">
+| <PREDICATE: "PREDICATE">
+| <OBJECT: "OBJECT">
 | <EXISTS: "exists">
 | <NOT: "not">
 | <AS: "as">
@@ -207,6 +211,10 @@ TOKENS
 | <LT: "<">
 | <LE: "<=">
 | <GE: ">=">
+| <GT2: ">>">
+| <LT2: "<<">
+| <L_ANN: "{|">
+| <R_ANN: "|}">
 | <BANG: "!">
 | <TILDE: "~">
 | <COLON: ":">
@@ -243,10 +251,9 @@ TOKENS
 }
 
 NON-TERMINALS
-	QueryUnit	:=	ByteOrderMark Query <EOF>
+	QueryUnit	:=	Query <EOF>
 	Query	:=	Prologue ( SelectQuery | ConstructQuery | DescribeQuery | AskQuery ) ValuesClause
-	UpdateUnit	:=	ByteOrderMark Update <EOF>
-	ByteOrderMark	:=	( <BOM> )?
+	UpdateUnit	:=	Update <EOF>
 	Prologue	:=	( BaseDecl | PrefixDecl )*
 	BaseDecl	:=	<BASE> IRIREF
 	PrefixDecl	:=	<PREFIX> <PNAME_NS> IRIREF
@@ -313,6 +320,7 @@ NON-TERMINALS
 		|	NumericLiteral
 		|	BooleanLiteral
 		|	<UNDEF>
+		|	QuotedTripleData
 	MinusGraphPattern	:=	<MINUS_P> GroupGraphPattern
 	GroupOrUnionGraphPattern	:=	GroupGraphPattern ( <UNION> GroupGraphPattern )*
 	Filter	:=	<FILTER> Constraint
@@ -328,7 +336,7 @@ NON-TERMINALS
 	PropertyListNotEmpty	:=	Verb ObjectList ( <SEMICOLON> ( Verb ObjectList )? )*
 	Verb	:=	( VarOrIri | <KW_A> )
 	ObjectList	:=	Object ( <COMMA> Object )*
-	Object	:=	GraphNode
+	Object	:=	GraphNode Annotation
 	TriplesSameSubjectPath	:=	VarOrTerm PropertyListPathNotEmpty
 		|	TriplesNodePath PropertyListPath
 	PropertyListPath	:=	( PropertyListPathNotEmpty )?
@@ -336,7 +344,7 @@ NON-TERMINALS
 	VerbPath	:=	Path
 	VerbSimple	:=	Var
 	ObjectListPath	:=	ObjectPath ( <COMMA> ObjectPath )*
-	ObjectPath	:=	GraphNodePath
+	ObjectPath	:=	GraphNodePath AnnotationPath
 	Path	:=	PathAlternative
 	PathAlternative	:=	PathSequence ( <VBAR> PathSequence )*
 	PathSequence	:=	PathEltOrInverse ( <SLASH> PathEltOrInverse )*
@@ -355,20 +363,22 @@ NON-TERMINALS
 	BlankNodePropertyListPath	:=	<LBRACKET> PropertyListPathNotEmpty <RBRACKET>
 	Collection	:=	<LPAREN> ( GraphNode )+ <RPAREN>
 	CollectionPath	:=	<LPAREN> ( GraphNodePath )+ <RPAREN>
+	AnnotationPath	:=	( <L_ANN> PropertyListPathNotEmpty <R_ANN> )?
+	Annotation	:=	( <L_ANN> PropertyListNotEmpty <R_ANN> )?
 	GraphNode	:=	VarOrTerm
 		|	TriplesNode
 	GraphNodePath	:=	VarOrTerm
 		|	TriplesNodePath
-	VarOrTerm	:=	( Var | GraphTerm )
-	VarOrIri	:=	( Var | iri )
-	VarOrBlankNodeOrIri	:=	( Var | BlankNode | iri )
-	Var	:=	( <VAR1> | <VAR2> )
-	GraphTerm	:=	iri
+	VarOrTerm	:=	( Var | iri | RDFLiteral | NumericLiteral | BooleanLiteral | BlankNode | <NIL> | QuotedTriple )
+	QuotedTriple	:=	<LT2> VarOrTerm Verb VarOrTerm <GT2>
+	QuotedTripleData	:=	<LT2> ( DataValueTerm ) ( iri | <KW_A> ) ( DataValueTerm ) <GT2>
+	DataValueTerm	:=	iri
 		|	RDFLiteral
 		|	NumericLiteral
 		|	BooleanLiteral
-		|	BlankNode
-		|	<NIL>
+		|	QuotedTripleData
+	VarOrIri	:=	( Var | iri )
+	Var	:=	( <VAR1> | <VAR2> )
 	Expression	:=	ConditionalOrExpression
 	ConditionalOrExpression	:=	ConditionalAndExpression ( <SC_OR> ConditionalAndExpression )*
 	ConditionalAndExpression	:=	ValueLogical ( <SC_AND> ValueLogical )*
@@ -381,7 +391,9 @@ NON-TERMINALS
 		|	<PLUS> PrimaryExpression
 		|	<MINUS> PrimaryExpression
 		|	PrimaryExpression
-	PrimaryExpression	:=	( BrackettedExpression | BuiltInCall | iriOrFunction | RDFLiteral | NumericLiteral | BooleanLiteral | Var )
+	PrimaryExpression	:=	( BrackettedExpression | BuiltInCall | iriOrFunction | RDFLiteral | NumericLiteral | BooleanLiteral | Var | ExprQuotedTriple )
+	ExprVarOrTerm	:=	( iri | RDFLiteral | NumericLiteral | BooleanLiteral | Var | ExprQuotedTriple )
+	ExprQuotedTriple	:=	<LT2> ExprVarOrTerm Verb ExprVarOrTerm <GT2>
 	BrackettedExpression	:=	<LPAREN> Expression <RPAREN>
 	BuiltInCall	:=	Aggregate
 		|	<STR> <LPAREN> Expression <RPAREN>
@@ -438,6 +450,11 @@ NON-TERMINALS
 		|	RegexExpression
 		|	ExistsFunc
 		|	NotExistsFunc
+		|	<IS_TRIPLE> <LPAREN> Expression <RPAREN>
+		|	<TRIPLE> <LPAREN> Expression <COMMA> Expression <COMMA> Expression <RPAREN>
+		|	<SUBJECT> <LPAREN> Expression <RPAREN>
+		|	<PREDICATE> <LPAREN> Expression <RPAREN>
+		|	<OBJECT> <LPAREN> Expression <RPAREN>
 	RegexExpression	:=	<REGEX> <LPAREN> Expression <COMMA> Expression ( <COMMA> Expression )? <RPAREN>
 	SubstringExpression	:=	<SUBSTR> <LPAREN> Expression <COMMA> Expression ( <COMMA> Expression )? <RPAREN>
 	StrReplaceExpression	:=	<REPLACE> <LPAREN> Expression <COMMA> Expression <COMMA> Expression ( <COMMA> Expression )? <RPAREN>

--- a/jena-arq/src/main/java/org/apache/jena/query/Syntax.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/Syntax.java
@@ -57,8 +57,8 @@ public class Syntax extends Symbol {
      */
     public static Syntax defaultUpdateSyntax = defaultSyntax;
 
-    /** The query syntax currently that is standardized, published, SPARQL Query */
-    public static final Syntax syntaxSPARQL = syntaxSPARQL_11;
+    /** The latest SPARQL query syntax - no ARQ syntax extensions. */
+    public static final Syntax syntaxSPARQL = syntaxSPARQL_12;
 
     public static TranslationTable<Syntax> querySyntaxNames = new TranslationTable<>(true);
     static {

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/LangParserBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/LangParserBase.java
@@ -130,7 +130,13 @@ public class LangParserBase {
         return n ;
     }
 
+    /** @deprecated Use {@link #createQuotedTriple} */
+    @Deprecated
     protected Node createTripleTerm(Node s, Node p, Node o, int line, int column) {
+        return createQuotedTriple(s, p, o, line, column);
+    }
+
+    protected Node createQuotedTriple(Node s, Node p, Node o, int line, int column) {
         return profile.createTripleNode(s, p, o, line, column);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/javacc/TokenMgrError.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/javacc/TokenMgrError.java
@@ -123,11 +123,10 @@ public class TokenMgrError extends Error
    * Note: You can customize the lexical error message by modifying this method.
    */
   protected static String LexicalErr(boolean EOFSeen, int lexState, int errorLine, int errorColumn, String errorAfter, int curChar) {
-    char curChar1 = (char)curChar;
     return("Lexical error at line " + //
           errorLine + ", column " + //
           errorColumn + ".  Encountered: " + //
-          (EOFSeen ? "<EOF>" : ("'" + addEscapes(String.valueOf(curChar)) + "' (" + (int)curChar + "),")) + //
+          (EOFSeen ? "<EOF>" : ("'" + addEscapes(String.valueOf(curChar)) + "' (" + curChar + "),")) + //
           (errorAfter == null || errorAfter.length() == 0 ? "" : " after prefix \"" + addEscapes(errorAfter) + "\"")) + //
           (lexState == 0 ? "" : " (in lexical state " + lexState + ")");
   }
@@ -165,4 +164,4 @@ public class TokenMgrError extends Error
     this(LexicalErr(EOFSeen, lexState, errorLine, errorColumn, errorAfter, curChar), reason);
   }
 }
-/* JavaCC - OriginalChecksum=cc48a0e796ab5bbd5916ae20e6023f73 (do not edit this line) */
+/* JavaCC - OriginalChecksum=d9be68a0e6bddc4b5d4d52579b110992 (do not edit this line) */

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/javacc/TurtleJavacc.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/javacc/TurtleJavacc.java
@@ -246,7 +246,7 @@ emitTriple(token.beginLine, token.beginColumn, s, p, o) ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case L_ANN:{
       jj_consume_token(L_ANN);
-Node x = createTripleTerm(s, p, o, token.beginLine, token.beginColumn);
+Node x = createQuotedTriple(s, p, o, token.beginLine, token.beginColumn);
       PredicateObjectList(x);
       jj_consume_token(R_ANN);
       break;
@@ -299,7 +299,7 @@ s = createURI(iri, token.beginLine, token.beginColumn) ;
       break;
       }
     case LT2:{
-      s = EmbTriple();
+      s = QuotedTriple();
       break;
       }
     default:
@@ -354,7 +354,7 @@ o = createURI(iri, token.beginLine, token.beginColumn) ;
       break;
       }
     case LT2:{
-      o = EmbTriple();
+      o = QuotedTriple();
       break;
       }
     default:
@@ -366,7 +366,7 @@ o = createURI(iri, token.beginLine, token.beginColumn) ;
     throw new Error("Missing return statement in function");
 }
 
-  final public Node EmbSubject() throws ParseException {Node o ; String iri;
+  final public Node QuotedTripleSubject() throws ParseException {Node o ; String iri;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IRIref:
     case PNAME_NS:
@@ -381,7 +381,7 @@ o = createURI(iri, token.beginLine, token.beginColumn) ;
       break;
       }
     case LT2:{
-      o = EmbTriple();
+      o = QuotedTriple();
       break;
       }
     default:
@@ -393,7 +393,7 @@ o = createURI(iri, token.beginLine, token.beginColumn) ;
     throw new Error("Missing return statement in function");
 }
 
-  final public Node EmbObject() throws ParseException {Node o ; String iri;
+  final public Node QuotedTripleObject() throws ParseException {Node o ; String iri;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IRIref:
     case PNAME_NS:
@@ -420,7 +420,7 @@ o = createURI(iri, token.beginLine, token.beginColumn) ;
       break;
       }
     case LT2:{
-      o = EmbTriple();
+      o = QuotedTriple();
       break;
       }
     default:
@@ -433,14 +433,13 @@ o = createURI(iri, token.beginLine, token.beginColumn) ;
 }
 
 // The syntax for RDF-star <<>>
-  final public Node EmbTriple() throws ParseException {Node s , p , o ; Token t ;
+  final public Node QuotedTriple() throws ParseException {Node s , p , o ; Token t ;
     t = jj_consume_token(LT2);
-int beginLine = t.beginLine; int beginColumn = t.beginColumn; t = null;
-    s = EmbSubject();
+    s = QuotedTripleSubject();
     p = Verb();
-    o = EmbObject();
+    o = QuotedTripleObject();
     jj_consume_token(GT2);
-Node n = createTripleTerm(s, p, o, beginLine, beginColumn);
+Node n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn);
     {if ("" != null) return n;}
     throw new Error("Missing return statement in function");
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/QueryParserBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/QueryParserBase.java
@@ -399,7 +399,13 @@ public class QueryParserBase
         return null;
     }
 
+    /** @deprecated Use {@link #createQuotedTrple}. */
+    @Deprecated
     protected Node createTripleTerm(Node s, Node p, Node o, int line, int column) {
+        return createQuotedTriple(s, p, o, line, column);
+    }
+
+    protected Node createQuotedTriple(Node s, Node p, Node o, int line, int column) {
         return NodeFactory.createTripleNode(s, p, o);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
@@ -2857,11 +2857,6 @@ finishDataBlockValueRow(beginLine, beginColumn) ;
 
   final public Node DataBlockValue() throws ParseException {Node n ; String iri ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case LT2:{
-      n = TripleTermData();
-{if ("" != null) return n ;}
-      break;
-      }
     case IRIref:
     case PNAME_NS:
     case PNAME_LN:{
@@ -2899,6 +2894,11 @@ finishDataBlockValueRow(beginLine, beginColumn) ;
     case UNDEF:{
       jj_consume_token(UNDEF);
 {if ("" != null) return null ;}
+      break;
+      }
+    case LT2:{
+      n = QuotedTripleData();
+{if ("" != null) return n ;}
       break;
       }
     default:
@@ -4097,7 +4097,7 @@ if ( lastCell != null )
     case L_ANN:{
       jj_consume_token(L_ANN);
 Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
-        Node x = createTripleTerm(s, pAnn, o, token.beginLine, token.beginColumn);
+        Node x = createQuotedTriple(s, pAnn, o, token.beginLine, token.beginColumn);
       PropertyListPathNotEmpty(x, acc);
       jj_consume_token(R_ANN);
       break;
@@ -4113,7 +4113,7 @@ Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginCo
     case L_ANN:{
       jj_consume_token(L_ANN);
 Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
-        Node x = createTripleTerm(s, p, o, token.beginLine, token.beginColumn);
+        Node x = createQuotedTriple(s, p, o, token.beginLine, token.beginColumn);
       PropertyListNotEmpty(x, acc);
       jj_consume_token(R_ANN);
       break;
@@ -4212,12 +4212,8 @@ Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginCo
     throw new Error("Missing return statement in function");
 }
 
-  final public Node VarOrTerm() throws ParseException {Node n = null ;
+  final public Node VarOrTerm() throws ParseException {Node n = null ; String iri ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case LT2:{
-      n = TripleTerm();
-      break;
-      }
     case VAR1:
     case VAR2:{
       n = Var();
@@ -4225,10 +4221,19 @@ Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginCo
       }
     case IRIref:
     case PNAME_NS:
-    case PNAME_LN:
-    case BLANK_NODE_LABEL:
-    case TRUE:
-    case FALSE:
+    case PNAME_LN:{
+      iri = iri();
+{if ("" != null) return createNode(iri) ;}
+      break;
+      }
+    case STRING_LITERAL1:
+    case STRING_LITERAL2:
+    case STRING_LITERAL_LONG1:
+    case STRING_LITERAL_LONG2:{
+      n = RDFLiteral();
+{if ("" != null) return n ;}
+      break;
+      }
     case INTEGER:
     case DECIMAL:
     case DOUBLE:
@@ -4237,14 +4242,30 @@ Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginCo
     case DOUBLE_POSITIVE:
     case INTEGER_NEGATIVE:
     case DECIMAL_NEGATIVE:
-    case DOUBLE_NEGATIVE:
-    case STRING_LITERAL1:
-    case STRING_LITERAL2:
-    case STRING_LITERAL_LONG1:
-    case STRING_LITERAL_LONG2:
-    case NIL:
+    case DOUBLE_NEGATIVE:{
+      n = NumericLiteral();
+{if ("" != null) return n ;}
+      break;
+      }
+    case TRUE:
+    case FALSE:{
+      n = BooleanLiteral();
+{if ("" != null) return n ;}
+      break;
+      }
+    case BLANK_NODE_LABEL:
     case ANON:{
-      n = GraphTerm();
+      n = BlankNode();
+{if ("" != null) return n ;}
+      break;
+      }
+    case NIL:{
+      jj_consume_token(NIL);
+{if ("" != null) return nRDFnil ;}
+      break;
+      }
+    case LT2:{
+      n = QuotedTriple();
       break;
       }
     default:
@@ -4256,18 +4277,18 @@ Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginCo
     throw new Error("Missing return statement in function");
 }
 
-  final public Node TripleTerm() throws ParseException {Node n = null ; Token t ; Node s , p , o ;
+  final public Node QuotedTriple() throws ParseException {Node n = null ; Token t ; Node s , p , o ;
     t = jj_consume_token(LT2);
     s = VarOrTerm();
     p = Verb();
     o = VarOrTerm();
-n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn);
+n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn);
     jj_consume_token(GT2);
 {if ("" != null) return n;}
     throw new Error("Missing return statement in function");
 }
 
-  final public Node TripleTermData() throws ParseException {Node n = null ; Token t ; String iri ; Node s , p , o ;
+  final public Node QuotedTripleData() throws ParseException {Node n = null ; Token t ; String iri ; Node s , p , o ;
     t = jj_consume_token(LT2);
     s = DataValueTerm();
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4289,7 +4310,7 @@ p = nRDFtype ;
       throw new ParseException();
     }
     o = DataValueTerm();
-n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn);
+n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn);
     jj_consume_token(GT2);
 {if ("" != null) return n;}
     throw new Error("Missing return statement in function");
@@ -4332,7 +4353,7 @@ n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn);
       break;
       }
     case LT2:{
-      n = TripleTermData();
+      n = QuotedTripleData();
 {if ("" != null) return n ;}
       break;
       }
@@ -4414,61 +4435,6 @@ n = createNode(iri) ;
     throw new Error("Missing return statement in function");
 }
 
-  final public Node GraphTerm() throws ParseException {Node n ; String iri ;
-    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case IRIref:
-    case PNAME_NS:
-    case PNAME_LN:{
-      iri = iri();
-{if ("" != null) return createNode(iri) ;}
-      break;
-      }
-    case STRING_LITERAL1:
-    case STRING_LITERAL2:
-    case STRING_LITERAL_LONG1:
-    case STRING_LITERAL_LONG2:{
-      n = RDFLiteral();
-{if ("" != null) return n ;}
-      break;
-      }
-    case INTEGER:
-    case DECIMAL:
-    case DOUBLE:
-    case INTEGER_POSITIVE:
-    case DECIMAL_POSITIVE:
-    case DOUBLE_POSITIVE:
-    case INTEGER_NEGATIVE:
-    case DECIMAL_NEGATIVE:
-    case DOUBLE_NEGATIVE:{
-      n = NumericLiteral();
-{if ("" != null) return n ;}
-      break;
-      }
-    case TRUE:
-    case FALSE:{
-      n = BooleanLiteral();
-{if ("" != null) return n ;}
-      break;
-      }
-    case BLANK_NODE_LABEL:
-    case ANON:{
-      n = BlankNode();
-{if ("" != null) return n ;}
-      break;
-      }
-    case NIL:{
-      jj_consume_token(NIL);
-{if ("" != null) return nRDFnil ;}
-      break;
-      }
-    default:
-      jj_la1[139] = jj_gen;
-      jj_consume_token(-1);
-      throw new ParseException();
-    }
-    throw new Error("Missing return statement in function");
-}
-
   final public Expr Expression() throws ParseException {Expr expr ;
     expr = ConditionalOrExpression();
 {if ("" != null) return expr ;}
@@ -4485,7 +4451,7 @@ n = createNode(iri) ;
         break;
         }
       default:
-        jj_la1[140] = jj_gen;
+        jj_la1[139] = jj_gen;
         break label_37;
       }
       jj_consume_token(SC_OR);
@@ -4506,7 +4472,7 @@ expr1 = new E_LogicalOr(expr1, expr2) ;
         break;
         }
       default:
-        jj_la1[141] = jj_gen;
+        jj_la1[140] = jj_gen;
         break label_38;
       }
       jj_consume_token(SC_AND);
@@ -4585,14 +4551,14 @@ expr1 = new E_NotOneOf(expr1, a) ;
         break;
         }
       default:
-        jj_la1[142] = jj_gen;
+        jj_la1[141] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[143] = jj_gen;
+      jj_la1[142] = jj_gen;
       ;
     }
 {if ("" != null) return expr1 ;}
@@ -4622,7 +4588,7 @@ expr1 = new E_NotOneOf(expr1, a) ;
         break;
         }
       default:
-        jj_la1[144] = jj_gen;
+        jj_la1[143] = jj_gen;
         break label_39;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4664,7 +4630,7 @@ n = stripSign(n) ;
           break;
           }
         default:
-          jj_la1[145] = jj_gen;
+          jj_la1[144] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -4677,7 +4643,7 @@ n = stripSign(n) ;
             break;
             }
           default:
-            jj_la1[146] = jj_gen;
+            jj_la1[145] = jj_gen;
             break label_40;
           }
           switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4694,7 +4660,7 @@ expr2 = new E_Divide(expr2, expr3) ;
             break;
             }
           default:
-            jj_la1[147] = jj_gen;
+            jj_la1[146] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -4706,7 +4672,7 @@ if ( addition )
         break;
         }
       default:
-        jj_la1[148] = jj_gen;
+        jj_la1[147] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4728,7 +4694,7 @@ if ( addition )
         break;
         }
       default:
-        jj_la1[149] = jj_gen;
+        jj_la1[148] = jj_gen;
         break label_41;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4757,7 +4723,7 @@ expr1 = new E_OpNumericIntegerDivide(expr1, expr2) ;
         break;
         }
       default:
-        jj_la1[150] = jj_gen;
+        jj_la1[149] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4893,7 +4859,7 @@ expr1 = new E_OpNumericIntegerDivide(expr1, expr2) ;
       break;
       }
     default:
-      jj_la1[151] = jj_gen;
+      jj_la1[150] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5032,12 +4998,12 @@ expr1 = new E_OpNumericIntegerDivide(expr1, expr2) ;
       break;
       }
     case LT2:{
-      n = ExprTripleTerm();
+      n = ExprQuotedTriple();
 {if ("" != null) return asExpr(n) ;}
       break;
       }
     default:
-      jj_la1[152] = jj_gen;
+      jj_la1[151] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5083,11 +5049,11 @@ n = createNode(s);
       break;
       }
     case LT2:{
-      n = ExprTripleTerm();
+      n = ExprQuotedTriple();
       break;
       }
     default:
-      jj_la1[153] = jj_gen;
+      jj_la1[152] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5095,12 +5061,12 @@ n = createNode(s);
     throw new Error("Missing return statement in function");
 }
 
-  final public Node ExprTripleTerm() throws ParseException {Token t ; Node s,p,o,n;
+  final public Node ExprQuotedTriple() throws ParseException {Token t ; Node s,p,o,n;
     t = jj_consume_token(LT2);
     s = ExprVarOrTerm();
     p = Verb();
     o = ExprVarOrTerm();
-n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn);
+n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn);
     jj_consume_token(GT2);
 {if ("" != null) return n;}
     throw new Error("Missing return statement in function");
@@ -5191,7 +5157,7 @@ n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn);
         break;
         }
       default:
-        jj_la1[154] = jj_gen;
+        jj_la1[153] = jj_gen;
         ;
       }
       jj_consume_token(RPAREN);
@@ -5209,7 +5175,7 @@ n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn);
         break;
         }
       default:
-        jj_la1[155] = jj_gen;
+        jj_la1[154] = jj_gen;
         ;
       }
       jj_consume_token(RPAREN);
@@ -5232,7 +5198,7 @@ n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn);
         break;
         }
       default:
-        jj_la1[156] = jj_gen;
+        jj_la1[155] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5469,7 +5435,7 @@ n = createTripleTerm(s, p, o, t.beginLine, t.beginColumn);
         break;
         }
       default:
-        jj_la1[157] = jj_gen;
+        jj_la1[156] = jj_gen;
         ;
       }
       jj_consume_token(RPAREN);
@@ -5560,7 +5526,7 @@ a.add(expr) ;
           break;
           }
         default:
-          jj_la1[158] = jj_gen;
+          jj_la1[157] = jj_gen;
           break label_42;
         }
         jj_consume_token(COMMA);
@@ -5713,7 +5679,7 @@ a.add(expr) ;
       break;
       }
     default:
-      jj_la1[159] = jj_gen;
+      jj_la1[158] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5733,7 +5699,7 @@ a.add(expr) ;
       break;
       }
     default:
-      jj_la1[160] = jj_gen;
+      jj_la1[159] = jj_gen;
       ;
     }
     jj_consume_token(RPAREN);
@@ -5754,7 +5720,7 @@ a.add(expr) ;
       break;
       }
     default:
-      jj_la1[161] = jj_gen;
+      jj_la1[160] = jj_gen;
       ;
     }
     jj_consume_token(RPAREN);
@@ -5777,7 +5743,7 @@ a.add(expr) ;
       break;
       }
     default:
-      jj_la1[162] = jj_gen;
+      jj_la1[161] = jj_gen;
       ;
     }
     jj_consume_token(RPAREN);
@@ -5817,7 +5783,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[163] = jj_gen;
+        jj_la1[162] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -5934,7 +5900,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[164] = jj_gen;
+        jj_la1[163] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -5953,7 +5919,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[165] = jj_gen;
+        jj_la1[164] = jj_gen;
         ;
       }
       expr = Expression();
@@ -5971,7 +5937,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[166] = jj_gen;
+        jj_la1[165] = jj_gen;
         ;
       }
       expr = Expression();
@@ -5989,7 +5955,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[167] = jj_gen;
+        jj_la1[166] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6007,7 +5973,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[168] = jj_gen;
+        jj_la1[167] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6025,7 +5991,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[169] = jj_gen;
+        jj_la1[168] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6043,7 +6009,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[170] = jj_gen;
+        jj_la1[169] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6061,7 +6027,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[171] = jj_gen;
+        jj_la1[170] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6079,7 +6045,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[172] = jj_gen;
+        jj_la1[171] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6100,7 +6066,7 @@ ordered.add(expr2) ;
             break;
             }
           default:
-            jj_la1[173] = jj_gen;
+            jj_la1[172] = jj_gen;
             ;
           }
         } else {
@@ -6114,7 +6080,7 @@ ordered.add(expr2) ;
             break;
             }
           default:
-            jj_la1[174] = jj_gen;
+            jj_la1[173] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -6122,7 +6088,7 @@ ordered.add(expr2) ;
         break;
         }
       default:
-        jj_la1[175] = jj_gen;
+        jj_la1[174] = jj_gen;
         ;
       }
       jj_consume_token(RPAREN);
@@ -6139,7 +6105,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[176] = jj_gen;
+        jj_la1[175] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6157,7 +6123,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[177] = jj_gen;
+        jj_la1[176] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6175,7 +6141,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[178] = jj_gen;
+        jj_la1[177] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6193,7 +6159,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[179] = jj_gen;
+        jj_la1[178] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6211,7 +6177,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[180] = jj_gen;
+        jj_la1[179] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6229,7 +6195,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[181] = jj_gen;
+        jj_la1[180] = jj_gen;
         ;
       }
       expr = Expression();
@@ -6247,7 +6213,7 @@ agg = AggregatorFactory.createCustom(iri, a) ;
       break;
       }
     default:
-      jj_la1[182] = jj_gen;
+      jj_la1[181] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6270,7 +6236,7 @@ Expr exprAgg = getQuery().allocAggregate(agg) ;
       break;
       }
     default:
-      jj_la1[183] = jj_gen;
+      jj_la1[182] = jj_gen;
       ;
     }
 if ( a == null )
@@ -6304,14 +6270,14 @@ lang = stripChars(t.image, 1) ;
         break;
         }
       default:
-        jj_la1[184] = jj_gen;
+        jj_la1[183] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[185] = jj_gen;
+      jj_la1[184] = jj_gen;
       ;
     }
 {if ("" != null) return createLiteral(lex, lang, uri) ;}
@@ -6339,7 +6305,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[186] = jj_gen;
+      jj_la1[185] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6365,7 +6331,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[187] = jj_gen;
+      jj_la1[186] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6390,7 +6356,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[188] = jj_gen;
+      jj_la1[187] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6415,7 +6381,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[189] = jj_gen;
+      jj_la1[188] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6435,7 +6401,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[190] = jj_gen;
+      jj_la1[189] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6465,7 +6431,7 @@ lex = stripQuotes3(t.image) ;
       break;
       }
     default:
-      jj_la1[191] = jj_gen;
+      jj_la1[190] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6489,7 +6455,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
       break;
       }
     default:
-      jj_la1[192] = jj_gen;
+      jj_la1[191] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6509,7 +6475,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
       break;
       }
     default:
-      jj_la1[193] = jj_gen;
+      jj_la1[192] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6529,7 +6495,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
       break;
       }
     default:
-      jj_la1[194] = jj_gen;
+      jj_la1[193] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -6582,77 +6548,63 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     finally { jj_save(4, xla); }
   }
 
-  private boolean jj_3R_RegexExpression_1521_5_120()
+  private boolean jj_3R_RegexExpression_1516_5_120()
  {
     if (jj_scan_token(REGEX)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1515_5_110()
+  private boolean jj_3R_BuiltInCall_1510_5_110()
  {
     if (jj_scan_token(OBJECT)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1513_5_109()
+  private boolean jj_3R_BuiltInCall_1508_5_109()
  {
     if (jj_scan_token(PREDICATE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1511_5_108()
+  private boolean jj_3R_BuiltInCall_1506_5_108()
  {
     if (jj_scan_token(SUBJECT)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1509_5_107()
+  private boolean jj_3R_BuiltInCall_1504_5_107()
  {
     if (jj_scan_token(TRIPLE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1507_5_106()
+  private boolean jj_3R_BuiltInCall_1501_5_105()
+ {
+    if (jj_3R_NotExistsFunc_1557_4_122()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_BuiltInCall_1502_3_106()
  {
     if (jj_scan_token(IS_TRIPLE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1506_5_105()
+  private boolean jj_3R_BuiltInCall_1500_5_104()
  {
-    if (jj_3R_NotExistsFunc_1562_4_122()) return true;
+    if (jj_3R_ExistsFunc_1551_4_121()) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1505_5_104()
+  private boolean jj_3R_BuiltInCall_1499_5_103()
  {
-    if (jj_3R_ExistsFunc_1556_4_121()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_BuiltInCall_1504_5_103()
- {
-    if (jj_3R_RegexExpression_1521_5_120()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_BuiltInCall_1501_5_102()
- {
-    if (jj_scan_token(IS_NUMERIC)) return true;
-    if (jj_scan_token(LPAREN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_BuiltInCall_1499_5_101()
- {
-    if (jj_scan_token(IS_LITERAL)) return true;
-    if (jj_scan_token(LPAREN)) return true;
+    if (jj_3R_RegexExpression_1516_5_120()) return true;
     return false;
   }
 
@@ -6705,573 +6657,587 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_Collection_1116_3_157()
+  private boolean jj_3R_Collection_1115_3_165()
  {
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1497_5_100()
+  private boolean jj_3R_BuiltInCall_1496_5_102()
+ {
+    if (jj_scan_token(IS_NUMERIC)) return true;
+    if (jj_scan_token(LPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_BuiltInCall_1494_5_101()
+ {
+    if (jj_scan_token(IS_LITERAL)) return true;
+    if (jj_scan_token(LPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_BuiltInCall_1492_5_100()
  {
     if (jj_scan_token(IS_BLANK)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1495_5_99()
+  private boolean jj_3R_BuiltInCall_1490_5_99()
  {
     if (jj_scan_token(IS_URI)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1493_5_98()
+  private boolean jj_3R_BuiltInCall_1488_5_98()
  {
     if (jj_scan_token(IS_IRI)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1491_5_97()
+  private boolean jj_3R_BuiltInCall_1486_5_97()
  {
     if (jj_scan_token(SAME_TERM)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1489_5_96()
+  private boolean jj_3R_BuiltInCall_1484_5_96()
  {
     if (jj_scan_token(STRDT)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1487_5_95()
+  private boolean jj_3R_BuiltInCall_1482_5_95()
  {
     if (jj_scan_token(STRLANG)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1483_5_94()
+  private boolean jj_3R_BuiltInCall_1478_5_94()
  {
     if (jj_scan_token(IF)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1476_5_93()
+  private boolean jj_3R_BlankNodePropertyList_1092_3_166()
+ {
+    if (jj_scan_token(LBRACKET)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_BuiltInCall_1471_5_93()
  {
     if (jj_scan_token(CALL)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BlankNodePropertyList_1093_3_158()
+  private boolean jj_3R_TriplesNode_1088_3_156()
  {
-    if (jj_scan_token(LBRACKET)) return true;
+    if (jj_3R_BlankNodePropertyList_1092_3_166()) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1474_5_92()
+  private boolean jj_3R_BuiltInCall_1469_5_92()
  {
     if (jj_scan_token(COALESCE)) return true;
-    if (jj_3R_ExpressionList_834_3_117()) return true;
+    if (jj_3R_ExpressionList_833_3_117()) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1473_5_91()
+  private boolean jj_3R_BuiltInCall_1468_5_91()
  {
     if (jj_scan_token(VERSION)) return true;
     if (jj_scan_token(NIL)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1472_5_90()
+  private boolean jj_3R_TriplesNode_1086_3_126()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_TriplesNode_1086_3_155()) {
+    jj_scanpos = xsp;
+    if (jj_3R_TriplesNode_1088_3_156()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_TriplesNode_1086_3_155()
+ {
+    if (jj_3R_Collection_1115_3_165()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_BuiltInCall_1467_5_90()
  {
     if (jj_scan_token(SHA512)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1471_5_89()
+  private boolean jj_3R_BuiltInCall_1466_5_89()
  {
     if (jj_scan_token(SHA384)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_TriplesNode_1089_3_151()
- {
-    if (jj_3R_BlankNodePropertyList_1093_3_158()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_BuiltInCall_1470_5_88()
+  private boolean jj_3R_BuiltInCall_1465_5_88()
  {
     if (jj_scan_token(SHA256)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1469_5_87()
+  private boolean jj_3R_BuiltInCall_1464_5_87()
  {
     if (jj_scan_token(SHA1)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_TriplesNode_1087_3_126()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_TriplesNode_1087_3_150()) {
-    jj_scanpos = xsp;
-    if (jj_3R_TriplesNode_1089_3_151()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_TriplesNode_1087_3_150()
- {
-    if (jj_3R_Collection_1116_3_157()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_BuiltInCall_1468_5_86()
+  private boolean jj_3R_BuiltInCall_1463_5_86()
  {
     if (jj_scan_token(MD5)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1467_5_85()
+  private boolean jj_3R_BuiltInCall_1462_5_85()
  {
     if (jj_scan_token(STRUUID)) return true;
     if (jj_scan_token(NIL)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1466_5_84()
+  private boolean jj_3R_BuiltInCall_1461_5_84()
  {
     if (jj_scan_token(UUID)) return true;
     if (jj_scan_token(NIL)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1465_5_83()
+  private boolean jj_3R_BuiltInCall_1460_5_83()
  {
     if (jj_scan_token(NOW)) return true;
     if (jj_scan_token(NIL)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1462_5_82()
+  private boolean jj_3R_BuiltInCall_1457_5_82()
  {
     if (jj_scan_token(ADJUST)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1461_5_81()
+  private boolean jj_3R_BuiltInCall_1456_5_81()
  {
     if (jj_scan_token(TZ)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1460_5_80()
+  private boolean jj_3R_BuiltInCall_1455_5_80()
  {
     if (jj_scan_token(TIMEZONE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1459_5_79()
+  private boolean jj_3R_BuiltInCall_1454_5_79()
  {
     if (jj_scan_token(SECONDS)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1458_5_78()
+  private boolean jj_3R_BuiltInCall_1453_5_78()
  {
     if (jj_scan_token(MINUTES)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1457_5_77()
+  private boolean jj_3R_BuiltInCall_1452_5_77()
  {
     if (jj_scan_token(HOURS)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1456_5_76()
+  private boolean jj_3R_BuiltInCall_1451_5_76()
  {
     if (jj_scan_token(DAY)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1455_5_75()
+  private boolean jj_3R_BuiltInCall_1450_5_75()
  {
     if (jj_scan_token(MONTH)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1454_5_74()
+  private boolean jj_3R_BuiltInCall_1449_5_74()
  {
     if (jj_scan_token(YEAR)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1452_5_73()
+  private boolean jj_3R_BuiltInCall_1447_5_73()
  {
     if (jj_scan_token(STRAFTER)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1450_5_72()
+  private boolean jj_3R_BuiltInCall_1445_5_72()
  {
     if (jj_scan_token(STRBEFORE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1448_5_71()
+  private boolean jj_3R_BuiltInCall_1443_5_71()
  {
     if (jj_scan_token(STRENDS)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1446_5_70()
+  private boolean jj_3R_BuiltInCall_1441_5_70()
  {
     if (jj_scan_token(STRSTARTS)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1444_5_69()
+  private boolean jj_3R_BuiltInCall_1439_5_69()
  {
     if (jj_scan_token(CONTAINS)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1443_5_68()
+  private boolean jj_3R_BuiltInCall_1438_5_68()
  {
     if (jj_scan_token(ENCODE_FOR_URI)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1442_5_67()
+  private boolean jj_3R_BuiltInCall_1437_5_67()
  {
     if (jj_scan_token(LCASE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1441_5_66()
+  private boolean jj_3R_BuiltInCall_1436_5_66()
  {
     if (jj_scan_token(UCASE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1440_5_65()
+  private boolean jj_3R_BuiltInCall_1435_5_65()
  {
-    if (jj_3R_StrReplaceExpression_1545_3_119()) return true;
+    if (jj_3R_StrReplaceExpression_1540_3_119()) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1439_5_64()
+  private boolean jj_3R_BuiltInCall_1434_5_64()
  {
     if (jj_scan_token(STRLEN)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1438_5_63()
+  private boolean jj_3R_BuiltInCall_1433_5_63()
  {
-    if (jj_3R_SubstringExpression_1533_5_118()) return true;
+    if (jj_3R_SubstringExpression_1528_5_118()) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1437_5_62()
+  private boolean jj_3R_BuiltInCall_1432_5_62()
  {
     if (jj_scan_token(CONCAT)) return true;
-    if (jj_3R_ExpressionList_834_3_117()) return true;
+    if (jj_3R_ExpressionList_833_3_117()) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1436_5_61()
+  private boolean jj_3R_BuiltInCall_1431_5_61()
  {
     if (jj_scan_token(IDIV)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1435_5_60()
+  private boolean jj_3R_BuiltInCall_1430_5_60()
  {
     if (jj_scan_token(MOD)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1434_5_59()
+  private boolean jj_3R_BuiltInCall_1429_5_59()
  {
     if (jj_scan_token(ROUND)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1433_5_58()
+  private boolean jj_3R_BuiltInCall_1428_5_58()
  {
     if (jj_scan_token(FLOOR)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1432_5_57()
+  private boolean jj_3R_BuiltInCall_1427_5_57()
  {
     if (jj_scan_token(CEIL)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1431_5_56()
+  private boolean jj_3R_BuiltInCall_1426_5_56()
  {
     if (jj_scan_token(ABS)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1430_5_55()
+  private boolean jj_3R_BuiltInCall_1425_5_55()
  {
     if (jj_scan_token(RAND)) return true;
     if (jj_scan_token(NIL)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1428_7_116()
+  private boolean jj_3R_BuiltInCall_1423_7_116()
  {
     if (jj_scan_token(NIL)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1425_7_115()
+  private boolean jj_3R_BuiltInCall_1420_7_115()
  {
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1424_5_54()
+  private boolean jj_3R_BuiltInCall_1419_5_54()
  {
     if (jj_scan_token(BNODE)) return true;
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_BuiltInCall_1425_7_115()) {
+    if (jj_3R_BuiltInCall_1420_7_115()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1428_7_116()) return true;
+    if (jj_3R_BuiltInCall_1423_7_116()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1422_5_53()
+  private boolean jj_3R_BuiltInCall_1417_5_53()
  {
     if (jj_scan_token(URI)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1420_5_52()
+  private boolean jj_3R_BuiltInCall_1415_5_52()
  {
     if (jj_scan_token(IRI)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1418_5_51()
+  private boolean jj_3R_BuiltInCall_1413_5_51()
  {
     if (jj_scan_token(BOUND)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1416_5_50()
+  private boolean jj_3R_BuiltInCall_1411_5_50()
  {
     if (jj_scan_token(DTYPE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1413_5_49()
+  private boolean jj_3R_BuiltInCall_1408_5_49()
  {
     if (jj_scan_token(LANGMATCHES)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1411_5_48()
+  private boolean jj_3R_BuiltInCall_1406_5_48()
  {
     if (jj_scan_token(LANG)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1409_5_47()
+  private boolean jj_3R_BuiltInCall_1404_5_47()
  {
     if (jj_scan_token(STR)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1407_5_46()
+  private boolean jj_3R_BuiltInCall_1402_5_46()
  {
-    if (jj_3R_Aggregate_1572_3_114()) return true;
+    if (jj_3R_Aggregate_1567_3_114()) return true;
     return false;
   }
 
-  private boolean jj_3R_BuiltInCall_1407_5_43()
+  private boolean jj_3R_BuiltInCall_1402_5_43()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_BuiltInCall_1407_5_46()) {
+    if (jj_3R_BuiltInCall_1402_5_46()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1409_5_47()) {
+    if (jj_3R_BuiltInCall_1404_5_47()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1411_5_48()) {
+    if (jj_3R_BuiltInCall_1406_5_48()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1413_5_49()) {
+    if (jj_3R_BuiltInCall_1408_5_49()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1416_5_50()) {
+    if (jj_3R_BuiltInCall_1411_5_50()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1418_5_51()) {
+    if (jj_3R_BuiltInCall_1413_5_51()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1420_5_52()) {
+    if (jj_3R_BuiltInCall_1415_5_52()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1422_5_53()) {
+    if (jj_3R_BuiltInCall_1417_5_53()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1424_5_54()) {
+    if (jj_3R_BuiltInCall_1419_5_54()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1430_5_55()) {
+    if (jj_3R_BuiltInCall_1425_5_55()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1431_5_56()) {
+    if (jj_3R_BuiltInCall_1426_5_56()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1432_5_57()) {
+    if (jj_3R_BuiltInCall_1427_5_57()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1433_5_58()) {
+    if (jj_3R_BuiltInCall_1428_5_58()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1434_5_59()) {
+    if (jj_3R_BuiltInCall_1429_5_59()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1435_5_60()) {
+    if (jj_3R_BuiltInCall_1430_5_60()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1436_5_61()) {
+    if (jj_3R_BuiltInCall_1431_5_61()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1437_5_62()) {
+    if (jj_3R_BuiltInCall_1432_5_62()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1438_5_63()) {
+    if (jj_3R_BuiltInCall_1433_5_63()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1439_5_64()) {
+    if (jj_3R_BuiltInCall_1434_5_64()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1440_5_65()) {
+    if (jj_3R_BuiltInCall_1435_5_65()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1441_5_66()) {
+    if (jj_3R_BuiltInCall_1436_5_66()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1442_5_67()) {
+    if (jj_3R_BuiltInCall_1437_5_67()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1443_5_68()) {
+    if (jj_3R_BuiltInCall_1438_5_68()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1444_5_69()) {
+    if (jj_3R_BuiltInCall_1439_5_69()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1446_5_70()) {
+    if (jj_3R_BuiltInCall_1441_5_70()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1448_5_71()) {
+    if (jj_3R_BuiltInCall_1443_5_71()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1450_5_72()) {
+    if (jj_3R_BuiltInCall_1445_5_72()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1452_5_73()) {
+    if (jj_3R_BuiltInCall_1447_5_73()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1454_5_74()) {
+    if (jj_3R_BuiltInCall_1449_5_74()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1455_5_75()) {
+    if (jj_3R_BuiltInCall_1450_5_75()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1456_5_76()) {
+    if (jj_3R_BuiltInCall_1451_5_76()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1457_5_77()) {
+    if (jj_3R_BuiltInCall_1452_5_77()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1458_5_78()) {
+    if (jj_3R_BuiltInCall_1453_5_78()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1459_5_79()) {
+    if (jj_3R_BuiltInCall_1454_5_79()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1460_5_80()) {
+    if (jj_3R_BuiltInCall_1455_5_80()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1461_5_81()) {
+    if (jj_3R_BuiltInCall_1456_5_81()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1462_5_82()) {
+    if (jj_3R_BuiltInCall_1457_5_82()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1465_5_83()) {
+    if (jj_3R_BuiltInCall_1460_5_83()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1466_5_84()) {
+    if (jj_3R_BuiltInCall_1461_5_84()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1467_5_85()) {
+    if (jj_3R_BuiltInCall_1462_5_85()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1468_5_86()) {
+    if (jj_3R_BuiltInCall_1463_5_86()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1469_5_87()) {
+    if (jj_3R_BuiltInCall_1464_5_87()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1470_5_88()) {
+    if (jj_3R_BuiltInCall_1465_5_88()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1471_5_89()) {
+    if (jj_3R_BuiltInCall_1466_5_89()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1472_5_90()) {
+    if (jj_3R_BuiltInCall_1467_5_90()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1473_5_91()) {
+    if (jj_3R_BuiltInCall_1468_5_91()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1474_5_92()) {
+    if (jj_3R_BuiltInCall_1469_5_92()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1476_5_93()) {
+    if (jj_3R_BuiltInCall_1471_5_93()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1483_5_94()) {
+    if (jj_3R_BuiltInCall_1478_5_94()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1487_5_95()) {
+    if (jj_3R_BuiltInCall_1482_5_95()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1489_5_96()) {
+    if (jj_3R_BuiltInCall_1484_5_96()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1491_5_97()) {
+    if (jj_3R_BuiltInCall_1486_5_97()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1493_5_98()) {
+    if (jj_3R_BuiltInCall_1488_5_98()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1495_5_99()) {
+    if (jj_3R_BuiltInCall_1490_5_99()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1497_5_100()) {
+    if (jj_3R_BuiltInCall_1492_5_100()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1499_5_101()) {
+    if (jj_3R_BuiltInCall_1494_5_101()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1501_5_102()) {
+    if (jj_3R_BuiltInCall_1496_5_102()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1504_5_103()) {
+    if (jj_3R_BuiltInCall_1499_5_103()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1505_5_104()) {
+    if (jj_3R_BuiltInCall_1500_5_104()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1506_5_105()) {
+    if (jj_3R_BuiltInCall_1501_5_105()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1507_5_106()) {
+    if (jj_3R_BuiltInCall_1502_3_106()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1509_5_107()) {
+    if (jj_3R_BuiltInCall_1504_5_107()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1511_5_108()) {
+    if (jj_3R_BuiltInCall_1506_5_108()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1513_5_109()) {
+    if (jj_3R_BuiltInCall_1508_5_109()) {
     jj_scanpos = xsp;
-    if (jj_3R_BuiltInCall_1515_5_110()) return true;
+    if (jj_3R_BuiltInCall_1510_5_110()) return true;
     }
     }
     }
@@ -7339,55 +7305,44 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_IRIREF_1732_3_153()
+  private boolean jj_3R_IRIREF_1727_3_158()
  {
     if (jj_scan_token(IRIref)) return true;
     return false;
   }
 
-  private boolean jj_3R_BlankNode_1728_3_181()
+  private boolean jj_3R_BlankNode_1723_3_176()
  {
     if (jj_scan_token(ANON)) return true;
     return false;
   }
 
-  private boolean jj_3R_BlankNode_1725_3_171()
+  private boolean jj_3R_BlankNode_1720_3_163()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_BlankNode_1725_3_180()) {
+    if (jj_3R_BlankNode_1720_3_175()) {
     jj_scanpos = xsp;
-    if (jj_3R_BlankNode_1728_3_181()) return true;
+    if (jj_3R_BlankNode_1723_3_176()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_BlankNode_1725_3_180()
+  private boolean jj_3R_BlankNode_1720_3_175()
  {
     if (jj_scan_token(BLANK_NODE_LABEL)) return true;
     return false;
   }
 
-  private boolean jj_3R_PrefixedName_1719_5_173()
+  private boolean jj_3R_PrefixedName_1714_5_186()
  {
     if (jj_scan_token(PNAME_NS)) return true;
     return false;
   }
 
-  private boolean jj_3R_PrefixedName_1716_5_172()
+  private boolean jj_3R_PrefixedName_1711_5_185()
  {
     if (jj_scan_token(PNAME_LN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_PrefixedName_1716_3_167()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_PrefixedName_1716_5_172()) {
-    jj_scanpos = xsp;
-    if (jj_3R_PrefixedName_1719_5_173()) return true;
-    }
     return false;
   }
 
@@ -7397,323 +7352,252 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_iri_1712_3_160()
- {
-    if (jj_3R_PrefixedName_1716_3_167()) return true;
-    return false;
-  }
-
   private boolean jj_3_3()
  {
     if (jj_scan_token(DOT)) return true;
-    if (jj_3R_TriplesSameSubject_862_3_45()) return true;
+    if (jj_3R_TriplesSameSubject_861_3_45()) return true;
     return false;
   }
 
-  private boolean jj_3R_iri_1710_3_152()
+  private boolean jj_3R_PrefixedName_1711_3_177()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_iri_1710_3_159()) {
+    if (jj_3R_PrefixedName_1711_5_185()) {
     jj_scanpos = xsp;
-    if (jj_3R_iri_1712_3_160()) return true;
+    if (jj_3R_PrefixedName_1714_5_186()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_iri_1710_3_159()
+  private boolean jj_3R_iri_1707_3_168()
  {
-    if (jj_3R_IRIREF_1732_3_153()) return true;
+    if (jj_3R_PrefixedName_1711_3_177()) return true;
     return false;
   }
 
-  private boolean jj_3R_String_1701_5_185()
+  private boolean jj_3R_iri_1705_3_157()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_iri_1705_3_167()) {
+    jj_scanpos = xsp;
+    if (jj_3R_iri_1707_3_168()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_iri_1705_3_167()
+ {
+    if (jj_3R_IRIREF_1727_3_158()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_String_1696_5_181()
  {
     if (jj_scan_token(STRING_LITERAL_LONG2)) return true;
     return false;
   }
 
-  private boolean jj_3R_String_1700_5_184()
+  private boolean jj_3R_String_1695_5_180()
  {
     if (jj_scan_token(STRING_LITERAL_LONG1)) return true;
     return false;
   }
 
-  private boolean jj_3R_String_1699_5_183()
+  private boolean jj_3R_String_1694_5_179()
  {
     if (jj_scan_token(STRING_LITERAL2)) return true;
     return false;
   }
 
-  private boolean jj_3R_String_1698_5_182()
+  private boolean jj_3R_String_1693_5_178()
  {
     if (jj_scan_token(STRING_LITERAL1)) return true;
     return false;
   }
 
-  private boolean jj_3R_String_1698_3_174()
+  private boolean jj_3R_String_1693_3_169()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_String_1698_5_182()) {
+    if (jj_3R_String_1693_5_178()) {
     jj_scanpos = xsp;
-    if (jj_3R_String_1699_5_183()) {
+    if (jj_3R_String_1694_5_179()) {
     jj_scanpos = xsp;
-    if (jj_3R_String_1700_5_184()) {
+    if (jj_3R_String_1695_5_180()) {
     jj_scanpos = xsp;
-    if (jj_3R_String_1701_5_185()) return true;
+    if (jj_3R_String_1696_5_181()) return true;
     }
     }
     }
     return false;
   }
 
-  private boolean jj_3R_BooleanLiteral_1694_3_179()
+  private boolean jj_3R_BooleanLiteral_1689_3_174()
  {
     if (jj_scan_token(FALSE)) return true;
     return false;
   }
 
-  private boolean jj_3R_BooleanLiteral_1692_3_170()
+  private boolean jj_3R_BooleanLiteral_1687_3_162()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_BooleanLiteral_1692_3_178()) {
+    if (jj_3R_BooleanLiteral_1687_3_173()) {
     jj_scanpos = xsp;
-    if (jj_3R_BooleanLiteral_1694_3_179()) return true;
+    if (jj_3R_BooleanLiteral_1689_3_174()) return true;
     }
     return false;
   }
 
-  private boolean jj_3R_BooleanLiteral_1692_3_178()
+  private boolean jj_3R_BooleanLiteral_1687_3_173()
  {
     if (jj_scan_token(TRUE)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralNegative_1688_3_197()
+  private boolean jj_3R_NumericLiteralNegative_1683_3_195()
  {
     if (jj_scan_token(DOUBLE_NEGATIVE)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralNegative_1687_3_196()
+  private boolean jj_3R_NumericLiteralNegative_1682_3_194()
  {
     if (jj_scan_token(DECIMAL_NEGATIVE)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralNegative_1686_3_195()
+  private boolean jj_3R_NumericLiteralNegative_1681_3_193()
  {
     if (jj_scan_token(INTEGER_NEGATIVE)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralNegative_1686_3_188()
+  private boolean jj_3R_NumericLiteralNegative_1681_3_184()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_NumericLiteralNegative_1686_3_195()) {
+    if (jj_3R_NumericLiteralNegative_1681_3_193()) {
     jj_scanpos = xsp;
-    if (jj_3R_NumericLiteralNegative_1687_3_196()) {
+    if (jj_3R_NumericLiteralNegative_1682_3_194()) {
     jj_scanpos = xsp;
-    if (jj_3R_NumericLiteralNegative_1688_3_197()) return true;
+    if (jj_3R_NumericLiteralNegative_1683_3_195()) return true;
     }
     }
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralPositive_1682_3_194()
+  private boolean jj_3R_NumericLiteralPositive_1677_3_192()
  {
     if (jj_scan_token(DOUBLE_POSITIVE)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralPositive_1681_3_193()
+  private boolean jj_3R_NumericLiteralPositive_1676_3_191()
  {
     if (jj_scan_token(DECIMAL_POSITIVE)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralPositive_1680_3_192()
+  private boolean jj_3R_NumericLiteralPositive_1675_3_190()
  {
     if (jj_scan_token(INTEGER_POSITIVE)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralPositive_1680_3_187()
+  private boolean jj_3R_NumericLiteralPositive_1675_3_183()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_NumericLiteralPositive_1680_3_192()) {
+    if (jj_3R_NumericLiteralPositive_1675_3_190()) {
     jj_scanpos = xsp;
-    if (jj_3R_NumericLiteralPositive_1681_3_193()) {
+    if (jj_3R_NumericLiteralPositive_1676_3_191()) {
     jj_scanpos = xsp;
-    if (jj_3R_NumericLiteralPositive_1682_3_194()) return true;
+    if (jj_3R_NumericLiteralPositive_1677_3_192()) return true;
     }
     }
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralUnsigned_1676_3_191()
+  private boolean jj_3R_NumericLiteralUnsigned_1671_3_189()
  {
     if (jj_scan_token(DOUBLE)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralUnsigned_1675_3_190()
+  private boolean jj_3R_NumericLiteralUnsigned_1670_3_188()
  {
     if (jj_scan_token(DECIMAL)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralUnsigned_1674_3_189()
+  private boolean jj_3R_NumericLiteralUnsigned_1669_3_187()
  {
     if (jj_scan_token(INTEGER)) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteralUnsigned_1674_3_186()
+  private boolean jj_3R_NumericLiteralUnsigned_1669_3_182()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_NumericLiteralUnsigned_1674_3_189()) {
+    if (jj_3R_NumericLiteralUnsigned_1669_3_187()) {
     jj_scanpos = xsp;
-    if (jj_3R_NumericLiteralUnsigned_1675_3_190()) {
+    if (jj_3R_NumericLiteralUnsigned_1670_3_188()) {
     jj_scanpos = xsp;
-    if (jj_3R_NumericLiteralUnsigned_1676_3_191()) return true;
+    if (jj_3R_NumericLiteralUnsigned_1671_3_189()) return true;
     }
     }
     return false;
   }
 
-  private boolean jj_3R_NumericLiteral_1668_5_177()
+  private boolean jj_3R_NumericLiteral_1663_5_172()
  {
-    if (jj_3R_NumericLiteralNegative_1686_3_188()) return true;
+    if (jj_3R_NumericLiteralNegative_1681_3_184()) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteral_1667_5_176()
+  private boolean jj_3R_NumericLiteral_1662_5_171()
  {
-    if (jj_3R_NumericLiteralPositive_1680_3_187()) return true;
+    if (jj_3R_NumericLiteralPositive_1675_3_183()) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteral_1666_5_175()
+  private boolean jj_3R_NumericLiteral_1661_5_170()
  {
-    if (jj_3R_NumericLiteralUnsigned_1674_3_186()) return true;
+    if (jj_3R_NumericLiteralUnsigned_1669_3_182()) return true;
     return false;
   }
 
-  private boolean jj_3R_NumericLiteral_1665_3_169()
+  private boolean jj_3R_NumericLiteral_1660_3_161()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_NumericLiteral_1666_5_175()) {
+    if (jj_3R_NumericLiteral_1661_5_170()) {
     jj_scanpos = xsp;
-    if (jj_3R_NumericLiteral_1667_5_176()) {
+    if (jj_3R_NumericLiteral_1662_5_171()) {
     jj_scanpos = xsp;
-    if (jj_3R_NumericLiteral_1668_5_177()) return true;
+    if (jj_3R_NumericLiteral_1663_5_172()) return true;
     }
     }
-    return false;
-  }
-
-  private boolean jj_3R_RDFLiteral_1654_3_168()
- {
-    if (jj_3R_String_1698_3_174()) return true;
     return false;
   }
 
   private boolean jj_3_1()
  {
-    if (jj_3R_BuiltInCall_1407_5_43()) return true;
+    if (jj_3R_BuiltInCall_1402_5_43()) return true;
     return false;
   }
 
-  private boolean jj_3R_GraphTerm_1253_3_166()
+  private boolean jj_3R_RDFLiteral_1649_3_160()
  {
-    if (jj_scan_token(NIL)) return true;
+    if (jj_3R_String_1693_3_169()) return true;
     return false;
   }
 
-  private boolean jj_3R_GraphTerm_1252_3_165()
- {
-    if (jj_3R_BlankNode_1725_3_171()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_GraphTerm_1251_3_164()
- {
-    if (jj_3R_BooleanLiteral_1692_3_170()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_GraphTerm_1250_3_163()
- {
-    if (jj_3R_NumericLiteral_1665_3_169()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_GraphTerm_1249_3_162()
- {
-    if (jj_3R_RDFLiteral_1654_3_168()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_TriplesSameSubject_865_3_113()
- {
-    if (jj_3R_TriplesNode_1087_3_126()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_GraphTerm_1248_3_156()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_GraphTerm_1248_3_161()) {
-    jj_scanpos = xsp;
-    if (jj_3R_GraphTerm_1249_3_162()) {
-    jj_scanpos = xsp;
-    if (jj_3R_GraphTerm_1250_3_163()) {
-    jj_scanpos = xsp;
-    if (jj_3R_GraphTerm_1251_3_164()) {
-    jj_scanpos = xsp;
-    if (jj_3R_GraphTerm_1252_3_165()) {
-    jj_scanpos = xsp;
-    if (jj_3R_GraphTerm_1253_3_166()) return true;
-    }
-    }
-    }
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_GraphTerm_1248_3_161()
- {
-    if (jj_3R_iri_1710_3_152()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_TriplesSameSubject_862_3_45()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_TriplesSameSubject_862_3_112()) {
-    jj_scanpos = xsp;
-    if (jj_3R_TriplesSameSubject_865_3_113()) return true;
-    }
-    return false;
-  }
-
-  private boolean jj_3R_TriplesSameSubject_862_3_112()
- {
-    if (jj_3R_VarOrTerm_1197_3_125()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_Var_1243_5_155()
+  private boolean jj_3R_Var_1247_5_159()
  {
     Token xsp;
     xsp = jj_scanpos;
@@ -7724,17 +7608,33 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3_4()
+  private boolean jj_3R_TriplesSameSubject_864_3_113()
  {
-    if (jj_scan_token(DOT)) return true;
-    if (jj_3R_TriplesSameSubject_862_3_45()) return true;
+    if (jj_3R_TriplesNode_1086_3_126()) return true;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1619_5_142()
+  private boolean jj_3R_TriplesSameSubject_861_3_45()
  {
-    if (jj_scan_token(AGG)) return true;
-    if (jj_3R_iri_1710_3_152()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_TriplesSameSubject_861_3_112()) {
+    jj_scanpos = xsp;
+    if (jj_3R_TriplesSameSubject_864_3_113()) return true;
+    }
+    return false;
+  }
+
+  private boolean jj_3R_TriplesSameSubject_861_3_112()
+ {
+    if (jj_3R_VarOrTerm_1196_3_125()) return true;
+    return false;
+  }
+
+  private boolean jj_3_4()
+ {
+    if (jj_scan_token(DOT)) return true;
+    if (jj_3R_TriplesSameSubject_861_3_45()) return true;
     return false;
   }
 
@@ -7744,17 +7644,10 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1617_5_141()
+  private boolean jj_3R_Aggregate_1614_5_142()
  {
-    if (jj_scan_token(VAR_POP)) return true;
-    if (jj_scan_token(LPAREN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_Aggregate_1615_5_140()
- {
-    if (jj_scan_token(VAR_SAMP)) return true;
-    if (jj_scan_token(LPAREN)) return true;
+    if (jj_scan_token(AGG)) return true;
+    if (jj_3R_iri_1705_3_157()) return true;
     return false;
   }
 
@@ -7762,34 +7655,27 @@ checkString(lex, t.beginLine, t.beginColumn) ;
  {
     if (jj_scan_token(PREFIX)) return true;
     if (jj_scan_token(PNAME_NS)) return true;
-    if (jj_3R_IRIREF_1732_3_153()) return true;
+    if (jj_3R_IRIREF_1727_3_158()) return true;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1613_5_139()
+  private boolean jj_3R_Aggregate_1612_5_141()
+ {
+    if (jj_scan_token(VAR_POP)) return true;
+    if (jj_scan_token(LPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_Aggregate_1610_5_140()
+ {
+    if (jj_scan_token(VAR_SAMP)) return true;
+    if (jj_scan_token(LPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_Aggregate_1608_5_139()
  {
     if (jj_scan_token(VARIANCE)) return true;
-    if (jj_scan_token(LPAREN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_Aggregate_1611_5_138()
- {
-    if (jj_scan_token(STDEV_POP)) return true;
-    if (jj_scan_token(LPAREN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_Aggregate_1609_5_137()
- {
-    if (jj_scan_token(STDEV_SAMP)) return true;
-    if (jj_scan_token(LPAREN)) return true;
-    return false;
-  }
-
-  private boolean jj_3R_Aggregate_1607_5_136()
- {
-    if (jj_scan_token(STDEV)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
@@ -7797,7 +7683,14 @@ checkString(lex, t.beginLine, t.beginColumn) ;
   private boolean jj_3R_BaseDecl_76_3_145()
  {
     if (jj_scan_token(BASE)) return true;
-    if (jj_3R_IRIREF_1732_3_153()) return true;
+    if (jj_3R_IRIREF_1727_3_158()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_Aggregate_1606_5_138()
+ {
+    if (jj_scan_token(STDEV_POP)) return true;
+    if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
@@ -7818,8 +7711,9 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_ExpressionList_837_5_143()
+  private boolean jj_3R_Aggregate_1604_5_137()
  {
+    if (jj_scan_token(STDEV_SAMP)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
@@ -7834,6 +7728,30 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
+  private boolean jj_3R_ExpressionList_836_5_143()
+ {
+    if (jj_scan_token(LPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_Aggregate_1602_5_136()
+ {
+    if (jj_scan_token(STDEV)) return true;
+    if (jj_scan_token(LPAREN)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_ExpressionList_833_3_117()
+ {
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_scan_token(185)) {
+    jj_scanpos = xsp;
+    if (jj_3R_ExpressionList_836_5_143()) return true;
+    }
+    return false;
+  }
+
   private boolean jj_3_5()
  {
     if (jj_scan_token(SEMICOLON)) return true;
@@ -7841,153 +7759,187 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_ExpressionList_834_3_117()
+  private boolean jj_3R_QuotedTriple_1209_3_164()
  {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_scan_token(185)) {
-    jj_scanpos = xsp;
-    if (jj_3R_ExpressionList_837_5_143()) return true;
-    }
+    if (jj_scan_token(LT2)) return true;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1594_5_135()
+  private boolean jj_3R_Aggregate_1589_5_135()
  {
     if (jj_scan_token(GROUP_CONCAT)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1592_5_134()
+  private boolean jj_3R_Aggregate_1587_5_134()
  {
     if (jj_scan_token(SAMPLE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1590_5_133()
+  private boolean jj_3R_VarOrTerm_1203_5_154()
+ {
+    if (jj_3R_QuotedTriple_1209_3_164()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_VarOrTerm_1202_5_153()
+ {
+    if (jj_scan_token(NIL)) return true;
+    return false;
+  }
+
+  private boolean jj_3R_Aggregate_1585_5_133()
  {
     if (jj_scan_token(MODE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1588_5_132()
+  private boolean jj_3R_VarOrTerm_1201_5_152()
+ {
+    if (jj_3R_BlankNode_1720_3_163()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_VarOrTerm_1200_5_151()
+ {
+    if (jj_3R_BooleanLiteral_1687_3_162()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_Aggregate_1583_5_132()
  {
     if (jj_scan_token(MEDIAN)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_TripleTerm_1205_3_154()
+  private boolean jj_3R_VarOrTerm_1199_5_150()
  {
-    if (jj_scan_token(LT2)) return true;
+    if (jj_3R_NumericLiteral_1660_3_161()) return true;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1586_5_131()
+  private boolean jj_3R_VarOrTerm_1198_5_149()
+ {
+    if (jj_3R_RDFLiteral_1649_3_160()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_Aggregate_1581_5_131()
  {
     if (jj_scan_token(AVG)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1584_5_130()
+  private boolean jj_3R_VarOrTerm_1197_5_148()
+ {
+    if (jj_3R_iri_1705_3_157()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_VarOrTerm_1196_5_147()
+ {
+    if (jj_3R_Var_1247_5_159()) return true;
+    return false;
+  }
+
+  private boolean jj_3R_Aggregate_1579_5_130()
  {
     if (jj_scan_token(MAX)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_VarOrTerm_1199_5_149()
+  private boolean jj_3R_VarOrTerm_1196_3_125()
  {
-    if (jj_3R_GraphTerm_1248_3_156()) return true;
+    Token xsp;
+    xsp = jj_scanpos;
+    if (jj_3R_VarOrTerm_1196_5_147()) {
+    jj_scanpos = xsp;
+    if (jj_3R_VarOrTerm_1197_5_148()) {
+    jj_scanpos = xsp;
+    if (jj_3R_VarOrTerm_1198_5_149()) {
+    jj_scanpos = xsp;
+    if (jj_3R_VarOrTerm_1199_5_150()) {
+    jj_scanpos = xsp;
+    if (jj_3R_VarOrTerm_1200_5_151()) {
+    jj_scanpos = xsp;
+    if (jj_3R_VarOrTerm_1201_5_152()) {
+    jj_scanpos = xsp;
+    if (jj_3R_VarOrTerm_1202_5_153()) {
+    jj_scanpos = xsp;
+    if (jj_3R_VarOrTerm_1203_5_154()) return true;
+    }
+    }
+    }
+    }
+    }
+    }
+    }
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1582_5_129()
+  private boolean jj_3R_Aggregate_1577_5_129()
  {
     if (jj_scan_token(MIN)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_VarOrTerm_1198_5_148()
- {
-    if (jj_3R_Var_1243_5_155()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_VarOrTerm_1197_5_147()
- {
-    if (jj_3R_TripleTerm_1205_3_154()) return true;
-    return false;
-  }
-
-  private boolean jj_3R_Aggregate_1580_5_128()
+  private boolean jj_3R_Aggregate_1575_5_128()
  {
     if (jj_scan_token(SUM)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_VarOrTerm_1197_3_125()
- {
-    Token xsp;
-    xsp = jj_scanpos;
-    if (jj_3R_VarOrTerm_1197_5_147()) {
-    jj_scanpos = xsp;
-    if (jj_3R_VarOrTerm_1198_5_148()) {
-    jj_scanpos = xsp;
-    if (jj_3R_VarOrTerm_1199_5_149()) return true;
-    }
-    }
-    return false;
-  }
-
-  private boolean jj_3R_Aggregate_1573_5_127()
+  private boolean jj_3R_Aggregate_1568_5_127()
  {
     if (jj_scan_token(COUNT)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_Aggregate_1572_3_114()
+  private boolean jj_3R_Aggregate_1567_3_114()
  {
     Token xsp;
     xsp = jj_scanpos;
-    if (jj_3R_Aggregate_1573_5_127()) {
+    if (jj_3R_Aggregate_1568_5_127()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1580_5_128()) {
+    if (jj_3R_Aggregate_1575_5_128()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1582_5_129()) {
+    if (jj_3R_Aggregate_1577_5_129()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1584_5_130()) {
+    if (jj_3R_Aggregate_1579_5_130()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1586_5_131()) {
+    if (jj_3R_Aggregate_1581_5_131()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1588_5_132()) {
+    if (jj_3R_Aggregate_1583_5_132()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1590_5_133()) {
+    if (jj_3R_Aggregate_1585_5_133()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1592_5_134()) {
+    if (jj_3R_Aggregate_1587_5_134()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1594_5_135()) {
+    if (jj_3R_Aggregate_1589_5_135()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1607_5_136()) {
+    if (jj_3R_Aggregate_1602_5_136()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1609_5_137()) {
+    if (jj_3R_Aggregate_1604_5_137()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1611_5_138()) {
+    if (jj_3R_Aggregate_1606_5_138()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1613_5_139()) {
+    if (jj_3R_Aggregate_1608_5_139()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1615_5_140()) {
+    if (jj_3R_Aggregate_1610_5_140()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1617_5_141()) {
+    if (jj_3R_Aggregate_1612_5_141()) {
     jj_scanpos = xsp;
-    if (jj_3R_Aggregate_1619_5_142()) return true;
+    if (jj_3R_Aggregate_1614_5_142()) return true;
     }
     }
     }
@@ -8006,28 +7958,28 @@ checkString(lex, t.beginLine, t.beginColumn) ;
     return false;
   }
 
-  private boolean jj_3R_NotExistsFunc_1562_4_122()
+  private boolean jj_3R_NotExistsFunc_1557_4_122()
  {
     if (jj_scan_token(NOT)) return true;
     if (jj_scan_token(EXISTS)) return true;
     return false;
   }
 
-  private boolean jj_3R_ExistsFunc_1556_4_121()
+  private boolean jj_3R_ExistsFunc_1551_4_121()
  {
     if (jj_scan_token(EXISTS)) return true;
     if (jj_3R_GroupGraphPattern_564_3_144()) return true;
     return false;
   }
 
-  private boolean jj_3R_StrReplaceExpression_1545_3_119()
+  private boolean jj_3R_StrReplaceExpression_1540_3_119()
  {
     if (jj_scan_token(REPLACE)) return true;
     if (jj_scan_token(LPAREN)) return true;
     return false;
   }
 
-  private boolean jj_3R_SubstringExpression_1533_5_118()
+  private boolean jj_3R_SubstringExpression_1528_5_118()
  {
     if (jj_scan_token(SUBSTR)) return true;
     if (jj_scan_token(LPAREN)) return true;
@@ -8045,7 +7997,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
   private Token jj_scanpos, jj_lastpos;
   private int jj_la;
   private int jj_gen;
-  final private int[] jj_la1 = new int[195];
+  final private int[] jj_la1 = new int[194];
   static private int[] jj_la1_0;
   static private int[] jj_la1_1;
   static private int[] jj_la1_2;
@@ -8065,28 +8017,28 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	   jj_la1_init_7();
 	}
 	private static void jj_la1_init_0() {
-	   jj_la1_0 = new int[] {0x1e400000,0x200,0x300000,0x300000,0x0,0x1800000,0x1800000,0x1c00,0x0,0xdc00,0xdc00,0xdc00,0x0,0x0,0x0,0xdc00,0xdc00,0x0,0x0,0x0,0x0,0x0,0xc000,0x1c00,0x0,0x0,0x0,0x80000000,0x60000000,0xdc00,0x0,0xdc00,0x1c00,0xdc00,0x0,0xdc00,0xdc00,0x40000000,0x20000000,0x60000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1c00,0x0,0x1c00,0x0,0xfc00,0x0,0x0,0xfc00,0xfc00,0xfc00,0x0,0x0,0xfc00,0x0,0xfc00,0x0,0x400000,0xfc00,0x0,0x0,0xfc00,0xfc00,0x0,0x0,0x0,0xc000,0x1c00,0xc000,0x0,0x0,0x1c00,0x0,0x1c00,0x0,0x1c00,0x800000,0x0,0x0,0x0,0x0,0x0,0xfc00,0x8dc00,0x0,0x8dc00,0x8dc00,0x0,0xfc00,0x88dc00,0x88dc00,0x0,0x88dc00,0x88dc00,0x0,0x0,0x0,0x0,0x0,0x881c00,0x0,0x0,0x0,0x0,0x881c00,0x0,0x81c00,0x81c00,0x81c00,0x81c00,0x0,0x0,0xfc00,0xfc00,0x0,0x0,0xfc00,0xfc00,0xfc00,0x81c00,0x1c00,0xdc00,0xfc00,0xc000,0x3c00,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xdc00,0xdc00,0xdc00,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x800000,0xdc00,0x800000,0x800000,0x800000,0x800000,0x800000,0x800000,0x800000,0x800000,0x0,0x0,0x0,0x800000,0x800000,0x800000,0x800000,0x800000,0x800000,0x0,0x0,0x10000,0x10000,0x0,0x0,0x0,0x0,0x0,0x0,0x1c00,0x1800,0x2000,};
+	   jj_la1_0 = new int[] {0x1e400000,0x200,0x300000,0x300000,0x0,0x1800000,0x1800000,0x1c00,0x0,0xdc00,0xdc00,0xdc00,0x0,0x0,0x0,0xdc00,0xdc00,0x0,0x0,0x0,0x0,0x0,0xc000,0x1c00,0x0,0x0,0x0,0x80000000,0x60000000,0xdc00,0x0,0xdc00,0x1c00,0xdc00,0x0,0xdc00,0xdc00,0x40000000,0x20000000,0x60000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1c00,0x0,0x1c00,0x0,0xfc00,0x0,0x0,0xfc00,0xfc00,0xfc00,0x0,0x0,0xfc00,0x0,0xfc00,0x0,0x400000,0xfc00,0x0,0x0,0xfc00,0xfc00,0x0,0x0,0x0,0xc000,0x1c00,0xc000,0x0,0x0,0x1c00,0x0,0x1c00,0x0,0x1c00,0x800000,0x0,0x0,0x0,0x0,0x0,0xfc00,0x8dc00,0x0,0x8dc00,0x8dc00,0x0,0xfc00,0x88dc00,0x88dc00,0x0,0x88dc00,0x88dc00,0x0,0x0,0x0,0x0,0x0,0x881c00,0x0,0x0,0x0,0x0,0x881c00,0x0,0x81c00,0x81c00,0x81c00,0x81c00,0x0,0x0,0xfc00,0xfc00,0x0,0x0,0xfc00,0xfc00,0xfc00,0x81c00,0x1c00,0xdc00,0xfc00,0xc000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xdc00,0xdc00,0xdc00,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x800000,0xdc00,0x800000,0x800000,0x800000,0x800000,0x800000,0x800000,0x800000,0x800000,0x0,0x0,0x0,0x800000,0x800000,0x800000,0x800000,0x800000,0x800000,0x0,0x0,0x10000,0x10000,0x0,0x0,0x0,0x0,0x0,0x0,0x1c00,0x1800,0x2000,};
 	}
 	private static void jj_la1_init_1() {
-	   jj_la1_1 = new int[] {0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x1000000,0xf0df0000,0xf0df0000,0xf0df0000,0x40,0x40,0xc0,0x0,0x0,0x40,0x80,0x40,0x40,0x0,0x0,0x20,0x80,0x2000000,0x4000000,0x0,0x0,0xf0df0000,0x1000000,0xf0df0000,0xf0df0000,0xf0df0018,0x18,0xf0df0000,0xf0df0018,0x0,0x0,0x0,0x2,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20,0x200,0x200,0x220,0x0,0x200,0x0,0x0,0x0,0x0,0x200,0x0,0x0,0x200,0x0,0x0,0x0,0x0,0xe0f602,0x0,0x0,0x0,0x0,0xe0f602,0x0,0x0,0x4,0x0,0x0,0x0,0x4,0x0,0x4,0x800,0xf0df0000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x800000,0x800000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xf0df0000,0xf0df0000,0x0,0x0,0x0,0x0,0x0,0x0,0xf0df0000,0x0,0x0,0x0,0x0,0xf0df0000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xf0000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_1 = new int[] {0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x1000000,0xf0fe0000,0xf0fe0000,0xf0fe0000,0x40,0x40,0xc0,0x0,0x0,0x40,0x80,0x40,0x40,0x0,0x0,0x20,0x80,0x2000000,0x4000000,0x0,0x0,0xf0fe0000,0x1000000,0xf0fe0000,0xf0fe0000,0xf0fe0018,0x18,0xf0fe0000,0xf0fe0018,0x0,0x0,0x0,0x2,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20,0x200,0x200,0x220,0x0,0x200,0x0,0x0,0x0,0x0,0x200,0x0,0x0,0x200,0x0,0x0,0x0,0x0,0xc1f602,0x0,0x0,0x0,0x0,0xc1f602,0x0,0x0,0x4,0x0,0x0,0x0,0x4,0x0,0x4,0x800,0xf0fe0000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x800000,0x800000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xf0fe0000,0xf0fe0000,0x0,0x0,0x0,0x0,0x0,0x0,0xf0fe0000,0x0,0x0,0x0,0x0,0xf0fe0000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xf0000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_2() {
-	   jj_la1_2 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0xff2f6fff,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0x0,0xff2f6fff,0xff2f6fff,0xff2f6fff,0x0,0xff2f6fff,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000,0x0,0x0,0x0,0x0,0x1000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xc00000,0xc00000,0x0,0xc00000,0xc00000,0x0,0x0,0x0,0x0,0x0,0xc00000,0x0,0x0,0x0,0x0,0xc00000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8000,0x8000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0x0,0x0,0x0,0x0,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xfff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_2 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0xff2f6fff,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0x0,0xff2f6fff,0xff2f6fff,0xff2f6fff,0x0,0xff2f6fff,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1000,0x0,0x0,0x0,0x0,0x1000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xc00000,0xc00000,0x0,0xc00000,0xc00000,0x0,0x0,0x0,0x0,0x0,0xc00000,0x0,0x0,0x0,0x0,0xc00000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8000,0x8000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0xff2f6fff,0x0,0x0,0x0,0x0,0xff2f6fff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xfff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_3() {
-	   jj_la1_3 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffff,0xffffffff,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffff,0x0,0xffffffff,0xffffffff,0xffffffff,0x0,0xffffffff,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xc00,0xc00,0xffffffff,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffff,0x0,0x0,0x0,0x0,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_3 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffff,0xffffffff,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffff,0x0,0xffffffff,0xffffffff,0xffffffff,0x0,0xffffffff,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xc00,0xc00,0xffffffff,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffff,0x0,0x0,0x0,0x0,0xffffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_4() {
-	   jj_la1_4 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x1f7f,0x1f7f,0x1f7f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x0,0x0,0x0,0x0,0x0,0x77f,0x0,0x77f,0x77f,0x77f,0x0,0x77f,0x77f,0x0,0x0,0x0,0x0,0x0,0x9ffc000,0x9ffc000,0x4000000,0x10000000,0x4000000,0x4000000,0x4000000,0x4000000,0x4000000,0x4000000,0x0,0x4000,0xc000,0x0,0x0,0x0,0x40000000,0xc0000000,0x1800,0x0,0x0,0x1800,0x1800,0x1800,0x0,0x0,0x1800,0x0,0x1800,0x0,0x0,0x1800,0x0,0x0,0x1800,0x1800,0x0,0x0,0x4000000,0x0,0x1800,0x0,0x0,0x0,0x1800,0x0,0x1800,0x0,0x77f,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x1800,0x0,0x0,0x1800,0x1800,0x1800,0x0,0x1800,0x0,0x0,0x0,0x1800,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1f7f,0x1f7f,0x1800,0x0,0x0,0x0,0x0,0x0,0x77f,0x0,0x0,0x0,0x0,0x1f7f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x0,0x0,0x0,};
+	   jj_la1_4 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x1f7f,0x1f7f,0x1f7f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x0,0x0,0x0,0x0,0x0,0x77f,0x0,0x77f,0x77f,0x77f,0x0,0x77f,0x77f,0x0,0x0,0x0,0x0,0x0,0x9ffc000,0x9ffc000,0x4000000,0x10000000,0x4000000,0x4000000,0x4000000,0x4000000,0x4000000,0x4000000,0x0,0x4000,0xc000,0x0,0x0,0x0,0x40000000,0xc0000000,0x1800,0x0,0x0,0x1800,0x1800,0x1800,0x0,0x0,0x1800,0x0,0x1800,0x0,0x0,0x1800,0x0,0x0,0x1800,0x1800,0x0,0x0,0x4000000,0x0,0x1800,0x0,0x0,0x0,0x1800,0x0,0x1800,0x0,0x77f,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x1800,0x0,0x0,0x1800,0x1800,0x1800,0x0,0x1800,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1f7f,0x1f7f,0x1800,0x0,0x0,0x0,0x0,0x0,0x77f,0x0,0x0,0x0,0x0,0x1f7f,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1800,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_5() {
-	   jj_la1_5 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x780ff8,0x0,0xf80ff8,0xf80ff8,0xf80ff8,0x0,0x0,0x4000000,0x0,0x0,0x0,0x4000000,0x0,0x0,0x0,0x780ff8,0x0,0x0,0x0,0x0,0x0,0x0,0x800000,0x0,0x800000,0x800000,0x800000,0x0,0x800000,0x800000,0x0,0x0,0x0,0x0,0x80000000,0x1,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x2,0x0,0x0,0x0,0x0,0x52f80ff8,0x0,0x0,0x52f80ff8,0x52f80ff8,0x52f80ff8,0x4000000,0x0,0x52f80ff8,0x0,0x52f80ff8,0x0,0x0,0x52f80ff8,0x4000000,0x0,0x52f80ff8,0x52f80ff8,0x0,0x4000000,0x0,0x2800000,0x780ff8,0x0,0x2800000,0x2800000,0x780ff8,0x2800000,0x780ff8,0x0,0x800000,0x0,0x0,0x2800000,0x0,0x2800000,0x0,0x52f80ff8,0x0,0x80000000,0x0,0x0,0x0,0x52f80ff8,0x800000,0x800000,0x80000000,0x800000,0x800000,0x0,0x0,0x0,0x0,0x4000000,0x800000,0x8000008,0x8000000,0x8,0x4000000,0x800000,0x0,0x0,0x800000,0x0,0x0,0x10800000,0x10800000,0x52f80ff8,0x52f80ff8,0x0,0x0,0x52f80ff8,0x52f80ff8,0x42780ff8,0x0,0x780ff8,0x0,0x40000000,0x0,0x42780ff8,0x0,0x0,0x0,0x0,0xfc0,0xfc0,0x0,0x0,0xfc0,0x0,0x0,0xf80ff8,0xf80ff8,0x780ff8,0x0,0x0,0x2800000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xf80ff8,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x80000000,0x80000000,0x80000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2800000,0x0,0x0,0xff8,0x38,0x1c0,0xe00,0x0,0x780000,0x0,0x0,0x40000000,};
+	   jj_la1_5 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x780ff8,0x0,0xf80ff8,0xf80ff8,0xf80ff8,0x0,0x0,0x4000000,0x0,0x0,0x0,0x4000000,0x0,0x0,0x0,0x780ff8,0x0,0x0,0x0,0x0,0x0,0x0,0x800000,0x0,0x800000,0x800000,0x800000,0x0,0x800000,0x800000,0x0,0x0,0x0,0x0,0x80000000,0x1,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x2,0x0,0x0,0x0,0x0,0x52f80ff8,0x0,0x0,0x52f80ff8,0x52f80ff8,0x52f80ff8,0x4000000,0x0,0x52f80ff8,0x0,0x52f80ff8,0x0,0x0,0x52f80ff8,0x4000000,0x0,0x52f80ff8,0x52f80ff8,0x0,0x4000000,0x0,0x2800000,0x780ff8,0x0,0x2800000,0x2800000,0x780ff8,0x2800000,0x780ff8,0x0,0x800000,0x0,0x0,0x2800000,0x0,0x2800000,0x0,0x52f80ff8,0x0,0x80000000,0x0,0x0,0x0,0x52f80ff8,0x800000,0x800000,0x80000000,0x800000,0x800000,0x0,0x0,0x0,0x0,0x4000000,0x800000,0x8000008,0x8000000,0x8,0x4000000,0x800000,0x0,0x0,0x800000,0x0,0x0,0x10800000,0x10800000,0x52f80ff8,0x52f80ff8,0x0,0x0,0x52f80ff8,0x52f80ff8,0x42780ff8,0x0,0x780ff8,0x0,0x40000000,0x0,0x0,0x0,0x0,0x0,0xfc0,0xfc0,0x0,0x0,0xfc0,0x0,0x0,0xf80ff8,0xf80ff8,0x780ff8,0x0,0x0,0x2800000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xf80ff8,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x80000000,0x80000000,0x80000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2800000,0x0,0x0,0xff8,0x38,0x1c0,0xe00,0x0,0x780000,0x0,0x0,0x40000000,};
 	}
 	private static void jj_la1_init_6() {
-	   jj_la1_6 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x80000,0x0,0x0,0x0,0x0,0x80000,0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200,0x0,0x2,0x200,0x200,0x200,0x0,0x2,0x200,0x0,0x200,0x2,0x0,0x200,0x0,0x2,0x200,0x200,0x2,0x0,0x0,0x0,0x200,0x0,0x0,0x0,0x200,0x0,0x200,0x0,0x0,0x0,0x1,0x0,0x1,0x0,0x2,0x200,0x0,0x0,0x0,0x0,0x1,0x200,0x2001000,0x2001000,0x0,0x2001000,0x2001000,0x1,0x1000000,0x2100000,0x2100000,0x100a0000,0x2001000,0x0,0x1,0xa0001,0x100a0000,0x1000,0x1000000,0x2000000,0x2000000,0x0,0x2000000,0x0,0x0,0x200,0x200,0x400,0x400,0x200,0x200,0x200,0x0,0x200,0x0,0x0,0x0,0x0,0x8000,0x10000,0xfc,0xfc,0x60000,0x0,0x180000,0x180000,0x60000,0x180000,0x180000,0x61200,0x200,0x200,0x1,0x1,0x0,0x1,0x1,0x0,0x1,0x1,0x1,0x0,0xe1200,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200000,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_6 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x80000,0x0,0x0,0x0,0x0,0x80000,0x0,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200,0x0,0x2,0x200,0x200,0x200,0x0,0x2,0x200,0x0,0x200,0x2,0x0,0x200,0x0,0x2,0x200,0x200,0x2,0x0,0x0,0x0,0x200,0x0,0x0,0x0,0x200,0x0,0x200,0x0,0x0,0x0,0x1,0x0,0x1,0x0,0x2,0x200,0x0,0x0,0x0,0x0,0x1,0x200,0x2001000,0x2001000,0x0,0x2001000,0x2001000,0x1,0x1000000,0x2100000,0x2100000,0x100a0000,0x2001000,0x0,0x1,0xa0001,0x100a0000,0x1000,0x1000000,0x2000000,0x2000000,0x0,0x2000000,0x0,0x0,0x200,0x200,0x400,0x400,0x200,0x200,0x200,0x0,0x200,0x0,0x0,0x0,0x8000,0x10000,0xfc,0xfc,0x60000,0x0,0x180000,0x180000,0x60000,0x180000,0x180000,0x61200,0x200,0x200,0x1,0x1,0x0,0x1,0x1,0x0,0x1,0x1,0x1,0x0,0xe1200,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200000,0x200000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_7() {
-	   jj_la1_7 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_7 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
   final private JJCalls[] jj_2_rtns = new JJCalls[5];
   private boolean jj_rescan = false;
@@ -8103,7 +8055,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 195; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 194; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -8118,7 +8070,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 195; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 194; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -8129,7 +8081,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 195; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 194; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -8148,7 +8100,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 195; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 194; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -8158,7 +8110,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 195; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 194; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -8168,7 +8120,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 195; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 194; i++) jj_la1[i] = -1;
 	 for (int i = 0; i < jj_2_rtns.length; i++) jj_2_rtns[i] = new JJCalls();
   }
 
@@ -8304,7 +8256,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	   la1tokens[jj_kind] = true;
 	   jj_kind = -1;
 	 }
-	 for (int i = 0; i < 195; i++) {
+	 for (int i = 0; i < 194; i++) {
 	   if (jj_la1[i] == jj_gen) {
 		 for (int j = 0; j < 32; j++) {
 		   if ((jj_la1_0[i] & (1<<j)) != 0) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParserConstants.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParserConstants.java
@@ -95,17 +95,17 @@ public interface ARQParserConstants {
   /** RegularExpression Id. */
   int LET = 47;
   /** RegularExpression Id. */
-  int TRIPLE = 48;
+  int LATERAL = 48;
   /** RegularExpression Id. */
-  int IS_TRIPLE = 49;
+  int TRIPLE = 49;
   /** RegularExpression Id. */
-  int SUBJECT = 50;
+  int IS_TRIPLE = 50;
   /** RegularExpression Id. */
-  int PREDICATE = 51;
+  int SUBJECT = 51;
   /** RegularExpression Id. */
-  int OBJECT = 52;
+  int PREDICATE = 52;
   /** RegularExpression Id. */
-  int LATERAL = 53;
+  int OBJECT = 53;
   /** RegularExpression Id. */
   int EXISTS = 54;
   /** RegularExpression Id. */
@@ -518,12 +518,12 @@ public interface ARQParserConstants {
     "\"bind\"",
     "\"service\"",
     "\"LET\"",
+    "\"LATERAL\"",
     "\"TRIPLE\"",
     "\"isTRIPLE\"",
     "\"SUBJECT\"",
     "\"PREDICATE\"",
     "\"OBJECT\"",
-    "\"LATERAL\"",
     "\"exists\"",
     "\"not\"",
     "\"as\"",

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParserTokenManager.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParserTokenManager.java
@@ -114,25 +114,25 @@ private int jjMoveStringLiteralDfa0_0(){
       case 72:
          return jjMoveStringLiteralDfa1_0(0x400000000000000L, 0x800000000000000L, 0x0L, 0x0L);
       case 73:
-         return jjMoveStringLiteralDfa1_0(0x2000000000000L, 0x807c0058000L, 0x10004000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x4000000000000L, 0x807c0058000L, 0x10004000L, 0x0L);
       case 74:
          return jjMoveStringLiteralDfa1_0(0x2000000L, 0x0L, 0x0L, 0x0L);
       case 76:
-         return jjMoveStringLiteralDfa1_0(0x20800020000000L, 0x2000030000000L, 0x80000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x1800020000000L, 0x2000030000000L, 0x80000L, 0x0L);
       case 77:
          return jjMoveStringLiteralDfa1_0(0xc000100000000000L, 0x120004000040000cL, 0x2800020L, 0x0L);
       case 78:
          return jjMoveStringLiteralDfa1_0(0x80002000000000L, 0x0L, 0x2L, 0x0L);
       case 79:
-         return jjMoveStringLiteralDfa1_0(0x100400c0000000L, 0x0L, 0x0L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x200400c0000000L, 0x0L, 0x0L, 0x0L);
       case 80:
-         return jjMoveStringLiteralDfa1_0(0x8000000200000L, 0x0L, 0x0L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x10000000200000L, 0x0L, 0x0L, 0x0L);
       case 82:
          return jjMoveStringLiteralDfa1_0(0x1000000L, 0x822800000000L, 0x0L, 0x0L);
       case 83:
-         return jjMoveStringLiteralDfa1_0(0x804400000400000L, 0x20f0601007800471L, 0x40007c8L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x808400000400000L, 0x20f0601007800471L, 0x40007c8L, 0x0L);
       case 84:
-         return jjMoveStringLiteralDfa1_0(0x1000000000000L, 0xc000000000000000L, 0x20000800L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x2000000000000L, 0xc000000000000000L, 0x20000800L, 0x0L);
       case 85:
          return jjMoveStringLiteralDfa1_0(0x80400000000L, 0x1000000080000L, 0x200000004L, 0x0L);
       case 86:
@@ -168,25 +168,25 @@ private int jjMoveStringLiteralDfa0_0(){
       case 104:
          return jjMoveStringLiteralDfa1_0(0x400000000000000L, 0x800000000000000L, 0x0L, 0x0L);
       case 105:
-         return jjMoveStringLiteralDfa1_0(0x2000000000000L, 0x807c0058000L, 0x10004000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x4000000000000L, 0x807c0058000L, 0x10004000L, 0x0L);
       case 106:
          return jjMoveStringLiteralDfa1_0(0x2000000L, 0x0L, 0x0L, 0x0L);
       case 108:
-         return jjMoveStringLiteralDfa1_0(0x20800020000000L, 0x2000030000000L, 0x80000L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x1800020000000L, 0x2000030000000L, 0x80000L, 0x0L);
       case 109:
          return jjMoveStringLiteralDfa1_0(0xc000100000000000L, 0x120004000040000cL, 0x2800020L, 0x0L);
       case 110:
          return jjMoveStringLiteralDfa1_0(0x80002000000000L, 0x0L, 0x2L, 0x0L);
       case 111:
-         return jjMoveStringLiteralDfa1_0(0x100400c0000000L, 0x0L, 0x0L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x200400c0000000L, 0x0L, 0x0L, 0x0L);
       case 112:
-         return jjMoveStringLiteralDfa1_0(0x8000000200000L, 0x0L, 0x0L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x10000000200000L, 0x0L, 0x0L, 0x0L);
       case 114:
          return jjMoveStringLiteralDfa1_0(0x1000000L, 0x822800000000L, 0x0L, 0x0L);
       case 115:
-         return jjMoveStringLiteralDfa1_0(0x804400000400000L, 0x20f0601007800471L, 0x40007c8L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x808400000400000L, 0x20f0601007800471L, 0x40007c8L, 0x0L);
       case 116:
-         return jjMoveStringLiteralDfa1_0(0x1000000000000L, 0xc000000000000000L, 0x20000800L, 0x0L);
+         return jjMoveStringLiteralDfa1_0(0x2000000000000L, 0xc000000000000000L, 0x20000800L, 0x0L);
       case 117:
          return jjMoveStringLiteralDfa1_0(0x80400000000L, 0x1000000080000L, 0x200000004L, 0x0L);
       case 118:
@@ -277,9 +277,9 @@ private int jjMoveStringLiteralDfa1_0(long active0, long active1, long active2, 
          }
          break;
       case 65:
-         return jjMoveStringLiteralDfa2_0(active0, 0x8420002200100000L, active1, 0x400003038300780L, active2, 0x3000L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x8401002200100000L, active1, 0x400003038300780L, active2, 0x3000L, active3, 0L);
       case 66:
-         return jjMoveStringLiteralDfa2_0(active0, 0x10000000000000L, active1, 0x4000000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x20000000000000L, active1, 0x4000000000L, active2, 0L, active3, 0L);
       case 67:
          return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x3000000000000L, active2, 0L, active3, 0L);
       case 68:
@@ -318,18 +318,18 @@ private int jjMoveStringLiteralDfa1_0(long active0, long active1, long active2, 
       case 80:
          return jjMoveStringLiteralDfa2_0(active0, 0x40000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 82:
-         return jjMoveStringLiteralDfa2_0(active0, 0x209024080200000L, active1, 0xc0800L, active2, 0x8200800L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x212024080200000L, active1, 0xc0800L, active2, 0x8200800L, active3, 0L);
       case 83:
          if ((active0 & 0x100000000000000L) != 0L)
          {
             jjmatchedKind = 56;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x2000812000000L, active1, 0x7c0000000L, active2, 0x200000000L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x4000812000000L, active1, 0x7c0000000L, active2, 0x200000000L, active3, 0L);
       case 84:
          return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0xf0400007000070L, active2, 0x8L, active3, 0L);
       case 85:
-         return jjMoveStringLiteralDfa2_0(active0, 0x4000000000000L, active1, 0x200000400001L, active2, 0x4L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x8000000000000L, active1, 0x200000400001L, active2, 0x4L, active3, 0L);
       case 86:
          return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x2L, active2, 0L, active3, 0L);
       case 88:
@@ -356,9 +356,9 @@ private int jjMoveStringLiteralDfa1_0(long active0, long active1, long active2, 
          }
          break;
       case 97:
-         return jjMoveStringLiteralDfa2_0(active0, 0x8420002200100000L, active1, 0x400003038300780L, active2, 0x3000L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x8401002200100000L, active1, 0x400003038300780L, active2, 0x3000L, active3, 0L);
       case 98:
-         return jjMoveStringLiteralDfa2_0(active0, 0x10000000000000L, active1, 0x4000000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x20000000000000L, active1, 0x4000000000L, active2, 0L, active3, 0L);
       case 99:
          return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x3000000000000L, active2, 0L, active3, 0L);
       case 100:
@@ -397,18 +397,18 @@ private int jjMoveStringLiteralDfa1_0(long active0, long active1, long active2, 
       case 112:
          return jjMoveStringLiteralDfa2_0(active0, 0x40000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 114:
-         return jjMoveStringLiteralDfa2_0(active0, 0x209024080200000L, active1, 0xc0800L, active2, 0x8200800L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x212024080200000L, active1, 0xc0800L, active2, 0x8200800L, active3, 0L);
       case 115:
          if ((active0 & 0x100000000000000L) != 0L)
          {
             jjmatchedKind = 56;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x2000812000000L, active1, 0x7c0000000L, active2, 0x200000000L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x4000812000000L, active1, 0x7c0000000L, active2, 0x200000000L, active3, 0L);
       case 116:
          return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0xf0400007000070L, active2, 0x8L, active3, 0L);
       case 117:
-         return jjMoveStringLiteralDfa2_0(active0, 0x4000000000000L, active1, 0x200000400001L, active2, 0x4L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x8000000000000L, active1, 0x200000400001L, active2, 0x4L, active3, 0L);
       case 118:
          return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x2L, active2, 0L, active3, 0L);
       case 120:
@@ -470,7 +470,7 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
       case 65:
          return jjMoveStringLiteralDfa3_0(active0, 0x20000000000L, active1, 0x103000000004000L, active2, 0x807c0L);
       case 66:
-         return jjMoveStringLiteralDfa3_0(active0, 0x4000000000000L, active1, 0x200100000000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x8000000000000L, active1, 0x200100000000L, active2, 0L);
       case 67:
          if ((active0 & 0x800000000L) != 0L)
          {
@@ -496,7 +496,7 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
          }
          return jjMoveStringLiteralDfa3_0(active0, 0x481000000L, active1, 0x7cL, active2, 0L);
       case 69:
-         return jjMoveStringLiteralDfa3_0(active0, 0x8008000200000L, active1, 0L, active2, 0x300000L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x10008000200000L, active1, 0L, active2, 0x300000L);
       case 70:
          return jjMoveStringLiteralDfa3_0(active0, 0x40000000L, active1, 0L, active2, 0x40000000L);
       case 71:
@@ -522,9 +522,9 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
             jjmatchedKind = 83;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x41080000000000L, active1, 0x88080000000L, active2, 0x200000004L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x42080000000000L, active1, 0x88080000000L, active2, 0x200000004L);
       case 74:
-         return jjMoveStringLiteralDfa3_0(active0, 0x10000000000000L, active1, 0L, active2, 0x1L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x20000000000000L, active1, 0L, active2, 0x1L);
       case 75:
          if ((active0 & 0x10000000L) != 0L)
          {
@@ -582,7 +582,7 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
             jjmatchedKind = 55;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x22040000000000L, active1, 0x8000000L, active2, 0x112002000L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x5040000000000L, active1, 0x8000000L, active2, 0x112002000L);
       case 85:
          return jjMoveStringLiteralDfa3_0(active0, 0x2000000000000000L, active1, 0x800020040002000L, active2, 0x800L);
       case 86:
@@ -611,7 +611,7 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
       case 97:
          return jjMoveStringLiteralDfa3_0(active0, 0x20000000000L, active1, 0x103000000004000L, active2, 0x807c0L);
       case 98:
-         return jjMoveStringLiteralDfa3_0(active0, 0x4000000000000L, active1, 0x200100000000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x8000000000000L, active1, 0x200100000000L, active2, 0L);
       case 99:
          if ((active0 & 0x800000000L) != 0L)
          {
@@ -637,7 +637,7 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
          }
          return jjMoveStringLiteralDfa3_0(active0, 0x481000000L, active1, 0x7cL, active2, 0L);
       case 101:
-         return jjMoveStringLiteralDfa3_0(active0, 0x8008000200000L, active1, 0L, active2, 0x300000L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x10008000200000L, active1, 0L, active2, 0x300000L);
       case 102:
          return jjMoveStringLiteralDfa3_0(active0, 0x40000000L, active1, 0L, active2, 0x40000000L);
       case 103:
@@ -663,9 +663,9 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
             jjmatchedKind = 83;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x41080000000000L, active1, 0x88080000000L, active2, 0x200000004L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x42080000000000L, active1, 0x88080000000L, active2, 0x200000004L);
       case 106:
-         return jjMoveStringLiteralDfa3_0(active0, 0x10000000000000L, active1, 0L, active2, 0x1L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x20000000000000L, active1, 0L, active2, 0x1L);
       case 107:
          if ((active0 & 0x10000000L) != 0L)
          {
@@ -723,7 +723,7 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
             jjmatchedKind = 55;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x22040000000000L, active1, 0x8000000L, active2, 0x112002000L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x5040000000000L, active1, 0x8000000L, active2, 0x112002000L);
       case 117:
          return jjMoveStringLiteralDfa3_0(active0, 0x2000000000000000L, active1, 0x800020040002000L, active2, 0x800L);
       case 118:
@@ -818,7 +818,7 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
             jjmatchedKind = 147;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x8000000000000L, active1, 0x4020000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x10000000000000L, active1, 0x4020000L, active2, 0L);
       case 69:
          if ((active0 & 0x100000L) != 0L)
          {
@@ -840,7 +840,7 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
             jjmatchedKind = 151;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x30002480400000L, active1, 0x4020001800000070L, active2, 0x400c000L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x21002480400000L, active1, 0x4020001800000070L, active2, 0x400c000L);
       case 70:
          return jjMoveStringLiteralDfa4_0(active0, 0x200000L, active1, 0L, active2, 0L);
       case 71:
@@ -860,7 +860,7 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
       case 73:
          return jjMoveStringLiteralDfa4_0(active0, 0x400040020000000L, active1, 0x200000084L, active2, 0L);
       case 74:
-         return jjMoveStringLiteralDfa4_0(active0, 0x4000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x8000000000000L, active1, 0L, active2, 0L);
       case 76:
          if ((active1 & 0x200000L) != 0L)
          {
@@ -900,14 +900,14 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
             jjmatchedKind = 155;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x1020000000000L, active1, 0x400L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x2020000000000L, active1, 0x400L, active2, 0L);
       case 82:
          if ((active1 & 0x100000000000000L) != 0L)
          {
             jjmatchedKind = 120;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x2008000000000L, active1, 0x8000000c0800000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x4008000000000L, active1, 0x8000000c0800000L, active2, 0L);
       case 83:
          return jjMoveStringLiteralDfa4_0(active0, 0x40000048000000L, active1, 0x13200000000000L, active2, 0x1010L);
       case 84:
@@ -977,7 +977,7 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
             jjmatchedKind = 147;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x8000000000000L, active1, 0x4020000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x10000000000000L, active1, 0x4020000L, active2, 0L);
       case 101:
          if ((active0 & 0x100000L) != 0L)
          {
@@ -999,7 +999,7 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
             jjmatchedKind = 151;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x30002480400000L, active1, 0x4020001800000070L, active2, 0x400c000L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x21002480400000L, active1, 0x4020001800000070L, active2, 0x400c000L);
       case 102:
          return jjMoveStringLiteralDfa4_0(active0, 0x200000L, active1, 0L, active2, 0L);
       case 103:
@@ -1019,7 +1019,7 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
       case 105:
          return jjMoveStringLiteralDfa4_0(active0, 0x400040020000000L, active1, 0x200000084L, active2, 0L);
       case 106:
-         return jjMoveStringLiteralDfa4_0(active0, 0x4000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x8000000000000L, active1, 0L, active2, 0L);
       case 108:
          if ((active1 & 0x200000L) != 0L)
          {
@@ -1059,14 +1059,14 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
             jjmatchedKind = 155;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x1020000000000L, active1, 0x400L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x2020000000000L, active1, 0x400L, active2, 0L);
       case 114:
          if ((active1 & 0x100000000000000L) != 0L)
          {
             jjmatchedKind = 120;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x2008000000000L, active1, 0x8000000c0800000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x4008000000000L, active1, 0x8000000c0800000L, active2, 0L);
       case 115:
          return jjMoveStringLiteralDfa4_0(active0, 0x40000048000000L, active1, 0x13200000000000L, active2, 0x1010L);
       case 116:
@@ -1117,7 +1117,7 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
       case 65:
          return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x8900102000084L, active2, 0L);
       case 67:
-         return jjMoveStringLiteralDfa5_0(active0, 0x10000001400000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x20000001400000L, active1, 0L, active2, 0L);
       case 68:
          if ((active0 & 0x2000000000L) != 0L)
          {
@@ -1161,7 +1161,7 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
             jjmatchedKind = 140;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x4000240000000L, active1, 0x40400000005000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x8000240000000L, active1, 0x40400000005000L, active2, 0L);
       case 70:
          if ((active0 & 0x400000000L) != 0L)
          {
@@ -1204,9 +1204,9 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
             jjmatchedKind = 95;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0xa400000a00000L, active1, 0L, active2, 0x10L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x14400000a00000L, active1, 0L, active2, 0x10L);
       case 76:
-         return jjMoveStringLiteralDfa5_0(active0, 0x1000000000000L, active1, 0x400L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x2000000000000L, active1, 0x400L, active2, 0L);
       case 77:
          return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x420000000L, active2, 0L);
       case 78:
@@ -1241,7 +1241,7 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
             jjmatchedKind = 148;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x820000004000000L, active1, 0L, active2, 0x4000L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x801000004000000L, active1, 0L, active2, 0x4000L);
       case 83:
          if ((active0 & 0x100000000000L) != 0L)
          {
@@ -1292,7 +1292,7 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
       case 97:
          return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x8900102000084L, active2, 0L);
       case 99:
-         return jjMoveStringLiteralDfa5_0(active0, 0x10000001400000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x20000001400000L, active1, 0L, active2, 0L);
       case 100:
          if ((active0 & 0x2000000000L) != 0L)
          {
@@ -1336,7 +1336,7 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
             jjmatchedKind = 140;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x4000240000000L, active1, 0x40400000005000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x8000240000000L, active1, 0x40400000005000L, active2, 0L);
       case 102:
          if ((active0 & 0x400000000L) != 0L)
          {
@@ -1379,9 +1379,9 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
             jjmatchedKind = 95;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0xa400000a00000L, active1, 0L, active2, 0x10L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x14400000a00000L, active1, 0L, active2, 0x10L);
       case 108:
-         return jjMoveStringLiteralDfa5_0(active0, 0x1000000000000L, active1, 0x400L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x2000000000000L, active1, 0x400L, active2, 0L);
       case 109:
          return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x420000000L, active2, 0L);
       case 110:
@@ -1416,7 +1416,7 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
             jjmatchedKind = 148;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x820000004000000L, active1, 0L, active2, 0x4000L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x801000004000000L, active1, 0L, active2, 0x4000L);
       case 115:
          if ((active0 & 0x100000000000L) != 0L)
          {
@@ -1505,15 +1505,15 @@ private int jjMoveStringLiteralDfa5_0(long old0, long active0, long old1, long a
          }
          break;
       case 65:
-         return jjMoveStringLiteralDfa6_0(active0, 0x820000000000000L, active1, 0x10000020000100L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x801000000000000L, active1, 0x10000020000100L, active2, 0L);
       case 67:
-         return jjMoveStringLiteralDfa6_0(active0, 0xc400000000000L, active1, 0x800000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x18400000000000L, active1, 0x800000000000L, active2, 0L);
       case 68:
          return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x2020000000000000L, active2, 0L);
       case 69:
-         if ((active0 & 0x1000000000000L) != 0L)
+         if ((active0 & 0x2000000000000L) != 0L)
          {
-            jjmatchedKind = 48;
+            jjmatchedKind = 49;
             jjmatchedPos = 5;
          }
          else if ((active1 & 0x400L) != 0L)
@@ -1560,7 +1560,7 @@ private int jjMoveStringLiteralDfa5_0(long old0, long active0, long old1, long a
       case 79:
          return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x4000000000000200L, active2, 0x10L);
       case 80:
-         return jjMoveStringLiteralDfa6_0(active0, 0x2000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x4000000000000L, active1, 0L, active2, 0L);
       case 82:
          if ((active1 & 0x1000L) != 0L)
          {
@@ -1596,9 +1596,9 @@ private int jjMoveStringLiteralDfa5_0(long old0, long active0, long old1, long a
             jjmatchedKind = 30;
             jjmatchedPos = 5;
          }
-         else if ((active0 & 0x10000000000000L) != 0L)
+         else if ((active0 & 0x20000000000000L) != 0L)
          {
-            jjmatchedKind = 52;
+            jjmatchedKind = 53;
             jjmatchedPos = 5;
          }
          else if ((active1 & 0x100000000000L) != 0L)
@@ -1634,15 +1634,15 @@ private int jjMoveStringLiteralDfa5_0(long old0, long active0, long old1, long a
       case 95:
          return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x860L, active2, 0L);
       case 97:
-         return jjMoveStringLiteralDfa6_0(active0, 0x820000000000000L, active1, 0x10000020000100L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x801000000000000L, active1, 0x10000020000100L, active2, 0L);
       case 99:
-         return jjMoveStringLiteralDfa6_0(active0, 0xc400000000000L, active1, 0x800000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x18400000000000L, active1, 0x800000000000L, active2, 0L);
       case 100:
          return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x2020000000000000L, active2, 0L);
       case 101:
-         if ((active0 & 0x1000000000000L) != 0L)
+         if ((active0 & 0x2000000000000L) != 0L)
          {
-            jjmatchedKind = 48;
+            jjmatchedKind = 49;
             jjmatchedPos = 5;
          }
          else if ((active1 & 0x400L) != 0L)
@@ -1689,7 +1689,7 @@ private int jjMoveStringLiteralDfa5_0(long old0, long active0, long old1, long a
       case 111:
          return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x4000000000000200L, active2, 0x10L);
       case 112:
-         return jjMoveStringLiteralDfa6_0(active0, 0x2000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x4000000000000L, active1, 0L, active2, 0L);
       case 114:
          if ((active1 & 0x1000L) != 0L)
          {
@@ -1725,9 +1725,9 @@ private int jjMoveStringLiteralDfa5_0(long old0, long active0, long old1, long a
             jjmatchedKind = 30;
             jjmatchedPos = 5;
          }
-         else if ((active0 & 0x10000000000000L) != 0L)
+         else if ((active0 & 0x20000000000000L) != 0L)
          {
-            jjmatchedKind = 52;
+            jjmatchedKind = 53;
             jjmatchedPos = 5;
          }
          else if ((active1 & 0x100000000000L) != 0L)
@@ -1775,7 +1775,7 @@ private int jjMoveStringLiteralDfa6_0(long old0, long active0, long old1, long a
    switch(curChar)
    {
       case 65:
-         return jjMoveStringLiteralDfa7_0(active0, 0x8040000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x10040000000000L, active1, 0L, active2, 0L);
       case 66:
          return jjMoveStringLiteralDfa7_0(active0, 0x4000000L, active1, 0L, active2, 0L);
       case 67:
@@ -1819,12 +1819,12 @@ private int jjMoveStringLiteralDfa6_0(long old0, long active0, long old1, long a
          }
          break;
       case 76:
-         if ((active0 & 0x20000000000000L) != 0L)
+         if ((active0 & 0x1000000000000L) != 0L)
          {
-            jjmatchedKind = 53;
+            jjmatchedKind = 48;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0x2000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x4000000000000L, active1, 0L, active2, 0L);
       case 77:
          return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x100L, active2, 0L);
       case 78:
@@ -1863,9 +1863,9 @@ private int jjMoveStringLiteralDfa6_0(long old0, long active0, long old1, long a
          }
          return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x800020L, active2, 0L);
       case 84:
-         if ((active0 & 0x4000000000000L) != 0L)
+         if ((active0 & 0x8000000000000L) != 0L)
          {
-            jjmatchedKind = 50;
+            jjmatchedKind = 51;
             jjmatchedPos = 6;
          }
          else if ((active2 & 0x40000000L) != 0L)
@@ -1879,7 +1879,7 @@ private int jjMoveStringLiteralDfa6_0(long old0, long active0, long old1, long a
       case 95:
          return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x4000000000000L, active2, 0L);
       case 97:
-         return jjMoveStringLiteralDfa7_0(active0, 0x8040000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x10040000000000L, active1, 0L, active2, 0L);
       case 98:
          return jjMoveStringLiteralDfa7_0(active0, 0x4000000L, active1, 0L, active2, 0L);
       case 99:
@@ -1923,12 +1923,12 @@ private int jjMoveStringLiteralDfa6_0(long old0, long active0, long old1, long a
          }
          break;
       case 108:
-         if ((active0 & 0x20000000000000L) != 0L)
+         if ((active0 & 0x1000000000000L) != 0L)
          {
-            jjmatchedKind = 53;
+            jjmatchedKind = 48;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0x2000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x4000000000000L, active1, 0L, active2, 0L);
       case 109:
          return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x100L, active2, 0L);
       case 110:
@@ -1967,9 +1967,9 @@ private int jjMoveStringLiteralDfa6_0(long old0, long active0, long old1, long a
          }
          return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x800020L, active2, 0L);
       case 116:
-         if ((active0 & 0x4000000000000L) != 0L)
+         if ((active0 & 0x8000000000000L) != 0L)
          {
-            jjmatchedKind = 50;
+            jjmatchedKind = 51;
             jjmatchedPos = 6;
          }
          else if ((active2 & 0x40000000L) != 0L)
@@ -2004,9 +2004,9 @@ private int jjMoveStringLiteralDfa7_0(long old0, long active0, long old1, long a
             jjmatchedKind = 26;
             jjmatchedPos = 7;
          }
-         else if ((active0 & 0x2000000000000L) != 0L)
+         else if ((active0 & 0x4000000000000L) != 0L)
          {
-            jjmatchedKind = 49;
+            jjmatchedKind = 50;
             jjmatchedPos = 7;
          }
          else if ((active1 & 0x80L) != 0L)
@@ -2082,7 +2082,7 @@ private int jjMoveStringLiteralDfa7_0(long old0, long active0, long old1, long a
             jjmatchedKind = 87;
             jjmatchedPos = 7;
          }
-         return jjMoveStringLiteralDfa8_0(active0, 0x8000000000000L, active1, 0x10000000000000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x10000000000000L, active1, 0x10000000000000L);
       case 97:
          return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x200000020L);
       case 99:
@@ -2093,9 +2093,9 @@ private int jjMoveStringLiteralDfa7_0(long old0, long active0, long old1, long a
             jjmatchedKind = 26;
             jjmatchedPos = 7;
          }
-         else if ((active0 & 0x2000000000000L) != 0L)
+         else if ((active0 & 0x4000000000000L) != 0L)
          {
-            jjmatchedKind = 49;
+            jjmatchedKind = 50;
             jjmatchedPos = 7;
          }
          else if ((active1 & 0x80L) != 0L)
@@ -2171,7 +2171,7 @@ private int jjMoveStringLiteralDfa7_0(long old0, long active0, long old1, long a
             jjmatchedKind = 87;
             jjmatchedPos = 7;
          }
-         return jjMoveStringLiteralDfa8_0(active0, 0x8000000000000L, active1, 0x10000000000000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x10000000000000L, active1, 0x10000000000000L);
       default :
          break;
    }
@@ -2194,9 +2194,9 @@ private int jjMoveStringLiteralDfa8_0(long old0, long active0, long old1, long a
          }
          break;
       case 69:
-         if ((active0 & 0x8000000000000L) != 0L)
+         if ((active0 & 0x10000000000000L) != 0L)
          {
-            jjmatchedKind = 51;
+            jjmatchedKind = 52;
             jjmatchedPos = 8;
          }
          else if ((active1 & 0x40000000000000L) != 0L)
@@ -2256,9 +2256,9 @@ private int jjMoveStringLiteralDfa8_0(long old0, long active0, long old1, long a
          }
          break;
       case 101:
-         if ((active0 & 0x8000000000000L) != 0L)
+         if ((active0 & 0x10000000000000L) != 0L)
          {
-            jjmatchedKind = 51;
+            jjmatchedKind = 52;
             jjmatchedPos = 8;
          }
          else if ((active1 & 0x40000000000000L) != 0L)

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/JavaCharStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/JavaCharStream.java
@@ -13,7 +13,7 @@ public
 class JavaCharStream
 {
   /** Whether parser is static. */
-
+  
 @SuppressWarnings("all")
 public static final boolean staticFlag = false;
 
@@ -65,7 +65,7 @@ public static final boolean staticFlag = false;
   }
 
 /* Position in buffer. */
-
+  
 @SuppressWarnings("all")
 public int bufpos = -1;
   int bufsize;
@@ -90,10 +90,10 @@ public int bufpos = -1;
   protected int tabSize = 1;
   protected boolean trackLineColumn = true;
 
-
+  
 @SuppressWarnings("all")
 public void setTabSize(int i) { tabSize = i; }
-
+  
 @SuppressWarnings("all")
 public int getTabSize() { return tabSize; }
 
@@ -185,7 +185,7 @@ public int getTabSize() { return tabSize; }
   }
 
 /* @return starting character for token. */
-
+  
 @SuppressWarnings("all")
 public char BeginToken() throws java.io.IOException
   {
@@ -267,7 +267,7 @@ public char BeginToken() throws java.io.IOException
   }
 
 /* Read a character. */
-
+  
 @SuppressWarnings("all")
 public char readChar() throws java.io.IOException
   {
@@ -367,7 +367,7 @@ public char readChar() throws java.io.IOException
    * @see #getEndColumn
    */
   @Deprecated
-
+  
 @SuppressWarnings("all")
 public int getColumn() {
     return bufcolumn[bufpos];
@@ -379,7 +379,7 @@ public int getColumn() {
    * @return the line number.
    */
   @Deprecated
-
+  
 @SuppressWarnings("all")
 public int getLine() {
     return bufline[bufpos];
@@ -388,7 +388,7 @@ public int getLine() {
 /** Get end column.
  * @return the end column or -1
  */
-
+  
 @SuppressWarnings("all")
 public int getEndColumn() {
     return bufcolumn[bufpos];
@@ -397,7 +397,7 @@ public int getEndColumn() {
 /** Get end line.
  * @return the end line number or -1
  */
-
+  
 @SuppressWarnings("all")
 public int getEndLine() {
     return bufline[bufpos];
@@ -405,21 +405,21 @@ public int getEndLine() {
 
 /** Get the beginning column.
  * @return column of token start */
-
+  
 @SuppressWarnings("all")
 public int getBeginColumn() {
     return bufcolumn[tokenBegin];
   }
 
 /** @return line number of token start */
-
+  
 @SuppressWarnings("all")
 public int getBeginLine() {
     return bufline[tokenBegin];
   }
 
 /** Retreat. */
-
+  
 @SuppressWarnings("all")
 public void backup(int amount) {
 
@@ -434,7 +434,7 @@ public void backup(int amount) {
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -455,7 +455,7 @@ public JavaCharStream(java.io.Reader dstream,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -463,13 +463,18 @@ public JavaCharStream(java.io.Reader dstream,
     this(dstream, startline, startcolumn, 4096);
   }
 
+/** Constructor.
+ * @param dstream the underlying data source.
+ * @param startline line number of the first character of the stream, mostly for error messages.
+ */
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream)
   {
     this(dstream, 1, 1, 4096);
   }
 /* Reinitialise. */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -492,7 +497,7 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -501,14 +506,14 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream)
   {
     ReInit(dstream, 1, 1, 4096);
   }
 /** Constructor. */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -522,7 +527,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -537,7 +542,7 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
                         int startcolumn) throws java.io.UnsupportedEncodingException
@@ -550,7 +555,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
                         int startcolumn)
@@ -563,7 +568,7 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -573,7 +578,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.
   /** Constructor.
    * @param dstream the underlying data source.
    */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream)
   {
@@ -587,7 +592,7 @@ public JavaCharStream(java.io.InputStream dstream)
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -601,7 +606,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -615,7 +620,7 @@ public void ReInit(java.io.InputStream dstream, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
                      int startcolumn) throws java.io.UnsupportedEncodingException
@@ -627,7 +632,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
                      int startcolumn)
@@ -639,7 +644,7 @@ public void ReInit(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -649,7 +654,7 @@ public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.
 /** Reinitialise.
  * @param dstream the underlying data source.
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream)
   {
@@ -658,7 +663,7 @@ public void ReInit(java.io.InputStream dstream)
 
   /** Get the token timage.
    * @return token image as String */
-
+  
 @SuppressWarnings("all")
 public String GetImage()
   {
@@ -672,7 +677,7 @@ public String GetImage()
   /** Get the suffix as an array of characters.
    * @param len the length of the array to return.
    * @return suffix */
-
+  
 @SuppressWarnings("all")
 public char[] GetSuffix(int len)
   {
@@ -691,7 +696,7 @@ public char[] GetSuffix(int len)
   }
 
   /** Set buffers back to null when finished. */
-
+  
 @SuppressWarnings("all")
 public void Done()
   {
@@ -707,7 +712,7 @@ public void Done()
    * @param newLine the new line number.
    * @param newCol the new column number.
    */
-
+  
 @SuppressWarnings("all")
 public void adjustBeginLineColumn(int newLine, int newCol)
   {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/SPARQLParser12.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/SPARQLParser12.java
@@ -16,7 +16,6 @@ import org.apache.jena.sparql.modify.request.* ;
 public class SPARQLParser12 extends SPARQLParser12Base implements SPARQLParser12Constants {
 
   final public void QueryUnit() throws ParseException {
-    ByteOrderMark();
 startQuery() ;
     Query();
     jj_consume_token(0);
@@ -51,23 +50,10 @@ finishQuery() ;
 }
 
   final public void UpdateUnit() throws ParseException {
-    ByteOrderMark();
 startUpdateRequest() ;
     Update();
     jj_consume_token(0);
 finishUpdateRequest() ;
-}
-
-  final public void ByteOrderMark() throws ParseException {
-    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case BOM:{
-      jj_consume_token(BOM);
-      break;
-      }
-    default:
-      jj_la1[1] = jj_gen;
-      ;
-    }
 }
 
   final public void Prologue() throws ParseException {
@@ -80,7 +66,7 @@ finishUpdateRequest() ;
         break;
         }
       default:
-        jj_la1[2] = jj_gen;
+        jj_la1[1] = jj_gen;
         break label_1;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -93,7 +79,7 @@ finishUpdateRequest() ;
         break;
         }
       default:
-        jj_la1[3] = jj_gen;
+        jj_la1[2] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -124,7 +110,7 @@ String s = fixupPrefix(t.image, t.beginLine, t.beginColumn);
         break;
         }
       default:
-        jj_la1[4] = jj_gen;
+        jj_la1[3] = jj_gen;
         break label_2;
       }
       DatasetClause();
@@ -158,14 +144,14 @@ getQuery().setReduced(true);
         break;
         }
       default:
-        jj_la1[5] = jj_gen;
+        jj_la1[4] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[6] = jj_gen;
+      jj_la1[5] = jj_gen;
       ;
     }
 setAllowAggregatesInExpressions(true) ;
@@ -194,7 +180,7 @@ getQuery().setQueryResultStar(false) ;
           break;
           }
         default:
-          jj_la1[7] = jj_gen;
+          jj_la1[6] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -206,7 +192,7 @@ getQuery().setQueryResultStar(false) ;
           break;
           }
         default:
-          jj_la1[8] = jj_gen;
+          jj_la1[7] = jj_gen;
           break label_3;
         }
       }
@@ -218,7 +204,7 @@ getQuery().setQueryResultStar(true) ;
       break;
       }
     default:
-      jj_la1[9] = jj_gen;
+      jj_la1[8] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -241,7 +227,7 @@ getQuery().setConstructTemplate(t) ;
           break;
           }
         default:
-          jj_la1[10] = jj_gen;
+          jj_la1[9] = jj_gen;
           break label_4;
         }
         DatasetClause();
@@ -260,7 +246,7 @@ getQuery().setConstructTemplate(t) ;
           break;
           }
         default:
-          jj_la1[11] = jj_gen;
+          jj_la1[10] = jj_gen;
           break label_5;
         }
         DatasetClause();
@@ -292,12 +278,13 @@ getQuery().setConstructTemplate(t) ;
       case LPAREN:
       case NIL:
       case LBRACKET:
-      case ANON:{
+      case ANON:
+      case LT2:{
         TriplesTemplate(acc);
         break;
         }
       default:
-        jj_la1[12] = jj_gen;
+        jj_la1[11] = jj_gen;
         ;
       }
       jj_consume_token(RBRACE);
@@ -311,7 +298,7 @@ t = new Template(acc.getBGP()) ;
       break;
       }
     default:
-      jj_la1[13] = jj_gen;
+      jj_la1[12] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -340,7 +327,7 @@ getQuery().addDescribeNode(n) ;
           break;
           }
         default:
-          jj_la1[14] = jj_gen;
+          jj_la1[13] = jj_gen;
           break label_6;
         }
       }
@@ -353,7 +340,7 @@ getQuery().setQueryResultStar(true) ;
       break;
       }
     default:
-      jj_la1[15] = jj_gen;
+      jj_la1[14] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -365,7 +352,7 @@ getQuery().setQueryResultStar(true) ;
         break;
         }
       default:
-        jj_la1[16] = jj_gen;
+        jj_la1[15] = jj_gen;
         break label_7;
       }
       DatasetClause();
@@ -377,7 +364,7 @@ getQuery().setQueryResultStar(true) ;
       break;
       }
     default:
-      jj_la1[17] = jj_gen;
+      jj_la1[16] = jj_gen;
       ;
     }
     SolutionModifier();
@@ -394,7 +381,7 @@ getQuery().setQueryAskType() ;
         break;
         }
       default:
-        jj_la1[18] = jj_gen;
+        jj_la1[17] = jj_gen;
         break label_8;
       }
       DatasetClause();
@@ -417,7 +404,7 @@ getQuery().setQueryAskType() ;
       break;
       }
     default:
-      jj_la1[19] = jj_gen;
+      jj_la1[18] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -447,7 +434,7 @@ getQuery().addNamedGraphURI(iri) ;
       break;
       }
     default:
-      jj_la1[20] = jj_gen;
+      jj_la1[19] = jj_gen;
       ;
     }
 startWherePattern() ;
@@ -463,7 +450,7 @@ finishWherePattern() ;
       break;
       }
     default:
-      jj_la1[21] = jj_gen;
+      jj_la1[20] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -472,7 +459,7 @@ finishWherePattern() ;
       break;
       }
     default:
-      jj_la1[22] = jj_gen;
+      jj_la1[21] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -481,7 +468,7 @@ finishWherePattern() ;
       break;
       }
     default:
-      jj_la1[23] = jj_gen;
+      jj_la1[22] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -491,7 +478,7 @@ finishWherePattern() ;
       break;
       }
     default:
-      jj_la1[24] = jj_gen;
+      jj_la1[23] = jj_gen;
       ;
     }
 }
@@ -508,6 +495,11 @@ finishWherePattern() ;
       case PNAME_LN:
       case VAR1:
       case VAR2:
+      case TRIPLE:
+      case IS_TRIPLE:
+      case SUBJECT:
+      case PREDICATE:
+      case OBJECT:
       case EXISTS:
       case NOT:
       case COUNT:
@@ -574,7 +566,7 @@ finishWherePattern() ;
         break;
         }
       default:
-        jj_la1[25] = jj_gen;
+        jj_la1[24] = jj_gen;
         break label_9;
       }
     }
@@ -582,6 +574,11 @@ finishWherePattern() ;
 
   final public void GroupCondition() throws ParseException {Var v = null ; Expr expr = null ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case TRIPLE:
+    case IS_TRIPLE:
+    case SUBJECT:
+    case PREDICATE:
+    case OBJECT:
     case EXISTS:
     case NOT:
     case COUNT:
@@ -664,7 +661,7 @@ getQuery().addGroupBy((Var)null, expr) ;
         break;
         }
       default:
-        jj_la1[26] = jj_gen;
+        jj_la1[25] = jj_gen;
         ;
       }
       jj_consume_token(RPAREN);
@@ -678,7 +675,7 @@ getQuery().addGroupBy(v) ;
       break;
       }
     default:
-      jj_la1[27] = jj_gen;
+      jj_la1[26] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -694,6 +691,109 @@ setAllowAggregatesInExpressions(true) ;
       case IRIref:
       case PNAME_NS:
       case PNAME_LN:
+      case TRIPLE:
+      case IS_TRIPLE:
+      case SUBJECT:
+      case PREDICATE:
+      case OBJECT:
+      case EXISTS:
+      case NOT:
+      case COUNT:
+      case MIN:
+      case MAX:
+      case SUM:
+      case AVG:
+      case SAMPLE:
+      case GROUP_CONCAT:
+      case BOUND:
+      case COALESCE:
+      case IF:
+      case BNODE:
+      case IRI:
+      case URI:
+      case STR:
+      case STRLANG:
+      case STRDT:
+      case DTYPE:
+      case LANG:
+      case LANGMATCHES:
+      case IS_URI:
+      case IS_IRI:
+      case IS_BLANK:
+      case IS_LITERAL:
+      case IS_NUMERIC:
+      case REGEX:
+      case SAME_TERM:
+      case RAND:
+      case ABS:
+      case CEIL:
+      case FLOOR:
+      case ROUND:
+      case CONCAT:
+      case SUBSTR:
+      case STRLEN:
+      case REPLACE:
+      case UCASE:
+      case LCASE:
+      case ENCODE_FOR_URI:
+      case CONTAINS:
+      case STRSTARTS:
+      case STRENDS:
+      case STRBEFORE:
+      case STRAFTER:
+      case YEAR:
+      case MONTH:
+      case DAY:
+      case HOURS:
+      case MINUTES:
+      case SECONDS:
+      case TIMEZONE:
+      case TZ:
+      case NOW:
+      case UUID:
+      case STRUUID:
+      case MD5:
+      case SHA1:
+      case SHA256:
+      case SHA384:
+      case SHA512:
+      case LPAREN:{
+        ;
+        break;
+        }
+      default:
+        jj_la1[27] = jj_gen;
+        break label_10;
+      }
+    }
+setAllowAggregatesInExpressions(false) ;
+}
+
+  final public void HavingCondition() throws ParseException {Expr c ;
+    c = Constraint();
+getQuery().addHavingCondition(c) ;
+}
+
+  final public void OrderClause() throws ParseException {
+setAllowAggregatesInExpressions(true) ;
+    jj_consume_token(ORDER);
+    jj_consume_token(BY);
+    label_11:
+    while (true) {
+      OrderCondition();
+      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+      case IRIref:
+      case PNAME_NS:
+      case PNAME_LN:
+      case VAR1:
+      case VAR2:
+      case ASC:
+      case DESC:
+      case TRIPLE:
+      case IS_TRIPLE:
+      case SUBJECT:
+      case PREDICATE:
+      case OBJECT:
       case EXISTS:
       case NOT:
       case COUNT:
@@ -761,99 +861,6 @@ setAllowAggregatesInExpressions(true) ;
         }
       default:
         jj_la1[28] = jj_gen;
-        break label_10;
-      }
-    }
-setAllowAggregatesInExpressions(false) ;
-}
-
-  final public void HavingCondition() throws ParseException {Expr c ;
-    c = Constraint();
-getQuery().addHavingCondition(c) ;
-}
-
-  final public void OrderClause() throws ParseException {
-setAllowAggregatesInExpressions(true) ;
-    jj_consume_token(ORDER);
-    jj_consume_token(BY);
-    label_11:
-    while (true) {
-      OrderCondition();
-      switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-      case IRIref:
-      case PNAME_NS:
-      case PNAME_LN:
-      case VAR1:
-      case VAR2:
-      case ASC:
-      case DESC:
-      case EXISTS:
-      case NOT:
-      case COUNT:
-      case MIN:
-      case MAX:
-      case SUM:
-      case AVG:
-      case SAMPLE:
-      case GROUP_CONCAT:
-      case BOUND:
-      case COALESCE:
-      case IF:
-      case BNODE:
-      case IRI:
-      case URI:
-      case STR:
-      case STRLANG:
-      case STRDT:
-      case DTYPE:
-      case LANG:
-      case LANGMATCHES:
-      case IS_URI:
-      case IS_IRI:
-      case IS_BLANK:
-      case IS_LITERAL:
-      case IS_NUMERIC:
-      case REGEX:
-      case SAME_TERM:
-      case RAND:
-      case ABS:
-      case CEIL:
-      case FLOOR:
-      case ROUND:
-      case CONCAT:
-      case SUBSTR:
-      case STRLEN:
-      case REPLACE:
-      case UCASE:
-      case LCASE:
-      case ENCODE_FOR_URI:
-      case CONTAINS:
-      case STRSTARTS:
-      case STRENDS:
-      case STRBEFORE:
-      case STRAFTER:
-      case YEAR:
-      case MONTH:
-      case DAY:
-      case HOURS:
-      case MINUTES:
-      case SECONDS:
-      case TIMEZONE:
-      case TZ:
-      case NOW:
-      case UUID:
-      case STRUUID:
-      case MD5:
-      case SHA1:
-      case SHA256:
-      case SHA384:
-      case SHA512:
-      case LPAREN:{
-        ;
-        break;
-        }
-      default:
-        jj_la1[29] = jj_gen;
         break label_11;
       }
     }
@@ -877,7 +884,7 @@ direction = Query.ORDER_DESCENDING ;
         break;
         }
       default:
-        jj_la1[30] = jj_gen;
+        jj_la1[29] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -889,6 +896,11 @@ direction = Query.ORDER_DESCENDING ;
     case PNAME_LN:
     case VAR1:
     case VAR2:
+    case TRIPLE:
+    case IS_TRIPLE:
+    case SUBJECT:
+    case PREDICATE:
+    case OBJECT:
     case EXISTS:
     case NOT:
     case COUNT:
@@ -955,6 +967,11 @@ direction = Query.ORDER_DESCENDING ;
       case IRIref:
       case PNAME_NS:
       case PNAME_LN:
+      case TRIPLE:
+      case IS_TRIPLE:
+      case SUBJECT:
+      case PREDICATE:
+      case OBJECT:
       case EXISTS:
       case NOT:
       case COUNT:
@@ -1026,14 +1043,14 @@ direction = Query.ORDER_DESCENDING ;
         break;
         }
       default:
-        jj_la1[31] = jj_gen;
+        jj_la1[30] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[32] = jj_gen;
+      jj_la1[31] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1053,7 +1070,7 @@ if ( v == null )
         break;
         }
       default:
-        jj_la1[33] = jj_gen;
+        jj_la1[32] = jj_gen;
         ;
       }
       break;
@@ -1066,13 +1083,13 @@ if ( v == null )
         break;
         }
       default:
-        jj_la1[34] = jj_gen;
+        jj_la1[33] = jj_gen;
         ;
       }
       break;
       }
     default:
-      jj_la1[35] = jj_gen;
+      jj_la1[34] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1100,7 +1117,7 @@ finishValuesClause(t.beginLine, t.beginColumn) ;
       break;
       }
     default:
-      jj_la1[36] = jj_gen;
+      jj_la1[35] = jj_gen;
       ;
     }
 }
@@ -1129,13 +1146,13 @@ finishValuesClause(t.beginLine, t.beginColumn) ;
         break;
         }
       default:
-        jj_la1[37] = jj_gen;
+        jj_la1[36] = jj_gen;
         ;
       }
       break;
       }
     default:
-      jj_la1[38] = jj_gen;
+      jj_la1[37] = jj_gen;
       ;
     }
 }
@@ -1190,7 +1207,7 @@ startUpdateOperation() ;
       break;
       }
     default:
-      jj_la1[39] = jj_gen;
+      jj_la1[38] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1207,7 +1224,7 @@ silent = true ;
       break;
       }
     default:
-      jj_la1[40] = jj_gen;
+      jj_la1[39] = jj_gen;
       ;
     }
     url = iri();
@@ -1218,7 +1235,7 @@ silent = true ;
       break;
       }
     default:
-      jj_la1[41] = jj_gen;
+      jj_la1[40] = jj_gen;
       ;
     }
 {if ("" != null) return new UpdateLoad(url, dest, silent) ;}
@@ -1234,7 +1251,7 @@ silent = true ;
       break;
       }
     default:
-      jj_la1[42] = jj_gen;
+      jj_la1[41] = jj_gen;
       ;
     }
     target = GraphRefAll();
@@ -1251,7 +1268,7 @@ silent = true ;
       break;
       }
     default:
-      jj_la1[43] = jj_gen;
+      jj_la1[42] = jj_gen;
       ;
     }
     target = GraphRefAll();
@@ -1268,7 +1285,7 @@ silent=true ;
       break;
       }
     default:
-      jj_la1[44] = jj_gen;
+      jj_la1[43] = jj_gen;
       ;
     }
     iri = GraphRef();
@@ -1285,7 +1302,7 @@ silent=true ;
       break;
       }
     default:
-      jj_la1[45] = jj_gen;
+      jj_la1[44] = jj_gen;
       ;
     }
     src = GraphOrDefault();
@@ -1304,7 +1321,7 @@ silent=true ;
       break;
       }
     default:
-      jj_la1[46] = jj_gen;
+      jj_la1[45] = jj_gen;
       ;
     }
     src = GraphOrDefault();
@@ -1323,7 +1340,7 @@ silent=true ;
       break;
       }
     default:
-      jj_la1[47] = jj_gen;
+      jj_la1[46] = jj_gen;
       ;
     }
     src = GraphOrDefault();
@@ -1372,7 +1389,7 @@ Node n = createNode(iri) ; up.setWithIRI(n) ;
       break;
       }
     default:
-      jj_la1[48] = jj_gen;
+      jj_la1[47] = jj_gen;
       ;
     }
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -1384,7 +1401,7 @@ Node n = createNode(iri) ; up.setWithIRI(n) ;
         break;
         }
       default:
-        jj_la1[49] = jj_gen;
+        jj_la1[48] = jj_gen;
         ;
       }
       break;
@@ -1394,7 +1411,7 @@ Node n = createNode(iri) ; up.setWithIRI(n) ;
       break;
       }
     default:
-      jj_la1[50] = jj_gen;
+      jj_la1[49] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1406,7 +1423,7 @@ Node n = createNode(iri) ; up.setWithIRI(n) ;
         break;
         }
       default:
-        jj_la1[51] = jj_gen;
+        jj_la1[50] = jj_gen;
         break label_12;
       }
       UsingClause(up);
@@ -1456,7 +1473,7 @@ n = createNode(iri) ; update.addUsingNamed(n) ;
       break;
       }
     default:
-      jj_la1[52] = jj_gen;
+      jj_la1[51] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1479,7 +1496,7 @@ n = createNode(iri) ; update.addUsingNamed(n) ;
         break;
         }
       default:
-        jj_la1[53] = jj_gen;
+        jj_la1[52] = jj_gen;
         ;
       }
       iri = iri();
@@ -1487,7 +1504,7 @@ n = createNode(iri) ; update.addUsingNamed(n) ;
       break;
       }
     default:
-      jj_la1[54] = jj_gen;
+      jj_la1[53] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1524,7 +1541,7 @@ n = createNode(iri) ; update.addUsingNamed(n) ;
       break;
       }
     default:
-      jj_la1[55] = jj_gen;
+      jj_la1[54] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1569,12 +1586,13 @@ n = createNode(iri) ; update.addUsingNamed(n) ;
     case LPAREN:
     case NIL:
     case LBRACKET:
-    case ANON:{
+    case ANON:
+    case LT2:{
       TriplesTemplate(acc);
       break;
       }
     default:
-      jj_la1[56] = jj_gen;
+      jj_la1[55] = jj_gen;
       ;
     }
     label_13:
@@ -1585,7 +1603,7 @@ n = createNode(iri) ; update.addUsingNamed(n) ;
         break;
         }
       default:
-        jj_la1[57] = jj_gen;
+        jj_la1[56] = jj_gen;
         break label_13;
       }
       QuadsNotTriples(acc);
@@ -1595,7 +1613,7 @@ n = createNode(iri) ; update.addUsingNamed(n) ;
         break;
         }
       default:
-        jj_la1[58] = jj_gen;
+        jj_la1[57] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -1623,12 +1641,13 @@ n = createNode(iri) ; update.addUsingNamed(n) ;
       case LPAREN:
       case NIL:
       case LBRACKET:
-      case ANON:{
+      case ANON:
+      case LT2:{
         TriplesTemplate(acc);
         break;
         }
       default:
-        jj_la1[59] = jj_gen;
+        jj_la1[58] = jj_gen;
         ;
       }
     }
@@ -1664,12 +1683,13 @@ setAccGraph(acc, gn) ;
     case LPAREN:
     case NIL:
     case LBRACKET:
-    case ANON:{
+    case ANON:
+    case LT2:{
       TriplesTemplate(acc);
       break;
       }
     default:
-      jj_la1[60] = jj_gen;
+      jj_la1[59] = jj_gen;
       ;
     }
     jj_consume_token(RBRACE);
@@ -1706,18 +1726,19 @@ setAccGraph(acc, prev) ;
       case LPAREN:
       case NIL:
       case LBRACKET:
-      case ANON:{
+      case ANON:
+      case LT2:{
         TriplesTemplate(acc);
         break;
         }
       default:
-        jj_la1[61] = jj_gen;
+        jj_la1[60] = jj_gen;
         ;
       }
       break;
       }
     default:
-      jj_la1[62] = jj_gen;
+      jj_la1[61] = jj_gen;
       ;
     }
 }
@@ -1734,7 +1755,7 @@ Query q = endSubSelect(beginLine, beginColumn) ;
       break;
       }
     default:
-      jj_la1[63] = jj_gen;
+      jj_la1[62] = jj_gen;
       el = GroupGraphPatternSub();
     }
     jj_consume_token(RBRACE);
@@ -1770,7 +1791,8 @@ startGroup(elg) ;
     case LPAREN:
     case NIL:
     case LBRACKET:
-    case ANON:{
+    case ANON:
+    case LT2:{
 startTriplesBlock() ;
       el = TriplesBlock(null);
 endTriplesBlock() ;
@@ -1778,7 +1800,7 @@ endTriplesBlock() ;
       break;
       }
     default:
-      jj_la1[64] = jj_gen;
+      jj_la1[63] = jj_gen;
       ;
     }
     label_14:
@@ -1796,7 +1818,7 @@ endTriplesBlock() ;
         break;
         }
       default:
-        jj_la1[65] = jj_gen;
+        jj_la1[64] = jj_gen;
         break label_14;
       }
       el = GraphPatternNotTriples();
@@ -1807,7 +1829,7 @@ elg.addElement(el) ;
         break;
         }
       default:
-        jj_la1[66] = jj_gen;
+        jj_la1[65] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -1835,7 +1857,8 @@ elg.addElement(el) ;
       case LPAREN:
       case NIL:
       case LBRACKET:
-      case ANON:{
+      case ANON:
+      case LT2:{
 startTriplesBlock() ;
         el = TriplesBlock(null);
 endTriplesBlock() ;
@@ -1843,7 +1866,7 @@ endTriplesBlock() ;
         break;
         }
       default:
-        jj_la1[67] = jj_gen;
+        jj_la1[66] = jj_gen;
         ;
       }
     }
@@ -1884,18 +1907,19 @@ if ( acc == null )
       case LPAREN:
       case NIL:
       case LBRACKET:
-      case ANON:{
+      case ANON:
+      case LT2:{
         TriplesBlock(acc);
         break;
         }
       default:
-        jj_la1[68] = jj_gen;
+        jj_la1[67] = jj_gen;
         ;
       }
       break;
       }
     default:
-      jj_la1[69] = jj_gen;
+      jj_la1[68] = jj_gen;
       ;
     }
 {if ("" != null) return acc ;}
@@ -1937,7 +1961,7 @@ if ( acc == null )
       break;
       }
     default:
-      jj_la1[70] = jj_gen;
+      jj_la1[69] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -1969,7 +1993,7 @@ silent=true;
       break;
       }
     default:
-      jj_la1[71] = jj_gen;
+      jj_la1[70] = jj_gen;
       ;
     }
     n = VarOrIri();
@@ -2013,7 +2037,7 @@ finishInlineData(beginLine, beginColumn) ;
       break;
       }
     default:
-      jj_la1[72] = jj_gen;
+      jj_la1[71] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2045,12 +2069,13 @@ beginLine = t.beginLine; beginColumn = t.beginColumn; t = null;
       case STRING_LITERAL1:
       case STRING_LITERAL2:
       case STRING_LITERAL_LONG1:
-      case STRING_LITERAL_LONG2:{
+      case STRING_LITERAL_LONG2:
+      case LT2:{
         ;
         break;
         }
       default:
-        jj_la1[73] = jj_gen;
+        jj_la1[72] = jj_gen;
         break label_15;
       }
       n = DataBlockValue();
@@ -2078,7 +2103,7 @@ startDataBlockValueRow(beginLine, beginColumn) ;
           break;
           }
         default:
-          jj_la1[74] = jj_gen;
+          jj_la1[73] = jj_gen;
           break label_16;
         }
         v = Var();
@@ -2088,7 +2113,7 @@ emitDataBlockVariable(v) ;
       break;
       }
     default:
-      jj_la1[75] = jj_gen;
+      jj_la1[74] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2102,7 +2127,7 @@ emitDataBlockVariable(v) ;
         break;
         }
       default:
-        jj_la1[76] = jj_gen;
+        jj_la1[75] = jj_gen;
         break label_17;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -2131,12 +2156,13 @@ startDataBlockValueRow(beginLine, beginColumn) ;
           case STRING_LITERAL1:
           case STRING_LITERAL2:
           case STRING_LITERAL_LONG1:
-          case STRING_LITERAL_LONG2:{
+          case STRING_LITERAL_LONG2:
+          case LT2:{
             ;
             break;
             }
           default:
-            jj_la1[77] = jj_gen;
+            jj_la1[76] = jj_gen;
             break label_18;
           }
           n = DataBlockValue();
@@ -2155,7 +2181,7 @@ finishDataBlockValueRow(beginLine, beginColumn) ;
         break;
         }
       default:
-        jj_la1[78] = jj_gen;
+        jj_la1[77] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -2204,8 +2230,13 @@ finishDataBlockValueRow(beginLine, beginColumn) ;
 {if ("" != null) return null ;}
       break;
       }
+    case LT2:{
+      n = QuotedTripleData();
+{if ("" != null) return n ;}
+      break;
+      }
     default:
-      jj_la1[79] = jj_gen;
+      jj_la1[78] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2229,7 +2260,7 @@ finishDataBlockValueRow(beginLine, beginColumn) ;
         break;
         }
       default:
-        jj_la1[80] = jj_gen;
+        jj_la1[79] = jj_gen;
         break label_19;
       }
       jj_consume_token(UNION);
@@ -2258,6 +2289,11 @@ el2.addElement(el) ;
       c = BrackettedExpression();
       break;
       }
+    case TRIPLE:
+    case IS_TRIPLE:
+    case SUBJECT:
+    case PREDICATE:
+    case OBJECT:
     case EXISTS:
     case NOT:
     case COUNT:
@@ -2329,7 +2365,7 @@ el2.addElement(el) ;
       break;
       }
     default:
-      jj_la1[81] = jj_gen;
+      jj_la1[80] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2370,7 +2406,7 @@ if ( ! getAllowAggregatesInExpressions() )
         break;
         }
       default:
-        jj_la1[82] = jj_gen;
+        jj_la1[81] = jj_gen;
         ;
       }
       expr = Expression();
@@ -2383,7 +2419,7 @@ args.add(expr) ;
           break;
           }
         default:
-          jj_la1[83] = jj_gen;
+          jj_la1[82] = jj_gen;
           break label_20;
         }
         jj_consume_token(COMMA);
@@ -2394,7 +2430,7 @@ args.add(expr) ;
       break;
       }
     default:
-      jj_la1[84] = jj_gen;
+      jj_la1[83] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2420,7 +2456,7 @@ exprList.add(expr) ;
           break;
           }
         default:
-          jj_la1[85] = jj_gen;
+          jj_la1[84] = jj_gen;
           break label_21;
         }
         jj_consume_token(COMMA);
@@ -2431,7 +2467,7 @@ exprList.add(expr) ;
       break;
       }
     default:
-      jj_la1[86] = jj_gen;
+      jj_la1[85] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2468,12 +2504,13 @@ setInConstructTemplate(true) ;
     case LPAREN:
     case NIL:
     case LBRACKET:
-    case ANON:{
+    case ANON:
+    case LT2:{
       ConstructTriples(acc);
       break;
       }
     default:
-      jj_la1[87] = jj_gen;
+      jj_la1[86] = jj_gen;
       ;
     }
     jj_consume_token(RBRACE);
@@ -2512,18 +2549,19 @@ setInConstructTemplate(false) ;
       case LPAREN:
       case NIL:
       case LBRACKET:
-      case ANON:{
+      case ANON:
+      case LT2:{
         ConstructTriples(acc);
         break;
         }
       default:
-        jj_la1[88] = jj_gen;
+        jj_la1[87] = jj_gen;
         ;
       }
       break;
       }
     default:
-      jj_la1[89] = jj_gen;
+      jj_la1[88] = jj_gen;
       ;
     }
 }
@@ -2552,7 +2590,8 @@ setInConstructTemplate(false) ;
     case STRING_LITERAL_LONG1:
     case STRING_LITERAL_LONG2:
     case NIL:
-    case ANON:{
+    case ANON:
+    case LT2:{
       s = VarOrTerm();
       PropertyListNotEmpty(s, acc);
       break;
@@ -2566,7 +2605,7 @@ insert(acc, tempAcc) ;
       break;
       }
     default:
-      jj_la1[90] = jj_gen;
+      jj_la1[89] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2584,7 +2623,7 @@ insert(acc, tempAcc) ;
       break;
       }
     default:
-      jj_la1[91] = jj_gen;
+      jj_la1[90] = jj_gen;
       ;
     }
 }
@@ -2600,7 +2639,7 @@ insert(acc, tempAcc) ;
         break;
         }
       default:
-        jj_la1[92] = jj_gen;
+        jj_la1[91] = jj_gen;
         break label_22;
       }
       jj_consume_token(SEMICOLON);
@@ -2616,7 +2655,7 @@ insert(acc, tempAcc) ;
         break;
         }
       default:
-        jj_la1[93] = jj_gen;
+        jj_la1[92] = jj_gen;
         ;
       }
     }
@@ -2638,7 +2677,7 @@ p = nRDFtype ;
       break;
       }
     default:
-      jj_la1[94] = jj_gen;
+      jj_la1[93] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2656,7 +2695,7 @@ p = nRDFtype ;
         break;
         }
       default:
-        jj_la1[95] = jj_gen;
+        jj_la1[94] = jj_gen;
         break label_23;
       }
       jj_consume_token(COMMA);
@@ -2668,6 +2707,7 @@ p = nRDFtype ;
 ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ;
     o = GraphNode(tempAcc);
 insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ;
+    Annotation(acc, s, p, path, o);
 }
 
   final public void TriplesSameSubjectPath(TripleCollector acc) throws ParseException {Node s ;
@@ -2694,7 +2734,8 @@ insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ;
     case STRING_LITERAL_LONG1:
     case STRING_LITERAL_LONG2:
     case NIL:
-    case ANON:{
+    case ANON:
+    case LT2:{
       s = VarOrTerm();
       PropertyListPathNotEmpty(s, acc);
       break;
@@ -2708,7 +2749,7 @@ insert(acc, tempAcc) ;
       break;
       }
     default:
-      jj_la1[96] = jj_gen;
+      jj_la1[95] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2729,7 +2770,7 @@ insert(acc, tempAcc) ;
       break;
       }
     default:
-      jj_la1[97] = jj_gen;
+      jj_la1[96] = jj_gen;
       ;
     }
 }
@@ -2752,7 +2793,7 @@ insert(acc, tempAcc) ;
       break;
       }
     default:
-      jj_la1[98] = jj_gen;
+      jj_la1[97] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2765,7 +2806,7 @@ insert(acc, tempAcc) ;
         break;
         }
       default:
-        jj_la1[99] = jj_gen;
+        jj_la1[98] = jj_gen;
         break label_24;
       }
       jj_consume_token(SEMICOLON);
@@ -2797,7 +2838,7 @@ path = null ; p = null ;
           break;
           }
         default:
-          jj_la1[100] = jj_gen;
+          jj_la1[99] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -2805,7 +2846,7 @@ path = null ; p = null ;
         break;
         }
       default:
-        jj_la1[101] = jj_gen;
+        jj_la1[100] = jj_gen;
         ;
       }
     }
@@ -2833,7 +2874,7 @@ path = null ; p = null ;
         break;
         }
       default:
-        jj_la1[102] = jj_gen;
+        jj_la1[101] = jj_gen;
         break label_25;
       }
       jj_consume_token(COMMA);
@@ -2845,6 +2886,7 @@ path = null ; p = null ;
 ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ;
     o = GraphNodePath(tempAcc);
 insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ;
+    AnnotationPath(acc, s, p, path, o);
 }
 
   final public Path Path() throws ParseException {Path p ;
@@ -2863,7 +2905,7 @@ insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ;
         break;
         }
       default:
-        jj_la1[103] = jj_gen;
+        jj_la1[102] = jj_gen;
         break label_26;
       }
       jj_consume_token(VBAR);
@@ -2884,7 +2926,7 @@ p1 = PathFactory.pathAlt(p1, p2) ;
         break;
         }
       default:
-        jj_la1[104] = jj_gen;
+        jj_la1[103] = jj_gen;
         break label_27;
       }
       jj_consume_token(SLASH);
@@ -2905,7 +2947,7 @@ p1 = PathFactory.pathSeq(p1, p2) ;
       break;
       }
     default:
-      jj_la1[105] = jj_gen;
+      jj_la1[104] = jj_gen;
       ;
     }
 {if ("" != null) return p ;}
@@ -2930,7 +2972,7 @@ p = PathFactory.pathInverse(p) ;
       break;
       }
     default:
-      jj_la1[106] = jj_gen;
+      jj_la1[105] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2956,7 +2998,7 @@ p = PathFactory.pathInverse(p) ;
       break;
       }
     default:
-      jj_la1[107] = jj_gen;
+      jj_la1[106] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -2989,7 +3031,7 @@ p = PathFactory.pathLink(nRDFtype) ;
       break;
       }
     default:
-      jj_la1[108] = jj_gen;
+      jj_la1[107] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3027,7 +3069,7 @@ pNegSet.add(p) ;
             break;
             }
           default:
-            jj_la1[109] = jj_gen;
+            jj_la1[108] = jj_gen;
             break label_28;
           }
           jj_consume_token(VBAR);
@@ -3037,14 +3079,14 @@ pNegSet.add(p) ;
         break;
         }
       default:
-        jj_la1[110] = jj_gen;
+        jj_la1[109] = jj_gen;
         ;
       }
       jj_consume_token(RPAREN);
       break;
       }
     default:
-      jj_la1[111] = jj_gen;
+      jj_la1[110] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3082,14 +3124,14 @@ n = createNode(str) ; {if ("" != null) return new P_ReverseLink(n) ;}
         break;
         }
       default:
-        jj_la1[112] = jj_gen;
+        jj_la1[111] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[113] = jj_gen;
+      jj_la1[112] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3115,7 +3157,7 @@ n = createNode(str) ; {if ("" != null) return new P_ReverseLink(n) ;}
       break;
       }
     default:
-      jj_la1[114] = jj_gen;
+      jj_la1[113] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3144,7 +3186,7 @@ Node n = createBNode( t.beginLine, t.beginColumn) ;
       break;
       }
     default:
-      jj_la1[115] = jj_gen;
+      jj_la1[114] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3199,12 +3241,13 @@ insert(acc, mark, cell, nRDFfirst, n) ;
       case LPAREN:
       case NIL:
       case LBRACKET:
-      case ANON:{
+      case ANON:
+      case LT2:{
         ;
         break;
         }
       default:
-        jj_la1[116] = jj_gen;
+        jj_la1[115] = jj_gen;
         break label_29;
       }
     }
@@ -3254,12 +3297,13 @@ insert(acc, mark, cell, nRDFfirst, n) ;
       case LPAREN:
       case NIL:
       case LBRACKET:
-      case ANON:{
+      case ANON:
+      case LT2:{
         ;
         break;
         }
       default:
-        jj_la1[117] = jj_gen;
+        jj_la1[116] = jj_gen;
         break label_30;
       }
     }
@@ -3268,6 +3312,38 @@ if ( lastCell != null )
        insert(acc, lastCell, nRDFrest, nRDFnil) ;
      {if ("" != null) return listHead ;}
     throw new Error("Missing return statement in function");
+}
+
+  final public void AnnotationPath(TripleCollector acc, Node s, Node p, Path path, Node o) throws ParseException {
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case L_ANN:{
+      jj_consume_token(L_ANN);
+Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
+        Node x = createQuotedTriple(s, pAnn, o, token.beginLine, token.beginColumn);
+      PropertyListPathNotEmpty(x, acc);
+      jj_consume_token(R_ANN);
+      break;
+      }
+    default:
+      jj_la1[117] = jj_gen;
+      ;
+    }
+}
+
+  final public void Annotation(TripleCollector acc, Node s, Node p, Path path, Node o) throws ParseException {
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case L_ANN:{
+      jj_consume_token(L_ANN);
+Node pAnn = preConditionAnnotation(s, p, path, o, token.beginLine, token.beginColumn) ;
+        Node x = createQuotedTriple(s, p, o, token.beginLine, token.beginColumn);
+      PropertyListNotEmpty(x, acc);
+      jj_consume_token(R_ANN);
+      break;
+      }
+    default:
+      jj_la1[118] = jj_gen;
+      ;
+    }
 }
 
   final public Node GraphNode(TripleCollectorMark acc) throws ParseException {Node n ;
@@ -3294,7 +3370,8 @@ if ( lastCell != null )
     case STRING_LITERAL_LONG1:
     case STRING_LITERAL_LONG2:
     case NIL:
-    case ANON:{
+    case ANON:
+    case LT2:{
       n = VarOrTerm();
 {if ("" != null) return n ;}
       break;
@@ -3306,7 +3383,7 @@ if ( lastCell != null )
       break;
       }
     default:
-      jj_la1[118] = jj_gen;
+      jj_la1[119] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3337,7 +3414,8 @@ if ( lastCell != null )
     case STRING_LITERAL_LONG1:
     case STRING_LITERAL_LONG2:
     case NIL:
-    case ANON:{
+    case ANON:
+    case LT2:{
       n = VarOrTerm();
 {if ("" != null) return n ;}
       break;
@@ -3349,125 +3427,20 @@ if ( lastCell != null )
       break;
       }
     default:
-      jj_la1[119] = jj_gen;
-      jj_consume_token(-1);
-      throw new ParseException();
-    }
-    throw new Error("Missing return statement in function");
-}
-
-  final public Node VarOrTerm() throws ParseException {Node n = null ;
-    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case VAR1:
-    case VAR2:{
-      n = Var();
-      break;
-      }
-    case IRIref:
-    case PNAME_NS:
-    case PNAME_LN:
-    case BLANK_NODE_LABEL:
-    case TRUE:
-    case FALSE:
-    case INTEGER:
-    case DECIMAL:
-    case DOUBLE:
-    case INTEGER_POSITIVE:
-    case DECIMAL_POSITIVE:
-    case DOUBLE_POSITIVE:
-    case INTEGER_NEGATIVE:
-    case DECIMAL_NEGATIVE:
-    case DOUBLE_NEGATIVE:
-    case STRING_LITERAL1:
-    case STRING_LITERAL2:
-    case STRING_LITERAL_LONG1:
-    case STRING_LITERAL_LONG2:
-    case NIL:
-    case ANON:{
-      n = GraphTerm();
-      break;
-      }
-    default:
       jj_la1[120] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
-{if ("" != null) return n ;}
     throw new Error("Missing return statement in function");
 }
 
-  final public Node VarOrIri() throws ParseException {Node n = null ; String iri ;
+  final public Node VarOrTerm() throws ParseException {Node n = null ; String iri ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case VAR1:
     case VAR2:{
       n = Var();
       break;
       }
-    case IRIref:
-    case PNAME_NS:
-    case PNAME_LN:{
-      iri = iri();
-n = createNode(iri) ;
-      break;
-      }
-    default:
-      jj_la1[121] = jj_gen;
-      jj_consume_token(-1);
-      throw new ParseException();
-    }
-{if ("" != null) return n ;}
-    throw new Error("Missing return statement in function");
-}
-
-  final public Node VarOrBlankNodeOrIri() throws ParseException {Node n = null ; String iri ;
-    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case VAR1:
-    case VAR2:{
-      n = Var();
-      break;
-      }
-    case BLANK_NODE_LABEL:
-    case ANON:{
-      n = BlankNode();
-      break;
-      }
-    case IRIref:
-    case PNAME_NS:
-    case PNAME_LN:{
-      iri = iri();
-n = createNode(iri) ;
-      break;
-      }
-    default:
-      jj_la1[122] = jj_gen;
-      jj_consume_token(-1);
-      throw new ParseException();
-    }
-{if ("" != null) return n ;}
-    throw new Error("Missing return statement in function");
-}
-
-  final public Var Var() throws ParseException {Token t ;
-    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
-    case VAR1:{
-      t = jj_consume_token(VAR1);
-      break;
-      }
-    case VAR2:{
-      t = jj_consume_token(VAR2);
-      break;
-      }
-    default:
-      jj_la1[123] = jj_gen;
-      jj_consume_token(-1);
-      throw new ParseException();
-    }
-{if ("" != null) return createVariable(t.image, t.beginLine, t.beginColumn) ;}
-    throw new Error("Missing return statement in function");
-}
-
-  final public Node GraphTerm() throws ParseException {Node n ; String iri ;
-    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IRIref:
     case PNAME_NS:
     case PNAME_LN:{
@@ -3513,11 +3486,146 @@ n = createNode(iri) ;
 {if ("" != null) return nRDFnil ;}
       break;
       }
+    case LT2:{
+      n = QuotedTriple();
+      break;
+      }
+    default:
+      jj_la1[121] = jj_gen;
+      jj_consume_token(-1);
+      throw new ParseException();
+    }
+{if ("" != null) return n ;}
+    throw new Error("Missing return statement in function");
+}
+
+  final public Node QuotedTriple() throws ParseException {Node n = null ; Token t ; Node s , p , o ;
+    t = jj_consume_token(LT2);
+    s = VarOrTerm();
+    p = Verb();
+    o = VarOrTerm();
+n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn);
+    jj_consume_token(GT2);
+{if ("" != null) return n;}
+    throw new Error("Missing return statement in function");
+}
+
+  final public Node QuotedTripleData() throws ParseException {Node n = null ; Token t ; String iri ; Node s , p , o ;
+    t = jj_consume_token(LT2);
+    s = DataValueTerm();
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case IRIref:
+    case PNAME_NS:
+    case PNAME_LN:{
+      iri = iri();
+p = createNode(iri) ;
+      break;
+      }
+    case KW_A:{
+      jj_consume_token(KW_A);
+p = nRDFtype ;
+      break;
+      }
+    default:
+      jj_la1[122] = jj_gen;
+      jj_consume_token(-1);
+      throw new ParseException();
+    }
+    o = DataValueTerm();
+n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn);
+    jj_consume_token(GT2);
+{if ("" != null) return n;}
+    throw new Error("Missing return statement in function");
+}
+
+  final public Node DataValueTerm() throws ParseException {Node n = null ; String iri ; Node s , p , o ;
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case IRIref:
+    case PNAME_NS:
+    case PNAME_LN:{
+      iri = iri();
+{if ("" != null) return createNode(iri) ;}
+      break;
+      }
+    case STRING_LITERAL1:
+    case STRING_LITERAL2:
+    case STRING_LITERAL_LONG1:
+    case STRING_LITERAL_LONG2:{
+      n = RDFLiteral();
+{if ("" != null) return n ;}
+      break;
+      }
+    case INTEGER:
+    case DECIMAL:
+    case DOUBLE:
+    case INTEGER_POSITIVE:
+    case DECIMAL_POSITIVE:
+    case DOUBLE_POSITIVE:
+    case INTEGER_NEGATIVE:
+    case DECIMAL_NEGATIVE:
+    case DOUBLE_NEGATIVE:{
+      n = NumericLiteral();
+{if ("" != null) return n ;}
+      break;
+      }
+    case TRUE:
+    case FALSE:{
+      n = BooleanLiteral();
+{if ("" != null) return n ;}
+      break;
+      }
+    case LT2:{
+      n = QuotedTripleData();
+{if ("" != null) return n ;}
+      break;
+      }
+    default:
+      jj_la1[123] = jj_gen;
+      jj_consume_token(-1);
+      throw new ParseException();
+    }
+    throw new Error("Missing return statement in function");
+}
+
+  final public Node VarOrIri() throws ParseException {Node n = null ; String iri ;
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case VAR1:
+    case VAR2:{
+      n = Var();
+      break;
+      }
+    case IRIref:
+    case PNAME_NS:
+    case PNAME_LN:{
+      iri = iri();
+n = createNode(iri) ;
+      break;
+      }
     default:
       jj_la1[124] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
+{if ("" != null) return n ;}
+    throw new Error("Missing return statement in function");
+}
+
+  final public Var Var() throws ParseException {Token t ;
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case VAR1:{
+      t = jj_consume_token(VAR1);
+      break;
+      }
+    case VAR2:{
+      t = jj_consume_token(VAR2);
+      break;
+      }
+    default:
+      jj_la1[125] = jj_gen;
+      jj_consume_token(-1);
+      throw new ParseException();
+    }
+{if ("" != null) return createVariable(t.image, t.beginLine, t.beginColumn) ;}
     throw new Error("Missing return statement in function");
 }
 
@@ -3537,7 +3645,7 @@ n = createNode(iri) ;
         break;
         }
       default:
-        jj_la1[125] = jj_gen;
+        jj_la1[126] = jj_gen;
         break label_31;
       }
       jj_consume_token(SC_OR);
@@ -3558,7 +3666,7 @@ expr1 = new E_LogicalOr(expr1, expr2) ;
         break;
         }
       default:
-        jj_la1[126] = jj_gen;
+        jj_la1[127] = jj_gen;
         break label_32;
       }
       jj_consume_token(SC_AND);
@@ -3637,14 +3745,14 @@ expr1 = new E_NotOneOf(expr1, a) ;
         break;
         }
       default:
-        jj_la1[127] = jj_gen;
+        jj_la1[128] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[128] = jj_gen;
+      jj_la1[129] = jj_gen;
       ;
     }
 {if ("" != null) return expr1 ;}
@@ -3674,7 +3782,7 @@ expr1 = new E_NotOneOf(expr1, a) ;
         break;
         }
       default:
-        jj_la1[129] = jj_gen;
+        jj_la1[130] = jj_gen;
         break label_33;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -3716,7 +3824,7 @@ n = stripSign(n) ;
           break;
           }
         default:
-          jj_la1[130] = jj_gen;
+          jj_la1[131] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -3729,7 +3837,7 @@ n = stripSign(n) ;
             break;
             }
           default:
-            jj_la1[131] = jj_gen;
+            jj_la1[132] = jj_gen;
             break label_34;
           }
           switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -3746,7 +3854,7 @@ expr2 = new E_Divide(expr2, expr3) ;
             break;
             }
           default:
-            jj_la1[132] = jj_gen;
+            jj_la1[133] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -3758,7 +3866,7 @@ if ( addition )
         break;
         }
       default:
-        jj_la1[133] = jj_gen;
+        jj_la1[134] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -3778,7 +3886,7 @@ if ( addition )
         break;
         }
       default:
-        jj_la1[134] = jj_gen;
+        jj_la1[135] = jj_gen;
         break label_35;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -3795,7 +3903,7 @@ expr1 = new E_Divide(expr1, expr2) ;
         break;
         }
       default:
-        jj_la1[135] = jj_gen;
+        jj_la1[136] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -3829,6 +3937,11 @@ expr1 = new E_Divide(expr1, expr2) ;
     case PNAME_LN:
     case VAR1:
     case VAR2:
+    case TRIPLE:
+    case IS_TRIPLE:
+    case SUBJECT:
+    case PREDICATE:
+    case OBJECT:
     case EXISTS:
     case NOT:
     case COUNT:
@@ -3905,13 +4018,14 @@ expr1 = new E_Divide(expr1, expr2) ;
     case STRING_LITERAL2:
     case STRING_LITERAL_LONG1:
     case STRING_LITERAL_LONG2:
-    case LPAREN:{
+    case LPAREN:
+    case LT2:{
       expr = PrimaryExpression();
 {if ("" != null) return expr ;}
       break;
       }
     default:
-      jj_la1[136] = jj_gen;
+      jj_la1[137] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -3925,6 +4039,11 @@ expr1 = new E_Divide(expr1, expr2) ;
 {if ("" != null) return expr ;}
       break;
       }
+    case TRIPLE:
+    case IS_TRIPLE:
+    case SUBJECT:
+    case PREDICATE:
+    case OBJECT:
     case EXISTS:
     case NOT:
     case COUNT:
@@ -4030,11 +4149,78 @@ expr1 = new E_Divide(expr1, expr2) ;
 {if ("" != null) return asExpr(n) ;}
       break;
       }
+    case LT2:{
+      n = ExprQuotedTriple();
+{if ("" != null) return asExpr(n) ;}
+      break;
+      }
     default:
-      jj_la1[137] = jj_gen;
+      jj_la1[138] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
+    throw new Error("Missing return statement in function");
+}
+
+  final public Node ExprVarOrTerm() throws ParseException {Node n; String s;
+    switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
+    case IRIref:
+    case PNAME_NS:
+    case PNAME_LN:{
+      s = iri();
+n = createNode(s);
+      break;
+      }
+    case STRING_LITERAL1:
+    case STRING_LITERAL2:
+    case STRING_LITERAL_LONG1:
+    case STRING_LITERAL_LONG2:{
+      n = RDFLiteral();
+      break;
+      }
+    case INTEGER:
+    case DECIMAL:
+    case DOUBLE:
+    case INTEGER_POSITIVE:
+    case DECIMAL_POSITIVE:
+    case DOUBLE_POSITIVE:
+    case INTEGER_NEGATIVE:
+    case DECIMAL_NEGATIVE:
+    case DOUBLE_NEGATIVE:{
+      n = NumericLiteral();
+      break;
+      }
+    case TRUE:
+    case FALSE:{
+      n = BooleanLiteral();
+      break;
+      }
+    case VAR1:
+    case VAR2:{
+      n = Var();
+      break;
+      }
+    case LT2:{
+      n = ExprQuotedTriple();
+      break;
+      }
+    default:
+      jj_la1[139] = jj_gen;
+      jj_consume_token(-1);
+      throw new ParseException();
+    }
+{if ("" != null) return n;}
+    throw new Error("Missing return statement in function");
+}
+
+  final public Node ExprQuotedTriple() throws ParseException {Token t ; Node s,p,o,n;
+    t = jj_consume_token(LT2);
+    s = ExprVarOrTerm();
+    p = Verb();
+    o = ExprVarOrTerm();
+n = createQuotedTriple(s, p, o, t.beginLine, t.beginColumn);
+    jj_consume_token(GT2);
+{if ("" != null) return n;}
     throw new Error("Missing return statement in function");
 }
 
@@ -4135,7 +4321,7 @@ expr1 = new E_Divide(expr1, expr2) ;
         break;
         }
       default:
-        jj_la1[138] = jj_gen;
+        jj_la1[140] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4502,8 +4688,52 @@ expr1 = new E_Divide(expr1, expr2) ;
 {if ("" != null) return expr ;}
       break;
       }
+    case IS_TRIPLE:{
+      jj_consume_token(IS_TRIPLE);
+      jj_consume_token(LPAREN);
+      expr = Expression();
+      jj_consume_token(RPAREN);
+{if ("" != null) return new E_IsTriple(expr) ;}
+      break;
+      }
+    case TRIPLE:{
+      jj_consume_token(TRIPLE);
+      jj_consume_token(LPAREN);
+      expr1 = Expression();
+      jj_consume_token(COMMA);
+      expr2 = Expression();
+      jj_consume_token(COMMA);
+      expr3 = Expression();
+      jj_consume_token(RPAREN);
+{if ("" != null) return new E_TripleFn(expr1, expr2, expr3) ;}
+      break;
+      }
+    case SUBJECT:{
+      jj_consume_token(SUBJECT);
+      jj_consume_token(LPAREN);
+      expr = Expression();
+      jj_consume_token(RPAREN);
+{if ("" != null) return new E_TripleSubject(expr) ;}
+      break;
+      }
+    case PREDICATE:{
+      jj_consume_token(PREDICATE);
+      jj_consume_token(LPAREN);
+      expr = Expression();
+      jj_consume_token(RPAREN);
+{if ("" != null) return new E_TriplePredicate(expr) ;}
+      break;
+      }
+    case OBJECT:{
+      jj_consume_token(OBJECT);
+      jj_consume_token(LPAREN);
+      expr = Expression();
+      jj_consume_token(RPAREN);
+{if ("" != null) return new E_TripleObject(expr) ;}
+      break;
+      }
     default:
-      jj_la1[139] = jj_gen;
+      jj_la1[141] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -4523,7 +4753,7 @@ expr1 = new E_Divide(expr1, expr2) ;
       break;
       }
     default:
-      jj_la1[140] = jj_gen;
+      jj_la1[142] = jj_gen;
       ;
     }
     jj_consume_token(RPAREN);
@@ -4544,7 +4774,7 @@ expr1 = new E_Divide(expr1, expr2) ;
       break;
       }
     default:
-      jj_la1[141] = jj_gen;
+      jj_la1[143] = jj_gen;
       ;
     }
     jj_consume_token(RPAREN);
@@ -4567,7 +4797,7 @@ expr1 = new E_Divide(expr1, expr2) ;
       break;
       }
     default:
-      jj_la1[142] = jj_gen;
+      jj_la1[144] = jj_gen;
       ;
     }
     jj_consume_token(RPAREN);
@@ -4607,7 +4837,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[143] = jj_gen;
+        jj_la1[145] = jj_gen;
         ;
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4620,6 +4850,11 @@ distinct = true ;
       case PNAME_LN:
       case VAR1:
       case VAR2:
+      case TRIPLE:
+      case IS_TRIPLE:
+      case SUBJECT:
+      case PREDICATE:
+      case OBJECT:
       case EXISTS:
       case NOT:
       case COUNT:
@@ -4697,6 +4932,7 @@ distinct = true ;
       case STRING_LITERAL_LONG1:
       case STRING_LITERAL_LONG2:
       case LPAREN:
+      case LT2:
       case BANG:
       case PLUS:
       case MINUS:{
@@ -4704,7 +4940,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[144] = jj_gen;
+        jj_la1[146] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -4723,7 +4959,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[145] = jj_gen;
+        jj_la1[147] = jj_gen;
         ;
       }
       expr = Expression();
@@ -4741,7 +4977,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[146] = jj_gen;
+        jj_la1[148] = jj_gen;
         ;
       }
       expr = Expression();
@@ -4759,7 +4995,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[147] = jj_gen;
+        jj_la1[149] = jj_gen;
         ;
       }
       expr = Expression();
@@ -4777,7 +5013,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[148] = jj_gen;
+        jj_la1[150] = jj_gen;
         ;
       }
       expr = Expression();
@@ -4795,7 +5031,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[149] = jj_gen;
+        jj_la1[151] = jj_gen;
         ;
       }
       expr = Expression();
@@ -4813,7 +5049,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[150] = jj_gen;
+        jj_la1[152] = jj_gen;
         ;
       }
       expr = Expression();
@@ -4826,7 +5062,7 @@ distinct = true ;
         break;
         }
       default:
-        jj_la1[151] = jj_gen;
+        jj_la1[153] = jj_gen;
         ;
       }
       jj_consume_token(RPAREN);
@@ -4834,7 +5070,7 @@ agg = AggregatorFactory.createGroupConcat(distinct, expr, sep, ordered) ;
       break;
       }
     default:
-      jj_la1[152] = jj_gen;
+      jj_la1[154] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -4857,7 +5093,7 @@ Expr exprAgg = getQuery().allocAggregate(agg) ;
       break;
       }
     default:
-      jj_la1[153] = jj_gen;
+      jj_la1[155] = jj_gen;
       ;
     }
 if ( a == null )
@@ -4891,14 +5127,14 @@ lang = stripChars(t.image, 1) ;
         break;
         }
       default:
-        jj_la1[154] = jj_gen;
+        jj_la1[156] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
       break;
       }
     default:
-      jj_la1[155] = jj_gen;
+      jj_la1[157] = jj_gen;
       ;
     }
 {if ("" != null) return createLiteral(lex, lang, uri) ;}
@@ -4926,7 +5162,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[156] = jj_gen;
+      jj_la1[158] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -4952,7 +5188,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[157] = jj_gen;
+      jj_la1[159] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -4977,7 +5213,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[158] = jj_gen;
+      jj_la1[160] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5002,7 +5238,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[159] = jj_gen;
+      jj_la1[161] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5022,7 +5258,7 @@ lang = stripChars(t.image, 1) ;
       break;
       }
     default:
-      jj_la1[160] = jj_gen;
+      jj_la1[162] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5052,7 +5288,7 @@ lex = stripQuotes3(t.image) ;
       break;
       }
     default:
-      jj_la1[161] = jj_gen;
+      jj_la1[163] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5076,7 +5312,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
       break;
       }
     default:
-      jj_la1[162] = jj_gen;
+      jj_la1[164] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5096,7 +5332,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
       break;
       }
     default:
-      jj_la1[163] = jj_gen;
+      jj_la1[165] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5116,7 +5352,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
       break;
       }
     default:
-      jj_la1[164] = jj_gen;
+      jj_la1[166] = jj_gen;
       jj_consume_token(-1);
       throw new ParseException();
     }
@@ -5138,7 +5374,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
   public Token jj_nt;
   private int jj_ntk;
   private int jj_gen;
-  final private int[] jj_la1 = new int[165];
+  final private int[] jj_la1 = new int[167];
   static private int[] jj_la1_0;
   static private int[] jj_la1_1;
   static private int[] jj_la1_2;
@@ -5156,25 +5392,25 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	   jj_la1_init_6();
 	}
 	private static void jj_la1_init_0() {
-	   jj_la1_0 = new int[] {0xe400000,0x200,0x300000,0x300000,0x0,0x1800000,0x1800000,0xc000,0xc000,0xc000,0x0,0x0,0xfc00,0x0,0xdc00,0xdc00,0x0,0x0,0x0,0x1c00,0x0,0x0,0x0,0x40000000,0x30000000,0xdc00,0x0,0xdc00,0x1c00,0xdc00,0x0,0xdc00,0xdc00,0x20000000,0x10000000,0x30000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1c00,0x0,0x1c00,0x0,0xfc00,0x0,0x0,0xfc00,0xfc00,0xfc00,0x0,0x400000,0xfc00,0x0,0x0,0xfc00,0xfc00,0x0,0x0,0x0,0xc000,0x1c00,0xc000,0x0,0x0,0x1c00,0x0,0x1c00,0x0,0x1c00,0x800000,0x0,0x0,0x0,0x0,0xfc00,0xfc00,0x0,0xfc00,0x8dc00,0x0,0x8dc00,0x8dc00,0x0,0xfc00,0x8dc00,0x8dc00,0x0,0x8dc00,0x8dc00,0x0,0x0,0x0,0x0,0x81c00,0x0,0x81c00,0x0,0x81c00,0x81c00,0x81c00,0x81c00,0x0,0x0,0xfc00,0xfc00,0xfc00,0xfc00,0xfc00,0xdc00,0xfc00,0xc000,0x3c00,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xdc00,0xdc00,0x0,0x0,0x0,0x0,0x0,0x800000,0xdc00,0x800000,0x800000,0x800000,0x800000,0x800000,0x800000,0x0,0x0,0x0,0x10000,0x10000,0x0,0x0,0x0,0x0,0x0,0x0,0x1c00,0x1800,0x2000,};
+	   jj_la1_0 = new int[] {0x7200000,0x180000,0x180000,0x0,0xc00000,0xc00000,0x6000,0x6000,0x6000,0x0,0x0,0x7e00,0x0,0x6e00,0x6e00,0x0,0x0,0x0,0xe00,0x0,0x0,0x0,0x20000000,0x18000000,0x6e00,0x0,0x6e00,0xe00,0x6e00,0x0,0x6e00,0x6e00,0x10000000,0x8000000,0x18000000,0x80000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xe00,0x0,0xe00,0x0,0x7e00,0x0,0x0,0x7e00,0x7e00,0x7e00,0x0,0x200000,0x7e00,0x80000000,0x0,0x7e00,0x7e00,0x0,0x80000000,0x0,0x6000,0xe00,0x6000,0x0,0x0,0xe00,0x0,0xe00,0x0,0xe00,0x400000,0x0,0x0,0x0,0x0,0x7e00,0x7e00,0x0,0x7e00,0x46e00,0x0,0x46e00,0x46e00,0x0,0x7e00,0x46e00,0x46e00,0x0,0x46e00,0x46e00,0x0,0x0,0x0,0x0,0x40e00,0x0,0x40e00,0x0,0x40e00,0x40e00,0x40e00,0x40e00,0x0,0x0,0x7e00,0x7e00,0x0,0x0,0x7e00,0x7e00,0x7e00,0x40e00,0xe00,0x6e00,0x6000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x6e00,0x6e00,0x6e00,0x0,0x0,0x0,0x0,0x0,0x400000,0x6e00,0x400000,0x400000,0x400000,0x400000,0x400000,0x400000,0x0,0x0,0x0,0x8000,0x8000,0x0,0x0,0x0,0x0,0x0,0x0,0xe00,0xc00,0x1000,};
 	}
 	private static void jj_la1_init_1() {
-	   jj_la1_1 = new int[] {0x0,0x0,0x0,0x0,0x20,0x0,0x0,0x0,0x0,0x0,0x20,0x20,0x0,0x60,0x0,0x0,0x20,0x40,0x20,0x10,0x40,0x20000,0x40000,0x0,0x0,0x3e0c000,0x10000,0x3e0c000,0x3e0c000,0x3e0c00c,0xc,0x3e0c000,0x3e0c00c,0x0,0x0,0x0,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x10,0x100,0x100,0x110,0x0,0x100,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3b01,0x0,0x0,0x0,0x0,0x3b01,0x0,0x0,0x2,0x0,0x0,0x0,0x2,0x0,0x2,0x400,0x3e0c000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8000,0x8000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3e0c000,0x3e0c000,0x0,0x3e0c000,0x0,0x0,0x0,0x0,0x3e0c000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3e00000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_1 = new int[] {0x0,0x0,0x0,0x10,0x0,0x0,0x0,0x0,0x0,0x10,0x10,0x0,0x30,0x0,0x0,0x10,0x20,0x10,0x8,0x20,0x200000,0x400000,0x0,0x0,0x3e0fe000,0x100000,0x3e0fe000,0x3e0fe000,0x3e0fe006,0x6,0x3e0fe000,0x3e0fe006,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8,0x80,0x80,0x88,0x0,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1d80,0x0,0x0,0x0,0x0,0x1d80,0x0,0x0,0x1,0x0,0x0,0x0,0x1,0x0,0x1,0x200,0x3e0fe000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x80000,0x80000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3e0fe000,0x3e0fe000,0x0,0x0,0x3e0fe000,0x0,0x0,0x0,0x0,0x3e0fe000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3e000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_2() {
-	   jj_la1_2 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffdb,0x0,0xffffffdb,0xffffffdb,0xffffffdb,0x0,0xffffffdb,0xffffffdb,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x4,0x0,0x0,0x0,0x0,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffdb,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20,0x20,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xffffffdb,0xffffffdb,0x0,0xffffffdb,0x0,0x0,0x0,0x0,0xffffffdb,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_2 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xfffffdb0,0x0,0xfffffdb0,0xfffffdb0,0xfffffdb0,0x0,0xfffffdb0,0xfffffdb0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x40,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xfffffdb0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200,0x200,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0xfffffdb0,0xfffffdb0,0x0,0x0,0xfffffdb0,0x0,0x0,0x0,0x0,0xfffffdb0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x30,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_3() {
-	   jj_la1_3 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x6000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1dfffff,0x0,0x1dfffff,0x1dfffff,0x1dfffff,0x0,0x1dfffff,0x1dfffff,0x0,0x0,0x0,0x0,0x0,0xf0000000,0xf0000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x10000000,0x30000000,0x0,0x0,0x0,0x0,0x0,0x6000000,0x0,0x0,0x6000000,0x6000000,0x6000000,0x0,0x0,0x6000000,0x0,0x0,0x6000000,0x6000000,0x0,0x0,0x0,0x0,0x6000000,0x0,0x0,0x0,0x6000000,0x0,0x6000000,0x0,0x1dfffff,0x0,0x0,0x0,0x0,0x0,0x6000000,0x6000000,0x0,0x6000000,0x0,0x0,0x0,0x0,0x0,0x6000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x6000000,0x6000000,0x6000000,0x6000000,0x6000000,0x0,0x0,0x0,0x6000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7dfffff,0x7dfffff,0x0,0x1dfffff,0x0,0x0,0x0,0x0,0x7dfffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x6000000,0x0,0x0,0x0,0x0,};
+	   jj_la1_3 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x60000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1dffffff,0x0,0x1dffffff,0x1dffffff,0x1dffffff,0x0,0x1dffffff,0x1dffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x60000000,0x0,0x0,0x60000000,0x60000000,0x60000000,0x0,0x0,0x60000000,0x0,0x0,0x60000000,0x60000000,0x0,0x0,0x0,0x0,0x60000000,0x0,0x0,0x0,0x60000000,0x0,0x60000000,0x0,0x1dffffff,0x0,0x0,0x0,0x0,0x0,0x60000000,0x60000000,0x0,0x60000000,0x0,0x0,0x0,0x0,0x0,0x60000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x60000000,0x60000000,0x0,0x0,0x60000000,0x60000000,0x60000000,0x0,0x60000000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x7dffffff,0x7dffffff,0x60000000,0x0,0x1dffffff,0x0,0x0,0x0,0x0,0x7dffffff,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x60000000,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_4() {
-	   jj_la1_4 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe0000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x427f,0x427f,0x100,0x400,0x100,0x100,0x100,0x100,0x100,0x100,0x4000,0x0,0x0,0x8000,0x0,0x0,0x1000,0x3000,0x3fe0000,0x0,0x0,0x3fe0000,0x3fe0000,0x3fe0000,0x0,0x0,0x3fe0000,0x0,0x0,0x3fe0000,0x3fe0000,0x0,0x0,0x100,0x0,0x3fe0000,0x0,0x0,0x0,0x3fe0000,0x0,0x3fe0000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe0000,0x3fe0000,0x0,0x3fe0000,0x0,0x0,0x0,0x0,0x0,0x3fe0000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe0000,0x3fe0000,0x3fe0000,0x3fe0000,0x3fe0000,0x0,0x0,0x0,0x3fe0000,0x0,0x0,0x0,0x0,0x3f00000,0x3f00000,0x0,0x0,0x3f00000,0x0,0x0,0x3fe0000,0x3fe0000,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe0000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe0000,0xe0000,0x700000,0x3800000,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_4 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe00000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x427ff,0x427ff,0x1000,0x4000,0x1000,0x1000,0x1000,0x1000,0x1000,0x1000,0x40000,0x1,0x3,0x80000,0x0,0x0,0x10000,0x30000,0x3fe00000,0x0,0x0,0x3fe00000,0x3fe00000,0x3fe00000,0x0,0x0,0x3fe00000,0x0,0x0,0x3fe00000,0x3fe00000,0x0,0x0,0x1000,0x0,0x3fe00000,0x0,0x0,0x0,0x3fe00000,0x0,0x3fe00000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe00000,0x3fe00000,0x0,0x3fe00000,0x0,0x0,0x0,0x0,0x0,0x3fe00000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe00000,0x3fe00000,0x0,0x0,0x3fe00000,0x3fe00000,0x3fe00000,0x0,0x3fe00000,0x0,0x0,0x0,0x0,0x0,0x0,0x3f000000,0x3f000000,0x0,0x0,0x3f000000,0x0,0x0,0x3fe00000,0x3fe00000,0x3fe00000,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe00000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x3fe00000,0xe00000,0x7000000,0x38000000,0x0,0x0,0x0,0x0,0x0,};
 	}
 	private static void jj_la1_init_5() {
-	   jj_la1_5 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20,0x20,0x20000020,0x0,0x0,0x14be,0x100,0x0,0x20000000,0x0,0x100,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20,0x0,0x20,0x20,0x20,0x0,0x20,0x20,0x0,0x0,0x0,0x0,0x2000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x14be,0x0,0x8000,0x14be,0x14be,0x14be,0x8000,0x0,0x14be,0x100,0x8000,0x14be,0x14be,0x8000,0x100,0x0,0xa0,0x1e,0x0,0xa0,0xa0,0x1e,0xa0,0x1e,0x0,0x20,0x0,0x4000,0xa0,0x4000,0xa0,0x14be,0x14be,0x8000,0x14be,0x0,0x2000,0x0,0x0,0x4000,0x14be,0x400020,0x400020,0x2000,0x400020,0x400020,0x4000,0x0,0x40000000,0x28000000,0x400020,0x28000000,0x400020,0x0,0x0,0x20,0x0,0x0,0x420,0x420,0x14be,0x14be,0x14be,0x14be,0x109e,0x0,0x1000,0x0,0x109e,0x2000000,0x4000000,0x3f0000,0x3f0000,0x18000000,0x0,0x60000000,0x60000000,0x18000000,0x60000000,0x60000000,0x1840003e,0x3e,0xa0,0x0,0x4000,0x4000,0x4000,0x0,0x3840003e,0x0,0x0,0x0,0x0,0x0,0x0,0x2000,0x0,0xa0,0x80000000,0x80000000,0x0,0x0,0x0,0x0,0x0,0x1e,0x0,0x0,0x1000,};
+	   jj_la1_5 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x200,0x200,0x200,0x0,0x0,0x8014be0,0x1000,0x0,0x0,0x0,0x1000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x200,0x0,0x200,0x200,0x200,0x0,0x200,0x200,0x0,0x0,0x0,0x0,0x20000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x8014be0,0x0,0x80000,0x8014be0,0x8014be0,0x8014be0,0x80000,0x0,0x8014be0,0x1000,0x80000,0x8014be0,0x8014be0,0x80000,0x1000,0x0,0xa00,0x80001e0,0x0,0xa00,0xa00,0x80001e0,0xa00,0x80001e0,0x0,0x200,0x0,0x40000,0xa00,0x40000,0xa00,0x8014be0,0x8014be0,0x80000,0x8014be0,0x0,0x20000,0x0,0x0,0x40000,0x8014be0,0x40000200,0x40000200,0x20000,0x40000200,0x40000200,0x40000,0x0,0x0,0x0,0x40000200,0x0,0x40000200,0x0,0x0,0x200,0x0,0x0,0x4200,0x4200,0x8014be0,0x8014be0,0x10000000,0x10000000,0x8014be0,0x8014be0,0x80109e0,0x0,0x80001e0,0x0,0x0,0x0,0x0,0x3f00000,0x3f00000,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x480003e0,0x80003e0,0x80001e0,0xa00,0x0,0x40000,0x40000,0x40000,0x0,0x480003e0,0x0,0x0,0x0,0x0,0x0,0x0,0x20000,0x0,0xa00,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x1e0,0x0,0x0,0x10000,};
 	}
 	private static void jj_la1_init_6() {
-	   jj_la1_6 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x4,0x4,0x0,0x4,0x4,0x0,0x2,0x0,0x20,0x4,0x20,0x0,0x2,0x4,0x4,0x0,0x4,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
+	   jj_la1_6 = new int[] {0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x20,0x0,0x0,0x0,0x0,0x0,0x20,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x400,0x400,0x0,0x400,0x400,0x0,0x200,0x40,0x2028,0x400,0x2028,0x0,0x200,0x400,0x400,0x0,0x400,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x2,0x4,0x0,0x0,0x18,0x0,0x60,0x60,0x18,0x60,0x60,0x18,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x38,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x80,0x80,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,0x0,};
 	}
 
   /** Constructor with InputStream. */
@@ -5188,7 +5424,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 165; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 167; i++) jj_la1[i] = -1;
   }
 
   /** Reinitialise. */
@@ -5202,7 +5438,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 165; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 167; i++) jj_la1[i] = -1;
   }
 
   /** Constructor. */
@@ -5212,7 +5448,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 165; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 167; i++) jj_la1[i] = -1;
   }
 
   /** Reinitialise. */
@@ -5230,7 +5466,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 165; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 167; i++) jj_la1[i] = -1;
   }
 
   /** Constructor with generated Token Manager. */
@@ -5239,7 +5475,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 165; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 167; i++) jj_la1[i] = -1;
   }
 
   /** Reinitialise. */
@@ -5248,7 +5484,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 	 token = new Token();
 	 jj_ntk = -1;
 	 jj_gen = 0;
-	 for (int i = 0; i < 165; i++) jj_la1[i] = -1;
+	 for (int i = 0; i < 167; i++) jj_la1[i] = -1;
   }
 
   private Token jj_consume_token(int kind) throws ParseException {
@@ -5299,12 +5535,12 @@ checkString(lex, t.beginLine, t.beginColumn) ;
   /** Generate ParseException. */
   public ParseException generateParseException() {
 	 jj_expentries.clear();
-	 boolean[] la1tokens = new boolean[209];
+	 boolean[] la1tokens = new boolean[217];
 	 if (jj_kind >= 0) {
 	   la1tokens[jj_kind] = true;
 	   jj_kind = -1;
 	 }
-	 for (int i = 0; i < 165; i++) {
+	 for (int i = 0; i < 167; i++) {
 	   if (jj_la1[i] == jj_gen) {
 		 for (int j = 0; j < 32; j++) {
 		   if ((jj_la1_0[i] & (1<<j)) != 0) {
@@ -5331,7 +5567,7 @@ checkString(lex, t.beginLine, t.beginColumn) ;
 		 }
 	   }
 	 }
-	 for (int i = 0; i < 209; i++) {
+	 for (int i = 0; i < 217; i++) {
 	   if (la1tokens[i]) {
 		 jj_expentry = new int[1];
 		 jj_expentry[0] = i;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/SPARQLParser12Constants.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/SPARQLParser12Constants.java
@@ -17,405 +17,421 @@ public interface SPARQLParser12Constants {
   /** RegularExpression Id. */
   int WSC = 8;
   /** RegularExpression Id. */
-  int BOM = 9;
+  int IRIref = 9;
   /** RegularExpression Id. */
-  int IRIref = 10;
+  int PNAME_NS = 10;
   /** RegularExpression Id. */
-  int PNAME_NS = 11;
+  int PNAME_LN = 11;
   /** RegularExpression Id. */
-  int PNAME_LN = 12;
+  int BLANK_NODE_LABEL = 12;
   /** RegularExpression Id. */
-  int BLANK_NODE_LABEL = 13;
+  int VAR1 = 13;
   /** RegularExpression Id. */
-  int VAR1 = 14;
+  int VAR2 = 14;
   /** RegularExpression Id. */
-  int VAR2 = 15;
+  int LANGTAG = 15;
   /** RegularExpression Id. */
-  int LANGTAG = 16;
+  int A2Z = 16;
   /** RegularExpression Id. */
-  int A2Z = 17;
+  int A2ZN = 17;
   /** RegularExpression Id. */
-  int A2ZN = 18;
+  int KW_A = 18;
   /** RegularExpression Id. */
-  int KW_A = 19;
+  int BASE = 19;
   /** RegularExpression Id. */
-  int BASE = 20;
+  int PREFIX = 20;
   /** RegularExpression Id. */
-  int PREFIX = 21;
+  int SELECT = 21;
   /** RegularExpression Id. */
-  int SELECT = 22;
+  int DISTINCT = 22;
   /** RegularExpression Id. */
-  int DISTINCT = 23;
+  int REDUCED = 23;
   /** RegularExpression Id. */
-  int REDUCED = 24;
+  int DESCRIBE = 24;
   /** RegularExpression Id. */
-  int DESCRIBE = 25;
+  int CONSTRUCT = 25;
   /** RegularExpression Id. */
-  int CONSTRUCT = 26;
+  int ASK = 26;
   /** RegularExpression Id. */
-  int ASK = 27;
+  int LIMIT = 27;
   /** RegularExpression Id. */
-  int LIMIT = 28;
+  int OFFSET = 28;
   /** RegularExpression Id. */
-  int OFFSET = 29;
+  int ORDER = 29;
   /** RegularExpression Id. */
-  int ORDER = 30;
+  int BY = 30;
   /** RegularExpression Id. */
-  int BY = 31;
+  int VALUES = 31;
   /** RegularExpression Id. */
-  int VALUES = 32;
+  int UNDEF = 32;
   /** RegularExpression Id. */
-  int UNDEF = 33;
+  int ASC = 33;
   /** RegularExpression Id. */
-  int ASC = 34;
+  int DESC = 34;
   /** RegularExpression Id. */
-  int DESC = 35;
+  int NAMED = 35;
   /** RegularExpression Id. */
-  int NAMED = 36;
+  int FROM = 36;
   /** RegularExpression Id. */
-  int FROM = 37;
+  int WHERE = 37;
   /** RegularExpression Id. */
-  int WHERE = 38;
+  int AND = 38;
   /** RegularExpression Id. */
-  int AND = 39;
+  int GRAPH = 39;
   /** RegularExpression Id. */
-  int GRAPH = 40;
+  int OPTIONAL = 40;
   /** RegularExpression Id. */
-  int OPTIONAL = 41;
+  int UNION = 41;
   /** RegularExpression Id. */
-  int UNION = 42;
+  int MINUS_P = 42;
   /** RegularExpression Id. */
-  int MINUS_P = 43;
+  int BIND = 43;
   /** RegularExpression Id. */
-  int BIND = 44;
+  int SERVICE = 44;
   /** RegularExpression Id. */
-  int SERVICE = 45;
+  int TRIPLE = 45;
   /** RegularExpression Id. */
-  int EXISTS = 46;
+  int IS_TRIPLE = 46;
   /** RegularExpression Id. */
-  int NOT = 47;
+  int SUBJECT = 47;
   /** RegularExpression Id. */
-  int AS = 48;
+  int PREDICATE = 48;
   /** RegularExpression Id. */
-  int GROUP = 49;
+  int OBJECT = 49;
   /** RegularExpression Id. */
-  int HAVING = 50;
+  int EXISTS = 50;
   /** RegularExpression Id. */
-  int SEPARATOR = 51;
+  int NOT = 51;
   /** RegularExpression Id. */
-  int AGG = 52;
+  int AS = 52;
   /** RegularExpression Id. */
-  int COUNT = 53;
+  int GROUP = 53;
   /** RegularExpression Id. */
-  int MIN = 54;
+  int HAVING = 54;
   /** RegularExpression Id. */
-  int MAX = 55;
+  int SEPARATOR = 55;
   /** RegularExpression Id. */
-  int SUM = 56;
+  int AGG = 56;
   /** RegularExpression Id. */
-  int AVG = 57;
+  int COUNT = 57;
   /** RegularExpression Id. */
-  int STDEV = 58;
+  int MIN = 58;
   /** RegularExpression Id. */
-  int STDEV_SAMP = 59;
+  int MAX = 59;
   /** RegularExpression Id. */
-  int STDEV_POP = 60;
+  int SUM = 60;
   /** RegularExpression Id. */
-  int VARIANCE = 61;
+  int AVG = 61;
   /** RegularExpression Id. */
-  int VAR_SAMP = 62;
+  int STDEV = 62;
   /** RegularExpression Id. */
-  int VAR_POP = 63;
+  int STDEV_SAMP = 63;
   /** RegularExpression Id. */
-  int SAMPLE = 64;
+  int STDEV_POP = 64;
   /** RegularExpression Id. */
-  int GROUP_CONCAT = 65;
+  int VARIANCE = 65;
   /** RegularExpression Id. */
-  int FILTER = 66;
+  int VAR_SAMP = 66;
   /** RegularExpression Id. */
-  int BOUND = 67;
+  int VAR_POP = 67;
   /** RegularExpression Id. */
-  int COALESCE = 68;
+  int SAMPLE = 68;
   /** RegularExpression Id. */
-  int IN = 69;
+  int GROUP_CONCAT = 69;
   /** RegularExpression Id. */
-  int IF = 70;
+  int FILTER = 70;
   /** RegularExpression Id. */
-  int BNODE = 71;
+  int BOUND = 71;
   /** RegularExpression Id. */
-  int IRI = 72;
+  int COALESCE = 72;
   /** RegularExpression Id. */
-  int URI = 73;
+  int IN = 73;
   /** RegularExpression Id. */
-  int STR = 74;
+  int IF = 74;
   /** RegularExpression Id. */
-  int STRLANG = 75;
+  int BNODE = 75;
   /** RegularExpression Id. */
-  int STRDT = 76;
+  int IRI = 76;
   /** RegularExpression Id. */
-  int DTYPE = 77;
+  int URI = 77;
   /** RegularExpression Id. */
-  int LANG = 78;
+  int STR = 78;
   /** RegularExpression Id. */
-  int LANGMATCHES = 79;
+  int STRLANG = 79;
   /** RegularExpression Id. */
-  int IS_URI = 80;
+  int STRDT = 80;
   /** RegularExpression Id. */
-  int IS_IRI = 81;
+  int DTYPE = 81;
   /** RegularExpression Id. */
-  int IS_BLANK = 82;
+  int LANG = 82;
   /** RegularExpression Id. */
-  int IS_LITERAL = 83;
+  int LANGMATCHES = 83;
   /** RegularExpression Id. */
-  int IS_NUMERIC = 84;
+  int IS_URI = 84;
   /** RegularExpression Id. */
-  int REGEX = 85;
+  int IS_IRI = 85;
   /** RegularExpression Id. */
-  int SAME_TERM = 86;
+  int IS_BLANK = 86;
   /** RegularExpression Id. */
-  int RAND = 87;
+  int IS_LITERAL = 87;
   /** RegularExpression Id. */
-  int ABS = 88;
+  int IS_NUMERIC = 88;
   /** RegularExpression Id. */
-  int CEIL = 89;
+  int REGEX = 89;
   /** RegularExpression Id. */
-  int FLOOR = 90;
+  int SAME_TERM = 90;
   /** RegularExpression Id. */
-  int ROUND = 91;
+  int RAND = 91;
   /** RegularExpression Id. */
-  int CONCAT = 92;
+  int ABS = 92;
   /** RegularExpression Id. */
-  int SUBSTR = 93;
+  int CEIL = 93;
   /** RegularExpression Id. */
-  int STRLEN = 94;
+  int FLOOR = 94;
   /** RegularExpression Id. */
-  int REPLACE = 95;
+  int ROUND = 95;
   /** RegularExpression Id. */
-  int UCASE = 96;
+  int CONCAT = 96;
   /** RegularExpression Id. */
-  int LCASE = 97;
+  int SUBSTR = 97;
   /** RegularExpression Id. */
-  int ENCODE_FOR_URI = 98;
+  int STRLEN = 98;
   /** RegularExpression Id. */
-  int CONTAINS = 99;
+  int REPLACE = 99;
   /** RegularExpression Id. */
-  int STRSTARTS = 100;
+  int UCASE = 100;
   /** RegularExpression Id. */
-  int STRENDS = 101;
+  int LCASE = 101;
   /** RegularExpression Id. */
-  int STRBEFORE = 102;
+  int ENCODE_FOR_URI = 102;
   /** RegularExpression Id. */
-  int STRAFTER = 103;
+  int CONTAINS = 103;
   /** RegularExpression Id. */
-  int YEAR = 104;
+  int STRSTARTS = 104;
   /** RegularExpression Id. */
-  int MONTH = 105;
+  int STRENDS = 105;
   /** RegularExpression Id. */
-  int DAY = 106;
+  int STRBEFORE = 106;
   /** RegularExpression Id. */
-  int HOURS = 107;
+  int STRAFTER = 107;
   /** RegularExpression Id. */
-  int MINUTES = 108;
+  int YEAR = 108;
   /** RegularExpression Id. */
-  int SECONDS = 109;
+  int MONTH = 109;
   /** RegularExpression Id. */
-  int TIMEZONE = 110;
+  int DAY = 110;
   /** RegularExpression Id. */
-  int TZ = 111;
+  int HOURS = 111;
   /** RegularExpression Id. */
-  int NOW = 112;
+  int MINUTES = 112;
   /** RegularExpression Id. */
-  int UUID = 113;
+  int SECONDS = 113;
   /** RegularExpression Id. */
-  int STRUUID = 114;
+  int TIMEZONE = 114;
   /** RegularExpression Id. */
-  int MD5 = 115;
+  int TZ = 115;
   /** RegularExpression Id. */
-  int SHA1 = 116;
+  int NOW = 116;
   /** RegularExpression Id. */
-  int SHA224 = 117;
+  int UUID = 117;
   /** RegularExpression Id. */
-  int SHA256 = 118;
+  int STRUUID = 118;
   /** RegularExpression Id. */
-  int SHA384 = 119;
+  int MD5 = 119;
   /** RegularExpression Id. */
-  int SHA512 = 120;
+  int SHA1 = 120;
   /** RegularExpression Id. */
-  int TRUE = 121;
+  int SHA224 = 121;
   /** RegularExpression Id. */
-  int FALSE = 122;
+  int SHA256 = 122;
   /** RegularExpression Id. */
-  int DATA = 123;
+  int SHA384 = 123;
   /** RegularExpression Id. */
-  int INSERT = 124;
+  int SHA512 = 124;
   /** RegularExpression Id. */
-  int DELETE = 125;
+  int TRUE = 125;
   /** RegularExpression Id. */
-  int INSERT_DATA = 126;
+  int FALSE = 126;
   /** RegularExpression Id. */
-  int DELETE_DATA = 127;
+  int DATA = 127;
   /** RegularExpression Id. */
-  int DELETE_WHERE = 128;
+  int INSERT = 128;
   /** RegularExpression Id. */
-  int LOAD = 129;
+  int DELETE = 129;
   /** RegularExpression Id. */
-  int CLEAR = 130;
+  int INSERT_DATA = 130;
   /** RegularExpression Id. */
-  int CREATE = 131;
+  int DELETE_DATA = 131;
   /** RegularExpression Id. */
-  int ADD = 132;
+  int DELETE_WHERE = 132;
   /** RegularExpression Id. */
-  int MOVE = 133;
+  int LOAD = 133;
   /** RegularExpression Id. */
-  int COPY = 134;
+  int CLEAR = 134;
   /** RegularExpression Id. */
-  int META = 135;
+  int CREATE = 135;
   /** RegularExpression Id. */
-  int SILENT = 136;
+  int ADD = 136;
   /** RegularExpression Id. */
-  int DROP = 137;
+  int MOVE = 137;
   /** RegularExpression Id. */
-  int INTO = 138;
+  int COPY = 138;
   /** RegularExpression Id. */
-  int TO = 139;
+  int META = 139;
   /** RegularExpression Id. */
-  int DFT = 140;
+  int SILENT = 140;
   /** RegularExpression Id. */
-  int ALL = 141;
+  int DROP = 141;
   /** RegularExpression Id. */
-  int WITH = 142;
+  int INTO = 142;
   /** RegularExpression Id. */
-  int USING = 143;
+  int TO = 143;
   /** RegularExpression Id. */
-  int DIGITS = 144;
+  int DFT = 144;
   /** RegularExpression Id. */
-  int INTEGER = 145;
+  int ALL = 145;
   /** RegularExpression Id. */
-  int DECIMAL = 146;
+  int WITH = 146;
   /** RegularExpression Id. */
-  int DOUBLE = 147;
+  int USING = 147;
   /** RegularExpression Id. */
-  int INTEGER_POSITIVE = 148;
+  int DIGITS = 148;
   /** RegularExpression Id. */
-  int DECIMAL_POSITIVE = 149;
+  int INTEGER = 149;
   /** RegularExpression Id. */
-  int DOUBLE_POSITIVE = 150;
+  int DECIMAL = 150;
   /** RegularExpression Id. */
-  int INTEGER_NEGATIVE = 151;
+  int DOUBLE = 151;
   /** RegularExpression Id. */
-  int DECIMAL_NEGATIVE = 152;
+  int INTEGER_POSITIVE = 152;
   /** RegularExpression Id. */
-  int DOUBLE_NEGATIVE = 153;
+  int DECIMAL_POSITIVE = 153;
   /** RegularExpression Id. */
-  int EXPONENT = 154;
+  int DOUBLE_POSITIVE = 154;
   /** RegularExpression Id. */
-  int QUOTE_3D = 155;
+  int INTEGER_NEGATIVE = 155;
   /** RegularExpression Id. */
-  int QUOTE_3S = 156;
+  int DECIMAL_NEGATIVE = 156;
   /** RegularExpression Id. */
-  int ECHAR = 157;
+  int DOUBLE_NEGATIVE = 157;
   /** RegularExpression Id. */
-  int UCHAR = 158;
+  int EXPONENT = 158;
   /** RegularExpression Id. */
-  int UCHAR4 = 159;
+  int QUOTE_3D = 159;
   /** RegularExpression Id. */
-  int UCHAR8 = 160;
+  int QUOTE_3S = 160;
   /** RegularExpression Id. */
-  int STRING_LITERAL1 = 161;
+  int ECHAR = 161;
   /** RegularExpression Id. */
-  int STRING_LITERAL2 = 162;
+  int UCHAR = 162;
   /** RegularExpression Id. */
-  int STRING_LITERAL_LONG1 = 163;
+  int UCHAR4 = 163;
   /** RegularExpression Id. */
-  int STRING_LITERAL_LONG2 = 164;
+  int UCHAR8 = 164;
   /** RegularExpression Id. */
-  int LPAREN = 165;
+  int STRING_LITERAL1 = 165;
   /** RegularExpression Id. */
-  int RPAREN = 166;
+  int STRING_LITERAL2 = 166;
   /** RegularExpression Id. */
-  int NIL = 167;
+  int STRING_LITERAL_LONG1 = 167;
   /** RegularExpression Id. */
-  int LBRACE = 168;
+  int STRING_LITERAL_LONG2 = 168;
   /** RegularExpression Id. */
-  int RBRACE = 169;
+  int LPAREN = 169;
   /** RegularExpression Id. */
-  int LBRACKET = 170;
+  int RPAREN = 170;
   /** RegularExpression Id. */
-  int RBRACKET = 171;
+  int NIL = 171;
   /** RegularExpression Id. */
-  int ANON = 172;
+  int LBRACE = 172;
   /** RegularExpression Id. */
-  int SEMICOLON = 173;
+  int RBRACE = 173;
   /** RegularExpression Id. */
-  int COMMA = 174;
+  int LBRACKET = 174;
   /** RegularExpression Id. */
-  int DOT = 175;
+  int RBRACKET = 175;
   /** RegularExpression Id. */
-  int EQ = 176;
+  int ANON = 176;
   /** RegularExpression Id. */
-  int NE = 177;
+  int SEMICOLON = 177;
   /** RegularExpression Id. */
-  int GT = 178;
+  int COMMA = 178;
   /** RegularExpression Id. */
-  int LT = 179;
+  int DOT = 179;
   /** RegularExpression Id. */
-  int LE = 180;
+  int EQ = 180;
   /** RegularExpression Id. */
-  int GE = 181;
+  int NE = 181;
   /** RegularExpression Id. */
-  int BANG = 182;
+  int GT = 182;
   /** RegularExpression Id. */
-  int TILDE = 183;
+  int LT = 183;
   /** RegularExpression Id. */
-  int COLON = 184;
+  int LE = 184;
   /** RegularExpression Id. */
-  int SC_OR = 185;
+  int GE = 185;
   /** RegularExpression Id. */
-  int SC_AND = 186;
+  int GT2 = 186;
   /** RegularExpression Id. */
-  int PLUS = 187;
+  int LT2 = 187;
   /** RegularExpression Id. */
-  int MINUS = 188;
+  int L_ANN = 188;
   /** RegularExpression Id. */
-  int STAR = 189;
+  int R_ANN = 189;
   /** RegularExpression Id. */
-  int SLASH = 190;
+  int BANG = 190;
   /** RegularExpression Id. */
-  int DATATYPE = 191;
+  int TILDE = 191;
   /** RegularExpression Id. */
-  int AT = 192;
+  int COLON = 192;
   /** RegularExpression Id. */
-  int VBAR = 193;
+  int SC_OR = 193;
   /** RegularExpression Id. */
-  int CARAT = 194;
+  int SC_AND = 194;
   /** RegularExpression Id. */
-  int FPATH = 195;
+  int PLUS = 195;
   /** RegularExpression Id. */
-  int RPATH = 196;
+  int MINUS = 196;
   /** RegularExpression Id. */
-  int QMARK = 197;
+  int STAR = 197;
   /** RegularExpression Id. */
-  int PN_CHARS_BASE = 198;
+  int SLASH = 198;
   /** RegularExpression Id. */
-  int PN_CHARS_U = 199;
+  int DATATYPE = 199;
   /** RegularExpression Id. */
-  int PN_CHARS = 200;
+  int AT = 200;
   /** RegularExpression Id. */
-  int PN_PREFIX = 201;
+  int VBAR = 201;
   /** RegularExpression Id. */
-  int PN_LOCAL = 202;
+  int CARAT = 202;
   /** RegularExpression Id. */
-  int VARNAME = 203;
+  int FPATH = 203;
   /** RegularExpression Id. */
-  int PN_LOCAL_ESC = 204;
+  int RPATH = 204;
   /** RegularExpression Id. */
-  int PLX = 205;
+  int QMARK = 205;
   /** RegularExpression Id. */
-  int HEX = 206;
+  int PN_CHARS_BASE = 206;
   /** RegularExpression Id. */
-  int PERCENT = 207;
+  int PN_CHARS_U = 207;
   /** RegularExpression Id. */
-  int UNKNOWN = 208;
+  int PN_CHARS = 208;
+  /** RegularExpression Id. */
+  int PN_PREFIX = 209;
+  /** RegularExpression Id. */
+  int PN_LOCAL = 210;
+  /** RegularExpression Id. */
+  int VARNAME = 211;
+  /** RegularExpression Id. */
+  int PN_LOCAL_ESC = 212;
+  /** RegularExpression Id. */
+  int PLX = 213;
+  /** RegularExpression Id. */
+  int HEX = 214;
+  /** RegularExpression Id. */
+  int PERCENT = 215;
+  /** RegularExpression Id. */
+  int UNKNOWN = 216;
 
   /** Lexical state. */
   int DEFAULT = 0;
@@ -431,7 +447,6 @@ public interface SPARQLParser12Constants {
     "<SINGLE_LINE_COMMENT>",
     "<WS>",
     "<WSC>",
-    "\"\\ufeff\"",
     "<IRIref>",
     "<PNAME_NS>",
     "<PNAME_LN>",
@@ -468,6 +483,11 @@ public interface SPARQLParser12Constants {
     "\"minus\"",
     "\"bind\"",
     "\"service\"",
+    "\"TRIPLE\"",
+    "\"isTRIPLE\"",
+    "\"SUBJECT\"",
+    "\"PREDICATE\"",
+    "\"OBJECT\"",
     "\"exists\"",
     "\"not\"",
     "\"as\"",
@@ -604,6 +624,10 @@ public interface SPARQLParser12Constants {
     "\"<\"",
     "\"<=\"",
     "\">=\"",
+    "\">>\"",
+    "\"<<\"",
+    "\"{|\"",
+    "\"|}\"",
     "\"!\"",
     "\"~\"",
     "\":\"",

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/SPARQLParser12TokenManager.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/SPARQLParser12TokenManager.java
@@ -45,163 +45,160 @@ private int jjMoveStringLiteralDfa0_0(){
          jjmatchedKind = 1;
          return jjMoveNfa_0(0, 0);
       case 33:
-         jjmatchedKind = 182;
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x2000000000000L, 0x0L);
-      case 38:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x400000000000000L, 0x0L);
-      case 40:
-         jjmatchedKind = 165;
-         return jjMoveNfa_0(0, 0);
-      case 41:
-         jjmatchedKind = 166;
-         return jjMoveNfa_0(0, 0);
-      case 42:
-         jjmatchedKind = 189;
-         return jjMoveNfa_0(0, 0);
-      case 43:
-         jjmatchedKind = 187;
-         return jjMoveNfa_0(0, 0);
-      case 44:
-         jjmatchedKind = 174;
-         return jjMoveNfa_0(0, 0);
-      case 45:
-         jjmatchedKind = 188;
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x0L, 0x8L);
-      case 46:
-         jjmatchedKind = 175;
-         return jjMoveNfa_0(0, 0);
-      case 47:
          jjmatchedKind = 190;
-         return jjMoveNfa_0(0, 0);
-      case 58:
-         jjmatchedKind = 184;
-         return jjMoveNfa_0(0, 0);
-      case 59:
-         jjmatchedKind = 173;
-         return jjMoveNfa_0(0, 0);
-      case 60:
-         jjmatchedKind = 179;
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x10000000000000L, 0x10L);
-      case 61:
-         jjmatchedKind = 176;
-         return jjMoveNfa_0(0, 0);
-      case 62:
-         jjmatchedKind = 178;
          return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x20000000000000L, 0x0L);
-      case 63:
-         jjmatchedKind = 197;
-         return jjMoveNfa_0(0, 0);
-      case 64:
-         jjmatchedKind = 192;
-         return jjMoveNfa_0(0, 0);
-      case 65:
-         return jjMoveStringLiteralDfa1_0(0x211008408000000L, 0x1000000L, 0x2010L, 0x0L);
-      case 66:
-         return jjMoveStringLiteralDfa1_0(0x100080100000L, 0x88L, 0x0L, 0x0L);
-      case 67:
-         return jjMoveStringLiteralDfa1_0(0x20000004000000L, 0x812000010L, 0x4cL, 0x0L);
-      case 68:
-         return jjMoveStringLiteralDfa1_0(0x802800000L, 0x2800040000002000L, 0x1200L, 0x0L);
-      case 69:
-         return jjMoveStringLiteralDfa1_0(0x400000000000L, 0x400000000L, 0x0L, 0x0L);
-      case 70:
-         return jjMoveStringLiteralDfa1_0(0x2000000000L, 0x400000004000004L, 0x0L, 0x0L);
-      case 71:
-         return jjMoveStringLiteralDfa1_0(0x2010000000000L, 0x2L, 0x0L, 0x0L);
-      case 72:
-         return jjMoveStringLiteralDfa1_0(0x4000000000000L, 0x80000000000L, 0x0L, 0x0L);
-      case 73:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x10000000001f0160L, 0x400L, 0x0L);
-      case 76:
-         return jjMoveStringLiteralDfa1_0(0x10000000L, 0x20000c000L, 0x2L, 0x0L);
-      case 77:
-         return jjMoveStringLiteralDfa1_0(0xc0080000000000L, 0x8120000000000L, 0xa0L, 0x0L);
-      case 78:
-         return jjMoveStringLiteralDfa1_0(0x801000000000L, 0x1000000000000L, 0x0L, 0x0L);
-      case 79:
-         return jjMoveStringLiteralDfa1_0(0x20060000000L, 0x0L, 0x0L, 0x0L);
-      case 80:
-         return jjMoveStringLiteralDfa1_0(0x200000L, 0x0L, 0x0L, 0x0L);
-      case 82:
-         return jjMoveStringLiteralDfa1_0(0x1000000L, 0x88a00000L, 0x0L, 0x0L);
-      case 83:
-         return jjMoveStringLiteralDfa1_0(0x1d08200000400000L, 0x1f420f060401c01L, 0x100L, 0x0L);
-      case 84:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x200c00000000000L, 0x800L, 0x0L);
-      case 85:
-         return jjMoveStringLiteralDfa1_0(0x40200000000L, 0x2000100000200L, 0x8000L, 0x0L);
-      case 86:
-         return jjMoveStringLiteralDfa1_0(0xe000000100000000L, 0x0L, 0x0L, 0x0L);
-      case 87:
-         return jjMoveStringLiteralDfa1_0(0x4000000000L, 0x0L, 0x4000L, 0x0L);
-      case 89:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x10000000000L, 0x0L, 0x0L);
-      case 91:
-         jjmatchedKind = 170;
-         return jjMoveNfa_0(0, 0);
-      case 93:
-         jjmatchedKind = 171;
-         return jjMoveNfa_0(0, 0);
-      case 94:
-         jjmatchedKind = 194;
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x8000000000000000L, 0x0L);
-      case 97:
-         jjmatchedKind = 19;
-         return jjMoveStringLiteralDfa1_0(0x211008408000000L, 0x1000000L, 0x2010L, 0x0L);
-      case 98:
-         return jjMoveStringLiteralDfa1_0(0x100080100000L, 0x88L, 0x0L, 0x0L);
-      case 99:
-         return jjMoveStringLiteralDfa1_0(0x20000004000000L, 0x812000010L, 0x4cL, 0x0L);
-      case 100:
-         return jjMoveStringLiteralDfa1_0(0x802800000L, 0x2800040000002000L, 0x1200L, 0x0L);
-      case 101:
-         return jjMoveStringLiteralDfa1_0(0x400000000000L, 0x400000000L, 0x0L, 0x0L);
-      case 102:
-         return jjMoveStringLiteralDfa1_0(0x2000000000L, 0x400000004000004L, 0x0L, 0x0L);
-      case 103:
-         return jjMoveStringLiteralDfa1_0(0x2010000000000L, 0x2L, 0x0L, 0x0L);
-      case 104:
-         return jjMoveStringLiteralDfa1_0(0x4000000000000L, 0x80000000000L, 0x0L, 0x0L);
-      case 105:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x10000000001f0160L, 0x400L, 0x0L);
-      case 108:
-         return jjMoveStringLiteralDfa1_0(0x10000000L, 0x20000c000L, 0x2L, 0x0L);
-      case 109:
-         return jjMoveStringLiteralDfa1_0(0xc0080000000000L, 0x8120000000000L, 0xa0L, 0x0L);
-      case 110:
-         return jjMoveStringLiteralDfa1_0(0x801000000000L, 0x1000000000000L, 0x0L, 0x0L);
-      case 111:
-         return jjMoveStringLiteralDfa1_0(0x20060000000L, 0x0L, 0x0L, 0x0L);
-      case 112:
-         return jjMoveStringLiteralDfa1_0(0x200000L, 0x0L, 0x0L, 0x0L);
-      case 114:
-         return jjMoveStringLiteralDfa1_0(0x1000000L, 0x88a00000L, 0x0L, 0x0L);
-      case 115:
-         return jjMoveStringLiteralDfa1_0(0x1d08200000400000L, 0x1f420f060401c01L, 0x100L, 0x0L);
-      case 116:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x200c00000000000L, 0x800L, 0x0L);
-      case 117:
-         return jjMoveStringLiteralDfa1_0(0x40200000000L, 0x2000100000200L, 0x8000L, 0x0L);
-      case 118:
-         return jjMoveStringLiteralDfa1_0(0xe000000100000000L, 0x0L, 0x0L, 0x0L);
-      case 119:
-         return jjMoveStringLiteralDfa1_0(0x4000000000L, 0x0L, 0x4000L, 0x0L);
-      case 121:
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x10000000000L, 0x0L, 0x0L);
-      case 123:
-         jjmatchedKind = 168;
-         return jjMoveNfa_0(0, 0);
-      case 124:
-         jjmatchedKind = 193;
-         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x200000000000000L, 0x0L);
-      case 125:
+      case 38:
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x0L, 0x4L);
+      case 40:
          jjmatchedKind = 169;
          return jjMoveNfa_0(0, 0);
-      case 126:
-         jjmatchedKind = 183;
+      case 41:
+         jjmatchedKind = 170;
          return jjMoveNfa_0(0, 0);
-      case 65279:
-         jjmatchedKind = 9;
+      case 42:
+         jjmatchedKind = 197;
+         return jjMoveNfa_0(0, 0);
+      case 43:
+         jjmatchedKind = 195;
+         return jjMoveNfa_0(0, 0);
+      case 44:
+         jjmatchedKind = 178;
+         return jjMoveNfa_0(0, 0);
+      case 45:
+         jjmatchedKind = 196;
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x0L, 0x800L);
+      case 46:
+         jjmatchedKind = 179;
+         return jjMoveNfa_0(0, 0);
+      case 47:
+         jjmatchedKind = 198;
+         return jjMoveNfa_0(0, 0);
+      case 58:
+         jjmatchedKind = 192;
+         return jjMoveNfa_0(0, 0);
+      case 59:
+         jjmatchedKind = 177;
+         return jjMoveNfa_0(0, 0);
+      case 60:
+         jjmatchedKind = 183;
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x900000000000000L, 0x1000L);
+      case 61:
+         jjmatchedKind = 180;
+         return jjMoveNfa_0(0, 0);
+      case 62:
+         jjmatchedKind = 182;
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x600000000000000L, 0x0L);
+      case 63:
+         jjmatchedKind = 205;
+         return jjMoveNfa_0(0, 0);
+      case 64:
+         jjmatchedKind = 200;
+         return jjMoveNfa_0(0, 0);
+      case 65:
+         return jjMoveStringLiteralDfa1_0(0x2110004204000000L, 0x10000000L, 0x20100L, 0x0L);
+      case 66:
+         return jjMoveStringLiteralDfa1_0(0x80040080000L, 0x880L, 0x0L, 0x0L);
+      case 67:
+         return jjMoveStringLiteralDfa1_0(0x200000002000000L, 0x8120000100L, 0x4c0L, 0x0L);
+      case 68:
+         return jjMoveStringLiteralDfa1_0(0x401400000L, 0x8000400000020000L, 0x12002L, 0x0L);
+      case 69:
+         return jjMoveStringLiteralDfa1_0(0x4000000000000L, 0x4000000000L, 0x0L, 0x0L);
+      case 70:
+         return jjMoveStringLiteralDfa1_0(0x1000000000L, 0x4000000040000040L, 0x0L, 0x0L);
+      case 71:
+         return jjMoveStringLiteralDfa1_0(0x20008000000000L, 0x20L, 0x0L, 0x0L);
+      case 72:
+         return jjMoveStringLiteralDfa1_0(0x40000000000000L, 0x800000000000L, 0x0L, 0x0L);
+      case 73:
+         return jjMoveStringLiteralDfa1_0(0x400000000000L, 0x1f01600L, 0x4001L, 0x0L);
+      case 76:
+         return jjMoveStringLiteralDfa1_0(0x8000000L, 0x20000c0000L, 0x20L, 0x0L);
+      case 77:
+         return jjMoveStringLiteralDfa1_0(0xc00040000000000L, 0x81200000000000L, 0xa00L, 0x0L);
+      case 78:
+         return jjMoveStringLiteralDfa1_0(0x8000800000000L, 0x10000000000000L, 0x0L, 0x0L);
+      case 79:
+         return jjMoveStringLiteralDfa1_0(0x2010030000000L, 0x0L, 0x0L, 0x0L);
+      case 80:
+         return jjMoveStringLiteralDfa1_0(0x1000000100000L, 0x0L, 0x0L, 0x0L);
+      case 82:
+         return jjMoveStringLiteralDfa1_0(0x800000L, 0x88a000000L, 0x0L, 0x0L);
+      case 83:
+         return jjMoveStringLiteralDfa1_0(0xd080900000200000L, 0x1f420f060401c011L, 0x1000L, 0x0L);
+      case 84:
+         return jjMoveStringLiteralDfa1_0(0x200000000000L, 0x200c000000000000L, 0x8000L, 0x0L);
+      case 85:
+         return jjMoveStringLiteralDfa1_0(0x20100000000L, 0x20001000002000L, 0x80000L, 0x0L);
+      case 86:
+         return jjMoveStringLiteralDfa1_0(0x80000000L, 0xeL, 0x0L, 0x0L);
+      case 87:
+         return jjMoveStringLiteralDfa1_0(0x2000000000L, 0x0L, 0x40000L, 0x0L);
+      case 89:
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x100000000000L, 0x0L, 0x0L);
+      case 91:
+         jjmatchedKind = 174;
+         return jjMoveNfa_0(0, 0);
+      case 93:
+         jjmatchedKind = 175;
+         return jjMoveNfa_0(0, 0);
+      case 94:
+         jjmatchedKind = 202;
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x0L, 0x80L);
+      case 97:
+         jjmatchedKind = 18;
+         return jjMoveStringLiteralDfa1_0(0x2110004204000000L, 0x10000000L, 0x20100L, 0x0L);
+      case 98:
+         return jjMoveStringLiteralDfa1_0(0x80040080000L, 0x880L, 0x0L, 0x0L);
+      case 99:
+         return jjMoveStringLiteralDfa1_0(0x200000002000000L, 0x8120000100L, 0x4c0L, 0x0L);
+      case 100:
+         return jjMoveStringLiteralDfa1_0(0x401400000L, 0x8000400000020000L, 0x12002L, 0x0L);
+      case 101:
+         return jjMoveStringLiteralDfa1_0(0x4000000000000L, 0x4000000000L, 0x0L, 0x0L);
+      case 102:
+         return jjMoveStringLiteralDfa1_0(0x1000000000L, 0x4000000040000040L, 0x0L, 0x0L);
+      case 103:
+         return jjMoveStringLiteralDfa1_0(0x20008000000000L, 0x20L, 0x0L, 0x0L);
+      case 104:
+         return jjMoveStringLiteralDfa1_0(0x40000000000000L, 0x800000000000L, 0x0L, 0x0L);
+      case 105:
+         return jjMoveStringLiteralDfa1_0(0x400000000000L, 0x1f01600L, 0x4001L, 0x0L);
+      case 108:
+         return jjMoveStringLiteralDfa1_0(0x8000000L, 0x20000c0000L, 0x20L, 0x0L);
+      case 109:
+         return jjMoveStringLiteralDfa1_0(0xc00040000000000L, 0x81200000000000L, 0xa00L, 0x0L);
+      case 110:
+         return jjMoveStringLiteralDfa1_0(0x8000800000000L, 0x10000000000000L, 0x0L, 0x0L);
+      case 111:
+         return jjMoveStringLiteralDfa1_0(0x2010030000000L, 0x0L, 0x0L, 0x0L);
+      case 112:
+         return jjMoveStringLiteralDfa1_0(0x1000000100000L, 0x0L, 0x0L, 0x0L);
+      case 114:
+         return jjMoveStringLiteralDfa1_0(0x800000L, 0x88a000000L, 0x0L, 0x0L);
+      case 115:
+         return jjMoveStringLiteralDfa1_0(0xd080900000200000L, 0x1f420f060401c011L, 0x1000L, 0x0L);
+      case 116:
+         return jjMoveStringLiteralDfa1_0(0x200000000000L, 0x200c000000000000L, 0x8000L, 0x0L);
+      case 117:
+         return jjMoveStringLiteralDfa1_0(0x20100000000L, 0x20001000002000L, 0x80000L, 0x0L);
+      case 118:
+         return jjMoveStringLiteralDfa1_0(0x80000000L, 0xeL, 0x0L, 0x0L);
+      case 119:
+         return jjMoveStringLiteralDfa1_0(0x2000000000L, 0x0L, 0x40000L, 0x0L);
+      case 121:
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x100000000000L, 0x0L, 0x0L);
+      case 123:
+         jjmatchedKind = 172;
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x1000000000000000L, 0x0L);
+      case 124:
+         jjmatchedKind = 201;
+         return jjMoveStringLiteralDfa1_0(0x0L, 0x0L, 0x2000000000000000L, 0x2L);
+      case 125:
+         jjmatchedKind = 173;
+         return jjMoveNfa_0(0, 0);
+      case 126:
+         jjmatchedKind = 191;
          return jjMoveNfa_0(0, 0);
       default :
          return jjMoveNfa_0(0, 0);
@@ -215,198 +212,222 @@ private int jjMoveStringLiteralDfa1_0(long active0, long active1, long active2, 
    switch(curChar)
    {
       case 38:
+         if ((active3 & 0x4L) != 0L)
+         {
+            jjmatchedKind = 194;
+            jjmatchedPos = 1;
+         }
+         break;
+      case 45:
+         if ((active3 & 0x1000L) != 0L)
+         {
+            jjmatchedKind = 204;
+            jjmatchedPos = 1;
+         }
+         break;
+      case 60:
+         if ((active2 & 0x800000000000000L) != 0L)
+         {
+            jjmatchedKind = 187;
+            jjmatchedPos = 1;
+         }
+         break;
+      case 61:
+         if ((active2 & 0x20000000000000L) != 0L)
+         {
+            jjmatchedKind = 181;
+            jjmatchedPos = 1;
+         }
+         else if ((active2 & 0x100000000000000L) != 0L)
+         {
+            jjmatchedKind = 184;
+            jjmatchedPos = 1;
+         }
+         else if ((active2 & 0x200000000000000L) != 0L)
+         {
+            jjmatchedKind = 185;
+            jjmatchedPos = 1;
+         }
+         break;
+      case 62:
          if ((active2 & 0x400000000000000L) != 0L)
          {
             jjmatchedKind = 186;
             jjmatchedPos = 1;
          }
-         break;
-      case 45:
-         if ((active3 & 0x10L) != 0L)
+         else if ((active3 & 0x800L) != 0L)
          {
-            jjmatchedKind = 196;
-            jjmatchedPos = 1;
-         }
-         break;
-      case 61:
-         if ((active2 & 0x2000000000000L) != 0L)
-         {
-            jjmatchedKind = 177;
-            jjmatchedPos = 1;
-         }
-         else if ((active2 & 0x10000000000000L) != 0L)
-         {
-            jjmatchedKind = 180;
-            jjmatchedPos = 1;
-         }
-         else if ((active2 & 0x20000000000000L) != 0L)
-         {
-            jjmatchedKind = 181;
-            jjmatchedPos = 1;
-         }
-         break;
-      case 62:
-         if ((active3 & 0x8L) != 0L)
-         {
-            jjmatchedKind = 195;
+            jjmatchedKind = 203;
             jjmatchedPos = 1;
          }
          break;
       case 65:
-         return jjMoveStringLiteralDfa2_0(active0, 0xe084001100100000L, active1, 0xc00040000c0e001L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x840000880080000L, active1, 0xc00040000c0e001eL, active2, 0L, active3, 0L);
       case 66:
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x1000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x2000000000000L, active1, 0x10000000L, active2, 0L, active3, 0L);
       case 67:
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x300000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x3000000000L, active2, 0L, active3, 0L);
       case 68:
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x8000000000000L, active2, 0x10L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x80000000000000L, active2, 0x100L, active3, 0L);
       case 69:
-         return jjMoveStringLiteralDfa2_0(active0, 0x8200803400000L, active1, 0x2000210082200000L, active2, 0x1080L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x80100401a00000L, active1, 0x2100822000000L, active2, 0x10802L, active3, 0L);
       case 70:
-         if ((active1 & 0x40L) != 0L)
+         if ((active1 & 0x400L) != 0L)
          {
-            jjmatchedKind = 70;
+            jjmatchedKind = 74;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x20000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x10000000L, active1, 0L, active2, 0L, active3, 0L);
       case 71:
-         return jjMoveStringLiteralDfa2_0(active0, 0x10000000000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x100000000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 72:
-         return jjMoveStringLiteralDfa2_0(active0, 0x4000000000L, active1, 0x1f0000000000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x2000000000L, active1, 0x1f00000000000000L, active2, 0L, active3, 0L);
       case 73:
-         return jjMoveStringLiteralDfa2_0(active0, 0x40180010800000L, active1, 0x500000000004L, active2, 0x4100L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x4000c0008400000L, active1, 0x5000000000040L, active2, 0x41000L, active3, 0L);
       case 76:
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x4000000L, active2, 0x2004L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x40000000L, active2, 0x20040L, active3, 0L);
       case 78:
-         if ((active1 & 0x20L) != 0L)
+         if ((active1 & 0x200L) != 0L)
          {
-            jjmatchedKind = 69;
+            jjmatchedKind = 73;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x48200000000L, active1, 0x1000000400000080L, active2, 0x400L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x24100000000L, active1, 0x4000000800L, active2, 0x4001L, active3, 0L);
       case 79:
-         if ((active2 & 0x800L) != 0L)
+         if ((active2 & 0x8000L) != 0L)
          {
-            jjmatchedKind = 139;
+            jjmatchedKind = 143;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x20800004000000L, active1, 0x10a0818000018L, active2, 0x62L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x208000002000000L, active1, 0x10a08180000180L, active2, 0x620L, active3, 0L);
       case 80:
-         return jjMoveStringLiteralDfa2_0(active0, 0x20000000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x10000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 82:
-         return jjMoveStringLiteralDfa2_0(active0, 0x2012040200000L, active1, 0x200000000000302L, active2, 0x208L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x21209020100000L, active1, 0x2000000000003020L, active2, 0x2080L, active3, 0L);
       case 83:
-         if ((active0 & 0x1000000000000L) != 0L)
+         if ((active0 & 0x10000000000000L) != 0L)
          {
-            jjmatchedKind = 48;
+            jjmatchedKind = 52;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x408000000L, active1, 0x1f0000L, active2, 0x8000L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x400204000000L, active1, 0x1f00000L, active2, 0x80000L, active3, 0L);
       case 84:
-         return jjMoveStringLiteralDfa2_0(active0, 0x1c00000000000000L, active1, 0x400f040001c00L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0xc000000000000000L, active1, 0x400f040001c001L, active2, 0L, active3, 0L);
       case 85:
-         return jjMoveStringLiteralDfa2_0(active0, 0x100000000000000L, active1, 0x2000020000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x1000800000000000L, active1, 0x20000200000000L, active2, 0L, active3, 0L);
       case 86:
-         return jjMoveStringLiteralDfa2_0(active0, 0x200000000000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x2000000000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 88:
-         return jjMoveStringLiteralDfa2_0(active0, 0x400000000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x4000000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 89:
-         if ((active0 & 0x80000000L) != 0L)
+         if ((active0 & 0x40000000L) != 0L)
          {
-            jjmatchedKind = 31;
+            jjmatchedKind = 30;
             jjmatchedPos = 1;
          }
          break;
       case 90:
-         if ((active1 & 0x800000000000L) != 0L)
+         if ((active1 & 0x8000000000000L) != 0L)
          {
-            jjmatchedKind = 111;
+            jjmatchedKind = 115;
             jjmatchedPos = 1;
          }
          break;
       case 94:
-         if ((active2 & 0x8000000000000000L) != 0L)
+         if ((active3 & 0x80L) != 0L)
          {
-            jjmatchedKind = 191;
+            jjmatchedKind = 199;
             jjmatchedPos = 1;
          }
          break;
       case 97:
-         return jjMoveStringLiteralDfa2_0(active0, 0xe084001100100000L, active1, 0xc00040000c0e001L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x840000880080000L, active1, 0xc00040000c0e001eL, active2, 0L, active3, 0L);
       case 98:
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x1000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x2000000000000L, active1, 0x10000000L, active2, 0L, active3, 0L);
       case 99:
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x300000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x3000000000L, active2, 0L, active3, 0L);
       case 100:
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x8000000000000L, active2, 0x10L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x80000000000000L, active2, 0x100L, active3, 0L);
       case 101:
-         return jjMoveStringLiteralDfa2_0(active0, 0x8200803400000L, active1, 0x2000210082200000L, active2, 0x1080L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x80100401a00000L, active1, 0x2100822000000L, active2, 0x10802L, active3, 0L);
       case 102:
-         if ((active1 & 0x40L) != 0L)
+         if ((active1 & 0x400L) != 0L)
          {
-            jjmatchedKind = 70;
+            jjmatchedKind = 74;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x20000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x10000000L, active1, 0L, active2, 0L, active3, 0L);
       case 103:
-         return jjMoveStringLiteralDfa2_0(active0, 0x10000000000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x100000000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 104:
-         return jjMoveStringLiteralDfa2_0(active0, 0x4000000000L, active1, 0x1f0000000000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x2000000000L, active1, 0x1f00000000000000L, active2, 0L, active3, 0L);
       case 105:
-         return jjMoveStringLiteralDfa2_0(active0, 0x40180010800000L, active1, 0x500000000004L, active2, 0x4100L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x4000c0008400000L, active1, 0x5000000000040L, active2, 0x41000L, active3, 0L);
       case 108:
-         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x4000000L, active2, 0x2004L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0L, active1, 0x40000000L, active2, 0x20040L, active3, 0L);
       case 110:
-         if ((active1 & 0x20L) != 0L)
+         if ((active1 & 0x200L) != 0L)
          {
-            jjmatchedKind = 69;
+            jjmatchedKind = 73;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x48200000000L, active1, 0x1000000400000080L, active2, 0x400L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x24100000000L, active1, 0x4000000800L, active2, 0x4001L, active3, 0L);
       case 111:
-         if ((active2 & 0x800L) != 0L)
+         if ((active2 & 0x8000L) != 0L)
          {
-            jjmatchedKind = 139;
+            jjmatchedKind = 143;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x20800004000000L, active1, 0x10a0818000018L, active2, 0x62L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x208000002000000L, active1, 0x10a08180000180L, active2, 0x620L, active3, 0L);
       case 112:
-         return jjMoveStringLiteralDfa2_0(active0, 0x20000000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x10000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 114:
-         return jjMoveStringLiteralDfa2_0(active0, 0x2012040200000L, active1, 0x200000000000302L, active2, 0x208L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x21209020100000L, active1, 0x2000000000003020L, active2, 0x2080L, active3, 0L);
       case 115:
-         if ((active0 & 0x1000000000000L) != 0L)
+         if ((active0 & 0x10000000000000L) != 0L)
          {
-            jjmatchedKind = 48;
+            jjmatchedKind = 52;
             jjmatchedPos = 1;
          }
-         return jjMoveStringLiteralDfa2_0(active0, 0x408000000L, active1, 0x1f0000L, active2, 0x8000L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x400204000000L, active1, 0x1f00000L, active2, 0x80000L, active3, 0L);
       case 116:
-         return jjMoveStringLiteralDfa2_0(active0, 0x1c00000000000000L, active1, 0x400f040001c00L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0xc000000000000000L, active1, 0x400f040001c001L, active2, 0L, active3, 0L);
       case 117:
-         return jjMoveStringLiteralDfa2_0(active0, 0x100000000000000L, active1, 0x2000020000000L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x1000800000000000L, active1, 0x20000200000000L, active2, 0L, active3, 0L);
       case 118:
-         return jjMoveStringLiteralDfa2_0(active0, 0x200000000000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x2000000000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 120:
-         return jjMoveStringLiteralDfa2_0(active0, 0x400000000000L, active1, 0L, active2, 0L, active3, 0L);
+         return jjMoveStringLiteralDfa2_0(active0, 0x4000000000000L, active1, 0L, active2, 0L, active3, 0L);
       case 121:
-         if ((active0 & 0x80000000L) != 0L)
+         if ((active0 & 0x40000000L) != 0L)
          {
-            jjmatchedKind = 31;
+            jjmatchedKind = 30;
             jjmatchedPos = 1;
          }
          break;
       case 122:
-         if ((active1 & 0x800000000000L) != 0L)
+         if ((active1 & 0x8000000000000L) != 0L)
          {
-            jjmatchedKind = 111;
+            jjmatchedKind = 115;
             jjmatchedPos = 1;
          }
          break;
       case 124:
-         if ((active2 & 0x200000000000000L) != 0L)
+         if ((active2 & 0x1000000000000000L) != 0L)
          {
-            jjmatchedKind = 185;
+            jjmatchedKind = 188;
+            jjmatchedPos = 1;
+         }
+         else if ((active3 & 0x2L) != 0L)
+         {
+            jjmatchedKind = 193;
+            jjmatchedPos = 1;
+         }
+         break;
+      case 125:
+         if ((active2 & 0x2000000000000000L) != 0L)
+         {
+            jjmatchedKind = 189;
             jjmatchedPos = 1;
          }
          break;
@@ -425,267 +446,271 @@ private int jjMoveStringLiteralDfa2_0(long old0, long active0, long old1, long a
    switch(curChar)
    {
       case 53:
-         if ((active1 & 0x8000000000000L) != 0L)
+         if ((active1 & 0x80000000000000L) != 0L)
          {
-            jjmatchedKind = 115;
+            jjmatchedKind = 119;
             jjmatchedPos = 2;
          }
          break;
       case 65:
-         return jjMoveStringLiteralDfa3_0(active0, 0x10000000000L, active1, 0x1f0010300000010L, active2, 0x2L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x8000000000L, active1, 0x1f00103000000100L, active2, 0x20L);
       case 66:
-         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x20040000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x800000000000L, active1, 0x200400000L, active2, 0L);
       case 67:
-         if ((active0 & 0x400000000L) != 0L)
+         if ((active0 & 0x200000000L) != 0L)
          {
-            jjmatchedKind = 34;
+            jjmatchedKind = 33;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x200400000000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x2004000000000L, active2, 0L);
       case 68:
-         if ((active0 & 0x8000000000L) != 0L)
+         if ((active0 & 0x4000000000L) != 0L)
          {
-            jjmatchedKind = 39;
+            jjmatchedKind = 38;
             jjmatchedPos = 2;
          }
-         else if ((active2 & 0x10L) != 0L)
+         else if ((active2 & 0x100L) != 0L)
          {
-            jjmatchedKind = 132;
+            jjmatchedKind = 136;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x1c00000241000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0xc000000120800000L, active1, 0x1L, active2, 0L);
       case 69:
-         return jjMoveStringLiteralDfa3_0(active0, 0x4000200000L, active1, 0L, active2, 0xcL);
+         return jjMoveStringLiteralDfa3_0(active0, 0x1002000100000L, active1, 0L, active2, 0xc0L);
       case 70:
-         return jjMoveStringLiteralDfa3_0(active0, 0x20000000L, active1, 0L, active2, 0x1000L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x10000000L, active1, 0L, active2, 0x10000L);
       case 71:
-         if ((active0 & 0x10000000000000L) != 0L)
+         if ((active0 & 0x100000000000000L) != 0L)
          {
-            jjmatchedKind = 52;
+            jjmatchedKind = 56;
             jjmatchedPos = 2;
          }
-         else if ((active0 & 0x200000000000000L) != 0L)
+         else if ((active0 & 0x2000000000000000L) != 0L)
          {
-            jjmatchedKind = 57;
+            jjmatchedKind = 61;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x200000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x2000000L, active2, 0L);
       case 73:
-         if ((active1 & 0x100L) != 0L)
+         if ((active1 & 0x1000L) != 0L)
          {
-            jjmatchedKind = 72;
+            jjmatchedKind = 76;
             jjmatchedPos = 2;
          }
-         else if ((active1 & 0x200L) != 0L)
+         else if ((active1 & 0x2000L) != 0L)
          {
-            jjmatchedKind = 73;
+            jjmatchedKind = 77;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x440000000000L, active1, 0x2000002020000L, active2, 0x8000L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x4220000000000L, active1, 0x20000020200000L, active2, 0x80000L);
+      case 74:
+         return jjMoveStringLiteralDfa3_0(active0, 0x2000000000000L, active1, 0L, active2, 0L);
       case 75:
-         if ((active0 & 0x8000000L) != 0L)
+         if ((active0 & 0x4000000L) != 0L)
          {
-            jjmatchedKind = 27;
+            jjmatchedKind = 26;
             jjmatchedPos = 2;
          }
          break;
       case 76:
-         if ((active2 & 0x2000L) != 0L)
+         if ((active2 & 0x20000L) != 0L)
          {
-            jjmatchedKind = 141;
+            jjmatchedKind = 145;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x100400000L, active1, 0x2400000000080004L, active2, 0x100L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x80200000L, active1, 0x4000000000800040L, active2, 0x1002L);
       case 77:
-         if ((active0 & 0x100000000000000L) != 0L)
+         if ((active0 & 0x1000000000000000L) != 0L)
          {
-            jjmatchedKind = 56;
+            jjmatchedKind = 60;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x1010000000L, active1, 0x400000400001L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x808000000L, active1, 0x4000004000010L, active2, 0L);
       case 78:
-         if ((active0 & 0x40000000000000L) != 0L)
+         if ((active0 & 0x400000000000000L) != 0L)
          {
-            jjmatchedKind = 54;
+            jjmatchedKind = 58;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x180004000000L, active1, 0x12081090c000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0xc0002000000L, active1, 0x12081090c0000L, active2, 0L);
       case 79:
-         return jjMoveStringLiteralDfa3_0(active0, 0x2002000000000L, active1, 0x4000082L, active2, 0x200L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x20001000000000L, active1, 0x40000820L, active2, 0x2000L);
       case 80:
-         return jjMoveStringLiteralDfa3_0(active0, 0x8000000000000L, active1, 0x80000000L, active2, 0x40L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x80000000000000L, active1, 0x800000000L, active2, 0x400L);
       case 82:
-         if ((active1 & 0x400L) != 0L)
+         if ((active1 & 0x4000L) != 0L)
          {
-            jjmatchedKind = 74;
+            jjmatchedKind = 78;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0xe000200000000000L, active1, 0x400f040001800L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x100000000000L, active1, 0x400f040001800eL, active2, 0L);
       case 83:
-         if ((active1 & 0x1000000L) != 0L)
+         if ((active1 & 0x10000000L) != 0L)
          {
-            jjmatchedKind = 88;
+            jjmatchedKind = 92;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x802900000L, active1, 0x1000000000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x401480000L, active1, 0L, active2, 0x1L);
       case 84:
-         if ((active0 & 0x800000000000L) != 0L)
+         if ((active0 & 0x8000000000000L) != 0L)
          {
-            jjmatchedKind = 47;
+            jjmatchedKind = 51;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x20000000000L, active1, 0x800000000002000L, active2, 0x4480L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x410000000000L, active1, 0x8000000000020000L, active2, 0x44800L);
       case 85:
-         return jjMoveStringLiteralDfa3_0(active0, 0x20000000000000L, active1, 0x200080008010008L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x200000000000000L, active1, 0x2000800080100080L, active2, 0L);
       case 86:
-         return jjMoveStringLiteralDfa3_0(active0, 0x4000000000000L, active1, 0L, active2, 0x20L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x40000000000000L, active1, 0L, active2, 0x200L);
       case 87:
-         if ((active1 & 0x1000000000000L) != 0L)
+         if ((active1 & 0x10000000000000L) != 0L)
          {
-            jjmatchedKind = 112;
+            jjmatchedKind = 116;
             jjmatchedPos = 2;
          }
          break;
       case 88:
-         if ((active0 & 0x80000000000000L) != 0L)
+         if ((active0 & 0x800000000000000L) != 0L)
          {
-            jjmatchedKind = 55;
+            jjmatchedKind = 59;
             jjmatchedPos = 2;
          }
          break;
       case 89:
-         if ((active1 & 0x40000000000L) != 0L)
+         if ((active1 & 0x400000000000L) != 0L)
          {
-            jjmatchedKind = 106;
+            jjmatchedKind = 110;
             jjmatchedPos = 2;
          }
          break;
       case 97:
-         return jjMoveStringLiteralDfa3_0(active0, 0x10000000000L, active1, 0x1f0010300000010L, active2, 0x2L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x8000000000L, active1, 0x1f00103000000100L, active2, 0x20L);
       case 98:
-         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x20040000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x800000000000L, active1, 0x200400000L, active2, 0L);
       case 99:
-         if ((active0 & 0x400000000L) != 0L)
+         if ((active0 & 0x200000000L) != 0L)
          {
-            jjmatchedKind = 34;
+            jjmatchedKind = 33;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x200400000000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x2004000000000L, active2, 0L);
       case 100:
-         if ((active0 & 0x8000000000L) != 0L)
+         if ((active0 & 0x4000000000L) != 0L)
          {
-            jjmatchedKind = 39;
+            jjmatchedKind = 38;
             jjmatchedPos = 2;
          }
-         else if ((active2 & 0x10L) != 0L)
+         else if ((active2 & 0x100L) != 0L)
          {
-            jjmatchedKind = 132;
+            jjmatchedKind = 136;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x1c00000241000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0xc000000120800000L, active1, 0x1L, active2, 0L);
       case 101:
-         return jjMoveStringLiteralDfa3_0(active0, 0x4000200000L, active1, 0L, active2, 0xcL);
+         return jjMoveStringLiteralDfa3_0(active0, 0x1002000100000L, active1, 0L, active2, 0xc0L);
       case 102:
-         return jjMoveStringLiteralDfa3_0(active0, 0x20000000L, active1, 0L, active2, 0x1000L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x10000000L, active1, 0L, active2, 0x10000L);
       case 103:
-         if ((active0 & 0x10000000000000L) != 0L)
-         {
-            jjmatchedKind = 52;
-            jjmatchedPos = 2;
-         }
-         else if ((active0 & 0x200000000000000L) != 0L)
-         {
-            jjmatchedKind = 57;
-            jjmatchedPos = 2;
-         }
-         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x200000L, active2, 0L);
-      case 105:
-         if ((active1 & 0x100L) != 0L)
-         {
-            jjmatchedKind = 72;
-            jjmatchedPos = 2;
-         }
-         else if ((active1 & 0x200L) != 0L)
-         {
-            jjmatchedKind = 73;
-            jjmatchedPos = 2;
-         }
-         return jjMoveStringLiteralDfa3_0(active0, 0x440000000000L, active1, 0x2000002020000L, active2, 0x8000L);
-      case 107:
-         if ((active0 & 0x8000000L) != 0L)
-         {
-            jjmatchedKind = 27;
-            jjmatchedPos = 2;
-         }
-         break;
-      case 108:
-         if ((active2 & 0x2000L) != 0L)
-         {
-            jjmatchedKind = 141;
-            jjmatchedPos = 2;
-         }
-         return jjMoveStringLiteralDfa3_0(active0, 0x100400000L, active1, 0x2400000000080004L, active2, 0x100L);
-      case 109:
          if ((active0 & 0x100000000000000L) != 0L)
          {
             jjmatchedKind = 56;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x1010000000L, active1, 0x400000400001L, active2, 0L);
+         else if ((active0 & 0x2000000000000000L) != 0L)
+         {
+            jjmatchedKind = 61;
+            jjmatchedPos = 2;
+         }
+         return jjMoveStringLiteralDfa3_0(active0, 0L, active1, 0x2000000L, active2, 0L);
+      case 105:
+         if ((active1 & 0x1000L) != 0L)
+         {
+            jjmatchedKind = 76;
+            jjmatchedPos = 2;
+         }
+         else if ((active1 & 0x2000L) != 0L)
+         {
+            jjmatchedKind = 77;
+            jjmatchedPos = 2;
+         }
+         return jjMoveStringLiteralDfa3_0(active0, 0x4220000000000L, active1, 0x20000020200000L, active2, 0x80000L);
+      case 106:
+         return jjMoveStringLiteralDfa3_0(active0, 0x2000000000000L, active1, 0L, active2, 0L);
+      case 107:
+         if ((active0 & 0x4000000L) != 0L)
+         {
+            jjmatchedKind = 26;
+            jjmatchedPos = 2;
+         }
+         break;
+      case 108:
+         if ((active2 & 0x20000L) != 0L)
+         {
+            jjmatchedKind = 145;
+            jjmatchedPos = 2;
+         }
+         return jjMoveStringLiteralDfa3_0(active0, 0x80200000L, active1, 0x4000000000800040L, active2, 0x1002L);
+      case 109:
+         if ((active0 & 0x1000000000000000L) != 0L)
+         {
+            jjmatchedKind = 60;
+            jjmatchedPos = 2;
+         }
+         return jjMoveStringLiteralDfa3_0(active0, 0x808000000L, active1, 0x4000004000010L, active2, 0L);
       case 110:
-         if ((active0 & 0x40000000000000L) != 0L)
+         if ((active0 & 0x400000000000000L) != 0L)
          {
-            jjmatchedKind = 54;
+            jjmatchedKind = 58;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x180004000000L, active1, 0x12081090c000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0xc0002000000L, active1, 0x12081090c0000L, active2, 0L);
       case 111:
-         return jjMoveStringLiteralDfa3_0(active0, 0x2002000000000L, active1, 0x4000082L, active2, 0x200L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x20001000000000L, active1, 0x40000820L, active2, 0x2000L);
       case 112:
-         return jjMoveStringLiteralDfa3_0(active0, 0x8000000000000L, active1, 0x80000000L, active2, 0x40L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x80000000000000L, active1, 0x800000000L, active2, 0x400L);
       case 114:
-         if ((active1 & 0x400L) != 0L)
+         if ((active1 & 0x4000L) != 0L)
          {
-            jjmatchedKind = 74;
+            jjmatchedKind = 78;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0xe000200000000000L, active1, 0x400f040001800L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x100000000000L, active1, 0x400f040001800eL, active2, 0L);
       case 115:
-         if ((active1 & 0x1000000L) != 0L)
+         if ((active1 & 0x10000000L) != 0L)
          {
-            jjmatchedKind = 88;
+            jjmatchedKind = 92;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x802900000L, active1, 0x1000000000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x401480000L, active1, 0L, active2, 0x1L);
       case 116:
-         if ((active0 & 0x800000000000L) != 0L)
+         if ((active0 & 0x8000000000000L) != 0L)
          {
-            jjmatchedKind = 47;
+            jjmatchedKind = 51;
             jjmatchedPos = 2;
          }
-         return jjMoveStringLiteralDfa3_0(active0, 0x20000000000L, active1, 0x800000000002000L, active2, 0x4480L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x410000000000L, active1, 0x8000000000020000L, active2, 0x44800L);
       case 117:
-         return jjMoveStringLiteralDfa3_0(active0, 0x20000000000000L, active1, 0x200080008010008L, active2, 0L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x200000000000000L, active1, 0x2000800080100080L, active2, 0L);
       case 118:
-         return jjMoveStringLiteralDfa3_0(active0, 0x4000000000000L, active1, 0L, active2, 0x20L);
+         return jjMoveStringLiteralDfa3_0(active0, 0x40000000000000L, active1, 0L, active2, 0x200L);
       case 119:
-         if ((active1 & 0x1000000000000L) != 0L)
+         if ((active1 & 0x10000000000000L) != 0L)
          {
-            jjmatchedKind = 112;
+            jjmatchedKind = 116;
             jjmatchedPos = 2;
          }
          break;
       case 120:
-         if ((active0 & 0x80000000000000L) != 0L)
+         if ((active0 & 0x800000000000000L) != 0L)
          {
-            jjmatchedKind = 55;
+            jjmatchedKind = 59;
             jjmatchedPos = 2;
          }
          break;
       case 121:
-         if ((active1 & 0x40000000000L) != 0L)
+         if ((active1 & 0x400000000000L) != 0L)
          {
-            jjmatchedKind = 106;
+            jjmatchedKind = 110;
             jjmatchedPos = 2;
          }
          break;
@@ -704,70 +729,53 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
    switch(curChar)
    {
       case 49:
-         if ((active1 & 0x10000000000000L) != 0L)
+         if ((active1 & 0x100000000000000L) != 0L)
          {
-            jjmatchedKind = 116;
+            jjmatchedKind = 120;
             jjmatchedPos = 3;
          }
          break;
       case 50:
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x60000000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x600000000000000L, active2, 0L);
       case 51:
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x80000000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x800000000000000L, active2, 0L);
       case 53:
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x100000000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x1000000000000000L, active2, 0L);
       case 65:
-         if ((active1 & 0x800000000000000L) != 0L)
+         if ((active1 & 0x8000000000000000L) != 0L)
          {
-            jjmatchedKind = 123;
+            jjmatchedKind = 127;
             jjmatchedPos = 3;
          }
-         else if ((active2 & 0x80L) != 0L)
+         else if ((active2 & 0x800L) != 0L)
          {
-            jjmatchedKind = 135;
+            jjmatchedKind = 139;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x8000000000000L, active1, 0x8000002000L, active2, 0x100cL);
+         return jjMoveStringLiteralDfa4_0(active0, 0x80000000000000L, active1, 0x80000020000L, active2, 0x100c0L);
       case 66:
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x4000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x40000000000L, active2, 0L);
       case 67:
-         if ((active0 & 0x800000000L) != 0L)
+         if ((active0 & 0x400000000L) != 0L)
          {
-            jjmatchedKind = 35;
+            jjmatchedKind = 34;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x2000000L, active1, 0x10000000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x1000000L, active1, 0x100000000L, active2, 0L);
       case 68:
-         if ((active0 & 0x100000000000L) != 0L)
+         if ((active0 & 0x80000000000L) != 0L)
          {
-            jjmatchedKind = 44;
+            jjmatchedKind = 43;
             jjmatchedPos = 3;
          }
-         else if ((active1 & 0x800000L) != 0L)
+         else if ((active1 & 0x8000000L) != 0L)
          {
-            jjmatchedKind = 87;
+            jjmatchedKind = 91;
             jjmatchedPos = 3;
          }
-         else if ((active1 & 0x2000000000000L) != 0L)
+         else if ((active1 & 0x20000000000000L) != 0L)
          {
-            jjmatchedKind = 113;
-            jjmatchedPos = 3;
-         }
-         else if ((active2 & 0x2L) != 0L)
-         {
-            jjmatchedKind = 129;
-            jjmatchedPos = 3;
-         }
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x1080L, active2, 0L);
-      case 69:
-         if ((active0 & 0x100000L) != 0L)
-         {
-            jjmatchedKind = 20;
-            jjmatchedPos = 3;
-         }
-         else if ((active1 & 0x200000000000000L) != 0L)
-         {
-            jjmatchedKind = 121;
+            jjmatchedKind = 117;
             jjmatchedPos = 3;
          }
          else if ((active2 & 0x20L) != 0L)
@@ -775,131 +783,133 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
             jjmatchedKind = 133;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x1c00001240400000L, active1, 0x3000402000600000L, active2, 0x100L);
-      case 70:
-         return jjMoveStringLiteralDfa4_0(active0, 0x200000L, active1, 0L, active2, 0L);
-      case 71:
-         if ((active1 & 0x4000L) != 0L)
+         return jjMoveStringLiteralDfa4_0(active0, 0x1000000000000L, active1, 0x10800L, active2, 0L);
+      case 69:
+         if ((active0 & 0x80000L) != 0L)
          {
-            jjmatchedKind = 78;
+            jjmatchedKind = 19;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x8000L, active2, 0L);
-      case 72:
-         if ((active2 & 0x4000L) != 0L)
+         else if ((active1 & 0x2000000000000000L) != 0L)
          {
-            jjmatchedKind = 142;
+            jjmatchedKind = 125;
+            jjmatchedPos = 3;
+         }
+         else if ((active2 & 0x200L) != 0L)
+         {
+            jjmatchedKind = 137;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0xc002000920200000L, active1, 0x4020006000001L, active2, 0x1003L);
+      case 70:
+         return jjMoveStringLiteralDfa4_0(active0, 0x100000L, active1, 0L, active2, 0L);
+      case 71:
+         if ((active1 & 0x40000L) != 0L)
+         {
+            jjmatchedKind = 82;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x80000L, active2, 0L);
+      case 72:
+         if ((active2 & 0x40000L) != 0L)
+         {
+            jjmatchedKind = 146;
             jjmatchedPos = 3;
          }
          break;
       case 73:
-         return jjMoveStringLiteralDfa4_0(active0, 0x2004020010000000L, active1, 0x80000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x40010008000000L, active1, 0x800002L, active2, 0L);
+      case 74:
+         return jjMoveStringLiteralDfa4_0(active0, 0x800000000000L, active1, 0L, active2, 0L);
       case 76:
-         if ((active1 & 0x2000000L) != 0L)
+         if ((active1 & 0x20000000L) != 0L)
          {
-            jjmatchedKind = 89;
+            jjmatchedKind = 93;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0xc0040810L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0xc00408100L, active2, 0L);
       case 77:
-         if ((active0 & 0x2000000000L) != 0L)
+         if ((active0 & 0x1000000000L) != 0L)
          {
-            jjmatchedKind = 37;
+            jjmatchedKind = 36;
             jjmatchedPos = 3;
          }
          break;
       case 78:
-         return jjMoveStringLiteralDfa4_0(active0, 0x20000000000000L, active1, 0x8000008L, active2, 0x8000L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x200000000000000L, active1, 0x80000080L, active2, 0x80000L);
       case 79:
+         if ((active2 & 0x4000L) != 0L)
+         {
+            jjmatchedKind = 142;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0x20000000000L, active1, 0x2004040000000L, active2, 0L);
+      case 80:
+         if ((active2 & 0x2000L) != 0L)
+         {
+            jjmatchedKind = 141;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0x208000000000L, active1, 0x10L, active2, 0L);
+      case 82:
+         if ((active1 & 0x100000000000L) != 0L)
+         {
+            jjmatchedKind = 108;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0x402000000000L, active1, 0x800000300000L, active2, 0L);
+      case 83:
+         return jjMoveStringLiteralDfa4_0(active0, 0x4000012000000L, active1, 0x4000013200000000L, active2, 0L);
+      case 84:
+         return jjMoveStringLiteralDfa4_0(active0, 0x400000L, active1, 0x208000000040L, active2, 0L);
+      case 85:
+         return jjMoveStringLiteralDfa4_0(active0, 0x20040080800000L, active1, 0x41000001000020L, active2, 0L);
+      case 86:
+         return jjMoveStringLiteralDfa4_0(active0, 0x100000000000L, active1, 0L, active2, 0L);
+      case 89:
          if ((active2 & 0x400L) != 0L)
          {
             jjmatchedKind = 138;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x40000000000L, active1, 0x200404000000L, active2, 0L);
-      case 80:
-         if ((active2 & 0x200L) != 0L)
-         {
-            jjmatchedKind = 137;
-            jjmatchedPos = 3;
-         }
-         return jjMoveStringLiteralDfa4_0(active0, 0x10000000000L, active1, 0x1L, active2, 0L);
-      case 82:
-         if ((active1 & 0x10000000000L) != 0L)
-         {
-            jjmatchedKind = 104;
-            jjmatchedPos = 3;
-         }
-         return jjMoveStringLiteralDfa4_0(active0, 0x4000000000L, active1, 0x80000030000L, active2, 0L);
-      case 83:
-         return jjMoveStringLiteralDfa4_0(active0, 0x400024000000L, active1, 0x400001320000000L, active2, 0L);
-      case 84:
-         return jjMoveStringLiteralDfa4_0(active0, 0x800000L, active1, 0x20800000004L, active2, 0L);
-      case 85:
-         return jjMoveStringLiteralDfa4_0(active0, 0x2080101000000L, active1, 0x4100000100002L, active2, 0L);
-      case 86:
-         return jjMoveStringLiteralDfa4_0(active0, 0x200000000000L, active1, 0L, active2, 0L);
-      case 89:
-         if ((active2 & 0x40L) != 0L)
-         {
-            jjmatchedKind = 134;
-            jjmatchedPos = 3;
-         }
          break;
       case 95:
-         return jjMoveStringLiteralDfa4_0(active0, 0xc000000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0xcL, active2, 0L);
       case 97:
-         if ((active1 & 0x800000000000000L) != 0L)
+         if ((active1 & 0x8000000000000000L) != 0L)
          {
-            jjmatchedKind = 123;
+            jjmatchedKind = 127;
             jjmatchedPos = 3;
          }
-         else if ((active2 & 0x80L) != 0L)
+         else if ((active2 & 0x800L) != 0L)
          {
-            jjmatchedKind = 135;
+            jjmatchedKind = 139;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x8000000000000L, active1, 0x8000002000L, active2, 0x100cL);
+         return jjMoveStringLiteralDfa4_0(active0, 0x80000000000000L, active1, 0x80000020000L, active2, 0x100c0L);
       case 98:
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x4000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x40000000000L, active2, 0L);
       case 99:
-         if ((active0 & 0x800000000L) != 0L)
+         if ((active0 & 0x400000000L) != 0L)
          {
-            jjmatchedKind = 35;
+            jjmatchedKind = 34;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x2000000L, active1, 0x10000000L, active2, 0L);
+         return jjMoveStringLiteralDfa4_0(active0, 0x1000000L, active1, 0x100000000L, active2, 0L);
       case 100:
-         if ((active0 & 0x100000000000L) != 0L)
+         if ((active0 & 0x80000000000L) != 0L)
          {
-            jjmatchedKind = 44;
+            jjmatchedKind = 43;
             jjmatchedPos = 3;
          }
-         else if ((active1 & 0x800000L) != 0L)
+         else if ((active1 & 0x8000000L) != 0L)
          {
-            jjmatchedKind = 87;
+            jjmatchedKind = 91;
             jjmatchedPos = 3;
          }
-         else if ((active1 & 0x2000000000000L) != 0L)
+         else if ((active1 & 0x20000000000000L) != 0L)
          {
-            jjmatchedKind = 113;
-            jjmatchedPos = 3;
-         }
-         else if ((active2 & 0x2L) != 0L)
-         {
-            jjmatchedKind = 129;
-            jjmatchedPos = 3;
-         }
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x1080L, active2, 0L);
-      case 101:
-         if ((active0 & 0x100000L) != 0L)
-         {
-            jjmatchedKind = 20;
-            jjmatchedPos = 3;
-         }
-         else if ((active1 & 0x200000000000000L) != 0L)
-         {
-            jjmatchedKind = 121;
+            jjmatchedKind = 117;
             jjmatchedPos = 3;
          }
          else if ((active2 & 0x20L) != 0L)
@@ -907,74 +917,93 @@ private int jjMoveStringLiteralDfa3_0(long old0, long active0, long old1, long a
             jjmatchedKind = 133;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0x1c00001240400000L, active1, 0x3000402000600000L, active2, 0x100L);
-      case 102:
-         return jjMoveStringLiteralDfa4_0(active0, 0x200000L, active1, 0L, active2, 0L);
-      case 103:
-         if ((active1 & 0x4000L) != 0L)
+         return jjMoveStringLiteralDfa4_0(active0, 0x1000000000000L, active1, 0x10800L, active2, 0L);
+      case 101:
+         if ((active0 & 0x80000L) != 0L)
          {
-            jjmatchedKind = 78;
+            jjmatchedKind = 19;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x8000L, active2, 0L);
+         else if ((active1 & 0x2000000000000000L) != 0L)
+         {
+            jjmatchedKind = 125;
+            jjmatchedPos = 3;
+         }
+         else if ((active2 & 0x200L) != 0L)
+         {
+            jjmatchedKind = 137;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0xc002000920200000L, active1, 0x4020006000001L, active2, 0x1003L);
+      case 102:
+         return jjMoveStringLiteralDfa4_0(active0, 0x100000L, active1, 0L, active2, 0L);
+      case 103:
+         if ((active1 & 0x40000L) != 0L)
+         {
+            jjmatchedKind = 82;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0x80000L, active2, 0L);
       case 104:
+         if ((active2 & 0x40000L) != 0L)
+         {
+            jjmatchedKind = 146;
+            jjmatchedPos = 3;
+         }
+         break;
+      case 105:
+         return jjMoveStringLiteralDfa4_0(active0, 0x40010008000000L, active1, 0x800002L, active2, 0L);
+      case 106:
+         return jjMoveStringLiteralDfa4_0(active0, 0x800000000000L, active1, 0L, active2, 0L);
+      case 108:
+         if ((active1 & 0x20000000L) != 0L)
+         {
+            jjmatchedKind = 93;
+            jjmatchedPos = 3;
+         }
+         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0xc00408100L, active2, 0L);
+      case 109:
+         if ((active0 & 0x1000000000L) != 0L)
+         {
+            jjmatchedKind = 36;
+            jjmatchedPos = 3;
+         }
+         break;
+      case 110:
+         return jjMoveStringLiteralDfa4_0(active0, 0x200000000000000L, active1, 0x80000080L, active2, 0x80000L);
+      case 111:
          if ((active2 & 0x4000L) != 0L)
          {
             jjmatchedKind = 142;
             jjmatchedPos = 3;
          }
-         break;
-      case 105:
-         return jjMoveStringLiteralDfa4_0(active0, 0x2004020010000000L, active1, 0x80000L, active2, 0L);
-      case 108:
-         if ((active1 & 0x2000000L) != 0L)
+         return jjMoveStringLiteralDfa4_0(active0, 0x20000000000L, active1, 0x2004040000000L, active2, 0L);
+      case 112:
+         if ((active2 & 0x2000L) != 0L)
          {
-            jjmatchedKind = 89;
+            jjmatchedKind = 141;
             jjmatchedPos = 3;
          }
-         return jjMoveStringLiteralDfa4_0(active0, 0L, active1, 0xc0040810L, active2, 0L);
-      case 109:
-         if ((active0 & 0x2000000000L) != 0L)
+         return jjMoveStringLiteralDfa4_0(active0, 0x208000000000L, active1, 0x10L, active2, 0L);
+      case 114:
+         if ((active1 & 0x100000000000L) != 0L)
          {
-            jjmatchedKind = 37;
+            jjmatchedKind = 108;
             jjmatchedPos = 3;
          }
-         break;
-      case 110:
-         return jjMoveStringLiteralDfa4_0(active0, 0x20000000000000L, active1, 0x8000008L, active2, 0x8000L);
-      case 111:
+         return jjMoveStringLiteralDfa4_0(active0, 0x402000000000L, active1, 0x800000300000L, active2, 0L);
+      case 115:
+         return jjMoveStringLiteralDfa4_0(active0, 0x4000012000000L, active1, 0x4000013200000000L, active2, 0L);
+      case 116:
+         return jjMoveStringLiteralDfa4_0(active0, 0x400000L, active1, 0x208000000040L, active2, 0L);
+      case 117:
+         return jjMoveStringLiteralDfa4_0(active0, 0x20040080800000L, active1, 0x41000001000020L, active2, 0L);
+      case 118:
+         return jjMoveStringLiteralDfa4_0(active0, 0x100000000000L, active1, 0L, active2, 0L);
+      case 121:
          if ((active2 & 0x400L) != 0L)
          {
             jjmatchedKind = 138;
-            jjmatchedPos = 3;
-         }
-         return jjMoveStringLiteralDfa4_0(active0, 0x40000000000L, active1, 0x200404000000L, active2, 0L);
-      case 112:
-         if ((active2 & 0x200L) != 0L)
-         {
-            jjmatchedKind = 137;
-            jjmatchedPos = 3;
-         }
-         return jjMoveStringLiteralDfa4_0(active0, 0x10000000000L, active1, 0x1L, active2, 0L);
-      case 114:
-         if ((active1 & 0x10000000000L) != 0L)
-         {
-            jjmatchedKind = 104;
-            jjmatchedPos = 3;
-         }
-         return jjMoveStringLiteralDfa4_0(active0, 0x4000000000L, active1, 0x80000030000L, active2, 0L);
-      case 115:
-         return jjMoveStringLiteralDfa4_0(active0, 0x400024000000L, active1, 0x400001320000000L, active2, 0L);
-      case 116:
-         return jjMoveStringLiteralDfa4_0(active0, 0x800000L, active1, 0x20800000004L, active2, 0L);
-      case 117:
-         return jjMoveStringLiteralDfa4_0(active0, 0x2080101000000L, active1, 0x4100000100002L, active2, 0L);
-      case 118:
-         return jjMoveStringLiteralDfa4_0(active0, 0x200000000000L, active1, 0L, active2, 0L);
-      case 121:
-         if ((active2 & 0x40L) != 0L)
-         {
-            jjmatchedKind = 134;
             jjmatchedPos = 3;
          }
          break;
@@ -993,38 +1022,21 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
    switch(curChar)
    {
       case 49:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x100000000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x1000000000000000L, active2, 0L);
       case 50:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x20000000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x200000000000000L, active2, 0L);
       case 53:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x40000000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x400000000000000L, active2, 0L);
       case 56:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x80000000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x800000000000000L, active2, 0L);
       case 65:
-         return jjMoveStringLiteralDfa5_0(active0, 0x2000000000000000L, active1, 0x890040800L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x8900408002L, active2, 0L);
       case 67:
-         return jjMoveStringLiteralDfa5_0(active0, 0x1400000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x2000000a00000L, active1, 0L, active2, 0L);
       case 68:
-         if ((active0 & 0x1000000000L) != 0L)
+         if ((active0 & 0x800000000L) != 0L)
          {
-            jjmatchedKind = 36;
-            jjmatchedPos = 4;
-         }
-         else if ((active1 & 0x8L) != 0L)
-         {
-            jjmatchedKind = 67;
-            jjmatchedPos = 4;
-         }
-         else if ((active1 & 0x8000000L) != 0L)
-         {
-            jjmatchedKind = 91;
-            jjmatchedPos = 4;
-         }
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x400000000L, active2, 0L);
-      case 69:
-         if ((active0 & 0x4000000000L) != 0L)
-         {
-            jjmatchedKind = 38;
+            jjmatchedKind = 35;
             jjmatchedPos = 4;
          }
          else if ((active1 & 0x80L) != 0L)
@@ -1032,169 +1044,169 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
             jjmatchedKind = 71;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x100000000L) != 0L)
+         else if ((active1 & 0x80000000L) != 0L)
          {
-            jjmatchedKind = 96;
+            jjmatchedKind = 95;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x200000000L) != 0L)
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4000000000L, active2, 0L);
+      case 69:
+         if ((active0 & 0x2000000000L) != 0L)
          {
-            jjmatchedKind = 97;
+            jjmatchedKind = 37;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x400000000000000L) != 0L)
+         else if ((active1 & 0x800L) != 0L)
          {
-            jjmatchedKind = 122;
+            jjmatchedKind = 75;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x120000000L, active1, 0x4040000014L, active2, 0L);
+         else if ((active1 & 0x1000000000L) != 0L)
+         {
+            jjmatchedKind = 100;
+            jjmatchedPos = 4;
+         }
+         else if ((active1 & 0x2000000000L) != 0L)
+         {
+            jjmatchedKind = 101;
+            jjmatchedPos = 4;
+         }
+         else if ((active1 & 0x4000000000000000L) != 0L)
+         {
+            jjmatchedKind = 126;
+            jjmatchedPos = 4;
+         }
+         return jjMoveStringLiteralDfa5_0(active0, 0x800090000000L, active1, 0x40400000140L, active2, 0L);
       case 70:
-         if ((active0 & 0x200000000L) != 0L)
+         if ((active0 & 0x100000000L) != 0L)
          {
-            jjmatchedKind = 33;
+            jjmatchedKind = 32;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x8000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x80000000000L, active2, 0L);
       case 71:
-         if ((active2 & 0x8000L) != 0L)
+         if ((active2 & 0x80000L) != 0L)
          {
-            jjmatchedKind = 143;
+            jjmatchedKind = 147;
             jjmatchedPos = 4;
          }
          break;
       case 72:
-         if ((active0 & 0x10000000000L) != 0L)
+         if ((active0 & 0x8000000000L) != 0L)
          {
-            jjmatchedKind = 40;
+            jjmatchedKind = 39;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x20000000000L) != 0L)
+         else if ((active1 & 0x200000000000L) != 0L)
          {
-            jjmatchedKind = 105;
+            jjmatchedKind = 109;
             jjmatchedPos = 4;
          }
          break;
       case 73:
-         if ((active1 & 0x10000L) != 0L)
+         if ((active1 & 0x100000L) != 0L)
          {
-            jjmatchedKind = 80;
+            jjmatchedKind = 84;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x20000L) != 0L)
+         else if ((active1 & 0x200000L) != 0L)
          {
-            jjmatchedKind = 81;
+            jjmatchedKind = 85;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x200000a00000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x1500000500000L, active1, 0L, active2, 0L);
       case 76:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x1L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x200000000000L, active1, 0x10L, active2, 0L);
       case 77:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x108000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x1080000L, active2, 0L);
       case 78:
+         if ((active0 & 0x20000000000L) != 0L)
+         {
+            jjmatchedKind = 41;
+            jjmatchedPos = 4;
+         }
+         return jjMoveStringLiteralDfa5_0(active0, 0x40000000000000L, active1, 0x2020000000000L, active2, 0x1000L);
+      case 79:
+         return jjMoveStringLiteralDfa5_0(active0, 0x10000000000L, active1, 0L, active2, 0L);
+      case 80:
+         if ((active0 & 0x20000000000000L) != 0L)
+         {
+            jjmatchedKind = 53;
+            jjmatchedPos = 4;
+         }
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x28L, active2, 0L);
+      case 82:
+         if ((active0 & 0x20000000L) != 0L)
+         {
+            jjmatchedKind = 29;
+            jjmatchedPos = 4;
+         }
+         else if ((active1 & 0x40000000L) != 0L)
+         {
+            jjmatchedKind = 94;
+            jjmatchedPos = 4;
+         }
+         else if ((active2 & 0x40L) != 0L)
+         {
+            jjmatchedKind = 134;
+            jjmatchedPos = 4;
+         }
+         return jjMoveStringLiteralDfa5_0(active0, 0x80000001000000L, active1, 0L, active2, 0x1L);
+      case 83:
          if ((active0 & 0x40000000000L) != 0L)
          {
             jjmatchedKind = 42;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x4000000000000L, active1, 0x202000000000L, active2, 0x100L);
-      case 79:
-         return jjMoveStringLiteralDfa5_0(active0, 0x20000000000L, active1, 0L, active2, 0L);
-      case 80:
-         if ((active0 & 0x2000000000000L) != 0L)
+         else if ((active1 & 0x800000000000L) != 0L)
          {
-            jjmatchedKind = 49;
+            jjmatchedKind = 111;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x8000000000000000L, active1, 0x2L, active2, 0L);
-      case 82:
-         if ((active0 & 0x40000000L) != 0L)
-         {
-            jjmatchedKind = 30;
-            jjmatchedPos = 4;
-         }
-         else if ((active1 & 0x4000000L) != 0L)
-         {
-            jjmatchedKind = 90;
-            jjmatchedPos = 4;
-         }
-         else if ((active2 & 0x4L) != 0L)
-         {
-            jjmatchedKind = 130;
-            jjmatchedPos = 4;
-         }
-         return jjMoveStringLiteralDfa5_0(active0, 0x8000002000000L, active1, 0x1000000000000000L, active2, 0L);
-      case 83:
-         if ((active0 & 0x80000000000L) != 0L)
-         {
-            jjmatchedKind = 43;
-            jjmatchedPos = 4;
-         }
-         else if ((active1 & 0x80000000000L) != 0L)
-         {
-            jjmatchedKind = 107;
-            jjmatchedPos = 4;
-         }
-         return jjMoveStringLiteralDfa5_0(active0, 0x4000000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4L, active2, 0L);
       case 84:
-         if ((active0 & 0x10000000L) != 0L)
+         if ((active0 & 0x8000000L) != 0L)
          {
-            jjmatchedKind = 28;
+            jjmatchedKind = 27;
             jjmatchedPos = 4;
          }
-         else if ((active0 & 0x20000000000000L) != 0L)
+         else if ((active0 & 0x200000000000000L) != 0L)
          {
-            jjmatchedKind = 53;
+            jjmatchedKind = 57;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x1000L) != 0L)
+         else if ((active1 & 0x10000L) != 0L)
          {
-            jjmatchedKind = 76;
+            jjmatchedKind = 80;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x400004000000L, active1, 0x2000101020482000L, active2, 0x8L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x4000002000000L, active1, 0x1010204820000L, active2, 0x82L);
       case 85:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4000000000000L, active2, 0x1000L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x40000000000000L, active2, 0x10000L);
       case 86:
-         if ((active0 & 0x400000000000000L) != 0L)
+         if ((active0 & 0x4000000000000000L) != 0L)
          {
-            jjmatchedKind = 58;
+            jjmatchedKind = 62;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x1800000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x8000000000000000L, active1, 0x1L, active2, 0L);
       case 88:
-         if ((active1 & 0x200000L) != 0L)
+         if ((active1 & 0x2000000L) != 0L)
          {
-            jjmatchedKind = 85;
+            jjmatchedKind = 89;
             jjmatchedPos = 4;
          }
          break;
       case 90:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x400000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4000000000000L, active2, 0L);
       case 97:
-         return jjMoveStringLiteralDfa5_0(active0, 0x2000000000000000L, active1, 0x890040800L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x8900408002L, active2, 0L);
       case 99:
-         return jjMoveStringLiteralDfa5_0(active0, 0x1400000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x2000000a00000L, active1, 0L, active2, 0L);
       case 100:
-         if ((active0 & 0x1000000000L) != 0L)
+         if ((active0 & 0x800000000L) != 0L)
          {
-            jjmatchedKind = 36;
-            jjmatchedPos = 4;
-         }
-         else if ((active1 & 0x8L) != 0L)
-         {
-            jjmatchedKind = 67;
-            jjmatchedPos = 4;
-         }
-         else if ((active1 & 0x8000000L) != 0L)
-         {
-            jjmatchedKind = 91;
-            jjmatchedPos = 4;
-         }
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x400000000L, active2, 0L);
-      case 101:
-         if ((active0 & 0x4000000000L) != 0L)
-         {
-            jjmatchedKind = 38;
+            jjmatchedKind = 35;
             jjmatchedPos = 4;
          }
          else if ((active1 & 0x80L) != 0L)
@@ -1202,144 +1214,161 @@ private int jjMoveStringLiteralDfa4_0(long old0, long active0, long old1, long a
             jjmatchedKind = 71;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x100000000L) != 0L)
+         else if ((active1 & 0x80000000L) != 0L)
          {
-            jjmatchedKind = 96;
+            jjmatchedKind = 95;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x200000000L) != 0L)
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4000000000L, active2, 0L);
+      case 101:
+         if ((active0 & 0x2000000000L) != 0L)
          {
-            jjmatchedKind = 97;
+            jjmatchedKind = 37;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x400000000000000L) != 0L)
+         else if ((active1 & 0x800L) != 0L)
          {
-            jjmatchedKind = 122;
+            jjmatchedKind = 75;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x120000000L, active1, 0x4040000014L, active2, 0L);
+         else if ((active1 & 0x1000000000L) != 0L)
+         {
+            jjmatchedKind = 100;
+            jjmatchedPos = 4;
+         }
+         else if ((active1 & 0x2000000000L) != 0L)
+         {
+            jjmatchedKind = 101;
+            jjmatchedPos = 4;
+         }
+         else if ((active1 & 0x4000000000000000L) != 0L)
+         {
+            jjmatchedKind = 126;
+            jjmatchedPos = 4;
+         }
+         return jjMoveStringLiteralDfa5_0(active0, 0x800090000000L, active1, 0x40400000140L, active2, 0L);
       case 102:
-         if ((active0 & 0x200000000L) != 0L)
+         if ((active0 & 0x100000000L) != 0L)
          {
-            jjmatchedKind = 33;
+            jjmatchedKind = 32;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x8000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x80000000000L, active2, 0L);
       case 103:
-         if ((active2 & 0x8000L) != 0L)
+         if ((active2 & 0x80000L) != 0L)
          {
-            jjmatchedKind = 143;
+            jjmatchedKind = 147;
             jjmatchedPos = 4;
          }
          break;
       case 104:
-         if ((active0 & 0x10000000000L) != 0L)
+         if ((active0 & 0x8000000000L) != 0L)
          {
-            jjmatchedKind = 40;
+            jjmatchedKind = 39;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x20000000000L) != 0L)
+         else if ((active1 & 0x200000000000L) != 0L)
          {
-            jjmatchedKind = 105;
+            jjmatchedKind = 109;
             jjmatchedPos = 4;
          }
          break;
       case 105:
-         if ((active1 & 0x10000L) != 0L)
+         if ((active1 & 0x100000L) != 0L)
          {
-            jjmatchedKind = 80;
+            jjmatchedKind = 84;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x20000L) != 0L)
+         else if ((active1 & 0x200000L) != 0L)
          {
-            jjmatchedKind = 81;
+            jjmatchedKind = 85;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x200000a00000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x1500000500000L, active1, 0L, active2, 0L);
       case 108:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x1L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x200000000000L, active1, 0x10L, active2, 0L);
       case 109:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x108000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x1080000L, active2, 0L);
       case 110:
+         if ((active0 & 0x20000000000L) != 0L)
+         {
+            jjmatchedKind = 41;
+            jjmatchedPos = 4;
+         }
+         return jjMoveStringLiteralDfa5_0(active0, 0x40000000000000L, active1, 0x2020000000000L, active2, 0x1000L);
+      case 111:
+         return jjMoveStringLiteralDfa5_0(active0, 0x10000000000L, active1, 0L, active2, 0L);
+      case 112:
+         if ((active0 & 0x20000000000000L) != 0L)
+         {
+            jjmatchedKind = 53;
+            jjmatchedPos = 4;
+         }
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x28L, active2, 0L);
+      case 114:
+         if ((active0 & 0x20000000L) != 0L)
+         {
+            jjmatchedKind = 29;
+            jjmatchedPos = 4;
+         }
+         else if ((active1 & 0x40000000L) != 0L)
+         {
+            jjmatchedKind = 94;
+            jjmatchedPos = 4;
+         }
+         else if ((active2 & 0x40L) != 0L)
+         {
+            jjmatchedKind = 134;
+            jjmatchedPos = 4;
+         }
+         return jjMoveStringLiteralDfa5_0(active0, 0x80000001000000L, active1, 0L, active2, 0x1L);
+      case 115:
          if ((active0 & 0x40000000000L) != 0L)
          {
             jjmatchedKind = 42;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x4000000000000L, active1, 0x202000000000L, active2, 0x100L);
-      case 111:
-         return jjMoveStringLiteralDfa5_0(active0, 0x20000000000L, active1, 0L, active2, 0L);
-      case 112:
-         if ((active0 & 0x2000000000000L) != 0L)
+         else if ((active1 & 0x800000000000L) != 0L)
          {
-            jjmatchedKind = 49;
+            jjmatchedKind = 111;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x8000000000000000L, active1, 0x2L, active2, 0L);
-      case 114:
-         if ((active0 & 0x40000000L) != 0L)
-         {
-            jjmatchedKind = 30;
-            jjmatchedPos = 4;
-         }
-         else if ((active1 & 0x4000000L) != 0L)
-         {
-            jjmatchedKind = 90;
-            jjmatchedPos = 4;
-         }
-         else if ((active2 & 0x4L) != 0L)
-         {
-            jjmatchedKind = 130;
-            jjmatchedPos = 4;
-         }
-         return jjMoveStringLiteralDfa5_0(active0, 0x8000002000000L, active1, 0x1000000000000000L, active2, 0L);
-      case 115:
-         if ((active0 & 0x80000000000L) != 0L)
-         {
-            jjmatchedKind = 43;
-            jjmatchedPos = 4;
-         }
-         else if ((active1 & 0x80000000000L) != 0L)
-         {
-            jjmatchedKind = 107;
-            jjmatchedPos = 4;
-         }
-         return jjMoveStringLiteralDfa5_0(active0, 0x4000000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4L, active2, 0L);
       case 116:
-         if ((active0 & 0x10000000L) != 0L)
+         if ((active0 & 0x8000000L) != 0L)
          {
-            jjmatchedKind = 28;
+            jjmatchedKind = 27;
             jjmatchedPos = 4;
          }
-         else if ((active0 & 0x20000000000000L) != 0L)
+         else if ((active0 & 0x200000000000000L) != 0L)
          {
-            jjmatchedKind = 53;
+            jjmatchedKind = 57;
             jjmatchedPos = 4;
          }
-         else if ((active1 & 0x1000L) != 0L)
+         else if ((active1 & 0x10000L) != 0L)
          {
-            jjmatchedKind = 76;
+            jjmatchedKind = 80;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x400004000000L, active1, 0x2000101020482000L, active2, 0x8L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x4000002000000L, active1, 0x1010204820000L, active2, 0x82L);
       case 117:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4000000000000L, active2, 0x1000L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x40000000000000L, active2, 0x10000L);
       case 118:
-         if ((active0 & 0x400000000000000L) != 0L)
+         if ((active0 & 0x4000000000000000L) != 0L)
          {
-            jjmatchedKind = 58;
+            jjmatchedKind = 62;
             jjmatchedPos = 4;
          }
-         return jjMoveStringLiteralDfa5_0(active0, 0x1800000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0x8000000000000000L, active1, 0x1L, active2, 0L);
       case 120:
-         if ((active1 & 0x200000L) != 0L)
+         if ((active1 & 0x2000000L) != 0L)
          {
-            jjmatchedKind = 85;
+            jjmatchedKind = 89;
             jjmatchedPos = 4;
          }
          break;
       case 122:
-         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x400000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa5_0(active0, 0L, active1, 0x4000000000000L, active2, 0L);
       default :
          break;
    }
@@ -1355,243 +1384,267 @@ private int jjMoveStringLiteralDfa5_0(long old0, long active0, long old1, long a
    switch(curChar)
    {
       case 50:
-         if ((active1 & 0x100000000000000L) != 0L)
+         if ((active1 & 0x1000000000000000L) != 0L)
          {
-            jjmatchedKind = 120;
+            jjmatchedKind = 124;
             jjmatchedPos = 5;
          }
          break;
       case 52:
-         if ((active1 & 0x20000000000000L) != 0L)
+         if ((active1 & 0x200000000000000L) != 0L)
          {
-            jjmatchedKind = 117;
+            jjmatchedKind = 121;
             jjmatchedPos = 5;
          }
-         else if ((active1 & 0x80000000000000L) != 0L)
+         else if ((active1 & 0x800000000000000L) != 0L)
          {
-            jjmatchedKind = 119;
+            jjmatchedKind = 123;
             jjmatchedPos = 5;
          }
          break;
       case 54:
-         if ((active1 & 0x40000000000000L) != 0L)
+         if ((active1 & 0x400000000000000L) != 0L)
          {
-            jjmatchedKind = 118;
+            jjmatchedKind = 122;
             jjmatchedPos = 5;
          }
          break;
       case 65:
-         return jjMoveStringLiteralDfa6_0(active0, 0x4008000000000000L, active1, 0x1000008000L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x80000000000000L, active1, 0x10000080004L, active2, 0L);
       case 67:
-         return jjMoveStringLiteralDfa6_0(active0, 0x200000000000L, active1, 0x80000000L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x1900000000000L, active1, 0x800000000L, active2, 0L);
       case 68:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x202000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x2020000000000L, active2, 0L);
       case 69:
-         if ((active1 & 0x1L) != 0L)
+         if ((active0 & 0x200000000000L) != 0L)
          {
-            jjmatchedKind = 64;
+            jjmatchedKind = 45;
             jjmatchedPos = 5;
          }
-         else if ((active1 & 0x2000000000000000L) != 0L)
+         else if ((active1 & 0x10L) != 0L)
          {
-            jjmatchedKind = 125;
+            jjmatchedKind = 68;
             jjmatchedPos = 5;
          }
-         else if ((active2 & 0x8L) != 0L)
+         else if ((active2 & 0x2L) != 0L)
          {
-            jjmatchedKind = 131;
+            jjmatchedKind = 129;
             jjmatchedPos = 5;
          }
-         return jjMoveStringLiteralDfa6_0(active0, 0x1000000L, active1, 0x100400580000L, active2, 0L);
+         else if ((active2 & 0x80L) != 0L)
+         {
+            jjmatchedKind = 135;
+            jjmatchedPos = 5;
+         }
+         return jjMoveStringLiteralDfa6_0(active0, 0x800000L, active1, 0x1004005800000L, active2, 0L);
       case 70:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x4000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x40000000000L, active2, 0L);
       case 71:
-         if ((active0 & 0x4000000000000L) != 0L)
+         if ((active0 & 0x40000000000000L) != 0L)
          {
-            jjmatchedKind = 50;
+            jjmatchedKind = 54;
             jjmatchedPos = 5;
          }
          break;
       case 73:
-         return jjMoveStringLiteralDfa6_0(active0, 0x2000000L, active1, 0x4000800000000L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x1000000L, active1, 0x40008000000000L, active2, 0L);
       case 76:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0L, active2, 0x1000L);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0L, active2, 0x10000L);
       case 78:
-         if ((active1 & 0x40000000L) != 0L)
+         if ((active1 & 0x400000000L) != 0L)
          {
-            jjmatchedKind = 94;
+            jjmatchedKind = 98;
             jjmatchedPos = 5;
          }
-         return jjMoveStringLiteralDfa6_0(active0, 0x2000020000800000L, active1, 0x40800L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x10000400000L, active1, 0x408002L, active2, 0L);
       case 79:
-         return jjMoveStringLiteralDfa6_0(active0, 0x8000000000000000L, active1, 0x400000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x4000000000008L, active2, 0L);
+      case 80:
+         return jjMoveStringLiteralDfa6_0(active0, 0x400000000000L, active1, 0L, active2, 0L);
       case 82:
-         if ((active1 & 0x4L) != 0L)
+         if ((active1 & 0x40L) != 0L)
          {
-            jjmatchedKind = 66;
+            jjmatchedKind = 70;
             jjmatchedPos = 5;
          }
-         else if ((active1 & 0x20000000L) != 0L)
+         else if ((active1 & 0x200000000L) != 0L)
          {
-            jjmatchedKind = 93;
+            jjmatchedKind = 97;
             jjmatchedPos = 5;
          }
-         return jjMoveStringLiteralDfa6_0(active0, 0x4000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0x2000000L, active1, 0L, active2, 0L);
       case 83:
-         if ((active0 & 0x100000000L) != 0L)
+         if ((active0 & 0x80000000L) != 0L)
          {
-            jjmatchedKind = 32;
+            jjmatchedKind = 31;
             jjmatchedPos = 5;
          }
-         else if ((active0 & 0x400000000000L) != 0L)
-         {
-            jjmatchedKind = 46;
-            jjmatchedPos = 5;
-         }
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x10L, active2, 0L);
-      case 84:
-         if ((active0 & 0x400000L) != 0L)
-         {
-            jjmatchedKind = 22;
-            jjmatchedPos = 5;
-         }
-         else if ((active0 & 0x20000000L) != 0L)
-         {
-            jjmatchedKind = 29;
-            jjmatchedPos = 5;
-         }
-         else if ((active1 & 0x10000000L) != 0L)
-         {
-            jjmatchedKind = 92;
-            jjmatchedPos = 5;
-         }
-         else if ((active1 & 0x1000000000000000L) != 0L)
-         {
-            jjmatchedKind = 124;
-            jjmatchedPos = 5;
-         }
-         else if ((active2 & 0x100L) != 0L)
-         {
-            jjmatchedKind = 136;
-            jjmatchedPos = 5;
-         }
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x8000000000L, active2, 0L);
-      case 88:
-         if ((active0 & 0x200000L) != 0L)
-         {
-            jjmatchedKind = 21;
-            jjmatchedPos = 5;
-         }
-         break;
-      case 89:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x2000L, active2, 0L);
-      case 95:
-         return jjMoveStringLiteralDfa6_0(active0, 0x1800000000000000L, active1, 0x2L, active2, 0L);
-      case 97:
-         return jjMoveStringLiteralDfa6_0(active0, 0x4008000000000000L, active1, 0x1000008000L, active2, 0L);
-      case 99:
-         return jjMoveStringLiteralDfa6_0(active0, 0x200000000000L, active1, 0x80000000L, active2, 0L);
-      case 100:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x202000000000L, active2, 0L);
-      case 101:
-         if ((active1 & 0x1L) != 0L)
-         {
-            jjmatchedKind = 64;
-            jjmatchedPos = 5;
-         }
-         else if ((active1 & 0x2000000000000000L) != 0L)
-         {
-            jjmatchedKind = 125;
-            jjmatchedPos = 5;
-         }
-         else if ((active2 & 0x8L) != 0L)
-         {
-            jjmatchedKind = 131;
-            jjmatchedPos = 5;
-         }
-         return jjMoveStringLiteralDfa6_0(active0, 0x1000000L, active1, 0x100400580000L, active2, 0L);
-      case 102:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x4000000000L, active2, 0L);
-      case 103:
-         if ((active0 & 0x4000000000000L) != 0L)
+         else if ((active0 & 0x4000000000000L) != 0L)
          {
             jjmatchedKind = 50;
             jjmatchedPos = 5;
          }
-         break;
-      case 105:
-         return jjMoveStringLiteralDfa6_0(active0, 0x2000000L, active1, 0x4000800000000L, active2, 0L);
-      case 108:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0L, active2, 0x1000L);
-      case 110:
-         if ((active1 & 0x40000000L) != 0L)
-         {
-            jjmatchedKind = 94;
-            jjmatchedPos = 5;
-         }
-         return jjMoveStringLiteralDfa6_0(active0, 0x2000020000800000L, active1, 0x40800L, active2, 0L);
-      case 111:
-         return jjMoveStringLiteralDfa6_0(active0, 0x8000000000000000L, active1, 0x400000000000L, active2, 0L);
-      case 114:
-         if ((active1 & 0x4L) != 0L)
-         {
-            jjmatchedKind = 66;
-            jjmatchedPos = 5;
-         }
-         else if ((active1 & 0x20000000L) != 0L)
-         {
-            jjmatchedKind = 93;
-            jjmatchedPos = 5;
-         }
-         return jjMoveStringLiteralDfa6_0(active0, 0x4000000L, active1, 0L, active2, 0L);
-      case 115:
-         if ((active0 & 0x100000000L) != 0L)
-         {
-            jjmatchedKind = 32;
-            jjmatchedPos = 5;
-         }
-         else if ((active0 & 0x400000000000L) != 0L)
-         {
-            jjmatchedKind = 46;
-            jjmatchedPos = 5;
-         }
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x10L, active2, 0L);
-      case 116:
-         if ((active0 & 0x400000L) != 0L)
-         {
-            jjmatchedKind = 22;
-            jjmatchedPos = 5;
-         }
-         else if ((active0 & 0x20000000L) != 0L)
-         {
-            jjmatchedKind = 29;
-            jjmatchedPos = 5;
-         }
-         else if ((active1 & 0x10000000L) != 0L)
-         {
-            jjmatchedKind = 92;
-            jjmatchedPos = 5;
-         }
-         else if ((active1 & 0x1000000000000000L) != 0L)
-         {
-            jjmatchedKind = 124;
-            jjmatchedPos = 5;
-         }
-         else if ((active2 & 0x100L) != 0L)
-         {
-            jjmatchedKind = 136;
-            jjmatchedPos = 5;
-         }
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x8000000000L, active2, 0L);
-      case 120:
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x100L, active2, 0L);
+      case 84:
          if ((active0 & 0x200000L) != 0L)
          {
             jjmatchedKind = 21;
             jjmatchedPos = 5;
          }
+         else if ((active0 & 0x10000000L) != 0L)
+         {
+            jjmatchedKind = 28;
+            jjmatchedPos = 5;
+         }
+         else if ((active0 & 0x2000000000000L) != 0L)
+         {
+            jjmatchedKind = 49;
+            jjmatchedPos = 5;
+         }
+         else if ((active1 & 0x100000000L) != 0L)
+         {
+            jjmatchedKind = 96;
+            jjmatchedPos = 5;
+         }
+         else if ((active2 & 0x1L) != 0L)
+         {
+            jjmatchedKind = 128;
+            jjmatchedPos = 5;
+         }
+         else if ((active2 & 0x1000L) != 0L)
+         {
+            jjmatchedKind = 140;
+            jjmatchedPos = 5;
+         }
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x80000000000L, active2, 0L);
+      case 88:
+         if ((active0 & 0x100000L) != 0L)
+         {
+            jjmatchedKind = 20;
+            jjmatchedPos = 5;
+         }
+         break;
+      case 89:
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x20000L, active2, 0L);
+      case 95:
+         return jjMoveStringLiteralDfa6_0(active0, 0x8000000000000000L, active1, 0x21L, active2, 0L);
+      case 97:
+         return jjMoveStringLiteralDfa6_0(active0, 0x80000000000000L, active1, 0x10000080004L, active2, 0L);
+      case 99:
+         return jjMoveStringLiteralDfa6_0(active0, 0x1900000000000L, active1, 0x800000000L, active2, 0L);
+      case 100:
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x2020000000000L, active2, 0L);
+      case 101:
+         if ((active0 & 0x200000000000L) != 0L)
+         {
+            jjmatchedKind = 45;
+            jjmatchedPos = 5;
+         }
+         else if ((active1 & 0x10L) != 0L)
+         {
+            jjmatchedKind = 68;
+            jjmatchedPos = 5;
+         }
+         else if ((active2 & 0x2L) != 0L)
+         {
+            jjmatchedKind = 129;
+            jjmatchedPos = 5;
+         }
+         else if ((active2 & 0x80L) != 0L)
+         {
+            jjmatchedKind = 135;
+            jjmatchedPos = 5;
+         }
+         return jjMoveStringLiteralDfa6_0(active0, 0x800000L, active1, 0x1004005800000L, active2, 0L);
+      case 102:
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x40000000000L, active2, 0L);
+      case 103:
+         if ((active0 & 0x40000000000000L) != 0L)
+         {
+            jjmatchedKind = 54;
+            jjmatchedPos = 5;
+         }
+         break;
+      case 105:
+         return jjMoveStringLiteralDfa6_0(active0, 0x1000000L, active1, 0x40008000000000L, active2, 0L);
+      case 108:
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0L, active2, 0x10000L);
+      case 110:
+         if ((active1 & 0x400000000L) != 0L)
+         {
+            jjmatchedKind = 98;
+            jjmatchedPos = 5;
+         }
+         return jjMoveStringLiteralDfa6_0(active0, 0x10000400000L, active1, 0x408002L, active2, 0L);
+      case 111:
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x4000000000008L, active2, 0L);
+      case 112:
+         return jjMoveStringLiteralDfa6_0(active0, 0x400000000000L, active1, 0L, active2, 0L);
+      case 114:
+         if ((active1 & 0x40L) != 0L)
+         {
+            jjmatchedKind = 70;
+            jjmatchedPos = 5;
+         }
+         else if ((active1 & 0x200000000L) != 0L)
+         {
+            jjmatchedKind = 97;
+            jjmatchedPos = 5;
+         }
+         return jjMoveStringLiteralDfa6_0(active0, 0x2000000L, active1, 0L, active2, 0L);
+      case 115:
+         if ((active0 & 0x80000000L) != 0L)
+         {
+            jjmatchedKind = 31;
+            jjmatchedPos = 5;
+         }
+         else if ((active0 & 0x4000000000000L) != 0L)
+         {
+            jjmatchedKind = 50;
+            jjmatchedPos = 5;
+         }
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x100L, active2, 0L);
+      case 116:
+         if ((active0 & 0x200000L) != 0L)
+         {
+            jjmatchedKind = 21;
+            jjmatchedPos = 5;
+         }
+         else if ((active0 & 0x10000000L) != 0L)
+         {
+            jjmatchedKind = 28;
+            jjmatchedPos = 5;
+         }
+         else if ((active0 & 0x2000000000000L) != 0L)
+         {
+            jjmatchedKind = 49;
+            jjmatchedPos = 5;
+         }
+         else if ((active1 & 0x100000000L) != 0L)
+         {
+            jjmatchedKind = 96;
+            jjmatchedPos = 5;
+         }
+         else if ((active2 & 0x1L) != 0L)
+         {
+            jjmatchedKind = 128;
+            jjmatchedPos = 5;
+         }
+         else if ((active2 & 0x1000L) != 0L)
+         {
+            jjmatchedKind = 140;
+            jjmatchedPos = 5;
+         }
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x80000000000L, active2, 0L);
+      case 120:
+         if ((active0 & 0x100000L) != 0L)
+         {
+            jjmatchedKind = 20;
+            jjmatchedPos = 5;
+         }
          break;
       case 121:
-         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x2000L, active2, 0L);
+         return jjMoveStringLiteralDfa6_0(active0, 0L, active1, 0x20000L, active2, 0L);
       default :
          break;
    }
@@ -1607,177 +1660,191 @@ private int jjMoveStringLiteralDfa6_0(long old0, long active0, long old1, long a
    switch(curChar)
    {
       case 65:
-         return jjMoveStringLiteralDfa7_0(active0, 0x20000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x1010000000000L, active1, 0L, active2, 0L);
       case 66:
-         return jjMoveStringLiteralDfa7_0(active0, 0x2000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x1000000L, active1, 0L, active2, 0L);
       case 67:
-         return jjMoveStringLiteralDfa7_0(active0, 0x2000000000800000L, active1, 0x12L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x400000L, active1, 0x122L, active2, 0L);
       case 68:
-         if ((active0 & 0x1000000L) != 0L)
+         if ((active0 & 0x800000L) != 0L)
          {
-            jjmatchedKind = 24;
+            jjmatchedKind = 23;
             jjmatchedPos = 6;
          }
-         else if ((active1 & 0x4000000000000L) != 0L)
+         else if ((active1 & 0x40000000000000L) != 0L)
          {
-            jjmatchedKind = 114;
+            jjmatchedKind = 118;
             jjmatchedPos = 6;
          }
          break;
       case 69:
-         if ((active0 & 0x200000000000L) != 0L)
+         if ((active0 & 0x100000000000L) != 0L)
          {
-            jjmatchedKind = 45;
+            jjmatchedKind = 44;
             jjmatchedPos = 6;
          }
-         else if ((active1 & 0x80000000L) != 0L)
+         else if ((active1 & 0x800000000L) != 0L)
          {
-            jjmatchedKind = 95;
+            jjmatchedKind = 99;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x8000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x80000000000L, active2, 0L);
       case 71:
-         if ((active1 & 0x800L) != 0L)
+         if ((active1 & 0x8000L) != 0L)
          {
-            jjmatchedKind = 75;
+            jjmatchedKind = 79;
             jjmatchedPos = 6;
          }
          break;
       case 75:
-         if ((active1 & 0x40000L) != 0L)
+         if ((active1 & 0x400000L) != 0L)
          {
-            jjmatchedKind = 82;
+            jjmatchedKind = 86;
             jjmatchedPos = 6;
          }
          break;
+      case 76:
+         return jjMoveStringLiteralDfa7_0(active0, 0x400000000000L, active1, 0L, active2, 0L);
       case 77:
-         return jjMoveStringLiteralDfa7_0(active0, 0x4000000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x4L, active2, 0L);
       case 78:
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x400800000000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x4008000000000L, active2, 0L);
       case 79:
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x4000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x40000000000L, active2, 0L);
       case 80:
-         if ((active0 & 0x8000000000000000L) != 0L)
+         if ((active1 & 0x8L) != 0L)
          {
-            jjmatchedKind = 63;
+            jjmatchedKind = 67;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0x1000000000000000L, active1, 0x2000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x20001L, active2, 0L);
       case 82:
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x1000580000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x10005800000L, active2, 0L);
       case 83:
-         if ((active1 & 0x2000000000L) != 0L)
+         if ((active1 & 0x20000000000L) != 0L)
          {
-            jjmatchedKind = 101;
+            jjmatchedKind = 105;
             jjmatchedPos = 6;
          }
-         else if ((active1 & 0x100000000000L) != 0L)
+         else if ((active1 & 0x1000000000000L) != 0L)
          {
-            jjmatchedKind = 108;
+            jjmatchedKind = 112;
             jjmatchedPos = 6;
          }
-         else if ((active1 & 0x200000000000L) != 0L)
+         else if ((active1 & 0x2000000000000L) != 0L)
          {
-            jjmatchedKind = 109;
+            jjmatchedKind = 113;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0x800000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x8000000000000000L, active1, 0L, active2, 0L);
       case 84:
-         if ((active2 & 0x1000L) != 0L)
+         if ((active0 & 0x800000000000L) != 0L)
          {
-            jjmatchedKind = 140;
+            jjmatchedKind = 47;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0x8000000000000L, active1, 0x8000L, active2, 0L);
+         else if ((active2 & 0x10000L) != 0L)
+         {
+            jjmatchedKind = 144;
+            jjmatchedPos = 6;
+         }
+         return jjMoveStringLiteralDfa7_0(active0, 0x80000000000000L, active1, 0x80000L, active2, 0L);
       case 85:
-         return jjMoveStringLiteralDfa7_0(active0, 0x4000000L, active1, 0L, active2, 0L);
-      case 95:
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x400000000L, active2, 0L);
-      case 97:
-         return jjMoveStringLiteralDfa7_0(active0, 0x20000000000L, active1, 0L, active2, 0L);
-      case 98:
          return jjMoveStringLiteralDfa7_0(active0, 0x2000000L, active1, 0L, active2, 0L);
+      case 95:
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x4000000000L, active2, 0L);
+      case 97:
+         return jjMoveStringLiteralDfa7_0(active0, 0x1010000000000L, active1, 0L, active2, 0L);
+      case 98:
+         return jjMoveStringLiteralDfa7_0(active0, 0x1000000L, active1, 0L, active2, 0L);
       case 99:
-         return jjMoveStringLiteralDfa7_0(active0, 0x2000000000800000L, active1, 0x12L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x400000L, active1, 0x122L, active2, 0L);
       case 100:
-         if ((active0 & 0x1000000L) != 0L)
+         if ((active0 & 0x800000L) != 0L)
          {
-            jjmatchedKind = 24;
+            jjmatchedKind = 23;
             jjmatchedPos = 6;
          }
-         else if ((active1 & 0x4000000000000L) != 0L)
+         else if ((active1 & 0x40000000000000L) != 0L)
          {
-            jjmatchedKind = 114;
+            jjmatchedKind = 118;
             jjmatchedPos = 6;
          }
          break;
       case 101:
-         if ((active0 & 0x200000000000L) != 0L)
+         if ((active0 & 0x100000000000L) != 0L)
          {
-            jjmatchedKind = 45;
+            jjmatchedKind = 44;
             jjmatchedPos = 6;
          }
-         else if ((active1 & 0x80000000L) != 0L)
+         else if ((active1 & 0x800000000L) != 0L)
          {
-            jjmatchedKind = 95;
+            jjmatchedKind = 99;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x8000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x80000000000L, active2, 0L);
       case 103:
-         if ((active1 & 0x800L) != 0L)
+         if ((active1 & 0x8000L) != 0L)
          {
-            jjmatchedKind = 75;
+            jjmatchedKind = 79;
             jjmatchedPos = 6;
          }
          break;
       case 107:
-         if ((active1 & 0x40000L) != 0L)
+         if ((active1 & 0x400000L) != 0L)
          {
-            jjmatchedKind = 82;
+            jjmatchedKind = 86;
             jjmatchedPos = 6;
          }
          break;
+      case 108:
+         return jjMoveStringLiteralDfa7_0(active0, 0x400000000000L, active1, 0L, active2, 0L);
       case 109:
-         return jjMoveStringLiteralDfa7_0(active0, 0x4000000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x4L, active2, 0L);
       case 110:
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x400800000000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x4008000000000L, active2, 0L);
       case 111:
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x4000000000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x40000000000L, active2, 0L);
       case 112:
-         if ((active0 & 0x8000000000000000L) != 0L)
+         if ((active1 & 0x8L) != 0L)
          {
-            jjmatchedKind = 63;
+            jjmatchedKind = 67;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0x1000000000000000L, active1, 0x2000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x20001L, active2, 0L);
       case 114:
-         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x1000580000L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0L, active1, 0x10005800000L, active2, 0L);
       case 115:
-         if ((active1 & 0x2000000000L) != 0L)
+         if ((active1 & 0x20000000000L) != 0L)
          {
-            jjmatchedKind = 101;
+            jjmatchedKind = 105;
             jjmatchedPos = 6;
          }
-         else if ((active1 & 0x100000000000L) != 0L)
+         else if ((active1 & 0x1000000000000L) != 0L)
          {
-            jjmatchedKind = 108;
+            jjmatchedKind = 112;
             jjmatchedPos = 6;
          }
-         else if ((active1 & 0x200000000000L) != 0L)
+         else if ((active1 & 0x2000000000000L) != 0L)
          {
-            jjmatchedKind = 109;
+            jjmatchedKind = 113;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0x800000000000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x8000000000000000L, active1, 0L, active2, 0L);
       case 116:
-         if ((active2 & 0x1000L) != 0L)
+         if ((active0 & 0x800000000000L) != 0L)
          {
-            jjmatchedKind = 140;
+            jjmatchedKind = 47;
             jjmatchedPos = 6;
          }
-         return jjMoveStringLiteralDfa7_0(active0, 0x8000000000000L, active1, 0x8000L, active2, 0L);
+         else if ((active2 & 0x10000L) != 0L)
+         {
+            jjmatchedKind = 144;
+            jjmatchedPos = 6;
+         }
+         return jjMoveStringLiteralDfa7_0(active0, 0x80000000000000L, active1, 0x80000L, active2, 0L);
       case 117:
-         return jjMoveStringLiteralDfa7_0(active0, 0x4000000L, active1, 0L, active2, 0L);
+         return jjMoveStringLiteralDfa7_0(active0, 0x2000000L, active1, 0L, active2, 0L);
       default :
          break;
    }
@@ -1793,163 +1860,173 @@ private int jjMoveStringLiteralDfa7_0(long old0, long active0, long old1, long a
    switch(curChar)
    {
       case 65:
-         return jjMoveStringLiteralDfa8_0(active0, 0x800000000000000L, active1, 0x80000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x8000000000000000L, active1, 0x800000L);
       case 67:
-         return jjMoveStringLiteralDfa8_0(active0, 0x4000000L, active1, 0x8000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x2000000L, active1, 0x80000L);
       case 69:
-         if ((active0 & 0x2000000L) != 0L)
+         if ((active0 & 0x1000000L) != 0L)
          {
-            jjmatchedKind = 25;
+            jjmatchedKind = 24;
             jjmatchedPos = 7;
          }
-         else if ((active0 & 0x2000000000000000L) != 0L)
+         else if ((active0 & 0x400000000000L) != 0L)
          {
-            jjmatchedKind = 61;
+            jjmatchedKind = 46;
             jjmatchedPos = 7;
          }
-         else if ((active1 & 0x10L) != 0L)
+         else if ((active1 & 0x2L) != 0L)
          {
-            jjmatchedKind = 68;
+            jjmatchedKind = 65;
             jjmatchedPos = 7;
          }
-         else if ((active1 & 0x2000L) != 0L)
+         else if ((active1 & 0x100L) != 0L)
          {
-            jjmatchedKind = 77;
+            jjmatchedKind = 72;
             jjmatchedPos = 7;
          }
-         else if ((active1 & 0x400000000000L) != 0L)
+         else if ((active1 & 0x20000L) != 0L)
          {
-            jjmatchedKind = 110;
+            jjmatchedKind = 81;
+            jjmatchedPos = 7;
+         }
+         else if ((active1 & 0x4000000000000L) != 0L)
+         {
+            jjmatchedKind = 114;
             jjmatchedPos = 7;
          }
          break;
       case 70:
-         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x400000000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x4000000000L);
       case 73:
-         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x100000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x1000000L);
       case 76:
-         if ((active0 & 0x20000000000L) != 0L)
+         if ((active0 & 0x10000000000L) != 0L)
          {
-            jjmatchedKind = 41;
+            jjmatchedKind = 40;
             jjmatchedPos = 7;
          }
          break;
       case 77:
-         if ((active1 & 0x400000L) != 0L)
+         if ((active1 & 0x4000000L) != 0L)
          {
-            jjmatchedKind = 86;
+            jjmatchedKind = 90;
             jjmatchedPos = 7;
          }
          break;
       case 79:
-         return jjMoveStringLiteralDfa8_0(active0, 0x1008000000000000L, active1, 0x2L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x80000000000000L, active1, 0x21L);
       case 80:
-         if ((active0 & 0x4000000000000000L) != 0L)
+         if ((active1 & 0x4L) != 0L)
          {
-            jjmatchedKind = 62;
+            jjmatchedKind = 66;
             jjmatchedPos = 7;
          }
          break;
       case 82:
+         if ((active1 & 0x80000000000L) != 0L)
+         {
+            jjmatchedKind = 107;
+            jjmatchedPos = 7;
+         }
+         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x40000000000L);
+      case 83:
          if ((active1 & 0x8000000000L) != 0L)
          {
             jjmatchedKind = 103;
-            jjmatchedPos = 7;
-         }
-         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x4000000000L);
-      case 83:
-         if ((active1 & 0x800000000L) != 0L)
-         {
-            jjmatchedKind = 99;
             jjmatchedPos = 7;
          }
          break;
       case 84:
-         if ((active0 & 0x800000L) != 0L)
+         if ((active0 & 0x400000L) != 0L)
          {
-            jjmatchedKind = 23;
+            jjmatchedKind = 22;
             jjmatchedPos = 7;
          }
-         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x1000000000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x1000000000000L, active1, 0x10000000000L);
       case 97:
-         return jjMoveStringLiteralDfa8_0(active0, 0x800000000000000L, active1, 0x80000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x8000000000000000L, active1, 0x800000L);
       case 99:
-         return jjMoveStringLiteralDfa8_0(active0, 0x4000000L, active1, 0x8000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x2000000L, active1, 0x80000L);
       case 101:
-         if ((active0 & 0x2000000L) != 0L)
+         if ((active0 & 0x1000000L) != 0L)
          {
-            jjmatchedKind = 25;
+            jjmatchedKind = 24;
             jjmatchedPos = 7;
          }
-         else if ((active0 & 0x2000000000000000L) != 0L)
+         else if ((active0 & 0x400000000000L) != 0L)
          {
-            jjmatchedKind = 61;
+            jjmatchedKind = 46;
             jjmatchedPos = 7;
          }
-         else if ((active1 & 0x10L) != 0L)
+         else if ((active1 & 0x2L) != 0L)
          {
-            jjmatchedKind = 68;
+            jjmatchedKind = 65;
             jjmatchedPos = 7;
          }
-         else if ((active1 & 0x2000L) != 0L)
+         else if ((active1 & 0x100L) != 0L)
          {
-            jjmatchedKind = 77;
+            jjmatchedKind = 72;
             jjmatchedPos = 7;
          }
-         else if ((active1 & 0x400000000000L) != 0L)
+         else if ((active1 & 0x20000L) != 0L)
          {
-            jjmatchedKind = 110;
+            jjmatchedKind = 81;
+            jjmatchedPos = 7;
+         }
+         else if ((active1 & 0x4000000000000L) != 0L)
+         {
+            jjmatchedKind = 114;
             jjmatchedPos = 7;
          }
          break;
       case 102:
-         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x400000000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x4000000000L);
       case 105:
-         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x100000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x1000000L);
       case 108:
-         if ((active0 & 0x20000000000L) != 0L)
+         if ((active0 & 0x10000000000L) != 0L)
          {
-            jjmatchedKind = 41;
+            jjmatchedKind = 40;
             jjmatchedPos = 7;
          }
          break;
       case 109:
-         if ((active1 & 0x400000L) != 0L)
+         if ((active1 & 0x4000000L) != 0L)
          {
-            jjmatchedKind = 86;
+            jjmatchedKind = 90;
             jjmatchedPos = 7;
          }
          break;
       case 111:
-         return jjMoveStringLiteralDfa8_0(active0, 0x1008000000000000L, active1, 0x2L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x80000000000000L, active1, 0x21L);
       case 112:
-         if ((active0 & 0x4000000000000000L) != 0L)
+         if ((active1 & 0x4L) != 0L)
          {
-            jjmatchedKind = 62;
+            jjmatchedKind = 66;
             jjmatchedPos = 7;
          }
          break;
       case 114:
+         if ((active1 & 0x80000000000L) != 0L)
+         {
+            jjmatchedKind = 107;
+            jjmatchedPos = 7;
+         }
+         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x40000000000L);
+      case 115:
          if ((active1 & 0x8000000000L) != 0L)
          {
             jjmatchedKind = 103;
             jjmatchedPos = 7;
          }
-         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x4000000000L);
-      case 115:
-         if ((active1 & 0x800000000L) != 0L)
-         {
-            jjmatchedKind = 99;
-            jjmatchedPos = 7;
-         }
          break;
       case 116:
-         if ((active0 & 0x800000L) != 0L)
+         if ((active0 & 0x400000L) != 0L)
          {
-            jjmatchedKind = 23;
+            jjmatchedKind = 22;
             jjmatchedPos = 7;
          }
-         return jjMoveStringLiteralDfa8_0(active0, 0L, active1, 0x1000000000L);
+         return jjMoveStringLiteralDfa8_0(active0, 0x1000000000000L, active1, 0x10000000000L);
       default :
          break;
    }
@@ -1965,116 +2042,126 @@ private int jjMoveStringLiteralDfa8_0(long old0, long active0, long old1, long a
    switch(curChar)
    {
       case 67:
-         if ((active1 & 0x100000L) != 0L)
+         if ((active1 & 0x1000000L) != 0L)
          {
-            jjmatchedKind = 84;
+            jjmatchedKind = 88;
             jjmatchedPos = 8;
          }
          break;
       case 69:
-         if ((active1 & 0x4000000000L) != 0L)
+         if ((active0 & 0x1000000000000L) != 0L)
          {
-            jjmatchedKind = 102;
+            jjmatchedKind = 48;
+            jjmatchedPos = 8;
+         }
+         else if ((active1 & 0x40000000000L) != 0L)
+         {
+            jjmatchedKind = 106;
             jjmatchedPos = 8;
          }
          break;
       case 72:
-         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x8000L);
+         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x80000L);
       case 76:
-         if ((active1 & 0x80000L) != 0L)
+         if ((active1 & 0x800000L) != 0L)
          {
-            jjmatchedKind = 83;
+            jjmatchedKind = 87;
             jjmatchedPos = 8;
          }
          break;
       case 77:
-         return jjMoveStringLiteralDfa9_0(active0, 0x800000000000000L, active1, 0L);
+         return jjMoveStringLiteralDfa9_0(active0, 0x8000000000000000L, active1, 0L);
       case 78:
-         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x2L);
+         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x20L);
       case 79:
-         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x400000000L);
+         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x4000000000L);
       case 80:
-         if ((active0 & 0x1000000000000000L) != 0L)
+         if ((active1 & 0x1L) != 0L)
          {
-            jjmatchedKind = 60;
+            jjmatchedKind = 64;
             jjmatchedPos = 8;
          }
          break;
       case 82:
-         if ((active0 & 0x8000000000000L) != 0L)
+         if ((active0 & 0x80000000000000L) != 0L)
          {
-            jjmatchedKind = 51;
+            jjmatchedKind = 55;
             jjmatchedPos = 8;
          }
          break;
       case 83:
-         if ((active1 & 0x1000000000L) != 0L)
+         if ((active1 & 0x10000000000L) != 0L)
          {
-            jjmatchedKind = 100;
+            jjmatchedKind = 104;
             jjmatchedPos = 8;
          }
          break;
       case 84:
-         if ((active0 & 0x4000000L) != 0L)
+         if ((active0 & 0x2000000L) != 0L)
          {
-            jjmatchedKind = 26;
+            jjmatchedKind = 25;
             jjmatchedPos = 8;
          }
          break;
       case 99:
-         if ((active1 & 0x100000L) != 0L)
+         if ((active1 & 0x1000000L) != 0L)
          {
-            jjmatchedKind = 84;
+            jjmatchedKind = 88;
             jjmatchedPos = 8;
          }
          break;
       case 101:
-         if ((active1 & 0x4000000000L) != 0L)
+         if ((active0 & 0x1000000000000L) != 0L)
          {
-            jjmatchedKind = 102;
+            jjmatchedKind = 48;
+            jjmatchedPos = 8;
+         }
+         else if ((active1 & 0x40000000000L) != 0L)
+         {
+            jjmatchedKind = 106;
             jjmatchedPos = 8;
          }
          break;
       case 104:
-         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x8000L);
+         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x80000L);
       case 108:
-         if ((active1 & 0x80000L) != 0L)
+         if ((active1 & 0x800000L) != 0L)
          {
-            jjmatchedKind = 83;
+            jjmatchedKind = 87;
             jjmatchedPos = 8;
          }
          break;
       case 109:
-         return jjMoveStringLiteralDfa9_0(active0, 0x800000000000000L, active1, 0L);
+         return jjMoveStringLiteralDfa9_0(active0, 0x8000000000000000L, active1, 0L);
       case 110:
-         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x2L);
+         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x20L);
       case 111:
-         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x400000000L);
+         return jjMoveStringLiteralDfa9_0(active0, 0L, active1, 0x4000000000L);
       case 112:
-         if ((active0 & 0x1000000000000000L) != 0L)
+         if ((active1 & 0x1L) != 0L)
          {
-            jjmatchedKind = 60;
+            jjmatchedKind = 64;
             jjmatchedPos = 8;
          }
          break;
       case 114:
-         if ((active0 & 0x8000000000000L) != 0L)
+         if ((active0 & 0x80000000000000L) != 0L)
          {
-            jjmatchedKind = 51;
+            jjmatchedKind = 55;
             jjmatchedPos = 8;
          }
          break;
       case 115:
-         if ((active1 & 0x1000000000L) != 0L)
+         if ((active1 & 0x10000000000L) != 0L)
          {
-            jjmatchedKind = 100;
+            jjmatchedKind = 104;
             jjmatchedPos = 8;
          }
          break;
       case 116:
-         if ((active0 & 0x4000000L) != 0L)
+         if ((active0 & 0x2000000L) != 0L)
          {
-            jjmatchedKind = 26;
+            jjmatchedKind = 25;
             jjmatchedPos = 8;
          }
          break;
@@ -2093,31 +2180,31 @@ private int jjMoveStringLiteralDfa9_0(long old0, long active0, long old1, long a
    switch(curChar)
    {
       case 67:
-         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x2L);
+         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x20L);
       case 69:
-         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x8000L);
+         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x80000L);
       case 80:
-         if ((active0 & 0x800000000000000L) != 0L)
+         if ((active0 & 0x8000000000000000L) != 0L)
          {
-            jjmatchedKind = 59;
+            jjmatchedKind = 63;
             jjmatchedPos = 9;
          }
          break;
       case 82:
-         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x400000000L);
+         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x4000000000L);
       case 99:
-         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x2L);
+         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x20L);
       case 101:
-         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x8000L);
+         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x80000L);
       case 112:
-         if ((active0 & 0x800000000000000L) != 0L)
+         if ((active0 & 0x8000000000000000L) != 0L)
          {
-            jjmatchedKind = 59;
+            jjmatchedKind = 63;
             jjmatchedPos = 9;
          }
          break;
       case 114:
-         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x400000000L);
+         return jjMoveStringLiteralDfa10_0(active0, 0L, active1, 0x4000000000L);
       default :
          break;
    }
@@ -2133,22 +2220,22 @@ private int jjMoveStringLiteralDfa10_0(long old0, long active0, long old1, long 
    switch(curChar)
    {
       case 65:
-         return jjMoveStringLiteralDfa11_0(active1, 0x2L);
+         return jjMoveStringLiteralDfa11_0(active1, 0x20L);
       case 83:
-         if ((active1 & 0x8000L) != 0L)
+         if ((active1 & 0x80000L) != 0L)
          {
-            jjmatchedKind = 79;
+            jjmatchedKind = 83;
             jjmatchedPos = 10;
          }
          break;
       case 95:
-         return jjMoveStringLiteralDfa11_0(active1, 0x400000000L);
+         return jjMoveStringLiteralDfa11_0(active1, 0x4000000000L);
       case 97:
-         return jjMoveStringLiteralDfa11_0(active1, 0x2L);
+         return jjMoveStringLiteralDfa11_0(active1, 0x20L);
       case 115:
-         if ((active1 & 0x8000L) != 0L)
+         if ((active1 & 0x80000L) != 0L)
          {
-            jjmatchedKind = 79;
+            jjmatchedKind = 83;
             jjmatchedPos = 10;
          }
          break;
@@ -2167,23 +2254,23 @@ private int jjMoveStringLiteralDfa11_0(long old1, long active1){
    switch(curChar)
    {
       case 84:
-         if ((active1 & 0x2L) != 0L)
+         if ((active1 & 0x20L) != 0L)
          {
-            jjmatchedKind = 65;
+            jjmatchedKind = 69;
             jjmatchedPos = 11;
          }
          break;
       case 85:
-         return jjMoveStringLiteralDfa12_0(active1, 0x400000000L);
+         return jjMoveStringLiteralDfa12_0(active1, 0x4000000000L);
       case 116:
-         if ((active1 & 0x2L) != 0L)
+         if ((active1 & 0x20L) != 0L)
          {
-            jjmatchedKind = 65;
+            jjmatchedKind = 69;
             jjmatchedPos = 11;
          }
          break;
       case 117:
-         return jjMoveStringLiteralDfa12_0(active1, 0x400000000L);
+         return jjMoveStringLiteralDfa12_0(active1, 0x4000000000L);
       default :
          break;
    }
@@ -2199,9 +2286,9 @@ private int jjMoveStringLiteralDfa12_0(long old1, long active1){
    switch(curChar)
    {
       case 82:
-         return jjMoveStringLiteralDfa13_0(active1, 0x400000000L);
+         return jjMoveStringLiteralDfa13_0(active1, 0x4000000000L);
       case 114:
-         return jjMoveStringLiteralDfa13_0(active1, 0x400000000L);
+         return jjMoveStringLiteralDfa13_0(active1, 0x4000000000L);
       default :
          break;
    }
@@ -2217,16 +2304,16 @@ private int jjMoveStringLiteralDfa13_0(long old1, long active1){
    switch(curChar)
    {
       case 73:
-         if ((active1 & 0x400000000L) != 0L)
+         if ((active1 & 0x4000000000L) != 0L)
          {
-            jjmatchedKind = 98;
+            jjmatchedKind = 102;
             jjmatchedPos = 13;
          }
          break;
       case 105:
-         if ((active1 & 0x400000000L) != 0L)
+         if ((active1 & 0x4000000000L) != 0L)
          {
-            jjmatchedKind = 98;
+            jjmatchedKind = 102;
             jjmatchedPos = 13;
          }
          break;
@@ -2299,8 +2386,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 0:
                   if ((0x3ff000000000000L & l) != 0L)
                   {
-                     if (kind > 145)
-                        kind = 145;
+                     if (kind > 149)
+                        kind = 149;
                      { jjCheckNAddStates(0, 6); }
                   }
                   else if (curChar == 45)
@@ -2311,8 +2398,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddTwoStates(195, 207); }
                   else if (curChar == 58)
                   {
-                     if (kind > 11)
-                        kind = 11;
+                     if (kind > 10)
+                        kind = 10;
                      { jjCheckNAddStates(17, 19); }
                   }
                   else if (curChar == 40)
@@ -2398,8 +2485,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(23, 25); }
                   break;
                case 17:
-                  if (curChar == 62 && kind > 10)
-                     kind = 10;
+                  if (curChar == 62 && kind > 9)
+                     kind = 9;
                   break;
                case 18:
                   if (curChar == 58)
@@ -2408,8 +2495,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 19:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 13)
-                     kind = 13;
+                  if (kind > 12)
+                     kind = 12;
                   { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 20:
@@ -2417,8 +2504,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 21:
-                  if ((0x3ff200000000000L & l) != 0L && kind > 13)
-                     kind = 13;
+                  if ((0x3ff200000000000L & l) != 0L && kind > 12)
+                     kind = 12;
                   break;
                case 23:
                   if (curChar == 63)
@@ -2428,8 +2515,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 25:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 14)
-                     kind = 14;
+                  if (kind > 13)
+                     kind = 13;
                   { jjCheckNAdd(25); }
                   break;
                case 26:
@@ -2440,8 +2527,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 28:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 15)
-                     kind = 15;
+                  if (kind > 14)
+                     kind = 14;
                   { jjCheckNAdd(28); }
                   break;
                case 31:
@@ -2451,8 +2538,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 32:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 16)
-                     kind = 16;
+                  if (kind > 15)
+                     kind = 15;
                   { jjCheckNAddTwoStates(31, 32); }
                   break;
                case 34:
@@ -2480,8 +2567,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 42;
                   break;
                case 50:
-                  if ((0x8400000000L & l) != 0L && kind > 157)
-                     kind = 157;
+                  if ((0x8400000000L & l) != 0L && kind > 161)
+                     kind = 161;
                   break;
                case 51:
                   if (curChar == 39)
@@ -2492,8 +2579,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(32, 34); }
                   break;
                case 53:
-                  if (curChar == 39 && kind > 161)
-                     kind = 161;
+                  if (curChar == 39 && kind > 165)
+                     kind = 165;
                   break;
                case 55:
                   if ((0x8400000000L & l) != 0L)
@@ -2540,8 +2627,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(29, 31); }
                   break;
                case 67:
-                  if (curChar == 34 && kind > 162)
-                     kind = 162;
+                  if (curChar == 34 && kind > 166)
+                     kind = 166;
                   break;
                case 69:
                   if ((0x8400000000L & l) != 0L)
@@ -2633,8 +2720,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(44, 47); }
                   break;
                case 95:
-                  if (curChar == 39 && kind > 163)
-                     kind = 163;
+                  if (curChar == 39 && kind > 167)
+                     kind = 167;
                   break;
                case 96:
                   if (curChar == 39)
@@ -2702,8 +2789,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(50, 53); }
                   break;
                case 115:
-                  if (curChar == 34 && kind > 164)
-                     kind = 164;
+                  if (curChar == 34 && kind > 168)
+                     kind = 168;
                   break;
                case 116:
                   if (curChar == 34)
@@ -2738,8 +2825,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(20, 22); }
                   break;
                case 124:
-                  if (curChar == 41 && kind > 167)
-                     kind = 167;
+                  if (curChar == 41 && kind > 171)
+                     kind = 171;
                   break;
                case 125:
                   if (curChar == 10)
@@ -2782,8 +2869,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 138;
                   break;
                case 138:
-                  if (curChar == 58 && kind > 11)
-                     kind = 11;
+                  if (curChar == 58 && kind > 10)
+                     kind = 10;
                   break;
                case 139:
                   if ((0x3ff600000000000L & l) != 0L)
@@ -2800,8 +2887,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 142:
                   if ((0x7ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 12)
-                     kind = 12;
+                  if (kind > 11)
+                     kind = 11;
                   { jjCheckNAddStates(75, 78); }
                   break;
                case 143:
@@ -2809,8 +2896,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(75, 78); }
                   break;
                case 144:
-                  if ((0x7ff200000000000L & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x7ff200000000000L & l) != 0L && kind > 11)
+                     kind = 11;
                   break;
                case 146:
                   if ((0xa800fffa00000000L & l) != 0L)
@@ -2833,18 +2920,18 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 151;
                   break;
                case 151:
-                  if ((0x3ff000000000000L & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x3ff000000000000L & l) != 0L && kind > 11)
+                     kind = 11;
                   break;
                case 152:
-                  if ((0xa800fffa00000000L & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0xa800fffa00000000L & l) != 0L && kind > 11)
+                     kind = 11;
                   break;
                case 154:
                   if ((0xa800fffa00000000L & l) == 0L)
                      break;
-                  if (kind > 12)
-                     kind = 12;
+                  if (kind > 11)
+                     kind = 11;
                   { jjCheckNAddStates(75, 78); }
                   break;
                case 155:
@@ -2858,15 +2945,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 157:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 12)
-                     kind = 12;
+                  if (kind > 11)
+                     kind = 11;
                   { jjCheckNAddStates(75, 78); }
                   break;
                case 158:
                   if (curChar != 58)
                      break;
-                  if (kind > 11)
-                     kind = 11;
+                  if (kind > 10)
+                     kind = 10;
                   { jjCheckNAddStates(17, 19); }
                   break;
                case 161:
@@ -2920,15 +3007,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 191:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 145)
-                     kind = 145;
+                  if (kind > 149)
+                     kind = 149;
                   { jjCheckNAddStates(0, 6); }
                   break;
                case 192:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 145)
-                     kind = 145;
+                  if (kind > 149)
+                     kind = 149;
                   { jjCheckNAdd(192); }
                   break;
                case 193:
@@ -2942,8 +3029,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 195:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 146)
-                     kind = 146;
+                  if (kind > 150)
+                     kind = 150;
                   { jjCheckNAdd(195); }
                   break;
                case 196:
@@ -2965,8 +3052,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 201:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 147)
-                     kind = 147;
+                  if (kind > 151)
+                     kind = 151;
                   { jjCheckNAdd(201); }
                   break;
                case 202:
@@ -2980,8 +3067,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 205:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 147)
-                     kind = 147;
+                  if (kind > 151)
+                     kind = 151;
                   { jjCheckNAdd(205); }
                   break;
                case 206:
@@ -2999,8 +3086,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 210:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 147)
-                     kind = 147;
+                  if (kind > 151)
+                     kind = 151;
                   { jjCheckNAdd(210); }
                   break;
                case 211:
@@ -3010,8 +3097,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 212:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 148)
-                     kind = 148;
+                  if (kind > 152)
+                     kind = 152;
                   { jjCheckNAdd(212); }
                   break;
                case 213:
@@ -3025,8 +3112,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 215:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 149)
-                     kind = 149;
+                  if (kind > 153)
+                     kind = 153;
                   { jjCheckNAdd(215); }
                   break;
                case 216:
@@ -3044,8 +3131,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 220:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 150)
-                     kind = 150;
+                  if (kind > 154)
+                     kind = 154;
                   { jjCheckNAdd(220); }
                   break;
                case 221:
@@ -3071,8 +3158,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 227:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 150)
-                     kind = 150;
+                  if (kind > 154)
+                     kind = 154;
                   { jjCheckNAdd(227); }
                   break;
                case 228:
@@ -3086,8 +3173,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 231:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 150)
-                     kind = 150;
+                  if (kind > 154)
+                     kind = 154;
                   { jjCheckNAdd(231); }
                   break;
                case 232:
@@ -3097,8 +3184,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 233:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 151)
-                     kind = 151;
+                  if (kind > 155)
+                     kind = 155;
                   { jjCheckNAdd(233); }
                   break;
                case 234:
@@ -3112,8 +3199,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 236:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 152)
-                     kind = 152;
+                  if (kind > 156)
+                     kind = 156;
                   { jjCheckNAdd(236); }
                   break;
                case 237:
@@ -3131,8 +3218,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 241:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 153)
-                     kind = 153;
+                  if (kind > 157)
+                     kind = 157;
                   { jjCheckNAdd(241); }
                   break;
                case 242:
@@ -3158,8 +3245,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 248:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 153)
-                     kind = 153;
+                  if (kind > 157)
+                     kind = 157;
                   { jjCheckNAdd(248); }
                   break;
                case 249:
@@ -3173,8 +3260,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 252:
                   if ((0x3ff000000000000L & l) == 0L)
                      break;
-                  if (kind > 153)
-                     kind = 153;
+                  if (kind > 157)
+                     kind = 157;
                   { jjCheckNAdd(252); }
                   break;
                default : break;
@@ -3256,8 +3343,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 19:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 13)
-                     kind = 13;
+                  if (kind > 12)
+                     kind = 12;
                   { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 20:
@@ -3265,8 +3352,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 21:
-                  if ((0x7fffffe87fffffeL & l) != 0L && kind > 13)
-                     kind = 13;
+                  if ((0x7fffffe87fffffeL & l) != 0L && kind > 12)
+                     kind = 12;
                   break;
                case 22:
                   if (curChar == 95)
@@ -3276,16 +3363,16 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 25:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 14)
-                     kind = 14;
+                  if (kind > 13)
+                     kind = 13;
                   { jjCheckNAdd(25); }
                   break;
                case 27:
                case 28:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 15)
-                     kind = 15;
+                  if (kind > 14)
+                     kind = 14;
                   { jjCheckNAdd(28); }
                   break;
                case 29:
@@ -3295,15 +3382,15 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 30:
                   if ((0x7fffffe07fffffeL & l) == 0L)
                      break;
-                  if (kind > 16)
-                     kind = 16;
+                  if (kind > 15)
+                     kind = 15;
                   { jjCheckNAddTwoStates(30, 31); }
                   break;
                case 32:
                   if ((0x7fffffe07fffffeL & l) == 0L)
                      break;
-                  if (kind > 16)
-                     kind = 16;
+                  if (kind > 15)
+                     kind = 15;
                   { jjCheckNAddTwoStates(31, 32); }
                   break;
                case 33:
@@ -3314,8 +3401,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                   { jjCheckNAddStates(35, 40); }
                   break;
                case 38:
-                  if ((0x200000002L & l) != 0L && kind > 126)
-                     kind = 126;
+                  if ((0x200000002L & l) != 0L && kind > 130)
+                     kind = 130;
                   break;
                case 39:
                   if ((0x10000000100000L & l) != 0L)
@@ -3354,8 +3441,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 50;
                   break;
                case 50:
-                  if ((0x14404410000000L & l) != 0L && kind > 157)
-                     kind = 157;
+                  if ((0x14404410000000L & l) != 0L && kind > 161)
+                     kind = 161;
                   break;
                case 52:
                   if ((0xffffffffefffffffL & l) != 0L)
@@ -3560,8 +3647,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                   { jjCheckNAddStates(62, 67); }
                   break;
                case 132:
-                  if (curChar == 93 && kind > 172)
-                     kind = 172;
+                  if (curChar == 93 && kind > 176)
+                     kind = 176;
                   break;
                case 135:
                   if ((0x7fffffe07fffffeL & l) != 0L)
@@ -3586,8 +3673,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 142:
                   if ((0x7fffffe87fffffeL & l) == 0L)
                      break;
-                  if (kind > 12)
-                     kind = 12;
+                  if (kind > 11)
+                     kind = 11;
                   { jjCheckNAddStates(75, 78); }
                   break;
                case 143:
@@ -3595,8 +3682,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(75, 78); }
                   break;
                case 144:
-                  if ((0x7fffffe87fffffeL & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x7fffffe87fffffeL & l) != 0L && kind > 11)
+                     kind = 11;
                   break;
                case 145:
                   if (curChar == 92)
@@ -3619,12 +3706,12 @@ private int jjMoveNfa_0(int startState, int curPos)
                      jjstateSet[jjnewStateCnt++] = 151;
                   break;
                case 151:
-                  if ((0x7e0000007eL & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x7e0000007eL & l) != 0L && kind > 11)
+                     kind = 11;
                   break;
                case 152:
-                  if ((0x4000000080000001L & l) != 0L && kind > 12)
-                     kind = 12;
+                  if ((0x4000000080000001L & l) != 0L && kind > 11)
+                     kind = 11;
                   break;
                case 153:
                   if (curChar == 92)
@@ -3633,8 +3720,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 154:
                   if ((0x4000000080000001L & l) == 0L)
                      break;
-                  if (kind > 12)
-                     kind = 12;
+                  if (kind > 11)
+                     kind = 11;
                   { jjCheckNAddStates(75, 78); }
                   break;
                case 156:
@@ -3644,8 +3731,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 157:
                   if ((0x7e0000007eL & l) == 0L)
                      break;
-                  if (kind > 12)
-                     kind = 12;
+                  if (kind > 11)
+                     kind = 11;
                   { jjCheckNAddStates(75, 78); }
                   break;
                case 159:
@@ -3660,8 +3747,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                   { jjCheckNAddStates(81, 86); }
                   break;
                case 165:
-                  if ((0x200000002L & l) != 0L && kind > 127)
-                     kind = 127;
+                  if ((0x200000002L & l) != 0L && kind > 131)
+                     kind = 131;
                   break;
                case 166:
                   if ((0x10000000100000L & l) != 0L)
@@ -3699,8 +3786,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                   { jjCheckNAddStates(90, 95); }
                   break;
                case 180:
-                  if ((0x2000000020L & l) != 0L && kind > 128)
-                     kind = 128;
+                  if ((0x2000000020L & l) != 0L && kind > 132)
+                     kind = 132;
                   break;
                case 181:
                   if ((0x4000000040000L & l) != 0L)
@@ -3803,8 +3890,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 19:
                   if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
                      break;
-                  if (kind > 13)
-                     kind = 13;
+                  if (kind > 12)
+                     kind = 12;
                   { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 20:
@@ -3812,35 +3899,35 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddTwoStates(20, 21); }
                   break;
                case 21:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 13)
-                     kind = 13;
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 12)
+                     kind = 12;
                   break;
                case 24:
                   if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
                      break;
-                  if (kind > 14)
-                     kind = 14;
+                  if (kind > 13)
+                     kind = 13;
                   { jjCheckNAdd(25); }
                   break;
                case 25:
                   if (!jjCanMove_2(hiByte, i1, i2, l1, l2))
                      break;
-                  if (kind > 14)
-                     kind = 14;
+                  if (kind > 13)
+                     kind = 13;
                   { jjCheckNAdd(25); }
                   break;
                case 27:
                   if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
                      break;
-                  if (kind > 15)
-                     kind = 15;
+                  if (kind > 14)
+                     kind = 14;
                   { jjCheckNAdd(28); }
                   break;
                case 28:
                   if (!jjCanMove_2(hiByte, i1, i2, l1, l2))
                      break;
-                  if (kind > 15)
-                     kind = 15;
+                  if (kind > 14)
+                     kind = 14;
                   { jjCheckNAdd(28); }
                   break;
                case 35:
@@ -3890,8 +3977,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                case 142:
                   if (!jjCanMove_1(hiByte, i1, i2, l1, l2))
                      break;
-                  if (kind > 12)
-                     kind = 12;
+                  if (kind > 11)
+                     kind = 11;
                   { jjCheckNAddStates(75, 78); }
                   break;
                case 143:
@@ -3899,8 +3986,8 @@ private int jjMoveNfa_0(int startState, int curPos)
                      { jjCheckNAddStates(75, 78); }
                   break;
                case 144:
-                  if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 12)
-                     kind = 12;
+                  if (jjCanMove_2(hiByte, i1, i2, l1, l2) && kind > 11)
+                     kind = 11;
                   break;
                case 162:
                   if (jjCanMove_0(hiByte, i1, i2, l1, l2))
@@ -3949,8 +4036,8 @@ private int jjMoveNfa_0(int startState, int curPos)
 
 /** Token literal values. */
 public static final String[] jjstrLiteralImages = {
-"", null, null, null, null, null, null, null, null, "\ufeff", null, null, null, 
-null, null, null, null, null, null, "\141", null, null, null, null, null, null, null, 
+"", null, null, null, null, null, null, null, null, null, null, null, null, 
+null, null, null, null, null, "\141", null, null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
@@ -3960,11 +4047,12 @@ null, null, null, null, null, null, null, null, null, null, null, null, null, nu
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
 null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
-null, null, null, null, null, null, null, null, null, null, null, null, "\50", 
-"\51", null, "\173", "\175", "\133", "\135", null, "\73", "\54", "\56", "\75", 
-"\41\75", "\76", "\74", "\74\75", "\76\75", "\41", "\176", "\72", "\174\174", "\46\46", 
-"\53", "\55", "\52", "\57", "\136\136", "\100", "\174", "\136", "\55\76", "\74\55", 
-"\77", null, null, null, null, null, null, null, null, null, null, null, };
+null, null, null, null, null, null, null, null, null, null, null, null, null, null, 
+null, null, "\50", "\51", null, "\173", "\175", "\133", "\135", null, "\73", "\54", 
+"\56", "\75", "\41\75", "\76", "\74", "\74\75", "\76\75", "\76\76", "\74\74", 
+"\173\174", "\174\175", "\41", "\176", "\72", "\174\174", "\46\46", "\53", "\55", "\52", 
+"\57", "\136\136", "\100", "\174", "\136", "\55\76", "\74\55", "\77", null, null, 
+null, null, null, null, null, null, null, null, null, };
 protected Token jjFillToken()
 {
    final Token t;
@@ -4264,10 +4352,10 @@ public static final int[] jjnewLexState = {
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
-   -1, -1, -1, -1, -1, -1, -1, -1, -1, 
+   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 
 };
 static final long[] jjtoToken = {
-   0xfffffffffff9fe01L, 0xffffffffffffffffL, 0xfffffffe23feffffL, 0x3fL, 
+   0xfffffffffffcfe01L, 0xffffffffffffffffL, 0xffffffe23fefffffL, 0x3fffL, 
 };
 static final long[] jjtoSkip = {
    0x7eL, 0x0L, 0x0L, 0x0L, 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/sse/ItemWriter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/sse/ItemWriter.java
@@ -44,10 +44,18 @@ public class ItemWriter
     }
 
     public static void write(IndentedWriter out, Item item, SerializationContext sCxt) {
-        writeFn(out, item, sCxt);
+        writeInline(out, item, sCxt);
     }
 
-    // Core function. Does not apply reverse lift.
+    // Core function. Does not apply reverse lift. Does not write prefixes or base.
+    private static void writeInline(IndentedWriter out, Item item, SerializationContext sCxt) {
+        Print pv = new Print(out, sCxt);
+        pv.startPrint();
+        item.visit(pv);
+        pv.finishPrint();
+    }
+
+    // Core function. Writes self contained output with prfixes and base.
     private static void writeFn(IndentedWriter out, Item item, SerializationContext sCxt) {
         Print pv = new Print(out, sCxt);
         pv.startPrint();
@@ -130,7 +138,9 @@ public class ItemWriter
             this.sCxt = sCxt;
         }
 
-        void startPrint() {
+        void startPrint() {}
+
+        void writeContext() {
             if ( sCxt != null ) {
                 if ( includeBase && sCxt.getBaseIRI() != null ) {
                     out.print("(base ");
@@ -151,7 +161,6 @@ public class ItemWriter
                 }
             }
         }
-
         void finishPrint() {
             if ( doneBase ) {
                 out.print(")");

--- a/jena-arq/src/test/java/org/apache/jena/riot/Scripts_AltTurtle.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/Scripts_AltTurtle.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith ;
 /** Execute turtle test with alt parser. */
 
 @RunWith(RunnerRIOT.class)
-@Label("RIOT-TurtleJCC")
+@Label("RIOT-TurtleJCC Scripts")
 @Manifests({
     "testing/RIOT/Lang/TurtleStd/manifest.ttl",
     "testing/RIOT/Lang/Turtle2/manifest.ttl",

--- a/jena-arq/src/test/java/org/apache/jena/riot/Scripts_LangSuite.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/Scripts_LangSuite.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith ;
 /** The test suites - these are driven by a manifest file and use external files for tests */
 
 @RunWith(RunnerRIOT.class)
-@Label("RIOT")
+@Label("RIOT Scripts")
 @Manifests({
     "testing/RIOT/Lang/manifest-all.ttl"
 })

--- a/jena-arq/src/test/java/org/apache/jena/riot/TC_Riot.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TC_Riot.java
@@ -50,7 +50,7 @@ import org.junit.runners.Suite ;
     , TS_RDFProtobuf.class
     , TS_RDFThrift.class
     , TS_RowSetRIOT.class
-    // And scripted tests.
+    // Scripted tests in ARQTestSuite.
 })
 
 public class TC_Riot

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/html/QueryValidatorHTML.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/validation/html/QueryValidatorHTML.java
@@ -46,7 +46,6 @@ public class QueryValidatorHTML {
     static final String paramFormat      = "outputFormat";
     static final String paramQuery       = "query";
     static final String paramSyntax      = "languageSyntax";
-    // static final String paramSyntaxExtended = "extendedSyntax";
 
     public static void executeHTML(HttpServletRequest httpRequest, HttpServletResponse httpResponse) {
         try {


### PR DESCRIPTION
GitHub issue resolved #1872
GitHub issue resolved #1881

This PR tracks the work done to develop the SPARQL 1.2 language grammar.

This is the `Syntax.syntaxSPARQL_12` parser language in Jena. It is not the default parser, which is the ARQ language - SPARQL with some extensions and efficiency re-writes specifically to suit JavaCC.

The Working Group material is definitive.

This PR is draft until the WG merges the initial update of the SPARQL grammar. There will likely be further changes over the life of the WG.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
