### PR TITLE
Upgrade of Java dependencies

### DIFF
--- a/jena-cmds/src/main/java/arq/query.java
+++ b/jena-cmds/src/main/java/arq/query.java
@@ -153,7 +153,7 @@ public class query extends CmdARQ
         // Warm up.
         for ( int i = 0 ; i < warmupCount ; i++ )
             // Include the results format so that is warmed up as well.
-            queryExec(false, modResults.getResultsFormat(), NullPrintStream.NULL_PRINT_STREAM) ;
+            queryExec(false, modResults.getResultsFormat(), NullPrintStream.INSTANCE) ;
 
         for ( int i = 0 ; i < repeatCount ; i++ )
             queryExec(modTime.timingEnabled(),  modResults.getResultsFormat(), System.out) ;

--- a/jena-cmds/src/test/java/org/apache/jena/cmds/TestCmdExt.java
+++ b/jena-cmds/src/test/java/org/apache/jena/cmds/TestCmdExt.java
@@ -38,7 +38,7 @@ public class TestCmdExt {
     @Before
     public void beforeTest() {
         stderr = System.err;
-        System.setErr(new PrintStream(NullOutputStream.NULL_OUTPUT_STREAM));
+        System.setErr(new PrintStream(NullOutputStream.INSTANCE));
     }
 
     @After

--- a/jena-extras/jena-commonsrdf/pom.xml
+++ b/jena-extras/jena-commonsrdf/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-rdf-api</artifactId>
-      <version>${ver.commonsrdf}</version>
+      <version>${ver.commons-rdf}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-rdf-simple</artifactId>
-      <version>${ver.commonsrdf}</version>
+      <version>${ver.commons-rdf}</version>
       <scope>test</scope>
     </dependency>
 

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/SRSInfoTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/SRSInfoTest.java
@@ -38,6 +38,7 @@ public class SRSInfoTest {
     public SRSInfoTest() {
     }
 
+
     @BeforeClass
     public static void setUpClass() {
     }
@@ -53,6 +54,18 @@ public class SRSInfoTest {
     @After
     public void tearDown() {
     }
+
+    // SIS 1.1
+    //public static final double OS_X1 = -104009.35713717458;
+    //public static final double OS_X2 = 688806.0073395987;
+    //public static final double OS_Y1 = -16627.734528041445;
+    //public static final double OS_Y2 = 1256558.4455361878;
+
+    // SIS 1.4
+    public static final double OS_X1 = -104009.35713717458;
+    public static final double OS_X2 = 688806.0073395987;
+    public static final double OS_Y1 = -16627.734528042376;
+    public static final double OS_Y2 = 1256558.445536187;
 
     /**
      * Test of buildDomainEnvelope method, of class SRSInfo.
@@ -99,10 +112,12 @@ public class SRSInfoTest {
         CoordinateReferenceSystem crs = CRS.forCode(srsURI);
         Boolean isAxisXY = SRSInfo.checkAxisXY(crs);
 
-        // SIS 1.0
-        //Envelope expResult = new Envelope(-118397.00138845091, 751441.7790901454, -16627.734375018626, 1272149.3463499574);
-        // SIS 1.1
-        Envelope expResult = new Envelope(-104009.35713717458, 688806.0073395987, -16627.734528041445, 1256558.4455361878);
+
+        Envelope expResult = new Envelope(OS_X1, OS_X2, OS_Y1, OS_Y2);
+
+
+        //expected:<Env[-104009.35713717458 : 688806.0073395987, -16627.734528041445 : 1256558.4455361878]>
+        // but was:<Env[-104009.35713717458 : 688806.0073395987, -16627.734528042376 : 1256558.445536187]>
 
         Envelope result = SRSInfo.buildDomainEnvelope(crs, isAxisXY);
         assertEquals(expResult, result);

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/spatial/SearchEnvelopeTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/spatial/SearchEnvelopeTest.java
@@ -67,10 +67,15 @@ public class SearchEnvelopeTest {
     //public static final double OS_Y1 = -16627.734375018626;
     //public static final double OS_Y2 = 1272149.3463499574;
     // SIS 1.1
+    //public static final double OS_X1 = -104009.35713717458;
+    //public static final double OS_X2 = 688806.0073395987;
+    //public static final double OS_Y1 = -16627.734528041445;
+    //public static final double OS_Y2 = 1256558.4455361878;
+    // SIS 1.4
     public static final double OS_X1 = -104009.35713717458;
     public static final double OS_X2 = 688806.0073395987;
-    public static final double OS_Y1 = -16627.734528041445;
-    public static final double OS_Y2 = 1256558.4455361878;
+    public static final double OS_Y1 = -16627.734528042376;
+    public static final double OS_Y2 = 1256558.445536187;
 
     /**
      * Test of build method, of class SearchEnvelope.
@@ -184,9 +189,12 @@ public class SearchEnvelopeTest {
 
         GeometryWrapper geometryWrapper = GeometryWrapper.extract("<http://www.opengis.net/def/crs/EPSG/0/27700> POINT(10.0 20.0)", WKTDatatype.URI);
         CardinalDirection direction = CardinalDirection.EAST;
-        SearchEnvelope expResult = new SearchEnvelope(new Envelope(10, OS_X2, OS_Y1, OS_Y2), SpatialIndexTestData.OSGB_SRS_INFO);
+        SearchEnvelope expResult = new SearchEnvelope(new Envelope(10.0, OS_X2, OS_Y1, OS_Y2), SpatialIndexTestData.OSGB_SRS_INFO);
         SearchEnvelope result = SearchEnvelope.build(geometryWrapper, SpatialIndexTestData.OSGB_SRS_INFO, direction);
         assertEquals(expResult, result);
+
+        //java.lang.AssertionError: expected:<SearchEnvelope{envelope=Env[10.0 : 688806.0073395987, -16627.734528041445 : 1256558.4455361878], wrappedEnvelope=null}>
+        // but was:<SearchEnvelope{envelope=Env                          [10.0 : 688806.0073395987, -16627.734528042376 : 1256558.445536187], wrappedEnvelope=null}>
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
     <!-- Testing -->
     <ver.junit>4.13.2</ver.junit>  
-    <ver.mockito>5.5.0</ver.mockito>
+    <ver.mockito>5.6.0</ver.mockito>
     <ver.awaitility>4.2.0</ver.awaitility>
     <ver.contract.tests>0.2.0</ver.contract.tests>
 
@@ -66,9 +66,9 @@
     <ver.slf4j>1.7.36</ver.slf4j>
     <ver.log4j2>2.21.0</ver.log4j2>
 
-    <ver.lucene>9.5.0</ver.lucene>
+    <ver.lucene>9.7.0</ver.lucene>
 
-    <ver.jetty>10.0.15</ver.jetty>
+    <ver.jetty>10.0.17</ver.jetty>
     <ver.shiro>1.12.0</ver.shiro>
 
     <ver.protobuf>3.24.3</ver.protobuf>
@@ -88,21 +88,21 @@
          and use that or later.
     -->
     <ver.jsonldjava>0.13.4</ver.jsonldjava>
-    <ver.jackson>2.15.2</ver.jackson>
+    <ver.jackson>2.15.3</ver.jackson>
     <ver.httpclient>4.5.14</ver.httpclient>
     <ver.httpcore>4.4.16</ver.httpcore>
 
     <ver.caffeine>3.1.8</ver.caffeine>
     <!-- Most of Jena uses other libraries for equivalent functionality. -->
-    <ver.guava>32.1.2-jre</ver.guava>
+    <ver.guava>32.1.3-jre</ver.guava>
 
     <ver.gson>2.10.1</ver.gson>
-    <ver.commonsio>2.11.0</ver.commonsio>
-    <ver.commonscli>1.5.0</ver.commonscli>
-    <ver.commonslang3>3.12.0</ver.commonslang3>
-    <ver.commonsrdf>0.5.0</ver.commonsrdf>
-    <ver.commonscsv>1.10.0</ver.commonscsv>
-    <ver.commons-codec>1.15</ver.commons-codec>
+    <ver.commons-io>2.14.0</ver.commons-io>
+    <ver.commons-cli>1.5.0</ver.commons-cli>
+    <ver.commons-lang3>3.13.0</ver.commons-lang3>
+    <ver.commons-rdf>0.5.0</ver.commons-rdf>
+    <ver.commons-csv>1.10.0</ver.commons-csv>
+    <ver.commons-codec>1.16.0</ver.commons-codec>
     <ver.commons-compress>1.24.0</ver.commons-compress>
     <ver.commons-collections>4.4</ver.commons-collections>
     <ver.dexxcollection>0.7</ver.dexxcollection>
@@ -116,7 +116,7 @@
 
     <!--- GeoSPARQL related -->
     <ver.jcommander>1.82</ver.jcommander>
-    <ver.sis>1.1</ver.sis>
+    <ver.sis>1.4</ver.sis>
     <ver.jts>1.19.0</ver.jts>
 
     <!-- 
@@ -306,7 +306,7 @@
        <dependency>
          <groupId>commons-io</groupId>
          <artifactId>commons-io</artifactId>
-         <version>${ver.commonsio}</version>
+         <version>${ver.commons-io}</version>
        </dependency>
        
        <dependency>
@@ -377,13 +377,13 @@
        <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-csv</artifactId>
-         <version>${ver.commonscsv}</version>
+         <version>${ver.commons-csv}</version>
        </dependency>
 
        <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-lang3</artifactId>
-         <version>${ver.commonslang3}</version>
+         <version>${ver.commons-lang3}</version>
        </dependency>
 
        <dependency>
@@ -709,13 +709,13 @@
        <dependency>
          <groupId>commons-cli</groupId>
          <artifactId>commons-cli</artifactId>
-         <version>${ver.commonscli}</version>
+         <version>${ver.commons-cli}</version>
        </dependency>
 
        <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-rdf-api</artifactId>
-         <version>${ver.commonsrdf}</version>
+         <version>${ver.commons-rdf}</version>
        </dependency>
 
        <dependency>


### PR DESCRIPTION
Dependency upgrades and adjustments needed due to these upgrades.

org.mockito:mockito-core : 5.5.0 -> 5.6.0
org.eclipse.jetty : 10.0.15 -> 10.0.17
com.fasterxml.jackson : 2.15.2 -> 2.15.3
com.google.guava:guava : 32.1.2-jre -> 32.1.3-jre
commons-io:commons-io: 2.11.0 -> 2.14.0
commons-codec:commons-codec: 1.15.0 -> 1.16.0
org.apache.commons:commons-lang3: 3.12.0 -> 3.13.0 
org.apache.sis.core:sis-referencing : 1.1 -> 1.4

orq.apache.lucene : 9.5.0 -> 9.7.0

This is not an upgrade to the current Lucene version 9.8.0. With Java21, I was getting test setup errors about NoSuchMethod (java.lang.foreign.Arena.ofShared), which is a Java21 "preview feature". 

---

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
