### PR TITLE
Revert "Bump ver.graalvm from 22.3.2 to 23.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <ver.roaringbitmap>0.9.45</ver.roaringbitmap>
 
     <!-- For testing, not shipped -->
-    <ver.graalvm>23.0.0</ver.graalvm>
+    <ver.graalvm>22.3.2</ver.graalvm>
     <ver.jython>2.7.3</ver.jython>
     <ver.org.openjdk.jmh>1.36</ver.org.openjdk.jmh>
 


### PR DESCRIPTION
graalvm 23 requires Java17.
Despite graalvm not being something the project ships, it is used in the build.
This PR reverts to a Java11 compatible verison.

This reverts commit 027956c2d9a58cccaeedaf7f7b63ca9042b18991.
