### PR TITLE
GH-2270: Properly process objects passed in as xsd:string literals.

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/datatypes/xsd/impl/XSDBaseStringType.java
+++ b/jena-core/src/main/java/org/apache/jena/datatypes/xsd/impl/XSDBaseStringType.java
@@ -61,4 +61,14 @@ public class XSDBaseStringType extends XSDDatatype {
             return value1.getValue().equals(value2.getValue());
         return false;
     }
+
+    /**
+     * Canonicalise a java Object value to a normal form.
+     * Used when objects are passed in as xsd:string type
+     * to ensure that indexing of typed literals works.
+     */
+    @Override
+    public Object cannonicalise( Object value ) {
+        return value.toString();
+    }
  }

--- a/jena-core/src/main/java/org/apache/jena/graph/impl/LiteralLabel.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/impl/LiteralLabel.java
@@ -451,7 +451,7 @@ final public class LiteralLabel {
         if ( !typeEquals )
             return false;
 
-        // Don't just use this.lexcialForm -- need to force delayed calculation from values.
+        // Don't just use this.lexicalForm -- need to force delayed calculation from values.
         boolean lexEquals = Objects.equals(getLexicalForm(), otherLiteral.getLexicalForm());
         if ( ! lexEquals )
             return false;

--- a/jena-core/src/test/java/org/apache/jena/datatypes/TestDatatypes.java
+++ b/jena-core/src/test/java/org/apache/jena/datatypes/TestDatatypes.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotNull ;
 import static org.junit.Assert.assertTrue ;
 
 import java.math.BigDecimal ;
+import java.util.UUID;
 
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
@@ -177,9 +178,33 @@ public class TestDatatypes {
         testValueToLex(Float.NEGATIVE_INFINITY, XSDDatatype.XSDfloat) ;
     }
 
+    @Test public void passAsString_UUID() {
+        testLiteralIsCorrectType(UUID.randomUUID(), XSDDatatype.XSDstring) ;
+    }
+
+    @Test public void passAsString_Integer() {
+        testLiteralIsCorrectType(5, XSDDatatype.XSDstring) ;
+    }
+
+    @Test public void passAsString_Float() {
+        testLiteralIsCorrectType(9.99f, XSDDatatype.XSDstring) ;
+    }
+    @Test public void passAsInteger_String() {
+        testLiteralIsCorrectType("5", XSDDatatype.XSDint) ;
+    }
+
+    @Test public void passAsFloat_String() {
+        testLiteralIsCorrectType("5.55", XSDDatatype.XSDfloat) ;
+    }
+
     private void testValueToLex(Object value, XSDDatatype datatype) {
         Node node = NodeFactory.createLiteralByValue(value, datatype) ;
         assertTrue("Not valid lexical form "+value+" -> "+node, datatype.isValid(node.getLiteralLexicalForm())) ;
+    }
+
+    private void testLiteralIsCorrectType(Object value, XSDDatatype datatype) {
+        Node node = NodeFactory.createLiteralByValue(value, datatype) ;
+        assertEquals("If passing object of type " + value.getClass().getSimpleName() + " as " + datatype.toString() + " it needs to be treated as " + datatype.getJavaClass().getSimpleName(), node.getLiteralValue().getClass(), datatype.getJavaClass());
     }
 
     private void valid(XSDDatatype xsddatatype, String string) {


### PR DESCRIPTION
GitHub issue resolved #2270 

Pull request Description:
As illustrated in the sample code on the linked issue, when creating literal nodes of xsd:string type we are not converting the given objects to Strings but rather are leaving them as the original classes. Instead of UUIDs, the same effect can be made if passed Integers, Floats or any other object type. 
`
NodeFactory.createLiteralByValue(UUID.randomUUID(), XSDDatatype.XSDstring);
NodeFactory.createLiteralByValue(9, XSDDatatype.XSDstring);
NodeFactory.createLiteralByValue(9.99f, XSDDatatype.XSDstring);
`
What's interesting is that for numeric types, this isn't the case and if passing a (valid) string to numeric type everything works as expected.
`
NodeFactory.createLiteralByValue("9", XSDDatatype.XSDint);
NodeFactory.createLiteralByValue("9.99", XSDDatatype.XSDfloat);
`

The fix is relatively simple. When processing the canonised form (using the "cannonicalise" (sic) method) of the XSDBaseStringType the original value is being returned. By contrast, if you look at the equivalent XSDBaseNumericType the value is converted into the appropriate type. 

To that end, I've added some tests to illustrate this by creating both string and numerical literal nodes passing in differing classes.

----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
