### PR TITLE
Fix flaky prefixmap

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -138,7 +138,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
 
     private StringBuilder cmd = new StringBuilder();
     private String baseUri;
-    private Map<String, Node> params = new LinkedHashMap<>();
+    private Map<String, Node> params = new HashMap<>();
     private Map<Integer, Node> positionalParams = new HashMap<>();
     private PrefixMapping prefixes;
     private Map<String, ValueReplacement> valuesReplacements = new HashMap<>();

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -138,7 +138,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
 
     private StringBuilder cmd = new StringBuilder();
     private String baseUri;
-    private Map<String, Node> params = new HashMap<>();
+    private Map<String, Node> params = new LinkedHashMap<>();
     private Map<Integer, Node> positionalParams = new HashMap<>();
     private PrefixMapping prefixes;
     private Map<String, ValueReplacement> valuesReplacements = new HashMap<>();

--- a/jena-core/src/main/java/org/apache/jena/shared/impl/PrefixMappingImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/shared/impl/PrefixMappingImpl.java
@@ -19,6 +19,7 @@
 package org.apache.jena.shared.impl;
 
 import java.util.ArrayList ;
+import java.util.LinkedHashMap;
 import java.util.List ;
 import java.util.Map ;
 import java.util.Map.Entry;
@@ -50,7 +51,7 @@ public class PrefixMappingImpl implements PrefixMapping
         // ConcurrentHashMaps protects against breaking each datastructure
         // but does not protect against inconsistency.
         prefixToURI = new ConcurrentHashMap<>();
-        URItoPrefix = new ConcurrentHashMap<>(); 
+        URItoPrefix = new ConcurrentHashMap<>();
         }
     
     protected void set(String prefix, String uri) {
@@ -187,7 +188,7 @@ public class PrefixMappingImpl implements PrefixMapping
         
     @Override
     public Map<String, String> getNsPrefixMap()
-        { return CollectionFactory.createHashedMap( prefixToURI ); }
+        { return new LinkedHashMap<>( prefixToURI ); }
         
     @Override
     public String getNsURIPrefix( String uri )


### PR DESCRIPTION
**Nondex** was used to check and locate the flakiness in the test. The test can be reproduced using the following command:
```shell
mvn install -pl jena-arq -am -DskipTests
mvn -pl jena-arq test -Dtest=org.apache.jena.riot.system.TestPrefixMapOverPrefixMapping#prefixMap_abbrev_10
mvn -pl jena-arq edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.apache.jena.riot.system.TestPrefixMapOverPrefixMapping#prefixMap_abbrev_10
``` 
----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
