### PR TITLE
One typo in Docker readme

### DIFF
--- a/jena-fuseki2/jena-fuseki-docker/README.md
+++ b/jena-fuseki2/jena-fuseki-docker/README.md
@@ -40,7 +40,7 @@ Note the build command must provide the version number.
 
 ## Test Run
 
-`docker-compose run` cam be used to test the build from the previous section.
+`docker-compose run` can be used to test the build from the previous section.
 
 Examples:
 


### PR DESCRIPTION
No associated issue, just had to confirm something in the doc while testing the image with Skosmos and noticed this type :+1:  :runner: 