### PR TITLE
GH-2273: XSD Duration division

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterFilterExpr.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterFilterExpr.java
@@ -18,55 +18,50 @@
 
 package org.apache.jena.sparql.engine.iterator;
 
-import org.apache.jena.atlas.io.IndentedWriter ;
-import org.apache.jena.atlas.lib.Lib ;
-import org.apache.jena.atlas.logging.Log ;
-import org.apache.jena.sparql.engine.ExecutionContext ;
-import org.apache.jena.sparql.engine.QueryIterator ;
-import org.apache.jena.sparql.engine.binding.Binding ;
-import org.apache.jena.sparql.expr.Expr ;
-import org.apache.jena.sparql.expr.ExprException ;
-import org.apache.jena.sparql.serializer.SerializationContext ;
-import org.apache.jena.sparql.util.ExprUtils ;
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprException;
+import org.apache.jena.sparql.serializer.SerializationContext;
+import org.apache.jena.sparql.util.ExprUtils;
 
-/** 
- *  Filter a stream of bindings by a constraint. */
+/**
+ * Filter a stream of bindings by a constraint.
+ */
 
-public class QueryIterFilterExpr extends QueryIterProcessBinding
-{
-    private final Expr expr ;
-    
-    public QueryIterFilterExpr(QueryIterator input, Expr expr, ExecutionContext context)
-    {
-        super(input, context) ;
-        this.expr = expr ;
+public class QueryIterFilterExpr extends QueryIterProcessBinding {
+    private final Expr expr;
+
+    public QueryIterFilterExpr(QueryIterator input, Expr expr, ExecutionContext context) {
+        super(input, context);
+        this.expr = expr;
     }
-    
+
     @Override
-    public Binding accept(Binding binding)
-    {
+    public Binding accept(Binding binding) {
         try {
+            // ExprNode.isSatisfied converts exceptions to ExprEvalException
             if ( expr.isSatisfied(binding, super.getExecContext()) )
-                return binding ;
-            return null ;
-        } catch (ExprException ex)
-        { // Some evaluation exception
-            Log.warn(this, "Expression Exception in "+expr, ex) ;
-            return null ;
-        }
-        catch (Exception ex)
-        {
-            Log.warn(this, "General exception in "+expr, ex) ;
-            return null ;
+                return binding;
+            return null;
+        } catch (ExprException ex) {
+            // Some evaluation exception: should not happen.
+            Log.warn(this, "Expression Exception in " + expr, ex);
+            return null;
+        } catch (Exception ex) {
+            Log.warn(this, "General exception in " + expr, ex);
+            return null;
         }
     }
 
     @Override
-    protected void details(IndentedWriter out, SerializationContext cxt)
-    { 
-        out.print(Lib.className(this)) ;
-        out.print(" ") ;
-        ExprUtils.fmtSPARQL(out, expr, cxt) ;
+    protected void details(IndentedWriter out, SerializationContext cxt) {
+        out.print(Lib.className(this));
+        out.print(" ");
+        ExprUtils.fmtSPARQL(out, expr, cxt);
     }
-       
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprNode.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprNode.java
@@ -57,7 +57,9 @@ public abstract class ExprNode implements Expr
     public abstract NodeValue eval(Binding binding, FunctionEnv env);
 
     @Override
-    public final Set<Var> getVarsMentioned()                    { return ExprVars.getVarsMentioned(this); }
+    public final Set<Var> getVarsMentioned() {
+        return ExprVars.getVarsMentioned(this);
+    }
 
     @Override
     public abstract int hashCode();

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValueOps.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValueOps.java
@@ -20,124 +20,252 @@ package org.apache.jena.sparql.expr;
 
 import static org.junit.Assert.assertEquals;
 
-import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.sparql.expr.nodevalue.NodeValueOps;
 import org.junit.Test;
 
-public class TestNodeValueOps
-{
+public class TestNodeValueOps {
     // ** Addition
     // Numerics
-    @Test public void nv_add_1() { testAdd("12", "13", "'25'^^xsd:integer" ); }
-    @Test public void nv_add_2() { testAdd("'12'^^xsd:decimal", "13", "'25.0'^^xsd:decimal" ); }
-    @Test public void nv_add_3() { testAdd("'12.0'^^xsd:decimal", "13", "'25.0'^^xsd:decimal" ); }
-    @Test public void nv_add_4() { testAdd("12e0", "13", "25.0e0" ); }
-
-    // Strings
-    @Test public void nv_add_10() { testAdd("'12'", "'13'", "'1213'" ); }
-
-    //Durations (need to test the wiring, not whether the calculation is right)
-    @Test public void nv_add_20() { testAdd("'PT1H'^^xsd:duration", "'PT1H'^^xsd:duration", "'PT2H'^^xsd:duration" ); }
-
-    @Test public void nv_add_21() { testAdd("'PT1H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration", "'PT2H'^^xsd:dayTimeDuration" ); }
-
-    // Outside the XSD spec.
-    //@Test public void nv_add_22() { testAdd("'P1Y'^^xsd:yearMonthDuration", "'PT4H'^^xsd:dayTimeDuration", "'P1YT4H'^^xsd:duration" ); }
-    @Test public void nv_add_22() {
-        try {
-            testAdd("'P1Y'^^xsd:yearMonthDuration", "'PT4H'^^xsd:dayTimeDuration", "'P1YT4H'^^xsd:duration" );
-        } catch (NullPointerException ex) {
-            if ( isProbablyIBMJVM() )
-                // IBM JDK causes NPE on this one.
-                // IllegalStateException is acceptable; NullPointerException is not.
-                Log.warn(this, "TestNodeValueOps.nv_add_22 - IBM JVM - reported issue in the support for xsd:xsd:yearMonthDuration/xsd:dayTimeDuration");
-            else
-                throw ex;
-        }
-        catch (IllegalStateException ex) {}
+    @Test
+    public void nv_add_1() {
+        testAdd("12", "13", "'25'^^xsd:integer");
     }
 
-    private static boolean isProbablyIBMJVM()
-    {
-        return System.getProperty("java.vm.name", "").contains("IBM");
+    @Test
+    public void nv_add_2() {
+        testAdd("'12'^^xsd:decimal", "13", "'25.0'^^xsd:decimal");
+    }
+
+    @Test
+    public void nv_add_3() {
+        testAdd("'12.0'^^xsd:decimal", "13", "'25.0'^^xsd:decimal");
+    }
+
+    @Test
+    public void nv_add_4() {
+        testAdd("12e0", "13", "25.0e0");
+    }
+
+    // Strings
+    @Test
+    public void nv_add_10() {
+        testAdd("'12'", "'13'", "'1213'");
+    }
+
+    // Durations (need to test the wiring, not whether the calculation is right)
+    @Test
+    public void nv_add_20() {
+        testAdd("'PT1H'^^xsd:duration", "'PT1H'^^xsd:duration", "'PT2H'^^xsd:duration");
+    }
+
+    @Test
+    public void nv_add_21() {
+        testAdd("'PT1H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration", "'PT2H'^^xsd:dayTimeDuration");
+    }
+
+    // Outside the XSD spec.
+    @Test
+    public void nv_add_22() {
+        testAdd("'P1Y'^^xsd:yearMonthDuration", "'PT4H'^^xsd:dayTimeDuration", "'P1YT4H'^^xsd:duration");
     }
 
     // Date/time + duration
-    @Test public void nv_add_23() { testAdd("'2000-01-01'^^xsd:date", "'P1Y'^^xsd:duration", "'2001-01-01'^^xsd:date"); }
-    @Test public void nv_add_24() { testAdd("'2000-01-01T00:00:00Z'^^xsd:dateTime",
-                                            "'P1Y1M'^^xsd:yearMonthDuration",
-                                            "'2001-02-01T00:00:00Z'^^xsd:dateTime"); }
-    @Test public void nv_add_25() { testAdd("'2000-01-01T00:00:00Z'^^xsd:dateTime",
-                                            "'P1Y1M1DT1H1M1.1S'^^xsd:duration",
-                                            "'2001-02-02T01:01:01.1Z'^^xsd:dateTime"); }
-    @Test public void nv_add_26() { testAdd("'00:00:00'^^xsd:time",
-                                            "'PT1H2M3.4S'^^xsd:duration",
-                                            "'01:02:03.4'^^xsd:time"); }
+    @Test
+    public void nv_add_23() {
+        testAdd("'2000-01-01'^^xsd:date", "'P1Y'^^xsd:duration", "'2001-01-01'^^xsd:date");
+    }
+
+    @Test
+    public void nv_add_24() {
+        testAdd("'2000-01-01T00:00:00Z'^^xsd:dateTime", "'P1Y1M'^^xsd:yearMonthDuration", "'2001-02-01T00:00:00Z'^^xsd:dateTime");
+    }
+
+    @Test
+    public void nv_add_25() {
+        testAdd("'2000-01-01T00:00:00Z'^^xsd:dateTime", "'P1Y1M1DT1H1M1.1S'^^xsd:duration", "'2001-02-02T01:01:01.1Z'^^xsd:dateTime");
+    }
+
+    @Test
+    public void nv_add_26() {
+        testAdd("'00:00:00'^^xsd:time", "'PT1H2M3.4S'^^xsd:duration", "'01:02:03.4'^^xsd:time");
+    }
 
     // Bad mixes
-    @Test(expected=ExprEvalException.class)
-    public void nv_add_50() { testAdd("'12'", "13"); }
+    @Test(expected = ExprEvalException.class)
+    public void nv_add_50() {
+        testAdd("'12'", "13");
+    }
 
-    @Test(expected=ExprEvalException.class)
-    public void nv_add_51() { testAdd("'12'", "'PT1H'^^xsd:duration"); }
+    @Test(expected = ExprEvalException.class)
+    public void nv_add_51() {
+        testAdd("'12'", "'PT1H'^^xsd:duration");
+    }
 
-    @Test(expected=ExprEvalException.class)
-    public void nv_add_52() { testAdd("'2012-04-05'^^xsd:date", "'2012-04-05'^^xsd:date"); }
+    @Test(expected = ExprEvalException.class)
+    public void nv_add_52() {
+        testAdd("'2012-04-05'^^xsd:date", "'2012-04-05'^^xsd:date");
+    }
 
     // ** Subtraction
     // Numerics
-    @Test public void nv_sub_1() { testSub("12", "13", "-1" ); }
-    @Test public void nv_sub_2() { testSub("12", "13.0", "-1.0" ); }
-    @Test public void nv_sub_3() { testSub("12e0", "13.0", "-1.0e0" ); }
-
-    // Durations
-    //Durations (need to test the wiring, not whether the calculation is right)
-    @Test public void nv_sub_20() { testSub("'PT2H'^^xsd:duration", "'PT1H'^^xsd:duration", "'PT1H'^^xsd:duration" ); }
-    @Test public void nv_sub_21() { testSub("'PT2H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration" ); }
-
-    //@Test public void nv_sub_22() { testSub("'P2Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration" ); }
-    @Test public void nv_sub_22() {
-        try {
-            testSub("'P2Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration" );
-        } catch (NullPointerException ex) {
-            if ( isProbablyIBMJVM() )
-                // IBM JDK causes NPE on this one.
-                Log.warn(this, "TestNodeValueOps.nv_sub_22 - IBM JVM - reported issue in the support for xsd:xsd:yearMonthDuration/xsd:dayTimeDuration");
-            else
-                throw ex;
-        }
-        catch (IllegalStateException ex) {}
+    @Test
+    public void nv_sub_1() {
+        testSub("12", "13", "-1");
     }
 
-    @Test public void nv_sub_23() { testSub("'P3D'^^xsd:dayTimeDuration", "'PT4H'^^xsd:dayTimeDuration", "'P2DT20H'^^xsd:dayTimeDuration" ); }
+    @Test
+    public void nv_sub_2() {
+        testSub("12", "13.0", "-1.0");
+    }
+
+    @Test
+    public void nv_sub_3() {
+        testSub("12e0", "13.0", "-1.0e0");
+    }
+
+    // Durations
+    @Test
+    public void nv_sub_20() {
+        testSub("'PT2H'^^xsd:duration", "'PT1H'^^xsd:duration", "'PT1H'^^xsd:duration");
+    }
+
+    @Test
+    public void nv_sub_21() {
+        testSub("'PT2H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration");
+    }
+
+    @Test
+    public void nv_sub_22() {
+        testSub("'P2Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration");
+    }
+
+    @Test
+    public void nv_sub_23() {
+        testSub("'P3D'^^xsd:dayTimeDuration", "'PT4H'^^xsd:dayTimeDuration", "'P2DT20H'^^xsd:dayTimeDuration");
+    }
 
     // Date/time - duration
-    @Test public void nv_sub_30() { testSub("'2000-01-01'^^xsd:date", "'P1Y'^^xsd:duration", "'1999-01-01'^^xsd:date"); }
-    @Test public void nv_sub_31() { testSub("'2000-01-01T00:00:00Z'^^xsd:dateTime",
-                                            "'P1Y1M'^^xsd:yearMonthDuration",
-                                            "'1998-12-01T00:00:00Z'^^xsd:dateTime"); }
-    @Test public void nv_sub_32() { testSub("'2000-01-01T00:00:00Z'^^xsd:dateTime",
-                                            "'P1Y1M1DT1H1M1.1S'^^xsd:duration",
-                                            "'1998-11-29T22:58:58.9Z'^^xsd:dateTime"); }
+    @Test
+    public void nv_sub_30() {
+        testSub("'2000-01-01'^^xsd:date", "'P1Y'^^xsd:duration", "'1999-01-01'^^xsd:date");
+    }
 
-    @Test public void nv_sub_33() { testSub("'10:11:12'^^xsd:time",
-                                            "'PT1H2M3.4S'^^xsd:duration",
-                                            "'09:09:08.6'^^xsd:time"); }
+    @Test
+    public void nv_sub_31() {
+        testSub("'2000-01-01T00:00:00Z'^^xsd:dateTime", "'P1Y1M'^^xsd:yearMonthDuration", "'1998-12-01T00:00:00Z'^^xsd:dateTime");
+    }
+
+    @Test
+    public void nv_sub_32() {
+        testSub("'2000-01-01T00:00:00Z'^^xsd:dateTime", "'P1Y1M1DT1H1M1.1S'^^xsd:duration", "'1998-11-29T22:58:58.9Z'^^xsd:dateTime");
+    }
+
+    @Test
+    public void nv_sub_33() {
+        testSub("'10:11:12'^^xsd:time", "'PT1H2M3.4S'^^xsd:duration", "'09:09:08.6'^^xsd:time");
+    }
     // Date/time - date/time
 
-    // Bad
-    @Test(expected=ExprEvalException.class)
-    public void nv_sub_50() { testSub("'12'", "'13'" ); }
+    @Test(expected = ExprEvalException.class)
+    public void nv_sub_50() {
+        testSub("'12'", "'13'");
+    }
 
     // ** Multiplication
 
-    @Test public void nv_mult_1() { testMult("12", "13", "156" ); }
-    @Test public void nv_mult_2() { testMult("-12", "13.0", "-156.0" ); }
-    @Test public void nv_mult_3() { testMult("'PT1H2M'^^xsd:duration", "2", "'PT2H4M'^^xsd:dayTimeDuration"); }
+    @Test
+    public void nv_mult_1() {
+        testMult("12", "13", "156");
+    }
+
+    @Test
+    public void nv_mult_2() {
+        testMult("-12", "13.0", "-156.0");
+    }
+
+    @Test
+    public void nv_mult_3() {
+        testMult("'PT1H2M'^^xsd:duration", "2", "'PT2H4M'^^xsd:duration");
+    }
 
     // ** Division
-    @Test public void nv_div_1() { testDiv("12", "2", "6.0" ); }
-    @Test public void nv_div_2() { testDiv("12", "2e0", "6.0e0" ); }
+    @Test
+    public void nv_div_num_1() {
+        testDiv("12", "2", "6.0");
+    }
+
+    @Test
+    public void nv_div_num_2() {
+        testDiv("12", "2e0", "6.0e0");
+    }
+
+    @Test
+    public void nv_div_dur_3() {
+        testDiv("'PT24H20M'^^xsd:duration", "2", "'PT12H10M'^^xsd:duration");
+    }
+
+    @Test
+    public void nv_div_dur_4() {
+        testDiv("'PT24H20M'^^xsd:dayTimeDuration", "2", "'PT12H10M'^^xsd:duration");
+    }
+
+    // Note - not normalized.
+    @Test
+    public void nv_div_dur_5() {
+        testDiv("'PT24H20M'^^xsd:dayTimeDuration", "0.1", "'PT240H200M'^^xsd:duration");
+    }
+
+    @Test
+    public void nv_div_dur_6() {
+        testDiv("'P2Y8M'^^xsd:duration", "2", "'P1Y4M'^^xsd:duration");
+    }
+
+    @Test
+    public void nv_div_dur_7() {
+        testDiv("'P2Y8M'^^xsd:yearMonthDuration", "2", "'P1Y4M'^^xsd:duration");
+    }
+
+    // Note - not normalized.
+    @Test
+    public void nv_div_dur_8() {
+        testDiv("'P2Y8M'^^xsd:yearMonthDuration", "0.1", "'P20Y80M'^^xsd:duration");
+    }
+
+    @Test(expected = ExprEvalException.class)
+    public void nv_div_dur_bad_1() {
+        // Year-month divided by day-time
+        testDiv("'P2Y8M'^^xsd:yearMonthDuration", "'PT12H10M'^^xsd:duration");
+    }
+
+    @Test(expected = ExprEvalException.class)
+    public void nv_div_dur_bad_2() {
+        // day-time divided by year-month.
+        testDiv("'PT12H10M'^^xsd:duration", "'P2Y8M'^^xsd:duration");
+    }
+
+    @Test(expected = ExprEvalException.class)
+    public void nv_div_dur_bad_3() {
+        // day-time divided by year-month.
+        testDiv("'PT12H10M'^^xsd:duration", "0");
+    }
+
+    @Test(expected = ExprEvalException.class)
+    public void nv_div_dur_bad_4() {
+        // day-time divided by year-month.
+        testDiv("'P1Y'^^xsd:duration", "0");
+    }
+
+    @Test(expected = ExprEvalException.class)
+    public void nv_div_dur_bad_5() {
+        // day-time divided by zero interval.
+        testDiv("'PT1H'^^xsd:duration", "'PT0S'^^xsd:duration");
+    }
+
+    @Test(expected = ExprEvalException.class)
+    public void nv_div_dur_bad_6() {
+        // year-month divided by zero interval.
+        testDiv("'P1Y'^^xsd:duration", "'P0Y'^^xsd:duration");
+    }
 
     // == Workers
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValueOps.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValueOps.java
@@ -20,39 +20,39 @@ package org.apache.jena.sparql.expr;
 
 import static org.junit.Assert.assertEquals;
 
-import org.apache.jena.atlas.logging.Log ;
-import org.apache.jena.sparql.expr.nodevalue.NodeValueOps ;
-import org.junit.Test ;
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.sparql.expr.nodevalue.NodeValueOps;
+import org.junit.Test;
 
 public class TestNodeValueOps
 {
     // ** Addition
     // Numerics
-    @Test public void nv_add_1() { testAdd("12", "13", "'25'^^xsd:integer" ) ; }
-    @Test public void nv_add_2() { testAdd("'12'^^xsd:decimal", "13", "'25.0'^^xsd:decimal" ) ; }
-    @Test public void nv_add_3() { testAdd("'12.0'^^xsd:decimal", "13", "'25.0'^^xsd:decimal" ) ; }
-    @Test public void nv_add_4() { testAdd("12e0", "13", "25.0e0" ) ; }
-    
+    @Test public void nv_add_1() { testAdd("12", "13", "'25'^^xsd:integer" ); }
+    @Test public void nv_add_2() { testAdd("'12'^^xsd:decimal", "13", "'25.0'^^xsd:decimal" ); }
+    @Test public void nv_add_3() { testAdd("'12.0'^^xsd:decimal", "13", "'25.0'^^xsd:decimal" ); }
+    @Test public void nv_add_4() { testAdd("12e0", "13", "25.0e0" ); }
+
     // Strings
-    @Test public void nv_add_10() { testAdd("'12'", "'13'", "'1213'" ) ; }
+    @Test public void nv_add_10() { testAdd("'12'", "'13'", "'1213'" ); }
 
     //Durations (need to test the wiring, not whether the calculation is right)
-    @Test public void nv_add_20() { testAdd("'PT1H'^^xsd:duration", "'PT1H'^^xsd:duration", "'PT2H'^^xsd:duration" ) ; }
-  
-    @Test public void nv_add_21() { testAdd("'PT1H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration", "'PT2H'^^xsd:dayTimeDuration" ) ; }
-    
+    @Test public void nv_add_20() { testAdd("'PT1H'^^xsd:duration", "'PT1H'^^xsd:duration", "'PT2H'^^xsd:duration" ); }
+
+    @Test public void nv_add_21() { testAdd("'PT1H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration", "'PT2H'^^xsd:dayTimeDuration" ); }
+
     // Outside the XSD spec.
-    //@Test public void nv_add_22() { testAdd("'P1Y'^^xsd:yearMonthDuration", "'PT4H'^^xsd:dayTimeDuration", "'P1YT4H'^^xsd:duration" ) ; }
+    //@Test public void nv_add_22() { testAdd("'P1Y'^^xsd:yearMonthDuration", "'PT4H'^^xsd:dayTimeDuration", "'P1YT4H'^^xsd:duration" ); }
     @Test public void nv_add_22() {
-        try { 
-            testAdd("'P1Y'^^xsd:yearMonthDuration", "'PT4H'^^xsd:dayTimeDuration", "'P1YT4H'^^xsd:duration" ) ;
+        try {
+            testAdd("'P1Y'^^xsd:yearMonthDuration", "'PT4H'^^xsd:dayTimeDuration", "'P1YT4H'^^xsd:duration" );
         } catch (NullPointerException ex) {
             if ( isProbablyIBMJVM() )
                 // IBM JDK causes NPE on this one.
-                // IllegalStateException is acceptable; NullPointerException is not. 
-                Log.warn(this, "TestNodeValueOps.nv_add_22 - IBM JVM - reported issue in the support for xsd:xsd:yearMonthDuration/xsd:dayTimeDuration") ;
+                // IllegalStateException is acceptable; NullPointerException is not.
+                Log.warn(this, "TestNodeValueOps.nv_add_22 - IBM JVM - reported issue in the support for xsd:xsd:yearMonthDuration/xsd:dayTimeDuration");
             else
-                throw ex ;
+                throw ex;
         }
         catch (IllegalStateException ex) {}
     }
@@ -61,141 +61,131 @@ public class TestNodeValueOps
     {
         return System.getProperty("java.vm.name", "").contains("IBM");
     }
-    
-    // Date/time + duration
-    @Test public void nv_add_23() { testAdd("'2000-01-01'^^xsd:date", "'P1Y'^^xsd:duration", "'2001-01-01'^^xsd:date") ; }
-    @Test public void nv_add_24() { testAdd("'2000-01-01T00:00:00Z'^^xsd:dateTime", 
-                                            "'P1Y1M'^^xsd:yearMonthDuration", 
-                                            "'2001-02-01T00:00:00Z'^^xsd:dateTime") ; }
-    @Test public void nv_add_25() { testAdd("'2000-01-01T00:00:00Z'^^xsd:dateTime", 
-                                            "'P1Y1M1DT1H1M1.1S'^^xsd:duration", 
-                                            "'2001-02-02T01:01:01.1Z'^^xsd:dateTime") ; }
-    @Test public void nv_add_26() { testAdd("'00:00:00'^^xsd:time", 
-                                            "'PT1H2M3.4S'^^xsd:duration", 
-                                            "'01:02:03.4'^^xsd:time") ; }
-    
-    // Bad mixes
-    @Test(expected=ExprEvalException.class) 
-    public void nv_add_50() { testAdd("'12'", "13") ; }
 
-    @Test(expected=ExprEvalException.class) 
-    public void nv_add_51() { testAdd("'12'", "'PT1H'^^xsd:duration") ; }
-    
-    @Test(expected=ExprEvalException.class) 
-    public void nv_add_52() { testAdd("'2012-04-05'^^xsd:date", "'2012-04-05'^^xsd:date") ; }
-    
+    // Date/time + duration
+    @Test public void nv_add_23() { testAdd("'2000-01-01'^^xsd:date", "'P1Y'^^xsd:duration", "'2001-01-01'^^xsd:date"); }
+    @Test public void nv_add_24() { testAdd("'2000-01-01T00:00:00Z'^^xsd:dateTime",
+                                            "'P1Y1M'^^xsd:yearMonthDuration",
+                                            "'2001-02-01T00:00:00Z'^^xsd:dateTime"); }
+    @Test public void nv_add_25() { testAdd("'2000-01-01T00:00:00Z'^^xsd:dateTime",
+                                            "'P1Y1M1DT1H1M1.1S'^^xsd:duration",
+                                            "'2001-02-02T01:01:01.1Z'^^xsd:dateTime"); }
+    @Test public void nv_add_26() { testAdd("'00:00:00'^^xsd:time",
+                                            "'PT1H2M3.4S'^^xsd:duration",
+                                            "'01:02:03.4'^^xsd:time"); }
+
+    // Bad mixes
+    @Test(expected=ExprEvalException.class)
+    public void nv_add_50() { testAdd("'12'", "13"); }
+
+    @Test(expected=ExprEvalException.class)
+    public void nv_add_51() { testAdd("'12'", "'PT1H'^^xsd:duration"); }
+
+    @Test(expected=ExprEvalException.class)
+    public void nv_add_52() { testAdd("'2012-04-05'^^xsd:date", "'2012-04-05'^^xsd:date"); }
+
     // ** Subtraction
     // Numerics
-    @Test public void nv_sub_1() { testSub("12", "13", "-1" ) ; }
-    @Test public void nv_sub_2() { testSub("12", "13.0", "-1.0" ) ; }
-    @Test public void nv_sub_3() { testSub("12e0", "13.0", "-1.0e0" ) ; }
-    
+    @Test public void nv_sub_1() { testSub("12", "13", "-1" ); }
+    @Test public void nv_sub_2() { testSub("12", "13.0", "-1.0" ); }
+    @Test public void nv_sub_3() { testSub("12e0", "13.0", "-1.0e0" ); }
+
     // Durations
     //Durations (need to test the wiring, not whether the calculation is right)
-    @Test public void nv_sub_20() { testSub("'PT2H'^^xsd:duration", "'PT1H'^^xsd:duration", "'PT1H'^^xsd:duration" ) ; }
-    @Test public void nv_sub_21() { testSub("'PT2H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration" ) ; }
-    
-    //@Test public void nv_sub_22() { testSub("'P2Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration" ) ; }
+    @Test public void nv_sub_20() { testSub("'PT2H'^^xsd:duration", "'PT1H'^^xsd:duration", "'PT1H'^^xsd:duration" ); }
+    @Test public void nv_sub_21() { testSub("'PT2H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration", "'PT1H'^^xsd:dayTimeDuration" ); }
+
+    //@Test public void nv_sub_22() { testSub("'P2Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration" ); }
     @Test public void nv_sub_22() {
-        try { 
-            testSub("'P2Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration" ) ;
+        try {
+            testSub("'P2Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration", "'P1Y'^^xsd:yearMonthDuration" );
         } catch (NullPointerException ex) {
             if ( isProbablyIBMJVM() )
                 // IBM JDK causes NPE on this one.
-                Log.warn(this, "TestNodeValueOps.nv_sub_22 - IBM JVM - reported issue in the support for xsd:xsd:yearMonthDuration/xsd:dayTimeDuration") ;
+                Log.warn(this, "TestNodeValueOps.nv_sub_22 - IBM JVM - reported issue in the support for xsd:xsd:yearMonthDuration/xsd:dayTimeDuration");
             else
-                throw ex ;
+                throw ex;
         }
         catch (IllegalStateException ex) {}
     }
-    
-    @Test public void nv_sub_23() { testSub("'P3D'^^xsd:dayTimeDuration", "'PT4H'^^xsd:dayTimeDuration", "'P2DT20H'^^xsd:dayTimeDuration" ) ; }
-    
+
+    @Test public void nv_sub_23() { testSub("'P3D'^^xsd:dayTimeDuration", "'PT4H'^^xsd:dayTimeDuration", "'P2DT20H'^^xsd:dayTimeDuration" ); }
+
     // Date/time - duration
-    @Test public void nv_sub_30() { testSub("'2000-01-01'^^xsd:date", "'P1Y'^^xsd:duration", "'1999-01-01'^^xsd:date") ; }
-    @Test public void nv_sub_31() { testSub("'2000-01-01T00:00:00Z'^^xsd:dateTime", 
-                                            "'P1Y1M'^^xsd:yearMonthDuration", 
-                                            "'1998-12-01T00:00:00Z'^^xsd:dateTime") ; }
-    @Test public void nv_sub_32() { testSub("'2000-01-01T00:00:00Z'^^xsd:dateTime", 
-                                            "'P1Y1M1DT1H1M1.1S'^^xsd:duration", 
-                                            "'1998-11-29T22:58:58.9Z'^^xsd:dateTime") ; }
-    
-    @Test public void nv_sub_33() { testSub("'10:11:12'^^xsd:time", 
-                                            "'PT1H2M3.4S'^^xsd:duration", 
-                                            "'09:09:08.6'^^xsd:time") ; }
+    @Test public void nv_sub_30() { testSub("'2000-01-01'^^xsd:date", "'P1Y'^^xsd:duration", "'1999-01-01'^^xsd:date"); }
+    @Test public void nv_sub_31() { testSub("'2000-01-01T00:00:00Z'^^xsd:dateTime",
+                                            "'P1Y1M'^^xsd:yearMonthDuration",
+                                            "'1998-12-01T00:00:00Z'^^xsd:dateTime"); }
+    @Test public void nv_sub_32() { testSub("'2000-01-01T00:00:00Z'^^xsd:dateTime",
+                                            "'P1Y1M1DT1H1M1.1S'^^xsd:duration",
+                                            "'1998-11-29T22:58:58.9Z'^^xsd:dateTime"); }
+
+    @Test public void nv_sub_33() { testSub("'10:11:12'^^xsd:time",
+                                            "'PT1H2M3.4S'^^xsd:duration",
+                                            "'09:09:08.6'^^xsd:time"); }
     // Date/time - date/time
-    
+
     // Bad
-    @Test(expected=ExprEvalException.class) 
-    public void nv_sub_50() { testSub("'12'", "'13'" ) ; }
+    @Test(expected=ExprEvalException.class)
+    public void nv_sub_50() { testSub("'12'", "'13'" ); }
 
     // ** Multiplication
-    
-    @Test public void nv_mult_1() { testMult("12", "13", "156" ) ; }
-    @Test public void nv_mult_2() { testMult("-12", "13.0", "-156.0" ) ; }
-    @Test public void nv_mult_3() { testMult("'PT1H2M'^^xsd:duration", "2", "'PT2H4M'^^xsd:dayTimeDuration") ; }
-    
+
+    @Test public void nv_mult_1() { testMult("12", "13", "156" ); }
+    @Test public void nv_mult_2() { testMult("-12", "13.0", "-156.0" ); }
+    @Test public void nv_mult_3() { testMult("'PT1H2M'^^xsd:duration", "2", "'PT2H4M'^^xsd:dayTimeDuration"); }
+
     // ** Division
-    @Test public void nv_div_1() { testDiv("12", "2", "6.0" ) ; }
-    @Test public void nv_div_2() { testDiv("12", "2e0", "6.0e0" ) ; }
-    
+    @Test public void nv_div_1() { testDiv("12", "2", "6.0" ); }
+    @Test public void nv_div_2() { testDiv("12", "2e0", "6.0e0" ); }
+
     // == Workers
-    
-    static void testAdd(String s1, String s2, String s3)
-    {
-        NodeValue nv3 = NodeValue.parse(s3) ;
-        NodeValue nv = testAdd(s1, s2) ;
-        assertEquals(nv3, nv) ;
-    }
-    
-    static NodeValue testAdd(String s1, String s2)
-    {
-        NodeValue nv1 = NodeValue.parse(s1) ;
-        NodeValue nv2 = NodeValue.parse(s2) ;
-        return NodeValueOps.additionNV(nv1, nv2) ;
-    }
-    
-    static void testSub(String s1, String s2, String s3)
-    {
-        NodeValue nv3 = NodeValue.parse(s3) ;
-        NodeValue nv = testSub(s1, s2) ;
-        assertEquals(nv3, nv) ;
-    }
-    
-    static NodeValue testSub(String s1, String s2)
-    {
-        NodeValue nv1 = NodeValue.parse(s1) ;
-        NodeValue nv2 = NodeValue.parse(s2) ;
-        return NodeValueOps.subtractionNV(nv1, nv2) ;
+
+    static void testAdd(String s1, String s2, String s3) {
+        NodeValue nv3 = NodeValue.parse(s3);
+        NodeValue nv = testAdd(s1, s2);
+        assertEquals(nv3, nv);
     }
 
-    static void testMult(String s1, String s2, String s3)
-    {
-        NodeValue nv3 = NodeValue.parse(s3) ;
-        NodeValue nv = testMult(s1, s2) ;
-        assertEquals(nv3, nv) ;
-    }
-    
-    static NodeValue testMult(String s1, String s2)
-    {
-        NodeValue nv1 = NodeValue.parse(s1) ;
-        NodeValue nv2 = NodeValue.parse(s2) ;
-        return NodeValueOps.multiplicationNV(nv1, nv2) ;
+    static NodeValue testAdd(String s1, String s2) {
+        NodeValue nv1 = NodeValue.parse(s1);
+        NodeValue nv2 = NodeValue.parse(s2);
+        return NodeValueOps.additionNV(nv1, nv2);
     }
 
-    static void testDiv(String s1, String s2, String s3)
-    {
-        NodeValue nv3 = NodeValue.parse(s3) ;
-        NodeValue nv = testDiv(s1, s2) ;
-        assertEquals(nv3, nv) ;
-    }
-    
-    static NodeValue testDiv(String s1, String s2)
-    {
-        NodeValue nv1 = NodeValue.parse(s1) ;
-        NodeValue nv2 = NodeValue.parse(s2) ;
-        return NodeValueOps.divisionNV(nv1, nv2) ;
+    static void testSub(String s1, String s2, String s3) {
+        NodeValue nv3 = NodeValue.parse(s3);
+        NodeValue nv = testSub(s1, s2);
+        assertEquals(nv3, nv);
     }
 
+    static NodeValue testSub(String s1, String s2) {
+        NodeValue nv1 = NodeValue.parse(s1);
+        NodeValue nv2 = NodeValue.parse(s2);
+        return NodeValueOps.subtractionNV(nv1, nv2);
+    }
+
+    static void testMult(String s1, String s2, String s3) {
+        NodeValue nv3 = NodeValue.parse(s3);
+        NodeValue nv = testMult(s1, s2);
+        assertEquals(nv3, nv);
+    }
+
+    static NodeValue testMult(String s1, String s2) {
+        NodeValue nv1 = NodeValue.parse(s1);
+        NodeValue nv2 = NodeValue.parse(s2);
+        return NodeValueOps.multiplicationNV(nv1, nv2);
+    }
+
+    static void testDiv(String s1, String s2, String s3) {
+        NodeValue nv3 = NodeValue.parse(s3);
+        NodeValue nv = testDiv(s1, s2);
+        assertEquals(nv3, nv);
+    }
+
+    static NodeValue testDiv(String s1, String s2) {
+        NodeValue nv1 = NodeValue.parse(s1);
+        NodeValue nv2 = NodeValue.parse(s2);
+        return NodeValueOps.divisionNV(nv1, nv2);
+    }
 }
-

--- a/jena-arq/src/test/java/org/apache/jena/sparql/sse/TestSSE_Basic.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/sse/TestSSE_Basic.java
@@ -20,230 +20,222 @@ package org.apache.jena.sparql.sse;
 
 import static org.junit.Assert.*;
 
-import org.apache.jena.datatypes.xsd.XSDDatatype ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.sparql.ARQConstants ;
-import org.apache.jena.sparql.core.Var ;
-import org.apache.jena.sparql.util.NodeFactoryExtra ;
-import org.junit.Test ;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.ARQConstants;
+import org.apache.jena.sparql.core.Var;
+import org.junit.Test;
 
 public class TestSSE_Basic
 {
     // Tests not requiring URI resolution or prefix name handling.
 
-    static Node int1 = org.apache.jena.graph.NodeFactory.createLiteral("1", XSDDatatype.XSDinteger) ;
-    static Node int2 = org.apache.jena.graph.NodeFactory.createLiteral("2", XSDDatatype.XSDinteger) ;
-    static Node int3 = org.apache.jena.graph.NodeFactory.createLiteral("3", XSDDatatype.XSDinteger) ;
-    static Node strLangEN = org.apache.jena.graph.NodeFactory.createLiteralLang("xyz", "en") ;
+    static Node int1 = org.apache.jena.graph.NodeFactory.createLiteral("1", XSDDatatype.XSDinteger);
+    static Node int2 = org.apache.jena.graph.NodeFactory.createLiteral("2", XSDDatatype.XSDinteger);
+    static Node int3 = org.apache.jena.graph.NodeFactory.createLiteral("3", XSDDatatype.XSDinteger);
+    static Node strLangEN = org.apache.jena.graph.NodeFactory.createLiteralLang("xyz", "en");
 
-    static Node typeLit1 = NodeFactoryExtra.createLiteralNode("123", null, "http://example/type") ;
+    static Node typeLit1 = NodeFactory.createLiteral("123", NodeFactory.getType("http://example/type"));
 
-    static Item int1i = Item.createNode(int1) ;
-    static Item int2i = Item.createNode(int2) ;
-    static Item int3i = Item.createNode(int3) ;
-
-//    public static TestSuite suite()
-//    {
-//        TestSuite ts = new TestSuite(TestSSE_Basic.class) ;
-//        ts.setName("SSE Basic") ;
-//        return ts ;
-//    }
+    static Item int1i = Item.createNode(int1);
+    static Item int2i = Item.createNode(int2);
+    static Item int3i = Item.createNode(int3);
 
     // ---- Parsing : not check for the correct outcome
-    @Test public void testParseTerm_01() { parse("'xyz'") ; }
-    @Test public void testParseTerm_02() { parse("'xyz'@en") ; }
-    @Test public void testParseTerm_03() { parseBad("'xyz' @en") ; }
+    @Test public void testParseTerm_01() { parse("'xyz'"); }
+    @Test public void testParseTerm_02() { parse("'xyz'@en"); }
+    @Test public void testParseTerm_03() { parseBad("'xyz' @en"); }
 
-    @Test public void testParseSymbol_01() { parse("a") ; }
-    @Test public void testParseSymbol_02() { parseBad("'a") ; }
+    @Test public void testParseSymbol_01() { parse("a"); }
+    @Test public void testParseSymbol_02() { parseBad("'a"); }
     // TODO Parser needs fixing
-    //@Test public void testParseSymbol_03() { parse("@a") ; }
-    @Test public void testParseSymbol_04() { parse("a@") ; }
+    //@Test public void testParseSymbol_03() { parse("@a"); }
+    @Test public void testParseSymbol_04() { parse("a@"); }
 
+    @Test public void testParseList_01() { parse("()"); }
+    @Test public void testParseList_02() { parse("(a)"); }
+    @Test public void testParseList_03() { parse(" (a)"); }
+    @Test public void testParseList_04() { parse("( a)"); }
+    @Test public void testParseList_05() { parse("(a )"); }
+    @Test public void testParseList_06() { parse("(a) "); }
+    @Test public void testParseList_07() { parse("('a') "); }
+    @Test public void testParseList_08() { parse("(<a>) "); }
 
-    @Test public void testParseList_01() { parse("()") ; }
-    @Test public void testParseList_02() { parse("(a)") ; }
-    @Test public void testParseList_03() { parse(" (a)") ; }
-    @Test public void testParseList_04() { parse("( a)") ; }
-    @Test public void testParseList_05() { parse("(a )") ; }
-    @Test public void testParseList_06() { parse("(a) ") ; }
-    @Test public void testParseList_07() { parse("('a') ") ; }
-    @Test public void testParseList_08() { parse("(<a>) ") ; }
-
-    @Test public void testParse_10() { parseBad("'foo' @en") ; }
+    @Test public void testParse_10() { parseBad("'foo' @en"); }
 
     // ---- Terms
-    @Test public void testLit_01() { testNode("'foo'") ; }
-    @Test public void testLit_02() { testNode("\"foo\"") ; }
-    @Test public void testLit_03() { testNode("''") ; }
-    @Test public void testLit_04() { testNode("\"\"") ; }
-    @Test public void testLit_05() { testNode("'foo'@en") ; }
-    @Test public void testLit_06() { parseBad("'foo' @en") ; }
-    @Test public void testLit_07() { parseBad("'") ; }
-    @Test public void testLit_08() { parseBad("'\"") ; }
-    @Test public void testLit_09() { parseBad("'''") ; }
-    @Test public void testLit_10() { parseBad("''@") ; }
-    @Test public void testLit_11() { testNode("'''abc\\ndef'''") ; }
+    @Test public void testLit_01() { testNode("'foo'"); }
+    @Test public void testLit_02() { testNode("\"foo\""); }
+    @Test public void testLit_03() { testNode("''"); }
+    @Test public void testLit_04() { testNode("\"\""); }
+    @Test public void testLit_05() { testNode("'foo'@en"); }
+    @Test public void testLit_06() { parseBad("'foo' @en"); }
+    @Test public void testLit_07() { parseBad("'"); }
+    @Test public void testLit_08() { parseBad("'\""); }
+    @Test public void testLit_09() { parseBad("'''"); }
+    @Test public void testLit_10() { parseBad("''@"); }
+    @Test public void testLit_11() { testNode("'''abc\\ndef'''"); }
 
-    @Test public void testLit_12()
-    {
-        Node n = org.apache.jena.graph.NodeFactory.createLiteralString("A\tB") ;
-        testNode("'''A\\tB'''", n) ;
+    @Test
+    public void testLit_12() {
+        Node n = org.apache.jena.graph.NodeFactory.createLiteralString("A\tB");
+        testNode("'''A\\tB'''", n);
     }
 
-    @Test public void testLit_13() { testNode("'abc\\ndef'") ; }
+    @Test public void testLit_13() { testNode("'abc\\ndef'"); }
 
-    @Test public void testNum_1() { testNode("1") ; }
-    @Test public void testNum_2() { testNode("1.1") ; }
-    @Test public void testNum_3() { testNode("1.0e6") ; }
+    @Test public void testNum_1() { testNode("1"); }
+    @Test public void testNum_2() { testNode("1.1"); }
+    @Test public void testNum_3() { testNode("1.0e6"); }
 
-    @Test public void testNum_4() { parseBadNode("1 ") ; }
+    @Test public void testNum_4() { parseBadNode("1 "); }
 
-    @Test public void testNum_5() { parseBadNode("1 1") ; }
+    @Test public void testNum_5() { parseBadNode("1 1"); }
 
-    @Test public void testURI_1() { testNode("<http://example/base>") ; }
-    @Test public void testURI_2() { parseBadNode("http://example/baseNoDelimiters") ; }
-    @Test public void testURI_3() { parseBadNode("<http://example/ space>") ; }
+    @Test public void testURI_1() { testNode("<http://example/base>"); }
+    @Test public void testURI_2() { parseBadNode("http://example/baseNoDelimiters"); }
+    @Test public void testURI_3() { parseBadNode("<http://example/ space>"); }
 
-    @Test public void testVar_01() { testVar("?x") ; }
-    @Test public void testVar_02() { testVar("?") ; }
-    @Test public void testVar_03() { testVar("?0") ; }
+    @Test public void testVar_01() { testVar("?x"); }
+    @Test public void testVar_02() { testVar("?"); }
+    @Test public void testVar_03() { testVar("?0"); }
     // See ARQConstants.anonVarMarker
-    @Test public void testVar_04() { testVar("??x") ; }
-    @Test public void testVar_05() { testVar("??") ; }
-    @Test public void testVar_06() { testVar("??0") ; }
+    @Test public void testVar_04() { testVar("??x"); }
+    @Test public void testVar_05() { testVar("??"); }
+    @Test public void testVar_06() { testVar("??0"); }
 
     // See ARQConstants.allocVarMarker
-    @Test public void testVar_07() { testVar("?"+ARQConstants.allocVarMarker+"0") ; }
-    @Test public void testVar_08() { testVar("?"+ARQConstants.allocVarMarker) ; }
+    @Test public void testVar_07() { testVar("?"+ARQConstants.allocVarMarker+"0"); }
+    @Test public void testVar_08() { testVar("?"+ARQConstants.allocVarMarker); }
 
     // Default allocations
-    @Test public void testVar_09()
-    {
-        Node v = parseNode("?") ;
-        assertTrue( v instanceof Var ) ;
-        String vn = ((Var)v).getVarName() ;
-        assertFalse(vn.equals("")) ;
+    @Test
+    public void testVar_09() {
+        Node v = parseNode("?");
+        assertTrue(v instanceof Var);
+        String vn = ((Var)v).getVarName();
+        assertFalse(vn.equals(""));
     }
 
-    @Test public void testVar_10()
-    {
-        Node v = parseNode("?"+ARQConstants.allocVarAnonMarker) ;
-        assertTrue( v instanceof Var ) ;
-        String vn = ((Var)v).getVarName() ;
-        assertFalse(vn.equals(ARQConstants.allocVarAnonMarker)) ;
+    @Test
+    public void testVar_10() {
+        Node v = parseNode("?" + ARQConstants.allocVarAnonMarker);
+        assertTrue(v instanceof Var);
+        String vn = ((Var)v).getVarName();
+        assertFalse(vn.equals(ARQConstants.allocVarAnonMarker));
     }
 
-    @Test public void testVar_11()
-    {
-        Node v = parseNode("?"+ARQConstants.allocVarMarker) ;
-        assertTrue( v instanceof Var ) ;
-        String vn = ((Var)v).getVarName() ;
-        assertFalse(vn.equals(ARQConstants.allocVarMarker)) ;
+    @Test
+    public void testVar_11() {
+        Node v = parseNode("?" + ARQConstants.allocVarMarker);
+        assertTrue(v instanceof Var);
+        String vn = ((Var)v).getVarName();
+        assertFalse(vn.equals(ARQConstants.allocVarMarker));
     }
 
-    @Test public void testWS_1() { parseBadNode("?x ") ; }
-    @Test public void testWS_2() { parseBadNode(" ?x") ; }
+    @Test public void testWS_1() { parseBadNode("?x "); }
+    @Test public void testWS_2() { parseBadNode(" ?x"); }
 
     // ---- Nodes
 
-    @Test public void testNode_1()    { testNode("3", int3) ; }
-    @Test public void testNode_2()    { testNode("<http://example/node1>", org.apache.jena.graph.NodeFactory.createURI("http://example/node1")) ; }
-    @Test public void testTypedLit_1() { testNode("\"123\"^^<http://example/type>", typeLit1) ; }
-    @Test public void testTypedLit_2() { testNode("'123'^^<http://example/type>", typeLit1) ; }
-    @Test public void testTypedLit_3() { testNode("'3'^^<"+XSDDatatype.XSDinteger.getURI()+">", int3) ; }
+    @Test public void testNode_1()    { testNode("3", int3); }
+    @Test public void testNode_2()    { testNode("<http://example/node1>", org.apache.jena.graph.NodeFactory.createURI("http://example/node1")); }
+    @Test public void testTypedLit_1() { testNode("\"123\"^^<http://example/type>", typeLit1); }
+    @Test public void testTypedLit_2() { testNode("'123'^^<http://example/type>", typeLit1); }
+    @Test public void testTypedLit_3() { testNode("'3'^^<"+XSDDatatype.XSDinteger.getURI()+">", int3); }
 
     // --- Symbols
 
-    @Test public void testSymbol_1()    { testSymbol("word") ; }
-    @Test public void testSymbol_2()    { testSymbol("+") ; }
+    @Test public void testSymbol_1()    { testSymbol("word"); }
+    @Test public void testSymbol_2()    { testSymbol("+"); }
     // XXX Parser broken
-//    @Test public void testSymbol_3()    { testSymbol("^^") ; }
-//    @Test public void testSymbol_4()    { testSymbol("^^<foo>") ; }
-//    @Test public void testSymbol_5()    { testSymbol("@") ; }
-//    @Test public void testSymbol_6()    { testSymbol("@en") ; }
+//    @Test public void testSymbol_3()    { testSymbol("^^"); }
+//    @Test public void testSymbol_4()    { testSymbol("^^<foo>"); }
+//    @Test public void testSymbol_5()    { testSymbol("@"); }
+//    @Test public void testSymbol_6()    { testSymbol("@en"); }
 
     // --- nil
 
-    @Test public void testNil_1()    { testItem("nil", Item.nil) ; }
-    @Test public void testNil_2()    { testNotItem("null", Item.nil) ; }
-    @Test public void testNil_3()    { testNotItem("()", Item.nil) ; }
+    @Test public void testNil_1()    { testItem("nil", Item.nil); }
+    @Test public void testNil_2()    { testNotItem("null", Item.nil); }
+    @Test public void testNil_3()    { testNotItem("()", Item.nil); }
     @Test public void testNil_4()
     {
-        Item x = Item.createList() ;
-        x.getList().add(Item.nil) ;
-        testItem("(nil)", x) ;
+        Item x = Item.createList();
+        x.getList().add(Item.nil);
+        testItem("(nil)", x);
     }
 
     // ---- Lists
 
     @Test public void testList_1()
     {
-        Item item = parse("()") ;
-        assertTrue(item.isList()) ;
-        assertEquals(item.getList().size(), 0 ) ;
+        Item item = parse("()");
+        assertTrue(item.isList());
+        assertEquals(item.getList().size(), 0 );
     }
 
-    @Test public void testList_2()    { testList("(1)", int1i) ; }
-    @Test public void testList_3()    { testList("(1 2)", int1i, int2i) ; }
-    @Test public void testList_4()    { testList("(1 a)", int1i, Item.createSymbol("a")) ; }
+    @Test public void testList_2()    { testList("(1)", int1i); }
+    @Test public void testList_3()    { testList("(1 2)", int1i, int2i); }
+    @Test public void testList_4()    { testList("(1 a)", int1i, Item.createSymbol("a")); }
 
     @Test public void testList_5()
     {
-        Item list = Item.createList() ;
-        list.getList().add(int1i) ;
-        testList("((1) a)", list, Item.createSymbol("a")) ;
+        Item list = Item.createList();
+        list.getList().add(int1i);
+        testList("((1) a)", list, Item.createSymbol("a"));
     }
 
     @Test public void testList_6()
-    { testList("(+ 1)", Item.createSymbol("+"), int1i) ; }
+    { testList("(+ 1)", Item.createSymbol("+"), int1i); }
 
     @Test public void testList_7()
-    { testList("[+ 1]", Item.createSymbol("+"), int1i) ; }
+    { testList("[+ 1]", Item.createSymbol("+"), int1i); }
 
 
     @Test public void testNum_01()
     {
-        Item item = SSE.parse("1") ;
-        assertEquals(1, item.getInt()) ;
+        Item item = SSE.parse("1");
+        assertEquals(1, item.getInt());
     }
 
     @Test public void testNum_02()
     {
-        Item item = SSE.parse("3") ;
-        assertEquals(3d, item.getDouble(), 0) ;
+        Item item = SSE.parse("3");
+        assertEquals(3d, item.getDouble(), 0);
     }
 
     @Test public void testNum_03()
     {
-        Item item = SSE.parse("2.5") ;      // Exact double
-        assertEquals(2.5d, item.getDouble(), 0) ;
+        Item item = SSE.parse("2.5");      // Exact double
+        assertEquals(2.5d, item.getDouble(), 0);
     }
 
     @Test public void testNum_04()
     {
-        Item item = SSE.parse("abc") ;
+        Item item = SSE.parse("abc");
         try {
-            item.getInt() ;
-            fail("Succeeded where exceptiSSE.on expected") ;
+            item.getInt();
+            fail("Succeeded where exceptiSSE.on expected");
         } catch (ItemException ex) {}
     }
 
     @Test public void testNum_05()
     {
-        Item item = SSE.parse("<x>") ;
+        Item item = SSE.parse("<x>");
         try {
-            item.getInt() ;
-            fail("Succeeded where exception expected") ;
+            item.getInt();
+            fail("Succeeded where exception expected");
         } catch (ItemException ex) {}
     }
 
 
-    @Test public void testMisc_01()    { testEquals("()") ; }
-    @Test public void testMisc_02()    { testEquals("(a)") ; }
-    @Test public void testMisc_10()    { testNotEquals("(a)", "a") ; }
-    @Test public void testMisc_11()    { testNotEquals("(a)", "()") ; }
-    @Test public void testMisc_12()    { testNotEquals("(a)", "(<a>)") ; }
+    @Test public void testMisc_01()    { testEquals("()"); }
+    @Test public void testMisc_02()    { testEquals("(a)"); }
+    @Test public void testMisc_10()    { testNotEquals("(a)", "a"); }
+    @Test public void testMisc_11()    { testNotEquals("(a)", "()"); }
+    @Test public void testMisc_12()    { testNotEquals("(a)", "(<a>)"); }
 
     @Test public void testTripleTerm_1()  { testNode("<< :s :p :o >>"); }
     @Test public void testTripleTerm_2()  { testNode("<<:s :p :o>>"); }
@@ -268,153 +260,132 @@ public class TestSSE_Basic
     @Test public void testQuotedTriple_14()  { parseBadNoLift("(qtriple <<:s :p :o >> :q "); }
 
 
-    @Test public void testTaggedList_1()
-    {
-        Item x = Item.createTagged("TAG") ;
-        assertTrue(x.isTagged()) ;
-        assertTrue(x.isTagged("TAG")) ;
+    @Test
+    public void testTaggedList_1() {
+        Item x = Item.createTagged("TAG");
+        assertTrue(x.isTagged());
+        assertTrue(x.isTagged("TAG"));
     }
 
-    @Test public void testTaggedList_2()
-    {
-        Item x = Item.createTagged("TAG") ;
-        Item.addPair(x.getList(), "KEY", "VALUE") ;
+    @Test
+    public void testTaggedList_2() {
+        Item x = Item.createTagged("TAG");
+        Item.addPair(x.getList(), "KEY", "VALUE");
 
-        Item y = Item.find(x.getList(), "KEY") ;
-        assertNotNull(y) ;
+        Item y = Item.find(x.getList(), "KEY");
+        assertNotNull(y);
 
-        Item z = Item.find(x.getList(), "KEYKEY") ;
-        assertNull(z) ;
+        Item z = Item.find(x.getList(), "KEYKEY");
+        assertNull(z);
     }
-
-
-
 
     // ---- Workers ----
 
-    private void testEquals(String x)
-    {
-        Item item1 = parse(x) ;
-        Item item2 = parse(x) ;
-        assertTrue(item1.equals(item2)) ;
-        assertTrue(item2.equals(item1)) ;
+    private void testEquals(String x) {
+        Item item1 = parse(x);
+        Item item2 = parse(x);
+        assertTrue(item1.equals(item2));
+        assertTrue(item2.equals(item1));
     }
 
-    private void testNotEquals(String x1, String x2)
-    {
-        Item item1 = parse(x1) ;
-        Item item2 = parse(x2) ;
-        assertFalse(item1.equals(item2)) ;
-        assertFalse(item2.equals(item1)) ;
+    private void testNotEquals(String x1, String x2) {
+        Item item1 = parse(x1);
+        Item item2 = parse(x2);
+        assertFalse(item1.equals(item2));
+        assertFalse(item2.equals(item1));
     }
 
-    private Item parse(String str)
-    {
-        Item item = SSE.parse(str) ;
-        return item ;
+    private Item parse(String str) {
+        Item item = SSE.parse(str);
+        return item;
     }
 
-    private void testSymbol(String str)
-    {
-        Item item = parse(str) ;
-        assertTrue(item.isSymbol()) ;
-        assertEquals(item.getSymbol(), str) ;
+    private void testSymbol(String str) {
+        Item item = parse(str);
+        assertTrue(item.isSymbol());
+        assertEquals(item.getSymbol(), str);
     }
 
-    private void testList(String str, Item item1)
-    {
-        Item item = parse(str) ;
-        assertTrue(item.isList()) ;
+    private void testList(String str, Item item1) {
+        Item item = parse(str);
+        assertTrue(item.isList());
 
-        Item i = item.getList().get(0) ;
+        Item i = item.getList().get(0);
 
-        assertEquals(1, item.getList().size()) ;
-        assertEquals(item.getList().get(0), item1) ;
+        assertEquals(1, item.getList().size());
+        assertEquals(item.getList().get(0), item1);
     }
 
-    private void testList(String str, Item item1, Item item2)
-    {
-        Item item = parse(str) ;
-        assertTrue(item.isList()) ;
-        assertEquals(2, item.getList().size()) ;
-        assertEquals(item.getList().get(0), item1) ;
-        assertEquals(item.getList().get(1), item2) ;
+    private void testList(String str, Item item1, Item item2) {
+        Item item = parse(str);
+        assertTrue(item.isList());
+        assertEquals(2, item.getList().size());
+        assertEquals(item.getList().get(0), item1);
+        assertEquals(item.getList().get(1), item2);
     }
 
-    private void testList(String str, Item item1, Item item2, Item item3)
-    {
-        Item item = parse(str) ;
-        assertTrue(item.isList()) ;
-        assertEquals(3, item.getList().size()) ;
-        assertEquals(item.getList().get(0), item1) ;
-        assertEquals(item.getList().get(1), item2) ;
-        assertEquals(item.getList().get(2), item3) ;
+    private void testList(String str, Item item1, Item item2, Item item3) {
+        Item item = parse(str);
+        assertTrue(item.isList());
+        assertEquals(3, item.getList().size());
+        assertEquals(item.getList().get(0), item1);
+        assertEquals(item.getList().get(1), item2);
+        assertEquals(item.getList().get(2), item3);
     }
 
-    private void testItem(String str, Item result)
-    {
-        Item item = parse(str) ;
-        assertEquals(result, item) ;
+    private void testItem(String str, Item result) {
+        Item item = parse(str);
+        assertEquals(result, item);
     }
 
-    private void testNotItem(String str, Item result)
-    {
-        Item item = parse(str) ;
-        assertFalse(result.equals(item)) ;
+    private void testNotItem(String str, Item result) {
+        Item item = parse(str);
+        assertFalse(result.equals(item));
     }
 
-    private void testNode(String str)
-    {
-        Node node = parseNode(str) ;
+    private void testNode(String str) {
+        Node node = parseNode(str);
     }
 
-    private void testVar(String str)
-    {
-        Node node = parseNode(str) ;
-        assertTrue( node instanceof Var ) ;
+    private void testVar(String str) {
+        Node node = parseNode(str);
+        assertTrue(node instanceof Var);
     }
 
-    private void testNode(String str, Node result)
-    {
-        Node node = parseNode(str) ;
-        assertEquals(result, node) ;
+    private void testNode(String str, Node result) {
+        Node node = parseNode(str);
+        assertEquals(result, node);
     }
 
-    private Node parseNode(String str)
-    {
-        // Not NodeFactory.parseNode which does not have all the features (e.g. "_" and "?")
-        return SSE.parseNode(str) ;
+    private Node parseNode(String str) {
+        // Not NodeFactory.parseNode which does not have all the features (e.g. "_"
+        // and "?")
+        return SSE.parseNode(str);
     }
 
-    private void parseBad(String str)
-    {
+    private void parseBad(String str) {
         try {
-            Item item = SSE.parse(str) ;
-            //System.out.println(str+" => "+item) ;
-            fail("Did not get a parse failure") ;
-        }
-        catch (ItemException | SSE_ParseException ex) {}
+            Item item = SSE.parse(str);
+            // System.out.println(str+" => "+item);
+            fail("Did not get a parse failure");
+        } catch (ItemException | SSE_ParseException ex) {}
     }
 
-    private void parseBadNoLift(String str)
-    {
+    private void parseBadNoLift(String str) {
         try {
-            Node node = SSE.parseNode(str) ;
-            //System.out.println(str+" => "+item) ;
-            fail("Did not get a parse failure") ;
-        }
-        catch (ItemException | SSE_ParseException ex) {}
+            Node node = SSE.parseNode(str);
+            // System.out.println(str+" => "+item);
+            fail("Did not get a parse failure");
+        } catch (ItemException | SSE_ParseException ex) {}
     }
 
-    private void parseBadNode(String str)
-    {
+    private void parseBadNode(String str) {
         try {
-            // Not NodeFactory.parseNode which does not have all the features (e.g. "_" and "?")
-            Node node = parseNode(str) ;
-            //System.out.println(str+" => "+item) ;
-            fail("Did not get a parse failure") ;
-        }
-        catch (ItemException | SSE_ParseException ex) {}
+            // Not NodeFactory.parseNode which does not have all the features (e.g.
+            // "_" and "?")
+            Node node = parseNode(str);
+            // System.out.println(str+" => "+item);
+            fail("Did not get a parse failure");
+        } catch (ItemException | SSE_ParseException ex) {}
     }
-
 }

--- a/jena-fuseki2/jena-fuseki-server/src/main/resources/META-INF/NOTICE
+++ b/jena-fuseki2/jena-fuseki-server/src/main/resources/META-INF/NOTICE
@@ -22,12 +22,6 @@ See https://github.com/HdrHistogram/HdrHistogram/blob/master/LICENSE.txt
 
 - - - - - - - - - - - - - - - - - - - - - - -
 
-This product bundles "jsonld-java", which is available under a
-BSD license (BSD-3-Clause). See 
-https://github.com/jsonld-java/jsonld-java/blob/master/LICENCE
-
-- - - - - - - - - - - - - - - - - - - - - - -
-
 This product bundles "Dexx Collections", which is available under an
 MIT license (MIT).  See https://github.com/andrewoma/dexx/blob/master/LICENSE.txt
   

--- a/jena-rdfpatch/src/main/java/org/apache/jena/rdfpatch/system/PatchSystem.java
+++ b/jena-rdfpatch/src/main/java/org/apache/jena/rdfpatch/system/PatchSystem.java
@@ -19,7 +19,6 @@
 package org.apache.jena.rdfpatch.system;
 
 import org.apache.jena.rdfpatch.filelog.VocabPatch;
-import org.apache.jena.sys.JenaSystem;
 
 public class PatchSystem {
 
@@ -35,14 +34,10 @@ public class PatchSystem {
         if ( initialized )
             return;
         synchronized(initLock) {
-            if ( initialized ) {
-                JenaSystem.logLifecycle("Patch.init - return");
+            if ( initialized )
                 return;
-            }
             initialized = true;
-            JenaSystem.logLifecycle("Patch.init - start");
             VocabPatch.init();
-            JenaSystem.logLifecycle("Patch.init - finish");
         }
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultipleProplistNotWorking.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultipleProplistNotWorking.java
@@ -18,6 +18,14 @@
 
 package org.apache.jena.query.text;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.*;
+
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.query.*;
@@ -26,21 +34,9 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
-
-
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.*;
-
-import static org.junit.Assert.*;
 
 // GH-2094
 public class TestTextMultipleProplistNotWorking extends AbstractTestDatasetWithTextIndexBase {
@@ -57,7 +53,7 @@ public class TestTextMultipleProplistNotWorking extends AbstractTestDatasetWithT
             "@prefix mx: <http://id.example.test/mx/#> ."
 
             );
-    protected static final String QUERY_PROLOG2 = 
+    protected static final String QUERY_PROLOG2 =
             StrUtils.strjoinNL(
                     "prefix res:  <" + RES_BASE + "> ",
                     "prefix spec: <" + SPEC_BASE + "> ",
@@ -244,12 +240,12 @@ public class TestTextMultipleProplistNotWorking extends AbstractTestDatasetWithT
         );
         Set<String> expectedURIs = new HashSet<>() ;
         expectedURIs.addAll( Arrays.asList("http://id.example.test/1","http://id.example.test/2")) ;
-        
+
         Map<String, Literal> literals = doTestSearchWithLiterals(queryString, expectedURIs) ;
 
         Map<String,Literal> literalsFromMtNote = doTestSearchWithLiterals(queryStringMtNote,expectedURIs);
         assertEquals(2, literals.size());
-        
+
         Literal value = literals.get("http://id.example.test/1");
         assertNotNull(value);
 


### PR DESCRIPTION
GitHub issue resolved #2273 

Pull request Description:
* Implement XSD duration division #2273
* Updates jena-fuseki-server NOTICE because Jena5 does not depend on jsonld-java any more.
* Misc tidy up.
----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
