### PR TITLE
Disable annotation processing (and avoid build warnings)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -957,6 +957,7 @@
            <version>${ver.plugin.compiler}</version>
            <configuration>
              <release>${java.version}</release>
+             <compilerArgument>-proc:none</compilerArgument>
            </configuration>
          </plugin>
 


### PR DESCRIPTION
Planned permanent change:
https://bugs.openjdk.org/browse/JDK-8306819

with notes/warnings in Java 22
https://bugs.openjdk.org/browse/JDK-8310061

and backported to Java21:
https://bugs.openjdk.org/browse/JDK-8311073

This PR is a build-related cleanup for Java21, which is compatible with Java17. 
In Java21, there were build warnings from javac about "annotation processing"

---

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
