### PR TITLE
Correct javadoc NodeFactory.createLiteral(String) deprecated message

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/graph/NodeFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/NodeFactory.java
@@ -83,7 +83,7 @@ public class NodeFactory {
         return new Node_Literal( lit );
     }
 
-    /** @deprecated Use {@link #createLiteral} */
+    /** @deprecated Use {@link #createLiteralString} */
     @Deprecated
     public static Node createLiteral(String string) {
         return createLiteralString(string);


### PR DESCRIPTION
The `@deprecated` message named the wrong method.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
