### PR TITLE
GH-1924: Add a "long" Turtle/TriG format variant

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFFormat.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFFormat.java
@@ -33,6 +33,8 @@ public class RDFFormat {
     public static final RDFFormatVariant BLOCKS         = new RDFFormatVariant("blocks") ;
     /** Print out one per line */
     public static final RDFFormatVariant FLAT           = new RDFFormatVariant("flat") ;
+    /** Print with fixed indentation width and linebreaks after each sequence element */
+    public static final RDFFormatVariant LONG           = new RDFFormatVariant("long") ;
 
     /** Use ASCII output (N-triples, N-Quads) */
     public static final RDFFormatVariant ASCII          = new RDFFormatVariant("ascii") ;
@@ -51,6 +53,8 @@ public class RDFFormat {
     public static final RDFFormat        TURTLE_BLOCKS  = new RDFFormat(Lang.TURTLE, BLOCKS) ;
     /** Turtle - one line per triple  */
     public static final RDFFormat        TURTLE_FLAT    = new RDFFormat(Lang.TURTLE, FLAT) ;
+    /** Turtle - with fixed indentation width and linebreaks after each sequence element */
+    public static final RDFFormat        TURTLE_LONG    = new RDFFormat(Lang.TURTLE, LONG) ;
 
     /** N-Triples in UTF-8 */
     public static final RDFFormat        NTRIPLES_UTF8  = new RDFFormat(Lang.NTRIPLES, UTF8) ;
@@ -78,6 +82,8 @@ public class RDFFormat {
     public static final RDFFormat        TRIG_BLOCKS    = new RDFFormat(Lang.TRIG, BLOCKS) ;
     /** TriG - one line per triple  */
     public static final RDFFormat        TRIG_FLAT      = new RDFFormat(Lang.TRIG, FLAT) ;
+    /** TriG - with fixed indentation width and linebreaks after each sequence element */
+    public static final RDFFormat        TRIG_LONG      = new RDFFormat(Lang.TRIG, LONG) ;
 
     /** SHACL Compact Syntax */
     public static final RDFFormat        SHACLC         = new RDFFormat(Lang.SHACLC);

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
@@ -68,6 +68,8 @@ public class RDFWriterRegistry
                 return new TurtleWriterBlocks() ;
             if ( Objects.equals(RDFFormat.TURTLE_FLAT, serialization) )
                 return new TurtleWriterFlat() ;
+            if ( Objects.equals(RDFFormat.TURTLE_LONG, serialization) )
+                return new TurtleWriterLong() ;
 
             if ( Objects.equals(RDFFormat.NTRIPLES_UTF8, serialization) )
                 return new NTriplesWriter() ;
@@ -97,6 +99,8 @@ public class RDFWriterRegistry
                 return new TriGWriterBlocks() ;
             if ( Objects.equals(RDFFormat.TRIG_FLAT, serialization) )
                 return new TriGWriterFlat() ;
+            if ( Objects.equals(RDFFormat.TRIG_LONG, serialization) )
+                return new TriGWriterLong() ;
             if ( Objects.equals(RDFFormat.NQUADS_UTF8, serialization) )
                 return new NQuadsWriter() ;
             if ( Objects.equals(RDFFormat.NQUADS_ASCII, serialization) )
@@ -159,6 +163,7 @@ public class RDFWriterRegistry
         register(RDFFormat.TURTLE_PRETTY,  wgfactory) ;
         register(RDFFormat.TURTLE_BLOCKS,  wgfactory) ;
         register(RDFFormat.TURTLE_FLAT,    wgfactory) ;
+        register(RDFFormat.TURTLE_LONG,    wgfactory) ;
 
         register(RDFFormat.NTRIPLES,       wgfactory) ;
         register(RDFFormat.NTRIPLES_ASCII, wgfactory) ;
@@ -213,6 +218,7 @@ public class RDFWriterRegistry
         register(RDFFormat.TRIG_PRETTY,    wgfactory) ;
         register(RDFFormat.TRIG_BLOCKS,    wgfactory) ;
         register(RDFFormat.TRIG_FLAT,      wgfactory) ;
+        register(RDFFormat.TRIG_LONG,      wgfactory) ;
 
         register(RDFFormat.NQUADS,         wgfactory) ;
         register(RDFFormat.NQUADS_ASCII,   wgfactory) ;

--- a/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
@@ -142,4 +142,10 @@ public class RIOT {
      * not output BASE even when given.
      */
     public static final Symbol symTurtleOmitBase = SystemARQ.allocSymbol(TURTLE_SYMBOL_BASE, "omitBase");
+
+
+    /**
+     * Printing style. Whether to use a "wide" or "long" indentation style.
+     */
+    public static final Symbol symTurtleIndentStyle = SystemARQ.allocSymbol(TURTLE_SYMBOL_BASE, "indentStyle");
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/IndentStyle.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/IndentStyle.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.writer;
+
+enum IndentStyle {
+    WIDE, LONG ;
+    public static IndentStyle create(String label) {
+        String s = label.toLowerCase() ;
+        switch(s) {
+            case "wide":
+                return IndentStyle.WIDE ;
+            case "long":
+                return IndentStyle.LONG ;
+        }
+        return null;
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/TriGWriterLong.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/TriGWriterLong.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.writer ;
+
+import org.apache.jena.atlas.io.IndentedWriter ;
+import org.apache.jena.riot.RIOT;
+import org.apache.jena.riot.system.PrefixMap ;
+import org.apache.jena.sparql.core.DatasetGraph ;
+import org.apache.jena.sparql.util.Context ;
+
+public class TriGWriterLong extends TriGWriter {
+
+    @Override
+    protected void output(IndentedWriter iOut, DatasetGraph dsg, PrefixMap prefixMap, String baseURI, Context context) {
+        context.set(RIOT.symTurtleIndentStyle, "long");
+        super.output(iOut, dsg, prefixMap, baseURI, context);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/TurtleWriterLong.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/TurtleWriterLong.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.writer ;
+
+import org.apache.jena.atlas.io.IndentedWriter ;
+import org.apache.jena.graph.Graph ;
+import org.apache.jena.riot.RIOT;
+import org.apache.jena.riot.system.PrefixMap ;
+import org.apache.jena.sparql.util.Context ;
+
+public class TurtleWriterLong extends TurtleWriter {
+
+    @Override
+    protected void output(IndentedWriter iOut, Graph graph, PrefixMap prefixMap, String baseURI, Context context) {
+        context.set(RIOT.symTurtleIndentStyle, "long");
+        super.output(iOut, graph, prefixMap, baseURI, context);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/WriterLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/WriterLib.java
@@ -26,6 +26,8 @@ import org.apache.jena.sparql.util.Context;
 
     private static final DirectiveStyle dftDirectiveStyle = DirectiveStyle.AT;
 
+    private static final IndentStyle dftIndentStyle = IndentStyle.WIDE;
+
     // Determine the directive style (applies to PREFIX and BASE).
     /*package*/ static DirectiveStyle directiveStyle(Context context) {
         if ( context == null )
@@ -42,5 +44,20 @@ import org.apache.jena.sparql.util.Context;
 
         // Default choice; includes null in context.
         return dftDirectiveStyle;
+    }
+
+    /*package*/ static IndentStyle indentStyle(Context context) {
+        if ( context == null )
+            return dftIndentStyle;
+        Object x = context.get(RIOT.symTurtleIndentStyle) ;
+
+        if ( x instanceof String ) {
+            String s = (String)x ;
+            IndentStyle style = IndentStyle.create(s);
+            return style == null ? dftIndentStyle : style;
+        }
+
+        // Default choice; includes null in context.
+        return dftIndentStyle;
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestTurtleWriter.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestTurtleWriter.java
@@ -40,10 +40,12 @@ public class TestTurtleWriter {
         x.add(new Object[]{"Turtle/Pretty", RDFFormat.TURTLE_PRETTY});
         x.add(new Object[]{"Turtle/Blocks", RDFFormat.TURTLE_BLOCKS});
         x.add(new Object[]{"Turtle/Flat", RDFFormat.TURTLE_FLAT});
+        x.add(new Object[]{"Turtle/Long", RDFFormat.TURTLE_LONG});
         x.add(new Object[]{"Trig", RDFFormat.TRIG});
         x.add(new Object[]{"Trig/Pretty", RDFFormat.TRIG_PRETTY});
         x.add(new Object[]{"Trig/Blocks", RDFFormat.TRIG_BLOCKS});
         x.add(new Object[]{"Trig/Flat", RDFFormat.TRIG_FLAT});
+        x.add(new Object[]{"Trig/Long", RDFFormat.TRIG_LONG});
         return x ; 
     }
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestTurtleWriterPretty.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestTurtleWriterPretty.java
@@ -39,7 +39,9 @@ public class TestTurtleWriterPretty {
     public static Iterable<Object[]> data() {
         List<Object[]> x = new ArrayList<>() ;
         x.add(new Object[]{"Turtle/Pretty", RDFFormat.TURTLE_PRETTY});
+        x.add(new Object[]{"Turtle/Long", RDFFormat.TURTLE_LONG});
         x.add(new Object[]{"Trig/Pretty", RDFFormat.TRIG_PRETTY});
+        x.add(new Object[]{"Trig/Long", RDFFormat.TRIG_LONG});
         return x ; 
     }
     

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRiotWriterGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestRiotWriterGraph.java
@@ -51,6 +51,7 @@ public class TestRiotWriterGraph extends AbstractWriterTest
             , { RDFFormat.TURTLE_PRETTY }
             , { RDFFormat.TURTLE_BLOCKS }
             , { RDFFormat.TURTLE_FLAT }
+            , { RDFFormat.TURTLE_LONG }
             , { RDFFormat.RDFXML }
             , { RDFFormat.RDFXML_PRETTY }
             , { RDFFormat.RDFXML_PLAIN }
@@ -73,6 +74,7 @@ public class TestRiotWriterGraph extends AbstractWriterTest
             , { RDFFormat.TRIG_PRETTY }
             , { RDFFormat.TRIG_BLOCKS }
             , { RDFFormat.TRIG_FLAT }
+            , { RDFFormat.TRIG_LONG }
             , { RDFFormat.NQUADS_UTF8}
             , { RDFFormat.NQUADS_ASCII}
             , { RDFFormat.NQUADS}

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestTurtleWriter.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestTurtleWriter.java
@@ -82,9 +82,6 @@ public class TestTurtleWriter {
     public void bnode_cycles_02() { blankNodeLang(cycle1, RDFFormat.TURTLE_BLOCKS) ; }
 
     @Test
-    public void bnode_cycles_03() { blankNodeLang(cycle1, RDFFormat.TURTLE_FLAT) ; }
-
-    @Test
     public void bnode_cycles_04() { blankNodeLang(cycle1, RDFFormat.TURTLE_PRETTY) ; }
 
     @Test
@@ -98,6 +95,9 @@ public class TestTurtleWriter {
 
     @Test
     public void bnode_cycles_08() { blankNodeLang(cycle2, RDFFormat.TURTLE_PRETTY) ; }
+
+    @Test
+    public void bnode_cycles_09() { blankNodeLang(cycle2, RDFFormat.TURTLE_LONG) ; }
 
     @Test
     public void bnode_cycles() {


### PR DESCRIPTION
GitHub issue resolved #1924  

Pull request Description:

Adds a "long” Turtle/TriG format variant is based on rdflib's "longturtle" format. It uses a fixed indentation width (2) and linebreaks after each sequence element.

----

 - [X] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [X] Commits have been squashed to remove intermediate development commit messages.
 - [X] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
