### PR TITLE
ParameterizedSparqlString: Fixed flaky tests due to HashMap

### DIFF
--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -1512,6 +1512,16 @@ public class TestParameterizedSparqlString {
         pss.setLiteral(second, " . } ; DROP ALL ; INSERT DATA { <s> <p> ");
 
         pss.asUpdate();
+        // Due to the unpredictability of the order of parameters in this.params,
+        // which is a HashMap, here the reverse order is checked to make sure
+        // an ARQException is thrown
+        pss.setLiteral("var", "a");
+        pss.setLiteral("var2", "b");
+
+        pss.setLiteral(second, "?" + first);
+        pss.setLiteral(first, " . } ; DROP ALL ; INSERT DATA { <s> <p> ");
+
+        pss.asUpdate();
         Assert.fail("Attempt to do SPARQL injection should result in an exception");
     }
 
@@ -1583,6 +1593,16 @@ public class TestParameterizedSparqlString {
 
         pss.setLiteral(first, " ?" + second + " ");
         pss.setLiteral(second, " . } ; DROP ALL ; INSERT DATA { <s> <p> ");
+
+        pss.asUpdate();
+        // Due to the unpredictability of the order of parameters in this.params,
+        // which is a HashMap, here the reverse order is checked to make sure
+        // an ARQException is thrown
+        pss.setLiteral("var", "a");
+        pss.setLiteral("var2", "b");
+
+        pss.setLiteral(second, " ?" + first + " ");
+        pss.setLiteral(first, " . } ; DROP ALL ; INSERT DATA { <s> <p> ");
 
         pss.asUpdate();
         Assert.fail("Attempt to do SPARQL injection should result in an exception");


### PR DESCRIPTION
Pull request Description:
### Issue

Tests like `org.apache.jena.query.TestParameterizedSparqlString#test_param_string_injection_10` makes more than one injections. `ParameterizedSparqlString.getVars()` is used to retrieve the order of injections, `getVars()` calls `this.params.keySet().iterator()` on the `ParameterizedSparqlString` object and the implementation of `params` of `ParameterizedSparqlString` is a `HashMap` which does not guarantee the order. So what is returned is not necessarily by the injection order.

https://github.com/apache/jena/blob/fc01d33e6c11eed68784f820bf2dd161868d1d37/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java#L1138

https://github.com/apache/jena/blob/fc01d33e6c11eed68784f820bf2dd161868d1d37/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java#L141

### Fix

The implementation of `params` of `ParameterizedSparqlString` is change to `LinkedHashMap` which guarantees the order returned is order of injection

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
