### PR TITLE
GH-2254: Compaction using a temporary directory and atomic move

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IO.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IO.java
@@ -579,7 +579,7 @@ public class IO
      * This function does not follow symbolic links.
      */
     public static void deleteAll(Path start) {
-        // Walks down the tree and delete directories on the way backup.
+        // Walk down the tree deleting files, and delete directories on the way backup.
         try {
             Files.walkFileTree(start, new SimpleFileVisitor<Path>() {
                 @Override
@@ -598,7 +598,7 @@ public class IO
                 }
             });
         }
-        catch (IOException ex) { IO.exception(ex); return; }
+        catch (IOException ex) { throw IOX.exception(ex); }
     }
 
     // Do nothing buffer.  Never read from this, it may be corrupt because it is shared.

--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
@@ -285,9 +285,23 @@ public class LogCtl {
 
     private static final String[] log4j2files = {"log4j2.properties", "log4j2.xml"};
 
+    /**
+     * Environment variable for debugging logging initialization.
+     * Set "true" to get trace on stderr.
+     */
+    // Must be final for static LogLogging to work.
+    public static final String envLogLoggingProperty = "JENA_LOGLOGGING";
+
+    /**
+     * Property variable for debugging logging initialization. Set "true" to get
+     * trace on stderr.
+     */
+    // Must be final for static LogLogging to work.
+    public static final String logLoggingProperty = "jena.logLogging";
+
     private static final boolean LogLogging =
-            System.getenv("JENA_LOGLOGGING") != null ||
-            System.getProperty("jena.loglogging") != null;
+            System.getenv(envLogLoggingProperty) != null ||
+            System.getProperty(logLoggingProperty) != null;
 
     private static void logLogging(String fmt, Object ... args) {
         if ( LogLogging ) {

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/sys/IO_DB.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/sys/IO_DB.java
@@ -46,7 +46,7 @@ public class IO_DB {
     }
 
     /** Convert a {@link Location} to a {@link File}. */
-    public static File asFile(org.apache.jena.dboe.base.file.Location loc) {
+    public static File asFile(Location loc) {
         return new File(loc.getDirectoryPath());
     }
 }

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/sys/IO_DB.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/sys/IO_DB.java
@@ -19,25 +19,17 @@
 package org.apache.jena.dboe.sys;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import org.apache.jena.atlas.RuntimeIOException;
-import org.apache.jena.atlas.logging.FmtLog;
-import org.apache.jena.dboe.DBOpEnvException;
 import org.apache.jena.dboe.base.file.Location;
 
 public class IO_DB {
     // Location == org.apache.jena.dboe.base.file.Location
-    
+
     /** Convert a {@link Path}  to a {@link Location}. */
     public static Location asLocation(Path path) {
         Objects.requireNonNull(path, "IOX.asLocation(null)");
@@ -56,51 +48,5 @@ public class IO_DB {
     /** Convert a {@link Location} to a {@link File}. */
     public static File asFile(org.apache.jena.dboe.base.file.Location loc) {
         return new File(loc.getDirectoryPath());
-    }
-
-    /** Find the files in this directory that have namebase as a prefix and
-     *  are then numbered.
-     *  <p>
-     *  Returns a sorted list from, low to high index.
-     */
-    public static List<Path> scanForDirByPattern(Path directory, String namebase, String nameSep) {
-        Pattern pattern = Pattern.compile(Pattern.quote(namebase)+
-                                          Pattern.quote(nameSep)+
-                                          "[\\d]+");
-        List<Path> paths = new ArrayList<>();
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory, namebase + "*")) {
-            for ( Path entry : stream ) {
-                if ( !pattern.matcher(entry.getFileName().toString()).matches() ) {
-                    throw new DBOpEnvException("Invalid filename for matching: "+entry.getFileName());
-                    // Alternative: Skip bad trailing parts but more likely there is a naming problem.
-                    //   LOG.warn("Invalid filename for matching: {} skipped", entry.getFileName());
-                    //   continue;
-                }
-                // Follows symbolic links.
-                if ( !Files.isDirectory(entry) )
-                    throw new DBOpEnvException("Not a directory: "+entry);
-                paths.add(entry);
-            }
-        }
-        catch (IOException ex) {
-            FmtLog.warn(IO_DB.class, "Can't inspect directory: (%s, %s)", directory, namebase);
-            throw new DBOpEnvException(ex);
-        }
-        Comparator<Path> comp = (f1, f2) -> {
-            int num1 = extractIndex(f1.getFileName().toString(), namebase, nameSep);
-            int num2 = extractIndex(f2.getFileName().toString(), namebase, nameSep);
-            return Integer.compare(num1, num2);
-        };
-        paths.sort(comp);
-        //indexes.sort(Long::compareTo);
-        return paths;
-    }
-
-    /** Given a filename in "base-NNNN" format, return the value of NNNN */
-    public static int extractIndex(String name, String namebase, String nameSep) {
-        int i = namebase.length()+nameSep.length();
-        String numStr = name.substring(i);
-        int num = Integer.parseInt(numStr);
-        return num;
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/spot/SpotTDB2.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/spot/SpotTDB2.java
@@ -33,7 +33,6 @@ import org.apache.jena.tdb2.TDBException;
 import org.apache.jena.tdb2.params.StoreParams;
 import org.apache.jena.tdb2.params.StoreParamsCodec;
 import org.apache.jena.tdb2.sys.DatabaseOps;
-import org.apache.jena.tdb2.sys.Util;
 
 class SpotTDB2 {
 
@@ -115,19 +114,9 @@ class SpotTDB2 {
 
     /** Return the current active database area within a database directory. */
     private static Path storageDir(Location location) {
-        // Database directory
-        Path path = IO_DB.asPath(location);
         // Storage directory in database directory.
-        Path db = findLocation(path, DatabaseOps.dbPrefix);
+        Path db = DatabaseOps.findStorageLocation(location);
         return db;
-    }
-
-    private static Path findLocation(Path directory, String namebase) {
-        if ( ! Files.exists(directory) )
-            return null;
-        // In-order, low to high.
-        List<Path> maybe = IO_DB.scanForDirByPattern(directory, namebase, DatabaseOps.SEP);
-        return Util.getLastOrNull(maybe);
     }
 
     // Places for StoreParams: location or default

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/TDB2.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/TDB2.java
@@ -126,7 +126,6 @@ public class TDB2 {
 
             SystemTDB.init();
             EnvTDB.processGlobalSystemProperties();
-
             MappingRegistry.addPrefixMapping(SystemTDB.tdbSymbolPrefix, SystemTDB.symbolNamespace);
             AssemblerUtils.init();
             VocabTDB2.init();

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/DatabaseOps.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/DatabaseOps.java
@@ -20,8 +20,10 @@ package org.apache.jena.tdb2.sys;
 
 import java.io.*;
 import java.nio.file.*;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
@@ -30,7 +32,9 @@ import org.apache.jena.atlas.io.IOX;
 import org.apache.jena.atlas.lib.DateTimeUtils;
 import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.atlas.lib.Pair;
+import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.dboe.DBOpEnvException;
 import org.apache.jena.dboe.base.file.Location;
 import org.apache.jena.dboe.sys.IO_DB;
 import org.apache.jena.dboe.sys.Names;
@@ -50,7 +54,8 @@ import org.apache.jena.tdb2.store.DatasetGraphTDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Operations on and about TDB2 databases.
+/**
+ * Operations related to TDB2 databases.
  * <p>
  * TDB2 uses a hierarchical structure to manage on disk.
  * <p>
@@ -68,9 +73,16 @@ import org.slf4j.LoggerFactory;
  */
 public class DatabaseOps {
     private static Logger LOG = LoggerFactory.getLogger(DatabaseOps.class);
-    public static final String dbPrefix     = "Data";
-    public static final String SEP          = "-";
-    public static final String startCount   = "0001";
+    // Composition of a database storage area directory name.
+    public static final String dbNameBase       = "Data";
+    public static final String SEP              = "-";
+    public static final String dbSuffixPattern  = "[\\d]+";
+
+    public static final String startCount       = "0001";
+
+    // Additional suffix used during compact
+    private static final String dbTmpSuffix      = "-tmp";
+    private static final String dbTmpPattern     = "[\\d]+"+dbTmpSuffix;
 
     private static final String BACKUPS_DIR  = "Backups";
     // Basename of the backup file. "backup_{DateTime}.nq.gz
@@ -101,15 +113,20 @@ public class DatabaseOps {
         if ( ! containerLocation.exists() )
             throw new TDBException("No such location: "+containerLocation);
         Path path = IO_DB.asPath(containerLocation);
+
+        // Clean any temporary files and directories that there might be.
+        cleanDatabaseDirectory(path);
+
         // Scan for DBs
-        Path existingStorage = findLocation(path, dbPrefix);
+        Path existingStorage = findStorageLocation(path);
         boolean isNewArea = (existingStorage == null);
 
         Path db = existingStorage;
         if ( db == null ) {
-            db = path.resolve(dbPrefix+SEP+startCount);
+            db = path.resolve(dbNameBase+SEP+startCount);
             IOX.createDirectory(db);
         }
+
         Location storageLocation = IO_DB.asLocation(db);
 
         // ---- Find the params (if any).
@@ -139,6 +156,11 @@ public class DatabaseOps {
         return appDSG;
     }
 
+    /**
+     * Clear out any partial compactions.
+     */
+    private static void cleanDatabaseDirectory(Path directory) {
+    }
 
     private static ReorderTransformation maybeTransform(ReorderTransformation reorderTransform, Location location) {
         if ( reorderTransform != null )
@@ -249,10 +271,10 @@ public class DatabaseOps {
     public static void compact(DatasetGraphSwitchable container, boolean shouldDeleteOld) {
         checkSupportsAdmin(container);
         synchronized(compactionLock) {
-            Path base = container.getContainerPath();
-            Path db1 = findLocation(base, dbPrefix);
+            Path containerPath = container.getContainerPath();
+            Path db1 = findStorageLocation(containerPath);
             if ( db1 == null )
-                throw new TDBException("No location: ("+base+", "+dbPrefix+")");
+                throw new TDBException("No location: ("+containerPath+", "+dbNameBase+")");
             Location loc1 = IO_DB.asLocation(db1);
 
             // -- Checks
@@ -266,15 +288,31 @@ public class DatabaseOps {
                 throw new TDBException("Inconsistent (not latest?) : "+loc1a+" : "+loc1);
 
             // Check version
-            int v = IO_DB.extractIndex(db1.getFileName().toString(), dbPrefix, SEP);
-            String next = FilenameUtils.filename(dbPrefix, SEP, v+1);
+            int v = extractIndex(db1.getFileName().toString(), dbNameBase, SEP);
+            String next = FilenameUtils.filename(dbNameBase, SEP, v+1);
 
             Path db2 = db1.getParent().resolve(next);
             IOX.createDirectory(db2);
             Location loc2 = IO_DB.asLocation(db2);
             LOG.debug(String.format("Compact %s -> %s\n", db1.getFileName(), db2.getFileName()));
 
-            compact(container, loc1, loc2);
+            Location loc2tmp = loc2;
+            try {
+                compact(container, loc1, loc2tmp);
+
+                Path path2 = Path.of(loc2.getDirectoryPath());
+                Path path2tmp = Path.of(loc2tmp.getDirectoryPath());
+
+                Files.move(path2tmp, path2);
+
+                // Move loc2tmp to loc2
+            } catch (IOException ex) {
+                // Delete loc2tmp;
+                throw IOX.exception(ex);
+            } catch (Throwable th) {
+                // Delete loc2tmp;
+                throw th;
+            }
 
             if ( shouldDeleteOld ) {
                 // Compact put each of the databases into exclusive mode to do the switchover.
@@ -337,7 +375,7 @@ public class DatabaseOps {
             CopyDSG.copy(dsgBase, dsgCompact);
 
             if ( false ) {
-                // DEVELOMENT. FAke a long copy time in state copy.
+                // DEVELOPMENT. Fake a long copy time in state copy.
                 System.err.println("-- Inside compact 1");
                 Lib.sleep(3_000);
                 System.err.println("-- Inside compact 2");
@@ -371,7 +409,6 @@ public class DatabaseOps {
             // Old readers continue on db1.
 
         });
-
 
         // This switches off the source database.
         // It waits until all transactions (readers) have finished.
@@ -407,11 +444,77 @@ public class DatabaseOps {
         }
     }
 
-    private static Path findLocation(Path directory, String namebase) {
+    /**
+     * Find the files in this directory that have namebase as a prefix and
+     * are then numbered.
+     *  <p>
+     * Returns a sorted list from, low to high index.
+     * @param directory Path to the data base directory
+     * @param namebase Initial common component of the name
+     * @param nameSep  Separator
+     * @param trailerPattern Pattern for the part of the name after the namebase.
+     * @return List<Path> List sorted low to high
+     *
+     */
+    private static List<Path> scanForDirByPattern(Path directory, String namebase, String nameSep, String trailerPattern) {
+        Pattern pattern = Pattern.compile(Pattern.quote(namebase)+
+                                          Pattern.quote(nameSep)+
+                                          trailerPattern);
+        List<Path> paths = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory, namebase + "*")) {
+            for ( Path entry : stream ) {
+                if ( !pattern.matcher(entry.getFileName().toString()).matches() ) {
+                    throw new DBOpEnvException("Invalid filename for matching: "+entry.getFileName());
+                    // Alternative: Skip bad trailing parts but more likely there is a naming problem.
+                    //   LOG.warn("Invalid filename for matching: {} skipped", entry.getFileName());
+                    //   continue;
+                }
+                // Follows symbolic links.
+                if ( !Files.isDirectory(entry) )
+                    throw new DBOpEnvException("Not a directory: "+entry);
+                paths.add(entry);
+            }
+        }
+        catch (IOException ex) {
+            FmtLog.warn(IO_DB.class, "Can't inspect directory: (%s, %s)", directory, namebase);
+            throw new DBOpEnvException(ex);
+        }
+        Comparator<Path> comp = (f1, f2) -> {
+            int num1 = extractIndex(f1.getFileName().toString(), namebase, nameSep);
+            int num2 = extractIndex(f2.getFileName().toString(), namebase, nameSep);
+            return Integer.compare(num1, num2);
+        };
+        paths.sort(comp);
+        //indexes.sort(Long::compareTo);
+        return paths;
+    }
+
+    /** Given a filename in "base-NNNN" format, return the value of NNNN */
+    public static int extractIndex(String name, String namebase, String nameSep) {
+        int i = namebase.length()+nameSep.length();
+        String numStr = name.substring(i);
+        int num = Integer.parseInt(numStr);
+        return num;
+    }
+
+    /**
+     * Find the active working storage area for a TDB2 database.
+     * Return null if none.
+     */
+    public static Path findStorageLocation(Location directory) {
+        Path dirPath = IO_DB.asPath(directory);
+        return findStorageLocation(dirPath);
+    }
+
+    /**
+     * Find the active working storage area for a TDB2 database.
+     * Return null if none.
+     */
+    public static Path findStorageLocation(Path directory) {
         if ( ! Files.exists(directory) )
             return null;
         // In-order, low to high.
-        List<Path> maybe = IO_DB.scanForDirByPattern(directory, namebase, SEP);
+        List<Path> maybe = scanForDirByPattern(directory, dbNameBase, SEP, dbSuffixPattern);
         return Util.getLastOrNull(maybe);
     }
 

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/setup/TestStoreParamsCreate.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/setup/TestStoreParamsCreate.java
@@ -44,7 +44,7 @@ public class TestStoreParamsCreate {
     // This may be different for each test
     private final String DB_DIR = ConfigTest.getCleanDir();
     private final Path dbContainer = Path.of(DB_DIR);
-    private final Path dbStorage = dbContainer.resolve(DatabaseOps.dbPrefix+DatabaseOps.SEP+DatabaseOps.startCount);
+    private final Path dbStorage = dbContainer.resolve(DatabaseOps.dbNameBase+DatabaseOps.SEP+DatabaseOps.startCount);
 
     private final Path cfgContainer = dbContainer.resolve(Names.TDB_CONFIG_FILE);
     private final Path cfgStorage = dbStorage.resolve(Names.TDB_CONFIG_FILE);


### PR DESCRIPTION
GitHub issue resolved #2254

Pull request Description:

Use a temporary directory for building the compacted storage.
Clear-up any stray temporary directories when creating the Java objects for the database.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
