### PR TITLE
Bump Apache Commons Compress from 1.23.0 to 1.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <ver.commonsrdf>0.5.0</ver.commonsrdf>
     <ver.commonscsv>1.10.0</ver.commonscsv>
     <ver.commons-codec>1.15</ver.commons-codec>
-    <ver.commons-compress>1.23.0</ver.commons-compress>
+    <ver.commons-compress>1.24.0</ver.commons-compress>
     <ver.commons-collections>4.4</ver.commons-collections>
     <ver.dexxcollection>0.7</ver.dexxcollection>
     <ver.micrometer>1.11.4</ver.micrometer>


### PR DESCRIPTION
This upgrade addresses [CVE-2023-42503](https://nvd.nist.gov/vuln/detail/CVE-2023-42503) (moderate).

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
