### PR TITLE
JENA-2354: Set Caffeine initial cache size to 25%

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheCaffeine.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheCaffeine.java
@@ -46,7 +46,7 @@ final public class CacheCaffeine<K,V> implements Cache<K, V>
         @SuppressWarnings("unchecked")
         Caffeine<K,V> builder = (Caffeine<K,V>)Caffeine.newBuilder()
             .maximumSize(size)
-            .initialCapacity(size/2)
+            .initialCapacity(size/4)
             // Eviction immediately using the caller thread.
             .executor(c->c.run());
 


### PR DESCRIPTION
Issue resolved : [JENA-2354](https://issues.apache.org/jira/browse/JENA-2354)

Pull request Description:
Set the initial size of the Caffeine cache to 25%, not 50%.

----
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
