### PR TITLE
[GH-1889] Use arguments for uid and gid, add group and user, re-work order of commands to make dirs and change ownership

### DIFF
--- a/jena-fuseki2/jena-fuseki-docker/Dockerfile
+++ b/jena-fuseki2/jena-fuseki-docker/Dockerfile
@@ -6,7 +6,7 @@
 ## the License.  You may obtain a copy of the License at
 ##
 ##     http://www.apache.org/licenses/LICENSE-2.0
-## 
+##
 ## Unless required by applicable law or agreed to in writing, software
 ## distributed under the License is distributed on an "AS IS" BASIS,
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,12 +72,6 @@ RUN \
 ADD entrypoint.sh .
 ADD log4j2.properties .
 
-# Run as this user
-# -H : no home directorry
-# -D : no password
-
-RUN adduser -H -D fuseki fuseki
-
 ## ---- Stage: Build runtime
 FROM alpine:${ALPINE_VERSION}
 
@@ -89,18 +83,32 @@ ARG FUSEKI_JAR
 
 COPY --from=base /opt/java-minimal /opt/java-minimal
 COPY --from=base /fuseki /fuseki
-COPY --from=base /etc/passwd /etc/passwd
 
 WORKDIR $FUSEKI_DIR
 
 ARG LOGS=${FUSEKI_DIR}/logs
 ARG DATA=${FUSEKI_DIR}/databases
 
+ARG JENA_USER=fuseki
+ARG JENA_GROUP=$JENA_USER
+ARG JENA_GID=1000
+ARG JENA_UID=1000
+
+# Run as this user
+# -H : no home directory
+# -D : no password
+RUN addgroup -g "${JENA_GID}" "${JENA_GROUP}" && \
+    adduser "${JENA_USER}" -G "${JENA_GROUP}" -s /bin/ash -u "${JENA_UID}" -H -D
+
+RUN mkdir --parents "${FUSEKI_DIR}" && \
+    chown -R $JENA_USER ${FUSEKI_DIR}
+
+USER $JENA_USER
+
 RUN \
     mkdir -p $LOGS && \
     mkdir -p $DATA && \
-    chown -R fuseki ${FUSEKI_DIR} && \
-    chmod a+x entrypoint.sh 
+    chmod a+x entrypoint.sh
 
 ## Default environment variables.
 ENV \
@@ -109,8 +117,6 @@ ENV \
     JENA_VERSION=${JENA_VERSION}        \
     FUSEKI_JAR="${FUSEKI_JAR}"          \
     FUSEKI_DIR="${FUSEKI_DIR}"
-
-USER fuseki
 
 EXPOSE 3030
 


### PR DESCRIPTION
GitHub issue resolved #1889

Pull request Description:

Moves `adduser` to final layer only (we were creating and then copying `/etc/passwd`). Runs `addgroup` before, and uses a fixed uid/gid for user and group.

Create base directory, changes ownership, and then switches to the Jena user in Docker. That creates everything else with the correct uid/gid/ownership.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx or JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
