### PR TITLE
docs(Literal): adopt docstring to fit the behaviour of `getString()`

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/rdf/model/Literal.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/Literal.java
@@ -163,11 +163,8 @@ public interface Literal extends RDFNode {
 
     /**
      * If the literal is interpretable as a string return its value.
-     * For typed literals this will throw an error for non string
-     * literals and one needs to use getLexicalForm to return the
-     * string form of other datatypes.
      *
-     * @return the literal string
+     * @return the literal string or its lexical value
      */
     public String getString() ;
 


### PR DESCRIPTION
GitHub issue resolved #2248 

Pull request Description:



----

 - [ ] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
