### PR TITLE
[Jena4] GH-2076: Fix for Iterator.remove in GraphMem

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/mem/HashCommon.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/HashCommon.java
@@ -34,40 +34,40 @@ public abstract class HashCommon<Key>
     /**
         Jeremy suggests, from his experiments, that load factors more than
         0.6 leave the table too dense, and little advantage is gained below 0.4.
-        Although that was with a quadratic probe, I'm borrowing the same 
-        plausible range, and use 0.5 by default. 
+        Although that was with a quadratic probe, I'm borrowing the same
+        plausible range, and use 0.5 by default.
     */
     protected static final double loadFactor = 0.5;
-    
+
     /**
         The keys of whatever table it is we're implementing. Since we share code
         for triple sets and for node->bunch maps, it has to be an Object array; we
         take the casting hit.
      */
     protected Key [] keys;
-    
+
     /**
         The capacity (length) of the key array.
     */
     public int capacity;
-    
+
     /**
         The threshold number of elements above which we resize the table;
         equal to the capacity times the load factor.
     */
     protected int threshold;
-    
+
     /**
         The number of active elements in the table, maintained incrementally.
     */
     protected int size = 0;
-    
+
     /**
         A count of the number of changes applied to this Hash object, used for
         detecting concurrent modifications.
     */
     protected int changes;
-    
+
     /**
         Initialise this hashed thingy to have <code>initialCapacity</code> as its
         capacity and the corresponding threshold. All the key elements start out
@@ -78,7 +78,7 @@ public abstract class HashCommon<Key>
         keys = newKeyArray( capacity = initialCapacity );
         threshold = (int) (capacity * loadFactor);
         }
-    
+
     /**
         Subclasses must implement to answer a new Key[size] array.
     */
@@ -96,40 +96,40 @@ public abstract class HashCommon<Key>
         /**
              A NotifyEmpty instance that ignores the notification.
         */
-        public static NotifyEmpty ignore = new NotifyEmpty() 
+        public static NotifyEmpty ignore = new NotifyEmpty()
             { @Override
             public void emptied() { }};
-        
+
         /**
              Method to call to notify that the collection has become empty.
         */
-        public void emptied(); 
-        }   
+        public void emptied();
+        }
 
     /**
-        When removeFrom [or remove] removes a key, it calls this method to 
-        remove any associated values, passing in the index of the key's slot. 
+        When removeFrom [or remove] removes a key, it calls this method to
+        remove any associated values, passing in the index of the key's slot.
         Subclasses override if they have any associated values.
     */
     protected void removeAssociatedValues( int here )
         {}
 
     /**
-        When removeFrom [or remove] moves a key, it calls this method to move 
+        When removeFrom [or remove] moves a key, it calls this method to move
         any associated values, passing in the index of the slot <code>here</code>
         to move to and the index of the slot <code>scan</code> to move from.
         Subclasses override if they have any associated values.
     */
     protected void moveAssociatedValues( int here, int scan )
         {}
-    
+
     /**
         Answer the item at index <code>i</code> of <code>keys</code>. This
         method is for testing purposes <i>only</i>.
     */
     public Object getItemForTestingAt( int i )
         { return keys[i]; }
-    
+
     /**
         Answer the initial index for the object <code>key</code> in the table.
         With luck, this will be the final position for that object. The initial index
@@ -148,8 +148,8 @@ public abstract class HashCommon<Key>
         voodoo to (try to) eliminate problems experienced by Wolfgang.
     */
     protected int improveHashCode( int hashCode )
-        { return hashCode * 127; }    
-    
+        { return hashCode * 127; }
+
     /**
         Search for the slot in which <code>key</code> is found. If it is absent,
         return the index of the free slot in which it could be placed. If it is present,
@@ -163,11 +163,11 @@ public abstract class HashCommon<Key>
         while (true)
             {
             Key current = keys[index];
-            if (current == null) return index; 
+            if (current == null) return index;
             if (key.equals( current )) return ~index;
             if (--index < 0) index += capacity;
             }
-        }   
+        }
 
     /**
         Remove the object <code>key</code> from this hash's keys if it
@@ -184,7 +184,7 @@ public abstract class HashCommon<Key>
         int slot = findSlot( key );
         if (slot < 0) removeFrom( ~slot );
         }
-    
+
     /**
         Work out the capacity and threshold sizes for a new improved bigger
         table (bigger by a factor of two, at present).
@@ -194,11 +194,11 @@ public abstract class HashCommon<Key>
         capacity = nextSize( capacity * 2 );
         threshold = (int) (capacity * loadFactor);
         }
-     
+
     // Hash tables are 0.25 to 0.5 full so these numbers
-    // are for storing about 1/3 of that number of items. 
+    // are for storing about 1/3 of that number of items.
     // The larger sizes are added so that the system has "soft failure"
-    // rather implying guaranteed performance. 
+    // rather implying guaranteed performance.
     // https://primes.utm.edu/lists/small/millions/
     static final int [] primes =
         {
@@ -206,7 +206,7 @@ public abstract class HashCommon<Key>
         19_853, 39_709, 79_423, 158_849, 317_701, 635_413,
         1_270_849, 2_541_701, 5_083_423
         , 10_166_857
-        , 20_333_759   
+        , 20_333_759
         , 40_667_527
         , 81_335_047
         , 162_670_111
@@ -214,17 +214,17 @@ public abstract class HashCommon<Key>
         , 650_680_469
         , 982_451_653 // 50 millionth prime - Largest at primes.utm.edu.
         };
-    
+
     protected static int nextSize(int atLeast) {
         for ( int prime : primes ) {
             if ( prime > atLeast )
                 return prime;
         }
         //return atLeast ;        // Input is 2*current capacity.
-        // There are some very large numbers in the primes table. 
-        throw new JenaException("Failed to find a 'next size': atleast = "+atLeast) ; 
+        // There are some very large numbers in the primes table.
+        throw new JenaException("Failed to find a 'next size': atleast = "+atLeast) ;
     }
-    
+
     /**
         Remove the triple at element <code>i</code> of <code>contents</code>.
         This is an implementation of Knuth's Algorithm R from tAoCP vol3, p 527,
@@ -268,8 +268,8 @@ public abstract class HashCommon<Key>
                     }
                 }
             }
-        }    
-    
+        }
+
     void showkeys()
         {
         if (false)
@@ -283,7 +283,7 @@ public abstract class HashCommon<Key>
 
     public ExtendedIterator<Key> keyIterator()
         { return keyIterator( NotifyEmpty.ignore ); }
-    
+
     public ExtendedIterator<Key> keyIterator( final NotifyEmpty container )
         {
         showkeys();
@@ -292,7 +292,7 @@ public abstract class HashCommon<Key>
         ExtendedIterator<Key> leftovers = new MovedKeysIterator( changes, container, movedKeys );
         return basic.andThen( leftovers );
         }
-    
+
     /**
         The MovedKeysIterator iterates over the elements of the <code>keys</code>
         list. It's not sufficient to just use List::iterator, because the .remove
@@ -310,14 +310,14 @@ public abstract class HashCommon<Key>
         final NotifyEmpty container;
 
         protected MovedKeysIterator( int initialChanges, NotifyEmpty container, List<Key> keys )
-            { 
-            this.movedKeys = keys; 
-            this.initialChanges = initialChanges; 
+            {
+            this.movedKeys = keys;
+            this.initialChanges = initialChanges;
             this.container = container;
             }
 
         @Override public boolean hasNext()
-            { 
+            {
             return index < movedKeys.size();
             }
 
@@ -335,9 +335,9 @@ public abstract class HashCommon<Key>
             }
 
         @Override public void remove()
-            { 
+            {
             if (changes > initialChanges) throw new ConcurrentModificationException();
-            primitiveRemove( movedKeys.get( index - 1 ) ); 
+            primitiveRemove( movedKeys.get( index - 1 ) );
             if (size == 0) container.emptied();
             }
         }
@@ -357,9 +357,9 @@ public abstract class HashCommon<Key>
         final NotifyEmpty container;
 
         protected BasicKeyIterator( int initialChanges, NotifyEmpty container, List<Key> movedKeys )
-            { 
-            this.movedKeys = movedKeys; 
-            this.initialChanges = initialChanges;  
+            {
+            this.movedKeys = movedKeys;
+            this.initialChanges = initialChanges;
             this.container = container;
             }
 
@@ -394,10 +394,9 @@ public abstract class HashCommon<Key>
         @Override public void remove()
             {
             if (changes > initialChanges) throw new ConcurrentModificationException();
-            // System.err.println( ">> keyIterator::remove, size := " + size +
-            // ", removing " + keys[index + 1] );
             Key moved = removeFrom( pos + 1 );
-            if (moved != null) movedKeys.add( moved );
+            if (moved != null && ! movedKeys.contains(moved) )
+                movedKeys.add( moved );
             if (size == 0) container.emptied();
             if (size < 0) throw new BrokenException( "BROKEN" );
             showkeys();

--- a/jena-core/src/main/java/org/apache/jena/util/iterator/NiceIterator.java
+++ b/jena-core/src/main/java/org/apache/jena/util/iterator/NiceIterator.java
@@ -153,7 +153,8 @@ public class NiceIterator<T> implements ExtendedIterator<T>
 
             @Override public void remove()
                 {
-                if (null == removeFrom) throw new IllegalStateException("no calls to next() since last call to remove()");
+                if (null == removeFrom)
+                    throw new IllegalStateException("no calls to next() since last call to remove()");
                 removeFrom.remove();
                 removeFrom = null;
                 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/AbstractTestPackage.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/AbstractTestPackage.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,9 +31,9 @@ import org.apache.jena.shared.Lock ;
 
 /**
  * Collected test suite for the .model package.
- * 
+ *
  * This is the base class for TestPackage implementations.
- * 
+ *
  * Model developers should extend this class to implement the package test
  * suite.
  * See TestPackage for example of usage.
@@ -44,7 +44,7 @@ public abstract class AbstractTestPackage extends TestSuite
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param suiteName
 	 *            The name for this TestPackage
 	 * @param modelFactory
@@ -119,7 +119,6 @@ public abstract class AbstractTestPackage extends TestSuite
 		addTest(TestModelExtract.class, modelFactory);
 		addTest(TestModelRead.class, modelFactory);
 		addTestSuite(TestPropertyImpl.class);
-		addTest(TestRemoveBug.class, modelFactory);
 		addTest(TestContainerConstructors.class, modelFactory);
 		addTest(TestAltMethods.class, modelFactory);
 		addTest(TestBagMethods.class, modelFactory);
@@ -147,7 +146,7 @@ public abstract class AbstractTestPackage extends TestSuite
 	 * Adds a test to the test suite by looking for the standard test methods.
 	 * These are
 	 * methods that start with "test" and have no arguments.
-	 * 
+	 *
 	 * @param testClass
 	 * @param constructorArgs
 	 * @throws SecurityException

--- a/jena-core/src/test/java/org/apache/jena/test/TestPackage.java
+++ b/jena-core/src/test/java/org/apache/jena/test/TestPackage.java
@@ -61,6 +61,9 @@ public class TestPackage extends TestCase {
         // Local TTL parser for tests - not fully compliant.
         addTest(ts,  "Turtle", org.apache.jena.ttl_test.test.turtle.TurtleTestSuite.suite()) ;
 
+        // Jena4 reports
+        addTest(ts,  "RemoveBug", org.apache.jena.test.jena4.TestRemoveBug.suite());
+
         return ts ;
     }
 

--- a/jena-core/testing/reports/graph-mem-broken-iterator-delete-01.ttl
+++ b/jena-core/testing/reports/graph-mem-broken-iterator-delete-01.ttl
@@ -1,0 +1,22 @@
+# graph-mem-broken-iterator-delete-01.ttl
+# This dataset is an ordered dump of HashCommon.keys with jena-4.9.0 and jena-4.10.0
+# It creates a situation where clearing all data using iterator.remove() on the iterator returned by graph.find() fails.
+
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#statusCode> "200"^^<http://www.w3.org/2001/XMLSchema#int> .
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#user> "-" .
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://www.w3.org/ns/prov#atTime> "2023-06-02T08:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#logRecord> "8955735dbec9f8a013df85d57bac725b - - [02/Jun/2023 10:00:00 +0200] \"GET /sparql?&timeout=60000&query=CONSTRUCT+%7B+%3Fsubject+%3Fproperty+%3Fvalue%7D+WHERE+%7B++%3Fsubject+%3Fproperty+%3Fvalue.+%3Fsubject+a+%3Ftype+.+%3Fsubject+rdfs%3Alabel+%3Flabel++FILTER+%28%28+lang%28%3Flabel%29+%3D+%22%22+%7C%7C+langMatches%28lang%28%3Flabel%29%2C+%22en%22%29%29+%26%26+%3Fsubject+%3D+%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2FLobbyist%3E%29+%7D+ORDER+BY+ASC%28%3Fsubject+%3Fproperty+%3Fvalue%29 HTTP/1.1\" 200 394 \"-\" \"-\" \"-\"" .
+# null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#query> "CONSTRUCT { ?subject ?property ?value} WHERE {  ?subject ?property ?value. ?subject a ?type . ?subject rdfs:label ?label  FILTER (( lang(?label) = \"\" || langMatches(lang(?label), \"en\")) && ?subject = <http://dbpedia.org/resource/Lobbyist>) } ORDER BY ASC(?subject ?property ?value)" .
+#, null, null, null, null, null, null, null, null, null, null, null, null,
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#sequenceId> "110723"^^<http://www.w3.org/2001/XMLSchema#long> .
+#, null, null, null, null, null, null, null, null, null,
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#uri> "/sparql?&timeout=60000&query=CONSTRUCT+%7B+%3Fsubject+%3Fproperty+%3Fvalue%7D+WHERE+%7B++%3Fsubject+%3Fproperty+%3Fvalue.+%3Fsubject+a+%3Ftype+.+%3Fsubject+rdfs%3Alabel+%3Flabel++FILTER+%28%28+lang%28%3Flabel%29+%3D+%22%22+%7C%7C+langMatches%28lang%28%3Flabel%29%2C+%22en%22%29%29+%26%26+%3Fsubject+%3D+%3Chttp%3A%2F%2Fdbpedia.org%2Fresource%2FLobbyist%3E%29+%7D+ORDER+BY+ASC%28%3Fsubject+%3Fproperty+%3Fvalue%29" .
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#verb> "GET" .
+# , null, null, null, null, null,
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#protocol> "HTTP/1.1" .
+# null, null,
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#numResponseBytes> "394"^^<http://www.w3.org/2001/XMLSchema#int> .
+# , null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#hostHash> "RNxI06DRVty3nU8fTEvds_BV31N6xtLq0JclkZQMNLM" .
+<_:50470aa7-9d2b-4695-be38-a96f6fc1d7c7> <http://lsq.aksw.org/vocab#endpoint> <http://dbpedia.org/sparql> .

--- a/pom.xml
+++ b/pom.xml
@@ -1059,16 +1059,6 @@
              <windowtitle>${project.name} ${project.version}</windowtitle>
              <doctitle>${project.name} ${project.version}</doctitle>
              <bottom>Licensed under the Apache License, Version 2.0</bottom>
-             <links>
-               <link>https://jena.apache.org/documentation/javadoc/jena/</link>
-               <link>https://jena.apache.org/documentation/javadoc/arq/</link>
-               <link>https://jena.apache.org/documentation/javadoc/tdb/</link>
-               <link>https://jena.apache.org/documentation/javadoc/text/</link>
-               <link>https://jena.apache.org/documentation/javadoc/rdfconnection/</link>
-               <link>https://jena.apache.org/documentation/javadoc/fuseki2/</link>
-               <link>https://jena.apache.org/documentation/javadoc/permissions/</link>
-               <link>https://jena.apache.org/documentation/javadoc/jdbc/</link>
-             </links>
              <!-- Settings for @apiNote, @implSpec and @implNote -->
              <tags>
                <tag>


### PR DESCRIPTION
GitHub issue: #2076

This is the `jena4` branch fix for #2076.

It includes a test case.

It also has a fix in the build because javadoc links to the website and there is no jena-jdbc javadoc any more.

Quite a lot of white space fixs in HashCommon, showing how long ago it was last touched!

---

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
