### PR TITLE
GH-2093: Correct WriterStreamRDFBlocks on mixed triples/quads

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/IndentStyle.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/IndentStyle.java
@@ -18,6 +18,12 @@
 
 package org.apache.jena.riot.writer;
 
+/**
+ * The "long" Turtle format variant is based on rdflib's "longturtle"
+ * format. It uses a fixed indentation width (2) and linebreaks after
+ * each sequence element.
+ */
+
 enum IndentStyle {
     WIDE, LONG ;
     public static IndentStyle create(String label) {


### PR DESCRIPTION
This closes #2093.

The output from WriterStreamRDFBlocks was incorrect if triples and quads are mixed. That can't happen parsing a single file because if it's quads, default graph triples come through as quads.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
