### PR TITLE
fix: NodeValue.makeNodeFloat(String) construct NodeValue with datatype XSDfloat

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -319,7 +319,7 @@ public abstract class NodeValue extends ExprNode
 
     public static NodeValue makeNodeFloat(String lexicalForm)
     {
-        NodeValue nv = makeNode(lexicalForm, null, XSDdouble.getURI()) ;
+        NodeValue nv = makeNode(lexicalForm, null, XSDfloat.getURI()) ;
         return nv ;
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
@@ -104,6 +104,14 @@ public class TestNodeValue
         assertTrue("Not same float: " + v1 + " & " + v2, v1.getFloat() == v2.getFloat());
         assertTrue("Not same float as double: " + v1 + " & " + v2, v1.getDouble() == v2.getDouble());
     }
+    
+    @Test
+    public void testFloat4() {
+        NodeValue v1 = NodeValue.makeNodeFloat("5.7");
+        NodeValue v2 = NodeValue.makeFloat(5.7f);
+        assertTrue("Not same float: " + v1 + " & " + v2, v1.getFloat() == v2.getFloat());
+        assertTrue("Not same float as double: " + v1 + " & " + v2, v1.getDouble() == v2.getDouble());
+    }
 
     @Test
     public void testDouble1() {


### PR DESCRIPTION
jena-arq NodeValue.makeNodeFloat(String) is supposed to construct a NodeValue with datatype XSDFloat. 
Instead, it currently constructs a NodeValue with datatype XSDDouble.

Updates NodeValue.makeNodeFloat(String) to construct a NodeValue with datatype XSDFloat.

Adds test TestNodeValue.float4() that confirms that makeNodeFloat(String) constructs a XSDFloat value.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
