### PR TITLE
Prepend Jena classpath to existing CLASSPATH

### DIFF
--- a/apache-jena/template.bin
+++ b/apache-jena/template.bin
@@ -105,4 +105,4 @@ then
     JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" JENA_CMD "$@" 
+"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP:$CLASSPATH" JENA_CMD "$@" 


### PR DESCRIPTION
This allows users of command-line tools to easily modify the the classpath to include locations of user-defined classes.

GitHub issue resolved: none

Pull request Description:

Modifies the classpath passed to Java to be the Jena classpath, followed by whatever the CLASSPATH environment variable is set to.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
