### PR TITLE
GH-1961: Thread-safe and consistent GraphTxn.find

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/system/Txn.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/Txn.java
@@ -18,10 +18,10 @@
 
 package org.apache.jena.system;
 
-import java.util.function.Supplier ;
+import java.util.function.Supplier;
 
 import org.apache.jena.query.TxnType;
-import org.apache.jena.sparql.core.Transactional ;
+import org.apache.jena.sparql.core.Transactional;
 
 /** Application utilities for executing code in transactions.
  * <p>
@@ -69,43 +69,43 @@ public class Txn {
 
     /** Execute application code in a transaction with the given {@link TxnType transaction type}. */
     public static <T extends Transactional> void exec(T txn, TxnType txnType, Runnable r) {
-        boolean b = txn.isInTransaction() ;
+        boolean b = txn.isInTransaction();
         if ( b )
             TxnOp.compatibleWithPromote(txnType, txn);
         else
-            txn.begin(txnType) ;
-        try { r.run() ; }
+            txn.begin(txnType);
+        try { r.run(); }
         catch (Throwable th) {
             onThrowable(th, txn);
-            throw th ;
+            throw th;
         }
         if ( !b ) {
             if ( txn.isInTransaction() )
                 // May have been explicit commit or abort.
-                txn.commit() ;
-            txn.end() ;
+                txn.commit();
+            txn.end();
         }
     }
 
     /** Execute and return a value in a transaction with the given {@link TxnType transaction type}. */
     public static <T extends Transactional, X> X calc(T txn, TxnType txnType, Supplier<X> r) {
-        boolean b = txn.isInTransaction() ;
+        boolean b = txn.isInTransaction();
         if ( b )
             TxnOp.compatibleWithPromote(txnType, txn);
         else
-            txn.begin(txnType) ;
+            txn.begin(txnType);
         X x;
-        try { x = r.get() ; }
+        try { x = r.get(); }
         catch (Throwable th) {
             onThrowable(th, txn);
-            throw th ;
+            throw th;
         }
 
         if ( !b ) {
             if ( txn.isInTransaction() )
                 // May have been explicit commit or abort.
-                txn.commit() ;
-            txn.end() ;
+                txn.commit();
+            txn.end();
         }
         return x;
     }
@@ -133,8 +133,8 @@ public class Txn {
     // Attempt some kind of cleanup.
     private static <T extends Transactional> void onThrowable(Throwable th, T txn) {
         try {
-            txn.abort() ;
-            txn.end() ;
+            txn.abort();
+            txn.end();
         } catch (Throwable th2) { th.addSuppressed(th2); }
     }
 }


### PR DESCRIPTION
GitHub issue resolved #1961

Pull request Description:
Provide `GraphTxn.find()` that transparently runs inside a transaction to ensure consistency.

This is like "autocommit" for SQL databases. It has all the consequences of that as well. It has more overhead, and does give application change consistency (e.g. a read-modify-write) is two transactions and other transactions/thread may change or view the database between the "read" and the "write").



----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
