### PR TITLE
GH-2370: Improve validation of dataset graph names

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/src/utils/validation.js
+++ b/jena-fuseki2/jena-fuseki-ui/src/utils/validation.js
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Utility functions for data validation in the UI.
+ *
+ * We must avoid repeating the validation when the backend server is handling this,
+ * unless we really want to do that (avoid large payloads, for security, etc.).
+ */
+
+/**
+ * Validates a Jena UI graph name.
+ *
+ * @param {string} graphName - The name of the graph provided by user or configuration file.
+ * @return {boolean} - true iff the given name of the graph provided is valid for Jena.
+ */
+export function validateGraphName (graphName) {
+  if (graphName === '' || graphName.trim() === '') {
+    return false
+  }
+  // No spaces allowed in graph names.
+  const pattern = /^\S+$/
+  if (!pattern.test(graphName)) {
+    return false
+  }
+  // Only valid URIs allowed.
+  try {
+    new URL(graphName)
+  } catch {
+    return false
+  }
+  // If it reached this part, then it's a valid graph name.
+  return true
+}

--- a/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Upload.vue
+++ b/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Upload.vue
@@ -60,7 +60,7 @@
                         placeholder="Leave blank for default graph"
                       />
                       <div class="invalid-feedback">
-                        Invalid graph name. Please remove any spaces.
+                        Invalid graph name. Please remove any spaces, and provide a valid URI (RFC 3986).
                       </div>
                     </div>
                   </div>
@@ -221,6 +221,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import currentDatasetMixin from '@/mixins/current-dataset'
 import currentDatasetMixinNavigationGuards from '@/mixins/current-dataset-navigation-guards'
 import { displayError } from '@/utils'
+import { validateGraphName } from '@/utils/validation'
 
 library.add(faPlus, faUpload, faTimesCircle, faMinusCircle)
 
@@ -418,15 +419,11 @@ export default {
       return this.validateGraphName() && this.validateFiles()
     },
     validateGraphName () {
-      // No spaces allowed in graph names.
-      const pattern = /^[^\s]+$/
       const graphName = this.$refs['dataset-graph-name'].value
-      if (graphName === '' || pattern.test(graphName)) {
-        this.graphNameClasses = ['form-control is-valid']
-        return true
-      }
-      this.graphNameClasses = ['form-control is-invalid']
-      return false
+      const isValidGraphName = validateGraphName(graphName)
+      const formValidationClass = isValidGraphName ? 'is-valid' : 'is-invalid'
+      this.graphNameClasses = ['form-control', formValidationClass]
+      return isValidGraphName
     },
     validateFiles () {
       if (this.upload.files !== null && this.upload.files.length > 0) {

--- a/jena-fuseki2/jena-fuseki-ui/tests/unit/utils/validation.spec.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/unit/utils/validation.spec.js
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest'
+import { validateGraphName } from '@/utils/validation'
+
+const VALID_GRAPH_NAMES = [
+  // From issue GH-2370 discussion
+  'urn:x-arq:UnionGraph',
+  'urn:x-arq:DefaultGraph',
+  'urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66',
+  'https://example.org/dataset',
+  'https://example.org/dataset#graph',
+  'https://example.org/dataset#graph?Aaa',
+  // From RFC-3986
+  'ftp://ftp.is.co.za/rfc/rfc1808.txt',
+  'http://www.ietf.org/rfc/rfc2396.txt',
+  'ldap://[2001:db8::7]/c=GB?objectClass?one',
+  'mailto:John.Doe@example.com',
+  'news:comp.infosystems.www.servers.unix',
+  'tel:+1-816-555-1212',
+  'telnet://192.0.2.16:80/',
+  'urn:oasis:names:specification:docbook:dtd:xml:4.1.2',
+  'foo://example.com:8042/over/there?name=ferret#nose',
+  'example://a/b/c/%7Bfoo%7D',
+  'eXAMPLE://a/./b/../b/%63/%7bfoo%7d',
+  'http://example.com:80/',
+  'ftp://cnn.example.com&story=breaking_news@10.0.0.1/top_story.htm',
+  // From URI.js docs
+  'uri://user:pass@example.com:123/one/two.three?q1=a1&q2=a2#body',
+  'HTTP://ABC.COM:80',
+  'HTTPS://ABC.COM:443/',
+  'WS://ABC.COM:80/chat#one',
+  'mailto:alpha@example.com,bravo@example.com?subject=SUBSCRIBE&body=Sign%20me%20up!',
+  'uri://www.example.org/red%09ros\xE9#red',
+  'uri://www.example.org/red%09ros%C3%A9#red',
+  'uri://www.example.org/D%C3%BCrst',
+  'uri://www.example.org/D\xFCrst',
+  'wss://example.com/foo?bar'
+]
+
+const INVALID_GRAPH_NAMES = [
+  // From issue GH-2370 discussion
+  'snoopy',
+  'test',
+  'default',
+  'wss://example.com/ foo?bar',
+  'https://this is an invalid URL.com',
+  'http%3A//www.example.com/other/graph'
+]
+
+describe('validation', () => {
+  it('Should reject empty graph names', () => {
+    expect(validateGraphName('')).to.equals(false)
+    expect(validateGraphName('  ')).to.equals(false)
+  })
+  it('Should reject graph names that contain spaces', () => {
+    expect(validateGraphName('jena graph')).to.equals(false)
+    expect(validateGraphName('')).to.equals(false)
+  })
+  it('Should reject graph names that are not valid URIs', () => {
+    for (let graphName of INVALID_GRAPH_NAMES) {
+      expect(validateGraphName(graphName)).to.equals(false)
+    }
+  })
+  it('Should accept valid graph names', () => {
+    for (let graphName of VALID_GRAPH_NAMES) {
+      expect(validateGraphName(graphName), `Rejected valid graph name "${graphName}"`).to.equals(true)
+    }
+  })
+})


### PR DESCRIPTION
GitHub issue resolved #2370

Pull request Description:

@afs, @jmkeil, first stab at #2370. Had a look at [^1] and [^2], and I saw some parts of the text mentioning "percent-encoded" in requests, and that the backend is supposed to return 400, as it's doing now. From quickly reading those two (skipping parts, trying to find info for validation), I think

1. empty is valid
2. spaces are no-no
3. otherwise it must be a URI
4. encoded URL is no-no, it must be a valid URI, without encoded parts

I extended the current validation to also check 3 and 4 now. Does that sound right?

This is a draft until I confirm that the fix looks good, then I will either write the tests, or modify the PR again to move the code to some JS module as that a lot easier to write unit-test against, instead of testing code buried somewhere in Vue code/components.

Cheers

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).

[^1]: https://www.w3.org/TR/2013/REC-sparql11-http-rdf-update-20130321/#http-post
[^2]: https://www.ietf.org/rfc/rfc3986.html