### PR TITLE
GH-2318: Protect against async shutdown

### DIFF
--- a/jena-cmds/src/main/java/tdb2/tdbloader.java
+++ b/jena-cmds/src/main/java/tdb2/tdbloader.java
@@ -18,6 +18,8 @@
 
 package tdb2;
 
+import static org.apache.jena.atlas.lib.ListUtils.toList;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -25,7 +27,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.jena.atlas.lib.InternalErrorException;
-import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.atlas.lib.Timer;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdException;
@@ -159,13 +160,14 @@ public class tdbloader extends CmdTDBGraph {
 
     // Check files exists before starting.
     private void checkFiles(List<String> urls) {
-        List<String> problemFiles = ListUtils.toList(urls.stream().filter(u -> FileUtils.isFile(u))  // Local
-                                                                                                     // files.
-                                                         .map(Paths::get)
-                                                         .filter(p -> !Files.exists(p) || !Files.isRegularFile(p /* follow
-                                                                                                                  * links */)
-                                                                      || !Files.isReadable(p))
-                                                         .map(Path::toString));
+        List<String> problemFiles = toList(urls.stream()
+                                           // Local files.
+                                           .filter(u -> FileUtils.isFile(u))
+                                           .map(Paths::get)
+                                           .filter(p -> !Files.exists(p) ||
+                                                        !Files.isRegularFile(p /* this follows links */) ||
+                                                        !Files.isReadable(p))
+                                           .map(Path::toString));
         if ( !problemFiles.isEmpty() ) {
             if ( problemFiles.size() == 1 )
                 throw new CmdException("Can't read file : " + problemFiles.get(0));

--- a/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestTransactionCoordinatorControl.java
+++ b/jena-db/jena-dboe-transaction/src/test/java/org/apache/jena/dboe/transaction/TestTransactionCoordinatorControl.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.jena.atlas.lib.ThreadLib;
 import org.apache.jena.dboe.base.file.Location;
-import org.apache.jena.system.Txn;
 import org.apache.jena.dboe.transaction.txn.Transaction;
 import org.apache.jena.dboe.transaction.txn.TransactionCoordinator;
 import org.apache.jena.dboe.transaction.txn.TransactionException;
@@ -33,6 +32,7 @@ import org.apache.jena.dboe.transaction.txn.TransactionalBase;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.system.ThreadAction;
 import org.apache.jena.system.ThreadTxn;
+import org.apache.jena.system.Txn;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -152,6 +152,39 @@ public class TestTransactionCoordinatorControl {
         Txn.executeWrite(unit, ()->{});
         b = txnMgr.tryExclusiveMode(false);
         assertTrue(b);
+    }
+
+    public void txn_coord_shutdown_1() {
+        txnMgr.shutdown();
+        txnMgr.shutdown();
+        // And again in after().
+    }
+
+    @Test(expected=TransactionException.class)
+    public void txn_coord_shutdown_2() {
+        Transaction txn = txnMgr.begin(TxnType.READ);
+        txnMgr.shutdown(true);
+        txn.commit();
+    }
+
+    @Test(expected=TransactionException.class)
+    public void txn_coord_shutdown_3() {
+        Transaction txn = txnMgr.begin(TxnType.WRITE);
+        txnMgr.shutdown(true);
+        txn.commit();
+    }
+
+    @Test(expected=TransactionException.class)
+    public void txn_coord_shutdown_4() {
+        txnMgr.shutdown(true);
+        txnMgr.begin(TxnType.READ);
+    }
+
+
+    @Test(expected=TransactionException.class)
+    public void txn_coord_shutdown_5() {
+        txnMgr.shutdown(true);
+        txnMgr.begin(TxnType.READ);
     }
 }
 

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/DatasetGraphSwitchable.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/DatasetGraphSwitchable.java
@@ -41,7 +41,7 @@ public class DatasetGraphSwitchable extends DatasetGraphTxnCtl
     private final PrefixMapSwitchable prefixes;
 
     public DatasetGraphSwitchable(Path base, Location location, DatasetGraph dsg) {
-        // Don't use the slot in datasetGraphWrapper - use the AtomicReference
+        // Don't use the slot in DatasetGraphWrapper - use the AtomicReference
         super(null, dsg.getContext());
         dsgx.set(dsg);
         this.basePath = base;
@@ -50,7 +50,7 @@ public class DatasetGraphSwitchable extends DatasetGraphTxnCtl
     }
 
     /**
-     * The dataset to use for redirection - can be overridden.
+     * The dataset to use for redirection - this can be overridden.
      * It is also guaranteed that this is called only once per
      * delegated call.  Changes to the wrapped object can be
      * made based on that contract.

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/PrefixMapSwitchable.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/PrefixMapSwitchable.java
@@ -22,17 +22,14 @@ import org.apache.jena.riot.system.PrefixMap;
 import org.apache.jena.riot.system.PrefixMapWrapper;
 
 /**
- * {@link PrefixMap} that goes to the current DatasetGraphTDB prefixes.
+ * A {@link PrefixMap} that indirects to the prefixes via the current storage
+ * setting of {@link DatasetGraphSwitchable}.
  */
-public class PrefixMapSwitchable extends PrefixMapWrapper {
-    // PrefixMapProxy not needed.
-    // TDB2 datasets already have switchability built-in.
-
+class PrefixMapSwitchable extends PrefixMapWrapper {
     private final DatasetGraphSwitchable dsgx;
-    protected DatasetGraphSwitchable getx() { return dsgx; }
 
     protected PrefixMapSwitchable(DatasetGraphSwitchable dsg) {
-        // We override get() so don't set the wrapped object
+        // We override PrefixMapWrapper getR() and getW() so don't set the wrapped object.
         super(null);
         this.dsgx = dsg;
     }


### PR DESCRIPTION
GitHub issue resolved #2318

Pull request Description:
There isn't a direct test of the presented problem; its asynchronous and timing dependent.

`shutdown` with no contract so there is no contract of specific behaviour or consequences on active transactions. It is an operation that is _caveat emptor_.

This PR makes a NullPointerException become a TransactionException.

There is test coverage for the new and better way to get the coordinator lock for synchronous use.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
