### PR TITLE
Switch to GraalVM v22 for Java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <ver.roaringbitmap>1.0.0</ver.roaringbitmap>
 
     <!-- For testing, not shipped -->
-    <ver.graalvm>23.0.1</ver.graalvm>
+    <ver.graalvm>22.3.4</ver.graalvm>
     <ver.jython>2.7.3</ver.jython>
     <ver.org.openjdk.jmh>1.37</ver.org.openjdk.jmh>
 


### PR DESCRIPTION
GraalVM v23 bumps the requirement to Java17.
Stick with v22 for Jena4.
(Surprising how many of our builds are Java17 under the covers - this only broke in one place)




