### PR TITLE
Miscellaneous cleaning up

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Pull request Description:
  - [ ] Tests are included.
  - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
  - [ ] Commits have been squashed to remove intermediate development commit messages.
- - [ ] Key commit messages start with the issue number (GH-xxxx, or if in JIRA, JENA-xxxx)
+ - [ ] Key commit messages start with the issue number (GH-xxxx)
 
 By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
@@ -451,7 +451,6 @@ public class RDFParser {
         throw new InternalErrorException("Both inputStream and javaReader are null");
     }
 
-    @SuppressWarnings("resource")
     private TypedInputStream openTypedInputStream(String urlStr, Path path) {
         // If path, use that.
         if ( path != null ) {

--- a/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RIOT.java
@@ -119,9 +119,11 @@ public class RIOT {
     private static String RDFXML_SYMBOL_BASE = "http://jena.apache.org/riot/rdfxml#";
 
     /**
-     * Access to the original legacy RDF/XML parser
-     * Use Lang constant {@link RRX#RDFXML_ARP0}
-     * @deprecated Do not use! This will be removed.
+     * Legacy access to the original legacy RDF/XML parser.
+     * The original ARP parser will be removed.
+     * Use {@link Lang} constant {@link RRX#RDFXML_ARP1} or {@link RRX#RDFXML_ARP0}
+     * to access ARP v1 (RIOT integration) or ARP v0 (the original ARP parser).
+     * @deprecated Do not use this symbol! This will be removed.
      */
     @Deprecated
     public static Symbol symRDFXML0 = SystemARQ.allocSymbol(RDFXML_SYMBOL_BASE, "rdfxml0");

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx/ParserRDFXML_SAX.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx/ParserRDFXML_SAX.java
@@ -420,9 +420,11 @@ public class ParserRDFXML_SAX
 // private ParseType parseType = null;
     public ParserRDFXML_SAX(String xmlBase, ParserProfile parserProfile, StreamRDF destination, Context context) {
         // Debug
-        if ( TRACE )
-        {
-            IndentedWriter out1 = IndentedWriter.stdout.clone().setFlushOnNewline(true).setUnitIndent(4).setLinePrefix("# ");
+        if ( TRACE ) {
+            IndentedWriter out1 = IndentedWriter.stdout.clone();
+            out1.setFlushOnNewline(true);
+            out1.setUnitIndent(4);
+            out1.setLinePrefix("# ");
             this.trace = out1;
             //IndentedWriter out2 = IndentedWriter.stdout.clone().setFlushOnNewline(true).setUnitIndent(4).setLinePrefix("! ");
         } else {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/sse/writers/SSEWriteLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/sse/writers/SSEWriteLib.java
@@ -22,6 +22,7 @@ import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.sparql.ARQInternalErrorException;
 import org.apache.jena.sparql.sse.Tags;
 
+/** Helper code for wring SSE. */
 public class SSEWriteLib
 {
     static final int UNDEF = 0;
@@ -33,51 +34,51 @@ public class SSEWriteLib
 
     // -- Normal markers
 
-    /** Start a tagged item - all one line - usual bracketting */
+    /** Start a tagged item - all one line - usual bracketing */
     public static void startOneLine(IndentedWriter out, String tag) {
         _start(out, Tags.LPAREN);
         out.print(tag);
         out.print(" ");
     }
 
-    /** Finish a tagged item - all one line - usual bracketting */
+    /** Finish a tagged item - all one line - usual bracketing */
     public static void finishOneLine(IndentedWriter out, String tag) {
         _finish(out, Tags.RPAREN);
     }
 
-    /** Start a tagged item - usual bracketting */
+    /** Start a tagged item - usual bracketing */
     public static void start(IndentedWriter out, String tag, int linePolicy)
     { _start(out, tag, linePolicy, Tags.LPAREN); }
 
-    /** Finish a tagged item - usual bracketting */
+    /** Finish a tagged item - usual bracketing */
     public static void finish(IndentedWriter out, String tag)
     { _finish(out, tag, Tags.RPAREN); }
 
-    /** Start an item - no tag - usual bracketting */
+    /** Start an item - no tag - usual bracketing */
     public static void start(IndentedWriter out)
     { _start(out, Tags.LPAREN); }
 
-    /** Finish an item - no tag - usual bracketting */
+    /** Finish an item - no tag - usual bracketing */
     public static void finish(IndentedWriter out)
     {  _finish(out, Tags.RPAREN);  }
 
     // -- With the other markers (conventionally, short things)
 
-    /** Start an item - alternative bracketting */
+    /** Start an item - alternative bracketing */
     public static void start2(IndentedWriter out, String tag, int linePolicy)
     { _start(out, tag, linePolicy, Tags.LBRACKET); }
 
-    /** Finish an item - alternative bracketting */
+    /** Finish an item - alternative bracketing */
     public static void finish2(IndentedWriter out, String tag)
     { _finish(out, tag, Tags.RBRACKET);  }
 
-    /** Start an item - no tag - alternative bracketting */
+    /** Start an item - no tag - alternative bracketing */
     public static void start2(IndentedWriter out)
     { _start(out, Tags.LBRACKET); }
 
-    /** Finish an item - no tag - alternative bracketting */
+    /** Finish an item - no tag - alternative bracketing */
     public static void finish2(IndentedWriter out)
-    { _finish(out, Tags.RBRACKET);  }
+    { _finish(out, Tags.RBRACKET); }
 
     // ---- Workers
 
@@ -89,7 +90,7 @@ public class SSEWriteLib
             case NL:    out.println(); break;
             case NoNL:  out.print(" "); break;
             case NoSP:  break;
-            case UNDEF: throw new ARQInternalErrorException("Explicit tag not no line policy");
+            case UNDEF: throw new ARQInternalErrorException("Tag provided but no line policy");
         }
         out.incIndent();
     }

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateAction.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateAction.java
@@ -321,7 +321,6 @@ public class UpdateAction
     }
 
     /** Parse update operations into a DatasetGraph by reading it from a file */
-    @SuppressWarnings("resource")
     public static void parseExecute(UsingList usingList, DatasetGraph dataset, String fileName, Binding inputBinding, String baseURI, Syntax syntax)
     {
         InputStream in = null ;

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/AWriter.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/AWriter.java
@@ -25,18 +25,18 @@ import org.apache.jena.atlas.lib.Closeable ;
 
 public interface AWriter extends Closeable, AutoCloseable
 {
-    public AWriter write(char ch) ;
-    public AWriter write(char[] cbuf) ;
-    public AWriter write(String string) ;
+    public void write(char ch) ;
+    public void write(char[] cbuf) ;
+    public void write(String string) ;
 
-    public AWriter print(char ch) ;
-    public AWriter print(char[] cbuf) ;
-    public AWriter print(String string) ;
-    public AWriter printf(String fmt, Object ...arg) ;
-    public AWriter println(String object) ;
-    public AWriter println() ;
+    public void print(char ch) ;
+    public void print(char[] cbuf) ;
+    public void print(String string) ;
+    public void printf(String fmt, Object ...arg) ;
+    public void println(String object) ;
+    public void println() ;
 
-    public AWriter flush() ;
+    public void flush() ;
     @Override
     public void close() ;
 }

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/AWriterBase.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/AWriterBase.java
@@ -24,10 +24,10 @@ package org.apache.jena.atlas.io;
 public abstract class AWriterBase implements AWriter
 {
     @Override
-    public final AWriter write(char ch)          { return print(ch) ; }
+    public final void write(char ch)          { print(ch) ; }
     @Override
-    public final AWriter write(char[] cbuf)      { return print(cbuf) ; }
+    public final void write(char[] cbuf)      { print(cbuf) ; }
     @Override
-    public final AWriter write(String string)    { return print(string) ; }
+    public final void write(String string)    { print(string) ; }
 }
 

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
@@ -125,7 +125,7 @@ public class IOX {
     }
 
     /**
-     * Write a file safely, but allow system to use copy-delete if the chnage can not
+     * Write a file safely, but allow system to use copy-delete if the change can not
      * be done atomically. Prefer {@link #safeWrite} which requires an atomic move.
      */
     public static boolean safeWriteOrCopy(Path file, Path tmpFile, IOConsumer<OutputStream> writerAction) {

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
@@ -115,61 +115,54 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
         startingNewLine = true;
     }
 
-    protected IndentedWriter rtnObject() { return this; }
-
     @Override
-    public IndentedWriter print(String str) {
+    public void print(String str) {
         if ( str == null )
             str = "null";
         if ( false ) {
             // Don't check for embedded newlines.
             write$(str);
-            return this;
+            return;
         }
         for ( int i = 0; i < str.length(); i++ )
             printOneChar(str.charAt(i));
-        return this;
     }
 
     @Override
-    public IndentedWriter printf(String formatStr, Object... args) {
+    public void printf(String formatStr, Object... args) {
         print(format(formatStr, args));
-        return this;
     }
 
     @Override
-    public IndentedWriter print(char ch)      { printOneChar(ch); return this; }
-    public IndentedWriter print(Object obj)   { print(String.valueOf(obj)); return this; }
+    public void print(char ch)      { printOneChar(ch); }
+    public void print(Object obj)   { print(String.valueOf(obj)); }
 
     @Override
-    public IndentedWriter println(String str) { print(str); newline(); return this; }
-    public IndentedWriter println(char ch)    { print(ch); newline(); return this; }
-    public IndentedWriter println(Object obj) { print(String.valueOf(obj)); newline(); return this; }
+    public void println(String str) { print(str); newline(); }
+    public void println(char ch)    { print(ch); newline(); }
+    public void println(Object obj) { print(String.valueOf(obj)); newline(); }
 
     @Override
-    public IndentedWriter println() { newline(); return this; }
+    public void println() { newline(); }
 
     @Override
-    public IndentedWriter print(char[] cbuf) {
+    public void print(char[] cbuf) {
         for ( char aCbuf : cbuf ) {
             printOneChar(aCbuf);
         }
-        return this;
     }
 
     /** Print a string N times */
-    public IndentedWriter print(String s, int n) {
+    public void print(String s, int n) {
         for ( int i = 0; i < n; i++ )
             print(s);
-        return this;
     }
 
     /** Print a char N times */
-    public IndentedWriter print(char ch, int n) {
+    public void print(char ch, int n) {
         lineStart();
         for ( int i = 0; i < n; i++ )
             printOneChar(ch);
-        return this;
     }
 
     private char lastChar = '\0';
@@ -201,7 +194,7 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     private void write$(String s)
     { try { out.write(s); } catch (IOException ex) { IO.exception(ex); } }
 
-    public IndentedWriter newline() {
+    public void newline() {
         lineStart();
 
         if ( endOfLineMarker != null )
@@ -215,15 +208,13 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
         // so if layered over a PrintWriter, need to flush that as well.
         if ( flushOnNewline )
             flush();
-        return this;
     }
 
     private boolean atStartOfLine() { return column <= currentIndent; }
 
-    public IndentedWriter ensureStartOfLine() {
+    public void ensureStartOfLine() {
         if ( !atStartOfLine() )
             newline();
-        return this;
     }
 
     public boolean atLineStart()        { return startingNewLine; }
@@ -253,28 +244,27 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     public void close() { IO.close(out); }
 
     @Override
-    public IndentedWriter flush() { IO.flush(out); return this; }
+    public void flush() { IO.flush(out); }
 
     /** Pad to the indent (if we are before it) */
-    public IndentedWriter pad() {
+    public void pad() {
         if ( startingNewLine && currentIndent > 0 )
             lineStart();
         padInternal();
-        return this;
     }
 
     /** Pad to a given number of columns EXCLUDING the indent.
      *
      * @param col Column number (first column is 1).
      */
-    public IndentedWriter pad(int col) { return pad(col, false); }
+    public void pad(int col) { pad(col, false); }
 
     /** Pad to a given number of columns maybe including the indent.
      *
      * @param col Column number (first column is 1).
      * @param absoluteColumn Whether to include the indent
      */
-    public IndentedWriter pad(int col, boolean absoluteColumn) {
+    public void pad(int col, boolean absoluteColumn) {
         // Make absolute
         if ( !absoluteColumn )
             col = col + currentIndent;
@@ -283,7 +273,6 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
             write$(' ');        // Always a space.
             column++;
         }
-        return this;
     }
 
     private void padInternal() {
@@ -312,18 +301,16 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
         return column;
     }
 
-    public IndentedWriter incIndent() { incIndent(unitIndent); return this; }
+    public void incIndent() { incIndent(unitIndent); }
 
-    public IndentedWriter incIndent(int x) {
+    public void incIndent(int x) {
         currentIndent += x;
-        return this;
     }
 
-    public IndentedWriter decIndent() { decIndent(unitIndent); return this; }
+    public void decIndent() { decIndent(unitIndent); }
 
-    public IndentedWriter decIndent(int x) {
+    public void decIndent(int x) {
         currentIndent -= x;
-        return this;
     }
 
     /** Position past current indent */
@@ -339,32 +326,25 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     public int getAbsoluteIndent()       { return currentIndent; }
 
     /** Set indent from the left hand edge. Returns {@code this}. */
-    public IndentedWriter setAbsoluteIndent(int x) { currentIndent = x; return rtnObject(); }
+    public void setAbsoluteIndent(int x) { currentIndent = x; }
 
     public boolean hasLineNumbers() {
         return lineNumbers;
     }
 
-    public IndentedWriter setLineNumbers(boolean lineNumbers) {
+    public void setLineNumbers(boolean lineNumbers) {
         this.lineNumbers = lineNumbers;
-        return rtnObject();
     }
 
     public String getEndOfLineMarker()              { return endOfLineMarker; }
 
     /** Set the marker included at end of line - set to null for "none".  Usually used for debugging. */
-    public IndentedWriter setEndOfLineMarker(String marker) {
-        endOfLineMarker = marker;
-        return rtnObject();
-    }
+    public void setEndOfLineMarker(String marker)  {  endOfLineMarker = marker; }
 
     /** Flat mode - print without NL, for a more compact representation*/
     public boolean inFlatMode()                     { return flatMode; }
     /** Flat mode - print without NL, for a more compact representation*/
-    public IndentedWriter setFlatMode(boolean flatMode) {
-        this.flatMode = flatMode;
-        return rtnObject();
-    }
+    public void setFlatMode(boolean flatMode)       { this.flatMode = flatMode; }
 
     /** Flush on newline **/
     public boolean getFlushOnNewline()              { return flushOnNewline; }
@@ -374,24 +354,17 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
      * but not by default otherwise. The underlying output, if it is a {@link PrintStream}
      * may also have a flush on newline as well (e.g {@link System#out}).
      */
-    public IndentedWriter setFlushOnNewline(boolean flushOnNewline) {
-        this.flushOnNewline = flushOnNewline;
-        return rtnObject();
-    }
+    public void setFlushOnNewline(boolean flushOnNewline) { this.flushOnNewline = flushOnNewline; }
 
     public char getPadChar()                        { return padChar; }
 
-    public IndentedWriter setPadChar(char ch) {
-        this.padChar = ch;
-        return rtnObject();
-    }
+    public void setPadChar(char ch)                 { this.padChar = ch; }
 
     public String getPadString()                    { return padString; }
 
-    public IndentedWriter setPadString(String str) {
+    public void setPadString(String str) {
         this.padString = str;
         this.unitIndent = str.length();
-        return rtnObject();
     }
 
     /** Initial string printed at the start of each line : defaults to no string. */
@@ -400,16 +373,14 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     }
 
     /** Set the initial string printed at the start of each line. */
-    public IndentedWriter setLinePrefix(String str) {
+    public void setLinePrefix(String str) {
         this.linePrefix = str;
-        return rtnObject();
     }
 
     public int getUnitIndent()         { return unitIndent; }
 
-    public IndentedWriter setUnitIndent(int x) {
+    public void setUnitIndent(int x) {
         unitIndent = x;
-        return rtnObject();
     }
 
     private int widthLineNumber = 3;
@@ -420,9 +391,8 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     /** Set the width of the number field.
      * There is also a single space after the number not included in this setting.
      */
-    public IndentedWriter setNumberWidth(int widthOfNumbers) {
+    public void setNumberWidth(int widthOfNumbers) {
         widthLineNumber = widthOfNumbers;
-        return rtnObject();
     }
 
     private void insertLineNumber() {

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/Writer2.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/Writer2.java
@@ -49,43 +49,39 @@ public class Writer2 extends AWriterBase implements AWriter, Closeable
     }
 
     @Override
-    public AWriter print(char ch) {
+    public void print(char ch) {
         try {
             writer.write(ch);
         } catch (IOException ex) {
             IO.exception(ex);
         }
-        return this;
     }
 
     @Override
-    public AWriter print(String string) {
+    public void print(String string) {
         try {
             writer.write(string);
         } catch (IOException ex) {
             IO.exception(ex);
         }
-        return this;
     }
 
     @Override
-    public AWriter print(char[] cbuf) {
+    public void print(char[] cbuf) {
         try {
             writer.write(cbuf);
         } catch (IOException ex) {
             IO.exception(ex);
         }
-        return this;
     }
 
     @Override
-    public AWriter flush() {
+    public void flush() {
         try {
             writer.flush();
         } catch (IOException ex) {
             IO.exception(ex);
         }
-        return this;
     }
 
     @Override
@@ -98,22 +94,19 @@ public class Writer2 extends AWriterBase implements AWriter, Closeable
     }
 
     @Override
-    public AWriter printf(String fmt, Object...args) {
+    public void printf(String fmt, Object...args) {
         print(String.format(fmt, args));
-        return this;
     }
 
     @Override
-    public AWriter println(String obj) {
+    public void println(String obj) {
         print(obj);
         print("\n");
-        return this;
     }
 
     @Override
-    public AWriter println() {
+    public void println() {
         print("\n");
-        return this;
     }
 
     @Override

--- a/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput0/StAX2ModelTest.java
+++ b/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput0/StAX2ModelTest.java
@@ -1160,20 +1160,15 @@ public class StAX2ModelTest extends TestCase {
         Model expected = ModelFactory.createDefaultModel();
         Model got = ModelFactory.createDefaultModel();
 
-        InputStream in;
-
         // Load expected using normal mechanism
-        try {
-            in = new FileInputStream(file);
+        try (InputStream in = new FileInputStream(file)) {
             expected.read(in, base);
-            in.close();
         } catch (Exception e) { return; }
 
-        in = new FileInputStream(file);
-        XMLEventReader eventStream = inputFactory.createXMLEventReader(base, in);
-        StAX2Model.read(eventStream, got, base);
-        in.close();
-
+        try (InputStream in = new FileInputStream(file)) {
+            XMLEventReader eventStream = inputFactory.createXMLEventReader(base, in);
+            StAX2Model.read(eventStream, got, base);
+        }
         boolean result = expected.isIsomorphicWith(got);
 
         /*if (!result) {

--- a/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput1/TestsStAX2Model.java
+++ b/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput1/TestsStAX2Model.java
@@ -1160,20 +1160,15 @@ public class TestsStAX2Model extends TestCase {
         Model expected = ModelFactory.createDefaultModel();
         Model got = ModelFactory.createDefaultModel();
 
-        InputStream in;
-
         // Load expected using normal mechanism
-        try {
-            in = new FileInputStream(file);
+        try (InputStream in = new FileInputStream(file)) {
             expected.read(in, base);
-            in.close();
         } catch (Exception e) { return; }
 
-        in = new FileInputStream(file);
-        XMLEventReader eventStream = inputFactory.createXMLEventReader(base, in);
-        StAX2Model.read(eventStream, got, base);
-        in.close();
-
+        try (InputStream in = new FileInputStream(file)) {
+            XMLEventReader eventStream = inputFactory.createXMLEventReader(base, in);
+            StAX2Model.read(eventStream, got, base);
+        }
         boolean result = expected.isIsomorphicWith(got);
 
         /*if (!result) {

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiShaclValidation.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiShaclValidation.java
@@ -21,7 +21,6 @@ package org.apache.jena.fuseki.main;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.http.HttpRDF;
 import org.apache.jena.rdfconnection.RDFConnection;
@@ -39,14 +38,12 @@ public class TestFusekiShaclValidation {
 
     @BeforeClass
     public static void beforeClass() {
-        int port = WebLib.choosePort();
-
         FusekiServer server = FusekiServer.create()
-            .port(port)
+            .port(0)
             .parseConfigFile(DIR+"config-validation.ttl")
             .build();
         server.start();
-        serverURL = "http://localhost:"+port;
+        serverURL = "http://localhost:"+server.getPort();
     }
 
     @AfterClass

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestServiceDatasetAuth.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestServiceDatasetAuth.java
@@ -43,9 +43,6 @@ public abstract class AbstractTestServiceDatasetAuth {
     private static AuthSetup auth2 = new AuthSetup("localhost", port, "user2", "pw2", null);
     private static AuthSetup auth3 = new AuthSetup("localhost", port, "user3", "pw3", null);
 
-    // @BeforeClass : subclass must set "server".
-    // Setup : user1 and user2 can query, user1 and user3 can update.
-
     @Test public void no_auth() {
         // No user -> fails login
         expectQuery401(() -> {

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestPasswdOnly.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestPasswdOnly.java
@@ -41,20 +41,21 @@ import org.junit.Test;
 public class TestPasswdOnly {
     protected static FusekiServer server;
     protected static int port;
-
-    private static AuthSetup auth1 = new AuthSetup("localhost", port, "user1", "pw1", null);
+    private static AuthSetup auth1;
 
     @BeforeClass public static void beforeClass () {
         port = WebLib.choosePort();
         server = FusekiServer.create()
             //.verbose(true)
-            .port(port)
+            .port(0)
             .add("/db", DatasetGraphFactory.createTxnMem())
             .passwordFile("testing/Access/passwd")
             // Should be default.
             //.serverAuthPolicy(Auth.ANY_USER)
             .build();
         server.start();
+        port = server.getPort();
+        auth1 = new AuthSetup("localhost", port, "user1", "pw1", null);
     }
 
     @AfterClass public static void afterClass () {

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionFuseki.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionFuseki.java
@@ -21,6 +21,7 @@ package org.apache.jena.test.rdfconnection;
 import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.main.FusekiTestLib;
+import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryParseException;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdfconnection.RDFConnection;
@@ -58,9 +59,14 @@ public class TestRDFConnectionFuseki extends TestRDFConnectionRemote {
             String level = LogCtl.getLevel(Fuseki.actionLog);
             try {
                 LogCtl.setLevel(Fuseki.actionLog, "ERROR");
-                FusekiTestLib.expectQueryFail(()->conn.query("FOOBAR").execSelect(), Code.BAD_REQUEST);
+                Runnable action = ()-> {
+                    try( QueryExecution qExec = conn.query("FOOBAR") ) {
+                        qExec.execSelect();
+                    }};
+                FusekiTestLib.expectQueryFail(action, Code.BAD_REQUEST);
             } finally {
                 LogCtl.setLevel(Fuseki.actionLog, level);
+                conn.close();
             }
         }
     }

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionRemote.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionRemote.java
@@ -24,6 +24,7 @@ import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.main.FusekiServer ;
 import org.apache.jena.fuseki.main.FusekiTestLib;
+import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryParseException;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
@@ -123,7 +124,11 @@ public class TestRDFConnectionRemote extends AbstractTestRDFConnection {
             String level = LogCtl.getLevel(Fuseki.actionLog);
             try {
                 LogCtl.setLevel(Fuseki.actionLog, "ERROR");
-                FusekiTestLib.expectQueryFail(()->conn.query("FOOBAR").execSelect(), Code.BAD_REQUEST);
+                Runnable action = ()-> {
+                    try( QueryExecution qExec = conn.query("FOOBAR") ) {
+                        qExec.execSelect();
+                    }};
+                FusekiTestLib.expectQueryFail(action, Code.BAD_REQUEST);
             } finally {
                 LogCtl.setLevel(Fuseki.actionLog, level);
             }

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkHTTP.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdflink/TestRDFLinkHTTP.java
@@ -29,6 +29,7 @@ import org.apache.jena.rdflink.RDFLinkFactory;
 import org.apache.jena.rdflink.RDFLinkHTTP;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.DatasetGraphFactory ;
+import org.apache.jena.sparql.exec.QueryExec;
 import org.apache.jena.sparql.exec.RowSet;
 import org.apache.jena.system.Txn ;
 import org.apache.jena.web.HttpSC.Code;
@@ -103,7 +104,13 @@ public class TestRDFLinkHTTP extends AbstractTestRDFLink {
             String level = LogCtl.getLevel(Fuseki.actionLog);
             try {
                 LogCtl.setLevel(Fuseki.actionLog, "ERROR");
-                FusekiTestLib.expectQueryFail(()->link.query("FOOBAR").select(), Code.BAD_REQUEST);
+                Runnable action = ()-> {
+                    try( QueryExec qExec = link.query("FOOBAR") ) {
+                        qExec.select();
+                    }};
+                FusekiTestLib.expectQueryFail(action, Code.BAD_REQUEST);
+                LogCtl.setLevel(Fuseki.actionLog, "ERROR");
+                FusekiTestLib.expectQueryFail(action, Code.BAD_REQUEST);
             } finally {
                 LogCtl.setLevel(Fuseki.actionLog, level);
             }

--- a/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextIndexLuceneAssembler.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/assembler/TextIndexLuceneAssembler.java
@@ -46,8 +46,7 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
         text:entityMap <#entMap> ;
         .
     */
-    
-    @SuppressWarnings("resource")
+
     @Override
     public TextIndex open(Assembler a, Resource root, Mode mode) {
         try {
@@ -55,10 +54,10 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
                 throw new TextIndexException("No 'text:directory' property on " + root) ;
 
             Directory directory ;
-            
+
             RDFNode n = root.getProperty(pDirectory).getObject() ;
             if ( n.isLiteral() ) {
-                String literalValue = n.asLiteral().getLexicalForm() ; 
+                String literalValue = n.asLiteral().getLexicalForm() ;
                 if (literalValue.equals("mem")) {
                     directory = new ByteBuffersDirectory() ;
                 } else {
@@ -71,7 +70,7 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
                 File dir = new File(path) ;
                 directory = FSDirectory.open(dir.toPath()) ;
             }
-            
+
             String queryParser = null;
             Statement queryParserStatement = root.getProperty(pQueryParser);
             if (null != queryParserStatement) {
@@ -112,14 +111,14 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
             Statement propListsStmt = root.getProperty(pPropLists);
             if (null != propListsStmt) {
                 RDFNode aNode = propListsStmt.getObject();
-                
+
                 if (! aNode.isResource()) {
                     throw new TextIndexException("text:propLists property is not a resource (list) : " + aNode);
                 }
-                
+
                 PropListsAssembler.open(a, (Resource) aNode);
             }
-            
+
             //define any filters and tokenizers first so they can be referenced in analyzer definitions if need be
             Statement defAnalyzersStatement = root.getProperty(pDefAnalyzers);
             if (null != defAnalyzersStatement) {
@@ -127,7 +126,7 @@ public class TextIndexLuceneAssembler extends AssemblerBase {
                 if (! aNode.isResource()) {
                     throw new TextIndexException("text:defineAnalyzers property is not a resource (list) : " + aNode);
                 }
-                
+
                 DefineFiltersAssembler.open(a, (Resource) aNode);
 
                 DefineTokenizersAssembler.open(a, (Resource) aNode);


### PR DESCRIPTION
Some clearing up.

The biggest change is to undo the chaining style of the `AWriter` abstraction (a simplifer writer-like interface) and also used in settter for `IndentedWriter`.

The chaining was to allow setters like `setLineNumbers` and output functions `print` to chain:

```
   AWriter out = IndentedWriter.stdout.clone().setLineNumbers(true);
   out.println("foo").println("bar");
```

But this causes a lot of IDE warnings. The result of a chain-able method is `this` but the IDE does not know that fact. 
It looks to the IDE like a fresh AutoClosable resource and it suggests try-with-resource. Only the outer resource needs that.

Fortunately, this is a primarily internal class, the chaining was added recently at 5.0.0, and chaining has not been retro-applied much in the code base.

---

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
