### PR TITLE
Gh 2358 from() and fromNamed() take object

### DIFF
--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AskBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/AskBuilder.java
@@ -84,25 +84,13 @@ public class AskBuilder extends AbstractQueryBuilder<AskBuilder>
     }
 
     @Override
-    public AskBuilder fromNamed(String graphName) {
+    public AskBuilder fromNamed(Object graphName) {
         getDatasetHandler().fromNamed(graphName);
         return this;
     }
 
     @Override
-    public AskBuilder fromNamed(Collection<String> graphNames) {
-        getDatasetHandler().fromNamed(graphNames);
-        return this;
-    }
-
-    @Override
-    public AskBuilder from(String graphName) {
-        getDatasetHandler().from(graphName);
-        return this;
-    }
-
-    @Override
-    public AskBuilder from(Collection<String> graphName) {
+    public AskBuilder from(Object graphName) {
         getDatasetHandler().from(graphName);
         return this;
     }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ConstructBuilder.java
@@ -98,25 +98,13 @@ public class ConstructBuilder extends AbstractQueryBuilder<ConstructBuilder> imp
     }
 
     @Override
-    public ConstructBuilder fromNamed(String graphName) {
+    public ConstructBuilder fromNamed(Object graphName) {
         getDatasetHandler().fromNamed(graphName);
         return this;
     }
 
     @Override
-    public ConstructBuilder fromNamed(Collection<String> graphNames) {
-        getDatasetHandler().fromNamed(graphNames);
-        return this;
-    }
-
-    @Override
-    public ConstructBuilder from(String graphName) {
-        getDatasetHandler().from(graphName);
-        return this;
-    }
-
-    @Override
-    public ConstructBuilder from(Collection<String> graphName) {
+    public ConstructBuilder from(Object graphName) {
         getDatasetHandler().from(graphName);
         return this;
     }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/DescribeBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/DescribeBuilder.java
@@ -386,25 +386,13 @@ public class DescribeBuilder extends AbstractQueryBuilder<DescribeBuilder> imple
     }
 
     @Override
-    public DescribeBuilder fromNamed(String graphName) {
+    public DescribeBuilder fromNamed(Object graphName) {
         getDatasetHandler().fromNamed(graphName);
         return this;
     }
 
     @Override
-    public DescribeBuilder fromNamed(Collection<String> graphNames) {
-        getDatasetHandler().fromNamed(graphNames);
-        return this;
-    }
-
-    @Override
-    public DescribeBuilder from(String graphName) {
-        getDatasetHandler().from(graphName);
-        return this;
-    }
-
-    @Override
-    public DescribeBuilder from(Collection<String> graphName) {
+    public DescribeBuilder from(Object graphName) {
         getDatasetHandler().from(graphName);
         return this;
     }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/SelectBuilder.java
@@ -138,25 +138,13 @@ public class SelectBuilder extends AbstractQueryBuilder<SelectBuilder> implement
     }
 
     @Override
-    public SelectBuilder fromNamed(String graphName) {
+    public SelectBuilder fromNamed(Object graphName) {
         getDatasetHandler().fromNamed(graphName);
         return this;
     }
 
     @Override
-    public SelectBuilder fromNamed(Collection<String> graphNames) {
-        getDatasetHandler().fromNamed(graphNames);
-        return this;
-    }
-
-    @Override
-    public SelectBuilder from(String graphName) {
-        getDatasetHandler().from(graphName);
-        return this;
-    }
-
-    @Override
-    public SelectBuilder from(Collection<String> graphName) {
+    public SelectBuilder from(Object graphName) {
         getDatasetHandler().from(graphName);
         return this;
     }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
@@ -123,8 +123,8 @@ public class UpdateBuilder {
     }
 
     /**
-     * Checks that deletes or inserts have been added to the builder.
-     * @return true if there are any delete or insert statements.
+     * Checks that no deletes or inserts have been added to the builder.
+     * @return true if there are no delete or insert statements.
      */
     public boolean isEmpty() {
         return deletes.isEmpty() && inserts.isEmpty();

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
@@ -123,6 +123,14 @@ public class UpdateBuilder {
     }
 
     /**
+     * Checks that deletes or inserts have been added to the builder.
+     * @return true if there are any delete or insert statements.
+     */
+    public boolean isEmpty() {
+        return deletes.isEmpty() && inserts.isEmpty();
+    }
+
+    /**
      * Build the update.
      *
      * <b>Note: the update does not include the prefix statements</b> use
@@ -132,7 +140,7 @@ public class UpdateBuilder {
      */
     public Update build() {
 
-        if (deletes.isEmpty() && inserts.isEmpty()) {
+        if (isEmpty()) {
             throw new IllegalStateException("At least one delete or insert must be specified");
         }
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/DatasetClause.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/clauses/DatasetClause.java
@@ -17,8 +17,6 @@
  */
 package org.apache.jena.arq.querybuilder.clauses;
 
-import java.util.Collection;
-
 import org.apache.jena.arq.querybuilder.AbstractQueryBuilder;
 import org.apache.jena.arq.querybuilder.handlers.DatasetHandler;
 
@@ -35,15 +33,7 @@ public interface DatasetClause<T extends AbstractQueryBuilder<T>> {
      * @param graphName the graph name to add.
      * @return This builder for chaining.
      */
-    public T fromNamed(String graphName);
-
-    /**
-     * Add several "FROM NAMED" graph names.
-     * 
-     * @param graphNames the collection graph names to add.
-     * @return This builder for chaining.
-     */
-    public T fromNamed(Collection<String> graphNames);
+    public T fromNamed(Object graphName);
 
     /**
      * Add the "FROM" graph name.
@@ -51,15 +41,7 @@ public interface DatasetClause<T extends AbstractQueryBuilder<T>> {
      * @param graphName the graph name to add.
      * @return This builder for chaining.
      */
-    public T from(String graphName);
-
-    /**
-     * Add several "FROM" graph names.
-     * 
-     * @param graphName the collection graph names to add.
-     * @return This builder for chaining.
-     */
-    public T from(Collection<String> graphName);
+    public T from(Object graphName);
 
     /**
      * Get the Dataset handler for this clause.

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandler.java
@@ -21,7 +21,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.jena.graph.FrontsNode;
 import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Node_Literal;
+import org.apache.jena.graph.Node_URI;
 import org.apache.jena.query.Query;
 import org.apache.jena.sparql.core.Var;
 
@@ -54,24 +57,42 @@ public class DatasetHandler implements Handler {
     }
 
     /**
+     * Converts an object into a graph name.
+     * @param graphName the object that represents the graph name.
+     * @return the string that is the graph name.
+     */
+    String asGraphName(Object graphName) {
+        // package private for testing access
+        if (graphName instanceof String) {
+            return (String) graphName;
+        }
+        if (graphName instanceof FrontsNode) {
+            return asGraphName(((FrontsNode)graphName).asNode());
+        }
+        if (graphName instanceof Node_URI) {
+            return ((Node_URI)graphName).getURI();
+        }
+        if (graphName instanceof Node_Literal) {
+            return asGraphName(((Node_Literal)graphName).getLiteralValue());
+        }
+
+        return graphName.toString();
+    }
+
+    /**
      * Add a graph name to the from named list.
      *
      * @param graphName The graph name to add.
      */
-    public void fromNamed(String graphName) {
-        query.addNamedGraphURI(graphName);
-    }
-
-    /**
-     * Add the graph names to the from named list.
-     *
-     * The names are ordered in as defined in the collection.
-     *
-     * @param graphNames The from names to add.
-     */
-    public void fromNamed(Collection<String> graphNames) {
-        for (String uri : graphNames) {
-            query.addNamedGraphURI(uri);
+    public void fromNamed(Object graphName) {
+        if (graphName instanceof Collection) {
+            ((Collection<?>)graphName).forEach(this::fromNamed);
+        } else if (graphName instanceof Object[]) {
+            for (Object o : ((Object[])graphName)) {
+                fromNamed(o);
+            }
+        } else {
+            query.addNamedGraphURI(asGraphName(graphName));
         }
     }
 
@@ -80,20 +101,15 @@ public class DatasetHandler implements Handler {
      *
      * @param graphName the name to add.
      */
-    public void from(String graphName) {
-        query.addGraphURI(graphName);
-    }
-
-    /**
-     * Add the graph names to the named list.
-     *
-     * The names are ordered in as defined in the collection.
-     *
-     * @param graphNames The names to add.
-     */
-    public void from(Collection<String> graphNames) {
-        for (String uri : graphNames) {
-            query.addGraphURI(uri);
+    public void from(Object graphName) {
+        if (graphName instanceof Collection) {
+            ((Collection<?>)graphName).forEach(this::from);
+        } else if (graphName instanceof Object[]) {
+            for (Object o : ((Object[])graphName)) {
+                from(o);
+            }
+        } else {
+            query.addGraphURI(asGraphName(graphName));
         }
     }
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandler.java
@@ -17,9 +17,9 @@
  */
 package org.apache.jena.arq.querybuilder.handlers;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.apache.jena.graph.FrontsNode;
 import org.apache.jena.graph.Node;
@@ -80,37 +80,47 @@ public class DatasetHandler implements Handler {
     }
 
     /**
-     * Add a graph name to the from named list.
+     * Add one or more named graphs to the query.
+     * if {@code graphName} is a {@code collection} or an array each element in the 
+     * @code collection} or array is converted to a string and the result added to the 
+     * query.
      *
-     * @param graphName The graph name to add.
+     * @param graphName the name to add.
+     * @see #asGraphName(Object)
      */
     public void fromNamed(Object graphName) {
-        if (graphName instanceof Collection) {
-            ((Collection<?>)graphName).forEach(this::fromNamed);
-        } else if (graphName instanceof Object[]) {
-            for (Object o : ((Object[])graphName)) {
-                fromNamed(o);
-            }
-        } else {
-            query.addNamedGraphURI(asGraphName(graphName));
-        }
+        processGraphName(query::addNamedGraphURI, graphName);
     }
 
     /**
-     * Add the graph names to the from list.
-     *
-     * @param graphName the name to add.
+     * Converts performs a single level of unwrapping an Iterable before calling
+     * the {@code process} method with the graph name converted to a string.
+     * @param process the process that accepts the string graph name.
+     * @param graphName the Object that represents one or more graph names.
+     * @see #asGraphName(Object)
      */
-    public void from(Object graphName) {
-        if (graphName instanceof Collection) {
-            ((Collection<?>)graphName).forEach(this::from);
-        } else if (graphName instanceof Object[]) {
-            for (Object o : ((Object[])graphName)) {
-                from(o);
+    private void processGraphName(Consumer<String> process, Object graphName) {
+        if (graphName instanceof Iterable collection) {
+            for (Object o : collection) {
+                process.accept(asGraphName(o));
             }
         } else {
-            query.addGraphURI(asGraphName(graphName));
+            process.accept(asGraphName(graphName));
         }
+    }
+
+
+    /**
+     * Add one or more graph names to the query.
+     * if {@code graphName} is a {@code collection} or an array each element in the 
+     * @code collection} or array is converted to a string and the result added to the 
+     * query.
+     *
+     * @param graphName the name to add.
+     * @see #asGraphName(Object)
+     */
+    public void from(Object graphName) {
+        processGraphName(query::addGraphURI, graphName);
     }
 
     /**

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandler.java
@@ -100,8 +100,8 @@ public class DatasetHandler implements Handler {
      * @see #asGraphName(Object)
      */
     private void processGraphName(Consumer<String> process, Object graphName) {
-        if (graphName instanceof Iterable collection) {
-            for (Object o : collection) {
+        if (graphName instanceof Iterable) {
+            for (Object o : (Iterable)graphName) {
                 process.accept(asGraphName(o));
             }
         } else {

--- a/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandlerTest.java
+++ b/jena-extras/jena-querybuilder/src/test/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandlerTest.java
@@ -17,15 +17,20 @@
  */
 package org.apache.jena.arq.querybuilder.handlers;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Query;
+import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.sparql.core.Var;
 import org.junit.Before;
 import org.junit.Test;
@@ -70,6 +75,18 @@ public class DatasetHandlerTest extends AbstractHandlerTest {
     public void fromString() {
         handler.from("foo");
         assertTrue(query.toString().contains("FROM <foo>"));
+    }
+
+    @Test
+    public void asGraphNameTest() throws URISyntaxException {
+        assertEquals("urn:example.com:uri", handler.asGraphName(new URI("urn:example.com:uri")));
+        assertEquals("urn:example.com:node", handler.asGraphName(NodeFactory.createURI("urn:example.com:node")));
+        assertEquals("five", handler.asGraphName(ResourceFactory.createPlainLiteral("five")));
+        assertEquals("6", handler.asGraphName(ResourceFactory.createTypedLiteral(6)));
+        Node n = NodeFactory.createBlankNode();
+        assertEquals(n.toString(), handler.asGraphName(n));
+        UUID uuid = UUID.randomUUID();
+        assertEquals(uuid.toString(), handler.asGraphName(uuid));
     }
 
     @Test


### PR DESCRIPTION
GitHub issue resolved #2358

Pull request Description:
Changes QueryBuilder `from()` and `fromNamed()` methods to accept Objects.

No documentation change required.
----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
