### PR TITLE
JENA-2357 Add Collection as a valid type for where clause node in query builder.

### DIFF
--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AbstractQueryBuilder.java
@@ -146,13 +146,45 @@ public abstract class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>>
      * @param p the predicate object
      * @param o the object object.
      * @return a TriplePath
+     * @deprecated Use {@link makeTriplePaths(Object, Object, Object)}
      */
+    @Deprecated(since="5.0.0")
     public TriplePath makeTriplePath(Object s, Object p, Object o) {
         final Object po = makeNodeOrPath(p);
         if (po instanceof Path) {
             return new TriplePath(makeNode(s), (Path) po, makeNode(o));
         }
         return new TriplePath(Triple.create(makeNode(s), (Node) po, makeNode(o)));
+    }
+    
+    /**
+     * Make a collecton triple path from the objects.
+     *
+     * For subject, predicate and objects nodes
+     * <ul>
+     * <li>Will return Node.ANY if object is null.</li>
+     * <li>Will return the enclosed Node from a FrontsNode</li>
+     * <li>Will return the object if it is a Node.</li>
+     * <li>For {@code subject} and {@code object} <em>only</em>, if the object is a collection, will convert each item
+     * in the collection into a node and create an RDF list. All RDF list nodes are included in the collection.</li> 
+     * <li>If the object is a String
+     * <ul>
+     * <li>For <code>predicate</code> <em>only</em>, will attempt to parse as a path</li>
+     * <li>for subject, predicate and object will call NodeFactoryExtra.parseNode()
+     * using the currently defined prefixes if the object is a String</li>
+     * </ul>
+     * </li>
+     * <li>Will create a literal representation if the parseNode() fails or for any
+     * other object type.</li>
+     * </ul>
+     *
+     * @param s The subject object
+     * @param p the predicate object
+     * @param o the object object.
+     * @return a TriplePath
+     */
+    public List<TriplePath> makeTriplePaths(Object s, Object p, Object o) {
+        return Converters.makeTriplePaths(s, p, o, query.getPrefixMapping());
     }
 
     /**

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AskBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AskBuilder.java
@@ -114,6 +114,12 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
     }
 
     @Override
+    public AskBuilder addWhere(Collection<TriplePath> collection) {
+        getWhereHandler().addWhere(collection);
+        return this;
+    }
+
+    @Override
     public AskBuilder addWhere(Triple t) {
         getWhereHandler().addWhere(new TriplePath(t));
         return this;
@@ -127,7 +133,7 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
 
     @Override
     public AskBuilder addWhere(Object s, Object p, Object o) {
-        getWhereHandler().addWhere(makeTriplePath(s, p, o));
+        getWhereHandler().addWhere(makeTriplePaths(s, p, o));
         return this;
     }
 
@@ -185,8 +191,7 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
 
     @Override
     public AskBuilder addOptional(Triple t) {
-        getWhereHandler().addOptional(new TriplePath(t));
-        return this;
+        return addOptional(new TriplePath(t));
     }
 
     @Override
@@ -196,14 +201,19 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
     }
 
     @Override
-    public AskBuilder addOptional(FrontsTriple t) {
-        getWhereHandler().addOptional(new TriplePath(t.asTriple()));
+    public AskBuilder addOptional(Collection<TriplePath> collection) {
+        getWhereHandler().addOptional(collection);
         return this;
     }
 
     @Override
+    public AskBuilder addOptional(FrontsTriple t) {
+        return addOptional(new TriplePath(t.asTriple()));
+    }
+
+    @Override
     public AskBuilder addOptional(Object s, Object p, Object o) {
-        getWhereHandler().addOptional(makeTriplePath(s, p, o));
+        getWhereHandler().addOptional(makeTriplePaths(s, p, o));
         return this;
     }
 
@@ -240,25 +250,31 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
 
     @Override
     public AskBuilder addGraph(Object graph, FrontsTriple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple.asTriple()));
+        addGraph(graph, new TriplePath(triple.asTriple()));
         return this;
     }
 
     @Override
     public AskBuilder addGraph(Object graph, Object subject, Object predicate, Object object) {
-        getWhereHandler().addGraph(makeNode(graph), makeTriplePath(subject, predicate, object));
+        getWhereHandler().addGraph(makeNode(graph), makeTriplePaths(subject, predicate, object));
         return this;
     }
 
     @Override
     public AskBuilder addGraph(Object graph, Triple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple));
+        addGraph(graph, new TriplePath(triple));
         return this;
     }
 
     @Override
     public AskBuilder addGraph(Object graph, TriplePath triplePath) {
         getWhereHandler().addGraph(makeNode(graph), triplePath);
+        return this;
+    }
+
+    @Override
+    public AskBuilder addGraph(Object graph, Collection<TriplePath> collection) {
+        getWhereHandler().addGraph(makeNode(graph), collection);
         return this;
     }
 
@@ -363,6 +379,10 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
         return handlerBlock.getModifierHandler();
     }
 
+    /*
+     * @deprecated use {@code addWhere(Converters.makeCollection(List.of(Object...)))}, or simply call {@link #addWhere(Object, Object, Object)} passing the collection for one of the objects.
+     */
+    @Deprecated(since="5.0.0")
     @Override
     public Node list(Object... objs) {
         return getWhereHandler().list(objs);

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.jena.arq.querybuilder;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -211,6 +212,12 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
     }
 
     @Override
+    public ConstructBuilder addWhere(Collection<TriplePath> collection) {
+        getWhereHandler().addWhere(collection);
+        return this;
+    }
+    
+    @Override
     public ConstructBuilder addWhere(Triple t) {
         getWhereHandler().addWhere(new TriplePath(t));
         return this;
@@ -224,7 +231,7 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
 
     @Override
     public ConstructBuilder addWhere(Object s, Object p, Object o) {
-        getWhereHandler().addWhere(makeTriplePath(s, p, o));
+        getWhereHandler().addWhere(makeTriplePaths(s, p, o));
         return this;
     }
 
@@ -276,14 +283,19 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
 
     @Override
     public ConstructBuilder addOptional(TriplePath t) {
-        getWhereHandler().addOptional(t);
+        getWhereHandler().addOptional(Arrays.asList(t));
         return this;
     }
 
     @Override
-    public ConstructBuilder addOptional(Triple t) {
-        getWhereHandler().addOptional(new TriplePath(t));
+    public ConstructBuilder addOptional(Collection<TriplePath> collection) {
+        getWhereHandler().addOptional(collection);
         return this;
+    }
+    
+    @Override
+    public ConstructBuilder addOptional(Triple t) {
+        return addOptional(new TriplePath(t));
     }
 
     @Override
@@ -294,13 +306,12 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
 
     @Override
     public ConstructBuilder addOptional(FrontsTriple t) {
-        getWhereHandler().addOptional(new TriplePath(t.asTriple()));
-        return this;
+        return addOptional(new TriplePath(t.asTriple()));
     }
 
     @Override
     public ConstructBuilder addOptional(Object s, Object p, Object o) {
-        getWhereHandler().addOptional(makeTriplePath(s, p, o));
+        getWhereHandler().addOptional(makeTriplePaths(s, p, o));
         return this;
     }
 
@@ -337,25 +348,29 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
 
     @Override
     public ConstructBuilder addGraph(Object graph, FrontsTriple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple.asTriple()));
-        return this;
+        return addGraph(graph, new TriplePath(triple.asTriple()));
     }
 
     @Override
     public ConstructBuilder addGraph(Object graph, Object subject, Object predicate, Object object) {
-        getWhereHandler().addGraph(makeNode(graph), makeTriplePath(subject, predicate, object));
+        getWhereHandler().addGraph(makeNode(graph), makeTriplePaths(subject, predicate, object));
         return this;
     }
 
     @Override
     public ConstructBuilder addGraph(Object graph, Triple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple));
-        return this;
+        return addGraph(graph, new TriplePath(triple));
     }
 
     @Override
     public ConstructBuilder addGraph(Object graph, TriplePath triplePath) {
-        getWhereHandler().addGraph(makeNode(graph), triplePath);
+        getWhereHandler().addGraph(makeNode(graph), Arrays.asList(triplePath));
+        return this;
+    }
+    
+    @Override
+    public ConstructBuilder addGraph(Object graph, Collection<TriplePath> collection) {
+        getWhereHandler().addGraph(makeNode(graph), collection);
         return this;
     }
 
@@ -387,6 +402,10 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
         return addConstruct(Triple.create(makeNode(s), makeNode(p), makeNode(o)));
     }
 
+    /*
+     * @deprecated use {@code addWhere(Converters.makeCollection(List.of(Object...)))}, or simply call {@link #addWhere(Object, Object, Object)} passing the collection for one of the objects.
+     */
+    @Deprecated(since="5.0.0")
     @Override
     public Node list(Object... objs) {
         return getWhereHandler().list(objs);

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/DescribeBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/DescribeBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.jena.arq.querybuilder;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -197,6 +198,13 @@ public class DescribeBuilder extends AbstractQueryBuilder<DescribeBuilder> imple
         getWhereHandler().addWhere(t);
         return this;
     }
+    
+
+    @Override
+    public DescribeBuilder addWhere(Collection<TriplePath> collection) {
+        getWhereHandler().addWhere(collection);
+        return this;
+    }
 
     @Override
     public DescribeBuilder addWhere(FrontsTriple t) {
@@ -206,7 +214,7 @@ public class DescribeBuilder extends AbstractQueryBuilder<DescribeBuilder> imple
 
     @Override
     public DescribeBuilder addWhere(Object s, Object p, Object o) {
-        getWhereHandler().addWhere(makeTriplePath(s, p, o));
+        getWhereHandler().addWhere(makeTriplePaths(s, p, o));
         return this;
     }
 
@@ -258,25 +266,29 @@ public class DescribeBuilder extends AbstractQueryBuilder<DescribeBuilder> imple
 
     @Override
     public DescribeBuilder addOptional(Triple t) {
-        getWhereHandler().addOptional(new TriplePath(t));
-        return this;
+        return addOptional(new TriplePath(t));
     }
 
     @Override
     public DescribeBuilder addOptional(TriplePath t) {
-        getWhereHandler().addOptional(t);
+        getWhereHandler().addOptional(Arrays.asList(t));
         return this;
     }
 
     @Override
     public DescribeBuilder addOptional(FrontsTriple t) {
-        getWhereHandler().addOptional(new TriplePath(t.asTriple()));
+        return addOptional(new TriplePath(t.asTriple()));
+    }
+
+    @Override
+    public DescribeBuilder addOptional(Collection<TriplePath> collection) {
+        getWhereHandler().addOptional(collection);
         return this;
     }
 
     @Override
     public DescribeBuilder addOptional(Object s, Object p, Object o) {
-        getWhereHandler().addOptional(makeTriplePath(s, p, o));
+        getWhereHandler().addOptional(makeTriplePaths(s, p, o));
         return this;
     }
 
@@ -319,25 +331,30 @@ public class DescribeBuilder extends AbstractQueryBuilder<DescribeBuilder> imple
 
     @Override
     public DescribeBuilder addGraph(Object graph, FrontsTriple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple.asTriple()));
+        addGraph(graph, new TriplePath(triple.asTriple()));
         return this;
     }
 
     @Override
     public DescribeBuilder addGraph(Object graph, Object subject, Object predicate, Object object) {
-        getWhereHandler().addGraph(makeNode(graph), makeTriplePath(subject, predicate, object));
+        getWhereHandler().addGraph(makeNode(graph), makeTriplePaths(subject, predicate, object));
         return this;
     }
 
     @Override
     public DescribeBuilder addGraph(Object graph, Triple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple));
-        return this;
+        return addGraph(graph, new TriplePath(triple));
     }
 
     @Override
     public DescribeBuilder addGraph(Object graph, TriplePath triplePath) {
-        getWhereHandler().addGraph(makeNode(graph), triplePath);
+        getWhereHandler().addGraph(makeNode(graph), Arrays.asList(triplePath));
+        return this;
+    }
+    
+    @Override
+    public DescribeBuilder addGraph(Object graph, Collection<TriplePath> collection) {
+        getWhereHandler().addGraph(makeNode(graph), collection);
         return this;
     }
 
@@ -353,6 +370,10 @@ public class DescribeBuilder extends AbstractQueryBuilder<DescribeBuilder> imple
         return this;
     }
 
+    /*
+     * @deprecated use {@code addWhere(Converters.makeCollection(List.of(Object...)))}, or simply call {@link #addWhere(Object, Object, Object)} passing the collection for one of the objects.
+     */
+    @Deprecated(since="5.0.0")
     @Override
     public Node list(Object... objs) {
         return getWhereHandler().list(objs);

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.jena.arq.querybuilder;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -303,6 +304,14 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
     }
 
     @Override
+    public SelectBuilder addWhere(Collection<TriplePath> collection) {
+        getWhereHandler().addWhere(collection);
+        return this;
+    }
+    
+    
+
+    @Override
     public SelectBuilder addWhere(Triple t) {
         getWhereHandler().addWhere(new TriplePath(t));
         return this;
@@ -316,7 +325,7 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
 
     @Override
     public SelectBuilder addWhere(Object s, Object p, Object o) {
-        getWhereHandler().addWhere(makeTriplePath(s, p, o));
+        getWhereHandler().addWhere(makeTriplePaths(s, p, o));
         return this;
     }
 
@@ -368,25 +377,29 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
 
     @Override
     public SelectBuilder addOptional(TriplePath t) {
-        getWhereHandler().addOptional(t);
+        getWhereHandler().addOptional(Arrays.asList(t));
         return this;
     }
 
     @Override
     public SelectBuilder addOptional(Triple t) {
-        getWhereHandler().addOptional(new TriplePath(t));
-        return this;
+        return addOptional(new TriplePath(t));
     }
 
     @Override
     public SelectBuilder addOptional(FrontsTriple t) {
-        getWhereHandler().addOptional(new TriplePath(t.asTriple()));
+        return addOptional(new TriplePath(t.asTriple()));
+    }
+
+    @Override
+    public SelectBuilder addOptional(Collection<TriplePath> collection) {
+        getWhereHandler().addOptional(collection);
         return this;
     }
 
     @Override
     public SelectBuilder addOptional(Object s, Object p, Object o) {
-        getWhereHandler().addOptional(makeTriplePath(s, p, o));
+        getWhereHandler().addOptional(makeTriplePaths(s, p, o));
         return this;
     }
 
@@ -429,28 +442,32 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
 
     @Override
     public SelectBuilder addGraph(Object graph, FrontsTriple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple.asTriple()));
-        return this;
+        return addGraph(graph, new TriplePath(triple.asTriple()));
     }
 
     @Override
     public SelectBuilder addGraph(Object graph, Object subject, Object predicate, Object object) {
-        getWhereHandler().addGraph(makeNode(graph), makeTriplePath(subject, predicate, object));
+        getWhereHandler().addGraph(makeNode(graph), makeTriplePaths(subject, predicate, object));
         return this;
     }
 
     @Override
     public SelectBuilder addGraph(Object graph, Triple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple));
-        return this;
+        return addGraph(graph, new TriplePath(triple));
     }
 
     @Override
     public SelectBuilder addGraph(Object graph, TriplePath triplePath) {
-        getWhereHandler().addGraph(makeNode(graph), triplePath);
+        getWhereHandler().addGraph(makeNode(graph), Arrays.asList(triplePath));
         return this;
     }
 
+    @Override
+    public SelectBuilder addGraph(Object graph, Collection<TriplePath> collection) {
+        getWhereHandler().addGraph(makeNode(graph), collection);
+        return this;
+    }
+    
     @Override
     public SelectBuilder addBind(Expr expression, Object var) {
         getWhereHandler().addBind(expression, Converters.makeVar(var));
@@ -468,7 +485,10 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
         return handlerBlock.getSelectHandler();
     }
 
-    @Override
+    /*
+     * @deprecated use {@code addWhere(Converters.makeCollection(List.of(Object...)))}, or simply call {@link #addWhere(Object, Object, Object)} passing the collection for one of the objects.
+     */
+    @Deprecated(since="5.0.0")    @Override
     public Node list(Object... objs) {
         return getWhereHandler().list(objs);
     }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/WhereBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/WhereBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.arq.querybuilder;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -64,13 +65,20 @@ public class WhereBuilder extends AbstractQueryBuilder<WhereBuilder> implements 
     }
 
     @Override
+    public WhereBuilder addWhere(Collection<TriplePath> collection) {
+        getWhereHandler().addWhere(collection);
+        return this;
+    }
+
+    @Override
     public WhereBuilder addWhere(FrontsTriple t) {
         return addWhere(t.asTriple());
     }
 
     @Override
     public WhereBuilder addWhere(Object s, Object p, Object o) {
-        return addWhere(makeTriplePath(s, p, o));
+        handler.addWhere(makeTriplePaths(s, p, o));
+        return this;
     }
 
     @Override
@@ -126,20 +134,26 @@ public class WhereBuilder extends AbstractQueryBuilder<WhereBuilder> implements 
     }
 
     @Override
+    public WhereBuilder addOptional(Collection<TriplePath> collection) {
+        getWhereHandler().addOptional(collection);
+        return this;
+    }
+
+    @Override
     public WhereBuilder addOptional(Triple t) {
-        getWhereHandler().addOptional(new TriplePath(t));
+        addOptional(new TriplePath(t));
         return this;
     }
 
     @Override
     public WhereBuilder addOptional(FrontsTriple t) {
-        getWhereHandler().addOptional(new TriplePath(t.asTriple()));
+        addOptional(new TriplePath(t.asTriple()));
         return this;
     }
 
     @Override
     public WhereBuilder addOptional(Object s, Object p, Object o) {
-        getWhereHandler().addOptional(makeTriplePath(s, p, o));
+        getWhereHandler().addOptional(makeTriplePaths(s, p, o));
         return this;
     }
 
@@ -182,28 +196,34 @@ public class WhereBuilder extends AbstractQueryBuilder<WhereBuilder> implements 
 
     @Override
     public WhereBuilder addGraph(Object graph, FrontsTriple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple.asTriple()));
+        addGraph(graph, new TriplePath(triple.asTriple()));
         return this;
     }
 
     @Override
     public WhereBuilder addGraph(Object graph, Object subject, Object predicate, Object object) {
-        getWhereHandler().addGraph(makeNode(graph), makeTriplePath(subject, predicate, object));
+        getWhereHandler().addGraph(makeNode(graph), makeTriplePaths(subject, predicate, object));
         return this;
     }
 
     @Override
     public WhereBuilder addGraph(Object graph, Triple triple) {
-        getWhereHandler().addGraph(makeNode(graph), new TriplePath(triple));
+        addGraph(makeNode(graph), new TriplePath(triple));
         return this;
     }
 
     @Override
     public WhereBuilder addGraph(Object graph, TriplePath triplePath) {
-        getWhereHandler().addGraph(makeNode(graph), triplePath);
+        getWhereHandler().addGraph(makeNode(graph), Arrays.asList(triplePath));
         return this;
     }
 
+    @Override
+    public WhereBuilder addGraph(Object graph, Collection<TriplePath> collection) {
+        getWhereHandler().addGraph(makeNode(graph), collection);
+        return this;
+    }
+    
     @Override
     public WhereBuilder addBind(Expr expression, Object var) {
         getWhereHandler().addBind(expression, Converters.makeVar(var));
@@ -216,7 +236,10 @@ public class WhereBuilder extends AbstractQueryBuilder<WhereBuilder> implements 
         return this;
     }
 
-    @Override
+    /*
+     * @deprecated use {@code addWhere(Converters.makeCollection(List.of(Object...)))}, or simply call {@link #addWhere(Object, Object, Object)} passing the collection for one of the objects.
+     */
+    @Deprecated(since="5.0.0")    @Override
     public Node list(Object... objs) {
         return getWhereHandler().list(objs);
     }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/WhereClause.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/WhereClause.java
@@ -43,7 +43,7 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
     /**
      * Adds a triple to the where clause.
      *
-     * @param t The triple path to add
+     * @param t The triple to add
      * @return This Builder for chaining.
      */
     public T addWhere(Triple t);
@@ -55,6 +55,15 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      * @return This Builder for chaining.
      */
     public T addWhere(TriplePath t);
+    
+    /**
+     * Adds a collections of triple paths to the where clause.
+     *
+     * @param collection The collection of triple paths to add
+     * @return This Builder for chaining.
+     */
+    public T addWhere(Collection<TriplePath> collection);
+
 
     /**
      * Adds a triple to the where clause.
@@ -227,6 +236,14 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      * @return This Builder for chaining.
      */
     public T addOptional(TriplePath t);
+    
+    /**
+     * Adds a collection of triple paths as the optional clauses.
+     *
+     * @param collection The collection of triple paths to add
+     * @return This Builder for chaining.
+     */
+    public T addOptional(Collection<TriplePath> collection);
 
     /**
      * Adds an optional triple as to the where clause.
@@ -357,6 +374,15 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      * @return This builder for chaining.
      */
     public T addGraph(Object graph, TriplePath triplePath);
+    
+    /**
+     * Adds a collection of triple paths as the optional clauses.
+     *
+     * @param graph The iri or variable identifying the graph.
+     * @param collection The collection of triple paths to add
+     * @return This Builder for chaining.
+     */
+    public T addGraph(Object graph, Collection<TriplePath> collection);
 
     /**
      * Add a bind statement to the query *
@@ -401,7 +427,9 @@ public interface WhereClause<T extends AbstractQueryBuilder<T>> {
      *
      * @param objs the list of objects for the list.
      * @return the first blank node in the list.
+     * @deprecated use {@code addWhere(Converters.makeCollection(List.of(Object...)))}, or simply call {@link #addWhere(Object, Object, Object)} passing the collection for one of the objects.
      */
+    @Deprecated(since="5.0.0")
     public Node list(Object... objs);
 
     /**

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/rewriters/AbstractRewriter.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/rewriters/AbstractRewriter.java
@@ -100,7 +100,7 @@ public class AbstractRewriter<T> {
      * @param t The triple path to rewrite.
      * @return the triple path after rewriting.
      */
-    protected final TriplePath rewrite(TriplePath t) {
+    public TriplePath rewrite(TriplePath t) {
         if (t.getPath() == null) {
             return new TriplePath(
                     Triple.create(changeNode(t.getSubject()), changeNode(t.getPredicate()), changeNode(t.getObject())));
@@ -116,7 +116,7 @@ public class AbstractRewriter<T> {
      * @param t The triple to rewrite.
      * @return The rewritten triple.
      */
-    protected final Triple rewrite(Triple t) {
+    public final Triple rewrite(Triple t) {
         return Triple.create(changeNode(t.getSubject()), changeNode(t.getPredicate()), changeNode(t.getObject()));
     }
 
@@ -127,7 +127,7 @@ public class AbstractRewriter<T> {
      * @param n The node to rewrite.
      * @return the rewritten node.
      */
-    protected final Node changeNode(Node n) {
+    protected Node changeNode(Node n) {
         if (n == null) {
             return n;
         }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/updatebuilder/WhereQuadHolder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/updatebuilder/WhereQuadHolder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.jena.arq.querybuilder.updatebuilder;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -222,6 +223,17 @@ public class WhereQuadHolder implements QuadHolder {
     }
 
     /**
+     * Add a {@code TriplePath} collection to the where clause
+     *
+     * @param t The triple path to add.
+     * @throws IllegalArgumentException If the triple path is not a valid triple
+     * path for a where clause.
+     */
+    public void addWhere(Collection<TriplePath> t) throws IllegalArgumentException {
+        t.forEach(this::addWhere);
+    }
+    
+    /**
      * Add an optional triple to the where clause
      *
      * @param t The triple path to add.
@@ -232,6 +244,20 @@ public class WhereQuadHolder implements QuadHolder {
         testTriple(t);
         ElementPathBlock epb = new ElementPathBlock();
         epb.addTriple(t);
+        ElementOptional opt = new ElementOptional(epb);
+        getClause().addElement(opt);
+    }
+    
+    /**
+     * Add an optional TriplePath to the where clause
+     *
+     * @param t The triple path to add.
+     * @throws IllegalArgumentException If the triple is not a valid triple for a
+     * where clause.
+     */
+    public void addOptional(Collection<TriplePath> t) throws IllegalArgumentException {
+        ElementPathBlock epb = new ElementPathBlock();
+        t.forEach( tp -> {testTriple(tp);epb.addTriple(tp);});
         ElementOptional opt = new ElementOptional(epb);
         getClause().addElement(opt);
     }
@@ -379,7 +405,9 @@ public class WhereQuadHolder implements QuadHolder {
      *
      * @param objs the list of objects for the list.
      * @return the first blank node in the list.
+     * @deprecated use {@code Converters.makeCollection(List.of(Object...))}
      */
+    @Deprecated(since="5.0.0")
     public Node list(Object... objs) {
         Node retval = NodeFactory.createBlankNode();
         Node lastObject = retval;

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/TestAbstractQueryBuilder.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/TestAbstractQueryBuilder.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.arq;
+
+import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
+import org.apache.jena.arq.querybuilder.handlers.HandlerBlock;
+import org.apache.jena.query.QueryFactory;
+
+/**
+ * Class to create AbstractQueryBuilders for AbstractQueryBuilder parameter tests.
+ */
+@SuppressWarnings("rawtypes")
+public class TestAbstractQueryBuilder extends AbstractQueryBuilder {
+    
+    public HandlerBlock handlerBlock = new HandlerBlock( QueryFactory.create());
+
+    @Override
+    public HandlerBlock getHandlerBlock() {
+        return handlerBlock;
+    }
+
+}

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/AskBuilderTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/AskBuilderTest.java
@@ -99,6 +99,7 @@ public class AskBuilderTest extends AbstractRegexpBasedTest {
                 query);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testList() {
         builder.addWhere(builder.list("<one>", "?two", "'three'"), "<foo>", "<bar>");

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/ConstructBuilderTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/ConstructBuilderTest.java
@@ -102,6 +102,7 @@ public class ConstructBuilderTest extends AbstractRegexpBasedTest {
                 query);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testList() {
         builder.addWhere(builder.list("<one>", "?two", "'three'"), "<foo>", "<bar>");

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/SelectBuilderTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/SelectBuilderTest.java
@@ -36,7 +36,6 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.core.TriplePath;
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.lang.sparql_11.ParseException;
 import org.apache.jena.sparql.syntax.ElementPathBlock;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.XSD;
@@ -55,7 +54,7 @@ public class SelectBuilderTest extends AbstractRegexpBasedTest {
     @Test
     public void testSelectAsterisk() {
         builder.addVar("*").addWhere("?s", "?p", "?o");
-
+        
         assertContainsRegex(SELECT + "\\*" + SPACE + WHERE + OPEN_CURLY + var("s") + SPACE + var("p") + SPACE + var("o")
                 + OPT_SPACE + CLOSE_CURLY, builder.buildString());
 
@@ -126,14 +125,13 @@ public class SelectBuilderTest extends AbstractRegexpBasedTest {
     @Test
     public void testNoVars() {
         builder.addWhere("?s", "?p", "?o");
-        String query = builder.buildString();
-
-        assertContainsRegex(SELECT + "\\*" + SPACE, query);
+        Query q = builder.build();
+        assertTrue( q.isQueryResultStar() );
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testList() {
-
         builder.addVar("*").addWhere(builder.list("<one>", "?two", "'three'"), "<foo>", "<bar>");
         Query query = builder.build();
 
@@ -175,7 +173,7 @@ public class SelectBuilderTest extends AbstractRegexpBasedTest {
     }
 
     @Test
-    public void testAggregatorsInSelect() throws ParseException {
+    public void testAggregatorsInSelect() {
         builder.addVar("?x").addVar("count(*)", "?c").addWhere("?x", "?p", "?o").addGroupBy("?x");
 
         Model m = ModelFactory.createDefaultModel();
@@ -218,7 +216,7 @@ public class SelectBuilderTest extends AbstractRegexpBasedTest {
     }
 
     @Test
-    public void testAggregatorsInSubQuery() throws ParseException {
+    public void testAggregatorsInSubQuery() {
 
         Model m = ModelFactory.createDefaultModel();
         Resource r = m.createResource("urn:one");
@@ -250,7 +248,7 @@ public class SelectBuilderTest extends AbstractRegexpBasedTest {
     }
 
     @Test
-    public void testVarReplacementInSubQuery() throws ParseException {
+    public void testVarReplacementInSubQuery() {
 
         Model m = ModelFactory.createDefaultModel();
         Resource r = m.createResource("urn:one");

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/clauses/SolutionModifierTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/clauses/SolutionModifierTest.java
@@ -37,7 +37,6 @@ import org.apache.jena.sparql.expr.E_Random;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprVar;
 import org.apache.jena.sparql.expr.nodevalue.NodeValueInteger;
-import org.apache.jena.sparql.lang.sparql_11.ParseException;
 import org.junit.After;
 import org.junit.Assert;
 import org.xenei.junit.contract.Contract;
@@ -297,7 +296,7 @@ public class SolutionModifierTest<T extends SolutionModifierClause<?>> extends A
     }
 
     @ContractTest
-    public void testAddHavingString() throws ParseException {
+    public void testAddHavingString() {
         SolutionModifierClause<?> solutionModifier = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = solutionModifier.addHaving("?foo<10");
 
@@ -334,7 +333,7 @@ public class SolutionModifierTest<T extends SolutionModifierClause<?>> extends A
     }
 
     @ContractTest
-    public void testAddHavingObject() throws ParseException {
+    public void testAddHavingObject() {
         SolutionModifierClause<?> solutionModifier = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = solutionModifier.addHaving(Var.alloc("foo"));
         
@@ -361,7 +360,7 @@ public class SolutionModifierTest<T extends SolutionModifierClause<?>> extends A
     }
 
     @ContractTest
-    public void testAddHavingExpr() throws ParseException {
+    public void testAddHavingExpr() {
         SolutionModifierClause<?> solutionModifier = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = solutionModifier.addHaving(new E_Random());
         
@@ -468,7 +467,7 @@ public class SolutionModifierTest<T extends SolutionModifierClause<?>> extends A
     }
 
     @ContractTest
-    public void testSetVarsHaving() throws ParseException {
+    public void testSetVarsHaving() {
         Var v = Var.alloc("v");
         SolutionModifierClause<?> solutionModifier = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = solutionModifier.addHaving("?v");
@@ -484,7 +483,7 @@ public class SolutionModifierTest<T extends SolutionModifierClause<?>> extends A
     }
 
     @ContractTest
-    public void testSetVarsHaving_Node_Variable() throws ParseException {
+    public void testSetVarsHaving_Node_Variable() {
         Node v = NodeFactory.createVariable("v");
         SolutionModifierClause<?> solutionModifier = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = solutionModifier.addHaving(v);

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/clauses/WhereClauseTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/clauses/WhereClauseTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.*;
 
+import org.apache.jena.arq.TestAbstractQueryBuilder;
 import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
 import org.apache.jena.arq.querybuilder.SelectBuilder;
 import org.apache.jena.arq.querybuilder.WhereBuilder;
@@ -44,7 +45,6 @@ import org.apache.jena.sparql.expr.E_Random;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprVar;
 import org.apache.jena.sparql.expr.nodevalue.NodeValueInteger;
-import org.apache.jena.sparql.lang.sparql_11.ParseException;
 import org.apache.jena.sparql.path.P_Link;
 import org.apache.jena.sparql.path.P_Seq;
 import org.apache.jena.sparql.path.Path;
@@ -59,7 +59,7 @@ import org.xenei.junit.contract.IProducer;
 @Contract(WhereClause.class)
 public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTest {
 
-    // the producer we will user
+    // the producer we will use
     private IProducer<T> producer;
 
     @Contract.Inject
@@ -78,7 +78,7 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
     }
 
     @ContractTest
-    public void testAddWhereStrings() {
+    public void testAddWhere3Objects() {
         WhereClause<?> whereClause = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = whereClause.addWhere("<one>", "<two>", "three");
 
@@ -86,6 +86,102 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
         Triple t = Triple.create(NodeFactory.createURI("one"), NodeFactory.createURI("two"),
                 NodeFactory.createLiteral("three"));
         epb.addTriple(t);
+
+        WhereValidator visitor = new WhereValidator(epb);
+        builder.build().getQueryPattern().visit(visitor);
+        assertTrue(visitor.matching);
+    }
+    
+
+    @ContractTest
+    public void testAddWhereAbstractQueryBuilder() {
+        WhereClause<?> whereClause = getProducer().newInstance();
+        TriplePath tp = new TriplePath(Triple.create(NodeFactory.createURI("one"), NodeFactory.createURI("two"), NodeFactory.createURI("three")));
+
+        TestAbstractQueryBuilder abstractQueryBuilder = new TestAbstractQueryBuilder();
+        abstractQueryBuilder.getHandlerBlock().getWhereHandler().addWhere(tp);
+        AbstractQueryBuilder<?> builder = whereClause.addWhere(abstractQueryBuilder);
+        
+        ElementPathBlock epb = new ElementPathBlock();
+        epb.addTriplePath(tp);
+        WhereValidator visitor = new WhereValidator(epb);
+        builder.build().getQueryPattern().visit(visitor);
+        assertTrue(visitor.matching);
+    }
+    
+    @ContractTest
+    public void testAddWhereTriplePath() {
+        WhereClause<?> whereClause = getProducer().newInstance();
+        PrefixMapping pmap = new PrefixMappingImpl();
+        pmap.setNsPrefix("ts", "urn:test:");
+        Path path = PathParser.parse("ts:two/ts:dos", pmap);
+        TriplePath first = new TriplePath(NodeFactory.createURI("one"), path, NodeFactory.createURI("three"));
+        
+        AbstractQueryBuilder<?> builder = whereClause
+                .addWhere(first);
+
+        ElementPathBlock epb = new ElementPathBlock();
+        epb.addTriplePath(first);
+
+        WhereValidator visitor = new WhereValidator(epb);
+        builder.build().getQueryPattern().visit(visitor);
+        assertTrue(visitor.matching);
+    }
+    
+
+    @ContractTest
+    public void testAddWhereTriple() {
+        WhereClause<?> whereClause = getProducer().newInstance();
+        Triple triple = Triple.create(NodeFactory.createURI("one"), NodeFactory.createURI("two"), NodeFactory.createURI("three"));
+
+        AbstractQueryBuilder<?> builder = whereClause
+                .addWhere(triple);
+
+        ElementPathBlock epb = new ElementPathBlock();
+        epb.addTriple(triple);
+
+        WhereValidator visitor = new WhereValidator(epb);
+        builder.build().getQueryPattern().visit(visitor);
+        assertTrue(visitor.matching);
+    }
+
+    @ContractTest
+    public void testAddWhereFrontsTriple() {
+        WhereClause<?> whereClause = getProducer().newInstance();
+        Triple triple = Triple.create(NodeFactory.createURI("one"), NodeFactory.createURI("two"), NodeFactory.createURI("three"));
+        FrontsTriple front = new FrontsTriple() {
+
+            @Override
+            public Triple asTriple() {
+                return triple;
+            }};
+        
+        AbstractQueryBuilder<?> builder = whereClause
+                .addWhere(front);
+
+        ElementPathBlock epb = new ElementPathBlock();
+        epb.addTriple(triple);
+
+        WhereValidator visitor = new WhereValidator(epb);
+        builder.build().getQueryPattern().visit(visitor);
+        assertTrue(visitor.matching);
+    }
+
+    @ContractTest
+    public void testAddWhereTriplePathCollection() {
+        WhereClause<?> whereClause = getProducer().newInstance();
+        PrefixMapping pmap = new PrefixMappingImpl();
+        pmap.setNsPrefix("ts", "urn:test:");
+        Path path = PathParser.parse("ts:two/ts:dos", pmap);
+        TriplePath first = new TriplePath(NodeFactory.createURI("one"), path, NodeFactory.createURI("three"));
+        TriplePath second = new TriplePath(NodeFactory.createURI("for"), path, NodeFactory.createURI("six"));
+
+        AbstractQueryBuilder<?> builder = whereClause
+                .addWhere(List.of(first, second));
+
+        ElementPathBlock epb = new ElementPathBlock();
+        epb.addTriplePath(first);
+        epb.addTriplePath(second);
 
         WhereValidator visitor = new WhereValidator(epb);
         builder.build().getQueryPattern().visit(visitor);
@@ -197,6 +293,28 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
     }
 
     @ContractTest
+    public void testAddOptionalTriplePathCollection() {
+        WhereClause<?> whereClause = getProducer().newInstance();
+        PrefixMapping pmap = new PrefixMappingImpl();
+        pmap.setNsPrefix("ts", "urn:test:");
+        Path path = PathParser.parse("ts:two/ts:dos", pmap);
+        TriplePath first = new TriplePath(NodeFactory.createURI("one"), path, NodeFactory.createURI("three"));
+        TriplePath second = new TriplePath(NodeFactory.createURI("for"), path, NodeFactory.createURI("six"));
+
+        AbstractQueryBuilder<?> builder = whereClause
+                .addOptional(List.of(first, second));
+
+        ElementPathBlock epb = new ElementPathBlock();
+        ElementOptional optional = new ElementOptional(epb);
+        epb.addTriplePath(first);
+        epb.addTriplePath(second);
+
+        WhereValidator visitor = new WhereValidator(optional);
+        builder.build().getQueryPattern().visit(visitor);
+        assertTrue(visitor.matching);
+    }
+    
+    @ContractTest
     public void testAddOptionalObjectsWithPath() {
         WhereClause<?> whereClause = getProducer().newInstance();
         PrefixMapping pmap = new PrefixMappingImpl();
@@ -275,7 +393,7 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
     }
 
     @ContractTest
-    public void testAddFilter() throws ParseException {
+    public void testAddFilter() {
         WhereClause<?> whereClause = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = whereClause.addFilter("?one<10");
 
@@ -437,7 +555,7 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
     }
 
     @ContractTest
-    public void testSetVarsInFilter() throws ParseException {
+    public void testSetVarsInFilter() {
         WhereClause<?> whereClause = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = whereClause.addFilter("?one < ?v");
 
@@ -697,7 +815,7 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
     }
 
     @ContractTest
-    public void testBindStringVar() throws ParseException {
+    public void testBindStringVar() {
         Var v = Var.alloc("foo");
         WhereClause<?> whereClause = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = whereClause.addBind("rand()", v);
@@ -719,7 +837,7 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
     }
 
     @ContractTest
-    public void testBindStringVar_Node_Variable() throws ParseException {
+    public void testBindStringVar_Node_Variable() {
         Node v = NodeFactory.createVariable("foo");
         WhereClause<?> whereClause = getProducer().newInstance();
         AbstractQueryBuilder<?> builder = whereClause.addBind("rand()", v);
@@ -780,6 +898,7 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
 
     }
 
+    @SuppressWarnings("deprecation")
     @ContractTest
     public void testList() {
         WhereClause<?> whereClause = getProducer().newInstance();
@@ -832,7 +951,25 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
     }
 
     @ContractTest
-    public void testAddGraph_frontsTriple() {
+    public void testAddGraphAbstractQueryBuilder() {
+        WhereClause<?> whereClause = getProducer().newInstance();
+        TriplePath tp = new TriplePath(Triple.create(NodeFactory.createURI("one"), NodeFactory.createURI("two"), NodeFactory.createURI("three")));
+
+        TestAbstractQueryBuilder abstractQueryBuilder = new TestAbstractQueryBuilder();
+        abstractQueryBuilder.getHandlerBlock().getWhereHandler().addWhere(tp);
+        AbstractQueryBuilder<?> builder = whereClause.addGraph( "<g>", abstractQueryBuilder);
+        
+        ElementPathBlock epb = new ElementPathBlock();
+        ElementNamedGraph eng = new ElementNamedGraph(NodeFactory.createURI("g"), epb);
+        
+        epb.addTriplePath(tp);
+        WhereValidator visitor = new WhereValidator(eng);
+        builder.build().getQueryPattern().visit(visitor);
+        assertTrue(visitor.matching);
+    }
+    
+    @ContractTest
+    public void testAddGraphFrontsTriple() {
         final Node s = NodeFactory.createURI("s");
         final Node p = NodeFactory.createURI("p");
         final Node o = NodeFactory.createURI("o");
@@ -877,7 +1014,7 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
     }
 
     @ContractTest
-    public void testAddGraph_triple() {
+    public void testAddGraphTriple() {
         final Node s = NodeFactory.createURI("s");
         final Node p = NodeFactory.createURI("p");
         final Node o = NodeFactory.createURI("o");
@@ -896,7 +1033,7 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
     }
 
     @ContractTest
-    public void testAddGraph_triplePath() {
+    public void testAddGraphTriplePath() {
         final Node s = NodeFactory.createURI("s");
         final Node p = NodeFactory.createURI("p");
         final Node o = NodeFactory.createURI("o");
@@ -912,6 +1049,28 @@ public class WhereClauseTest<T extends WhereClause<?>> extends AbstractClauseTes
 
         WhereValidator visitor = new WhereValidator(eng);
         query.getQueryPattern().visit(visitor);
+        assertTrue(visitor.matching);
+    }
+    
+    @ContractTest
+    public void testAddGraphTriplePathCollection() {
+        WhereClause<?> whereClause = getProducer().newInstance();
+        PrefixMapping pmap = new PrefixMappingImpl();
+        pmap.setNsPrefix("ts", "urn:test:");
+        Path path = PathParser.parse("ts:two/ts:dos", pmap);
+        TriplePath first = new TriplePath(NodeFactory.createURI("one"), path, NodeFactory.createURI("three"));
+        TriplePath second = new TriplePath(NodeFactory.createURI("for"), path, NodeFactory.createURI("six"));
+
+        AbstractQueryBuilder<?> builder = whereClause
+                .addGraph("<g>", List.of(first, second));
+
+        ElementPathBlock epb = new ElementPathBlock();
+        ElementNamedGraph eng = new ElementNamedGraph(NodeFactory.createURI("g"), epb);
+        epb.addTriplePath(first);
+        epb.addTriplePath(second);
+
+        WhereValidator visitor = new WhereValidator(eng);
+        builder.build().getQueryPattern().visit(visitor);
         assertTrue(visitor.matching);
     }
 

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/handlers/SolutionModifierHandlerTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/handlers/SolutionModifierHandlerTest.java
@@ -28,7 +28,6 @@ import org.apache.jena.query.Query;
 import org.apache.jena.query.SortCondition;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.expr.E_Random;
-import org.apache.jena.sparql.lang.sparql_11.ParseException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,7 +43,7 @@ public class SolutionModifierHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void testAddAll() throws ParseException {
+    public void testAddAll() {
         SolutionModifierHandler solutionModifier2 = new SolutionModifierHandler(new Query());
         solutionModifier2.addOrderBy(Var.alloc("orderBy"));
         solutionModifier2.addGroupBy(Var.alloc("groupBy"));
@@ -63,7 +62,7 @@ public class SolutionModifierHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void testAll() throws ParseException {
+    public void testAll() {
         solutionModifier.addOrderBy(Var.alloc("orderBy"));
         solutionModifier.addGroupBy(Var.alloc("groupBy"));
         solutionModifier.addHaving("SUM(?lprice) > 10");
@@ -130,7 +129,7 @@ public class SolutionModifierHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void testAddHavingString() throws ParseException {
+    public void testAddHavingString() {
         solutionModifier.addHaving("?having<10");
         assertContainsRegex(HAVING + OPEN_PAREN + var("having") + OPT_SPACE + LT + 10 + CLOSE_PAREN, query.toString());
 
@@ -141,7 +140,7 @@ public class SolutionModifierHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void testAddHavingVar() throws ParseException {
+    public void testAddHavingVar() {
         solutionModifier.addHaving(Var.alloc("foo"));
         assertContainsRegex(HAVING + var("foo"), query.toString());
 
@@ -150,7 +149,7 @@ public class SolutionModifierHandlerTest extends AbstractHandlerTest {
     }
 
     @Test
-    public void testAddHavingExpr() throws ParseException {
+    public void testAddHavingExpr() {
         solutionModifier.addHaving(new E_Random());
         assertContainsRegex(HAVING + "rand" + OPEN_PAREN + CLOSE_PAREN, query.toString());
 


### PR DESCRIPTION
GitHub issue resolved #

Pull request Description:  Adds the ability to use a Collection object as a node in the query builder.

`AddWhere( A, B, List.of( C, D ))` should yield the same as `SELECT * WHERE { A B (C D) }` 


----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
