### PR TITLE
GH-2257: Don't handle java.io.tmpdir in a special way

### DIFF
--- a/apache-jena/bin/arq
+++ b/apache-jena/bin/arq
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/infer
+++ b/apache-jena/bin/infer
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/iri
+++ b/apache-jena/bin/iri
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/jena.version
+++ b/apache-jena/bin/jena.version
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/juuid
+++ b/apache-jena/bin/juuid
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/nquads
+++ b/apache-jena/bin/nquads
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/ntriples
+++ b/apache-jena/bin/ntriples
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/qparse
+++ b/apache-jena/bin/qparse
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rdfcat
+++ b/apache-jena/bin/rdfcat
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rdfcompare
+++ b/apache-jena/bin/rdfcompare
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rdfcopy
+++ b/apache-jena/bin/rdfcopy
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rdfdiff
+++ b/apache-jena/bin/rdfdiff
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rdfparse
+++ b/apache-jena/bin/rdfparse
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rdfpatch
+++ b/apache-jena/bin/rdfpatch
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rdfxml
+++ b/apache-jena/bin/rdfxml
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/riot
+++ b/apache-jena/bin/riot
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rset
+++ b/apache-jena/bin/rset
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rsparql
+++ b/apache-jena/bin/rsparql
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/rupdate
+++ b/apache-jena/bin/rupdate
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/schemagen
+++ b/apache-jena/bin/schemagen
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/shacl
+++ b/apache-jena/bin/shacl
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/shex
+++ b/apache-jena/bin/shex
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/sparql
+++ b/apache-jena/bin/sparql
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdb2.tdbbackup
+++ b/apache-jena/bin/tdb2.tdbbackup
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdb2.tdbcompact
+++ b/apache-jena/bin/tdb2.tdbcompact
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdb2.tdbdump
+++ b/apache-jena/bin/tdb2.tdbdump
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdb2.tdbloader
+++ b/apache-jena/bin/tdb2.tdbloader
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdb2.tdbquery
+++ b/apache-jena/bin/tdb2.tdbquery
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdb2.tdbstats
+++ b/apache-jena/bin/tdb2.tdbstats
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdb2.tdbupdate
+++ b/apache-jena/bin/tdb2.tdbupdate
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdbbackup
+++ b/apache-jena/bin/tdbbackup
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdbdump
+++ b/apache-jena/bin/tdbdump
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdbloader
+++ b/apache-jena/bin/tdbloader
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdbquery
+++ b/apache-jena/bin/tdbquery
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdbstats
+++ b/apache-jena/bin/tdbstats
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/tdbupdate
+++ b/apache-jena/bin/tdbupdate
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/trig
+++ b/apache-jena/bin/trig
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/turtle
+++ b/apache-jena/bin/turtle
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/uparse
+++ b/apache-jena/bin/uparse
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/update
+++ b/apache-jena/bin/update
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/utf8
+++ b/apache-jena/bin/utf8
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/wwwdec
+++ b/apache-jena/bin/wwwdec
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/bin/wwwenc
+++ b/apache-jena/bin/wwwenc
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/apache-jena/pom.xml
+++ b/apache-jena/pom.xml
@@ -134,7 +134,7 @@
     <!-- Require a logging implementation for command line tools --> 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>compile</scope>
     </dependency>
 

--- a/apache-jena/template.bin
+++ b/apache-jena/template.bin
@@ -96,16 +96,6 @@ case "$(uname)" in
    CYGWIN*) JENA_CP="$(cygpath -wp "$JENA_CP");";;
 esac
 
-# Respect TMPDIR or TMP (windows?) if present
-# important for tdbloader spill
-if [ -n "$TMPDIR" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMPDIR\""
-elif [ -n "$TMP" ]
-then
-    JVM_ARGS="$JVM_ARGS -Djava.io.tmpdir=\"$TMP\""
-fi
-
 ## Append any custom classpath
 if [ -n "$CLASSPATH" ]
 then

--- a/jena-benchmarks/jena-benchmarks-jmh/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-jmh/pom.xml
@@ -89,7 +89,7 @@
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/jena-fuseki2/jena-fuseki-fulljar/pom.xml
+++ b/jena-fuseki2/jena-fuseki-fulljar/pom.xml
@@ -62,7 +62,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/jena-fuseki2/jena-fuseki-war/pom.xml
+++ b/jena-fuseki2/jena-fuseki-war/pom.xml
@@ -52,7 +52,7 @@
     <!-- Require a logging implementation -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
     <ver.slf4j>2.0.7</ver.slf4j>
     <ver.log4j2>2.22.1</ver.log4j2>
 
-
     <!-- JSON-LD 1.1 -->
     <ver.titanium-json-ld>1.3.3</ver.titanium-json-ld>
     <ver.jakarta.json>2.0.1</ver.jakarta.json>


### PR DESCRIPTION
GitHub issue resolved #2257

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
