### PR TITLE
GH-2371: Add tooltip to progress bars (via title attr)

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Upload.vue
+++ b/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Upload.vue
@@ -122,20 +122,22 @@
                   <div class="pt-2 pb-2">
                     <div class="progress" style="height: 1.5rem;">
                       <div
-                        class="progress-bar"
-                        role="progressbar"
                         :style="`width: ${uploadSucceededPercentage}%`"
                         :aria-valuenow="uploadSucceededPercentage"
+                        :title="`${uploadSucceededCount}/${uploadCount}`"
+                        class="progress-bar"
+                        role="progressbar"
                         aria-valuemin="0"
                         aria-valuemax="100"
                       >
                         {{ uploadSucceededCount }}/{{ uploadCount }}
                       </div>
                       <div
-                        class="progress-bar bg-danger"
-                        role="progressbar"
                         :style="`width: ${uploadFailedPercentage}%`"
                         :aria-valuenow="uploadFailedPercentage"
+                        :title="`${uploadFailedCount}/${uploadCount}`"
+                        class="progress-bar bg-danger"
+                        role="progressbar"
                         aria-valuemin="0"
                         aria-valuemax="100"
                       >


### PR DESCRIPTION
GitHub issue resolved #2371  

Pull request Description:

Adds tooltips in case you have very long list and the text is not visible in the progress bars.

![image](https://github.com/apache/jena/assets/304786/eda5e356-2074-4bfb-b665-ce28fac1854c)

Here's a preview of the tooltip (dark tooltip, over one of the progress bars, mouse pointer not displayed).

![image](https://github.com/apache/jena/assets/304786/39422659-0893-4163-aab9-85fa9eeeb578)

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
