### PR TITLE
Improve JSON-LD handling

### DIFF
--- a/jena-cmds/src/main/java/tdb/tdbloader.java
+++ b/jena-cmds/src/main/java/tdb/tdbloader.java
@@ -114,8 +114,11 @@ public class tdbloader extends CmdTDBGraph {
 
         for ( String url : urls ) {
             Lang lang = RDFLanguages.filenameToLang(url);
-            if ( lang != null && RDFLanguages.isQuads(lang) ) {
-                throw new CmdException("Warning: Quads format given - only the default graph is loaded into the graph for --graph");
+            if ( lang != null && ! Lang.JSONLD.equals(lang) && RDFLanguages.isQuads(lang) ) {
+                // People think JSONLD is a single graph format.
+                if ( RDFLanguages.isQuads(lang) ) {
+                    System.err.println("Warning: Quads format given - only the default graph from the data is loaded into the graph for --graph");
+                }
             }
         }
 

--- a/jena-cmds/src/main/java/tdb2/tdbloader.java
+++ b/jena-cmds/src/main/java/tdb2/tdbloader.java
@@ -143,8 +143,11 @@ public class tdbloader extends CmdTDBGraph {
 
         for ( String url : urls ) {
             Lang lang = RDFLanguages.filenameToLang(url);
-            if ( lang != null && RDFLanguages.isQuads(lang) ) {
-                throw new CmdException("Warning: Quads format given - only the default graph is loaded into the graph for --graph");
+            if ( lang != null && ! Lang.JSONLD.equals(lang) && RDFLanguages.isQuads(lang) ) {
+                // People think JSONLD is a single graph format.
+                if ( RDFLanguages.isQuads(lang) ) {
+                    System.err.println("Warning: Quads format given - only the default graph from the data is loaded into the graph for --graph");
+                }
             }
         }
 


### PR DESCRIPTION
While JSON-LD can have multiple graphs in one file, it is commonly used for a single graph.

Don't reject JSON-LD data when loading in a single named graph (TDB1 and TDB2).

(if there is more than one named graph in the input a warning is printed during loading).

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
