### PR TITLE
GH-2153: Compile Element when not it is in an ElementGroup

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/AlgebraGenerator.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/AlgebraGenerator.java
@@ -195,7 +195,7 @@ public class AlgebraGenerator
 
         // Compile the consolidated group elements.
         // "current" is the completed part only - there may be thing pushed into the accumulator.
-        Op current = OpTable.unit();
+        Op current = OpLib.unit();
         Deque<Op> acc = new ArrayDeque<>();
 
         for ( Element elt : groupElts ) {
@@ -322,6 +322,14 @@ public class AlgebraGenerator
         return compileUnknownElement(elt, "compile/Element not recognized: "+Lib.className(elt));
     }
 
+    protected Op compileElementFilter(ElementFilter elt) {
+        // Filters should appear in a ElementGroup.
+        // If the query was created programmatically, the app or querybuilder may
+        // have omitted the ElementGroup. Deal with this by creating the same Op structure
+        // as a group-of-one with ElementFilter.
+        return OpFilter.filter(elt.getExpr(), OpLib.unit());
+    }
+
     protected Op compileElementUnion(ElementUnion el) {
         Op current = null;
 
@@ -394,7 +402,7 @@ public class AlgebraGenerator
     protected Op compilePathBlock(PathBlock pathBlock) {
         // Empty path block : the parser does not generate this case.
         if ( pathBlock.size() == 0 )
-            return OpTable.unit();
+            return OpLib.unit();
 
         // Always turns the most basic paths to triples.
         return PathLib.pathToTriples(pathBlock);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/AlgebraGenerator.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/AlgebraGenerator.java
@@ -97,7 +97,8 @@ public class AlgebraGenerator
      * @return Compiled algebra
      */
     public Op compile(Query query) {
-        Op op = compile(query.getQueryPattern());     // Not compileElement - may need to apply simplification.
+        Element el = query.getQueryPattern();
+        Op op = compile(el);     // Not compileElement - may need to apply simplification.
         op = compileModifiers(query, op);
         return op;
     }
@@ -123,32 +124,32 @@ public class AlgebraGenerator
 
     // This is the operation to call for recursive application.
     protected Op compileElement(Element elt) {
-        if ( elt instanceof ElementGroup )
-            return compileElementGroup((ElementGroup)elt);
+        if ( elt instanceof ElementGroup elt2)
+            return compileElementGroup(elt2);
 
-        if ( elt instanceof ElementUnion )
-            return compileElementUnion((ElementUnion)elt);
+        if ( elt instanceof ElementUnion elt2 )
+            return compileElementUnion(elt2);
 
-        if ( elt instanceof ElementNamedGraph )
-            return compileElementGraph((ElementNamedGraph)elt);
+        if ( elt instanceof ElementNamedGraph elt2 )
+            return compileElementGraph(elt2);
 
-        if ( elt instanceof ElementService )
-            return compileElementService((ElementService)elt);
+        if ( elt instanceof ElementService elt2 )
+            return compileElementService(elt2);
 
         // This is only here for queries built programmatically
         // (triple patterns not in a group)
-        if ( elt instanceof ElementTriplesBlock )
-            return compileBasicPattern(((ElementTriplesBlock)elt).getPattern());
+        if ( elt instanceof ElementTriplesBlock elt2 )
+            return compileBasicPattern(elt2.getPattern());
 
         // Ditto.
-        if ( elt instanceof ElementPathBlock )
-            return compilePathBlock(((ElementPathBlock)elt).getPattern());
+        if ( elt instanceof ElementPathBlock elt2 )
+            return compilePathBlock(elt2.getPattern());
 
-        if ( elt instanceof ElementSubQuery )
-            return compileElementSubquery((ElementSubQuery)elt);
+        if ( elt instanceof ElementSubQuery elt2 )
+            return compileElementSubquery(elt2);
 
-        if ( elt instanceof ElementData )
-            return compileElementData((ElementData)elt);
+        if ( elt instanceof ElementData elt2 )
+            return compileElementData(elt2);
 
         if ( elt == null )
             return OpNull.create();
@@ -243,9 +244,7 @@ public class AlgebraGenerator
             // but SPARQL 1.0 does and also we cope for programmatically built
             // queries
 
-            if ( elt instanceof ElementTriplesBlock ) {
-                ElementTriplesBlock etb = (ElementTriplesBlock)elt;
-
+            if ( elt instanceof ElementTriplesBlock etb) {
                 if ( currentPathBlock == null ) {
                     ElementPathBlock etb2 = new ElementPathBlock();
                     currentPathBlock = etb2.getPattern();
@@ -259,9 +258,7 @@ public class AlgebraGenerator
 
             // To PathLib
 
-            if ( elt instanceof ElementPathBlock ) {
-                ElementPathBlock epb = (ElementPathBlock)elt;
-
+            if ( elt instanceof ElementPathBlock epb ) {
                 if ( currentPathBlock == null ) {
                     ElementPathBlock etb2 = new ElementPathBlock();
                     currentPathBlock = etb2.getPattern();
@@ -286,31 +283,20 @@ public class AlgebraGenerator
     protected Op compileOneInGroup(Element elt, Op current, Deque<Op> acc) {
         // Elements that operate over their left hand size (query syntax).
 
-        if ( elt instanceof ElementAssign ) {
-            ElementAssign assign = (ElementAssign)elt;
+        if ( elt instanceof ElementAssign assign)
             return OpAssign.assign(current, assign.getVar(), assign.getExpr());
-        }
 
-        if ( elt instanceof ElementBind ) {
-            ElementBind bind = (ElementBind)elt;
+        if ( elt instanceof ElementBind bind )
             return OpExtend.create(current, bind.getVar(), bind.getExpr());
-        }
 
-        if ( elt instanceof ElementOptional ) {
-            ElementOptional eltOpt = (ElementOptional)elt;
+        if ( elt instanceof ElementOptional eltOpt )
             return compileElementOptional(eltOpt, current);
-        }
 
-        if ( elt instanceof ElementLateral ) {
-            ElementLateral eltLateral = (ElementLateral)elt;
+        if ( elt instanceof ElementLateral eltLateral )
             return compileElementLateral(eltLateral, current);
-        }
 
-        if ( elt instanceof ElementMinus ) {
-            ElementMinus elt2 = (ElementMinus)elt;
-            Op op = compileElementMinus(current, elt2);
-            return op;
-        }
+        if ( elt instanceof ElementMinus elt2 )
+            return compileElementMinus(current, elt2);
 
         // All elements that simply "join" into the algebra.
         if ( elt instanceof ElementGroup || elt instanceof ElementNamedGraph || elt instanceof ElementService || elt instanceof ElementUnion
@@ -322,24 +308,17 @@ public class AlgebraGenerator
 
         // Specials.
 
-        if ( elt instanceof ElementExists ) {
-            ElementExists elt2 = (ElementExists)elt;
-            Op op = compileElementExists(current, elt2);
-            return op;
-        }
+        if ( elt instanceof ElementExists elt2 )
+            return compileElementExists(current, elt2);
 
-        if ( elt instanceof ElementNotExists ) {
-            ElementNotExists elt2 = (ElementNotExists)elt;
-            Op op = compileElementNotExists(current, elt2);
-            return op;
-        }
+        if ( elt instanceof ElementNotExists elt2 )
+            return compileElementNotExists(current, elt2);
 
         // Filters were collected together by prepareGroup
         // This only handles filters left in place by some magic.
-        if ( elt instanceof ElementFilter ) {
-            ElementFilter f = (ElementFilter)elt;
-            return OpFilter.filter(f.getExpr(), current);
-        }
+        if ( elt instanceof ElementFilter ef)
+            return OpFilter.filter(ef.getExpr(), current);
+
         return compileUnknownElement(elt, "compile/Element not recognized: "+Lib.className(elt));
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpLib.java
@@ -18,8 +18,10 @@
 
 package org.apache.jena.sparql.algebra;
 
+import org.apache.jena.sparql.algebra.op.OpTable;
 import org.apache.jena.sparql.core.Quad;
 
+/** Functions relating to {@link Op}s. */
 public class OpLib
 {
     /** Convert a pattern, assumed to be quad form,
@@ -32,4 +34,22 @@ public class OpLib
         op = Transformer.transform(t, op);
         return op;
     }
+
+    // XXX These may change to be a specific Op implementation.
+    // Needs a visitor change.
+
+    /**
+     * Return an {@code Op} that is the join unit - {@code (join unit(), X) = X)}.
+     * It is one row of zero columns.
+     */
+    public static Op unit() {
+        return OpTable.unit();
+    }
+
+    /**
+     * Return an {@code Op} that is the join zero - {@code (join empty(), X) = empty)}.
+     * It is zero rows.
+     */
+    public static Op empty()
+    { return OpTable.empty(); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/PropertyFunctionGenerator.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/PropertyFunctionGenerator.java
@@ -28,7 +28,6 @@ import org.apache.jena.graph.Triple ;
 import org.apache.jena.sparql.algebra.op.OpBGP ;
 import org.apache.jena.sparql.algebra.op.OpPropFunc ;
 import org.apache.jena.sparql.algebra.op.OpSequence ;
-import org.apache.jena.sparql.algebra.op.OpTable ;
 import org.apache.jena.sparql.core.BasicPattern ;
 import org.apache.jena.sparql.expr.Expr ;
 import org.apache.jena.sparql.expr.ExprLib;
@@ -185,7 +184,7 @@ public class PropertyFunctionGenerator
         if ( pattern == null || pattern.isEmpty() )
         {
             if ( op == null )
-                return OpTable.unit() ;
+                return OpLib.unit() ;
             return op ;
         }
         OpBGP opBGP = new OpBGP(pattern) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpQuadBlock.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpQuadBlock.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.OpVisitor;
 import org.apache.jena.sparql.algebra.Transform;
 import org.apache.jena.sparql.core.BasicPattern;
@@ -105,7 +106,7 @@ public class OpQuadBlock extends Op0
     /** Convenience - convert to OpQuadPatterns which are more widely used (currently?) */
     public Op convertOp()    {
         if ( quads.size() == 0 )
-            return  OpTable.empty();
+            return  OpLib.empty();
 
         if ( quads.size() == 1 )
         {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpTable.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpTable.java
@@ -25,16 +25,17 @@ import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 public class OpTable extends Op0
 {
+    /** Prefer {@link OpLib#unit} for a unit {@code Op}. Use this function specifically for a unit table. */
     public static OpTable unit()
     { return new OpTable(TableFactory.createUnit()); }
 
-    public static OpTable create(Table table)
-    // Check for Unit-ness?
-    { return new OpTable(table); }
-
+    /** Prefer {@link OpLib#empty} for a zero {@code Op}. Use this function specifically for a zero table. */
     public static OpTable empty()
-    // Check for Unit-ness?
     { return new OpTable(TableFactory.createEmpty()); }
+
+    public static OpTable create(Table table) {
+        return new OpTable(table);
+    }
 
     private Table table;
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterEquality.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterEquality.java
@@ -24,6 +24,7 @@ import org.apache.jena.atlas.lib.Pair ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.rdf.model.impl.Util ;
 import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.OpVars ;
 import org.apache.jena.sparql.algebra.TransformCopy ;
 import org.apache.jena.sparql.algebra.op.* ;
@@ -371,7 +372,7 @@ public class TransformFilterEquality extends TransformCopy {
     }
 
     private static Op rebuild(Op2 subOp, List<Op> ops) {
-        Op chain = OpTable.unit();
+        Op chain = OpLib.unit();
         for (Op op : ops) {
             chain = subOp.copy(chain, op);
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterImplicitJoin.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterImplicitJoin.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.apache.jena.atlas.lib.Pair;
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.OpVars ;
 import org.apache.jena.sparql.algebra.TransformCopy ;
 import org.apache.jena.sparql.algebra.op.* ;
@@ -439,7 +440,7 @@ public class TransformFilterImplicitJoin extends TransformCopy {
     }
 
     private static Op rebuild(Op2 subOp, List<Op> ops) {
-        Op chain = OpTable.unit();
+        Op chain = OpLib.unit();
         for (Op op : ops) {
             chain = subOp.copy(chain, op);
         }
@@ -470,7 +471,7 @@ public class TransformFilterImplicitJoin extends TransformCopy {
     		}
 
     		// If both sides of the union guarantee to produce errors then just replace the whole thing with table empty
-    		if (leftEmpty && rightEmpty) return OpTable.empty();
+    		if (leftEmpty && rightEmpty) return OpLib.empty();
     		if (leftEmpty) return union.getRight();
     		if (rightEmpty) return union.getLeft();
     	}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterInequality.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterInequality.java
@@ -120,7 +120,7 @@ public class TransformFilterInequality extends TransformCopy {
         // Special case : deduce that the filter will always "eval unbound"
         // hence eliminate all rows. Return the empty table.
         if (testSpecialCaseUnused(subOp, inequalities, remaining))
-            return OpTable.empty();
+            return OpLib.empty();
 
         // Special case: the deep left op of a OpConditional/OpLeftJoin is unit
         // table.
@@ -355,7 +355,7 @@ public class TransformFilterInequality extends TransformCopy {
     }
 
     private static Op rebuild(Op2 subOp, List<Op> ops) {
-        Op chain = OpTable.unit();
+        Op chain = OpLib.unit();
         for (Op op : ops) {
             chain = subOp.copy(chain, op);
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterPlacement.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterPlacement.java
@@ -24,6 +24,7 @@ import org.apache.jena.atlas.lib.Lib ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.OpVars ;
 import org.apache.jena.sparql.algebra.TransformCopy ;
 import org.apache.jena.sparql.algebra.op.* ;
@@ -851,7 +852,7 @@ public class TransformFilterPlacement extends TransformCopy {
             Set<Var> exprVars = expr.getVarsMentioned() ;
             if ( patternVarsScope.containsAll(exprVars) ) {
                 if ( op == null )
-                    op = OpTable.unit() ;
+                    op = OpLib.unit() ;
                 op = OpFilter.filter(expr, op) ;
                 iter.remove() ;
             }
@@ -878,7 +879,7 @@ public class TransformFilterPlacement extends TransformCopy {
 
         for ( Expr expr : exprs ) {
             if ( op == null )
-                op = OpTable.unit() ;
+                op = OpLib.unit() ;
             op = OpFilter.filter(expr, op) ;
         }
         return op ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterPlacementConservative.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterPlacementConservative.java
@@ -32,6 +32,7 @@ import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.OpVars ;
 import org.apache.jena.sparql.algebra.TransformCopy ;
 import org.apache.jena.sparql.algebra.op.* ;
@@ -253,7 +254,7 @@ public class TransformFilterPlacementConservative extends TransformCopy {
             Set<Var> exprVars = expr.getVarsMentioned();
             if (patternVarsScope.containsAll(exprVars)) {
                 if (op == null)
-                    op = OpTable.unit();
+                    op = OpLib.unit();
                 op = OpFilter.filter(expr, op);
                 iter.remove();
             }
@@ -269,7 +270,7 @@ public class TransformFilterPlacementConservative extends TransformCopy {
         for (Iterator<Expr> iter = exprs.iterator(); iter.hasNext();) {
             Expr expr = iter.next();
             if (op == null)
-                op = OpTable.unit();
+                op = OpLib.unit();
             op = OpFilter.filter(expr, op);
             iter.remove();
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformPattern2Join.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformPattern2Join.java
@@ -22,6 +22,7 @@ import java.util.List ;
 
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.TransformCopy ;
 import org.apache.jena.sparql.algebra.op.* ;
 import org.apache.jena.sparql.core.BasicPattern ;
@@ -52,7 +53,7 @@ public class TransformPattern2Join extends TransformCopy
     private static Op expand(BasicPattern bgp)
     {
         if ( bgp.getList().isEmpty() )
-            return OpTable.unit() ;
+            return OpLib.unit() ;
         Op op = null ;
         for ( Triple t : bgp.getList() )
         {
@@ -65,7 +66,7 @@ public class TransformPattern2Join extends TransformCopy
     private static Op expand(QuadPattern quads)
     {
         if ( quads.getList().isEmpty() )
-            return OpTable.unit() ;
+            return OpLib.unit() ;
         Op op = null ;
         for ( Quad q : quads.getList() )
         {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformPromoteTableEmpty.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformPromoteTableEmpty.java
@@ -19,6 +19,7 @@
 package org.apache.jena.sparql.algebra.optimize;
 
 import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.TransformCopy ;
 import org.apache.jena.sparql.algebra.op.* ;
 
@@ -109,7 +110,7 @@ public class TransformPromoteTableEmpty extends TransformCopy {
     public Op transform(OpJoin opJoin, Op left, Op right) {
         // If either side is table empty return table empty
         if (isTableEmpty(left) || isTableEmpty(right)) {
-            return OpTable.empty();
+            return OpLib.empty();
         }
         return super.transform(opJoin, left, right);
     }
@@ -119,7 +120,7 @@ public class TransformPromoteTableEmpty extends TransformCopy {
         // If LHS is table empty return table empty
         // If RHS is table empty can eliminate left join and just leave LHS
         if (isTableEmpty(left)) {
-            return OpTable.empty();
+            return OpLib.empty();
         } else if (isTableEmpty(right)) {
             return left;
         }
@@ -132,7 +133,7 @@ public class TransformPromoteTableEmpty extends TransformCopy {
         // If RHS is table empty can eliminate minus and just leave LHS since no
         // shared variables means no effect
         if (isTableEmpty(left)) {
-            return OpTable.empty();
+            return OpLib.empty();
         } else if (isTableEmpty(right)) {
             return left;
         }
@@ -145,7 +146,7 @@ public class TransformPromoteTableEmpty extends TransformCopy {
         // If both are table empty return table empty
         if (isTableEmpty(left)) {
             if (isTableEmpty(right)) {
-                return OpTable.empty();
+                return OpLib.empty();
             } else {
                 return right;
             }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/sse/builders/BuilderOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/sse/builders/BuilderOp.java
@@ -25,6 +25,7 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.SortCondition;
 import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.Table;
 import org.apache.jena.sparql.algebra.op.*;
 import org.apache.jena.sparql.core.*;
@@ -371,7 +372,7 @@ public class BuilderOp
 		BuilderLib.checkLength(2, 3, list, "condition");
 		Op left = build(list, 1);
 		// No second argument means unit.
-		Op right = OpTable.unit();
+		Op right = OpLib.unit();
 		if ( list.size() != 2 )
 			right  = build(list, 2);
 		Op op = new OpConditional(left, right);
@@ -573,7 +574,7 @@ public class BuilderOp
 		VarExprList x = BuilderExpr.buildNamedExprOrExprList(list.get(1));
 		Op sub;
 		if ( list.size() == 2 )
-			sub = OpTable.unit();
+			sub = OpLib.unit();
 		else
 			sub = build(list, 2);
 		return OpAssign.create(sub, x);
@@ -584,7 +585,7 @@ public class BuilderOp
 		VarExprList x = BuilderExpr.buildNamedExprOrExprList(list.get(1));
 		Op sub;
 		if ( list.size() == 2 )
-			sub = OpTable.unit();
+			sub = OpLib.unit();
 		else
 			sub = build(list, 2);
 		return OpExtend.create(sub, x);

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestAlgebraTranslate.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestAlgebraTranslate.java
@@ -24,80 +24,82 @@ import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.Query ;
 import org.apache.jena.query.QueryFactory ;
 import org.apache.jena.query.Syntax ;
+import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.sparql.syntax.*;
 import org.junit.Test ;
 
-/** Test translation of syntax to algebra - no otpimization */ 
-public class TestAlgebraTranslate 
-{    
+/** Test translation of syntax to algebra - no optimization */
+public class TestAlgebraTranslate
+{
     @Test public void translate_01() { test("?s ?p ?o", "(bgp (triple ?s ?p ?o))") ; }
-    
-    @Test public void translate_02() { test("?s ?p ?o2 . BIND(?v+1 AS ?v1)", 
+
+    @Test public void translate_02() { test("?s ?p ?o2 . BIND(?v+1 AS ?v1)",
                                             "(extend [(?v1 (+ ?v 1))]",
                                             "   (bgp [triple ?s ?p ?o2]))"
                                             ) ; }
-    
+
     @Test public void translate_03() { test("?s ?p ?o2 . LET(?v1 := ?v+1) LET(?v2 := ?v+2)",
-                                            "(assign ((?v1 (+ ?v 1)) (?v2 (+ ?v 2)))", 
+                                            "(assign ((?v1 (+ ?v 1)) (?v2 (+ ?v 2)))",
                                             "  (bgp (triple ?s ?p ?o2)))"
                                             ) ; }
 
     @Test public void translate_04() { test("?s ?p ?o2 . BIND(?v+1 AS ?v1) BIND(?v + 2 AS ?v2)",
                                             // If combining (extend) during generation.
-                                            //"(extend ((?v1 (+ ?v 1)) (?v2 (+ ?v 2)))", 
+                                            //"(extend ((?v1 (+ ?v 1)) (?v2 (+ ?v 2)))",
                                             "  (extend ((?v2 (+ ?v 2)))",
                                             "    (extend ((?v1 (+ ?v 1)))",
                                             "      (bgp (triple ?s ?p ?o2))))"
                                             ) ; }
-    
-    
+
+
     @Test public void translate_05() { test("?s ?p ?o2 BIND(?v+1 AS ?v1) LET(?v2 := ?v+2)",
-                                            "(assign ((?v2 (+ ?v 2)))", 
-                                            "  (extend ((?v1 (+ ?v 1)))", 
+                                            "(assign ((?v2 (+ ?v 2)))",
+                                            "  (extend ((?v1 (+ ?v 1)))",
                                             "    (bgp (triple ?s ?p ?o2))))"
                                             ) ; }
 
     @Test public void translate_06() { test("?s ?p ?o2 LET(?v2 := ?v+2) BIND(?v+1 AS ?v1)",
-                                            "(extend ((?v1 (+ ?v 1)))", 
-                                            "  (assign ((?v2 (+ ?v 2)))", 
+                                            "(extend ((?v1 (+ ?v 1)))",
+                                            "  (assign ((?v2 (+ ?v 2)))",
                                             "    (bgp (triple ?s ?p ?o2))))"
                                             ) ; }
 
     @Test public void translate_07() { test("{ ?s ?p ?o1 . } BIND(?v+1 AS ?v1)",
-                                            "(extend ((?v1 (+ ?v 1)))", 
-                                            "  (bgp (triple ?s ?p ?o1)) )" 
+                                            "(extend ((?v1 (+ ?v 1)))",
+                                            "  (bgp (triple ?s ?p ?o1)) )"
                                             ) ; }
 
-    @Test public void translate_08() { test("BIND(5 AS ?v1)", "(extend ((?v1 5)) [table unit])") ; } 
+    @Test public void translate_08() { test("BIND(5 AS ?v1)", "(extend ((?v1 5)) [table unit])") ; }
 
     @Test public void translate_09() { test("{ ?s ?p ?o1 . } ?s ?p ?o2 . BIND(?v+1 AS ?v1)",
                                             "(extend ((?v1 (+ ?v 1)))",
                                             "  (join",
-                                            "    (bgp (triple ?s ?p ?o1))", 
+                                            "    (bgp (triple ?s ?p ?o1))",
                                             "    (bgp (triple ?s ?p ?o2))))"
                                             ) ; }
-    
+
     @Test public void translate_10() { test("?s ?p ?o2 . ?s ?p ?o3 . BIND(?v+1 AS ?v1)",
                                             "(extend ((?v1 (+ ?v 1)))",
                                             "   [bgp (triple ?s ?p ?o2) (triple ?s ?p ?o3)])"
-                                            ) ; } 
-    
+                                            ) ; }
+
     @Test public void translate_11() { test("{ SELECT * {?s ?p ?o2}} BIND(?o+1 AS ?v1)",
                                             "(extend [(?v1 (+ ?o 1))]",
                                             "   (bgp (triple ?s ?p ?o2)))"
-                                            ) ; } 
-    
+                                            ) ; }
+
 
     @Test public void translate_20() { test("?s1 ?p ?o . ?s2 ?p ?o OPTIONAL { ?s ?p3 ?o3 . ?s ?p4 ?o4 }",
                                             "(leftjoin",
                                             "  [bgp (?s1 ?p ?o) (?s2 ?p ?o)]",
                                             "  [bgp (?s ?p3 ?o3) (?s ?p4 ?o4)] )") ; }
-                                            
+
     @Test public void translate_21() { test("?s1 ?p ?o . ?s2 ?p ?o BIND (99 AS ?z) OPTIONAL { ?s ?p3 ?o3 . ?s ?p4 ?o4 }",
                                             "(leftjoin",
                                             "  (extend ((?z 99))[bgp (?s1 ?p ?o) (?s2 ?p ?o)])",
                                             "  [bgp (?s ?p3 ?o3) (?s ?p4 ?o4)] )") ; }
-                                            
+
     @Test public void translate_22() { test("BIND (99 AS ?z) OPTIONAL { ?s ?p3 ?o3 . ?s ?p4 ?o4 }",
                                             "(leftjoin",
                                             "  (extend ((?z 99))[table unit])",
@@ -107,37 +109,93 @@ public class TestAlgebraTranslate
                                             "(leftjoin",
                                             "  [table unit]",
                                             "  [extend ((?z 99)) (table unit)] )" ) ; }
-    
+
+    // ---- Cases that can not be written in query syntax
+    // GH-2153.
+    // From Jena 3.7.0.
+    // This comment written for Jena 5.0.0.
+    //
+    // The querybuilder creates forms of the syntax tree that
+    // will not occur from the parser. In particular, it creates sub-element
+    // with no group. In SPARQL {} is a group even if it has one member.
+    // The parser does not have any smarts - it is done in the optimizer.
+    // The querybuilder can generate forms where the sub-element is directly
+    // the element that would be inside a group of one.
+    // See BuildElementVisitor.visit(ElementGroup).
+
+    @Test public void translate_80() {
+        // No group. This can be generated by querybuilder. GH-2153.
+        Element el = new ElementFilter(SSE.parseExpr("true"));
+        testElement(el, "(filter true [table unit])");
+    }
+
+    @Test public void translate_81() {
+        Element el = new ElementBind(Var.alloc("x"), SSE.parseExpr("true"));
+        testElement(el, "(extend ((?x true)) [table unit])");
+    }
+
+    @Test public void translate_82() {
+        Element el = new ElementAssign(Var.alloc("x"), SSE.parseExpr("true"));
+        testElement(el, "(assign ((?x true)) [table unit])");
+    }
+
+    @Test public void translate_83() {
+        ElementGroup elSub = new ElementGroup();
+        Element el = new ElementOptional(elSub);
+        testElement(el, "(leftjoin [table unit] [table unit])");
+    }
+
+    @Test public void translate_84() {
+        // Variant of translate_83 adding something to make the optional look different.
+        ElementGroup elSub = new ElementGroup();
+        ElementTriplesBlock etb = new ElementTriplesBlock();
+        etb.addTriple(SSE.parseTriple("(:s :p :o)"));
+        elSub.addElement(etb);
+        Element el = new ElementOptional(elSub);
+        testElement(el, "(leftjoin [table unit] (bgp (:s :p :o)))");
+    }
+
+    @Test public void translate_85() {
+        ElementGroup elSub = new ElementGroup();
+        Element el = new ElementMinus(elSub);
+        testElement(el, "(minus [table unit] [table unit])");
+    }
+
+    // ----
+
     protected AlgebraGenerator getGenerator() {
         return new AlgebraGenerator();
     }
-    
-    // Helper.  Prints the test result (check it!)
-    protected void test(String qs)
-    {
-        qs = "SELECT * {\n"+qs+"\n}" ;
-        Query query = QueryFactory.create(qs, Syntax.syntaxARQ) ;
-        Op opActual = this.getGenerator().compile(query) ;
-        String x = opActual.toString() ;
-        x = x.replaceAll("\n$", "") ;
-        x = x.replace("\n", "\", \n\"") ;
-        System.out.print('"') ;
-        System.out.print(x) ;
-        System.out.println('"') ;
-        System.out.println() ;
-    }
-    
-    
-    protected void test(String qs, String... y)
-    {
-        qs = "SELECT * {\n"+qs+"\n}" ;
-        Query query = QueryFactory.create(qs, Syntax.syntaxARQ) ;
 
-        String opStr = StrUtils.strjoinNL(y) ;
-        Op opExpected = SSE.parseOp(opStr) ;
-        Op opActual = this.getGenerator().compile(query) ;
-        assertEquals(opExpected, opActual) ;
+    // Helper. Prints the test actual Op.
+    protected void printDetails(String qs) {
+        qs = "SELECT * {\n" + qs + "\n}";
+        Query query = QueryFactory.create(qs, Syntax.syntaxARQ);
+        Op opActual = this.getGenerator().compile(query);
+        String x = opActual.toString();
+        x = x.replaceAll("\n$", "");
+        x = x.replace("\n", "\", \n\"");
+        System.out.print('"');
+        System.out.print(x);
+        System.out.println('"');
+        System.out.println();
     }
 
+    protected void test(String qs, String...y) {
+        qs = "SELECT * {\n" + qs + "\n}";
+        Query query = QueryFactory.create(qs, Syntax.syntaxARQ);
+        String opStr = StrUtils.strjoinNL(y);
+        Op opExpected = SSE.parseOp(opStr);
+        Op opActual = this.getGenerator().compile(query);
+        assertEquals(opExpected, opActual);
+    }
+
+    // Test based on an exact element structure.
+    protected void testElement(Element el, String...y) {
+        String opStr = StrUtils.strjoinNL(y);
+        Op opExpected = SSE.parseOp(opStr);
+        Op opActual = this.getGenerator().compile(el);
+        assertEquals(opExpected, opActual);
+    }
 }
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestOptimizer.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestOptimizer.java
@@ -25,9 +25,9 @@ import static org.junit.Assert.assertTrue;
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.op.OpAssign;
 import org.apache.jena.sparql.algebra.op.OpExtend;
-import org.apache.jena.sparql.algebra.op.OpTable;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.ExprVar;
@@ -272,7 +272,7 @@ public class TestOptimizer {
     }
 
     @Test public void combine_extend_01() {
-        Op extend = OpExtend.create(OpTable.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
+        Op extend = OpExtend.create(OpLib.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
         extend = OpExtend.create(extend, new VarExprList(Var.alloc("y"), new NodeValueInteger(2)));
 
         String opExpectedString = StrUtils.strjoinNL(
@@ -283,7 +283,7 @@ public class TestOptimizer {
     }
 
     @Test public void combine_extend_02() {
-        Op extend = OpExtend.create(OpTable.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
+        Op extend = OpExtend.create(OpLib.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
         extend = OpExtend.create(extend, new VarExprList(Var.alloc("y"), new ExprVar("x")));
 
         String opExpectedString = StrUtils.strjoinNL(
@@ -295,7 +295,7 @@ public class TestOptimizer {
 
     @Test public void combine_extend_03() {
         // Technically illegal SPARQL here but useful to validate that the optimizer doesn't do the wrong thing
-        Op extend = OpExtend.create(OpTable.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
+        Op extend = OpExtend.create(OpLib.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
         extend = OpExtend.create(extend, new VarExprList(Var.alloc("x"), new NodeValueInteger(2)));
 
         String opExpectedString = StrUtils.strjoinNL(
@@ -335,7 +335,7 @@ public class TestOptimizer {
 
 
     @Test public void combine_assign_01() {
-        Op assign = OpAssign.create(OpTable.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
+        Op assign = OpAssign.create(OpLib.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
         assign = OpAssign.create(assign, new VarExprList(Var.alloc("y"), new NodeValueInteger(2)));
 
         String opExpectedString = StrUtils.strjoinNL(
@@ -346,7 +346,7 @@ public class TestOptimizer {
     }
 
     @Test public void combine_assign_02() {
-        Op assign = OpAssign.create(OpTable.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
+        Op assign = OpAssign.create(OpLib.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
         assign = OpAssign.create(assign, new VarExprList(Var.alloc("y"), new ExprVar("x")));
 
         String opExpectedString = StrUtils.strjoinNL(
@@ -357,7 +357,7 @@ public class TestOptimizer {
     }
 
     @Test public void combine_assign_03() {
-        Op assign = OpAssign.create(OpTable.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
+        Op assign = OpAssign.create(OpLib.unit(), new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
         assign = OpAssign.create(assign, new VarExprList(Var.alloc("x"), new NodeValueInteger(2)));
 
         String opExpectedString = StrUtils.strjoinNL(

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformPromoteTableEmpty.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestTransformPromoteTableEmpty.java
@@ -20,10 +20,10 @@ package org.apache.jena.sparql.algebra.optimize;
 
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.Transform ;
 import org.apache.jena.sparql.algebra.Transformer ;
 import org.apache.jena.sparql.algebra.op.OpExtend ;
-import org.apache.jena.sparql.algebra.op.OpTable ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.core.VarExprList ;
 import org.apache.jena.sparql.expr.nodevalue.NodeValueInteger ;
@@ -54,7 +54,7 @@ public class TestTransformPromoteTableEmpty {
     @Test
     public void promote_table_empty_assignment_03() {
         // Force algebra to have separate extends by using extendDirect()
-        Op input = OpTable.empty();
+        Op input = OpLib.empty();
         input = OpExtend.create(input, new VarExprList(Var.alloc("x"), new NodeValueInteger(1)));
         input = OpExtend.create(input, new VarExprList(Var.alloc("y"), new NodeValueInteger(2)));
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/sse/TestSSE_Builder.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/sse/TestSSE_Builder.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.algebra.OpLib;
 import org.apache.jena.sparql.algebra.TableFactory;
 import org.apache.jena.sparql.algebra.op.OpLabel ;
 import org.apache.jena.sparql.algebra.op.OpNull ;
@@ -56,7 +57,7 @@ public class TestSSE_Builder
     @Test public void testOp_02() { opSame("(null)", OpNull.create()) ; }
     @Test public void testOp_03() { opSame("(bgp [triple ?s ?p ?o])") ; }
 
-    @Test public void testOp_04() { opSame("(label 'ABC' (table unit))", OpLabel.create("ABC", OpTable.unit())) ; }
+    @Test public void testOp_04() { opSame("(label 'ABC' (table unit))", OpLabel.create("ABC", OpLib.unit())) ; }
 
     private static void opSame(String str) {
         opSame(str, SSE.parseOp(str)) ;
@@ -249,14 +250,14 @@ public class TestSSE_Builder
 
     @Test
     public void testBuildTable_01() {
-        Op expected = OpTable.unit();
+        Op expected = OpLib.unit();
         Op actual = SSE.parseOp("(table unit)");
         assertEquals(expected, actual);
     }
 
     @Test
     public void testBuildTable_02() {
-        Op expected = OpTable.empty();
+        Op expected = OpLib.empty();
         Op actual = SSE.parseOp("(table empty)");
         assertEquals(expected, actual);
     }

--- a/jena-extras/jena-serviceenhancer/src/main/java/org/apache/jena/sparql/service/enhancer/impl/BatchQueryRewriter.java
+++ b/jena-extras/jena-serviceenhancer/src/main/java/org/apache/jena/sparql/service/enhancer/impl/BatchQueryRewriter.java
@@ -35,11 +35,8 @@ import org.apache.jena.query.Query;
 import org.apache.jena.query.SortCondition;
 import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.algebra.OpAsQuery;
-import org.apache.jena.sparql.algebra.op.OpExtend;
-import org.apache.jena.sparql.algebra.op.OpOrder;
-import org.apache.jena.sparql.algebra.op.OpSlice;
-import org.apache.jena.sparql.algebra.op.OpTable;
-import org.apache.jena.sparql.algebra.op.OpUnion;
+import org.apache.jena.sparql.algebra.OpLib;
+import org.apache.jena.sparql.algebra.op.*;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.main.QC;
@@ -141,7 +138,7 @@ public class BatchQueryRewriter {
         sortConditions.addAll(localSortConditions);
 
         if (!omitEndMarker) {
-            Op endMarker = OpExtend.create(OpTable.unit(), idxVar, NV_REMOTE_END_MARKER);
+            Op endMarker = OpExtend.create(OpLib.unit(), idxVar, NV_REMOTE_END_MARKER);
             newOp = newOp == null ? endMarker : OpUnion.create(newOp, endMarker);
         }
 


### PR DESCRIPTION
Part of #2153

Handle the non-parser case of a `ElementFilter` in the query AST which is not within a `ElementGroup`.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
