### PR TITLE
Fixes GraphTxn find() for incorrect attempt to create a nested transaction

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphTxn.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphTxn.java
@@ -115,7 +115,7 @@ public class GraphTxn extends GraphWrapper implements Transactional {
         IteratorTxn(GraphTxn graph, ExtendedIterator<T> base) {
             super(base, true);  // removeDenied.
             this.graph = graph;
-            needIterTxn = graph.getT().isInTransaction();
+            needIterTxn = ! graph.getT().isInTransaction();
             if ( needIterTxn )
                 graph.begin(TxnType.READ);
         }


### PR DESCRIPTION
Fix inverted logic causing `GraphTxn` to incorrectly attempt a nested transaction, this was already fixed on `main` by https://github.com/apache/jena/commit/0baf13e3fba0cfd66299cdabcd57bc39382a4298

Backports a fixed inverted logic check that was already addressed on main onto the jena4 branch

GitHub issue resolved #2086

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
