### PR TITLE
Errors and warnings when quads in, triples out

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/StreamRDFWriter.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/StreamRDFWriter.java
@@ -28,7 +28,6 @@ import org.apache.jena.atlas.io.AWriter ;
 import org.apache.jena.atlas.io.IO ;
 import org.apache.jena.atlas.lib.CharSpace ;
 import org.apache.jena.graph.Graph ;
-import org.apache.jena.graph.Triple ;
 import org.apache.jena.riot.* ;
 import org.apache.jena.riot.protobuf.ProtobufRDF;
 import org.apache.jena.riot.thrift.ThriftRDF;
@@ -37,7 +36,6 @@ import org.apache.jena.riot.writer.WriterStreamRDFBlocks ;
 import org.apache.jena.riot.writer.WriterStreamRDFFlat ;
 import org.apache.jena.riot.writer.WriterStreamRDFPlain ;
 import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.util.Context;
 
 /** Write RDF in a streaming fashion.
@@ -221,10 +219,7 @@ public class StreamRDFWriter {
             return null;
         if ( context == null )
             context = RIOT.getContext().copy();
-        StreamRDF stream = x.create(output, format, context) ;
-        if ( ! RDFLanguages.isQuads(format.getLang()) )
-            // Only pass through triples.
-            stream = new StreamTriplesOnly(stream) ;
+        StreamRDF stream = x.create(output, format, context);
         return stream ;
     }
 
@@ -308,26 +303,8 @@ public class StreamRDFWriter {
         StreamRDFOps.datasetToStream(datasetGraph, stream) ;
     }
 
-    private static class StreamTriplesOnly extends StreamRDFWrapper {
-
-        public StreamTriplesOnly(StreamRDF sink) {
-            super(sink) ;
-        }
-
-        @Override public void quad(Quad quad) {
-            if ( quad.isTriple() || quad.isDefaultGraph() || quad.isUnionGraph() ) {
-                triple(quad.asTriple()) ;
-            }
-        }
-
-        @Override public void triple(Triple triple)
-        { other.triple(triple) ; }
-    }
-
     /** Writer registry */
     public static class WriterRegistry<T> {
-        // But RDFWriterregistry is two registries with shared Map<Lang, RDFFormat>
-        // Coudl refator but the benefit is not so great.
 
         private Map<RDFFormat, T>     formatRegistry  = new HashMap<>() ;
         private Map<Lang, RDFFormat>  langToFormat    = new HashMap<>() ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/StreamTriplesOnly.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/StreamTriplesOnly.java
@@ -18,27 +18,25 @@
 
 package org.apache.jena.riot.system;
 
-import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.sparql.core.Quad;
-import org.slf4j.Logger;
 
 /**
  * {@link StreamRDF} that expects triples not quads.
- * Issues a warning when the first quad is seen.
+ * Runs an action the first time a quad is seen.
  * Quads that are the default graph or no graph are redirected to {@link StreamRDF#triple}.
  */
 public class StreamTriplesOnly extends StreamRDFWrapper {
 
-    public static StreamRDF warnIfQuads(Logger log, StreamRDF stream) {
-        return new StreamTriplesOnly(log, stream);
+    public static StreamRDF actionIfQuads(StreamRDF stream, Runnable action) {
+        return new StreamTriplesOnly(stream, action);
     }
 
     private boolean seenQuads = false;
-    private final Logger log;
+    private final Runnable action;
 
-    private StreamTriplesOnly(Logger logger, StreamRDF sink) {
+    private StreamTriplesOnly(StreamRDF sink, Runnable action) {
         super(sink) ;
-        this.log = logger;
+        this.action = action;
     }
 
     @Override
@@ -48,7 +46,7 @@ public class StreamTriplesOnly extends StreamRDFWrapper {
             return;
         }
         if ( ! seenQuads ) {
-            Log.warn(log, "Quads in triples output - quads ignored");
+            action.run();
             seenQuads = true;
         }
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/StreamTriplesOnly.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/StreamTriplesOnly.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.system;
+
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.sparql.core.Quad;
+import org.slf4j.Logger;
+
+/**
+ * {@link StreamRDF} that expects triples not quads.
+ * Issues a warning when the first quad is seen.
+ * Quads that are the default graph or no graph are redirected to {@link StreamRDF#triple}.
+ */
+public class StreamTriplesOnly extends StreamRDFWrapper {
+
+    public static StreamRDF warnIfQuads(Logger log, StreamRDF stream) {
+        return new StreamTriplesOnly(log, stream);
+    }
+
+    private boolean seenQuads = false;
+    private final Logger log;
+
+    private StreamTriplesOnly(Logger logger, StreamRDF sink) {
+        super(sink) ;
+        this.log = logger;
+    }
+
+    @Override
+    public void quad(Quad quad) {
+        if ( quad.isTriple() || quad.isDefaultGraph() || quad.isUnionGraph() ) {
+            triple(quad.asTriple()) ;
+            return;
+        }
+        if ( ! seenQuads ) {
+            Log.warn(log, "Quads in triples output - quads ignored");
+            seenQuads = true;
+        }
+    }
+
+//        @Override public void triple(Triple triple)
+//        { other.triple(triple) ; }
+}
+

--- a/jena-cmds/src/main/java/arq/cmdline/ModLangOutput.java
+++ b/jena-cmds/src/main/java/arq/cmdline/ModLangOutput.java
@@ -18,35 +18,35 @@
 
 package arq.cmdline;
 
-import java.io.PrintStream ;
-import java.util.HashSet ;
-import java.util.Set ;
+import java.io.PrintStream;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.jena.cmd.*;
 import org.apache.jena.ext.com.google.common.base.Objects;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFFormat ;
-import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.riot.RDFWriterRegistry ;
-import org.apache.jena.riot.system.StreamRDFWriter ;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.riot.RDFWriterRegistry;
+import org.apache.jena.riot.system.StreamRDFWriter;
 
 public class ModLangOutput extends ModBase
 {
-    protected ArgDecl argOutput       = new ArgDecl(ArgDecl.HasValue, "out", "output") ;
-    protected ArgDecl argPretty       = new ArgDecl(ArgDecl.HasValue, "formatted", "pretty", "fmt") ;
-    protected ArgDecl argStream       = new ArgDecl(ArgDecl.HasValue, "stream") ;
-    protected ArgDecl argCompress     = new ArgDecl(ArgDecl.NoValue, "compress") ;
-    private boolean compressedOutput  = false ;
-    private RDFFormat streamOutput    = null ;
-    private RDFFormat formattedOutput = null ;
+    protected ArgDecl argOutput       = new ArgDecl(ArgDecl.HasValue, "out", "output");
+    protected ArgDecl argPretty       = new ArgDecl(ArgDecl.HasValue, "formatted", "pretty", "fmt");
+    protected ArgDecl argStream       = new ArgDecl(ArgDecl.HasValue, "stream");
+    protected ArgDecl argCompress     = new ArgDecl(ArgDecl.NoValue, "compress");
+    private boolean compressedOutput  = false;
+    private RDFFormat streamOutput    = null;
+    private RDFFormat formattedOutput = null;
 
     @Override
     public void registerWith(CmdGeneral cmdLine) {
-        cmdLine.getUsage().startCategory("Output control") ;
-        cmdLine.add(argOutput,    "--output=FMT",     "Output in the given format, streaming if possible.") ;
-        cmdLine.add(argPretty,    "--formatted=FMT",  "Output, using pretty printing (consumes memory)") ;
-        cmdLine.add(argStream,    "--stream=FMT",     "Output, using a streaming format") ;
-        cmdLine.add(argCompress,  "--compress",       "Compress the output with gzip") ;
+        cmdLine.getUsage().startCategory("Output control");
+        cmdLine.add(argOutput,    "--output=FMT",     "Output in the given format, streaming if possible.");
+        cmdLine.add(argPretty,    "--formatted=FMT",  "Output, using pretty printing (consumes memory)");
+        cmdLine.add(argStream,    "--stream=FMT",     "Output, using a streaming format");
+        cmdLine.add(argCompress,  "--compress",       "Compress the output with gzip");
     }
 
     @Override
@@ -63,46 +63,47 @@ public class ModLangOutput extends ModBase
             if ( x >= 2 )
                 throw new CmdException("Multiple output choices given: Use one of--stream, --output and --formatted");
         }
+
         if ( cmdLine.contains(argPretty) ) {
-            String langName = cmdLine.getValue(argPretty) ;
-            Lang lang = RDFLanguages.nameToLang(langName) ;
+            String langName = cmdLine.getValue(argPretty);
+            Lang lang = RDFLanguages.nameToLang(langName);
             if ( lang == null )
-                throw new CmdException("Not recognized as an RDF language : '"+langName+"'") ;
-            formattedOutput = RDFWriterRegistry.defaultSerialization(lang) ;
+                throw new CmdException("Not recognized as an RDF language : '"+langName+"'");
+            formattedOutput = RDFWriterRegistry.defaultSerialization(lang);
             if ( formattedOutput == null ) {
-                System.err.println("Language '"+lang.getLabel()+"' not registered.") ;
-                printRegistered(System.err) ;
-                throw new CmdException("No output set: '"+langName+"'") ;
+                System.err.println("Language '"+lang.getLabel()+"' not registered.");
+                printRegistered(System.err);
+                throw new CmdException("No output set: '"+langName+"'");
             }
         }
 
         if ( cmdLine.contains(argStream) ) {
-            String langName = cmdLine.getValue(argStream) ;
-            Lang lang = RDFLanguages.nameToLang(langName) ;
+            String langName = cmdLine.getValue(argStream);
+            Lang lang = RDFLanguages.nameToLang(langName);
             if ( lang == null )
-                throw new CmdException("Not recognized as an RDF language : '"+langName+"'") ;
-            streamOutput = StreamRDFWriter.defaultSerialization(lang) ;
+                throw new CmdException("Not recognized as an RDF language : '"+langName+"'");
+            streamOutput = StreamRDFWriter.defaultSerialization(lang);
             if ( streamOutput == null ) {
-                System.err.println("Language '"+lang.getLabel()+"' not registered for streaming.") ;
-                printRegistered(System.err) ;
-                throw new CmdException("No output set: '"+langName+"'") ;
+                System.err.println("Language '"+lang.getLabel()+"' not registered for streaming.");
+                printRegistered(System.err);
+                throw new CmdException("No output set: '"+langName+"'");
             }
         }
 
         if ( cmdLine.contains(argOutput) ) {
-            String langName = cmdLine.getValue(argOutput) ;
-            Lang lang = RDFLanguages.nameToLang(langName) ;
+            String langName = cmdLine.getValue(argOutput);
+            Lang lang = RDFLanguages.nameToLang(langName);
             if ( lang == null )
-                throw new CmdException("Not recognized as an RDF language : '"+langName+"'") ;
+                throw new CmdException("Not recognized as an RDF language : '"+langName+"'");
 
             if ( StreamRDFWriter.registered(lang) ) {
-                streamOutput = StreamRDFWriter.defaultSerialization(lang) ;
+                streamOutput = StreamRDFWriter.defaultSerialization(lang);
             } else {
-                formattedOutput = RDFWriterRegistry.defaultSerialization(lang) ;
+                formattedOutput = RDFWriterRegistry.defaultSerialization(lang);
                 if ( formattedOutput == null ) {
-                    System.err.println("Language '"+lang.getLabel()+"' not recognized.") ;
-                    printRegistered(System.err) ;
-                    throw new CmdException("No output set: '"+langName+"'") ;
+                    System.err.println("Language '"+lang.getLabel()+"' not recognized.");
+                    printRegistered(System.err);
+                    throw new CmdException("No output set: '"+langName+"'");
                 }
                 // Non-streaming block-style writers.
                 // The normal RDF/XML writer is the pretty one, also know as "RDF/XML-ABBREV"
@@ -119,52 +120,51 @@ public class ModLangOutput extends ModBase
             }
         }
 
-        if ( cmdLine.contains(argCompress))
-            compressedOutput = true ;
+        compressedOutput = cmdLine.contains(argCompress);
 
         if ( streamOutput == null && formattedOutput == null )
-            streamOutput = RDFFormat.NQUADS ;
+            streamOutput = RDFFormat.NQUADS;
     }
 
-    private static Set<Lang>  hiddenLanguages = new HashSet<>() ;
+    private static Set<Lang>  hiddenLanguages = new HashSet<>();
     static {
-        hiddenLanguages.add(Lang.RDFNULL) ;
-        hiddenLanguages.add(Lang.CSV) ;
+        hiddenLanguages.add(Lang.RDFNULL);
+        hiddenLanguages.add(Lang.CSV);
     }
 
     private static void printRegistered(PrintStream out) {
-        out.println("Streaming languages:") ;
-        Set<Lang> seen = new HashSet<>() ;
+        out.println("Streaming languages:");
+        Set<Lang> seen = new HashSet<>();
         for ( RDFFormat fmt : StreamRDFWriter.registered()) {
-            Lang lang = fmt.getLang() ;
+            Lang lang = fmt.getLang();
             if ( hiddenLanguages.contains(lang))
-                continue ;
+                continue;
             if ( seen.contains(lang) )
-                continue ;
-            seen.add(lang) ;
-            out.println("   "+lang.getLabel()) ;
+                continue;
+            seen.add(lang);
+            out.println("   "+lang.getLabel());
         }
-        System.err.println("Non-streaming languages:") ;
+        System.err.println("Non-streaming languages:");
         for ( RDFFormat fmt : RDFWriterRegistry.registeredFormats() ) {
-            Lang lang = fmt.getLang() ;
+            Lang lang = fmt.getLang();
             if ( hiddenLanguages.contains(lang))
-                continue ;
+                continue;
             if ( seen.contains(lang) )
-                continue ;
-            seen.add(lang) ;
-            out.println("   "+lang.getLabel()) ;
+                continue;
+            seen.add(lang);
+            out.println("   "+lang.getLabel());
         }
     }
 
     public RDFFormat getOutputStreamFormat() {
-        return streamOutput ;
+        return streamOutput;
     }
 
     public RDFFormat getOutputFormatted() {
-        return formattedOutput ;
+        return formattedOutput;
     }
 
     public boolean compressedOutput() {
-        return compressedOutput ;
+        return compressedOutput;
     }
 }

--- a/jena-cmds/src/main/java/arq/cmdline/ModLangOutput.java
+++ b/jena-cmds/src/main/java/arq/cmdline/ModLangOutput.java
@@ -51,6 +51,9 @@ public class ModLangOutput extends ModBase
 
     @Override
     public void processArgs(CmdArgModule cmdLine) {
+
+        // [QT]  ** check only one of argPretty, argStream, argOutput **
+
         if ( cmdLine.contains(argPretty) ) {
             String langName = cmdLine.getValue(argPretty) ;
             Lang lang = RDFLanguages.nameToLang(langName) ;
@@ -94,7 +97,7 @@ public class ModLangOutput extends ModBase
                 }
                 // Non-streaming block-style writers.
                 // The normal RDF/XML writer is the pretty one, also know as "RDF/XML-ABBREV"
-                // but it can occassionally use a lot of stack and heap.
+                // but it can occasionally uses a lot of stack and heap.
                 //
                 // The RDF/XML basic writer ("Basic") is not streaming but does not
                 // consume a lot of stack and heap as it writes in a flat block style.

--- a/jena-cmds/src/main/java/arq/cmdline/ModLangOutput.java
+++ b/jena-cmds/src/main/java/arq/cmdline/ModLangOutput.java
@@ -36,7 +36,7 @@ public class ModLangOutput extends ModBase
     protected ArgDecl argPretty       = new ArgDecl(ArgDecl.HasValue, "formatted", "pretty", "fmt") ;
     protected ArgDecl argStream       = new ArgDecl(ArgDecl.HasValue, "stream") ;
     protected ArgDecl argCompress     = new ArgDecl(ArgDecl.NoValue, "compress") ;
-    private boolean compressedOutput = false ;
+    private boolean compressedOutput  = false ;
     private RDFFormat streamOutput    = null ;
     private RDFFormat formattedOutput = null ;
 
@@ -51,9 +51,18 @@ public class ModLangOutput extends ModBase
 
     @Override
     public void processArgs(CmdArgModule cmdLine) {
+        {
+            int x = 0;
+            if ( cmdLine.contains(argPretty) )
+                x++;
+            if ( cmdLine.contains(argStream) )
+                x++;
+            if ( cmdLine.contains(argOutput) )
+                x++;
 
-        // [QT]  ** check only one of argPretty, argStream, argOutput **
-
+            if ( x >= 2 )
+                throw new CmdException("Multiple output choices given: Use one of--stream, --output and --formatted");
+        }
         if ( cmdLine.contains(argPretty) ) {
             String langName = cmdLine.getValue(argPretty) ;
             Lang lang = RDFLanguages.nameToLang(langName) ;

--- a/jena-cmds/src/main/java/arq/cmdline/ModLangParse.java
+++ b/jena-cmds/src/main/java/arq/cmdline/ModLangParse.java
@@ -47,6 +47,7 @@ public class ModLangParse extends ModBase
     private ArgDecl argRDFS     = new ArgDecl(ArgDecl.HasValue, "rdfs");
 
     private ArgDecl argSyntax   = new ArgDecl(ArgDecl.HasValue, "syntax");
+    private ArgDecl argMerge    = new ArgDecl(ArgDecl.NoValue, "merge", "union");
 
     private String rdfsVocabFilename    = null;
     private Model  rdfsVocab            = null;
@@ -64,6 +65,8 @@ public class ModLangParse extends ModBase
     private boolean strict              = false;
     private boolean validate            = false;
     private boolean outputCount         = false;
+    private boolean quadsToTriples    = false;
+
     private Lang lang                   = null;
 
     @Override
@@ -77,6 +80,7 @@ public class ModLangParse extends ModBase
         cmdLine.add(argStrict,  "--strict",         "Run with in strict mode");
         cmdLine.add(argValidate,"--validate",       "Same as --sink --check --strict");
         cmdLine.add(argCount,   "--count",          "Count triples/quads parsed, not output them");
+        cmdLine.add(argMerge,   "--merge",          "Convert quads to triples");
         cmdLine.add(argRDFS,    "--rdfs=file",      "Apply some RDFS inference using the vocabulary in the file");
         cmdLine.add(argNoCheck, "--nocheck",        "Turn off checking of RDF terms");
 
@@ -139,6 +143,8 @@ public class ModLangParse extends ModBase
             outputCount = true;
         }
 
+        quadsToTriples = cmdLine.contains(argMerge);
+
         if ( cmdLine.contains(argRDFS) ) {
             try {
                 rdfsVocabFilename = cmdLine.getArg(argRDFS).getValue();
@@ -169,6 +175,10 @@ public class ModLangParse extends ModBase
 
     public boolean outputCount() {
         return outputCount;
+    }
+
+    public boolean mergeQuads() {
+        return quadsToTriples;
     }
 
     public boolean stopOnBadTerm() {

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/WhereHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/WhereHandler.java
@@ -166,18 +166,20 @@ public class WhereHandler implements Handler {
      */
     private static void testTriple(TriplePath t) {
         // verify Triple is valid
-        boolean validSubject = t.getSubject().isURI() || t.getSubject().isBlank() || t.getSubject().isVariable()
-                || t.getSubject().equals(Node.ANY);
+        boolean validSubject =
+                t.getSubject().isURI() || t.getSubject().isBlank() || t.getObject().isNodeTriple()
+                || t.getSubject().isVariable() || t.getSubject().equals(Node.ANY);
         boolean validPredicate;
 
         if (t.isTriple()) {
-            validPredicate = t.getPredicate().isURI() || t.getPredicate().isVariable()
-                    || t.getPredicate().equals(Node.ANY);
+            validPredicate = t.getPredicate().isURI()
+                    || t.getPredicate().isVariable() || t.getPredicate().equals(Node.ANY);
         } else {
             validPredicate = t.getPath() != null;
         }
 
-        boolean validObject = t.getObject().isURI() || t.getObject().isLiteral() || t.getObject().isBlank()
+        boolean validObject =
+                t.getObject().isURI() || t.getObject().isLiteral() || t.getObject().isBlank() || t.getObject().isNodeTriple()
                 || t.getObject().isVariable() || t.getObject().equals(Node.ANY);
 
         if (!validSubject || !validPredicate || !validObject) {


### PR DESCRIPTION
GitHub issue resolved #1873

Changes to the command line:
* warn if inputs include quads but output is triple only.
* warn if inputs generate quads but output is triple only (stream default graph only)
* error if inputs generate quads but formatted (i.e. buffered) output is triple only



----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
