### PR TITLE
Update dependencies to include JUnit5 and use junit-vintage-engine

### DIFF
--- a/jena-arq/pom.xml
+++ b/jena-arq/pom.xml
@@ -117,8 +117,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-base/pom.xml
+++ b/jena-base/pom.xml
@@ -101,12 +101,12 @@
       <groupId>com.github.andrewoma.dexx</groupId>
       <artifactId>collection</artifactId>
     </dependency>
-    
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
+
+     <dependency>
+       <groupId>org.junit.vintage</groupId>
+       <artifactId>junit-vintage-engine</artifactId>
+       <scope>test</scope>
+     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jena-benchmarks/jena-benchmarks-jmh/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-jmh/pom.xml
@@ -94,8 +94,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/jena-cmds/pom.xml
+++ b/jena-cmds/pom.xml
@@ -157,8 +157,8 @@
     -->
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-core/pom.xml
+++ b/jena-core/pom.xml
@@ -53,42 +53,42 @@
     </dependency>
 
     <dependency>
-        <groupId>org.apache.jena</groupId>
-        <artifactId>jena-iri</artifactId>
-        <version>5.0.0-SNAPSHOT</version>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-iri</artifactId>
+      <version>5.0.0-SNAPSHOT</version>
     </dependency>
-
-      <dependency>
-          <artifactId>commons-cli</artifactId>
-          <groupId>commons-cli</groupId>
-      </dependency>
-
-      <dependency>
-          <groupId>org.roaringbitmap</groupId>
-          <artifactId>RoaringBitmap</artifactId>
-      </dependency>
-
-      <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <scope>test</scope>
-      </dependency>
-
-      <dependency>
-          <groupId>org.xenei</groupId>
-          <artifactId>junit-contracts</artifactId>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-cli</artifactId>
-          <groupId>commons-cli</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>commons-logging</artifactId>
-          <groupId>commons-logging</groupId>
-        </exclusion>
-      </exclusions>
+    
+    <dependency>
+      <artifactId>commons-cli</artifactId>
+      <groupId>commons-cli</groupId>
     </dependency>
+    
+      <dependency>
+        <groupId>org.roaringbitmap</groupId>
+        <artifactId>RoaringBitmap</artifactId>
+      </dependency>
+
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.xenei</groupId>
+        <artifactId>junit-contracts</artifactId>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-cli</artifactId>
+            <groupId>commons-cli</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -151,7 +151,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <includes>
-            <include>org/apache/jena/test/TestPackage.java</include>
+            <include>org/apache/jena/test/TestPackage_core.java</include>
             <include>**/*_CS.java</include>
           </includes>
         </configuration>

--- a/jena-db/jena-dboe-index-test/pom.xml
+++ b/jena-db/jena-dboe-index-test/pom.xml
@@ -44,22 +44,28 @@
     </dependency>
 
     <dependency>
-      <!--  Bring junit into scope-compile -->
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>compile</scope>
+    </dependency>
+      
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>
     </dependency>
-
-    <!--
-        Fix necessary for java11 (not java17)
-        when building javadoc.
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>[2.1,)</version>
-      <scope>compile</scope>
-    </dependency>
-    -->
 
   </dependencies>
 

--- a/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/AbstractTestIndex.java
+++ b/jena-db/jena-dboe-index-test/src/main/java/org/apache/jena/dboe/index/testlib/AbstractTestIndex.java
@@ -18,19 +18,23 @@
 
 package org.apache.jena.dboe.index.testlib;
 
-import static org.apache.jena.dboe.index.testlib.IndexTestLib.*;
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.testDelete;
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.testIndexContents;
+import static org.apache.jena.dboe.index.testlib.IndexTestLib.testInsert;
 import static org.apache.jena.dboe.test.RecordLib.intToRecord;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import org.apache.jena.dboe.base.record.Record;
 import org.apache.jena.dboe.index.Index;
 import org.apache.jena.dboe.test.RecordLib;
-import org.junit.Assert;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.After ;
+import org.junit.Test ;
 
 //import org.apache.jena.tdb.base.record.RecordLib;
 
-public abstract class AbstractTestIndex extends Assert
+public abstract class AbstractTestIndex
 {
     Index index = null;
 

--- a/jena-db/pom.xml
+++ b/jena-db/pom.xml
@@ -51,8 +51,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-examples/pom.xml
+++ b/jena-examples/pom.xml
@@ -62,8 +62,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/jena-extras/jena-commonsrdf/pom.xml
+++ b/jena-extras/jena-commonsrdf/pom.xml
@@ -68,8 +68,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-extras/jena-querybuilder/pom.xml
+++ b/jena-extras/jena-querybuilder/pom.xml
@@ -70,8 +70,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-extras/jena-serviceenhancer/pom.xml
+++ b/jena-extras/jena-serviceenhancer/pom.xml
@@ -46,22 +46,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.xenei</groupId>
-      <artifactId>junit-contracts</artifactId> 
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-cli</artifactId>
-          <groupId>commons-cli</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>commons-logging</artifactId>
-          <groupId>commons-logging</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/jena-fuseki2/jena-fuseki-access/pom.xml
+++ b/jena-fuseki2/jena-fuseki-access/pom.xml
@@ -42,8 +42,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-fuseki2/jena-fuseki-core/pom.xml
+++ b/jena-fuseki2/jena-fuseki-core/pom.xml
@@ -104,8 +104,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -105,8 +105,8 @@
       </dependency>
 
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
         <scope>test</scope>
       </dependency>
 

--- a/jena-fuseki2/jena-fuseki-main/pom.xml
+++ b/jena-fuseki2/jena-fuseki-main/pom.xml
@@ -69,8 +69,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-fuseki2/jena-fuseki-webapp/pom.xml
+++ b/jena-fuseki2/jena-fuseki-webapp/pom.xml
@@ -130,8 +130,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -92,8 +92,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-integration-tests/pom.xml
+++ b/jena-integration-tests/pom.xml
@@ -150,8 +150,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-iri/pom.xml
+++ b/jena-iri/pom.xml
@@ -41,8 +41,8 @@
   <dependencies>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-permissions/pom.xml
+++ b/jena-permissions/pom.xml
@@ -198,8 +198,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
     </dependency>
 
     <dependency>

--- a/jena-rdfconnection/pom.xml
+++ b/jena-rdfconnection/pom.xml
@@ -79,8 +79,8 @@
     <!-- Tests is also done in jena-integration-tests -->
     
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-rdfpatch/pom.xml
+++ b/jena-rdfpatch/pom.xml
@@ -48,8 +48,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>  

--- a/jena-shacl/pom.xml
+++ b/jena-shacl/pom.xml
@@ -52,8 +52,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-shex/pom.xml
+++ b/jena-shex/pom.xml
@@ -53,8 +53,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-tdb1/pom.xml
+++ b/jena-tdb1/pom.xml
@@ -69,8 +69,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-tdb2/pom.xml
+++ b/jena-tdb2/pom.xml
@@ -62,8 +62,8 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-text/pom.xml
+++ b/jena-text/pom.xml
@@ -95,8 +95,8 @@
     </dependency>
     
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,10 @@
     <ver.roaringbitmap>1.0.5</ver.roaringbitmap>
 
     <!-- Testing -->
-    <ver.junit>4.13.2</ver.junit>  
+    <ver.junit4>4.13.2</ver.junit4>
+    <ver.junit5>5.10.2</ver.junit5>
+    <ver.junit5-platform>1.10.2</ver.junit5-platform>
+ 
     <ver.mockito>5.11.0</ver.mockito>
     <ver.awaitility>4.2.0</ver.awaitility>
     <ver.contract.tests>0.2.0</ver.contract.tests>
@@ -286,10 +289,33 @@
 
   <dependencyManagement>
     <dependencies>
+
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${ver.junit5}</version>
+        <scope>test</scope>
+      </dependency>
+      
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite</artifactId>
+        <version>${ver.junit5-platform}</version>
+        <scope>test</scope>
+      </dependency>
+      
+      <!-- Includes JUnit 4 : Needed for older testing code. -->
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>${ver.junit5}</version>
+        <scope>test</scope>
+      </dependency>
+
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${ver.junit}</version>
+        <version>${ver.junit4}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
GitHub issue resolved #2336

Pull request Description:
Switch to JUnit5 and use junit-vintage-engine (JUnit4, JUnit3 compatibility)

`jena-serviceenhancer` does not seem to use org.xenei contract tests - dependency removed.

`org.xenei junit-contracts` is used by `jena-core`, `jena-permissions` and `jena-querybuilder`.
The last release was in 2018. It depends on JUnit 4.2.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
