### PR TITLE
Debug text prop not working in some cases

### DIFF
--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
@@ -723,6 +723,10 @@ public class TextIndexLucene implements TextIndex {
         List<String> searchForTags = Util.getSearchForTags(lang);
         boolean usingSearchFor = Util.usingSearchFor(lang);
 
+        // The set will reduce lucene text field expressions
+        // to unique expressions
+        Set<String> uniquePropListQueryStrings = new LinkedHashSet<>();
+
         if (props.isEmpty()) {
             // we got here via
             //    ?s text:query "some query string"
@@ -746,8 +750,9 @@ public class TextIndexLucene implements TextIndex {
 
         log.trace("query$ PROCESSING LIST of properties: {}; Lucene queryString: {}; textFields: {} ", props, qString, textFields) ;
         for (String textField : textFields) {
-            qString += composeQField(qs, textField, lang, usingSearchFor, searchForTags);
+            uniquePropListQueryStrings.add(composeQField(qs, textField, lang, usingSearchFor, searchForTags));
         }
+        qString += String.join("", uniquePropListQueryStrings);
 
         // we need to check whether there was a lang arg either on the query string
         // or explicitly as an input arg and add it to the qString; otherwise, Lucene

--- a/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/TextIndexLucene.java
@@ -694,17 +694,18 @@ public class TextIndexLucene implements TextIndex {
 
     private String composeQField(String qs, String textField, String lang, boolean usingSearchFor, List<String> searchForTags) {
         String textClause = "";
+        String fieldGroupingQueryString = "(" + qs + ")";
 
         if (usingSearchFor) {
             for (String tag : searchForTags) {
                 String tf = textField + "_" + tag;
-                textClause += tf + ":" + qs + " ";
+                textClause += tf + ": " + fieldGroupingQueryString + " ";
             }
         } else {
             if (this.isMultilingual && StringUtils.isNotEmpty(lang) && !lang.equals("none")) {
                 textField += "_" + lang;
             }
-            textClause = textField + ":" + qs + " ";
+            textClause = textField + ": " + fieldGroupingQueryString + " ";
         }
 
         return textClause;

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -65,6 +65,7 @@ import org.junit.runners.Suite.SuiteClasses;
     , TestTextHighlighting.class
     , TestTextDefineAnalyzers.class
     , TestTextMultilingualEnhancements.class
+    , TestTextMultipleProplistNotWorking.class
 
     , TestPropListsAssembler.class
     , TestTextPropLists.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultipleProplistNotWorking.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultipleProplistNotWorking.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.query.text;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.atlas.lib.StrUtils;
+import org.apache.jena.query.*;
+import org.apache.jena.query.text.assembler.TextAssembler;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+// GH-2094
+public class TestTextMultipleProplistNotWorking extends AbstractTestDatasetWithTextIndexBase {
+
+    private static final String RES_BASE = "http://example.org/resource#";
+    private static final String SPEC_BASE = "http://example.org/spec#";
+    private static final String SPEC_ROOT_LOCAL = "lucene_text_dataset";
+    private static final String SPEC_ROOT_URI = SPEC_BASE + SPEC_ROOT_LOCAL;
+    private static final String SPEC;
+
+    protected static final String TURTLE_PROLOG2 =
+            StrUtils.strjoinNL("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .",
+            "@prefix mt: <http://id.example.test/vocab/#> .",
+            "@prefix mx: <http://id.example.test/mx/#> ."
+
+            );
+    protected static final String QUERY_PROLOG2 = 
+            StrUtils.strjoinNL(
+                    "prefix res:  <" + RES_BASE + "> ",
+                    "prefix spec: <" + SPEC_BASE + "> ",
+                    "prefix mt: <http://id.example.test/vocab/#>",
+                    "prefix text: <http://jena.apache.org/text#> ",
+                    "prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> ",
+                    "prefix skos: <http://www.w3.org/2004/02/skos/core#> "
+                    );
+    static {
+        SPEC = StrUtils.strjoinNL(
+                "@prefix :        <http://example.org/spec#> .",
+                "@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .",
+                "@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .",
+                "@prefix tdb2:    <http://jena.apache.org/2016/tdb#> .",
+                "@prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .",
+                "@prefix text:    <http://jena.apache.org/text#> .",
+                "@prefix fuseki:  <http://jena.apache.org/fuseki#> .",
+                "@prefix mt:      <http://id.example.test/vocab/#> .",
+                "@prefix mx:      <http://id.example.test/mx/#> .",
+
+                "[] ja:loadClass       \"org.apache.jena.query.text.TextQuery\" .",
+                "text:TextDataset      rdfs:subClassOf   ja:RDFDataset .",
+                "text:TextIndexLucene  rdfs:subClassOf   text:TextIndex .",
+
+                ":lucene_text_dataset",
+                "    a text:TextDataset ;",
+                "    text:dataset   <#dataset> ;",
+                "    text:index     <#indexLucene> ;",
+                "    .",
+
+                "# A TDB dataset used for RDF storage",
+                "<#dataset> ",
+                "    a tdb2:DatasetTDB2 ;",
+                "    tdb2:location  \"--mem--\" ;",
+                "    .",
+
+                "# Text index description",
+
+                "<#indexLucene> ",
+                "    a text:TextIndexLucene ;",
+                "    text:storeValues true ;",
+                "    text:directory \"mem\" ;",
+                "    text:defineAnalyzers (",
+                "      [ text:addLang \"en-01\" ;",
+                "        text:searchFor ( \"en-01\" \"en-02\" ) ;",
+                "        text:analyzer [ a text:StandardAnalyzer ]",
+                "      ]",
+                "     ",
+                "      [ text:addLang \"en-02\" ;",
+                "        text:searchFor ( \"en-01\" \"en-02\" ) ;",
+                "        text:analyzer [ a text:StandardAnalyzer ]",
+                "      ] ) ;",
+                "    text:entityMap <#entMap> ;",
+                "        text:propLists (",
+                "        [ text:propListProp mt:defQuery ;",
+                "          text:props ( ",
+                "             rdfs:label",
+                "             mt:altLabel",
+                "             mt:alt_label",
+                "             mx:alt_label",
+                "             ) ;",
+                "        ]",
+                "        [ text:propListProp mt:includeNotes ;",
+                "          text:props (",
+                "               rdfs:label",
+                "               mt:altLabel",
+                "               mt:alt_label",
+                "               mx:alt_label           ",
+                "               mt:note",
+                "             ) ;",
+                "        ]",
+                "    ) ;",
+                "     .",
+
+                "<#entMap> ",
+                "    a text:EntityMap ;",
+                "    text:defaultField     \"comment\" ;",
+                "    text:entityField      \"uri\" ;",
+                "    text:uidField         \"uid\" ;",
+                "    text:langField        \"lang\" ;",
+                "    text:graphField       \"graph\" ;",
+                "    text:map (",
+                "[ text:field \"comment\" ; text:predicate rdfs:comment ]",
+                "         [ text:field \"ftext\" ; text:predicate rdfs:label ]",
+                "         [ text:field \"ftext\" ; text:predicate mt:altLabel ]",
+                "         [ text:field \"ftext\" ; text:predicate mt:alt_label ]",
+                "         [ text:field \"ftext\" ; text:predicate mx:alt_label ]",
+                "         [ text:field \"note\" ; text:predicate mt:note ]",
+                "         ) ."
+
+                );
+    }
+
+    @Before
+    public void before() {
+
+
+        Reader reader = new StringReader(SPEC);
+        Model specModel = ModelFactory.createDefaultModel();
+        specModel.read(reader, "", "TURTLE");
+        TextAssembler.init();
+        Resource root = specModel.getResource(SPEC_ROOT_URI);
+        dataset = (Dataset) Assembler.general.open(root);
+    }
+
+    @After
+    public void after() {
+        dataset.close();
+    }
+
+    private void putTurtleInModel(String turtle, String modelName) {
+        Model model = modelName != null ? dataset.getNamedModel(modelName) : dataset.getDefaultModel() ;
+        Reader reader = new StringReader(turtle) ;
+        dataset.begin(ReadWrite.WRITE) ;
+        try {
+            model.read(reader, "", "TURTLE") ;
+            dataset.commit() ;
+        }
+        finally {
+            dataset.end();
+        }
+    }
+
+    protected Map<String,Literal> doTestSearchWithLiterals(String queryString, Set<String> expectedEntityURIs) {
+        Map<String,Literal> literals = new HashMap<>();
+        Query query = QueryFactory.create(queryString) ;
+        dataset.begin(ReadWrite.READ);
+        try(QueryExecution qexec = QueryExecutionFactory.create(query, dataset)) {
+            ResultSet results = qexec.execSelect() ;
+            assertEquals(expectedEntityURIs.size() > 0, results.hasNext());
+            int count;
+            for (count=0; results.hasNext(); count++) {
+                QuerySolution soln = results.nextSolution();
+                String entityUri = soln.getResource("s").getURI();
+                assertTrue(expectedEntityURIs.contains(entityUri));
+                Literal literal = soln.getLiteral("lit");
+                assertNotNull(literal);
+                literals.put(entityUri, literal);
+            }
+            assertEquals(expectedEntityURIs.size(), count);
+        }
+        finally {
+            dataset.end() ;
+        }
+        return literals;
+    }
+
+    @Test
+    public void test01TextPropNotWorkingInSomeCases() {
+        final String turtleA = StrUtils.strjoinNL(
+                TURTLE_PROLOG2,
+                "<http://id.example.test/1>",
+                "  rdfs:label\"beer\"@en ;",
+                "  mt:altLabel\"pint\"@en ;",
+                "  mx:alt_label\"pivečko\"@cs ;",
+                "  mt:note\"Booze is a pleasure\"@en,\"Chlast je slast\"@cs .",
+
+                "<http://id.example.test/2>",
+                "  mt:alt_label\"ale\"@en,\"burgundy\"@en ;",
+                "  rdfs:label\"wine \"@en ;",
+                "  mt:altLabel\"champagne\"@en ;",
+                "  mx:alt_label\"víno\"@cs ;",
+                "  mt:note\"Red or white\"@en,\"Červené či bílé\"@cs .",
+
+                "<http://id.example.test/3>",
+                "  mt:alt_label\"Scotch\"@en ;",
+                "  rdfs:comment\"Johnnie Walker red label \"@en ."
+
+                );
+        putTurtleInModel(turtleA, null) ;
+        String queryString = StrUtils.strjoinNL(
+                QUERY_PROLOG2,
+                "SELECT ?s ?lit",
+                "WHERE {",
+                "  (?s ?sc ?lit) text:query ( mt:includeNotes 'red booze' ) . ",
+                "}"
+                );
+        String queryStringMtNote = StrUtils.strjoinNL(
+                QUERY_PROLOG2,
+                "SELECT ?s ?lit",
+                "WHERE {",
+                "  (?s ?sc ?lit)  text:query ( mt:note \"red booze\" ) . ",
+                "}"
+        );
+        Set<String> expectedURIs = new HashSet<>() ;
+        expectedURIs.addAll( Arrays.asList("http://id.example.test/1","http://id.example.test/2")) ;
+        
+        Map<String, Literal> literals = doTestSearchWithLiterals(queryString, expectedURIs) ;
+
+        Map<String,Literal> literalsFromMtNote = doTestSearchWithLiterals(queryStringMtNote,expectedURIs);
+        assertEquals(2, literals.size());
+        
+        Literal value = literals.get("http://id.example.test/1");
+        assertNotNull(value);
+
+        Literal valueNote = literalsFromMtNote.get("http://id.example.test/1");
+        assertNotNull(valueNote);
+
+        value = literals.get("http://id.example.test/2");
+        assertNotNull(value);
+
+        valueNote = literalsFromMtNote.get("http://id.example.test/2");
+        assertNotNull(valueNote);
+    }
+
+    @Test
+    public void test02TextPropNotWorkingInSomeCases() {
+        final String turtleA = StrUtils.strjoinNL(
+                TURTLE_PROLOG2,
+                "<http://id.example.test/1>",
+                "  rdfs:label\"beer\"@en-01 ;",
+                "  mt:altLabel\"pint\"@en-01 ;",
+                "  mx:alt_label\"pivečko\"@cs ;",
+                "  mt:note\"Booze is a pleasure\"@en-01,\"Chlast je slast\"@cs .",
+
+                "<http://id.example.test/2>",
+                "  mt:alt_label\"ale\"@en-01 , \"burgundy\"@en-01 ;",
+                "  rdfs:label\"wine \"@en-01 ;",
+                "  mt:altLabel\"champagne\"@en-01 ;",
+                "  mx:alt_label\"víno\"@cs ;",
+                "  mt:note\"Red or white\"@en-01,\"Červené či bílé\"@cs .",
+
+                "<http://id.example.test/3>",
+                "  mt:alt_label\"Scotch\"@en-01 ;",
+                "  rdfs:comment\"Johnnie Walker red label \"@en-01 ."
+
+        );
+        putTurtleInModel(turtleA, null) ;
+        String queryString = StrUtils.strjoinNL(
+                QUERY_PROLOG2,
+                "SELECT ?s ?lit",
+                "WHERE {",
+                "  (?s ?sc ?lit) text:query ( mt:includeNotes \"red booze\"@en-02 ) . ",
+                "}"
+        );
+        String queryStringMtNote = StrUtils.strjoinNL(
+                QUERY_PROLOG2,
+                "SELECT ?s ?lit",
+                "WHERE {",
+                "  (?s ?sc ?lit)  text:query ( mt:note \"red booze\"@en-02 ) . ",
+                "}"
+        );
+        Set<String> expectedURIs = new HashSet<>() ;
+        expectedURIs.addAll( Arrays.asList("http://id.example.test/1","http://id.example.test/2")) ;
+
+        Map<String, Literal> literals = doTestSearchWithLiterals(queryString, expectedURIs) ;
+
+        Map<String,Literal> literalsFromMtNote = doTestSearchWithLiterals(queryStringMtNote,expectedURIs);
+        assertEquals(2, literals.size());
+
+        Literal value = literals.get("http://id.example.test/1");
+        assertNotNull(value);
+
+        Literal valueNote = literalsFromMtNote.get("http://id.example.test/1");
+        assertNotNull(valueNote);
+
+        value = literals.get("http://id.example.test/2");
+        assertNotNull(value);
+
+        valueNote = literalsFromMtNote.get("http://id.example.test/2");
+        assertNotNull(valueNote);
+    }
+}


### PR DESCRIPTION
GitHub issue resolved #2094

Pull request Description:

* Add field grouping (parens) to composeQField method to fix #2094 

I see a similar fix with parens is also used in other paths in the code for example in line 765 and 771 of the same file.

```
   qString = "(" + qString + ") AND " + (!lang.equals("none") ? langField+":"+lang : "-"+langField+":*");
            log.trace("query$ ADDING LANG qString: {} ", qString) ;
        }
```

```
  if (graphURI != null) {
            String escaped = QueryParserBase.escape(graphURI) ;
            qString = "(" + qString + ") AND " + getDocDef().getGraphField() + ":" + escaped ;
        }
```

*  Add a unique set to remove duplicate query clauses on propLists which is mentioned by @rvesse 

> It also looks like we generate duplicate query clauses when multiple properties map to the same Lucene field which might be unnecessary?

----

 - [x] Tests are included.
 - [x] (Not applicable) Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).