### PR TITLE
GH-2297: Add CORS configuration file as command line parameter to Fuseki Main

### DIFF
--- a/jena-cmds/src/main/java/org/apache/jena/cmd/CommandLineBase.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/CommandLineBase.java
@@ -69,7 +69,15 @@ public class CommandLineBase {
 
         boolean positional = false;
 
+        if (null == argv) {
+            return argList;
+        }
+
         for ( String anArgv : argv ) {
+            if (null == anArgv) {
+                continue;
+            }
+
             String argStr = anArgv;
 
             if ( positional || !argStr.startsWith("-") ) {

--- a/jena-fuseki2/jena-fuseki-core/pom.xml
+++ b/jena-fuseki2/jena-fuseki-core/pom.xml
@@ -120,6 +120,12 @@
       <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TS_FusekiCore.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TS_FusekiCore.java
@@ -19,6 +19,7 @@
 package org.apache.jena.fuseki;
 
 import org.apache.jena.fuseki.server.TestDispatchOnURI;
+import org.apache.jena.fuseki.servlets.TestCrossOriginFilter;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -27,7 +28,8 @@ import org.junit.runners.Suite.SuiteClasses;
 @RunWith(Suite.class)
 @SuiteClasses({
     TestValidators.class,
-    TestDispatchOnURI.class
+    TestDispatchOnURI.class,
+    TestCrossOriginFilter.class
 })
 public class TS_FusekiCore {}
 

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/servlets/TestCrossOriginFilter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/servlets/TestCrossOriginFilter.java
@@ -1,0 +1,446 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.fuseki.servlets;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+import static org.apache.jena.fuseki.servlets.CrossOriginFilter.*;
+import static org.mockito.Mockito.*;
+
+public class TestCrossOriginFilter {
+    private static class TestFilterConfig implements FilterConfig {
+        Map<String,String> parameterMap;
+
+        public TestFilterConfig() {
+            this(emptyMap());
+        }
+
+        public TestFilterConfig(Map<String,String> initMap) {
+            parameterMap = initMap;
+        }
+
+        @Override
+        public String getFilterName() {
+            return "TestFilter";
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return null;
+        }
+
+        @Override
+        public String getInitParameter(String s) {
+            return parameterMap.get(s);
+        }
+
+        @Override
+        public Enumeration<String> getInitParameterNames() {
+            return Collections.enumeration(parameterMap.keySet());
+        }
+    }
+
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    @Before
+    public void setUpTest() {
+        when(httpServletRequest.getHeader("Origin")).thenReturn("http://localhost:12335");
+        when(httpServletRequest.getHeaders("Connection")).thenReturn(Collections.emptyEnumeration());
+        when(httpServletRequest.getRequestURI()).thenReturn("/relevant-url");
+        when(httpServletRequest.getHeader("Access-Control-Request-Method")).thenReturn("POST");
+        when(httpServletRequest.getMethod()).thenReturn("OPTIONS");
+    }
+
+    @Test
+    public void test_AccessControlRequestHeaders() throws ServletException, IOException {
+        // given
+        CrossOriginFilter cut = new CrossOriginFilter();
+
+        String allowedList = "content-type, accept, origin";
+        String oneWrong  = "content-type, unrecognised, accept, origin";
+
+        when(httpServletRequest.getHeader("Access-Control-Request-Headers")).thenReturn(oneWrong);
+
+        cut.init(new TestFilterConfig());
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(0)).setHeader(eq("Access-Control-Allow-Headers"), any());
+
+        // when
+        when(httpServletRequest.getHeader("Access-Control-Request-Headers")).thenReturn(allowedList);
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).setHeader("Access-Control-Allow-Headers", "X-Requested-With,Content-Type,Accept,Origin");
+    }
+
+    @Test
+    public void test_SimpleRequest() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getMethod()).thenReturn("GET");
+        when(httpServletRequest.getHeader("Access-Control-Request-Method")).thenReturn(null);
+
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(
+                Map.of(ALLOW_CREDENTIALS_PARAM, "true",
+                       EXPOSED_HEADERS_PARAM, "exposedHeader"))
+        );
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_EXPOSE_HEADERS_HEADER, "exposedHeader");
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader("Access-Control-Allow-Origin", "http://localhost:12335");
+        verify(httpServletResponse, times(1)).setHeader("Access-Control-Allow-Credentials", "true");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_allowAllHeaders() throws ServletException, IOException {
+        // given
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(
+                Map.of(ALLOWED_HEADERS_PARAM, "*")
+        ));
+        String anyHeaders  = "content-type, unrecognised, accept, origin";
+        when(httpServletRequest.getHeader("Access-Control-Request-Headers")).thenReturn(anyHeaders);
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "http://localhost:12335");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_MAX_AGE_HEADER, "1800");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,HEAD");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "content-type,unrecognised,accept,origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_ignoreInvalidAge() throws ServletException, IOException {
+        // given
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(
+                Map.of(PREFLIGHT_MAX_AGE_PARAM, "INVALID")
+        ));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "http://localhost:12335");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,HEAD");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "X-Requested-With,Content-Type,Accept,Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_handleOldChainPreflightParam() throws ServletException, IOException {
+        // given
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(
+                Map.of(OLD_CHAIN_PREFLIGHT_PARAM, "false")
+        ));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "http://localhost:12335");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_MAX_AGE_HEADER, "1800");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,HEAD");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "X-Requested-With,Content-Type,Accept,Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_destroy_clearsConfig() throws ServletException, IOException {
+        // given
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(
+                Map.of(ALLOW_CREDENTIALS_PARAM, "true",
+                       EXPOSED_HEADERS_PARAM, "exposedHeader"))
+        );
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "http://localhost:12335");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_MAX_AGE_HEADER, "1800");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,HEAD");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "X-Requested-With,Content-Type,Accept,Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+        // then
+        cut.destroy();
+        // then
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+        verify(httpServletResponse, times(2)).addHeader("Vary", "Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_complexNonFlightRequest_treatedAsSimple() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getMethod()).thenReturn("PUT");
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig());
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "http://localhost:12335");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_emptyOrigin() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getHeader("Origin")).thenReturn(null);
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig());
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_allowedOrigins_specific() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getHeader("Origin")).thenReturn("localhost:12345");
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(Map.of(
+                ALLOWED_ORIGINS_PARAM, "localhost:12345"
+        )));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "localhost:12345");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_MAX_AGE_HEADER, "1800");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,HEAD");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "X-Requested-With,Content-Type,Accept,Origin");
+
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_allowedOrigins_regex() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getHeader("Origin")).thenReturn("localhost:12345");
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(Map.of(
+                ALLOWED_ORIGINS_PARAM, "localhost:*"
+        )));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "localhost:12345");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_MAX_AGE_HEADER, "1800");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,HEAD");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "X-Requested-With,Content-Type,Accept,Origin");
+
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+
+    @Test
+    public void test_allowedOrigins_noMatch() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getHeader("Origin")).thenReturn("localhost:999999");
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(Map.of(
+                ALLOWED_ORIGINS_PARAM, "   ,localhost:54321, , localhost:12345"
+        )));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_allowedOrigins_emptyString() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getHeader("Origin")).thenReturn("  ");
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(Map.of(
+                ALLOWED_ORIGINS_PARAM, " localhost:54321, ,localhost:12345"
+        )));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_allowedOrigins_noMatchWithEmptyString() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getHeader("Origin")).thenReturn(" x xx xxx   ");
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(Map.of(
+                ALLOWED_ORIGINS_PARAM, " localhost:54321, ,localhost:12345"
+        )));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_allowedTimedOrigins_specific() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getHeader("Origin")).thenReturn("localhost:12345");
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(Map.of(
+                ALLOWED_TIMING_ORIGINS_PARAM, "localhost:12345"
+        )));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "localhost:12345");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_MAX_AGE_HEADER, "1800");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,HEAD");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "X-Requested-With,Content-Type,Accept,Origin");
+        verify(httpServletResponse, times(1)).setHeader(TIMING_ALLOW_ORIGIN_HEADER,"localhost:12345");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_allowedTimedOrigins_regex() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getHeader("Origin")).thenReturn("localhost:12345");
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(Map.of(
+                ALLOWED_TIMING_ORIGINS_PARAM, "localhost:*"
+        )));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "localhost:12345");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_MAX_AGE_HEADER, "1800");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,HEAD");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "X-Requested-With,Content-Type,Accept,Origin");
+        verify(httpServletResponse, times(1)).setHeader(TIMING_ALLOW_ORIGIN_HEADER,"localhost:12345");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+
+    @Test
+    public void test_allowedTimedOrigins_noMatch() throws ServletException, IOException {
+        // given
+        when(httpServletRequest.getHeader("Origin")).thenReturn("localhost:999999");
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig(Map.of(
+                ALLOWED_TIMING_ORIGINS_PARAM, "localhost:54321, localhost:12345"
+        )));
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, "localhost:999999");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER, "true");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_MAX_AGE_HEADER, "1800");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_METHODS_HEADER, "GET,POST,HEAD");
+        verify(httpServletResponse, times(1)).setHeader(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, "X-Requested-With,Content-Type,Accept,Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+    @Test
+    public void test_requestDisabled() throws ServletException, IOException {
+        // given
+        Enumeration<String> connections = Collections.enumeration(List.of("Random", "Upgrade"));
+        when(httpServletRequest.getHeaders("Connection")).thenReturn(connections);
+        Enumeration<String> upgrades = Collections.enumeration(List.of("SomethingElse", "WebSocket"));
+        when(httpServletRequest.getHeaders("Upgrade")).thenReturn(upgrades);
+
+        CrossOriginFilter cut = new CrossOriginFilter();
+        cut.init(new TestFilterConfig());
+
+        // when
+        cut.doFilter(httpServletRequest, httpServletResponse, chain);
+
+        // then
+        verify(httpServletResponse, times(1)).addHeader("Vary", "Origin");
+        verifyNoMoreInteractions(httpServletResponse);
+    }
+
+
+}

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
@@ -52,6 +52,7 @@ class ServerConfig {
     public FusekiModules fusekiModules  = null;
 
     public boolean withCORS             = true;
+    public String corsConfigFile        = null;
     public boolean withPing             = false;
     public boolean withStats            = false;
     public boolean withMetrics          = false;

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
@@ -33,6 +33,7 @@ import org.junit.runners.Suite.SuiteClasses;
   , TestMultipleEmbedded.class
   , TestFusekiCustomOperation.class
   , TestFusekiMainCmd.class
+  , TestFusekiMainCmdArguments.class
   , TestFusekiStdSetup.class
   , TestFusekiStdReadOnlySetup.class
   , TestConfigFile.class

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmd.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmd.java
@@ -18,24 +18,32 @@
 
 package org.apache.jena.fuseki.main;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.stream.Stream;
-
 import org.apache.jena.atlas.json.JSON;
 import org.apache.jena.atlas.lib.FileOps;
 import org.apache.jena.atlas.web.TypedInputStream;
 import org.apache.jena.fuseki.main.cmds.FusekiMain;
 import org.apache.jena.fuseki.system.FusekiLogging;
+import org.apache.jena.http.HttpEnv;
+import org.apache.jena.http.HttpLib;
 import org.apache.jena.http.HttpOp;
 import org.apache.jena.query.ResultSetFormatter;
 import org.apache.jena.rdfconnection.RDFConnection;
+import org.apache.jena.riot.web.HttpNames;
 import org.junit.After;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.apache.jena.http.HttpLib.execute;
+import static org.apache.jena.http.HttpLib.toRequestURI;
+import static org.apache.jena.riot.web.HttpNames.METHOD_OPTIONS;
+import static org.junit.Assert.*;
 
 /** Test features */
 public class TestFusekiMainCmd {
@@ -122,5 +130,80 @@ public class TestFusekiMainCmd {
         String x1 = HttpOp.httpGetString(serverURL+"/$/tasks");
         assertNotNull(x1);
         // Leaves "DB-compact" behind.
+    }
+
+    @Test public void test_CORS_default_success() {
+        // given
+        String defaultHeaders = "X-Requested-With, Content-Type, Accept, Origin, Last-Modified, Authorization";
+        Map<String,String> headersToPass = Map.of("Access-Control-Request-Method", "POST",
+                                                  "Origin", "localhost:12345",
+                                                  "Access-Control-Request-Headers", defaultHeaders);
+        String expectedAllowedHeaders = "X-Requested-With,Content-Type,Accept,Origin,Last-Modified,Authorization";
+        server("--mem", "/ds");
+        // when
+        HttpResponse<InputStream> response = makeOptionsCall(serverURL + "/ds", headersToPass);
+        // then
+        assertNotNull(response);
+        assertEquals(response.statusCode(), 200);
+        String actualAllowedHeaders = HttpLib.responseHeader(response, HttpNames.hAccessControlAllowHeaders);
+        assertNotNull("Expecting valid headers", actualAllowedHeaders);
+        assertEquals(expectedAllowedHeaders, actualAllowedHeaders);
+    }
+
+    @Test public void test_CORS_default_fail() {
+        // given
+        String unrecognisedHeader = "Content-Type, unknown-header";
+        Map<String,String> headersToPass = Map.of("Access-Control-Request-Method", "POST","Access-Control-Request-Headers", unrecognisedHeader);
+        server("--mem", "/ds");
+        // when
+        HttpResponse<InputStream> response = makeOptionsCall(serverURL + "/ds", headersToPass);
+        // then
+        assertNotNull(response);
+        assertEquals(response.statusCode(), 200);
+        String actualAllowedHeaders = HttpLib.responseHeader(response, HttpNames.hAccessControlAllowHeaders);
+        assertNull("No headers expected given invalid request", actualAllowedHeaders);
+    }
+
+    @Test public void test_CORS_config_success() {
+        // given
+        String nonDefaultAllowedHeader = "Content-Type, Custom-Header";
+        Map<String,String> headersToPass = Map.of("Access-Control-Request-Method", "POST",
+                                                  "Origin", "http://localhost:5173",
+                                                  "Access-Control-Request-Headers", nonDefaultAllowedHeader);
+        String expectedAllowedHeaders = "X-Requested-With,Content-Type,Accept,Origin,Last-Modified,Authorization,Custom-Header";
+        server("--mem", "--CORS=testing/Config/cors.properties","/ds");
+        // when
+        HttpResponse<InputStream> response = makeOptionsCall(serverURL + "/ds", headersToPass);
+        // then
+        assertNotNull(response);
+        assertEquals(response.statusCode(), 200);
+        String actualAllowedHeaders = HttpLib.responseHeader(response, HttpNames.hAccessControlAllowHeaders);
+        assertNotNull("Expecting valid headers", actualAllowedHeaders);
+        assertEquals(expectedAllowedHeaders, actualAllowedHeaders);
+    }
+
+    @Test public void test_CORS_noConfig() {
+        // given
+        String defaultHeader = "Content-Type";
+        Map<String,String> headersToPass = Map.of("Access-Control-Request-Method", "POST","Access-Control-Request-Headers", defaultHeader);
+        server("--mem", "--noCORS", "/ds");
+        // when
+        HttpResponse<InputStream> response = makeOptionsCall(serverURL + "/ds", headersToPass);
+        // then
+        assertNotNull(response);
+        assertEquals(response.statusCode(), 200);
+        String actualAllowedHeaders = HttpLib.responseHeader(response, HttpNames.hAccessControlAllowHeaders);
+        assertNull("No headers expected given invalid request", actualAllowedHeaders);
+    }
+
+    private HttpResponse<InputStream> makeOptionsCall(String url, Map<String,String> headers) {
+        HttpRequest.Builder builder =
+                HttpLib.requestBuilderFor(url).uri(toRequestURI(url))
+                       .method(METHOD_OPTIONS, HttpRequest.BodyPublishers.noBody());
+        for (Map.Entry<String,String> entry : headers.entrySet()){
+            builder.header(entry.getKey(), entry.getValue());
+        }
+        HttpRequest request = builder.build();
+        return execute(HttpEnv.getDftHttpClient(), request);
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.fuseki.main;
+
+import org.apache.jena.cmd.CmdException;
+import org.apache.jena.fuseki.main.cmds.FusekiMain;
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.*;
+
+/**
+ * NOTE: we will randomise the port (--port=0) on all happy paths in order to avoid conflict with existing runs.
+ */
+public class TestFusekiMainCmdArguments {
+
+    @Test
+    public void test_happy_empty() {
+        // given
+        List<String> arguments = List.of("--port=0", "--empty", "/dataset");
+        // when
+        FusekiServer server = buildServer(buildCmdLineArguments(arguments));
+        // then
+        assertNotNull(server);
+    }
+
+    @Test
+    public void test_happy_localhost() {
+        // given
+        List<String> arguments = List.of("--port=0", "--localhost", "--mem", "/dataset");
+        // when
+        FusekiServer server = buildServer(buildCmdLineArguments(arguments));
+        // then
+        assertNotNull(server);
+    }
+
+    @Test
+    public void test_error_noDataSetProvided() {
+        // given
+        List<String> arguments = List.of("/dataset");
+        String expectedMessage = "No dataset specified on the command line.";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_noArguments_emptyString() {
+        // given
+        String emptyString = "";
+        String expectedMessage = "No dataset specified on the command line.";
+        // when
+        Throwable actual = null;
+        try {
+            buildServer(emptyString);
+        } catch (Exception e) {
+            actual = e;
+        }
+        // then
+        assertNotNull(actual);
+        assertTrue("Expecting correct exception", (actual instanceof CmdException));
+        assertEquals("Expecting correct message", expectedMessage, actual.getMessage());
+    }
+
+    @Test
+    public void test_error_noArguments_null() {
+        // given
+        String nullString = null;
+        String expectedMessage = "No dataset specified on the command line.";
+        // when
+        Throwable actual = null;
+        try {
+            buildServer(nullString);
+        } catch (Exception e) {
+            actual = e;
+        }
+        // then
+        assertNotNull(actual);
+        assertTrue("Expecting correct exception", (actual instanceof CmdException));
+        assertEquals("Expecting correct message", expectedMessage, actual.getMessage());
+    }
+
+    @Test
+    public void test_error_noArguments_emptyList() {
+        // given
+        List<String> arguments = emptyList();
+        String expectedMessage = "No dataset specified on the command line.";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_tooManyDataSetsProvided() {
+        // given
+        List<String> arguments =
+                List.of("--mem", "--file=file", "--dataset=dataset", "--tdb=file", "--memtdb=file", "--config=file");
+        String expectedMessage = "Multiple ways providing a dataset. Only one of --mem, --file, --loc or --conf";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_allowEmpty_withAdditionalDataset() {
+        // given
+        List<String> arguments = List.of("--mem", "--empty");
+        String expectedMessage = "Dataset provided but 'no dataset' flag given";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_configFileWithDataset() {
+        // given
+        List<String> arguments = List.of("--config=file", "/dataset");
+        String expectedMessage = "Can't have both a configuration file and a service name";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_configFileWithRDFS() {
+        // given
+        List<String> arguments = List.of("--config=file", "--rdfs=file");
+        String expectedMessage = "Need to define RDFS setup in the configuration file.";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_missingServiceName() {
+        // given
+        List<String> arguments = List.of("--mem");
+        String expectedMessage = "Missing service name";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_multipleServiceNames() {
+        // given
+        List<String> arguments = List.of("--mem", "/path1", "/path2");
+        String expectedMessage = "Multiple dataset path names given";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_configFileAndUpdate() {
+        // given
+        List<String> arguments = List.of("--config=file", "--update");
+        String expectedMessage =
+                "--update and a configuration file does not make sense (control using the configuration file only)";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_configFileMissingFile() {
+        // given
+        List<String> arguments = List.of("--config=file");
+        String expectedMessage = "File not found: file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_configFile_directory() {
+        // given
+        List<String> arguments = List.of("--config=testing/");
+        String expectedMessage = "Is a directory: testing/";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_invalidPort() {
+        // given
+        List<String> arguments = List.of("--mem", "--port=ERROR", "/path");
+        String expectedMessage = "port : bad port number: 'ERROR'";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_jettyConfigFileAndPort() {
+        // given
+        List<String> arguments = List.of("--mem", "--jetty=file", "--port=99", "/path");
+        String expectedMessage = "Cannot specify the port and also provide a Jetty configuration file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_jettyConfigFileAndLocalHost() {
+        // given
+        List<String> arguments = List.of("--mem", "--jetty=file", "--localhost", "/path");
+        String expectedMessage = "Cannot specify 'localhost' and also provide a Jetty configuration file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+
+    @Test
+    public void test_error_argConfigFile_MissingFile() {
+        // given
+        List<String> arguments = List.of("--file=file", "/dataset");
+        String expectedMessage = "File not found: file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+
+    @Test
+    public void test_error_argConfigFile_UnrecognisedFileType() {
+        // given
+        List<String> arguments = List.of("--file=testing/Config/cors.properties", "/dataset");
+        String expectedMessage = "Cannot guess language for file: testing/Config/cors.properties";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_argConfigFile_wrongFormat() {
+        // given
+        List<String> arguments = List.of("--file=testing/Config/invalid.ttl", "/dataset");
+        String expectedMessage = "Failed to load file: testing/Config/invalid.ttl";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_missingRDFSFile() {
+        // given
+        List<String> arguments = List.of("--mem", "--rdfs=missing_file", "/dataset");
+        String expectedMessage = "No such file for RDFS: missing_file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_missingSparqlerFile() {
+        // given
+        List<String> arguments = List.of("--sparqler=missing_file", "/dataset");
+        String expectedMessage = "File area not found: missing_file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+
+    @Test
+    public void test_error_incorrectContextPath() {
+        // given
+        List<String> arguments = List.of("--mem", "--contextPath=wrongPath/", "/dataset");
+        String expectedMessage = "Path base must not end with \"/\": 'wrongPath/'";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_argBase_missingFile() {
+        // given
+        List<String> arguments = List.of("--mem", "--base=missing_file", "/dataset");
+        String expectedMessage = "File area not found: missing_file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_passwdFile_withJetty() {
+        // given
+        List<String> arguments = List.of("--mem", "--passwd=missing_file", "--jetty=file", "/dataset");
+        String expectedMessage = "Can't specify a password file and also provide a Jetty configuration file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_httpsConfig() {
+        // given
+        List<String> arguments = List.of("--mem", "--httpsPort=12345", "/dataset");
+        String expectedMessage = "https port given but not certificate details via --https";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_httpsConfig_withJetty() {
+        // given
+        List<String> arguments = List.of("--mem", "--httpsPort=12345", "--https=something", "--jetty=file", "/dataset");
+        String expectedMessage = "Can't specify \"https\" and also provide a Jetty configuration file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_auth_withJetty() {
+        // given
+        List<String> arguments = List.of("--mem", "--auth=12345", "--jetty=file", "/dataset");
+        String expectedMessage = "Can't specify authentication and also provide a Jetty configuration file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_jetty_missingFile() {
+        // given
+        List<String> arguments = List.of("--mem", "--jetty=missing_file", "/dataset");
+        String expectedMessage = "Jetty config file not found: missing_file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_error_corsConfig_missingFile() {
+        // given
+        List<String> arguments = List.of("--mem", "--CORS=file", "--localhost", "/path");
+        String expectedMessage = "CORS config file not found: file";
+        // when, then
+        testForCmdException(arguments, expectedMessage);
+    }
+
+    @Test
+    public void test_happy_corsConfig() {
+        // given
+        List<String> arguments = List.of("--mem", "--CORS=testing/Config/cors.properties", "--localhost", "/path");
+        // when
+        FusekiServer server = buildServer(buildCmdLineArguments(arguments));
+        // then
+        assertNotNull(server);
+    }
+
+    private static void testForCmdException(List<String> arguments, String expectedMessage) {
+        // when
+        Throwable actual = null;
+        try {
+            buildServer(buildCmdLineArguments(arguments));
+        } catch (Exception e) {
+            actual = e;
+        }
+        // then
+        assertNotNull(actual);
+        assertTrue("Expecting correct exception", (actual instanceof CmdException));
+        assertEquals("Expecting correct message", expectedMessage, actual.getMessage());
+    }
+
+
+    private static String[] buildCmdLineArguments(List<String> listArgs) {
+        return listArgs.toArray(new String[0]);
+    }
+
+    private static FusekiServer buildServer(String... cmdline) {
+        FusekiServer server = FusekiMain.build(cmdline);
+        server.start();
+        return server;
+    }
+
+}

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/cors.properties
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/cors.properties
@@ -1,0 +1,5 @@
+allowedOrigins=*
+allowedMethods=GET,POST,DELETE,PUT,HEAD,OPTIONS,PATCH
+allowedHeaders=X-Requested-With, Content-Type, Accept, Origin, Last-Modified, Authorization, Custom-Header
+exposedHeaders=Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma
+chainPreflight=false

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/invalid.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/invalid.ttl
@@ -1,0 +1,2 @@
+# An empty file for testing error conditions
+Rubbish entry that is not going to work


### PR DESCRIPTION
GitHub issue resolved #2297 

Pull request Description:
Enabling the potential passing of a configuration file containing the desired CORS configuration so that we have a greater choice than present - none or default. 

Also some tidying up of spellings, some better error checks and improved testing of the existing Cross Origin Filter class and all of the exceptional cases for Fuseki Main's command-line arg processing. 


----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
