### PR TITLE
Bump Axios from 1.5.1 to 1.6.1

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/package.json
+++ b/jena-fuseki2/jena-fuseki-ui/package.json
@@ -25,7 +25,7 @@
     "@zazuko/yasqe": "^4.2.32",
     "@zazuko/yasr": "^4.2.32",
     "@vue/compat": "^3.3.6",
-    "axios": "^1.5.1",
+    "axios": "^1.6.1",
     "bootstrap": "^5.3.2",
     "follow-redirects": "^1.15.3",
     "mitt": "^3.0.1",

--- a/jena-fuseki2/jena-fuseki-ui/yarn.lock
+++ b/jena-fuseki2/jena-fuseki-ui/yarn.lock
@@ -1207,7 +1207,7 @@ axios@^0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
-axios@^1.5.1:
+axios@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.1.tgz#76550d644bf0a2d469a01f9244db6753208397d7"
   integrity sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==


### PR DESCRIPTION
Addresses CVE-2023-45857

Version 1.6.1 was being used anyway.

----
By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
