### PR TITLE
GH-1990: Fix GraphReadOnly; deprecate UnmodifiableGraph

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphReadOnly.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphReadOnly.java
@@ -26,11 +26,12 @@ import org.apache.jena.graph.impl.SimpleTransactionHandler ;
 import org.apache.jena.graph.impl.WrappedGraph ;
 import org.apache.jena.shared.AddDeniedException ;
 import org.apache.jena.shared.DeleteDeniedException ;
+import org.apache.jena.shared.PrefixMapping;
 
 public class GraphReadOnly extends WrappedGraph
 {
     public GraphReadOnly(Graph graph) { super(graph) ; }
-    
+
     @Override
     public void add(Triple t) throws AddDeniedException
     { throw new AddDeniedException("read-only graph") ; }
@@ -42,22 +43,27 @@ public class GraphReadOnly extends WrappedGraph
     @Override
     public void delete(Triple t) throws DeleteDeniedException
     { throw new DeleteDeniedException("read-only graph") ; }
-    
+
     @Override
     public void performDelete(Triple t) throws DeleteDeniedException
     { throw new DeleteDeniedException("read-only graph") ; }
-    
+
     @Override
-    public void remove(Node s, Node p, Node o) 
+    public void remove(Node s, Node p, Node o)
     { throw new DeleteDeniedException("read-only graph") ; }
-    
+
     @Override
-    public void clear() 
+    public void clear()
     { throw new DeleteDeniedException("read-only graph") ; }
 
     @Override
     public TransactionHandler getTransactionHandler() {
-        // AKA "no".  
+        // AKA "no".
         return new SimpleTransactionHandler() ;
+    }
+
+    @Override
+    public PrefixMapping getPrefixMapping() {
+        return new PrefixMappingReadOnly(getWrapped().getPrefixMapping());
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/PrefixMappingReadOnly.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/PrefixMappingReadOnly.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.graph;
+
+import java.util.Map ;
+
+import org.apache.jena.shared.JenaException;
+import org.apache.jena.shared.PrefixMapping ;
+
+public class PrefixMappingReadOnly implements PrefixMapping {
+
+    private final PrefixMapping other;
+
+    public PrefixMappingReadOnly(PrefixMapping other) {
+        this.other = other;
+    }
+
+    private JenaException exception() {
+        return new JenaException("Read-only prefix mapping");
+    }
+
+    // Throw an exception for all updates.
+
+    @Override
+    public PrefixMapping setNsPrefix(String prefix, String uri) {
+        throw exception();
+    }
+
+    @Override
+    public PrefixMapping removeNsPrefix(String prefix) {
+        throw exception();
+    }
+
+    @Override
+    public PrefixMapping clearNsPrefixMap() {
+        throw exception();
+    }
+
+    @Override
+    public PrefixMapping setNsPrefixes(PrefixMapping other) {
+        throw exception();
+    }
+
+    @Override
+    public PrefixMapping setNsPrefixes(Map<String, String> map) {
+        throw exception();
+    }
+
+    @Override
+    public PrefixMapping withDefaultMappings(PrefixMapping map) {
+        throw exception();
+    }
+
+    // Pass to the underlying prefix mapping for read operations.
+
+    @Override
+    public String getNsPrefixURI(String prefix) {
+        return other.getNsPrefixURI(prefix);
+    }
+
+    @Override
+    public String getNsURIPrefix(String uri) {
+        return other.getNsURIPrefix(uri);
+    }
+
+    @Override
+    public Map<String, String> getNsPrefixMap() {
+        return other.getNsPrefixMap();
+    }
+
+    @Override
+    public String expandPrefix(String prefixed) {
+        return other.expandPrefix(prefixed);
+    }
+
+    @Override
+    public String shortForm(String uri) {
+        return other.shortForm(uri);
+    }
+
+    @Override
+    public String qnameFor(String uri) {
+        return other.qnameFor(uri);
+    }
+
+    @Override
+    public PrefixMapping lock() {
+        return this;
+    }
+
+    @Override
+    public int numPrefixes() {
+        return other.numPrefixes();
+    }
+
+    @Override
+    public boolean samePrefixMappingAs(PrefixMapping prefixMapping) {
+        return other.samePrefixMappingAs(prefixMapping);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/UnmodifiableGraph.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/UnmodifiableGraph.java
@@ -19,24 +19,15 @@
 package org.apache.jena.sparql.graph;
 
 import org.apache.jena.graph.Graph ;
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.graph.impl.WrappedGraph ;
 
-public class UnmodifiableGraph extends WrappedGraph
+/**
+ * @deprecated Use {@link GraphReadOnly}
+ *
+ */
+@Deprecated
+public class UnmodifiableGraph extends GraphReadOnly
 {
-    public UnmodifiableGraph(Graph base)
-    {
-        super(base) ;
+    public UnmodifiableGraph(Graph base) {
+        super(base);
     }
-    
-    /** Return base graph that this class protects.  Caveat emptor. */
-    public Graph unwrap()   { return super.base ; }
-    
-    @Override
-    public void performAdd(Triple triple)
-    { throw new UnsupportedOperationException() ; }
-    
-    @Override
-    public void performDelete(Triple triple)
-    { throw new UnsupportedOperationException() ; }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/graph/TS_Graph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/graph/TS_Graph.java
@@ -28,6 +28,7 @@ import org.junit.runners.Suite ;
     , TestGraphUnionRead.class
     , TestPrefixMappingMem.class
     , TestPrefixMappingPrefixMap.class
+    , TestGraphReadOnly.class
 })
 public class TS_Graph
 {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/graph/TestGraphReadOnly.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/graph/TestGraphReadOnly.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.graph;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.shared.AddDeniedException;
+import org.apache.jena.shared.DeleteDeniedException;
+import org.apache.jena.shared.JenaException;
+import org.apache.jena.sparql.sse.SSE;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestGraphReadOnly {
+
+    private static Graph baseGraph;
+    private static Triple triple;
+
+    @BeforeClass public static void beforeClass() {
+        baseGraph = GraphFactory.createDefaultGraph();
+        triple = SSE.parseTriple("(:s :p :o)");
+        baseGraph.getPrefixMapping().setNsPrefix("ex", "http://example/");
+    }
+
+    @Test(expected=AddDeniedException.class)
+    public void read_only_add() {
+        Graph graph = new GraphReadOnly(baseGraph);
+        graph.add(triple);
+    }
+
+    @Test(expected=DeleteDeniedException.class)
+    public void read_only_delete() {
+        Graph graph = new GraphReadOnly(baseGraph);
+        graph.delete(triple);
+    }
+
+    @Test(expected=JenaException.class)
+    public void read_only_remove() {
+        Graph graph = new GraphReadOnly(baseGraph);
+        graph.remove(null, null, null);
+    }
+
+    @Test(expected=JenaException.class)
+    public void read_only_clear() {
+        Graph graph = new GraphReadOnly(baseGraph);
+        graph.clear();
+    }
+
+    @Test(expected=JenaException.class)
+    public void read_only_prefixmapping_set() {
+        Graph graph = new GraphReadOnly(baseGraph);
+        // Does not matter that it is alread defined.
+        graph.getPrefixMapping().setNsPrefix("ex", "http://example/");
+    }
+
+    @Test(expected=JenaException.class)
+    public void read_only_prefixmapping_remove() {
+        Graph graph = new GraphReadOnly(baseGraph);
+        graph.getPrefixMapping().removeNsPrefix("empty");
+    }
+
+    @Test(expected=JenaException.class)
+    public void read_only_prefixmapping_clear() {
+        Graph graph = new GraphReadOnly(baseGraph);
+        // Does not matter that it is alread defined.
+        graph.getPrefixMapping().clearNsPrefixMap();
+    }
+
+    @Test(expected=JenaException.class)
+    public void unmodified_add() {
+        @SuppressWarnings("deprecation")
+        Graph graph = new UnmodifiableGraph(baseGraph);
+        graph.add(triple);
+    }
+
+    @Test(expected=JenaException.class)
+    public void unmodified_prefixmapping() {
+        @SuppressWarnings("deprecation")
+        Graph graph = new UnmodifiableGraph(baseGraph);
+        graph.add(triple);
+    }
+
+}


### PR DESCRIPTION
GitHub issue resolved #1990

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
