### PR TITLE
Don't fail test on bind failure of the default port

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -147,6 +147,16 @@ public class FusekiServer {
         return new Builder(serviceDispatchRegistry);
     }
 
+    /**
+     * Default port when running in Java via {@code FusekiServer....build()}.
+     * The server will be http://localhost:3330.
+     *
+     * This is not the command line port (3030) which the command line programme sets.
+     *
+     * See {@link FusekiMain#defaultPort} and {@link FusekiMain#defaultHttpsPort}.
+     */
+    public static final int DefaultServerPort  = 3330;
+
     private final Server server;
     private int httpPort;
     private int httpsPort;
@@ -375,7 +385,6 @@ public class FusekiServer {
 
     /** FusekiServer.Builder */
     public static class Builder {
-        private static final int DefaultServerPort  = 3330;
         private static final int PortUnset          = -2;
         private static final int PortInactive       = -3;
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -64,8 +64,10 @@ import org.apache.jena.tdb1.transaction.TransactionManager;
 import org.slf4j.Logger;
 
 public class FusekiMain extends CmdARQ {
-    private static int defaultPort          = 3030;
-    private static int defaultHttpsPort     = 3043;
+    /** Default HTTP port when running from the command line. */
+    public static int defaultPort          = 3030;
+    /** Default HTTPS port when running from the command line. */
+    public static int defaultHttpsPort     = 3043;
 
     private static ArgDecl  argMem          = new ArgDecl(ArgDecl.NoValue,  "mem");
     private static ArgDecl  argUpdate       = new ArgDecl(ArgDecl.NoValue,  "update", "allowUpdate");


### PR DESCRIPTION
Make the tests a little easier to use for developers.

The "default port" tests might clash with other use of Fuseki on the same machine.

---

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
