### PR TITLE
GH-1919: Migrate to GraphMemFactory. Deprecate oaj.graph.Factory

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.sparql.graph;
 
-import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.impl.GraphPlain;
 import org.apache.jena.rdf.model.Model;
@@ -38,7 +38,7 @@ public class GraphFactory {
      * @see #createDefaultGraph
      */
     public static Graph createGraphMem() {
-        return Factory.createGraphMem();
+        return GraphMemFactory.createGraphMem();
     }
 
     /**
@@ -62,7 +62,7 @@ public class GraphFactory {
 
     /** Create a graph - always the Jena default graph type */
     public static Graph createJenaDefaultGraph() {
-        return Factory.createDefaultGraph();
+        return GraphMemFactory.createDefaultGraph();
     }
 
     /** Graph that uses same-term for find() and contains(). */

--- a/jena-arq/src/main/java/org/apache/jena/system/buffering/BufferingGraph.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/buffering/BufferingGraph.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.logging.Log;
-import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
@@ -67,7 +67,7 @@ public class BufferingGraph extends GraphWrapper implements BufferingCtl {
         super(graph);
         prefixMapping = new BufferingPrefixMapping(graph.getPrefixMapping());
         if ( graph.getCapabilities().handlesLiteralTyping())
-            addedGraph = Factory.createDefaultGraph();
+            addedGraph = GraphMemFactory.createDefaultGraph();
         else
             addedGraph = GraphPlain.plain();
     }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraph.java
@@ -123,7 +123,7 @@ public abstract class AbstractTestUpdateGraph extends AbstractTestUpdateBase
     @Test
     public void testInsert3() {
         DatasetGraph gStore = getEmptyDatasetGraph();
-        gStore.addGraph(graphIRI, Factory.createDefaultGraph());
+        gStore.addGraph(graphIRI, GraphMemFactory.createDefaultGraph());
         UpdateModify insert = new UpdateModify();
         insert.getInsertAcc().addQuad(new Quad(graphIRI, triple1));
         UpdateAction.execute(insert, gStore);
@@ -207,7 +207,7 @@ public abstract class AbstractTestUpdateGraph extends AbstractTestUpdateBase
     public void testModify1() {
         DatasetGraph gStore = getEmptyDatasetGraph();
         defaultGraphData(gStore, data2());
-        namedGraphData(gStore, graphIRI, Factory.createDefaultGraph());
+        namedGraphData(gStore, graphIRI, GraphMemFactory.createDefaultGraph());
 
         UpdateModify modify = new UpdateModify();
         Element element = QueryFactory.createElement("{ ?s <http://example/p> ?o }");
@@ -253,7 +253,7 @@ public abstract class AbstractTestUpdateGraph extends AbstractTestUpdateBase
     public void testModifyInitialBindings() {
         DatasetGraph gStore = getEmptyDatasetGraph();
         defaultGraphData(gStore, data12());
-        namedGraphData(gStore, graphIRI, Factory.createDefaultGraph());
+        namedGraphData(gStore, graphIRI, GraphMemFactory.createDefaultGraph());
 
         Binding initialBinding = BindingFactory.binding(Var.alloc("o"), o1);
 
@@ -436,7 +436,7 @@ public abstract class AbstractTestUpdateGraph extends AbstractTestUpdateBase
     }
 
     private static Graph data(Triple...triples) {
-        Graph graph = Factory.createDefaultGraph();
+        Graph graph = GraphMemFactory.createDefaultGraph();
         for ( Triple t : triples )
             graph.add(t);
         return graph;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPathPF.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPathPF.java
@@ -25,7 +25,7 @@ import java.util.List ;
 
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.junit.AssertExtra ;
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
@@ -70,7 +70,7 @@ public class TestPathPF
         ":s1 :p (4 5) .\n" +
         ":s3 :p (8 9) .\n" ;
     
-    private static Graph graph2 = Factory.createDefaultGraph() ;
+    private static Graph graph2 = GraphMemFactory.createDefaultGraph() ;
     static { RDFDataMgr.read(graph2, new StringReader(data), null, Lang.TTL); }
     
     @BeforeClass public static void beforeClass() {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/util/TestList.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/util/TestList.java
@@ -184,7 +184,7 @@ public class TestList
     }
 // --------
     
-    private static GNode gnode(Node n)  { return new GNode(Factory.createDefaultGraph(), n) ; }
+    private static GNode gnode(Node n)  { return new GNode(GraphMemFactory.createDefaultGraph(), n) ; }
     
     private static GNode parse(String str)
     { 
@@ -219,7 +219,7 @@ public class TestList
     private static Node s2 = NodeFactory.createURI("http://example/s2") ;
     private static Node s3 = NodeFactory.createURI("http://example/s3") ;
     
-    private static Graph graph = Factory.createDefaultGraph() ;
+    private static Graph graph = GraphMemFactory.createDefaultGraph() ;
     static { RDFDataMgr.read(graph, new StringReader(data), null, Lang.TTL); }
     
     

--- a/jena-core/src/main/java/org/apache/jena/assembler/assemblers/ReasonerFactoryAssembler.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/assemblers/ReasonerFactoryAssembler.java
@@ -78,7 +78,7 @@ public class ReasonerFactoryAssembler extends AssemblerBase implements Assembler
 
     private Graph loadSchema( Resource root, Assembler a )
         {
-        Graph result = Factory.createDefaultGraph();
+        Graph result = GraphMemFactory.createDefaultGraph();
         for (StmtIterator models = root.listProperties( JA.ja_schema ); models.hasNext();)
             loadSchema( result, a, getResource( models.nextStatement() ) );
         return result;

--- a/jena-core/src/main/java/org/apache/jena/assembler/assemblers/UnionModelAssembler.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/assemblers/UnionModelAssembler.java
@@ -21,7 +21,7 @@ package org.apache.jena.assembler.assemblers;
 import org.apache.jena.assembler.Assembler ;
 import org.apache.jena.assembler.JA ;
 import org.apache.jena.assembler.Mode ;
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.compose.MultiUnion ;
 import org.apache.jena.rdf.model.Model ;
@@ -45,7 +45,7 @@ public class UnionModelAssembler extends ModelAssembler implements Assembler
     private Graph getRootModel( Assembler a, Resource root, Mode mode )
         {
         Resource r = getUniqueResource( root, JA.rootModel );
-        return r == null ? Factory.empty() : a.openModel( r, mode ).getGraph();
+        return r == null ? GraphMemFactory.empty() : a.openModel( r, mode ).getGraph();
         }
 
     private void addSubModels( Assembler a, Resource root, MultiUnion union, Mode mode )

--- a/jena-core/src/main/java/org/apache/jena/graph/GraphExtract.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/GraphExtract.java
@@ -41,7 +41,7 @@ public class GraphExtract
          TripleBoundary passed to the constructor.
     */
     public Graph extract( Node node, Graph graph )
-        { return extractInto( Factory.createGraphMem(), node, graph ); }
+        { return extractInto( GraphMemFactory.createGraphMem(), node, graph ); }
     
     /**
          Answer the graph <code>toUpdate</code> augmented with the sub-graph of

--- a/jena-core/src/main/java/org/apache/jena/graph/GraphMemFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/GraphMemFactory.java
@@ -18,42 +18,36 @@
 
 package org.apache.jena.graph;
 
+import org.apache.jena.graph.impl.GraphBase ;
 import org.apache.jena.mem.GraphMem ;
+import org.apache.jena.util.iterator.ExtendedIterator ;
+import org.apache.jena.util.iterator.NullIterator ;
 
 /**
-    A factory class for creating Graphs.
-   @deprecated Use GraphMemFactory
+    A factory class for creating memory Graphs.
 */
 
-@Deprecated
-public class Factory
-    {
-    private Factory()
-        { super(); }
+@SuppressWarnings("deprecation")
+public class GraphMemFactory
+{
+    private GraphMemFactory() {}
 
     /**
         Answer a memory-based Graph.
-    */
+     */
     public static Graph createDefaultGraph()
-        { return GraphMemFactory.createGraphMem( ); }
+    { return GraphMemFactory.createGraphMem( ); }
 
     public static Graph createGraphMem()
-        { return GraphMemFactory.createGraphMem( ); }
+    { return new GraphMem(); }
 
-    /** @deprecated To be removed */
-    @Deprecated
-    public static Graph createGraphMemWithTransactionHandler( final TransactionHandler th )
-        {
-        Graph g = new GraphMem()
-            {
-            @Override
-            public TransactionHandler getTransactionHandler()
-                {  return th; }
-            };
-        return g;
+    private final static Graph emptyGraph = new GraphBase() {
+        @Override
+        protected ExtendedIterator<Triple> graphBaseFind(Triple triplePattern) {
+            return NullIterator.instance() ;
         }
+    } ;
 
     /** Immutable graph with no triples */
-    public static Graph empty() { return GraphMemFactory.empty() ; }
-
-    }
+    public static Graph empty() { return emptyGraph ; }
+}

--- a/jena-core/src/main/java/org/apache/jena/graph/impl/GraphPlain.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/impl/GraphPlain.java
@@ -47,7 +47,7 @@ public class GraphPlain extends WrappedGraph
 
     /** Return a graph that only has term-equality. */
     public static Graph plain() {
-        return plain(Factory.createDefaultGraph());
+        return plain(GraphMemFactory.createDefaultGraph());
     }
 
     private final Capabilities capabilities;

--- a/jena-core/src/main/java/org/apache/jena/graph/impl/SimpleGraphMaker.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/impl/SimpleGraphMaker.java
@@ -45,7 +45,7 @@ public class SimpleGraphMaker extends BaseGraphMaker
     private Map<String, Graph> graphs = new HashMap<>();
 
     public Graph create()
-    { return Factory.createGraphMem(); }
+    { return GraphMemFactory.createGraphMem(); }
 
     /**
         Create a graph and record it with the given name in the local map.
@@ -56,7 +56,7 @@ public class SimpleGraphMaker extends BaseGraphMaker
         GraphMemBase already = (GraphMemBase) graphs.get( name );
         if (already == null)
         {
-            Graph result = Factory.createGraphMem( );
+            Graph result = GraphMemFactory.createGraphMem( );
             graphs.put( name, result );
             return result;            
         }

--- a/jena-core/src/main/java/org/apache/jena/mem/GraphMem.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/GraphMem.java
@@ -25,7 +25,7 @@ import org.apache.jena.util.iterator.ExtendedIterator ;
 import java.util.stream.Stream;
 
 /** @deprecated This implementation of GraphMem will be replaced by a new implementation at Jena 4.6.0.
- *   Application should be using {@link Factory#createDefaultGraph()} for a general purpose graph or {@link Factory#createGraphMem()}
+ *   Application should be using {@link GraphMemFactory#createDefaultGraph()} for a general purpose graph or {@link GraphMemFactory#createGraphMem()}
  *   to specific this style of implementation.
 */
 @Deprecated

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
@@ -22,7 +22,7 @@ import java.util.Set ;
 
 import org.apache.jena.assembler.Assembler ;
 import org.apache.jena.assembler.AssemblerHelp ;
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.compose.Union ;
 import org.apache.jena.graph.impl.SimpleGraphMaker ;
@@ -88,7 +88,7 @@ public class ModelFactory extends ModelFactoryBase
         Answer a fresh Model with the default specification.
     */
     public static Model createDefaultModel()
-        { return new ModelCom( Factory.createGraphMem( ) ); }
+        { return new ModelCom( GraphMemFactory.createGraphMem( ) ); }
 
     /**
         Answer a model that encapsulates the given graph. Existing prefixes are

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/BasicForwardRuleInfGraph.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/BasicForwardRuleInfGraph.java
@@ -21,7 +21,7 @@ package org.apache.jena.reasoner.rulesys;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -408,7 +408,7 @@ public class BasicForwardRuleInfGraph extends BaseInfGraph implements ForwardRul
                 return dg;
             }
         }
-        Graph dg = Factory.createGraphMem( ); 
+        Graph dg = GraphMemFactory.createGraphMem( ); 
         safeDeductions = new SafeGraph( dg );
         return dg;
     }

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/FBRuleInfGraph.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/FBRuleInfGraph.java
@@ -447,7 +447,7 @@ public class FBRuleInfGraph  extends BasicForwardRuleInfGraph implements Backwar
 
         // Call any optional preprocessing hook
         if (preprocessorHooks != null && preprocessorHooks.size() > 0) {
-            Graph inserts = Factory.createGraphMem();
+            Graph inserts = GraphMemFactory.createGraphMem();
             for ( RulePreprocessHook hook : preprocessorHooks )
             {
                 hook.run( this, dataFind, inserts );

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/GenericRuleReasoner.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/GenericRuleReasoner.java
@@ -22,7 +22,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
@@ -410,7 +410,7 @@ public class GenericRuleReasoner extends FBRuleReasoner {
     protected synchronized InfGraph getPreload() {
         // We only support this in HYBRID mode
         if (cachePreload && preload == null && mode == HYBRID) {
-            preload = new FBRuleInfGraph( this, rules, null, Factory.createDefaultGraph() );
+            preload = new FBRuleInfGraph( this, rules, null, GraphMemFactory.createDefaultGraph() );
             if (enableTGCCaching) ((FBRuleInfGraph)preload).setUseTGCCache();
             preload.prepare();
         }

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/LPBackwardRuleInfGraph.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/LPBackwardRuleInfGraph.java
@@ -99,7 +99,7 @@ public class LPBackwardRuleInfGraph extends BaseInfGraph implements BackwardRule
     public synchronized void prepare() {
         if (this.isPrepared()) return;
         
-        fdeductions = new FGraph( Factory.createGraphMem() );
+        fdeductions = new FGraph( GraphMemFactory.createGraphMem() );
         extractAxioms();
         dataFind = fdata;
         if (fdeductions != null) {

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BFRuleContext.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BFRuleContext.java
@@ -66,7 +66,7 @@ public class BFRuleContext implements RuleContext {
         env = new BindingStack();
         stack = new ArrayList<>();
         pending = new ArrayList<>();
-        pendingCache = Factory.createGraphMem();
+        pendingCache = GraphMemFactory.createGraphMem();
     }
     
     /**

--- a/jena-core/src/main/java/org/apache/jena/shared/RandomOrderGraph.java
+++ b/jena-core/src/main/java/org/apache/jena/shared/RandomOrderGraph.java
@@ -29,7 +29,7 @@ import org.apache.jena.util.iterator.* ;
 public class RandomOrderGraph extends WrappedGraph {
 
 	public static Graph createDefaultGraph() {
-		return new RandomOrderGraph(Factory.createDefaultGraph());
+		return new RandomOrderGraph(GraphMemFactory.createDefaultGraph());
 	}
 
 	public static Model createDefaultModel() {

--- a/jena-core/src/test/java/org/apache/jena/assembler/test/MockTransactionModel.java
+++ b/jena-core/src/test/java/org/apache/jena/assembler/test/MockTransactionModel.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.apache.jena.assembler.* ;
 import org.apache.jena.assembler.assemblers.ModelAssembler ;
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.rdf.model.impl.ModelCom ;
 import org.apache.jena.rdf.model.test.ModelTestBase ;
@@ -53,7 +53,7 @@ final class MockTransactionModel extends ModelAssembler
     @Override
     protected Model openEmptyModel( Assembler a, Resource root, Mode irrelevant )
         {
-        return new ModelCom( Factory.createDefaultGraph() ) 
+        return new ModelCom( GraphMemFactory.createDefaultGraph() ) 
             {
             @Override
             public Model begin()

--- a/jena-core/src/test/java/org/apache/jena/enhanced/test/TestPackage_enh.java
+++ b/jena-core/src/test/java/org/apache/jena/enhanced/test/TestPackage_enh.java
@@ -140,7 +140,7 @@ public class TestPackage_enh extends GraphTestBase  {
      *  The methods tested are as and supports.
      */
     private static void basic(String title, Personality<RDFNode> p) {
-        Graph g = Factory.createGraphMem();
+        Graph g = GraphMemFactory.createGraphMem();
         TestModel model =  new TestModelImpl(g,p);
         // create some data
         graphAdd( g, "x R y;" );
@@ -236,7 +236,7 @@ public class TestPackage_enh extends GraphTestBase  {
 	}
 
     private void follow(String title, Personality<RDFNode> p) {
-        Graph g = Factory.createGraphMem();
+        Graph g = GraphMemFactory.createGraphMem();
         TestModel model =  new TestModelImpl(g,p);
         // create some data
         graphAdd( g, "a b c;" );
@@ -307,7 +307,7 @@ public class TestPackage_enh extends GraphTestBase  {
     	// bitOfBoth is a surprising personality ...
     	// we can have two different java objects implementing the same interface.
 
-		Graph g = Factory.createGraphMem();
+		Graph g = GraphMemFactory.createGraphMem();
 		TestModel model =  new TestModelImpl(g,bitOfBoth);
 		// create some data
 		graphAdd( g, "a a a;" );
@@ -376,7 +376,7 @@ public class TestPackage_enh extends GraphTestBase  {
 
     public void testSimple()
         {
-        Graph g = Factory.createGraphMem();
+        Graph g = GraphMemFactory.createGraphMem();
         Personality<RDFNode> ours = BuiltinPersonalities.model.copy().add( Example.class, Example.factory );
         EnhGraph eg = new EnhGraph( g, ours );
         Node n = NodeFactory.createURI( "spoo:bar" );
@@ -400,7 +400,7 @@ public class TestPackage_enh extends GraphTestBase  {
 
     public void testAlreadyLinkedViewException()
         {
-         Graph g = Factory.createGraphMem();
+         Graph g = GraphMemFactory.createGraphMem();
          Personality<RDFNode> ours = BuiltinPersonalities.model.copy().add( Example.class, Example.factory );
          EnhGraph eg = new EnhGraph( g, ours );
          Node n = NodeCreateUtils.create( "spoo:bar" );
@@ -424,7 +424,7 @@ public class TestPackage_enh extends GraphTestBase  {
     */
     public void testNullPointerTrap()
         {
-        EnhGraph eg = new EnhGraph( Factory.createGraphMem(), new Personality<RDFNode>() );
+        EnhGraph eg = new EnhGraph( GraphMemFactory.createGraphMem(), new Personality<RDFNode>() );
         Node n = NodeCreateUtils.create( "eh:something" );
         EnhNode en = new EnhNode( n, eg );
         try
@@ -442,7 +442,7 @@ public class TestPackage_enh extends GraphTestBase  {
 
     public void testNullPointerTrapInCanSupport()
         {
-        EnhGraph eg = new EnhGraph( Factory.createGraphMem(), new Personality<RDFNode>() );
+        EnhGraph eg = new EnhGraph( GraphMemFactory.createGraphMem(), new Personality<RDFNode>() );
         Node n = NodeCreateUtils.create( "eh:something" );
         EnhNode en = new EnhNode( n, eg );
         assertFalse( en.canAs( Property.class ) );

--- a/jena-core/src/test/java/org/apache/jena/graph/TestGraphUtil.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/TestGraphUtil.java
@@ -30,7 +30,7 @@ public class TestGraphUtil {
     private static Graph graph2 = make(2);
 
     private static Graph make(int N) {
-        Graph graph = Factory.createGraphMem();
+        Graph graph = GraphMemFactory.createGraphMem();
         for ( int i = 0 ; i < N ; i++ ) {
             Triple t = GraphTestBase.triple("a P 'x"+i+"'");
             graph.add(t);

--- a/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestCaseBasic.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestCaseBasic.java
@@ -36,7 +36,7 @@ public class TestCaseBasic extends org.apache.jena.regression.TestCaseBasic
     private Graph newGraph( Constructor< ? extends Graph> cons ) throws Exception
     	{
     	return cons.newInstance
-            ( Factory.createGraphMem(), Factory.createGraphMem() );
+            ( GraphMemFactory.createGraphMem(), GraphMemFactory.createGraphMem() );
     	}
     	
     @Override public void setUp() throws Exception

--- a/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestDyadic.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestDyadic.java
@@ -65,7 +65,7 @@ public abstract class TestDyadic extends AbstractTestGraph
     
     public void testDyadicOperands()
         {
-        Graph g = Factory.createGraphMem(), h = Factory.createGraphMem();
+        Graph g = GraphMemFactory.createGraphMem(), h = GraphMemFactory.createGraphMem();
         Dyadic d = new Dyadic( g, h )
             {
             @Override protected ExtendedIterator<Triple> _graphBaseFind( Triple m ) { return null; }

--- a/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestMultiUnionReifier.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestMultiUnionReifier.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.graph.compose.test;
 
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.GraphUtil ;
 import org.apache.jena.graph.Triple ;
@@ -55,7 +55,7 @@ public class TestMultiUnionReifier extends ModelTestBase
     
     private Graph graph( String facts )
         {
-        Graph result = Factory.createDefaultGraph( );
+        Graph result = GraphMemFactory.createDefaultGraph( );
         String [] factArray = facts.split( ";" );
             for ( String aFactArray : factArray )
             {

--- a/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestPackage_compose.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestPackage_compose.java
@@ -20,7 +20,7 @@ package org.apache.jena.graph.compose.test;
 
 
 import junit.framework.*;
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.compose.* ;
 import org.apache.jena.rdf.model.Model ;
@@ -39,7 +39,7 @@ public class TestPackage_compose extends TestCase {
 			@Override
 			Graph getGraph()
 			{
-				return new Intersection(Factory.createGraphMem(), Factory.createGraphMem());
+				return new Intersection(GraphMemFactory.createGraphMem(), GraphMemFactory.createGraphMem());
 			}};
 
     	AbstractTestPackage atp = new AbstractTestPackage( "Intersection",  gmf ){};
@@ -53,7 +53,7 @@ public class TestPackage_compose extends TestCase {
 			@Override
 			Graph getGraph()
 			{
-				return new Difference(Factory.createGraphMem(), Factory.createGraphMem());
+				return new Difference(GraphMemFactory.createGraphMem(), GraphMemFactory.createGraphMem());
 			}};
 
     	atp = new AbstractTestPackage( "Difference",  gmf ){};
@@ -67,7 +67,7 @@ public class TestPackage_compose extends TestCase {
 			@Override
 			Graph getGraph()
 			{
-				return new Union(Factory.createGraphMem(), Factory.createGraphMem());
+				return new Union(GraphMemFactory.createGraphMem(), GraphMemFactory.createGraphMem());
 			}};
 
     	atp = new AbstractTestPackage( "Union",  gmf ){};

--- a/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestPolyadicPrefixMapping.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/compose/test/TestPolyadicPrefixMapping.java
@@ -46,9 +46,9 @@ public class TestPolyadicPrefixMapping extends AbstractTestPrefixMapping
     @Override
     public void setUp()
         {
-        gBase = Factory.createDefaultGraph();
-        g1 = Factory.createDefaultGraph();
-        g2 = Factory.createDefaultGraph();
+        gBase = GraphMemFactory.createDefaultGraph();
+        g1 = GraphMemFactory.createDefaultGraph();
+        g2 = GraphMemFactory.createDefaultGraph();
         poly = new MultiUnion( new Graph[] {gBase, g1, g2} );
         poly.setBaseGraph( gBase );
         }
@@ -56,9 +56,9 @@ public class TestPolyadicPrefixMapping extends AbstractTestPrefixMapping
     @Override
     protected PrefixMapping getMapping()
         {
-        Graph gBase = Factory.createDefaultGraph();
-        Graph g1 = Factory.createDefaultGraph();
-        Graph g2 = Factory.createDefaultGraph();
+        Graph gBase = GraphMemFactory.createDefaultGraph();
+        Graph g1 = GraphMemFactory.createDefaultGraph();
+        Graph g2 = GraphMemFactory.createDefaultGraph();
         Polyadic poly = new MultiUnion( new Graph[] {gBase, g1, g2} );
         return new PolyadicPrefixMappingImpl( poly ); 
         }        

--- a/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestGraph.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestGraph.java
@@ -970,7 +970,7 @@ public abstract class AbstractTestGraph extends GraphTestBase
 
     protected Graph copy( Graph g )
     {
-        Graph result = Factory.createDefaultGraph();
+        Graph result = GraphMemFactory.createDefaultGraph();
         GraphUtil.addInto(result, g) ;
         return result;
     }

--- a/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestReifier.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestReifier.java
@@ -80,7 +80,7 @@ public abstract class AbstractTestReifier extends GraphTestBase
     {
         Graph g = getGraph( );
         ReifierStd.reifyAs( g, node( "a" ), triple( "p Q r" ) );
-        Graph r = Factory.createDefaultGraph( );
+        Graph r = GraphMemFactory.createDefaultGraph( );
         graphAdd( r, "a rdf:type rdf:Statement; a rdf:subject p; a rdf:predicate Q; a rdf:object r" );
         assertEquals( 4, g.size() );
         assertIsomorphic( r, g );

--- a/jena-core/src/test/java/org/apache/jena/graph/test/GraphTestBase.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/GraphTestBase.java
@@ -185,7 +185,7 @@ public class GraphTestBase extends JenaTestBase
     */
     public static Graph newGraph()
         {
-        Graph result = Factory.createGraphMem();
+        Graph result = GraphMemFactory.createGraphMem();
         result.getPrefixMapping().setNsPrefixes( PrefixMapping.Extended );
         return result;
         }

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestFactory.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestFactory.java
@@ -31,6 +31,6 @@ public class TestFactory extends GraphTestBase
         
     public void testFactory()
         {
-        Factory.createDefaultGraph();
+        GraphMemFactory.createDefaultGraph();
         }        
     }

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestGraph.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestGraph.java
@@ -25,7 +25,7 @@ package org.apache.jena.graph.test;
 
 import junit.framework.Test ;
 import junit.framework.TestSuite ;
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.impl.WrappedGraph ;
 import org.apache.jena.mem.GraphMem ;
@@ -61,7 +61,7 @@ public class TestGraph extends GraphTestBase
     */
     public void testWrappedSame()
         {
-        Graph m = Factory.createGraphMem();
+        Graph m = GraphMemFactory.createGraphMem();
         Graph w = new WrappedGraph( m );
         graphAdd( m, "a trumps b; c eats d" );
         assertIsomorphic( m, w );
@@ -75,6 +75,6 @@ public class TestGraph extends GraphTestBase
     public static class WrappedGraphMem extends WrappedGraph
         {
         public WrappedGraphMem( )
-            { super( Factory.createGraphMem( ) ); }
+            { super( GraphMemFactory.createGraphMem( ) ); }
         }
     }

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestGraphListener.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestGraphListener.java
@@ -145,7 +145,7 @@ public class TestGraphListener extends MetaTestGraph {
 
     @Override
 	public Graph getGraph() {
-    	Graph g = Factory.createGraphMem();
+    	Graph g = GraphMemFactory.createGraphMem();
 
     	g.getEventManager().register(new CheckChanges("simple tracking",g));
 	    return g;

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestGraphPrefixMapping.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestGraphPrefixMapping.java
@@ -19,7 +19,7 @@
 package org.apache.jena.graph.test;
 
 import junit.framework.TestSuite;
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.shared.AbstractTestPrefixMapping ;
 import org.apache.jena.shared.PrefixMapping ;
@@ -34,7 +34,7 @@ public class TestGraphPrefixMapping extends GraphTestBase
     
     public void testGraphPrefixMapping()
         { 
-        Graph g = Factory.createDefaultGraph();
+        Graph g = GraphMemFactory.createDefaultGraph();
         AbstractTestPrefixMapping.testUseEasyPrefix
             ( "from Graph", g.getPrefixMapping() ); 
         testSameMapping( g );

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestNode.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestNode.java
@@ -508,7 +508,7 @@ public class TestNode extends GraphTestBase
         Node_Triple nt = new Node_Triple(s, p, o);
         nt.visitWith(nv);
         // ---
-        Graph g = Factory.empty();
+        Graph g = GraphMemFactory.empty();
         Node_Graph ng = new Node_Graph(g);
         ng.visitWith(nv);
     }

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestNodeExtras.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestNodeExtras.java
@@ -41,7 +41,7 @@ public class TestNodeExtras {
 
     private static Node_Graph newGraphTerm(Graph graph)                 { return new Node_Graph(graph); }
 
-    private static Node_Graph newGraphTerm()                            { return new Node_Graph(Factory.empty()); }
+    private static Node_Graph newGraphTerm()                            { return new Node_Graph(GraphMemFactory.empty()); }
 
      @Test public void term_triple_1() {
         Node nt = newTripleTerm(s,p,o);

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestTypedLiterals.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestTypedLiterals.java
@@ -472,7 +472,7 @@ public class TestTypedLiterals extends TestCase {
         Node np = NodeFactory.createURI("p") ;
         Node nx1 = NodeFactory.createLiteral("0.50", dt) ;
         Node nx2 = NodeFactory.createLiteral("0.500", dt) ;
-        Graph graph = Factory.createDefaultGraph() ;
+        Graph graph = GraphMemFactory.createDefaultGraph() ;
         graph.add(Triple.create(ns, np, nx1)) ;
         assertTrue( graph.find(Node.ANY, Node.ANY, nx2).hasNext() );
     }

--- a/jena-core/src/test/java/org/apache/jena/mem/test/TestGraphMem2.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/test/TestGraphMem2.java
@@ -34,7 +34,7 @@ public class TestGraphMem2 extends AbstractTestGraph
     { return new TestSuite( TestGraphMem2.class ); }
     
     @Override
-    public Graph getGraph() { return Factory.createGraphMem(); }
+    public Graph getGraph() { return GraphMemFactory.createGraphMem(); }
     
     public void testBrokenIndexes()
         {

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestContains.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestContains.java
@@ -18,7 +18,7 @@
 
 package org.apache.jena.rdf.model.test;
 
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.rdf.model.impl.ModelCom ;
@@ -93,7 +93,7 @@ public class TestContains extends AbstractModelTestBase
 
 	public void testModelComContainsSPcallsContainsSPO()
 	{
-		final Graph g = Factory.createDefaultGraph();
+		final Graph g = GraphMemFactory.createDefaultGraph();
 		final boolean[] wasCalled = { false };
 		// FIXME change to dynamic proxy
 		final Model m = new ModelCom(g) {

--- a/jena-core/src/test/java/org/apache/jena/rdfxml/xmloutput/TestXMLFeatures.java
+++ b/jena-core/src/test/java/org/apache/jena/rdfxml/xmloutput/TestXMLFeatures.java
@@ -421,7 +421,7 @@ public class TestXMLFeatures extends XMLOutputTestBase {
         blockLogger() ;
         Node blank = NodeFactory.createBlankNode() ;
         Node prop = NodeFactory.createURI(s) ;
-        Graph g = Factory.createGraphMem() ;
+        Graph g = GraphMemFactory.createGraphMem() ;
         g.add(Triple.create(blank, prop, blank)) ;
         // create Model
         Model m = ModelFactory.createModelForGraph(g) ;

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/impl/TestLPBRuleEngine.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/impl/TestLPBRuleEngine.java
@@ -54,7 +54,7 @@ public class TestLPBRuleEngine extends TestCase {
 
 	@Test
 	public void testTabledGoalsCacheHits() throws Exception {
-		Graph data = Factory.createGraphMem();
+		Graph data = GraphMemFactory.createGraphMem();
 		data.add(Triple.create(a, ty, C1));
 		List<Rule> rules = Rule
 				.parseRules("[r1:  (?x p ?t) <- (?x rdf:type C1), makeInstance(?x, p, C2, ?t)]"
@@ -94,7 +94,7 @@ public class TestLPBRuleEngine extends TestCase {
 
 	@Test
 	public void testTabledGoalsLeak() throws Exception {
-		Graph data = Factory.createGraphMem();
+		Graph data = GraphMemFactory.createGraphMem();
 		data.add(Triple.create(a, ty, C1));
 		List<Rule> rules = Rule
 				.parseRules("[r1:  (?x p ?t) <- (?x rdf:type C1), makeInstance(?x, p, C2, ?t)]"
@@ -135,7 +135,7 @@ public class TestLPBRuleEngine extends TestCase {
 		// Set the cache size very small just for this test
 		System.setProperty("jena.rulesys.lp.max_cached_tabled_goals", "" + MAX);
 		try {
-			Graph data = Factory.createGraphMem();
+			Graph data = GraphMemFactory.createGraphMem();
 			data.add(Triple.create(a, ty, C1));
 			List<Rule> rules = Rule
 					.parseRules("[r1:  (?x p ?t) <- (?x rdf:type C1), makeInstance(?x, p, C2, ?t)]"

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/impl/TestLPBRuleEngineLeak.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/impl/TestLPBRuleEngineLeak.java
@@ -27,7 +27,7 @@ import junit.framework.TestSuite;
 
 import org.junit.Test;
 
-import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -62,7 +62,7 @@ public class TestLPBRuleEngineLeak extends TestCase {
 
 	@Test
 	public void testNotLeakingActiveInterpreters() throws Exception {
-		Graph data = Factory.createGraphMem();
+		Graph data = GraphMemFactory.createGraphMem();
 		data.add(Triple.create(a, ty, C1));
 		data.add(Triple.create(b, ty, C1));
 		List<Rule> rules = Rule
@@ -107,7 +107,7 @@ public class TestLPBRuleEngineLeak extends TestCase {
 	
 	@Test
 	public void testTabledGoalsCacheHits() throws Exception {
-		Graph data = Factory.createGraphMem();
+		Graph data = GraphMemFactory.createGraphMem();
 		data.add(Triple.create(a, ty, C1));
 		List<Rule> rules = Rule
 				.parseRules("[r1:  (?x p ?t) <- (?x rdf:type C1), makeInstance(?x, p, C2, ?t)]"

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/impl/TestRestartableLBRule.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/impl/TestRestartableLBRule.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
-import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.TransactionHandler;
 import org.apache.jena.graph.Triple;
@@ -107,7 +107,7 @@ public class TestRestartableLBRule extends TestCase {
 
     class DummyTxnGraph extends GraphBase implements Graph {
         TransactionHandler th = new DummyTxnHandler();
-        Graph base = Factory.createGraphMem();
+        Graph base = GraphMemFactory.createGraphMem();
 
         @Override
         public void performAdd( Triple t ) { base.add(t); }

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/DebugOWL.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/DebugOWL.java
@@ -87,7 +87,7 @@ public class DebugOWL {
      * Construct an empty test harness.
      */
     public DebugOWL(int config) {
-        testdata = Factory.createGraphMem();
+        testdata = GraphMemFactory.createGraphMem();
         schema = null;
         
         switch(config) {
@@ -173,7 +173,7 @@ public class DebugOWL {
                         + (withProps ? " with properties" : ""));
         
         // Create the tree
-        testdata = Factory.createGraphMem();
+        testdata = GraphMemFactory.createGraphMem();
         // First level
         int conceptPtr = 0;
         int levelStart = 0;

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/DebugRules.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/DebugRules.java
@@ -21,7 +21,7 @@ package org.apache.jena.reasoner.rulesys.test;
 import java.util.Iterator ;
 import java.util.List ;
 
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.reasoner.InfGraph ;
 import org.apache.jena.reasoner.rulesys.BasicForwardRuleReasoner ;
@@ -50,7 +50,7 @@ public class DebugRules {
     public void run() {
         
         BasicForwardRuleReasoner reasoner = new BasicForwardRuleReasoner(ruleset);
-        InfGraph result = reasoner.bind(Factory.createGraphMem());
+        InfGraph result = reasoner.bind(GraphMemFactory.createGraphMem());
         System.out.println("Final graph state");
         for (Iterator<Triple> i = result.find(null, null, null); i.hasNext(); ) {
             System.out.println(PrintUtil.print(i.next()));

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestBackchainer.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestBackchainer.java
@@ -230,12 +230,12 @@ public class TestBackchainer extends TestCase {
      * the raw data successfully.
      */
     public void testListData() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         for ( Triple dataElt : dataElts )
         {
             data.add( dataElt );
         }
-        Graph schema = Factory.createGraphMem();
+        Graph schema = GraphMemFactory.createGraphMem();
         schema.add(Triple.create(c, p, c));
         
         // Case of schema and data but no rule axioms
@@ -279,7 +279,7 @@ public class TestBackchainer extends TestCase {
      */
     public void testBaseRules1() {    
         List<Rule> rules = Rule.parseRules("[r1: (?a r ?c) <- (?a p ?b),(?b p ?c)]");        
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(b, p, c));
         data.add(Triple.create(b, p, d));
@@ -302,7 +302,7 @@ public class TestBackchainer extends TestCase {
                 "[r2: (?a r ?b) <- (?a q ?b)]" +
                 "[r3: (?a r ?b) <- (?a s ?c), (?c s ?b)]"
         );        
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(b, q, c));
         data.add(Triple.create(a, s, b));
@@ -328,7 +328,7 @@ public class TestBackchainer extends TestCase {
                 "[r3: (?a r ?b) <- (?a t ?c), (?c t ?b)]" +
                 "[r4: (?a t ?b) <- (?a s ?b)]"
         );        
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(b, q, c));
         data.add(Triple.create(a, s, b));
@@ -350,7 +350,7 @@ public class TestBackchainer extends TestCase {
     public void testBaseRules3() {    
         List<Rule> rules = Rule.parseRules("[rule: (?a rdfs:subPropertyOf ?c) <- (?a rdfs:subPropertyOf ?b),(?b rdfs:subPropertyOf ?c)]");        
         Reasoner reasoner =  createReasoner(rules);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(p, sP, q) );
         data.add(Triple.create(q, sP, r) );
         data.add(Triple.create(p, sP, s) );
@@ -375,7 +375,7 @@ public class TestBackchainer extends TestCase {
     public void testBaseRules3b() {    
         List<Rule> rules = Rule.parseRules("[rule: (?a rdfs:subPropertyOf ?c) <- (?a rdfs:subPropertyOf ?b),(?b rdfs:subPropertyOf ?c)]");        
         Reasoner reasoner =  createReasoner(rules);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(p, sP, q) );
         data.add(Triple.create(q, sP, r) );
         data.add(Triple.create(r, sP, t) );
@@ -400,7 +400,7 @@ public class TestBackchainer extends TestCase {
      * Test basic rule operations - simple AND/OR with tabling.
      */
     public void testBaseRules4() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, r, b));
         data.add(Triple.create(b, r, c));
         data.add(Triple.create(b, r, b));
@@ -424,7 +424,7 @@ public class TestBackchainer extends TestCase {
      * Test basic rule operations - simple AND/OR with tabling.
      */
     public void testBaseRulesXSB1() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(p, c, q));
         data.add(Triple.create(q, c, r));
         data.add(Triple.create(p, d, q));
@@ -449,7 +449,7 @@ public class TestBackchainer extends TestCase {
      * Test basic functor usage.
      */
     public void testFunctors1() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(a, q, c));
         List<Rule> rules = Rule.parseRules(
@@ -469,7 +469,7 @@ public class TestBackchainer extends TestCase {
      * Test basic functor usage.
      */
     public void testFunctors2() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(a, q, c));
         data.add(Triple.create(a, t, d));
@@ -493,7 +493,7 @@ public class TestBackchainer extends TestCase {
      * Test basic functor usage.
      */
     public void testFunctors3() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, s, b));
         data.add(Triple.create(a, t, c));
         List<Rule> rules = Rule.parseRules(
@@ -514,7 +514,7 @@ public class TestBackchainer extends TestCase {
      * Test basic builtin usage.
      */
     public void testBuiltin1() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         List<Rule> rules = Rule.parseRules(
             "[a1: -> (a p 2) ]" +
             "[a2: -> (a q 3) ]" +
@@ -533,7 +533,7 @@ public class TestBackchainer extends TestCase {
      * Test basic builtin usage.
      */
     public void testBuiltin2() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(a, q, c));
         List<Rule> rules = Rule.parseRules(
@@ -558,7 +558,7 @@ public class TestBackchainer extends TestCase {
      * Test basic builtin usage.
      */
     public void testBuiltin3() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         List<Rule> rules = Rule.parseRules(
             "[r1: (a p b ) <- unbound(?x) ]"
         );
@@ -575,7 +575,7 @@ public class TestBackchainer extends TestCase {
      * Test basic ground head patterns.
      */
     public void testGroundHead() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, r, b));
         List<Rule> rules = Rule.parseRules(
             "[r1: (a p b ) <- (a r b) ]"
@@ -615,7 +615,7 @@ public class TestBackchainer extends TestCase {
      */
     public void testRebind() {
         List<Rule> rules = Rule.parseRules("[r1: (?a r ?c) <- (?a p ?b),(?b p ?c)]");        
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(b, p, c));
         data.add(Triple.create(b, p, d));
@@ -627,7 +627,7 @@ public class TestBackchainer extends TestCase {
                 Triple.create(a, r, c),
                 Triple.create(a, r, d)
             } );
-        Graph ndata = Factory.createGraphMem();
+        Graph ndata = GraphMemFactory.createGraphMem();
         ndata.add(Triple.create(a, p, d));
         ndata.add(Triple.create(d, p, b));
         infgraph.rebind(ndata);
@@ -643,7 +643,7 @@ public class TestBackchainer extends TestCase {
      * Test troublesome rdfs rules
      */
     public void testRDFSProblemsb() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(C1, sC, C2));
         data.add(Triple.create(C2, sC, C3));
         data.add(Triple.create(C1, ty, RDFS.Class.asNode()));
@@ -671,7 +671,7 @@ public class TestBackchainer extends TestCase {
      * Test troublesome rdfs rules
      */
     public void testRDFSProblems() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(p, sP, q));
         data.add(Triple.create(q, sP, r));
         data.add(Triple.create(C1, sC, C2));
@@ -703,7 +703,7 @@ public class TestBackchainer extends TestCase {
      * Test complex rule head unification
      */
     public void testHeadUnify() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(c, q, d));
         List<Rule> rules = Rule.parseRules(
             "[r1: (c r ?x) <- (?x p f(?x b))]" +
@@ -727,7 +727,7 @@ public class TestBackchainer extends TestCase {
                   Triple.create(c, r, a)
               } );
             
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, q, a));
         data.add(Triple.create(a, q, b));
         data.add(Triple.create(a, q, c));
@@ -762,7 +762,7 @@ public class TestBackchainer extends TestCase {
      * Test restriction example
      */
     public void testRestriction1() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, ty, r));
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(r, sC, C1));
@@ -789,7 +789,7 @@ public class TestBackchainer extends TestCase {
      * is a problem. 
      */
     public void testRestriction2() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, ty, OWL.Thing.asNode()));
         data.add(Triple.create(p, ty, OWL.FunctionalProperty.asNode()));
         data.add(Triple.create(c, OWL.equivalentClass.asNode(), C1));
@@ -833,7 +833,7 @@ public class TestBackchainer extends TestCase {
      * Test restriction example
      */
     public void testRestriction3() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, ty, r));
         data.add(Triple.create(r, sC, C1));
         data.add(Triple.create(C1, ty, OWL.Restriction.asNode()));
@@ -860,7 +860,7 @@ public class TestBackchainer extends TestCase {
      * Test close and halt operation.
      */
     public void testClose() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(p, sP, q));
         data.add(Triple.create(q, sP, r));
         data.add(Triple.create(C1, sC, C2));
@@ -896,7 +896,7 @@ public class TestBackchainer extends TestCase {
      * Test problematic rdfs case
      */
     public void testBug1() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         Node p = NodeFactory.createURI("http://www.hpl.hp.com/semweb/2003/eg#p");
         Node r = NodeFactory.createURI("http://www.hpl.hp.com/semweb/2003/eg#r");
         Node C1 = NodeFactory.createURI("http://www.hpl.hp.com/semweb/2003/eg#C1");

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestBasicLP.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestBasicLP.java
@@ -436,7 +436,7 @@ public class TestBasicLP  extends TestCase {
             "[r1: (?x r C1) <- (?x p b)]" +
             "[r1: (?x r C2) <- (?x p b)]" +
             "[r2: (?x r C3) <- (?x r C3) (?x p b)]");
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         InfGraph infgraph =  makeInfGraph(rules, data);
         ExtendedIterator<Triple> i = infgraph.find(Node.ANY, r, Node.ANY);
@@ -1060,7 +1060,7 @@ public class TestBasicLP  extends TestCase {
                     Triple.create(C2, sC, C3),
                     Triple.create(a, ty, C1)
                 };
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         for ( Triple triple : triples )
         {
             data.add( triple );
@@ -1117,7 +1117,7 @@ public class TestBasicLP  extends TestCase {
                        "[testRule2: (C2, q, ?a) <- (C1 q ?a)]" +
                        "[testRule3: (a p ?a)  <- (C2 p ?a), (C2 q ?a)]";
         List<Rule> ruleList = Rule.parseRules(rules);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(C1, p, C3));
         data.add(Triple.create(C1, q, C4));
         data.add(Triple.create(C1, q, C3));
@@ -1219,7 +1219,7 @@ public class TestBasicLP  extends TestCase {
         String ruleSrc = "[(a r ?n) <- (a p ?l), listLength(?l, ?n)]" +
         "[(a s ?e) <- (a p ?l), listEntry(?l, 1, ?e)]";
         List<Rule> rules = Rule.parseRules(ruleSrc);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, Util.makeList(new Node[]{C1,C2,C3},data)));
         InfGraph infgraph =  makeInfGraph(rules, data);
         TestUtil.assertIteratorValues(this, 
@@ -1239,7 +1239,7 @@ public class TestBasicLP  extends TestCase {
         "[(a s d) <- (a p ?l), (a, r, ?j) listEqual(?l, ?j)]" +
         "[(a s e) <- (a p ?l), (a, r, ?j) listNotEqual(?l, ?j)]"
             );
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, 
             Util.makeList( new Node[]{C1, Util.makeIntNode(3), C3}, data) ));
         data.add(Triple.create(a, q, 
@@ -1258,7 +1258,7 @@ public class TestBasicLP  extends TestCase {
         "[(b r ?j) <- (a p ?l), (a, q, ?j) listContains(?l, ?j)]" +
         "[(b s ?j) <- (a p ?l), (a, q, ?j) listNotContains(?l, ?j)]"
             );
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, 
             Util.makeList( new Node[]{C1, Util.makeIntNode(3), C3}, data) ));
         data.add(Triple.create(a, q, C1));
@@ -1281,7 +1281,7 @@ public class TestBasicLP  extends TestCase {
     public void testCME() {
         String ruleSrc = "(?a p 1) <- (?a p 0). (?a p 2) <- (?a p 0).";
         List<Rule> rules = Rule.parseRules(ruleSrc);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, Util.makeIntNode(0)));
         InfGraph infgraph =  makeInfGraph(rules, data);
         
@@ -1318,7 +1318,7 @@ public class TestBasicLP  extends TestCase {
      */
     private void doTest(String ruleSrc, Triple[] triples, Triple query, Object[] results) {
         List<Rule> rules = Rule.parseRules(ruleSrc);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         for ( Triple triple : triples )
         {
             data.add( triple );
@@ -1337,7 +1337,7 @@ public class TestBasicLP  extends TestCase {
      */
     private void doTest(String ruleSrc, Node[] tabled, Triple[] triples, Triple query, Object[] results) {
         List<Rule> rules = Rule.parseRules(ruleSrc);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         for ( Triple triple : triples )
         {
             data.add( triple );

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestBasics.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestBasics.java
@@ -361,7 +361,7 @@ public class TestBasics extends TestCase  {
                        "[r4: (n4 ?p ?a) -> (n4, ?a, ?p)]";
         List<Rule> ruleList = Rule.parseRules(rules);
 
-        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(Factory.createGraphMem());
+        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(GraphMemFactory.createGraphMem());
         infgraph.add(Triple.create(n1, p, n2));
         infgraph.add(Triple.create(n2, p, n3));
         infgraph.add(Triple.create(n2, q, n3));
@@ -388,7 +388,7 @@ public class TestBasics extends TestCase  {
                        "[testRule3: (n2 p ?a), (n2 q ?a) -> (res p ?a)]";
         List<Rule> ruleList = Rule.parseRules(rules);
 
-        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(Factory.createGraphMem());
+        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(GraphMemFactory.createGraphMem());
         infgraph.setDerivationLogging(true);
         infgraph.add(Triple.create(n1, p, n3));
         infgraph.add(Triple.create(n1, q, n4));
@@ -433,7 +433,7 @@ public class TestBasics extends TestCase  {
                        "[axiom1: -> (n1 p n3)]";
         List<Rule> ruleList = Rule.parseRules(rules);
 
-        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(Factory.createGraphMem());
+        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(GraphMemFactory.createGraphMem());
         TestUtil.assertIteratorValues(this, infgraph.find(null, null, null),
             new Triple[] {
                 Triple.create(n1, p, n3),
@@ -464,9 +464,9 @@ public class TestBasics extends TestCase  {
                        "[testRule2: (n1 q ?a) -> (n2, q, ?a)]" +
                        "[testRule3: (n2 p ?a), (n2 q ?a) -> (res p ?a)]";
         List<Rule> ruleList = Rule.parseRules(rules);
-        Graph schema = Factory.createGraphMem();
+        Graph schema = GraphMemFactory.createGraphMem();
         schema.add(Triple.create(n1, p, n3));
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, q, n4));
         data.add(Triple.create(n1, q, n3));
 
@@ -539,7 +539,7 @@ public class TestBasics extends TestCase  {
                        "";
         List<Rule> ruleList = Rule.parseRules(rules);
 
-        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(Factory.createGraphMem());
+        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(GraphMemFactory.createGraphMem());
         TestUtil.assertIteratorValues(this, infgraph.find(n1, q, null),
             new Triple[] {
                 Triple.create(n1, q, Util.makeIntNode(2)),
@@ -561,7 +561,7 @@ public class TestBasics extends TestCase  {
                        "";
         List<Rule> ruleList = Rule.parseRules(rules);
 
-        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(Factory.createGraphMem());
+        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(GraphMemFactory.createGraphMem());
         infgraph.add(Triple.create(n1, p, Util.makeIntNode(1)));
         infgraph.add(Triple.create(n1, p, Util.makeIntNode(2)));
         infgraph.add(Triple.create(n1, q, Util.makeIntNode(2)));
@@ -583,7 +583,7 @@ public class TestBasics extends TestCase  {
                        "";
         List<Rule> ruleList = Rule.parseRules(rules);
 
-        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(Factory.createGraphMem());
+        InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(GraphMemFactory.createGraphMem());
         infgraph.add(Triple.create(n1, p, Util.makeIntNode(1)));
         infgraph.add(Triple.create(n1, p, Util.makeIntNode(2)));
         infgraph.add(Triple.create(n1, q, Util.makeIntNode(2)));
@@ -601,7 +601,7 @@ public class TestBasics extends TestCase  {
     public void testRebind() {
         String rules = "[rule1: (?x p ?y) -> (?x q ?y)]";
         List<Rule> ruleList = Rule.parseRules(rules);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, n2));
         InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(data);
         TestUtil.assertIteratorValues(this, infgraph.find(n1, null, null),
@@ -609,7 +609,7 @@ public class TestBasics extends TestCase  {
                 Triple.create(n1, p, n2),
                 Triple.create(n1, q, n2)
             });
-        Graph ndata = Factory.createGraphMem();
+        Graph ndata = GraphMemFactory.createGraphMem();
         ndata.add(Triple.create(n1, p, n3));
         infgraph.rebind(ndata);
         TestUtil.assertIteratorValues(this, infgraph.find(n1, null, null),
@@ -625,7 +625,7 @@ public class TestBasics extends TestCase  {
     public void testSize() {
         String rules = "[rule1: (?x p ?y) -> (?x q ?y)]";
         List<Rule> ruleList = Rule.parseRules(rules);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, n2));
         InfGraph infgraph = new BasicForwardRuleReasoner(ruleList).bind(data);
         assertEquals(infgraph.size(), 2);
@@ -659,7 +659,7 @@ public class TestBasics extends TestCase  {
      * Test the list conversion utility that is used in some of the builtins.
      */
     public void testConvertList() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         Node first = RDF.Nodes.first;
         Node rest  = RDF.Nodes.rest;
         Node nil = RDF.Nodes.nil;

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestFBRules.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestFBRules.java
@@ -120,7 +120,7 @@ public class TestFBRules extends TestCase {
      * Assemble a test infGraph from a rule source and empty data
      */
     public InfGraph createInfGraph(String rules) {
-        return createReasoner( Rule.parseRules(rules) ).bind(Factory.createGraphMem());
+        return createReasoner( Rule.parseRules(rules) ).bind(GraphMemFactory.createGraphMem());
     }
 
     /**
@@ -229,9 +229,9 @@ public class TestFBRules extends TestCase {
                        "[testRule3: (n2 p ?a), (n2 q ?a) -> (res p ?a)]" +
                        "[testBRule4: (n3 p ?a) <- (n1, p, ?a)]";
         List<Rule> ruleList = Rule.parseRules(rules);
-        Graph schema = Factory.createGraphMem();
+        Graph schema = GraphMemFactory.createGraphMem();
         schema.add(Triple.create(n1, p, n3));
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, q, n4));
         data.add(Triple.create(n1, q, n3));
         
@@ -278,7 +278,7 @@ public class TestFBRules extends TestCase {
      */
     public void testRebind() {
         String rules = "[rule1: (?x p ?y) -> (?x q ?y)]";
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, n2));
         InfGraph infgraph = createInfGraph(rules, data);
         TestUtil.assertIteratorValues(this, infgraph.find(n1, null, null),
@@ -286,7 +286,7 @@ public class TestFBRules extends TestCase {
                 Triple.create(n1, p, n2),
                 Triple.create(n1, q, n2)
             });
-        Graph ndata = Factory.createGraphMem();
+        Graph ndata = GraphMemFactory.createGraphMem();
         ndata.add(Triple.create(n1, p, n3));
         infgraph.rebind(ndata);
         TestUtil.assertIteratorValues(this, infgraph.find(n1, null, null),
@@ -349,7 +349,7 @@ public class TestFBRules extends TestCase {
      */
     public void testClose() {
         String rules = "[rule1: (?x p ?y) -> (?x q ?y)]";
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, n2));
         InfGraph infgraph = createInfGraph(rules, data);
         TestUtil.assertIteratorValues(this, infgraph.find(n1, null, null),
@@ -371,7 +371,7 @@ public class TestFBRules extends TestCase {
      * Test example pure backchaining rules
      */
     public void testBackchain1() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(p, sP, q));
         data.add(Triple.create(q, sP, r));
         data.add(Triple.create(C1, sC, C2));
@@ -401,7 +401,7 @@ public class TestFBRules extends TestCase {
      * Test complex rule head unification
      */
     public void testBackchain2() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(c, q, d));
         String rules = 
             "[r1: (c r ?x) <- (?x p f(?x b))]" +
@@ -421,7 +421,7 @@ public class TestFBRules extends TestCase {
                   Triple.create(c, r, a)
               } );
             
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, q, a));
         data.add(Triple.create(a, q, b));
         data.add(Triple.create(a, q, c));
@@ -452,7 +452,7 @@ public class TestFBRules extends TestCase {
      * Test restriction example
      */
     public void testBackchain3() {    
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, ty, r));
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(r, sC, C1));
@@ -475,7 +475,7 @@ public class TestFBRules extends TestCase {
      * Test example hybrid rule.
      */
     public void testHybrid1() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(p, ty, s));
         String rules =
@@ -492,7 +492,7 @@ public class TestFBRules extends TestCase {
      * Test example hybrid rule.
      */
     public void testHybrid2() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, r, b));
         data.add(Triple.create(p, ty, s));
         String rules = 
@@ -527,7 +527,7 @@ public class TestFBRules extends TestCase {
      * Test example hybrid rules for rdfs.
      */
     public void testHybridRDFS() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(p, RDFS.range.asNode(), C1));
         String rules = 
@@ -551,7 +551,7 @@ public class TestFBRules extends TestCase {
      * Test example hybrid rules for rdfs.
      */
     public void testHybridRDFS2() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         data.add(Triple.create(p, sP, r));
         data.add(Triple.create(r, RDFS.range.asNode(), C1));
@@ -570,7 +570,7 @@ public class TestFBRules extends TestCase {
      * Test access to makeInstance machinery from a Brule.
      */
     public void testMakeInstance() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, ty, C1));
         String rules = 
         "[r1:  (?x p ?t) <- (?x rdf:type C1), makeInstance(?x, p, C2, ?t)]" +
@@ -589,7 +589,7 @@ public class TestFBRules extends TestCase {
      * Test access to makeInstance machinery from a Brule.
      */
     public void testMakeInstances() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, ty, C1));
         String rules = 
         "[r1:  (?x p ?t) <- (?x rdf:type C1), makeInstance(?x, p, ?t)]" ;
@@ -605,7 +605,7 @@ public class TestFBRules extends TestCase {
      * Test case for makeInstance which failed during development.
      */
     public void testMakeInstanceBug() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, ty, r));
         data.add(Triple.create(r, sC, Functor.makeFunctorNode("some", new Node[] {p, C1})));
         String rules = 
@@ -630,7 +630,7 @@ public class TestFBRules extends TestCase {
         "[r1: (?x p f(a, ?x)) -> (?x q f(?x)) ]" +
         "[r1: (?x p f(a, 0)) -> (?x s res) ]" +
                        "";
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, Util.makeIntNode(2)) );
         data.add(Triple.create(n2, p, Functor.makeFunctorNode("f", new Node[] {
                                         a, Util.makeIntNode(0)  })));
@@ -664,7 +664,7 @@ public class TestFBRules extends TestCase {
         "[r5: (?x q ?vx), (?y q ?vy), notEqual(?vx, ?vy) -> (?x ne ?y)]" +
         "[r6: (?x q ?vx), (?y q ?vy), equal(?vx, ?vy) -> (?x eq ?y)]" +
                        "";
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, q, Util.makeIntNode(2)) );
         data.add(Triple.create(n2, q, Util.makeIntNode(2)) );
         data.add(Triple.create(n3, q, Util.makeIntNode(3)) );
@@ -690,7 +690,7 @@ public class TestFBRules extends TestCase {
             });
         
         // Floating point comparisons
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, q, Util.makeIntNode(2)) );
         data.add(Triple.create(n2, q, Util.makeDoubleNode(2.2)) );
         data.add(Triple.create(n3, q, Util.makeDoubleNode(2.3)) );
@@ -710,7 +710,7 @@ public class TestFBRules extends TestCase {
             });
             
         // XSD timeDate point comparisons
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         XSDDatatype dt = new XSDDatatype("dateTime");
         data.add(Triple.create(n1, q, NodeFactory.createLiteral("2000-03-04T20:00:00Z", XSDDatatype.XSDdateTime)));
         data.add(Triple.create(n2, q, NodeFactory.createLiteral("2001-03-04T20:00:00Z", XSDDatatype.XSDdateTime)));
@@ -763,7 +763,7 @@ public class TestFBRules extends TestCase {
         "[r4: (?x p ?a), (?x q ?b), min(?b, ?a, ?c) -> (?x r ?c)]" +
         "[r4: (?x p ?a), (?x q ?b), max(?b, ?a, ?c) -> (?x x ?c)]" +
                        "";
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, Util.makeIntNode(3)) );
         data.add(Triple.create(n1, q, Util.makeIntNode(5)) );
         infgraph = createInfGraph(rules, data);
@@ -787,7 +787,7 @@ public class TestFBRules extends TestCase {
         "[r1: (?x p ?y), isBNode(?y) -> (?x s 'bNode')]" +
         "[r1: (?x p ?y), notBNode(?y) -> (?x s 'notBNode')]" +
                        "";
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, Util.makeIntNode(3)) );
         data.add(Triple.create(n2, p, res));
         data.add(Triple.create(n3, p, NodeFactory.createBlankNode()));
@@ -818,7 +818,7 @@ public class TestFBRules extends TestCase {
         "[r1: (?x p ?y), notDType(?y, http://www.w3.org/2001/XMLSchema#int) -> (?x s 'notXSDInt')]" +
         "[r1: (?x p ?y), notDType(?y, http://www.w3.org/2001/XMLSchema#string) -> (?x s 'notXSDString')]" +
                        "";
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, Util.makeIntNode(3)) );
         data.add(Triple.create(n2, p, NodeFactory.createLiteral("foo")) );
         data.add(Triple.create(n3, p, NodeFactory.createLiteral("foo", XSDDatatype.XSDstring)) );
@@ -851,7 +851,7 @@ public class TestFBRules extends TestCase {
             
         // Literal counting
         rules = "[r1: (?x p ?y), countLiteralValues(?x, p, ?c) -> (?x s ?c)]";
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, Util.makeIntNode(2)) );
         data.add(Triple.create(n1, p, Util.makeIntNode(2)) );
         data.add(Triple.create(n1, p, Util.makeIntNode(3)) );
@@ -865,7 +865,7 @@ public class TestFBRules extends TestCase {
         // Map list operation
         rules = "[r1: (n1 p ?l) -> listMapAsSubject(?l, q, C1)]" +
                 "[r2: (n1 p ?l) -> listMapAsObject ( a, q, ?l)]";
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, Util.makeList(new Node[]{b, c, d}, data) ));
         infgraph = createInfGraph(rules, data);
         TestUtil.assertIteratorValues(this, infgraph.find(null, q, null),
@@ -887,7 +887,7 @@ public class TestFBRules extends TestCase {
             "[r1: (?x p ?y) strConcat(?y, rdf:type, 'foo', ?z) -> (?x q ?z) ] \n" + 
             "[r1: (?x p ?y) strConcat(?z) -> (?x q ?z) ] \n" + 
             "[r2: (?x p ?y) uriConcat('http://jena.hpl.hp.com/test#', ?y, ?z) -> (?x q ?z) ]";
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, NodeFactory.createLiteral("test")) );
         InfGraph infgraph = createInfGraph(rules, data);
         
@@ -902,7 +902,7 @@ public class TestFBRules extends TestCase {
             "[r1: (?x p ?y) regex(?y, '(.*)\\\\s(.*) (f.*)') -> (?x q 'ok') ] \n" +
             "[r2: (?x p ?y) regex(?y, '(.*)\\\\s(.*) (f.*)', ?m1, ?m2, ?m3) -> (?x r ?m2) ] \n" +
             "";
-        data = Factory.createGraphMem();
+        data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, NodeFactory.createLiteral("foo bar foo")) );
         data.add(Triple.create(n2, p, NodeFactory.createLiteral("foo bar baz")) );
         infgraph = createInfGraph(rules, data);
@@ -923,7 +923,7 @@ public class TestFBRules extends TestCase {
         String rules =  
             "[r2: (?x p ?y) regex(?y, '((Boys)|(Girls))(.*)', ?m1, ?m2, ?m3, ?m4) ->  (?x q ?m2) (?x r ?m3) (?x s ?m4) ] \n" +
             "";
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, NodeFactory.createLiteral("Girls44")) );
         InfGraph infgraph = createInfGraph(rules, data);
         infgraph.prepare();
@@ -956,7 +956,7 @@ public class TestFBRules extends TestCase {
         String rules =  
             "[r1: (?x p ?a), (?x q ?b), (?x r ?c) " + op + "(?a, ?b, ?c) -> (?x s ?c)]\n " +
             "[r2: (?x p ?a), (?x q ?b), (?x t ?c) " + op + "(?a, ?b, ?c) -> (?x u ?c)]";
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, Util.makeIntNode(arg1)) );
         data.add(Triple.create(n1, q, Util.makeIntNode(arg2)) );
         data.add(Triple.create(n1, r, Util.makeIntNode(expected)) );
@@ -1003,7 +1003,7 @@ public class TestFBRules extends TestCase {
 //            listFBGraph("direct databind case", (FBRuleInfGraph)infgraph);
             assertEquals(5, count);
             
-            infgraph = reasoner.bindSchema(data).bind(Factory.createGraphMem());
+            infgraph = reasoner.bindSchema(data).bind(GraphMemFactory.createGraphMem());
             count = 0;
             for (Iterator<Triple> i = infgraph.find(null, rbPrototypeProp, null); i.hasNext(); ) {
                 Triple t = i.next();
@@ -1042,7 +1042,7 @@ public class TestFBRules extends TestCase {
     
     private Node getSkolem(Node x, Node y) {
         String rules =  "[r1: (?n p ?x) (?n q ?y) makeSkolem(?s ?x ?y) -> (?n s ?s)]";
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, x));
         data.add(Triple.create(n1, q, y));
         InfGraph infgraph = createInfGraph(rules, data);
@@ -1051,7 +1051,7 @@ public class TestFBRules extends TestCase {
     
     private Node getSkolem(Node x) {
         String rules =  "[r1: (?n p ?x)  makeSkolem(?s ?x) -> (?n s ?s)]";
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(n1, p, x));
         InfGraph infgraph = createInfGraph(rules, data);
         return infgraph.find(n1, s, Node.ANY).next().getObject();
@@ -1061,8 +1061,8 @@ public class TestFBRules extends TestCase {
      * Check cost of creating an empty OWL closure.
      */
     public void temp() {
-        Graph data = Factory.createGraphMem();
-        Graph data2 = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
+        Graph data2 = GraphMemFactory.createGraphMem();
         Reasoner reasoner =  new OWLFBRuleReasoner(OWLFBRuleReasonerFactory.theInstance());
         FBRuleInfGraph infgraph = (FBRuleInfGraph)reasoner.bind(data);
         FBRuleInfGraph infgraph2 = (FBRuleInfGraph)reasoner.bind(data2);

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestGenericRules.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestGenericRules.java
@@ -94,7 +94,7 @@ public class TestGenericRules extends TestCase {
      * Minimal rule tester to check basic pattern match, forward style.
      */
     public void testForward() {
-        Graph test = Factory.createGraphMem();
+        Graph test = GraphMemFactory.createGraphMem();
         test.add(Triple.create(a, p, b));
         test.add(Triple.create(b, p, c));
         
@@ -107,7 +107,7 @@ public class TestGenericRules extends TestCase {
         TestUtil.assertIteratorValues(this, infgraph.find(null, p, null), ans);
         
         // Check schema bind version
-        infgraph = reasoner.bindSchema(test).bind(Factory.createGraphMem());
+        infgraph = reasoner.bindSchema(test).bind(GraphMemFactory.createGraphMem());
         TestUtil.assertIteratorValues(this, infgraph.find(null, p, null), ans);
     }
      
@@ -115,7 +115,7 @@ public class TestGenericRules extends TestCase {
      * Minimal rule tester to check basic pattern match, backward style.
      */
     public void testBackward() {
-        Graph test = Factory.createGraphMem();
+        Graph test = GraphMemFactory.createGraphMem();
         test.add(Triple.create(a, p, b));
         test.add(Triple.create(b, p, c));
         
@@ -128,7 +128,7 @@ public class TestGenericRules extends TestCase {
         TestUtil.assertIteratorValues(this, infgraph.find(null, p, null), ans);
         
         // Check schema bind version
-        infgraph = reasoner.bindSchema(test).bind(Factory.createGraphMem());
+        infgraph = reasoner.bindSchema(test).bind(GraphMemFactory.createGraphMem());
         TestUtil.assertIteratorValues(this, infgraph.find(null, p, null), ans);
     }
     
@@ -136,7 +136,7 @@ public class TestGenericRules extends TestCase {
      * Test example hybrid rule.
      */
     public void testHybrid() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, r, b));
         data.add(Triple.create(p, ty, s));
         List<Rule> rules = Rule.parseRules(
@@ -175,7 +175,7 @@ public class TestGenericRules extends TestCase {
      * Test early detection of illegal backward rules.
      */
     public void testBRuleErrorHandling() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         List<Rule> rules = Rule.parseRules(
                     "[a1: -> [(?x eg:p ?y) (?x eg:q ?y) <- (?x eg:r ?y)]]"
                 );
@@ -196,7 +196,7 @@ public class TestGenericRules extends TestCase {
      * Test example parameter setting
      */
     public void testParameters() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, r, b));
         data.add(Triple.create(p, ty, s));
 
@@ -251,7 +251,7 @@ public class TestGenericRules extends TestCase {
         configuration.addProperty(ReasonerVocabulary.PROPruleSet, "testing/reasoners/ruleset2.rules");
         reasoner = (GenericRuleReasoner)GenericRuleReasonerFactory.theInstance().create(configuration);
         
-        infgraph = reasoner.bind(Factory.createGraphMem());
+        infgraph = reasoner.bind(GraphMemFactory.createGraphMem());
         Node an = NodeFactory.createURI(PrintUtil.egNS + "a");
         Node C = NodeFactory.createURI(PrintUtil.egNS + "C");
         Node D = NodeFactory.createURI(PrintUtil.egNS + "D");
@@ -298,7 +298,7 @@ public class TestGenericRules extends TestCase {
      * Test control of functor filtering
      */
     public void testHybridFunctorFilter() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, r, b));
         data.add(Triple.create(a, p, s));
         List<Rule> rules = Rule.parseRules( "[r0: (?x r ?y) (?x p ?z) -> (?x q func(?y, ?z)) ]" );        
@@ -334,7 +334,7 @@ public class TestGenericRules extends TestCase {
      * TODO: arrange test to run in a separate thread with a timeout
      */
     public void doTestFunctorLooping(RuleMode mode) {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, r, b));
         List<Rule> rules = Rule.parseRules( "(?x r ?y) -> (?x p func(?x)). (?x p ?y) -> (?x p func(?x))." );        
         GenericRuleReasoner reasoner = (GenericRuleReasoner)GenericRuleReasonerFactory.theInstance().create(null);
@@ -416,7 +416,7 @@ public class TestGenericRules extends TestCase {
      * @param useTGC set to true to use transitive caching
      */
     public void doTestAddRemove(boolean useTGC) {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, C1));
         data.add(Triple.create(C1, sC, C2));
         data.add(Triple.create(C2, sC, C3));
@@ -476,7 +476,7 @@ public class TestGenericRules extends TestCase {
      * Resolve a bug using remove in rules themselves.
      */
     public void testAddRemove2() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, Util.makeIntNode(0)));
         List<Rule> rules = Rule.parseRules(
                 "(?x p ?v)-> (?x q inc(1, a)).\n" +

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestLPDerivation.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestLPDerivation.java
@@ -95,7 +95,7 @@ public class TestLPDerivation extends TestCase {
      */
     private void doTest(String ruleSrc, Node[] tabled, Triple[] triples, Triple query, Triple[] matches, int rulenumber) {
         List<Rule> rules = Rule.parseRules(ruleSrc);
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         for ( Triple triple : triples )
         {
             data.add( triple );

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRDFS9.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRDFS9.java
@@ -66,13 +66,13 @@ public class TestRDFS9 extends TestCase {
         Node sC = RDFS.subClassOf.asNode();
         Node ty = RDF.type.asNode();
         
-        Graph tdata = Factory.createGraphMem();
+        Graph tdata = GraphMemFactory.createGraphMem();
         tdata.add(Triple.create(C1, sC, C2));
         tdata.add(Triple.create(C2, sC, C3));
         tdata.add(Triple.create(p, RDFS.subPropertyOf.asNode(), q));
         tdata.add(Triple.create(q, RDFS.subPropertyOf.asNode(), r));
         tdata.add(Triple.create(r, RDFS.domain.asNode(), D));
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add(Triple.create(a, p, b));
         InfGraph igraph = ReasonerRegistry.getRDFSReasoner().bind(new Union(tdata, data));
         TestUtil.assertIteratorValues(this, igraph.find(a, ty, null),

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRETE.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRETE.java
@@ -229,11 +229,11 @@ public class TestRETE  extends TestCase {
      */
     private void doRuleTest(String rules, Triple[] adds, Triple[] expected) {
         List<Rule> ruleList = Rule.parseRules(rules);
-        BasicForwardRuleInfGraph infgraph = new BasicForwardRuleInfGraph(null, new ArrayList<Rule>(), null, Factory.createGraphMem());
+        BasicForwardRuleInfGraph infgraph = new BasicForwardRuleInfGraph(null, new ArrayList<Rule>(), null, GraphMemFactory.createGraphMem());
 //        infgraph.setTraceOn(true);
         RETEEngine engine = new RETEEngine(infgraph, ruleList);
         infgraph.prepare();
-        engine.init(true, new FGraph(Factory.createGraphMem()));
+        engine.init(true, new FGraph(GraphMemFactory.createGraphMem()));
         for ( Triple add : adds )
         {
             engine.addTriple( add, true );
@@ -250,14 +250,14 @@ public class TestRETE  extends TestCase {
         String rules = "[testRule1: (a p ?x) (b p ?x) -> (n1 p ?x) ]" +
                        "[testRule2: (?x q ?y) -> (?x p ?y)]";
         List<Rule> ruleList = Rule.parseRules(rules);
-        Graph schema = Factory.createGraphMem();
+        Graph schema = GraphMemFactory.createGraphMem();
         schema.add(Triple.create(a, q, c));
         schema.add(Triple.create(a, q, d));
 
-        Graph data1 = Factory.createGraphMem();
+        Graph data1 = GraphMemFactory.createGraphMem();
         data1.add(Triple.create(b, q, c));
         
-        Graph data2 = Factory.createGraphMem();
+        Graph data2 = GraphMemFactory.createGraphMem();
         data2.add(Triple.create(b, q, d));
         
         GenericRuleReasoner reasoner =  new GenericRuleReasoner(ruleList);

--- a/jena-core/src/test/java/org/apache/jena/reasoner/test/ReasonerTester.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/test/ReasonerTester.java
@@ -25,7 +25,7 @@ import java.io.Reader ;
 import java.util.* ;
 
 import junit.framework.TestCase ;
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -156,7 +156,7 @@ public class ReasonerTester {
             boolean cache = predicate.equals(tboxP) || predicate.equals(dataP);
             return loadFile(fileName, cache).getGraph();
         } else {
-            return Factory.createGraphMem();
+            return GraphMemFactory.createGraphMem();
         }
     }
     
@@ -277,7 +277,7 @@ public class ReasonerTester {
         
         // Run each query triple and accumulate the results
         Graph queryG = loadTestFile(test, queryP);
-        Graph resultG = Factory.createGraphMem();
+        Graph resultG = GraphMemFactory.createGraphMem();
 
         Iterator<Triple> queries = queryG.find(null, null, null);
         while (queries.hasNext()) {

--- a/jena-core/src/test/java/org/apache/jena/reasoner/test/TestReasoners.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/test/TestReasoners.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -89,7 +89,7 @@ public class TestReasoners extends TestCase {
      * Test rebind operation for the transitive reasoner
      */
     public void testTransitiveRebind() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         Node C1 = NodeFactory.createURI("C1");
         Node C2 = NodeFactory.createURI("C2");
         Node C3 = NodeFactory.createURI("C3");
@@ -107,7 +107,7 @@ public class TestReasoners extends TestCase {
                 Triple.create(C1, RDFS.subClassOf.asNode(), C2),
                 Triple.create(C1, RDFS.subClassOf.asNode(), C3)
             } );
-        Graph data2 = Factory.createGraphMem();
+        Graph data2 = GraphMemFactory.createGraphMem();
         data2.add( Triple.create(C1, RDFS.subClassOf.asNode(), C2) );
         data2.add( Triple.create(C2, RDFS.subClassOf.asNode(), C4) );
         infgraph.rebind(data2);
@@ -155,7 +155,7 @@ public class TestReasoners extends TestCase {
      * Test delete operation for Transtive reasoner.
      */
     public void testTransitiveRemove() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         Node a = NodeFactory.createURI("a");
         Node b = NodeFactory.createURI("b");
         Node c = NodeFactory.createURI("c");
@@ -234,7 +234,7 @@ public class TestReasoners extends TestCase {
      * Test metalevel add/remove subproperty operations for a reasoner.
      */
     public void doTestMetaLevel(ReasonerFactory rf) {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         Node c1 = NodeFactory.createURI("C1");
         Node c2 = NodeFactory.createURI("C2");
         Node c3 = NodeFactory.createURI("C3");
@@ -381,7 +381,7 @@ public class TestReasoners extends TestCase {
      * Test rebind operation for the RDFS reasoner
      */
     public void testRDFSRebind() {
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         Node C1 = NodeFactory.createURI("C1");
         Node C2 = NodeFactory.createURI("C2");
         Node C3 = NodeFactory.createURI("C3");
@@ -397,7 +397,7 @@ public class TestReasoners extends TestCase {
                 Triple.create(C1, RDFS.subClassOf.asNode(), C2),
                 Triple.create(C1, RDFS.subClassOf.asNode(), C3)
             } );
-        Graph data2 = Factory.createGraphMem();
+        Graph data2 = GraphMemFactory.createGraphMem();
         data2.add( Triple.create(C1, RDFS.subClassOf.asNode(), C2) );
         data2.add( Triple.create(C2, RDFS.subClassOf.asNode(), C4) );
         infgraph.rebind(data2);
@@ -492,9 +492,9 @@ public class TestReasoners extends TestCase {
         Node c2 = NodeFactory.createURI("C2");
         Node c3 = NodeFactory.createURI("C3");
         Node sC = RDFS.subClassOf.asNode();
-        Graph data = Factory.createGraphMem();
+        Graph data = GraphMemFactory.createGraphMem();
         data.add( Triple.create(c2, sC, c3));
-        Graph premise = Factory.createGraphMem();
+        Graph premise = GraphMemFactory.createGraphMem();
         premise.add( Triple.create(c1, sC, c2));
         Reasoner reasoner = rf.create(null);
         InfGraph infgraph = reasoner.bind(data);

--- a/jena-core/src/test/java/org/apache/jena/reasoner/test/WGReasonerTester.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/test/WGReasonerTester.java
@@ -27,7 +27,7 @@ import java.util.ArrayList ;
 import java.util.List ;
 
 import junit.framework.TestCase ;
-import org.apache.jena.graph.Factory ;
+import org.apache.jena.graph.GraphMemFactory ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.rdf.model.impl.PropertyImpl ;
@@ -195,7 +195,7 @@ public class WGReasonerTester {
             String fileName = test.getRequiredProperty(predicate).getObject().toString();
             return loadFile(fileName).getGraph();
         } else {
-            return Factory.createGraphMem();
+            return GraphMemFactory.createGraphMem();
         }
     }
 

--- a/jena-core/src/test/java/org/apache/jena/testing_framework/GraphHelper.java
+++ b/jena-core/src/test/java/org/apache/jena/testing_framework/GraphHelper.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.GraphUtil;
 import org.apache.jena.graph.Node;
@@ -205,7 +205,7 @@ public class GraphHelper extends TestUtils {
 	 * Answer a new memory-based graph with Extended prefixes.
 	 */
 	public static Graph memGraph() {
-		Graph result = Factory.createGraphMem();
+		Graph result = GraphMemFactory.createGraphMem();
 		result.getPrefixMapping().setNsPrefixes(PrefixMapping.Extended);
 		return result;
 	}

--- a/jena-core/src/test/java/org/apache/jena/testing_framework/TestFileData.java
+++ b/jena-core/src/test/java/org/apache/jena/testing_framework/TestFileData.java
@@ -210,7 +210,7 @@ public class TestFileData {
 
 	public static Graph getGraph() {
 		
-		Graph g = Factory.createGraphMem();
+		Graph g = GraphMemFactory.createGraphMem();
 
 		g.add(Triple.create(NodeFactory.createURI("http://example.com/subject"),
 				NodeFactory.createURI("http://example.com/predicate"),

--- a/jena-core/src/test/java/org/apache/jena/util/TestMonitors.java
+++ b/jena-core/src/test/java/org/apache/jena/util/TestMonitors.java
@@ -64,7 +64,7 @@ public class TestMonitors extends TestCase {
      * Basic graph level test, no monitoring
      */
     public void testBasics() {
-        Graph base = Factory.createGraphMem();
+        Graph base = GraphMemFactory.createGraphMem();
         MonitorGraph monitor = new MonitorGraph(base);
         
         // base data
@@ -97,7 +97,7 @@ public class TestMonitors extends TestCase {
      * Monitoring test.
      */
     public void testListener() {
-        Graph base = Factory.createGraphMem();
+        Graph base = GraphMemFactory.createGraphMem();
         MonitorGraph monitor = new MonitorGraph(base);
         RecordingListener listener = new RecordingListener();
         monitor.getEventManager().register(listener);

--- a/jena-core/src/test/java/org/apache/jena/util/TestPrefixMappingUtils.java
+++ b/jena-core/src/test/java/org/apache/jena/util/TestPrefixMappingUtils.java
@@ -22,7 +22,7 @@ import java.io.StringReader ;
 
 import junit.framework.JUnit4TestAdapter;
 import org.apache.jena.atlas.lib.StrUtils ;
-import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -39,7 +39,7 @@ public class TestPrefixMappingUtils {
     }
 
     static Graph create (String data) {
-        Graph graph = Factory.createGraphMem() ;
+        Graph graph = GraphMemFactory.createGraphMem() ;
         Model m = ModelFactory.createModelForGraph(graph);
         m.read(new StringReader(data), null, "TTL");
         return graph ;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/GraphLoadUtils.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/GraphLoadUtils.java
@@ -20,7 +20,7 @@
 package org.apache.jena.fuseki.system;
 
 import org.apache.jena.fuseki.Fuseki;
-import org.apache.jena.graph.Factory;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -35,7 +35,7 @@ public class GraphLoadUtils
     // ---- Model level
 
     public static Model readModel(String uri, int limit) {
-        Graph g = Factory.createGraphMem();
+        Graph g = GraphMemFactory.createGraphMem();
         readUtil(g, uri, limit);
         return ModelFactory.createModelForGraph(g);
     }
@@ -48,7 +48,7 @@ public class GraphLoadUtils
     // ---- Graph level
 
     public static Graph readGraph(String uri, int limit) {
-        Graph g = Factory.createGraphMem();
+        Graph g = GraphMemFactory.createGraphMem();
         readUtil(g, uri, limit);
         return g;
     }

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/TestBlankNodeBinary.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/TestBlankNodeBinary.java
@@ -57,14 +57,14 @@ public class TestBlankNodeBinary {
     @Test public void binaryThrift() {
         Triple t = Triple.create(n(":s"), n(":p"), NodeFactory.createBlankNode("ABCD"));
         Node obj = t.getObject();
-        Graph graph = Factory.createDefaultGraph();
+        Graph graph = GraphMemFactory.createDefaultGraph();
         graph.add(t);
 
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         RDFDataMgr.write(bout, graph, Lang.RDFTHRIFT);
 
         ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
-        Graph graph1 = Factory.createDefaultGraph();
+        Graph graph1 = GraphMemFactory.createDefaultGraph();
         RDFDataMgr.read(graph1, bin, Lang.RDFTHRIFT);
 
         Node obj1 = graph1.find().next().getObject();

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestBlankNodeBinary.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestBlankNodeBinary.java
@@ -56,14 +56,14 @@ public class TestBlankNodeBinary {
     @Test public void binaryThrift() {
         Triple t = Triple.create(n(":s"), n(":p"), NodeFactory.createBlankNode("ABCD"));
         Node obj = t.getObject(); 
-        Graph graph = Factory.createDefaultGraph();
+        Graph graph = GraphMemFactory.createDefaultGraph();
         graph.add(t);
         
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         RDFDataMgr.write(bout, graph, Lang.RDFTHRIFT);
         
         ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
-        Graph graph1 = Factory.createDefaultGraph();
+        Graph graph1 = GraphMemFactory.createDefaultGraph();
         RDFDataMgr.read(graph1, bin, Lang.RDFTHRIFT);
         
         Node obj1 = graph1.find().next().getObject();


### PR DESCRIPTION
GitHub issue resolved #1919

Steps taken in this PR:

* Refactor/rename of Factory to GraphMemFactory
* Put back Factory, deprecate it; call GraphMemFactory functions.
* In GraphMemFactory, remove a function that has been deprecated and marked "To be removed "  for over a year

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
