### PR TITLE
GH-2233: Improved handling of specifically set HTTP headers in RDFLinkHTTP

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/sys/ExecHTTPBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/sys/ExecHTTPBuilder.java
@@ -109,7 +109,7 @@ public abstract class ExecHTTPBuilder<X, Y> {
     }
 
     /** Set the query */
-    private void setQuery(Query query, String queryStr) {
+    protected void setQuery(Query query, String queryStr) {
         this.query = query;
         this.queryString = queryStr;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTP.java
@@ -147,6 +147,11 @@ public class QueryExecHTTP implements QueryExec {
         this.httpClient = HttpLib.dft(httpClient, HttpEnv.getDftHttpClient());
     }
 
+    /** Getter for the appProvidedAcceptHeader. Only used for testing. */
+    public String getAppProvidedAcceptHeader() {
+        return appProvidedAcceptHeader;
+    }
+
     /** The Content-Type response header received (null before the remote operation is attempted). */
     public String getHttpResponseContentType() {
         return httpResponseContentType;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTPBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTPBuilder.java
@@ -36,7 +36,7 @@ public class QueryExecHTTPBuilder extends ExecHTTPBuilder<QueryExecHTTP, QueryEx
 
     public static QueryExecHTTPBuilder service(String serviceURL) { return create().endpoint(serviceURL); }
 
-    private QueryExecHTTPBuilder() {}
+    protected QueryExecHTTPBuilder() {}
 
     @Override
     protected QueryExecHTTPBuilder thisBuilder() {

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkHTTP.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkHTTP.java
@@ -109,4 +109,12 @@ public class TestRDFLinkHTTP extends AbstractTestRDFLink {
             }
         }
     }
+
+    @Test(expected = QueryParseException.class)
+    public void non_standard_syntax_3() {
+        RDFLink link = link(true);
+        try (link) {
+            link.query("custom");
+        }
+    }
 }

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemoteBuilder.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionRemoteBuilder.java
@@ -28,6 +28,8 @@ import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.riot.RiotException;
+import org.apache.jena.sparql.exec.http.QuerySendMode;
+import org.apache.jena.sparql.exec.http.UpdateSendMode;
 
 /** Builder class for {@link RDFConnectionRemote} */
 
@@ -102,7 +104,7 @@ public class RDFConnectionRemoteBuilder {
      * Use null for "none".
      */
     public RDFConnectionRemoteBuilder gspEndpoint(String sGSP) {
-		builder.gspEndpoint(sGSP);
+        builder.gspEndpoint(sGSP);
         return this;
     }
 
@@ -115,7 +117,7 @@ public class RDFConnectionRemoteBuilder {
 
     /** Set the {@link HttpClient} for the connection to be built */
     public RDFConnectionRemoteBuilder httpClient(HttpClient httpClient) {
-		builder.httpClient(httpClient);
+        builder.httpClient(httpClient);
         return this;
     }
 
@@ -124,7 +126,7 @@ public class RDFConnectionRemoteBuilder {
      * This must be a quads format.
      */
     public RDFConnectionRemoteBuilder quadsFormat(RDFFormat fmtQuads) {
-		builder.quadsFormat(fmtQuads);
+        builder.quadsFormat(fmtQuads);
         return this;
     }
 
@@ -134,7 +136,7 @@ public class RDFConnectionRemoteBuilder {
      * This must be a quads format.
      */
     public RDFConnectionRemoteBuilder quadsFormat(Lang langQuads) {
-		builder.quadsFormat(langQuads);
+        builder.quadsFormat(langQuads);
         return this;
     }
 
@@ -143,7 +145,7 @@ public class RDFConnectionRemoteBuilder {
      * This must be a quads format.
      */
     public RDFConnectionRemoteBuilder quadsFormat(String langQuads) {
-		builder.quadsFormat(langQuads);
+        builder.quadsFormat(langQuads);
         return this;
     }
 
@@ -151,7 +153,7 @@ public class RDFConnectionRemoteBuilder {
      * This is used for the SPARQ Graph Store Protocol.
      */
     public RDFConnectionRemoteBuilder triplesFormat(RDFFormat fmtTriples) {
-		builder.triplesFormat(fmtTriples);
+        builder.triplesFormat(fmtTriples);
         return this;
     }
 
@@ -159,7 +161,7 @@ public class RDFConnectionRemoteBuilder {
      * This is used for the SPARQ Graph Store Protocol.
      */
     public RDFConnectionRemoteBuilder triplesFormat(Lang langTriples) {
-		builder.triplesFormat(langTriples);
+        builder.triplesFormat(langTriples);
         return this;
     }
 
@@ -167,7 +169,7 @@ public class RDFConnectionRemoteBuilder {
      * This is used for the SPARQ Graph Store Protocol.
      */
     public RDFConnectionRemoteBuilder triplesFormat(String langTriples) {
-		builder.triplesFormat(langTriples);
+        builder.triplesFormat(langTriples);
         Lang lang = RDFLanguages.nameToLang(langTriples);
         if ( lang == null )
             throw new RiotException("Language name not recognized: "+langTriples);
@@ -177,25 +179,25 @@ public class RDFConnectionRemoteBuilder {
 
     /** Set the HTTP {@code Accept:} header used to fetch RDF graph using the SPARQL Graph Store Protocol. */
     public RDFConnectionRemoteBuilder acceptHeaderGraph(String acceptGraph) {
-		builder.acceptHeaderGraph(acceptGraph);
+        builder.acceptHeaderGraph(acceptGraph);
         return this;
     }
 
     /** Set the HTTP {@code Accept:} header used to fetch RDF datasets using HTTP GET operations. */
     public RDFConnectionRemoteBuilder acceptHeaderDataset(String acceptDataset) {
-		builder.acceptHeaderDataset(acceptDataset);
+        builder.acceptHeaderDataset(acceptDataset);
         return this;
     }
 
     /** Set the HTTP {@code Accept:} header used to when making a SPARQL Protocol SELECT query. */
     public RDFConnectionRemoteBuilder acceptHeaderSelectQuery(String acceptSelectHeader) {
-		builder.acceptHeaderSelectQuery(acceptSelectHeader);
+        builder.acceptHeaderSelectQuery(acceptSelectHeader);
         return this;
     }
 
     /** Set the HTTP {@code Accept:} header used to when making a SPARQL Protocol ASK query. */
     public RDFConnectionRemoteBuilder acceptHeaderAskQuery(String acceptAskHeader) {
-		builder.acceptHeaderAskQuery(acceptAskHeader);
+        builder.acceptHeaderAskQuery(acceptAskHeader);
         return this;
     }
 
@@ -203,7 +205,7 @@ public class RDFConnectionRemoteBuilder {
      * SPARQL Protocol query if no query type specific setting available.
      */
     public RDFConnectionRemoteBuilder acceptHeaderQuery(String acceptHeader) {
-		builder.acceptHeaderQuery(acceptHeader);
+        builder.acceptHeaderQuery(acceptHeader);
         return this;
     }
 
@@ -211,7 +213,25 @@ public class RDFConnectionRemoteBuilder {
      * Set the flag for whether to check SPARQL queries and SPARQL updates provided as a string.
      */
     public RDFConnectionRemoteBuilder parseCheckSPARQL(boolean parseCheck) {
-		builder.parseCheckSPARQL(parseCheck);
+        builder.parseCheckSPARQL(parseCheck);
+        return this;
+    }
+
+    /**
+     * Set the strategy that determines how to send a query over HTTP.
+     * See {@link QuerySendMode}.
+     */
+    public RDFConnectionRemoteBuilder querySendMode(QuerySendMode sendMode) {
+        builder.querySendMode(sendMode);
+        return this;
+    }
+
+    /**
+     * Set the strategy that determines how to send an update request over HTTP.
+     * See {@link UpdateSendMode}.
+     */
+    public RDFConnectionRemoteBuilder updateSendMode(UpdateSendMode sendMode) {
+        builder.updateSendMode(sendMode);
         return this;
     }
 

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkFuseki.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkFuseki.java
@@ -20,11 +20,12 @@ package org.apache.jena.rdflink;
 
 import java.net.http.HttpClient;
 
-import org.apache.jena.rdflink.RDFLinkFuseki;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.riot.resultset.ResultSetLang;
 import org.apache.jena.sparql.core.Transactional;
+import org.apache.jena.sparql.exec.http.QuerySendMode;
+import org.apache.jena.sparql.exec.http.UpdateSendMode;
 
 /**
  * Implementation of the {@link RDFLink} interface for connecting to an Apache Jena Fuseki.
@@ -87,19 +88,22 @@ public class RDFLinkFuseki extends RDFLinkHTTP {
             base.outputQuads, base.outputTriples,
             base.acceptDataset, base.acceptGraph,
             base.acceptSparqlResults, base.acceptSelectResult, base.acceptAskResult,
-            base.parseCheckQueries, base.parseCheckUpdates);
+            base.parseCheckQueries, base.parseCheckUpdates,
+            base.querySendMode, base.updateSendMode);
     }
 
     protected RDFLinkFuseki(Transactional txnLifecycle, HttpClient httpClient, String destination,
                             String queryURL, String updateURL, String gspURL, RDFFormat outputQuads, RDFFormat outputTriples,
                             String acceptDataset, String acceptGraph,
                             String acceptSparqlResults, String acceptSelectResult, String acceptAskResult,
-                            boolean parseCheckQueries, boolean parseCheckUpdates) {
+                            boolean parseCheckQueries, boolean parseCheckUpdates,
+                            QuerySendMode querySendMode, UpdateSendMode updateSendMode) {
         super(txnLifecycle, httpClient,
               destination, queryURL, updateURL, gspURL,
               outputQuads, outputTriples,
               acceptDataset, acceptGraph,
-              acceptSparqlResults, acceptSelectResult, acceptAskResult, parseCheckQueries, parseCheckUpdates);
+              acceptSparqlResults, acceptSelectResult, acceptAskResult, parseCheckQueries, parseCheckUpdates,
+              querySendMode, updateSendMode);
     }
 
     // Fuseki specific operations.

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTP.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTP.java
@@ -39,7 +39,9 @@ import org.apache.jena.sparql.exec.http.DSP;
 import org.apache.jena.sparql.exec.http.GSP;
 import org.apache.jena.sparql.exec.http.QueryExecHTTP;
 import org.apache.jena.sparql.exec.http.QueryExecHTTPBuilder;
+import org.apache.jena.sparql.exec.http.QuerySendMode;
 import org.apache.jena.sparql.exec.http.UpdateExecHTTPBuilder;
+import org.apache.jena.sparql.exec.http.UpdateSendMode;
 import org.apache.jena.sparql.util.Context;
 import org.apache.jena.system.Txn;
 import org.apache.jena.update.UpdateFactory;
@@ -79,6 +81,9 @@ public class RDFLinkHTTP implements RDFLink {
     // Whether to check SPARQL updates given as strings by parsing them.
     protected final boolean parseCheckUpdates;
 
+    protected final QuerySendMode querySendMode;
+    protected final UpdateSendMode updateSendMode;
+
     /** Create a {@link RDFLinkHTTPBuilder}. */
     public static RDFLinkHTTPBuilder newBuilder() {
         return new RDFLinkHTTPBuilder();
@@ -103,7 +108,8 @@ public class RDFLinkHTTP implements RDFLink {
                           String acceptDataset, String acceptGraph,
                           String acceptSparqlResults,
                           String acceptSelectResult, String acceptAskResult,
-                          boolean parseCheckQueries, boolean parseCheckUpdates) {
+                          boolean parseCheckQueries, boolean parseCheckUpdates,
+                          QuerySendMode querySendMode, UpdateSendMode updateSendMode) {
         // Any defaults.
         HttpClient hc =  httpClient!=null ? httpClient : HttpEnv.getDftHttpClient();
         if ( txnLifecycle == null )
@@ -124,6 +130,8 @@ public class RDFLinkHTTP implements RDFLink {
         this.acceptAskResult = acceptAskResult;
         this.parseCheckQueries = parseCheckQueries;
         this.parseCheckUpdates = parseCheckUpdates;
+        this.querySendMode = querySendMode;
+        this.updateSendMode = updateSendMode;
     }
 
     @Override
@@ -365,7 +373,7 @@ public class RDFLinkHTTP implements RDFLink {
     private QueryExecHTTPBuilderOverRDFLinkHTTP createQExecBuilder() {
         checkQuery();
         QueryExecHTTPBuilderOverRDFLinkHTTP builder = new QueryExecHTTPBuilderOverRDFLinkHTTP();
-        builder.endpoint(svcQuery).httpClient(httpClient);
+        builder.endpoint(svcQuery).httpClient(httpClient).sendMode(querySendMode);
         return builder;
     }
 
@@ -376,7 +384,6 @@ public class RDFLinkHTTP implements RDFLink {
             sBuff.append(", ");
         sBuff.append(acceptString);
     }
-
 
     /**
      * Return a {@link UpdateExecBuilder} that is initially configured for this link
@@ -392,7 +399,8 @@ public class RDFLinkHTTP implements RDFLink {
 
     /** Create a builder, configured with the link setup. */
     private UpdateExecHTTPBuilder createUExecBuilder() {
-        return UpdateExecHTTPBuilder.create().endpoint(svcUpdate).httpClient(httpClient);
+        return UpdateExecHTTPBuilder.create().endpoint(svcUpdate).httpClient(httpClient)
+                .sendMode(updateSendMode);
     }
 
     @Override

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTPBuilder.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTPBuilder.java
@@ -25,10 +25,11 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.apache.jena.http.HttpEnv;
-import org.apache.jena.rdflink.RDFLinkHTTPBuilder;
 import org.apache.jena.riot.*;
 import org.apache.jena.sparql.core.Transactional;
 import org.apache.jena.sparql.core.TransactionalLock;
+import org.apache.jena.sparql.exec.http.QuerySendMode;
+import org.apache.jena.sparql.exec.http.UpdateSendMode;
 
 /** Builder class for {@link RDFLinkHTTP} */
 public class RDFLinkHTTPBuilder {
@@ -61,6 +62,9 @@ public class RDFLinkHTTPBuilder {
     protected boolean       parseCheckQueries   = true;
     protected boolean       parseCheckUpdates   = true;
 
+    protected QuerySendMode  querySendMode      = QuerySendMode.systemDefault;
+    protected UpdateSendMode updateSendMode     = UpdateSendMode.systemDefault;
+
     protected RDFLinkHTTPBuilder() {
         // Default settings are the member declarations.
     }
@@ -85,6 +89,8 @@ public class RDFLinkHTTPBuilder {
         acceptAskResult     = base.acceptAskResult;
         parseCheckQueries   = base.parseCheckQueries;
         parseCheckUpdates   = base.parseCheckUpdates;
+
+        querySendMode       = base.querySendMode;
     }
 
     /** URL of the remote SPARQL endpoint.
@@ -274,6 +280,24 @@ public class RDFLinkHTTPBuilder {
         return this;
     }
 
+    /**
+     * Set the strategy that determines how to send a query over HTTP.
+     * See {@link QuerySendMode}.
+     */
+    public RDFLinkHTTPBuilder querySendMode(QuerySendMode sendMode) {
+        this.querySendMode = sendMode;
+        return this;
+    }
+
+    /**
+     * Set the strategy that determines how to send an update request over HTTP.
+     * See {@link UpdateSendMode}.
+     */
+    public RDFLinkHTTPBuilder updateSendMode(UpdateSendMode sendMode) {
+        this.updateSendMode = sendMode;
+        return this;
+    }
+
     private Function<RDFLinkHTTPBuilder, RDFLink> creator = null;
     /** Provide an alternative function to make the {@link RDFLink} object.
      * <p>
@@ -310,6 +334,7 @@ public class RDFLinkHTTPBuilder {
                                outputQuads, outputTriples,
                                acceptDataset, acceptGraph,
                                acceptSparqlResults, acceptSelectResult, acceptAskResult,
-                               parseCheckQueries, parseCheckUpdates);
+                               parseCheckQueries, parseCheckUpdates,
+                               querySendMode, updateSendMode);
     }
 }

--- a/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/TestRDFConnectionHTTP.java
+++ b/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/TestRDFConnectionHTTP.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.rdfconnection;
+
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.riot.WebContent;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.exec.http.QueryExecHTTP;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRDFConnectionHTTP {
+
+    @Test
+    public void test_select_01() {
+        doAssert(WebContent.contentTypeXML, "SELECT * { ?s a ?o } LIMIT 10");
+    }
+
+    @Test
+    public void test_ask_01() {
+        doAssert(WebContent.contentTypeJSON, "ASK { ?s a ?o }");
+    }
+
+    @Test
+    public void test_constructTriples_01() {
+        doAssert(WebContent.contentTypeTurtle, "CONSTRUCT WHERE { ?s a ?o } LIMIT 10");
+    }
+
+    @Test
+    public void test_constructQuads_01() {
+        doAssert(WebContent.contentTypeTriG, "CONSTRUCT WHERE { GRAPH ?g{ ?s a ?o } } LIMIT 10");
+    }
+
+    @Test
+    public void test_describe_01() {
+        doAssert(WebContent.contentTypeNTriples, "DESCRIBE <urn:x>");
+    }
+
+    private static RDFConnectionRemoteBuilder configureHeader(Query query, String header, RDFConnectionRemoteBuilder builder) {
+        return switch (query.queryType()) {
+        case SELECT -> builder.acceptHeaderSelectQuery(header);
+        case CONSTRUCT -> !query.isConstructQuad()
+                            ? builder.acceptHeaderGraph(header)
+                            : builder.acceptHeaderDataset(header);
+        case DESCRIBE -> builder.acceptHeaderGraph(header);
+        case ASK -> builder.acceptHeaderAskQuery(header);
+        default -> throw new UnsupportedOperationException("Unhandled query type for query: " + query);
+        };
+    }
+
+    /** Test whether the constructed QueryExec instance has the expected HTTP header set */
+    private static void doAssert(String expectedHeader, String queryString) {
+        Query query = QueryFactory.create(queryString);
+
+        try (RDFConnection conn = configureHeader(query, expectedHeader, RDFConnectionRemote.newBuilder())
+                .queryEndpoint("https://www.example.org/sparql") // Should never be resolved
+                .build()) {
+            try (QueryExecution qe = conn.query(queryString)) {
+                QueryExecHTTP qeh = (QueryExecHTTP)QueryExec.adapt(qe);
+                Assert.assertEquals(expectedHeader, qeh.getAppProvidedAcceptHeader());
+            }
+
+            try (QueryExecution qe = conn.newQuery().query(queryString).build()) {
+                QueryExecHTTP qeh = (QueryExecHTTP)QueryExec.adapt(qe);
+                Assert.assertEquals(expectedHeader, qeh.getAppProvidedAcceptHeader());
+            }
+
+            try (QueryExecution qe = conn.query(query)) {
+                QueryExecHTTP qeh = (QueryExecHTTP)QueryExec.adapt(qe);
+                Assert.assertEquals(expectedHeader, qeh.getAppProvidedAcceptHeader());
+            }
+
+            try (QueryExecution qe = conn.newQuery().query(query).build()) {
+                QueryExecHTTP qeh = (QueryExecHTTP)QueryExec.adapt(qe);
+                Assert.assertEquals(expectedHeader, qeh.getAppProvidedAcceptHeader());
+            }
+        }
+    }
+}


### PR DESCRIPTION
GitHub issue resolved #2233 
GitHub issue resolved #2255 

Pull request Description: This PR proposes 
* opening up  ARQ's QueryExecHTTPBuilder for subclassing, such that RDFLinkHTTP can override the buildX() method to set the effective header according to configuration.
* making the send modes for queries and updates configurable on `RDFLinkHTTPBuilder`.


----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
