### PR TITLE
GH-2281: Update to commons-fileupload2-jakarta-servlet6

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/pom.xml
+++ b/jena-fuseki2/jena-fuseki-core/pom.xml
@@ -74,7 +74,7 @@
 
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-fileupload2-jakarta</artifactId>
+      <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
     </dependency>
 
     <dependency>

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/DataUploader.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/DataUploader.java
@@ -30,7 +30,7 @@ import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.fileupload2.core.FileItemInput;
 import org.apache.commons.fileupload2.core.FileItemInputIterator;
-import org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.web.ContentType;
 import org.apache.jena.fuseki.servlets.*;

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <ver.commons-codec>1.16.1</ver.commons-codec>
     <ver.commons-compress>1.25.0</ver.commons-compress>
     <ver.commons-collections>4.4</ver.commons-collections>
-    <ver.commons-fileupload>2.0.0-M1</ver.commons-fileupload>
+    <ver.commons-fileupload>2.0.0-M2</ver.commons-fileupload>
 
     <ver.dexxcollection>0.7</ver.dexxcollection>
     <ver.micrometer>1.12.2</ver.micrometer>
@@ -382,7 +382,7 @@
 
       <dependency>
         <groupId>org.apache.commons</groupId>
-        <artifactId>commons-fileupload2-jakarta</artifactId>
+        <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
         <version>${ver.commons-fileupload}</version>
       </dependency>
 


### PR DESCRIPTION
GitHub issue resolved #2281

Apache Commons fileupload2 has split into servlet5 and servlet6 artifacts.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
