### PR TITLE
Upgrade of commons-compress 1.26.0 to 1.26.1. Adjust Iter.asStream to follow javadoc.

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/iterator/Iter.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/iterator/Iter.java
@@ -72,9 +72,9 @@ public class Iter<T> implements IteratorCloseable<T> {
 
     public static <T> Stream<T> asStream(Iterator<T> iterator, boolean parallel) {
         int characteristics = Spliterator.IMMUTABLE;
-        Stream<T> stream = StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, characteristics), parallel);
-        stream.onClose(()->close(iterator));
-        return stream;
+        Stream<T> stream1 = StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, characteristics), parallel);
+        Stream<T> stream2 = stream1.onClose(()->close(iterator));
+        return stream2;
     }
 
     // ---- Special iterators.

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <ver.commons-rdf>0.5.0</ver.commons-rdf>
     <ver.commons-csv>1.10.0</ver.commons-csv>
     <ver.commons-codec>1.16.1</ver.commons-codec>
-    <ver.commons-compress>1.26.0</ver.commons-compress>
+    <ver.commons-compress>1.26.1</ver.commons-compress>
     <ver.commons-collections>4.4</ver.commons-collections>
     <ver.commons-fileupload>2.0.0-M2</ver.commons-fileupload>
 


### PR DESCRIPTION
Pull request Description:
* incremental upgrade of commons-compress 1.26.0 to 1.26.1
* return result of `Stream.onClose` in accordance with the javadoc contract.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
