### PR TITLE
GH-2169: Remove compiler warnings around graph copy code

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/system/G.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/G.java
@@ -816,9 +816,11 @@ public class G {
      * @param src the graph to copy
      * @return a copy of the graph
      */
+    @SuppressWarnings("unchecked")
     public static Graph copy(Graph src) {
-        if(src instanceof Copyable<?>) {
-            return ((Copyable<Graph>)src).copy();
+        if(src instanceof Copyable<?> copyable) {
+            Copyable<Graph> copyableGraph = (Copyable<Graph>)copyable;
+            return copyableGraph.copy();
         }
         Graph dst = GraphMemFactory.createDefaultGraph();
         copyGraphSrcToDst(src, dst);

--- a/jena-arq/src/test/java/org/apache/jena/system/GTest.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/GTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import static org.apache.jena.testing_framework.GraphHelper.triple;
 import static org.junit.Assert.*;
 
+@SuppressWarnings("deprecation")
 public class GTest {
 
     @Test
@@ -33,8 +34,6 @@ public class GTest {
         // Test graph which implements Copyable<>
         {
             var graphImplementingCopyable = new GraphMem2Fast();
-
-            assertTrue(graphImplementingCopyable instanceof Copyable<?>);
 
             graphImplementingCopyable.add(triple("s1 p1 o1"));
             graphImplementingCopyable.add(triple("s1 p2 o1"));
@@ -56,7 +55,7 @@ public class GTest {
 
         // Test graph which does not implement Copyable<>
         {
-            var notCopyableGraph = new GraphMem();
+            GraphMem notCopyableGraph = new GraphMem();
 
             assertFalse(notCopyableGraph instanceof Copyable<?>);
 

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/Copyable.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/Copyable.java
@@ -27,7 +27,7 @@ public interface Copyable<T> {
 
     /**
      * Create a copy of this object.
-     * @return
+     * @return T
      */
     T copy();
 }

--- a/jena-core/src/main/java/org/apache/jena/mem2/collection/FastHashBase.java
+++ b/jena-core/src/main/java/org/apache/jena/mem2/collection/FastHashBase.java
@@ -94,7 +94,7 @@ public abstract class FastHashBase<K> implements JenaMapSetCommon<K> {
      *
      * @param baseToCopy
      */
-    protected <T extends FastHashBase> FastHashBase(final T baseToCopy)  {
+    protected <T extends FastHashBase<?>> FastHashBase(final T baseToCopy)  {
         this.positions = new int[baseToCopy.positions.length];
         System.arraycopy(baseToCopy.positions, 0, this.positions, 0, baseToCopy.positions.length);
 

--- a/jena-core/src/main/java/org/apache/jena/mem2/store/TripleStore.java
+++ b/jena-core/src/main/java/org/apache/jena/mem2/store/TripleStore.java
@@ -95,5 +95,6 @@ public interface TripleStore extends Copyable<TripleStore> {
      *
      * @return an independent copy of this store
      */
+    @Override
     TripleStore copy();
 }

--- a/jena-core/src/main/java/org/apache/jena/mem2/store/roaring/RoaringTripleStore.java
+++ b/jena-core/src/main/java/org/apache/jena/mem2/store/roaring/RoaringTripleStore.java
@@ -349,7 +349,7 @@ public class RoaringTripleStore implements TripleStore {
         /**
          * Create a copy of this set.
          *
-         * @return
+         * @return TripleSet
          */
         @Override
         public TripleSet copy() {

--- a/jena-core/src/test/java/org/apache/jena/mem2/GraphMem2Test.java
+++ b/jena-core/src/test/java/org/apache/jena/mem2/GraphMem2Test.java
@@ -177,10 +177,10 @@ public class GraphMem2Test {
 
         when(mockStore.copy()).thenReturn(mockStoreCopy);
 
-        var sut = new GraphMem2(mockStore);
-        var copy = sut.copy();
+        GraphMem2 sut = new GraphMem2(mockStore);
+        GraphMem2 copy = sut.copy();
 
-        assertTrue(copy instanceof GraphMem2);
+        assertNotNull(copy);
         assertEquals(mockStoreCopy, copy.tripleStore);
     }
 }


### PR DESCRIPTION
Clean the codebase of compiler warnings, mainly about unnecessary casts.

This follows on from PR #2316 that improves in-memory graph copy performance.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
