### PR TITLE
GH-1902: Handle null body for an error response.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -232,9 +232,9 @@ public class HttpLib {
      */
     static HttpException exception(HttpResponse<InputStream> response, int httpStatusCode) {
         URI uri = response.request().uri();
-        //long length = HttpLib.getContentLength(response);
-        // Not critical path code. Read body regardless.
         InputStream in = response.body();
+        if ( in == null )
+            return new HttpException(httpStatusCode, HttpSC.getMessage(httpStatusCode));
         try {
             String msg;
             try {

--- a/jena-arq/src/main/java/org/apache/jena/riot/other/G.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/other/G.java
@@ -941,7 +941,6 @@ public class G {
 //        Predicate<Triple> predicate = (t) -> sameTermMatch(o, t.getObject()) ;
 //        iter = iter.filterKeep(predicate) ;
 //    }
-
     }
 
     /**
@@ -963,11 +962,14 @@ public class G {
     public static boolean sameTermMatch(Node match, Node data) {
         if ( isNullOrAny(match) )
             return true;
+        if ( ! match.isLiteral() )
+            // Only literals have values
+            return match.equals(data);
 
         // Allow for case-insensitive language tag comparison.
         if ( ! Util.isLangString(data) || ! Util.isLangString(match) )
             // Any mix of node types except both strings with lang tags.
-            return match.equals(data) ;
+            return match.equals(data);
 
         // Both nodes with language tags : compare languages case insensitively.
         String lex1 = match.getLiteralLexicalForm();

--- a/jena-arq/src/main/java/org/apache/jena/sparql/SystemARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/SystemARQ.java
@@ -50,7 +50,7 @@ public class SystemARQ
     public static boolean ValueExtensions       = true ;
 
     /**
-     * Under strict {@literal F&O}, dateTimes and dates with no timezone have one magically applied.
+     * Under strict {@literal F&O}, dateTimes and dates that have no timezone have one magically applied.
      * This default timezone is implementation dependent and can lead to different answers
      * to queries depending on the timezone. Normally, ARQ uses XMLSchema dateTime comparisons,
      * which an yield "indeterminate", which in turn is an evaluation error.
@@ -58,7 +58,7 @@ public class SystemARQ
      */
     public static boolean StrictDateTimeFO      = false ;
 
-    /** Whether support for roman numerals (datatype http://rome.example.org/Numeral).
+    /** Whether support for Roman numerals (datatype http://rome.example.org/Numeral).
      *  Mainly a test of datatype extension.
      */
     public static boolean EnableRomanNumerals   = true ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTP.java
@@ -246,6 +246,8 @@ public class QueryExecHTTP implements QueryExec {
     }
 
     private String removeCharset(String contentType) {
+        if ( contentType == null )
+            return contentType;
         int idx = contentType.indexOf(';');
         if ( idx < 0 )
             return contentType;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValueCmp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValueCmp.java
@@ -226,7 +226,7 @@ public class NodeValueCmp {
                 // Must be same URI
                 if ( nv1.getDatatypeURI().equals(nv2.getDatatypeURI()) )
                     // Indeterminate possible.
-                    return XSDFuncOp.compareDateTimeXSD(nv1, nv2);
+                    return XSDFuncOp.compareDateTime(nv1, nv2);
                 raise(new ExprNotComparableException("Can't compare (incompatible temporal value spaces) "+nv1+" and "+nv2)) ;
 
 //            case VSPACE_DURATION_DAYTIME:

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -1141,14 +1141,13 @@ public class XSDFuncOp
         // "Comparison operators on xs:date, xs:gYearMonth and xs:gYear compare their
         // starting instants. These xs:dateTime values are calculated as described
         // below."
-        if ( SystemARQ.StrictDateTimeFO )
+       if ( SystemARQ.StrictDateTimeFO )
             return compareDateTimeFO(nv1, nv2) ;
-        return compareDateTimeXSD(nv1, nv2); //getXMLGregorianCalendarXSD(nv1), getXMLGregorianCalendarXSD(nv2)) ;
+        return compareDateTimeXSD(nv1, nv2);
     }
 
     /** Compare two date/times by XSD rules (dateTimes, one with and one without timezone can be indeterminate) */
     public static int compareDateTimeXSD(NodeValue nv1, NodeValue nv2) {
-
         XMLGregorianCalendar dt1 = getXMLGregorianCalendarXSD(nv1);
         XMLGregorianCalendar dt2 = getXMLGregorianCalendarXSD(nv2);
         int x = compareDateTime(dt1, dt2) ;
@@ -1668,7 +1667,6 @@ public class XSDFuncOp
         // In F&O, the expression op:duration-equal(xs:duration("P1Y"), xs:duration("P365D")) returns false().
         return XSDDuration.durationCompare(duration1, duration2);
     }
-
 
     public static final String implicitTimezoneStr = "Z" ;
     private static final NodeValue implicitTimezone_ = NodeValue.makeNode("PT0S", XSDDatatype.XSDdayTimeDuration);

--- a/jena-cmds/src/main/java/arq/qexpr.java
+++ b/jena-cmds/src/main/java/arq/qexpr.java
@@ -64,9 +64,9 @@ public class qexpr
             if ( ex.getCause() != null )
                 ex.getCause().printStackTrace(System.err) ;
         }
-        
+
     }
-    
+
     public static void execAndReturn(String... argv)
     {
         try {
@@ -80,21 +80,21 @@ public class qexpr
                 ex.getCause().printStackTrace(System.err) ;
         }
     }
-        
+
     public static void main2(String... argv)
     {
-        
+
         CmdLineArgs cl = new CmdLineArgs(argv) ;
-        
+
         ArgDecl helpDecl = new ArgDecl(ArgDecl.NoValue, "h", "help") ;
         cl.add(helpDecl) ;
-        
+
         ArgDecl verboseDecl = new ArgDecl(ArgDecl.NoValue, "v", "verbose") ;
         cl.add(verboseDecl) ;
-        
+
         ArgDecl versionDecl = new ArgDecl(ArgDecl.NoValue, "ver", "version", "V") ;
         cl.add(versionDecl) ;
-        
+
         ArgDecl quietDecl = new ArgDecl(ArgDecl.NoValue, "q", "quiet") ;
         cl.add(quietDecl) ;
 
@@ -103,7 +103,7 @@ public class qexpr
 
         ArgDecl strictDecl =  new ArgDecl(ArgDecl.NoValue, "strict") ;
         cl.add(strictDecl) ;
-        
+
         ArgDecl printDecl =  new ArgDecl(ArgDecl.HasValue, "print") ;
         cl.add(printDecl) ;
 
@@ -121,23 +121,23 @@ public class qexpr
             usage() ;
             throw new TerminationException(0) ;
         }
-        
+
         if ( cl.contains(versionDecl) )
         {
             System.out.println("ARQ Version: "+ARQ.VERSION+" (Jena: "+Jena.VERSION+")") ;
             throw new TerminationException(0) ;
         }
- 
+
         // ==== General things
         boolean verbose = cl.contains(verboseDecl) ;
         boolean quiet = cl.contains(quietDecl) ;
 
         if ( cl.contains(strictDecl) )
             ARQ.setStrictMode() ;
-        
+
         boolean actionCopySubstitute = cl.contains(reduceDecl) ;
         boolean actionPrintPrefix = false ;
-        boolean actionPrintSPARQL = false ; 
+        boolean actionPrintSPARQL = false ;
         boolean actionPrint = cl.contains(printDecl) ;
 
         for ( String v : cl.getValues( printDecl ) )
@@ -158,12 +158,12 @@ public class qexpr
         }
 
         // ==== Do it
-        
+
         for ( int i = 0 ; i < cl.getNumPositional() ; i++ )
         {
             String exprStr = cl.getPositionalArg(i) ;
             exprStr = cl.indirect(exprStr) ;
-            
+
             try {
                 PrefixMapping pmap = PrefixMapping.Factory.create()  ;
                 pmap.setNsPrefixes(ARQConstants.getGlobalPrefixMap()) ;
@@ -174,7 +174,7 @@ public class qexpr
                 if ( actionPrint )
                 {
                     IndentedWriter iOut =  IndentedWriter.stdout;
-                    
+
                     if ( actionPrintSPARQL ) {
                         ExprUtils.fmtSPARQL(iOut, expr);
                         iOut.ensureStartOfLine();
@@ -200,7 +200,7 @@ public class qexpr
                     {
                         // Default action
                         ARQ.getContext().set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime()) ;
-                        FunctionEnv env = new ExecutionContext(ARQ.getContext(), null, null, null) ; 
+                        FunctionEnv env = new ExecutionContext(ARQ.getContext(), null, null, null) ;
                         NodeValue r = expr.eval(null, env) ;
                         //System.out.println(r.asQuotedString()) ;
                         Node n = r.asNode() ;
@@ -209,6 +209,8 @@ public class qexpr
                     }
                 } catch (ExprEvalException ex)
                 {
+                    ex.printStackTrace();
+
                     System.out.println("Exception: "+ex.getMessage()) ;
                     throw new TerminationException(2) ;
                 }
@@ -219,9 +221,9 @@ public class qexpr
             }
         }
     }
-    
+
     static void usage() { usage(System.out) ; }
-    
+
     static void usage(java.io.PrintStream out)
     {
         out.println("Usage: [--print=[prefix|expr]] expression") ;


### PR DESCRIPTION

* Fixes #1902
* Fixes a report that missing content-type causes NPE.
* Call the switchable compare for xsd:dateTime (F&O vs XSD definitions of compare)

----

 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
