### PR TITLE
GH-2150 Fix for bad query AST builder generated

### DIFF
--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/rewriters/BuildElementVisitor.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/rewriters/BuildElementVisitor.java
@@ -125,8 +125,16 @@ public class BuildElementVisitor implements ElementVisitor {
             // noting to do
             result = el;
         } else if (lst.size() == 1) {
-            lst.get(0).visit(this);
-            // result is now set properly
+            // GH-2150 If the single element is an ElementFilter need to leave it as-is otherwise some built queries
+            // and updates will fail when we attempt to execute them as the Element AST will be considered invalid by
+            // AlgebraGenerator
+            Element singleton = lst.get(0);
+            if (singleton instanceof ElementFilter) {
+                result = el;
+            } else {
+                lst.get(0).visit(this);
+                // result is now set properly
+            }
         } else {
             updateList(lst);
             result = el;


### PR DESCRIPTION
GitHub issue resolved #2150

In some cases using the query builder API to create a query/update could result in an apparently valid query (when printing as a string) but the actual AST was bad.  When attempting to actually execute the query/update locally ARQ would fail to compile it as a result.

This commit fixes BuildElementVisitor to avoid an oversimplification of some AST elements, specifically an ElementGroup containing a single ElementFilter that was leading to the bad AST.

----

 - [ ] Tests are included.
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
