### PR TITLE
GH-2219 : Check for existence of Z axis and measure to avoid exception when neither is available

### DIFF
--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/jts/CustomCoordinateSequence.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/jts/CustomCoordinateSequence.java
@@ -394,7 +394,14 @@ public class CustomCoordinateSequence implements CoordinateSequence, Serializabl
     public void getCoordinate(int index, Coordinate coord) {
         coord.setX(x[index]);
         coord.setY(y[index]);
-        coord.setZ(z[index]);
+
+        if (spatialDimension > 2) {
+            coord.setZ(z[index]);
+        }
+
+        if (measuresDimension == 1) {
+            coord.setM(m[index]);
+        }
     }
 
     @Override

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/jts/CustomCoordinateSequenceTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/jts/CustomCoordinateSequenceTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.jena.geosparql.implementation.jts;
 
 import org.junit.*;
@@ -83,3 +100,5 @@ public class CustomCoordinateSequenceTest {
         assertEquals(2.0, coord.getM(), 0.001);
     }
 }
+
+

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/jts/CustomCoordinateSequenceTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/jts/CustomCoordinateSequenceTest.java
@@ -1,0 +1,85 @@
+package org.apache.jena.geosparql.implementation.jts;
+
+import org.junit.*;
+import org.locationtech.jts.geom.*;
+
+import static org.junit.Assert.*;
+
+public class CustomCoordinateSequenceTest {
+
+    public CustomCoordinateSequenceTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testGetCoordinate_2DSpatial_0DMeasure() {
+        CustomCoordinateSequence sequence = new CustomCoordinateSequence(CoordinateSequenceDimensions.XY, "1 1, 2 2, 3 3");
+        Coordinate coord = new CoordinateXY();
+        int index = 1;
+
+        sequence.getCoordinate(index, coord);
+
+        assertEquals(2.0, coord.getX(), 0.001);
+        assertEquals(2.0, coord.getY(), 0.001);
+        assertTrue(Double.isNaN(coord.getZ()));
+        assertTrue(Double.isNaN(coord.getM()));
+    }
+
+    @Test
+    public void testGetCoordinate_3DSpatial_0DMeasure() {
+        CustomCoordinateSequence sequence = new CustomCoordinateSequence(CoordinateSequenceDimensions.XYZ, "1 1 1, 2 2 2, 3 3 3");
+        Coordinate coord = new Coordinate();
+        int index = 1;
+
+        sequence.getCoordinate(index, coord);
+
+        assertEquals(2.0, coord.getX(), 0.001);
+        assertEquals(2.0, coord.getY(), 0.001);
+        assertEquals(2.0, coord.getZ(), 0.001);
+        assertTrue(Double.isNaN(coord.getM()));
+    }
+
+    @Test
+    public void testGetCoordinate_3DSpatial_1DMeasure() {
+        CustomCoordinateSequence sequence = new CustomCoordinateSequence(CoordinateSequenceDimensions.XYZM, "1 1 1 1, 2 2 2 2, 3 3 3 3");
+        System.out.println(sequence);
+        Coordinate coord = new CoordinateXYZM();
+        int index = 1;
+
+        sequence.getCoordinate(index, coord);
+
+        assertEquals(2.0, coord.getX(), 0.001);
+        assertEquals(2.0, coord.getY(), 0.001);
+        assertEquals(2.0, coord.getZ(), 0.001);
+        assertEquals(2.0, coord.getM(), 0.001);
+    }
+
+    @Test
+    public void testGetCoordinate_2DSpatial_1DMeasure() {
+        CustomCoordinateSequence sequence = new CustomCoordinateSequence(CoordinateSequenceDimensions.XYM, "1 1 1, 2 2 2, 3 3 3");
+        Coordinate coord = new CoordinateXYM();
+        int index = 1;
+
+        sequence.getCoordinate(index, coord);
+
+        assertEquals(2.0, coord.getX(), 0.001);
+        assertEquals(2.0, coord.getY(), 0.001);
+        assertTrue(Double.isNaN(coord.getZ()));
+        assertEquals(2.0, coord.getM(), 0.001);
+    }
+}


### PR DESCRIPTION
GitHub issue resolved #2219

Pull request Description:
Does fix an issue when Z axis isn't available.


----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
