### PR TITLE
GH-1943: Link to Dexx LICENSE. Put Dexx NOTICE in NOTICE files

### DIFF
--- a/apache-jena/dist/LICENSE
+++ b/apache-jena/dist/LICENSE
@@ -239,28 +239,10 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Dexx Collections
 https://github.com/andrewoma/dexx
-BSD-Style License
+MIT-Style License
   https://github.com/andrewoma/dexx/blob/master/LICENSE.txt
 
 Copyright (c) 2014 Andrew O'Malley
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 

--- a/apache-jena/dist/NOTICE
+++ b/apache-jena/dist/NOTICE
@@ -39,7 +39,7 @@ Copyright (c) 2004-2008 QOS.
 Dexx Collections
 Copyright (c) 2014 Andrew O'Malley
 https://github.com/andrewoma/dexx
-BSD-Style License
+MIT-Style License
   https://github.com/andrewoma/dexx/blob/master/LICENSE.txt
   
 and includes the following NOTICE

--- a/jena-fuseki2/apache-jena-fuseki/dist/LICENSE
+++ b/jena-fuseki2/apache-jena-fuseki/dist/LICENSE
@@ -206,6 +206,14 @@
 
 ## Bundled Dependencies ##
 
+Dexx Collections
+Copyright (c) 2014 Andrew O'Malley
+https://github.com/andrewoma/dexx
+MIT-Style License
+  https://github.com/andrewoma/dexx/blob/master/LICENSE.txt
+
+- - - - - - - - - - - - - - - - - - - - - - -
+
 Jakarta JSON Processing (JSON-P)
 https://eclipse-ee4j.github.io/jsonp/
 is licensed under the Eclipse Public License 2.0.

--- a/jena-fuseki2/apache-jena-fuseki/dist/NOTICE
+++ b/jena-fuseki2/apache-jena-fuseki/dist/NOTICE
@@ -18,6 +18,21 @@ PluggedIn Software under a BSD license.
 
 - - - - - - - - - - - - - - - - - - - - - - -
 
+Dexx Collections
+Copyright (c) 2014 Andrew O'Malley
+https://github.com/andrewoma/dexx
+MIT-Style License
+  https://github.com/andrewoma/dexx/blob/master/LICENSE.txt
+  
+and includes the following NOTICE
+----------
+Portions based on code from the Scala standard library.
+Copyright (c) 2002-2014 EPFL
+Copyright (c) 2011-2014 Typesafe, Inc.
+Licensed under BSD-style license (see licenses/LICENSE_Scala.txt)
+
+- - - - - - - - - - - - - - - - - - - - - - -
+
   Apache Xerces Java
    Copyright 1999-2013 The Apache Software Foundation
 


### PR DESCRIPTION
GitHub issue resolved #1943

Linking to licenses rather than text inclusions is acceptable nowadays.



----
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
