### PR TITLE
Update javadoc links to point to TDB2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1001,7 +1001,7 @@
             <links>
               <link>https://jena.apache.org/documentation/javadoc/jena/</link>
               <link>https://jena.apache.org/documentation/javadoc/arq/</link>
-              <link>https://jena.apache.org/documentation/javadoc/tdb/</link>
+              <link>https://jena.apache.org/documentation/javadoc/tdb2/</link>
               <link>https://jena.apache.org/documentation/javadoc/text/</link>
               <link>https://jena.apache.org/documentation/javadoc/rdfconnection/</link>
               <link>https://jena.apache.org/documentation/javadoc/fuseki2/</link>


### PR DESCRIPTION
Update the `<links>` section of the Javadoc configuration to point to TDB2.

Pointing to a non-existent URL cause the build to break if not explicitly set to "offline".

For Jena5, TDB2 is preferred.
