### PR TITLE
Bump Apache Shiro from 1.13.0 to 2.0.0

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/pom.xml
+++ b/jena-fuseki2/jena-fuseki-main/pom.xml
@@ -93,9 +93,16 @@
 
     <dependency>
       <groupId>org.apache.shiro</groupId>
-      <artifactId>shiro-web</artifactId>
+      <artifactId>shiro-config-core</artifactId>
       <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-web</artifactId>
       <classifier>jakarta</classifier>
+      <scope>test</scope>
       <optional>true</optional>
     </dependency>
 

--- a/jena-fuseki2/jena-fuseki-webapp/pom.xml
+++ b/jena-fuseki2/jena-fuseki-webapp/pom.xml
@@ -66,23 +66,28 @@
       <artifactId>jetty-ee10-webapp</artifactId>
     </dependency>
 
+    <!-- Shiro -->
+    
     <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-core</artifactId>
       <classifier>jakarta</classifier>
     </dependency>
-
-    <!-- Shiro 2.0.0
-    <dependency>
-      <groupId>org.apache.shiro</groupId>
-      <artifactId>shiro-jakarta-ee</artifactId>
-      <classifier>jakarta</classifier>
-    </dependency>
-    -->
-
+    
     <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-web</artifactId>
+      <classifier>jakarta</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-config-core</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-jakarta-ee</artifactId>
       <classifier>jakarta</classifier>
     </dependency>
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/ShiroEnvironmentLoader.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/ShiroEnvironmentLoader.java
@@ -27,8 +27,7 @@ import jakarta.servlet.ServletContextListener;
 
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.irix.IRIs;
-import org.apache.shiro.config.ConfigurationException;
-import org.apache.shiro.io.ResourceUtils;
+import org.apache.shiro.lang.io.ResourceUtils;
 import org.apache.shiro.web.env.EnvironmentLoader;
 import org.apache.shiro.web.env.ResourceBasedWebEnvironment;
 import org.apache.shiro.web.env.WebEnvironment;
@@ -50,7 +49,7 @@ public class ShiroEnvironmentLoader extends EnvironmentLoader implements Servlet
         try {
             // Shiro.
             initEnvironment(servletContext);
-        } catch (ConfigurationException  ex) {
+        } catch (Exception ex) {
             Fuseki.configLog.error("Shiro initialization failed: "+ex.getMessage());
             // Exit?
             throw ex;

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <ver.jakarta.json>2.0.1</ver.jakarta.json>
 
     <ver.jetty>12.0.6</ver.jetty>
-    <ver.shiro>1.13.0</ver.shiro>
+    <ver.shiro>2.0.0</ver.shiro>
 
     <ver.protobuf>3.25.3</ver.protobuf>
     <ver.libthrift>0.19.0</ver.libthrift>
@@ -468,25 +468,10 @@
 
       <dependency>
         <groupId>org.apache.shiro</groupId>
-        <artifactId>shiro-core</artifactId>
+        <artifactId>shiro-bom</artifactId>
         <version>${ver.shiro}</version>
-        <classifier>jakarta</classifier>
-      </dependency>
-
-      <!-- 2.0.0
-           <dependency>
-           <groupId>org.apache.shiro</groupId>
-           <artifactId>shiro-jakarta-ee</artifactId>
-           <version>${ver.shiro}</version>
-           <classifier>jakarta</classifier>
-           </dependency>
-      -->
-      
-      <dependency>
-        <groupId>org.apache.shiro</groupId>
-        <artifactId>shiro-web</artifactId>
-        <version>${ver.shiro}</version>
-        <classifier>jakarta</classifier>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <!-- Lucene dependencies -->


### PR DESCRIPTION
Update for Apache Shiro 2.0.0.

Use the Shiro BOM in top-level dependency management.

The combined jar shading (jena-fuseki-fulljar, jena-fuseki-server) looks better.

---

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
