### PR TITLE
GH-2066: Add and prefer RDFParser.fromString(text, Lang)

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
@@ -57,27 +57,27 @@ import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.sparql.util.Context;
 
 /**
- * An {@link RDFParser} is a process that will generate triples; {@link RDFParserBuilder}
- * provides the means to setup the parser.
+ * An {@link RDFParser} is a process that will generate triples and quads;
+ * {@link RDFParserBuilder} provides the means to create parsers.
  * <p>
  * An {@link RDFParser} has a predefined source; the target for output is given when the
- * "parse" method is called. It can be used multiple times in which case the same source
+ * "parse" step is called. It can be used multiple times in which case the same source
  * is reread. The destination can vary. The application is responsible for concurrency of
  * the destination of the parse operation.
+ * <p>
+ * Parser output is sent to a {@link StreamRDF}.
  *
- * The process is
- *
+ * The general process is
  * <pre>
  *    StreamRDF destination = ...
  *    RDFParser parser = RDFParser.create().source("filename.ttl").build();
  *    parser.parse(destination);
  * </pre>
- * or using abbreviated forms:
+ * There are various convenience forms to perform common tasks such as
+ * to parse a file and create a {@link Model}:
  * <pre>
- * RDFParser.source("filename.ttl").parse(destination);
+ *    Model model = RDFParser.source("filename.ttl").toModel();
  * </pre>
- * The {@code destination} {@link StreamRDF} and can be given as a
- * {@link Graph} or {@link DatasetGraph} as well.
  *
  * @see ReaderRIOT The interface to the syntax parsing process for each RDF syntax.
  */
@@ -150,21 +150,36 @@ public class RDFParser {
      * @param uriOrFile
      * @return RDFParserBuilder
      */
-
     public static RDFParserBuilder source(String uriOrFile) {
         return RDFParserBuilder.create().source(uriOrFile);
     }
 
     /**
-     * Create an {@link RDFParserBuilder} and set content to parse to be the
-     * given string. The syntax must be set with {@code .lang(...)}.
+     * Create an {@link RDFParserBuilder} and set content to be parsed to the
+     * string. The syntax must be set with {@code .lang(...)}.
      * <p>
      * Shortcut for {@code RDFParser.create.fromString(string)}.
+     *
      * @param string
      * @return RDFParserBuilder
+     * @deprecated Use {@link #fromString(String, Lang)}
      */
+    @Deprecated
     public static RDFParserBuilder fromString(String string) {
         return RDFParserBuilder.create().fromString(string);
+    }
+
+    /**
+     * Create an {@link RDFParserBuilder} and set content to be parsed
+     * together with the RDF syntax language.
+     * <p>
+     * Shortcut for {@code RDFParser.create.fromString(string).lang(lang)}.
+     * @param string
+     * @param lang
+     * @return RDFParserBuilder
+     */
+    public static RDFParserBuilder fromString(String string, Lang lang) {
+        return RDFParserBuilder.create().fromString(string).lang(lang);
     }
 
     /**

--- a/jena-arq/src/test/java/org/apache/jena/rdf_star/TestNQuadsStarParse.java
+++ b/jena-arq/src/test/java/org/apache/jena/rdf_star/TestNQuadsStarParse.java
@@ -38,7 +38,7 @@ public class TestNQuadsStarParse {
     @Test public void parse_nq_good_1()    { parse("<<<x:s> <x:p> <x:o>>> <x:q> '1' . "); }
 
     @Test public void parse_nq_good_2()    { parse("<<<x:s> <x:p> <x:o>>> <x:q> '1' <http://example/g> . "); }
-    
+
     @Test public void parse_nq_good_3()    { parse("<http://ex/x> <http://ex/p> <<<x:s> <x:p> <x:o>>> ."); }
 
     @Test public void parse_nq_good_4()    { parse("<http://ex/x> <http://ex/p> <<<x:s> <x:p> <x:o>>> <http://example/g> ."); }
@@ -56,6 +56,6 @@ public class TestNQuadsStarParse {
     public void parse_nq_bad_3()           { parse("<<<x:s> <x:p>' <x:o> <http://example/g> >> <x:p> <x:o>. "); }
 
     private void parse(String string) {
-        RDFParser.fromString(string).lang(Lang.NQUADS).errorHandler(silent).parse(sink);
+        RDFParser.fromString(string, Lang.NQUADS).errorHandler(silent).parse(sink);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/rdf_star/TestNTriplesStarParse.java
+++ b/jena-arq/src/test/java/org/apache/jena/rdf_star/TestNTriplesStarParse.java
@@ -43,7 +43,7 @@ public class TestNTriplesStarParse {
 
     @Test public void parse_nt_good_4()    { parse("<< << <x:s> <x:p> <x:o> >> <x:q> '1' >> <x:q> '2' ."); }
 
-    
+
     @Test(expected=RiotException.class)
     public void parse_nt_bad_1()           { parse("<<<x:s> <x:p> <x:o>>> . "); }
 
@@ -51,6 +51,6 @@ public class TestNTriplesStarParse {
     public void parse_nt_bad_2()           { parse("<<<x:s> 'str' <x:o>>> <x:p> <x:o>. "); }
 
     private void parse(String string) {
-        RDFParser.fromString(string).lang(Lang.NTRIPLES).errorHandler(silent).parse(sink);
+        RDFParser.fromString(string, Lang.NTRIPLES).errorHandler(silent).parse(sink);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/rdf_star/TestTrigStarParse.java
+++ b/jena-arq/src/test/java/org/apache/jena/rdf_star/TestTrigStarParse.java
@@ -58,6 +58,6 @@ public class TestTrigStarParse {
 
     private void parse(String string) {
         string = "PREFIX : <http://example/>\n"+string;
-        RDFParser.fromString(string).lang(Lang.TRIG).errorHandler(silent).parse(sink);
+        RDFParser.fromString(string, Lang.TRIG).errorHandler(silent).parse(sink);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/rdf_star/TestTurtleStarParse.java
+++ b/jena-arq/src/test/java/org/apache/jena/rdf_star/TestTurtleStarParse.java
@@ -73,6 +73,6 @@ public class TestTurtleStarParse {
         Lang lang2 = TurtleJCC.TTLJCC;
         Lang lang = lang1;
 
-        RDFParser.fromString(string).lang(lang).errorHandler(silent).parse(sink);
+        RDFParser.fromString(string, lang).errorHandler(silent).parse(sink);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestJsonLDReader.java
@@ -61,7 +61,7 @@ public class TestJsonLDReader {
         //     }
         String jsonld = "{ '@id': './relative', '@type': 'RelType', 'http://example/p': { '@id' : '#frag' } }";
         jsonld = jsonld.replaceAll("'",  "\"");
-        Graph g = RDFParser.fromString(jsonld).lang(Lang.JSONLD).base("http://base/abc").toGraph();
+        Graph g = RDFParser.fromString(jsonld, Lang.JSONLD).base("http://base/abc").toGraph();
         assertNotNull(g);
         Triple t = SSE.parseTriple("( <http://base/relative> <http://example/p> <http://base/abc#frag> )");
         assertTrue(g.contains(t));

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
@@ -106,7 +106,7 @@ public class TestRDFParser {
     // Shortcut source
     @Test public void source_shortcut_01() {
         Graph graph = GraphFactory.createGraphMem();
-        RDFParser.fromString(testdata).lang(Lang.TTL).parse(graph);
+        RDFParser.fromString(testdata, Lang.TTL).parse(graph);
         assertEquals(1, graph.size());
     }
 
@@ -246,8 +246,7 @@ public class TestRDFParser {
     @Test
     public void parser_fragment() {
         PrefixMap pmap = PrefixMapFactory.create(Map.of("", "http://example/"));
-        Graph g = RDFParser.fromString("<s> :p :o .")
-                .lang(Lang.TTL)
+        Graph g = RDFParser.fromString("<s> :p :o .", Lang.TTL)
                 .prefixes(pmap)
                 .base("http://base/")
                 .toGraph();

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestRDFXML_ReaderProperties.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestRDFXML_ReaderProperties.java
@@ -35,7 +35,7 @@ import org.apache.jena.riot.system.ErrorHandlerFactory;
 import org.junit.Test;
 
 /**
- * Tests for settign reder properties - specific to ARP0 and ARP1.
+ * Tests for setting reader properties - specific to ARP0 and ARP1.
  */
 public class TestRDFXML_ReaderProperties {
     @Test public void rdfxmlreaderProperties_arp0() {
@@ -46,7 +46,7 @@ public class TestRDFXML_ReaderProperties {
         execTest(RRX.RDFXML_ARP0);
     }
 
-    private void execTest(Lang parser) {
+    private void execTest(Lang parserLang) {
         // Inline illustrative data.
         String data = StrUtils.strjoinNL
                 ("<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -68,8 +68,7 @@ public class TestRDFXML_ReaderProperties {
 
         Model model = ModelFactory.createDefaultModel();
         // Build and run a parser
-        RDFParserBuilder builder = RDFParser.fromString(data)
-            .lang(parser)
+        RDFParserBuilder builder = RDFParser.fromString(data, parserLang)
             // Put a properties object into the Context.
             .set(SysRIOT.sysRdfReaderProperties, properties)
             // Exception on warning or error.

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestAsyncParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestAsyncParser.java
@@ -83,8 +83,8 @@ public class TestAsyncParser {
 
     @Test
     public void sources_1() {
-        RDFParserBuilder b1 = RDFParser.fromString("_:a <p> <o>.").lang(Lang.TTL);
-        RDFParserBuilder b2 = RDFParser.fromString("_:a <p> <o>.").lang(Lang.TTL);
+        RDFParserBuilder b1 = RDFParser.fromString("_:a <p> <o>.", Lang.TTL);
+        RDFParserBuilder b2 = RDFParser.fromString("_:a <p> <o>.", Lang.TTL);
         Graph graph = GraphFactory.createDefaultGraph();
         AsyncParser.asyncParseSources(List.of(b1,b2), StreamRDFLib.graph(graph));
         assertEquals(2, graph.size());

--- a/jena-arq/src/test/java/org/apache/jena/riot/writer/TestTurtleWriter.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/writer/TestTurtleWriter.java
@@ -46,8 +46,7 @@ public class TestTurtleWriter {
     static final Model baseTestData;
     static {
         baseTestData = ModelFactory.createDefaultModel();
-        RDFParser.fromString(TestTurtleWriter.basetester)
-            .lang(Lang.TTL)
+        RDFParser.fromString(TestTurtleWriter.basetester, Lang.TTL)
             .parse(baseTestData);
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPathQuery.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPathQuery.java
@@ -44,7 +44,7 @@ public class TestPathQuery {
             ,":x :q :s ."
             );
 
-    static Graph graph1 = RDFParser.fromString(graphStr1).lang(Lang.TTL).toGraph();
+    static Graph graph1 = RDFParser.fromString(graphStr1, Lang.TTL).toGraph();
 
     @Test public void testPathByQuery_unboundEnds_01() {
         // Query with path

--- a/jena-core/src/main/java/org/apache/jena/irix/IRIProviderJenaIRI.java
+++ b/jena-core/src/main/java/org/apache/jena/irix/IRIProviderJenaIRI.java
@@ -228,8 +228,7 @@ public class IRIProviderJenaIRI implements IRIProvider {
 
         // errors and warnings.
         if ( STRICT_FILE && isFILE(iri) ) {
-            if ( iriStr.startsWith("file://" ) && ! iriStr.startsWith("file:///") )
-                throw new IRIException("file: URLs should start file:///: <"+iriStr+">");
+            checkFile(iri, iriStr);
         } else if ( isUUID(iri, iriStr) ) {
             checkUUID(iri, iriStr);
         } else if ( isURNUUID(iri, iriStr) ) {
@@ -283,6 +282,11 @@ public class IRIProviderJenaIRI implements IRIProvider {
 
     private static boolean isURN(IRI iri)  { return "urn".equalsIgnoreCase(iri.getScheme()); }
     private static boolean isFILE(IRI iri) { return "file".equalsIgnoreCase(iri.getScheme()); }
+
+    private static void checkFile(IRI iri, String iriStr) {
+        if ( iriStr.startsWith("file://" ) && ! iriStr.startsWith("file:///") )
+            throw new IRIException("file: URLs should start file:///: <"+iriStr+">");
+    }
 
     private static boolean isUUID(IRI iri, String iriStr) {
         // Ignore case

--- a/jena-core/src/test/java/org/apache/jena/irix/TestRFC3986.java
+++ b/jena-core/src/test/java/org/apache/jena/irix/TestRFC3986.java
@@ -178,7 +178,7 @@ public class TestRFC3986 extends AbstractTestIRIx {
 
     @Test public void parse_file_01() { good("file:///file/name.txt"); }
 
-    // We reject "file://host/" forms.
+    // This is legal by RFC 8089, but not by earlier versions of the "file:" scheme.
     @Test public void parse_file_02() { badSpecific("file://host/file/name.txt"); }
 
     // This is legal by RFC 8089 (jena-iri, based on the original RFC 1738, fails this with missing authority).

--- a/jena-examples/src/main/java/arq/examples/ExModelStore01.java
+++ b/jena-examples/src/main/java/arq/examples/ExModelStore01.java
@@ -46,7 +46,7 @@ public class ExModelStore01 {
             FusekiLogging.setLogging();
             FusekiServer server = ExamplesServer.startServer(dsName, dsg, false);
             String dataURL = "http://localhost:"+server.getPort()+"/"+dsName;
-            RDFParser.fromString(rdfString).lang(Lang.TTL).parse(someData);
+            RDFParser.fromString(rdfString, Lang.TTL).parse(someData);
             exampleModelStore(dataURL);
 
         } catch (Throwable th) {

--- a/jena-examples/src/main/java/arq/examples/auth/ExAuth01_RDFConnectionPW.java
+++ b/jena-examples/src/main/java/arq/examples/auth/ExAuth01_RDFConnectionPW.java
@@ -59,7 +59,7 @@ public class ExAuth01_RDFConnectionPW {
             server = ExamplesServer.startServerWithAuth(dsName, dsg, true, "u", "p");
             serverURL = "http://localhost:"+server.getPort()+"/";
             dataURL = "http://localhost:"+server.getPort()+"/"+dsName;
-            RDFParser.fromString(rdfString).lang(Lang.TTL).parse(someData);
+            RDFParser.fromString(rdfString, Lang.TTL).parse(someData);
 
             // Examples
             exampleConnectionAuthWithHttpClient();

--- a/jena-examples/src/main/java/arq/examples/auth/ExAuth04_ServicePW.java
+++ b/jena-examples/src/main/java/arq/examples/auth/ExAuth04_ServicePW.java
@@ -58,7 +58,7 @@ public class ExAuth04_ServicePW {
             server = ExamplesServer.startServerWithAuth(dsName, dsg, true, "u", "p");
             serverURL = "http://localhost:"+server.getPort()+"/";
             dataURL = "http://localhost:"+server.getPort()+"/"+dsName;
-            RDFParser.fromString(rdfString).lang(Lang.TTL).parse(dsg);
+            RDFParser.fromString(rdfString, Lang.TTL).parse(dsg);
 
             exampleServiceByRegistry();
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiWebapp.java
@@ -312,7 +312,7 @@ public class FusekiWebapp
 
         String str = TemplateFunctions.templateFile(templateFile, params, Lang.TTL);
         Lang lang = RDFLanguages.filenameToLang(templateFile, Lang.TTL);
-        Model model = RDFParser.fromString(str).base(datasetPath).lang(lang).toModel();
+        Model model = RDFParser.fromString(str, lang).base(datasetPath).toModel();
 
         List<DataAccessPoint> defns = FusekiConfig.servicesAndDatasets(model);
         if ( defns.size() != 1 ) {


### PR DESCRIPTION
GitHub issue resolved #2066

Pull request Description:
This PR adds the operation RDFParser.fromString(text, Lang) and deprecates the original RDFParser.fromString(text).

Tests using the now-deprecated function have been changed to the new function. These are all the "Test*" file in the PR.


----

 - [x] Tests using the now-deprecated function have been changed
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
