### PR TITLE
SHACL improvements: always import on cmd validation ; support ?currentShape and ?shapesGraph

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocationMapper.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/stream/LocationMapper.java
@@ -18,9 +18,9 @@
 
 package org.apache.jena.riot.system.stream;
 
-import java.util.HashMap ;
 import java.util.Iterator ;
 import java.util.Map ;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
@@ -43,9 +43,9 @@ import org.slf4j.LoggerFactory ;
 
 public class LocationMapper
 {
-    static Logger log = LoggerFactory.getLogger(LocationMapper.class)  ;
-    Map<String, String> altLocations = new HashMap<>() ;
-    Map<String, String> altPrefixes = new HashMap<>() ;
+    private static Logger log = LoggerFactory.getLogger(LocationMapper.class)  ;
+    private Map<String, String> altLocations = new ConcurrentHashMap<>() ;
+    private Map<String, String> altPrefixes = new ConcurrentHashMap<>() ;
 
     /** Create a LocationMapper with no mapping yet */
     public LocationMapper() { }

--- a/jena-cmds/src/main/java/shacl/shacl_validate.java
+++ b/jena-cmds/src/main/java/shacl/shacl_validate.java
@@ -28,6 +28,7 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RiotException;
+import org.apache.jena.shacl.Imports;
 import org.apache.jena.shacl.ShaclValidator;
 import org.apache.jena.shacl.ValidationReport;
 import org.apache.jena.shacl.engine.ValidationContext;
@@ -116,12 +117,17 @@ public class shacl_validate extends CmdGeneral {
             node = NodeFactory.createURI(x);
         }
 
+        shapesGraph = Imports.withImports(shapesfile, shapesGraph);
+
         if ( isVerbose() )
             ValidationContext.VERBOSE = true;
 
         ValidationReport report = ( node != null )
             ? ShaclValidator.get().validate(shapesGraph, dataGraph, node)
             : ShaclValidator.get().validate(shapesGraph, dataGraph);
+
+        if ( isVerbose() )
+            System.out.println();
 
         if ( textOutput )
             ShLib.printReport(report);

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/Imports.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/Imports.java
@@ -29,25 +29,36 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.jena.atlas.lib.Pair;
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.GraphUtil;
 import org.apache.jena.graph.Node;
 import org.apache.jena.irix.IRIs;
 import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFParser;
 import org.apache.jena.riot.RiotParseException;
+import org.apache.jena.riot.system.stream.LocationMapper;
+import org.apache.jena.riot.system.stream.StreamManager;
+import org.apache.jena.shacl.sys.ShaclSystem;
 import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.system.G;
 import org.apache.jena.system.RDFDataException;
+import org.apache.jena.web.HttpSC;
+import org.slf4j.Logger;
 
 /**
  * Import processing.
  * <p>
- * Imports are triggered by a base (a single triple "? rdf:type owl:Ontology")
- * and imports (triples "base owl:Imports URI").
+ * Imports are triggered by a base (a single triple "? rdf:type owl:Ontology") and
+ * imports (triples "base owl:Imports URI").
  * <p>
  * If there are other "? owl:imports ?" triples, they are ignored.
  */
 public class Imports {
+
+    public static Logger importsLogger = ShaclSystem.shaclSystemLogger;
+
     private Imports() {}
 
     /**
@@ -69,8 +80,8 @@ public class Imports {
     }
 
     /**
-     * Process and return the owl:imports closure of a graph.
-     * The graph is included in the results.
+     * Process and return the owl:imports closure of a graph. The graph is included
+     * in the results.
      */
     public static Graph withImports(String url, Graph graph) {
         url = IRIs.resolve(url);
@@ -80,8 +91,11 @@ public class Imports {
     private static Graph withImportsWorker(String url, Graph graph) {
         // Partial check for any imports. Are there any imports triples?
         boolean hasImports = G.contains(graph, null, nodeOwlImports, null);
-        if ( ! hasImports )
+        if ( !hasImports )
             return graph;
+        if ( importsLogger.isDebugEnabled() ) {
+            importsLogger.debug("Imports");
+        }
         // Probably some work to do.
         // This is "import self", and start the "visited".
         Graph acc = GraphFactory.createDefaultGraph();
@@ -97,38 +111,72 @@ public class Imports {
     private static void processImports(Set<String> visited, Graph graph, Graph acc) {
         List<Node> imports = imports(graph);
         for ( Node imported : imports ) {
-            if ( ! imported.isURI() )
+            if ( !imported.isURI() )
                 // Ignore non-URIs.
                 continue;
             String uri = imported.getURI();
-            if ( visited.contains(uri) )
+            if ( importsLogger.isDebugEnabled() )
+                importsLogger.debug("Import: " + uri);
+
+            // FmtLog.info(Imports.class, "Import: %s", uri);
+            if ( visited.contains(uri) ) {
+                if ( importsLogger.isDebugEnabled() )
+                    importsLogger.debug("Skipped: " + uri);
                 continue;
+            }
             visited.add(uri);
             // Read into a temporary graph to isolate errors.
-            try {
-                Graph g2 = RDFDataMgr.loadGraph(uri);
-                GraphUtil.addInto(acc, g2);
-                processImports(visited, g2, acc);
-            } catch (RiotParseException ex) {
-                //FmtLog.error(Imports.class, "Parse error reading '%s': %s", uri, ex.getMessage());
-                throw ex;
-            }
+            Graph g2 = loadOneGraph(uri);
+            GraphUtil.addInto(acc, g2);
+            processImports(visited, g2, acc);
+        }
+    }
+
+    private static final LocationMapper mapSHACL = new LocationMapper();
+    static {
+        // Inclusion in this list does not imply the shapes file is parseable or actually works!
+        mapSHACL.addAltEntry("http://topbraid.org/tosh",    "http://topbraid.org/tosh.ttl");
+        mapSHACL.addAltEntry("http://datashapes.org/dash",  "http://datashapes.org/dash.ttl");
+        mapSHACL.addAltEntry("https://topbraid.org/tosh",   "https://topbraid.org/tosh.ttl");
+        mapSHACL.addAltEntry("https://datashapes.org/dash", "https://datashapes.org/dash.ttl");
+        //mapSHACL.addAltEntry("http://www.w3.org/ns/shacl",  "https://www.w3.org/ns/shacl");
+    }
+
+    public static StreamManager shaclImportsStreamManager = StreamManager.get().clone();
+    static {
+        if ( ! mapSHACL.isEmpty() )
+            shaclImportsStreamManager.locationMapper(mapSHACL.clone());
+    }
+
+    private static Graph loadOneGraph(String uriOrFile) {
+        try {
+            return RDFParser.source(uriOrFile)
+                    .streamManager(shaclImportsStreamManager)
+                    .toGraph();
+        } catch (HttpException ex) {
+            if ( ex.getStatusCode() == HttpSC.NOT_FOUND_404 )
+                FmtLog.error(importsLogger, "Not found: %s", uriOrFile);
+            else
+                FmtLog.error(importsLogger, "HTTP exception: " + ex.getMessage());
+            throw ex;
+        } catch (RiotParseException ex) {
+            FmtLog.error(importsLogger, "Parse error reading '%s': %s", uriOrFile, ex.getMessage());
+            throw ex;
         }
     }
 
     /** Return the imports for a graph */
     public static List<Node> imports(Graph graph) {
-        Pair<Node,List<Node>> pair = baseAndImports(graph);
+        Pair<Node, List<Node>> pair = baseAndImports(graph);
         return pair.getRight();
     }
 
     /**
-     * Locate the base (a single triple ? rdf:type owl:Ontology)
-     * and imports (triples "base owl:Imports URI").
-     * May return null for the base in which case all imports are returned.
-     *
+     * Locate the base (a single triple ? rdf:type owl:Ontology) and imports (triples
+     * "base owl:Imports URI"). May return null for the base in which case all
+     * imports are returned.
      */
-    public static Pair<Node,List<Node>> baseAndImports(Graph graph) {
+    public static Pair<Node, List<Node>> baseAndImports(Graph graph) {
         Node base = null;
         if ( G.containsOne(graph, null, nodeRDFType, nodeOwlOntology) ) {
             base = G.getOnePO(graph, nodeRDFType, nodeOwlOntology);
@@ -138,23 +186,24 @@ public class Imports {
     }
 
     /**
-     * Locate the base (a single triple ? rdf:type owl:Ontology).
-     * If none or more than one matching triple, then return null.
+     * Locate the base (a single triple ? rdf:type owl:Ontology). If none or more
+     * than one matching triple, then return null.
      */
     public static Node base(Graph graph) {
         // Filter for URI?
         try {
             return G.getZeroOrOnePO(graph, nodeRDFType, nodeOwlOntology);
-        } catch (RDFDataException ex) { return null; }
+        } catch (RDFDataException ex) {
+            return null;
+        }
     }
 
     /**
-     * Locate any imports (triples "base owl:Imports URI").
-     * Base may be a wildcard indicating "any owl:imports".
+     * Locate any imports (triples "base owl:Imports URI"). Base may be a wildcard
+     * indicating "any owl:imports".
      */
     public static List<Node> allImports(Node base, Graph graph) {
         List<Node> imports = iter(G.listSP(graph, base, nodeOwlImports)).filter(Node::isURI).collect(Collectors.toList());
         return imports;
     }
 }
-

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/Shapes.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/Shapes.java
@@ -57,7 +57,7 @@ public class Shapes implements Iterable<Shape> {
     private final Collection<Shape> rootShapes;
     // Declared shapes, not in targetShapes.
     private final Collection<Shape> declShapes;
-    // Shapes that are not declared shapes (by type), and not accessible from in targets.
+    // Shapes that are not declared shapes (by type), and not accessible from targets.
     // This is placeholder.
     // It should be disjoint with rootShapes and declShapes.
     private final Collection<Shape> otherShapes;

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/ValidationContext.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/ValidationContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.shacl.engine;
 
+import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.riot.system.ErrorHandler;
@@ -44,8 +45,8 @@ public class ValidationContext {
     private final Graph dataGraph;
     private boolean strict = false;
     private final ValidationListener validationListener;
-
     private final ErrorHandler errorHandler;
+    private final IndentedWriter out;
 
     public static ValidationContext create(Shapes shapes, Graph data) {
         return create(shapes, data, ShaclSystem.systemShaclErrorHandler, null);
@@ -74,17 +75,19 @@ public class ValidationContext {
         this.dataGraph = vCxt.dataGraph;
         this.verbose = vCxt.verbose;
         this.strict = vCxt.strict;
-        this.errorHandler = vCxt.errorHandler;
         this.validationListener = vCxt.validationListener;
+        this.errorHandler = vCxt.errorHandler;
+        this.out = vCxt.out;
     }
 
     private ValidationContext(Shapes shapes, Graph data, ErrorHandler errorHandler, ValidationListener validationListener) {
         this.shapes = shapes;
         this.dataGraph = data;
+        this.validationListener = validationListener;
         if ( errorHandler == null )
             errorHandler = ShaclSystem.systemShaclErrorHandler;
         this.errorHandler = errorHandler;
-        this.validationListener = validationListener;
+        this.out = IndentedWriter.stdout.clone();
         validationReportBuilder.addPrefixes(data.getPrefixMapping());
         validationReportBuilder.addPrefixes(shapes.getGraph().getPrefixMapping());
     }
@@ -105,6 +108,8 @@ public class ValidationContext {
     public ValidationReport generateReport() {
         return validationReportBuilder.build();
     }
+
+    public IndentedWriter out() { return out; }
 
     public boolean hasViolation() { return seenValidationReportEntry; }
 
@@ -134,7 +139,7 @@ public class ValidationContext {
     public Graph getDataGraph() {
         return dataGraph;
     }
-    
+
     public ErrorHandler getErrorHandler() {
         return errorHandler;
     }

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JLogConstraint.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/JLogConstraint.java
@@ -49,7 +49,7 @@ public class JLogConstraint extends ConstraintTerm {
     @Override
     public ReportItem validate(ValidationContext vCxt, Node n) {
         String msg = String.format("%s[%s]", message, ShLib.displayStr(n));
-        ShaclSystem.systemShaclLogger.warn(msg);
+        ShaclSystem.shaclSystemLogger.warn(msg);
         return null;
     }
 

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Constraints.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Constraints.java
@@ -82,6 +82,7 @@ public class Constraints {
         dispatch.put( SHACL.class_,            (g, s, p, o) -> new ClassConstraint(o)    );
         dispatch.put( SHACL.datatype,          (g, s, p, o) -> new DatatypeConstraint(o) );
         dispatch.put( SHACL.nodeKind,          (g, s, p, o) -> new NodeKindConstraint(o) );
+
         dispatch.put( SHACL.minCount,          (g, s, p, o) -> new MinCount(intValue(o)) );
         dispatch.put( SHACL.maxCount,          (g, s, p, o) -> new MaxCount(intValue(o)) );
 
@@ -97,14 +98,14 @@ public class Constraints {
         dispatch.put( SHACL.languageIn,        (g, s, p, o) -> new StrLanguageIn(listString(g, o)) );
         dispatch.put( SHACL.uniqueLang,        (g, s, p, o) -> new UniqueLangConstraint(booleanValueStrict(o)) );
 
-        dispatch.put( SHACL.hasValue,          (g, s, p, o) -> new HasValueConstraint(o) );
-        dispatch.put( SHACL.in,                (g, s, p, o) -> new InConstraint(list(g,o)) );
-        dispatch.put( SHACL.closed,            (g, s, p, o) -> new ClosedConstraint(g,s,booleanValue(o)) );
-
         dispatch.put( SHACL.equals,            (g, s, p, o) -> new EqualsConstraint( checkObjectIRI(g, s, p, o)) );
         dispatch.put( SHACL.disjoint,          (g, s, p, o) -> new DisjointConstraint( checkObjectIRI(g, s, p, o)) );
         dispatch.put( SHACL.lessThan,          (g, s, p, o) -> new LessThanConstraint( checkObjectIRI(g, s, p, o)) );
         dispatch.put( SHACL.lessThanOrEquals,  (g, s, p, o) -> new LessThanOrEqualsConstraint( checkObjectIRI(g, s, p, o)) );
+
+        dispatch.put( SHACL.hasValue,          (g, s, p, o) -> new HasValueConstraint(o) );
+        dispatch.put( SHACL.in,                (g, s, p, o) -> new InConstraint(list(g,o)) );
+        dispatch.put( SHACL.closed,            (g, s, p, o) -> new ClosedConstraint(g,s,booleanValue(o)) );
 
         // Below
         //dispatch.put( SHACL.not,                (g, s, p, o) -> notImplemented(p) );
@@ -168,7 +169,6 @@ public class Constraints {
      * Constraints require more that just the triple being inspected.
      */
     private static Constraint parseConstraint(Graph g, Node s, Node p, Node o, Map<Node, Shape> parsed, Set<Node> traversed) {
-
         // Test for single triple constraints.
         ConstraintMaker maker = dispatch.get(p);
         if ( maker != null )
@@ -182,18 +182,18 @@ public class Constraints {
 
         if ( p.equals(SHACL.or) ) {
             List<Node> elts = list(g, o);
-            List<Shape> shapes = elts.stream().map(x->ShapesParser.parseShapeStep(traversed, parsed, g, x)).collect(Collectors.toList());
+            List<Shape> shapes = shapes(g, parsed, traversed, elts);
             return new ShOr(shapes);
         }
         if ( p.equals(SHACL.and) ) {
             List<Node> elts = list(g, o);
-            List<Shape> shapes = elts.stream().map(x->ShapesParser.parseShapeStep(traversed, parsed, g, x)).collect(Collectors.toList());
+            List<Shape> shapes = shapes(g, parsed, traversed, elts);
             return new ShAnd(shapes);
         }
 
         if ( p.equals(SHACL.xone) ) {
             List<Node> elts = list(g, o);
-            List<Shape> shapes = elts.stream().map(x->ShapesParser.parseShapeStep(traversed, parsed, g, x)).collect(Collectors.toList());
+            List<Shape> shapes = shapes(g, parsed, traversed, elts);
             return new ShXone(shapes);
         }
 
@@ -243,6 +243,10 @@ public class Constraints {
         return null;
     }
 
+    private static List<Shape> shapes(Graph g, Map<Node, Shape> parsed, Set<Node> traversed, List<Node> elts) {
+        return elts.stream().map(x->ShapesParser.parseShapeStep(traversed, parsed, g, x)).collect(Collectors.toList());
+    }
+
     private static Constraint parseQualifiedValueShape(Graph g, Node s, Node p, Node o, Map<Node, Shape> parsed, Set<Node> traversed) {
         Shape sub = ShapesParser.parseShapeStep(traversed, parsed, g, o);
         // [PARSE] Syntax check needed
@@ -253,7 +257,7 @@ public class Constraints {
         Node qDisjoint = G.getZeroOrOneSP(g, s, SHACL.qualifiedValueShapesDisjoint);
         if ( vMin < 0 && vMax < 0 )
             throw new ShaclParseException("At least one of sh:qualifiedMinCount and sh:qualifiedMaxCount required");
-        return new QualifiedValueShape(sub, intValue(qMin, -1), intValue(qMax, -1), booleanValueStrict(qDisjoint)) ;
+        return new QualifiedValueShape(sub, vMin, vMax, booleanValueStrict(qDisjoint)) ;
     }
 
     interface ConstraintMaker {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ShapesParser.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/ShapesParser.java
@@ -303,7 +303,7 @@ public class ShapesParser {
                 return parsed.get(shapeNode);
             // Loop detection. Do before parsing.
             if ( traversed.contains(shapeNode) ) {
-                ShaclSystem.systemShaclLogger.warn("Cycle detected : node "+ShLib.displayStr(shapeNode));
+                ShaclSystem.shaclSystemLogger.warn("Cycle detected : node "+ShLib.displayStr(shapeNode));
                 // Put in a substitute shape.
                 return unshape(shapesGraph, shapeNode);
             }

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/sys/ShaclSystem.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/sys/ShaclSystem.java
@@ -26,14 +26,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ShaclSystem {
-    public static Logger systemShaclLogger = LoggerFactory.getLogger("SHACL"); 
-    public static ErrorHandler systemShaclErrorHandler = ErrorHandlerFactory.errorHandlerStd(systemShaclLogger);
-    
+    public static Logger shaclSystemLogger = LoggerFactory.getLogger("org.apache.jena.shacl.SHACL");
+    public static ErrorHandler systemShaclErrorHandler = ErrorHandlerFactory.errorHandlerStd(shaclSystemLogger);
+
     private static ShaclValidator globalDefault = new ShaclPlainValidator();
-    
+
     /** Set the current system-wide {@link ShaclValidator}. */
     public static void set(ShaclValidator validator) { globalDefault = validator; }
 
-    /** The current system-wide {@link ShaclValidator}. */ 
+    /** The current system-wide {@link ShaclValidator}. */
     public static ShaclValidator get() { return globalDefault; }
 }

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/validation/VLib.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/validation/VLib.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.atlas.lib.InternalErrorException;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
@@ -85,13 +84,12 @@ public class VLib {
     * graphs that were used to construct the shapes graph or the data graph. SHACL
     * processing is thus idempotent.
     */
-    private static IndentedWriter out  = IndentedWriter.clone(IndentedWriter.stdout);
-
     public static void validateShape(ValidationContext vCxt, Graph data, Shape shape, Node focusNode) {
         if ( shape.deactivated() )
             return;
+        vCxt.out().incIndent();
         if ( vCxt.isVerbose() )
-            out.println("S: "+shape);
+            vCxt.out().println("S: "+shape);
         vCxt.notifyValidationListener(() -> new FocusNodeValidationStartedEvent(vCxt, shape, focusNode));
         Path path;
         Set<Node> vNodes;
@@ -104,22 +102,23 @@ public class VLib {
             vCxt.notifyValidationListener(() -> new ValueNodesDeterminedForPropertyShapeEvent(vCxt, shape, focusNode, path, vNodes));
         } else {
             if ( vCxt.isVerbose() )
-                out.println("Z: "+shape);
+                vCxt.out().println("Z: "+shape);
             return;
         }
 
         // Constraints of this shape.
         for ( Constraint c : shape.getConstraints() ) {
+            vCxt.out().incIndent();
             if ( vCxt.isVerbose() )
-                out.println("C: "+c);
+                vCxt.out().println("C: "+c);
             evalConstraint(vCxt, data, shape, focusNode, path, vNodes, c);
+            vCxt.out().decIndent();
         }
 
         // Reachable shapes.
         // Follow sh:property (sh:node behaves as a constraint).
         validationPropertyShapes(vCxt, data, shape.getPropertyShapes(), focusNode);
-        if ( vCxt.isVerbose() )
-            out.println();
+        vCxt.out().decIndent();
         vCxt.notifyValidationListener(() -> new FocusNodeValidationFinishedEvent(vCxt, shape, focusNode));
     }
 
@@ -138,16 +137,18 @@ public class VLib {
         if ( propertyShape.deactivated() )
             return;
         if ( vCxt.isVerbose() )
-            out.println("P: "+propertyShape);
+            vCxt.out().println("P: "+propertyShape);
         vCxt.notifyValidationListener(() -> new FocusNodeValidationStartedEvent(vCxt, propertyShape, focusNode));
         Path path = propertyShape.getPath();
         Set<Node> vNodes = ShaclPaths.valueNodes(data, focusNode, path);
         vCxt.notifyValidationListener(() -> new ValueNodesDeterminedForPropertyShapeEvent(vCxt, propertyShape, focusNode, path, vNodes));
         for ( Constraint c : propertyShape.getConstraints() ) {
+            vCxt.out().incIndent();
             if ( vCxt.isVerbose() )
-                out.println("C: "+focusNode+" :: "+c);
+                vCxt.out().println("C: "+focusNode+" :: "+c);
             // Pass vNodes here.
             evalConstraint(vCxt, data, propertyShape, focusNode, path, vNodes, c);
+            vCxt.out().decIndent();
         }
         vNodes.forEach(vNode->{
             validationPropertyShapes(vCxt, data, propertyShape.getPropertyShapes(), vNode);

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/vocabulary/SHACL.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/vocabulary/SHACL.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.shacl.vocabulary;
 
+import java.util.Set;
+
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 
@@ -831,4 +833,26 @@ public class SHACL {
     public static final Node XoneConstraintComponent = createResource( "http://www.w3.org/ns/shacl#XoneConstraintComponent" );
 
     public static final Node XoneConstraintComponent_xone = createResource( "http://www.w3.org/ns/shacl#XoneConstraintComponent-xone" );
+
+    /** Set of all the constraint components in SHACL 1.0 Core and SPARQL : 32 items */
+    public static final Set<Node> allStdConstraintComponents;
+
+    static {
+        // Not including ConstraintComponent which is the class of constraint components
+        Node arrayAllConstraintComponents[] = {
+            AndConstraintComponent, ClassConstraintComponent, ClosedConstraintComponent, DatatypeConstraintComponent,
+            DisjointConstraintComponent, EqualsConstraintComponent, ExpressionConstraintComponent, HasValueConstraintComponent,
+            InConstraintComponent, JSConstraintComponent, LanguageInConstraintComponent,
+            LessThanConstraintComponent, LessThanOrEqualsConstraintComponent,
+            MaxCountConstraintComponent, MaxExclusiveConstraintComponent,
+            MaxInclusiveConstraintComponent, MaxLengthConstraintComponent,
+            MinCountConstraintComponent, MinExclusiveConstraintComponent,
+            MinInclusiveConstraintComponent, MinLengthConstraintComponent,
+            NodeConstraintComponent, NodeKindConstraintComponent,
+            NotConstraintComponent, OrConstraintComponent, PatternConstraintComponent, PropertyConstraintComponent,
+            QualifiedMaxCountConstraintComponent, QualifiedMinCountConstraintComponent, SPARQLConstraintComponent,
+            UniqueLangConstraintComponent, XoneConstraintComponent
+        };
+        allStdConstraintComponents = Set.of(arrayAllConstraintComponents);
+    }
 }

--- a/jena-shacl/src/test/files/local/manifest.ttl
+++ b/jena-shacl/src/test/files/local/manifest.ttl
@@ -7,6 +7,10 @@ PREFIX sh: <http://www.w3.org/ns/shacl#>
 PREFIX sht: <http://www.w3.org/ns/shacl-test#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
+## Not all the test are controlled by manifest because they
+## test features not easily captured in a single test file.
+## e.g. split shapes and data
+
 <>
   rdf:type mf:Manifest ;
   mf:include <additional/lang-simple-1.ttl> ;

--- a/jena-shacl/src/test/files/local/other/sparql-vars-001-data.ttl
+++ b/jena-shacl/src/test/files/local/other/sparql-vars-001-data.ttl
@@ -1,0 +1,10 @@
+PREFIX : <http://example/>
+
+:testDataSubject1 :p1 1 .
+   
+:testDataSubject2 :p1 2 .
+
+:testDataSubject3 :p2 1 .
+
+:testDataSubject3 :p2 2 .
+

--- a/jena-shacl/src/test/files/local/other/sparql-vars-001-results.ttl
+++ b/jena-shacl/src/test/files/local/other/sparql-vars-001-results.ttl
@@ -1,0 +1,18 @@
+PREFIX :     <http://example/>
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh:   <http://www.w3.org/ns/shacl#>
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+[ rdf:type     sh:ValidationReport;
+  sh:conforms  false;
+  sh:result    [ rdf:type                      sh:ValidationResult;
+                 sh:focusNode                  :testDataSubject1;
+                 sh:resultMessage              "Property-value pair (<http://example/p1> 1) found";
+                 sh:resultPath                 :p1;
+                 sh:resultSeverity             sh:Violation;
+                 sh:sourceConstraintComponent  sh:SPARQLConstraintComponent;
+                 sh:sourceShape                <file:///home/afs/ASF/jena5/jena-shacl/src/test/files/local/other/sparql-vars-001-shape.ttl#PropertyValueShape>;
+                 sh:value                      1
+               ]
+] .

--- a/jena-shacl/src/test/files/local/other/sparql-vars-001-shape.ttl
+++ b/jena-shacl/src/test/files/local/other/sparql-vars-001-shape.ttl
@@ -1,0 +1,35 @@
+# Test ?currentShape and ?shapesGraph
+
+PREFIX :      <http://example/>
+PREFIX rdf:       <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX sh:        <http://www.w3.org/ns/shacl#>
+## PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>
+
+
+<#prefixes>
+  sh:declare [ sh:prefix "ex";     sh:namespace "http://example/" ] ;
+  .
+
+<#PropertyValueShape>
+  rdf:type sh:NodeShape ;
+
+  sh:targetNode :testDataSubject1 ;
+  sh:targetNode :testDataSubject2 ;
+  sh:targetNode :testDataSubject3 ;
+  sh:targetNode :testDataSubject4 ;
+
+  sh:labelTemplate "Test for absence of a property-value pair, using SPARQL" ;
+  sh:prefixes <#prefixes> ;
+  # Target must not have this pair.
+  :propertyValue ( :p1 1 ) ;
+  sh:sparql [ 
+      sh:message "Property-value pair ({?path} {?value}) found" ;
+      sh:prefixes <#prefixes> ;
+      sh:select """
+		SELECT ?this (?property AS ?path) ?value {
+            GRAPH ?shapesGraph { ?currentShape ex:propertyValue ( ?property ?value ) }
+ 			?this ?property ?value .
+ 		}
+""" ;
+    ] ;
+.

--- a/jena-shacl/src/test/files/std/sparql/pre-binding/manifest.ttl
+++ b/jena-shacl/src/test/files/std/sparql/pre-binding/manifest.ttl
@@ -14,8 +14,7 @@
 ## 	mf:include <pre-binding-006.ttl> ;
 	mf:include <pre-binding-007.ttl> ;
     
-    # $shapesGraph not supported.
-## 	mf:include <shapesGraph-001.ttl> ;
+ 	mf:include <shapesGraph-001.ttl> ;
 
     # MINUS
 ## 	mf:include <unsupported-sparql-001.ttl> ;

--- a/jena-shacl/src/test/java/org/apache/jena/shacl/TC_SHACL.java
+++ b/jena-shacl/src/test/java/org/apache/jena/shacl/TC_SHACL.java
@@ -22,6 +22,7 @@ import org.apache.jena.shacl.compact.TS_Compact;
 import org.apache.jena.shacl.tests.TestImports;
 import org.apache.jena.shacl.tests.TestValidationReport;
 import org.apache.jena.shacl.tests.ValidationListenerTests;
+import org.apache.jena.shacl.tests.jena_shacl.JenaShaclTestsByCode;
 import org.apache.jena.shacl.tests.jena_shacl.TS_JenaShacl;
 import org.apache.jena.shacl.tests.std.TS_StdSHACL;
 import org.junit.runner.RunWith;
@@ -35,6 +36,7 @@ import org.junit.runners.Suite;
     , TS_Compact.class
     , TestImports.class
     , ValidationListenerTests.class
+    , JenaShaclTestsByCode.class
 } )
 
 public class TC_SHACL { }

--- a/jena-shacl/src/test/java/org/apache/jena/shacl/tests/jena_shacl/JenaShaclTestsByCode.java
+++ b/jena-shacl/src/test/java/org/apache/jena/shacl/tests/jena_shacl/JenaShaclTestsByCode.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.shacl.tests.jena_shacl;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.PrintStream;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.RDFWriter;
+import org.apache.jena.shacl.ShaclValidator;
+import org.apache.jena.sparql.util.IsoMatcher;
+import org.junit.Test;
+
+public class JenaShaclTestsByCode {
+    static final String DIR = "src/test/files/local/other/";
+    @Test public void sparql_vars_001() {
+        execTest("sparql-vars-001",
+                 DIR+"sparql-vars-001-data.ttl",
+                 DIR+"sparql-vars-001-shape.ttl",
+                 DIR+"sparql-vars-001-results.ttl");
+
+    }
+
+    private void execTest(String label, String datafile, String shapesfile, String expectedResults) {
+        Graph data = load(datafile) ;
+        Graph shapes = load(shapesfile) ;
+        Graph expected = load(expectedResults);
+
+        Graph actual = ShaclValidator.get().validate(shapes, data).getGraph();
+
+        boolean checkResults = IsoMatcher.isomorphic(expected, actual);
+        if ( ! checkResults ) {
+            PrintStream out = System.out;
+            out.println("==== Failure: "+label);
+            if ( false ) {
+                // Very verbose : enable for development/debugging!
+                out.println("== Data:");
+                write(out, data);
+                out.println("== Shapes:");
+                write(out, shapes);
+            }
+            out.println("== Expected:");
+            write(out, expected);
+            out.println("== Actual:");
+            write(out, actual);
+        }
+        assertTrue(checkResults);
+    }
+
+    private Graph load(String file) {
+        return RDFParser.source(file).toGraph();
+    }
+
+    private void write(PrintStream out, Graph graph) {
+        RDFWriter.source(graph).lang(Lang.TTL).output(out);
+    }
+
+}


### PR DESCRIPTION
This resolves #2157
This resolves #2158

Commit "Support ?currentShape and ?shapesGraph" helps with DASH. There are several different dash.ttl around.The datashape/dash on the web redefines spec-standard shapes leading to multiple validators for the same feature (e.g `sh:closed`).

A `StreamManager` for imports is provided to enable applications to use their own customized subsets of de-facto shared shapes libraries.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
