### PR TITLE
Accumulated code clean up

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/StrUtils.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/StrUtils.java
@@ -138,6 +138,15 @@ public class StrUtils //extends StringUtils
         return x.isEmpty() ? x : x.substring(0, x.length() - 1) ;
     }
 
+    /**
+     * Return the last character of a string,
+     * return char zero if the string is zero
+     * length.
+     */
+    public static char lastChar(String x) {
+        return x.isEmpty() ? 0 : x.charAt(x.length()-1);
+    }
+
     public static String noNewlineEnding(String x) {
         while (x.endsWith("\n") || x.endsWith("\r"))
             x = StrUtils.chop(x) ;

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/TestStrUtils.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/TestStrUtils.java
@@ -30,11 +30,11 @@ public class TestStrUtils
     static char marker = '_' ;
     static char esc[] = { ' ' , '_' } ;
 
-    static void test(String x) {
-        test(x, null);
+    static void testEnc(String x) {
+        testEnc(x, null);
     }
 
-    static void test(String x, String z) {
+    static void testEnc(String x, String z) {
         String y = StrUtils.encodeHex(x, marker, esc);
         if ( z != null )
             assertEquals(z, y);
@@ -48,43 +48,41 @@ public class TestStrUtils
         assertEquals(expected, x2);
     }
 
-    @Test public void enc01() { test("abc") ; }
-
-    @Test public void enc02() { test("") ; }
-
-    @Test public void enc03() { test("_", "_5F" ) ; }
-
-    @Test public void enc04() { test(" ", "_20" ) ; }
-
-    @Test public void enc05() { test("_ _", "_5F_20_5F" ) ; }
-
-    @Test public void enc06() { test("_5F", "_5F5F" ) ; }
-
-    @Test public void enc07() { test("_2") ; }
-
-    @Test public void enc08() { test("AB_CD", "AB_5FCD") ; }
+    @Test public void enc01() { testEnc("abc") ; }
+    @Test public void enc02() { testEnc("") ; }
+    @Test public void enc03() { testEnc("_", "_5F" ) ; }
+    @Test public void enc04() { testEnc(" ", "_20" ) ; }
+    @Test public void enc05() { testEnc("_ _", "_5F_20_5F" ) ; }
+    @Test public void enc06() { testEnc("_5F", "_5F5F" ) ; }
+    @Test public void enc07() { testEnc("_2") ; }
+    @Test public void enc08() { testEnc("AB_CD", "AB_5FCD") ; }
 
     // JENA-1890: Multibyte characters before the "_"
     // 사용_설명서 (Korean: "User's Guide")
 
-    @Test public void enc09() { test("\uC0AC\uC6A9_\uC124\uBA85\uC11C"); }
+    @Test public void enc09() { testEnc("\uC0AC\uC6A9_\uC124\uBA85\uC11C"); }
     // Same string, but using the glyphs for the codepoints, not the \ u value. Same string after Java parsing.
-    @Test public void enc09a() { test("사용_설명서"); }
+    @Test public void enc09a() { testEnc("사용_설명서"); }
 
     // The decode code works more generally than the encoder.
     // This tests the decode of the UTF=-8 byte encoding of 사용_설명서
     // Note "_5F" which is "_" encoded.
     @Test public void enc10() { testDecode("_EC_82_AC_EC_9A_A9_5F_EC_84_A4_EB_AA_85_EC_84_9C", "사용_설명서"); }
-
     @Test public void enc11() { testDecode("_41", "A"); }
 
     @Test(expected=AtlasException.class) public void enc20() { testDecode("_4", null); }
-
     @Test(expected=AtlasException.class) public void enc21() { testDecode("_", null); }
-
     @Test(expected=AtlasException.class) public void enc22() { testDecode("_X1", null); }
-
     @Test(expected=AtlasException.class) public void enc23() { testDecode("_1X", null); }
+
+    @Test public void lastChar01() { testLastChar("abc",  'c'); }
+    @Test public void lastChar02() { testLastChar(".",  '.'); }
+    @Test public void lastChar03() { testLastChar("",  (char)0); }
+
+    private static void testLastChar(String x, char expectedLastChar) {
+        char lastChar = StrUtils.lastChar(x);
+        assertEquals(expectedLastChar, lastChar);
+    }
 
     @Test public void prefix_ignorecase_1() {
         boolean b = StrUtils.strStartsWithIgnoreCase("foobar", "FOO");
@@ -113,6 +111,4 @@ public class TestStrUtils
         boolean b = StrUtils.strEndsWithIgnoreCase("bar", "foobar");
         assertFalse(b);
     }
-
-
 }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/Resource.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/Resource.java
@@ -29,12 +29,12 @@ import org.apache.jena.shared.PropertyNotFoundException ;
     a range of methods, such as <code>getProperty()</code> and
     <code>addProperty()</code> which will access or modify that model.  This
     enables the programmer to write code in a compact and easy style.
-    
+
 <p>
-    Resources created by ResourceFactory will not refer to any model, and will 
+    Resources created by ResourceFactory will not refer to any model, and will
     not permit operations which require a model. Such resources are useful
     as general constants.
- 
+
   <p>This interface provides methods supporting typed literals.  This means
      that methods are provided which will translate a built in type, or an
      object to an RDF Literal.  This translation is done by invoking the
@@ -63,7 +63,7 @@ public interface Resource extends RDFNode {
      * @return A unique id for an anonymous resource.
      */
     public AnonId getId();
-    
+
     /**
         Override RDFNode.inModel() to produce a statically-typed Resource
         in the given Model.
@@ -81,22 +81,22 @@ public interface Resource extends RDFNode {
      * @return The URI of the resource, or null if it's a bnode or statement.
      */
     public String getURI();
-    
+
     /**
      * Return the statement of this resource, or null if it is not an RDF-star triple term.
-     * This is not a resource for a reified statement.   
+     * This is not a resource for a reified statement.
      * @return The statement of this resource,or null if it is not an RDF-star triple term.
      */
     public Statement getStmtTerm();
 
-    /** Returns the namespace associated with this resource if it is a URI, else return null. 
-     * <p> 
-     * The namespace is suitable for use with localname in in RDF/XML.
+    /** Returns the namespace associated with this resource if it is a URI, else return null.
+     * <p>
+     * The namespace is suitable for use with localname in RDF/XML.
      * XML does not allow QNames to start with a digit and this method
      * reflects that restriction in the values for namespace and localname.
      * <p>
      * See functions in {@code SplitIRI} for other split algorithms.
-     *  
+     *
      * @return The namespace for this resource or null.
      */
     public String getNameSpace();
@@ -187,7 +187,7 @@ public interface Resource extends RDFNode {
      * @return An iterator over the statements.
      */
     public StmtIterator listProperties( Property p );
-    
+
     /** Return an iterator over all the properties of this resource with a specific language.
     *
     * <p>The model associated with this resource is searched and an iterator is
@@ -214,7 +214,7 @@ public interface Resource extends RDFNode {
         <code>this.getModel().createTypedLiteral(o)</code>.
     */
     public Resource addLiteral( Property p, boolean o );
-    
+
     /**
         Add the property <code>p</code> with the typed-literal value <code>o</code>
         to this resource, <i>ie</i> add (this, p, typed(o)) to this's model. Answer
@@ -222,7 +222,7 @@ public interface Resource extends RDFNode {
         <code>this.getModel().createTypedLiteral(o)</code>.
     */
     public Resource addLiteral( Property p, long o );
-    
+
     /**
         Add the property <code>p</code> with the typed-literal value <code>o</code>
         to this resource, <i>ie</i> add (this, p, typed(o)) to this's model. Answer
@@ -256,13 +256,13 @@ public interface Resource extends RDFNode {
     public Resource addLiteral( Property p, Object o );
 
     /**
-        Add the property <code>p</code> with the pre-constructed Literal value 
-        <code>o</code> to this resource, <i>ie</i> add (this, p, o) to this's 
+        Add the property <code>p</code> with the pre-constructed Literal value
+        <code>o</code> to this resource, <i>ie</i> add (this, p, o) to this's
         model. Answer this resource. <b>NOTE</b> thjat this is distinct from the
         other addLiteral methods in that the Literal is not turned into a Literal.
-    */    
+    */
     public Resource addLiteral( Property p, Literal o );
-    
+
     /** Add a property to this resource.
      *
      * <p>A statement with this resource as the subject, p as the predicate and o
@@ -318,7 +318,7 @@ public interface Resource extends RDFNode {
         a typed literal with the appropriate RDF type.
     */
     public boolean hasLiteral( Property p, boolean o );
-    
+
     /**
         Answer true iff this resource has the value <code>o</code> for
         property <code>p</code>. <code>o</code> is interpreted as
@@ -332,14 +332,14 @@ public interface Resource extends RDFNode {
         a typed literal with the appropriate RDF type.
     */
     public boolean hasLiteral( Property p, char o );
-    
+
     /**
         Answer true iff this resource has the value <code>o</code> for
         property <code>p</code>. <code>o</code> is interpreted as
         a typed literal with the appropriate RDF type.
     */
     public boolean hasLiteral( Property p, double o );
-    
+
     /**
         Answer true iff this resource has the value <code>o</code> for
         property <code>p</code>. <code>o</code> is interpreted as

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/Util.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/Util.java
@@ -29,103 +29,22 @@ import org.apache.jena.graph.TextDirection;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.shared.CannotEncodeCharacterException;
 import org.apache.jena.util.SplitIRI;
-import org.apache.jena.util.XMLChar;
 
 /** Some utility functions.
  */
 public class Util extends Object {
 
-    /**
-     * Given an absolute URI, determine the split point between the namespace
-     * part and the localname part. If there is no valid localname part then the
-     * length of the string is returned. The algorithm tries to find the longest
-     * NCName at the end of the uri, not immediately preceeded by the first
-     * colon in the string.
-     * <p>
-     * This operation follows XML QName rules which are more complicated than
-     * needed for Turtle and TriG.   For example, QName can't start with a digit.
-     *
-     * @param uri
-     * @return the index of the first character of the localname
-     * @see SplitIRI
-     */
-    public static int splitNamespaceXML(String uri) {
-
-        // XML Namespaces 1.0:
-        // A qname name is NCName ':' NCName
-        // NCName             ::=      NCNameStartChar NCNameChar*
-        // NCNameChar         ::=      NameChar - ':'
-        // NCNameStartChar    ::=      Letter | '_'
-        //
-        // XML 1.0
-        // NameStartChar      ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] |
-        //                        [#xD8-#xF6] | [#xF8-#x2FF] |
-        //                        [#x370-#x37D] | [#x37F-#x1FFF] |
-        //                        [#x200C-#x200D] | [#x2070-#x218F] |
-        //                        [#x2C00-#x2FEF] | [#x3001-#xD7FF] |
-        //                        [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
-        // NameChar           ::= NameStartChar | "-" | "." | [0-9] | #xB7 |
-        //                        [#x0300-#x036F] | [#x203F-#x2040]
-        // Name               ::= NameStartChar (NameChar)*
-
-        char ch;
-        int lg = uri.length();
-        if (lg == 0)
-            return 0;
-        int i = lg-1;
-        for (; i >= 1; i--) {
-            ch = uri.charAt(i);
-            if (notNameChar(ch)) break;
-        }
-
-        int j = i + 1;
-
-        if ( j >= lg )
-            return lg;
-
-        // Check we haven't split up a %-encoding.
-        if ( j >= 2 && uri.charAt(j-2) == '%' )
-            j = j+1;
-        if ( j >= 1 && uri.charAt(j-1) == '%' ) {
-            j = j+2;
-            if ( j > lg )
-                // JENA-1941: Protect against overshoot in the case of "%x"
-                // at end of a (bad) URI.
-                return lg;
-        }
-
-        // Have found the leftmost NCNameChar from the
-        // end of the URI string.
-        // Now scan forward for an NCNameStartChar
-        // The split must start with NCNameStart.
-        for (; j < lg; j++) {
-            ch = uri.charAt(j);
-//            if (XMLChar.isNCNameStart(ch))
-//                break;
-            if (XMLChar.isNCNameStart(ch))
-            {
-                // "mailto:" is special.
-                // split "mailto:me" as "mailto:m" and "e" !
-                // Keep part after mailto: with at least one character.
-                if ( j == 7 && uri.startsWith("mailto:"))
-                    // Don't split at "mailto:"
-                    continue;
-                else
-                    break;
-            }
-        }
-        return j;
-    }
-
-    /**
-	    answer true iff this is not a legal NCName character, ie, is
-	    a possible split-point start.
-    */
-    public static boolean notNameChar( char ch )
-        { return !XMLChar.isNCName( ch ); }
-
     protected static Pattern standardEntities =
         Pattern.compile( "&|<|>|\t|\n|\r|\'|\"" );
+
+    /**
+     * Given an absolute URI, determine the split point between the namespace
+     * part and the localname part. See {@link SplitIRI#splitNamespaceXML} for details.
+     */
+    public static int splitNamespaceXML(String uri) {
+        // Legacy. Call the moved code.
+        return SplitIRI.splitNamespaceXML(uri);
+    }
 
     public static String substituteStandardEntities( String s )
         {

--- a/jena-core/src/main/java/org/apache/jena/util/SplitIRI.java
+++ b/jena-core/src/main/java/org/apache/jena/util/SplitIRI.java
@@ -18,9 +18,9 @@
 
 package org.apache.jena.util;
 
-import org.apache.jena.graph.Node ;
-import org.apache.jena.rdf.model.impl.Util ;
-//import org.apache.jena.riot.system.RiotChars ;
+import org.apache.jena.graph.Node;
+import org.apache.jena.rdf.model.impl.Util;
+//import org.apache.jena.riot.system.RiotChars;
 
 /**
  * Code to split an URI or IRI into prefix and local part.
@@ -28,16 +28,15 @@ import org.apache.jena.rdf.model.impl.Util ;
  * reflecting RDF/XML history.
  * <p>
  * For display, use {@link #localname} and {@link #namespace}.
- * This follows Turtle, adds some pragmatic rulesm but does not escape
+ * This follows Turtle, adds some pragmatic rules but does not escape
  * any characters. A URI is split never split before the last {@code /}
  * or last {@code #}, if present.
  * See {@link #splitpoint} for more details.
  * <p>
- * This code form the machinery behind {@link Node#getLocalName}
- * {@link Node#getNameSpace} for URI Nodes.
+ * This code forms the machinery behind {@link Node#getLocalName}
+ * {@link Node#getNameSpace} for URI Nodes following the XML rules.
  * <p>
- * {@link #localnameTTL} is strict Turtle; it is the same local name as
- * before, but escaped if necessary.
+ * {@link #namespaceTTL} and {@link #localnameTTL} is strict Turtle; the local name is escaped if necessary.
  * <p>
  * The functions {@link #namespaceXML} and {@link #localnameXML}
  * apply the rules for XML qnames.
@@ -45,42 +44,46 @@ import org.apache.jena.rdf.model.impl.Util ;
 public class SplitIRI
 {
     /** Return the 'namespace' (prefix) for a URI string.
-     * Use with {@link #localname}
+     * Use with {@link #localname}.
+     * Return the input string if there is no splitpoint.
      */
     public static String namespace(String string) {
-        int i = splitpoint(string) ;
+        int i = splitpoint(string);
         if ( i < 0 )
-            return string ;
-        return string.substring(0, i) ;
+            return string;
+        return string.substring(0, i);
     }
 
     /** Calculate a localname - do not escape PN_LOCAL_ESC.
      * This is not guaranteed to be legal Turtle.
      * Use with {@link #namespace}
+     * Return an empty string if there is no splitpoint.
      */
     public static String localname(String string) {
-        int i = splitpoint(string) ;
+        int i = splitpoint(string);
         if ( i < 0 )
-            return "" ;
-        return string.substring(i) ;
+            return "";
+        return string.substring(i);
     }
 
-    /** Return the 'namespace' (prefix) for a URI string,
+    /**
+     * Return the 'namespace' (prefix) for a URI string,
      * legal for Turtle and goes with {@link #localnameTTL}
      */
     public static String namespaceTTL(String string) {
-        return namespace(string) ;
+        return namespace(string);
     }
 
-    /** Calculate a localname - enforce legal Turtle
+    /**
+     * Calculate a localname - enforce legal Turtle
      * escape PN_LOCAL_ESC, check for final '.'
      * Use with {@link #namespaceTTL}
      */
     public static String localnameTTL(String string) {
-        String x = localname(string) ;
+        String x = localname(string);
         if ( x.isEmpty())
-            return x ;
-        return escape_PN_LOCAL_ESC(x) ;
+            return x;
+        return escape_PN_LOCAL_ESC(x);
     }
 
     private static String escape_PN_LOCAL_ESC(String x) {
@@ -88,32 +91,32 @@ public class SplitIRI
         // is work to do then scan again doing the work.
         //'\' ('_' | '~' | '.' | '-' | '!' | '$' | '&' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%')
 
-        int N = x.length() ;
-        boolean escchar = false ;
-        for ( int i = 0 ; i < N ; i++ ) {
-            char ch = x.charAt(i) ;
+        int N = x.length();
+        boolean escchar = false;
+        for ( int i = 0; i < N; i++ ) {
+            char ch = x.charAt(i);
             if ( needsEscape(ch, (i==N-1)) ) {
-                escchar = true ;
-                break ;
+                escchar = true;
+                break;
             }
         }
         if ( ! escchar )
-            return x ;
-        StringBuilder sb = new StringBuilder(N+10) ;
-        for ( int i = 0 ; i < N ; i++ ) {
-            char ch = x.charAt(i) ;
+            return x;
+        StringBuilder sb = new StringBuilder(N+10);
+        for ( int i = 0; i < N; i++ ) {
+            char ch = x.charAt(i);
             // DOT only needs escaping at the end
             if ( needsEscape(ch, (i==N-1) )  )
-                sb.append('\\') ;
-            sb.append(ch) ;
+                sb.append('\\');
+            sb.append(ch);
         }
-        return sb.toString() ;
+        return sb.toString();
     }
 
     private static boolean needsEscape(char ch, boolean finalChar) {
         if ( ch == '.' )
-            return finalChar ;
-        return isPN_LOCAL_ESC(ch) ;
+            return finalChar;
+        return isPN_LOCAL_ESC(ch);
     }
 
     // @formatter:off
@@ -148,14 +151,14 @@ public class SplitIRI
      * @return The split point, or -1 for "not found".
      */
     public static int splitpoint(String uri) {
-        boolean isURN = uri.startsWith("urn:") ;
+        boolean isURN = uri.startsWith("urn:");
         // Fast track.  Still need to check validity of the prefix part.
-        int idx1 = uri.lastIndexOf('#') ;
+        int idx1 = uri.lastIndexOf('#');
         // Not so simple - \/ in local names
-        int idx2 = isURN ? uri.lastIndexOf(':') : uri.lastIndexOf('/') ;
+        int idx2 = isURN ? uri.lastIndexOf(':') : uri.lastIndexOf('/');
 
         // If absolute.
-        int idx3 = uri.indexOf(':') ;
+        int idx3 = uri.indexOf(':');
 
         // Note: local names can't end in "." in Turtle.
         // This is handled by escape_PN_LOCAL_ESC which will escape it as "\."
@@ -177,52 +180,52 @@ public class SplitIRI
         } else if ( idx1 >= 0 && idx2 >= 0 ) {
             // Fragment and path. Use fragment.
             // If "/" is in the fragment, it is not the split point.
-            limit = idx1 ;
+            limit = idx1;
         } else {
             limit = -1;
         }
 
         // At least idx3, the case of no "/" and no "#" in an absolute IRI
         if ( idx3 >= 0 )
-            limit = Math.max(limit, idx3) ;
+            limit = Math.max(limit, idx3);
 
         // Limit is our guess.
         // Now search end of URI to this guess checking the characters found.
 
-        int splitPoint = -1 ;
+        int splitPoint = -1;
         // Work backwards, checking for
         // ((PN_CHARS | '.' | ':' | PLX)*
-        for ( int i = uri.length()-1 ; i > limit ; i-- ) {
-            char ch = uri.charAt(i) ;
+        for ( int i = uri.length()-1; i > limit; i-- ) {
+            char ch = uri.charAt(i);
             if ( /*RiotChars.*/isPNChars_U_N(ch) || /*RiotChars.*/isPN_LOCAL_ESC(ch) || ch == ':' || ch == '-' || ch == '.' )
-                continue ;
-            splitPoint = i+1 ;
-            break ;
+                continue;
+            splitPoint = i+1;
+            break;
         }
         // limit was at the end.  No split point (we could escape the limit point)
         if ( splitPoint == -1 )
-            splitPoint = limit+1 ;
+            splitPoint = limit+1;
         // No split point.
         if ( splitPoint >= uri.length() )
-            return -1 ;
+            return -1;
 
         // Check the first character of the local name.
         // All characters are legal localname name characters but may not satisfy the additional
         // first character rule.  Move forward to first legal first character.
-        int ch = uri.charAt(splitPoint) ;
+        int ch = uri.charAt(splitPoint);
         while ( ch == '.' || ch == '-' ) {
-            splitPoint++ ;
+            splitPoint++;
             if ( splitPoint >= uri.length() )
-                return -1 ;
-            ch = uri.charAt(splitPoint) ;
+                return -1;
+            ch = uri.charAt(splitPoint);
         }
 
         // Checking the final '.' is done when checking for escapes.
-        return splitPoint ;
+        return splitPoint;
     }
 
     private static boolean checkhex(String uri, int i) {
-        return /*RiotChars.*/isHexChar(uri.charAt(i)) ;
+        return /*RiotChars.*/isHexChar(uri.charAt(i));
     }
 
     // Assuming legal URIs, there is no work to be done
@@ -233,10 +236,10 @@ public class SplitIRI
         if ( ch == '%' ) {
             if ( i+2 >= uri.length() ) {
                 // Too short
-                return -1 ;
+                return -1;
             }
             if ( ! checkhex(uri, i+1) || ! checkhex(uri, i+2) )
-                return -1 ;
+                return -1;
         }
 
      */
@@ -244,20 +247,20 @@ public class SplitIRI
      * This is the longest NCName at the end of the uri.
      * See {@link Util#splitNamespaceXML}.
      */
-    public static int splitXML(String string) { return Util.splitNamespaceXML(string) ; }
+    public static int splitXML(String string) { return Util.splitNamespaceXML(string); }
 
     /** Namespace, according to XML qname rules.
      * Use with {@link #localnameXML}.
      */
     public static String namespaceXML(String string) {
-        int i = splitXML(string) ;
-        return string.substring(0, i) ;
+        int i = splitXML(string);
+        return string.substring(0, i);
     }
 
     /** Localname, according to XML qname rules. */
     public static String localnameXML(String string) {
-        int i = splitXML(string) ;
-        return string.substring(i) ;
+        int i = splitXML(string);
+        return string.substring(i);
     }
 
     // Extracted from RiotChars
@@ -268,15 +271,15 @@ public class SplitIRI
             case '\\': case '_':  case '~': case '.': case '-': case '!': case '$':
             case '&':  case '\'': case '(': case ')': case '*': case '+': case ',':
             case ';':  case '=':  case '/': case '?': case '#': case '@': case '%':
-                return true ;
+                return true;
             default:
-                return false ;
+                return false;
         }
     }
 
     /** ASCII 0-9 */
     private static boolean isDigit(int ch) {
-        return range(ch, '0', '9') ;
+        return range(ch, '0', '9');
     }
 
     private static boolean isPNCharsBase(int ch) {
@@ -291,43 +294,43 @@ public class SplitIRI
             // Surrogate pairs
             r(ch, 0xD800, 0xDFFF) ||
             r(ch, 0xF900, 0xFDCF) || r(ch, 0xFDF0, 0xFFFD) ||
-            r(ch, 0x10000, 0xEFFFF) ; // Outside the basic plane.
+            r(ch, 0x10000, 0xEFFFF); // Outside the basic plane.
     }
 
     private static boolean isPNChars_U(int ch) {
         //PN_CHARS_BASE | '_'
-        return isPNCharsBase(ch) || ( ch == '_' ) ;
+        return isPNCharsBase(ch) || ( ch == '_' );
     }
 
     private static boolean isPNChars_U_N(int ch) {
         // PN_CHARS_U | [0-9]
-        return isPNCharsBase(ch) || ( ch == '_' ) || isDigit(ch) ;
+        return isPNCharsBase(ch) || ( ch == '_' ) || isDigit(ch);
     }
 
     private static boolean isPNChars(int ch) {
         // PN_CHARS ::=  PN_CHARS_U | '-' | [0-9] | #x00B7 | [#x0300-#x036F] | [#x203F-#x2040]
-        return isPNChars_U(ch) || isDigit(ch) || ( ch == '-' ) || ch == 0x00B7 || r(ch, 0x300, 0x036F) || r(ch, 0x203F, 0x2040) ;
+        return isPNChars_U(ch) || isDigit(ch) || ( ch == '-' ) || ch == 0x00B7 || r(ch, 0x300, 0x036F) || r(ch, 0x203F, 0x2040);
     }
 
     /** Hexadecimal character */
     private static boolean isHexChar(int ch) {
-        return range(ch, '0', '9') || range(ch, 'a', 'f') || range(ch, 'A', 'F') ;
+        return range(ch, '0', '9') || range(ch, 'a', 'f') || range(ch, 'A', 'F');
     }
 
     private static int valHexChar(int ch) {
         if ( range(ch, '0', '9') )
-            return ch - '0' ;
+            return ch - '0';
         if ( range(ch, 'a', 'f') )
-            return ch - 'a' + 10 ;
+            return ch - 'a' + 10;
         if ( range(ch, 'A', 'F') )
-            return ch - 'A' + 10 ;
-        return -1 ;
+            return ch - 'A' + 10;
+        return -1;
     }
 
-    private static boolean r(int ch, int a, int b) { return ( ch >= a && ch <= b ) ; }
+    private static boolean r(int ch, int a, int b) { return ( ch >= a && ch <= b ); }
 
     private static boolean range(int ch, char a, char b) {
-        return (ch >= a && ch <= b) ;
+        return (ch >= a && ch <= b);
     }
 }
 

--- a/jena-core/src/test/java/org/apache/jena/util/TestPackage_util.java
+++ b/jena-core/src/test/java/org/apache/jena/util/TestPackage_util.java
@@ -31,23 +31,26 @@ public class TestPackage_util extends TestSuite {
     static public TestSuite suite() {
         return new TestPackage_util();
     }
-    
+
     /** Creates new TestPackage */
     private TestPackage_util() {
         super( "util" );
-        addTest( "TestTokenzier",         TestTokenizer.suite());
-        addTest( "TestFileUtils",         TestFileUtils.suite() );
-        addTest( "TestHashUtils",         TestCollectionFactory.suite() );
-        addTest( "TestLocationMapper",    TestLocationMapper.suite() ) ;
-        addTest( "TestFileManager",       TestFileManager.suite()) ;
-        addTest( "TestMonitors",          TestMonitors.suite()) ;
-        addTest( "TestPrintUtil",         TestPrintUtil.suite()) ;
+        addTest( "TestTokenzier",          TestTokenizer.suite());
+        addTest( "TestFileUtils",          TestFileUtils.suite() );
+        addTest( "TestHashUtils",          TestCollectionFactory.suite() );
+        addTest( "TestLocationMapper",     TestLocationMapper.suite() ) ;
+        addTest( "TestFileManager",        TestFileManager.suite()) ;
+        addTest( "TestMonitors",           TestMonitors.suite()) ;
+        addTest( "TestPrintUtil",          TestPrintUtil.suite()) ;
         addTest( "TestPrefixMappingUtils", TestPrefixMappingUtils.suite() );
-        addTest( TestIteratorCollection.suite() );
-        addTest( "TestSplitIRI_XML",      TestSplitIRI_XML.suite()) ;
-        addTest( "TestSplitIRI_TTL",      TestSplitIRI_TTL.suite()) ;
-        addTest( "TestModelCollector",    TestModelCollector.suite()) ;
-        
+        addTest( "TestIteratorCollection", TestIteratorCollection.suite() );
+        addTest( "TestModelCollector",     TestModelCollector.suite()) ;
+
+        addTest( "TestSplitIRI_Display",   TestSplitIRI_Display.suite()) ;
+        addTest( "TestSplitIRI_XML",       TestSplitIRI_XML.suite()) ;
+        addTest( "TestSplitIRI_TTL",       TestSplitIRI_TTL.suite()) ;
+
+        // Needs the legacy N3 reader loaded.
         addTestSuite( TestLocators.class );
         addTestSuite( TestOneToManyMap.class );
     }
@@ -55,7 +58,7 @@ public class TestPackage_util extends TestSuite {
     private void addTest(String name, TestSuite tc) {
         tc.setName(name);
         addTest(tc);
-    }        
+    }
     private void addTest(String name, Test tc) {
         addTest(tc);
     }

--- a/jena-core/src/test/java/org/apache/jena/util/TestSplitIRI_Display.java
+++ b/jena-core/src/test/java/org/apache/jena/util/TestSplitIRI_Display.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.util;
+
+import static org.apache.jena.util.SplitIRI.* ;
+
+import junit.framework.JUnit4TestAdapter ;
+import org.junit.Assert ;
+import org.junit.Test ;
+
+/**
+ * Test splitting IRI strings using the display rules.
+ * See {SplitIRI} for details.
+ * Display is convenience - namespace+localname may not reconstruct the IRI.
+ */
+public class TestSplitIRI_Display {
+    public static junit.framework.Test suite() {
+        return new JUnit4TestAdapter(TestSplitIRI_Display.class) ;
+    }
+
+    // Basics
+    @Test public void split_basic_00() { testSplit("http://example/foo", "http://example/".length()) ; }
+    @Test public void split_basic_01() { testPrefixLocalname("http://example/foo",            "http://example/",      "foo"       ) ; }
+    @Test public void split_basic_02() { testPrefixLocalname("http://example/foo#bar",        "http://example/foo#",  "bar"       ) ; }
+    @Test public void split_basic_03() { testPrefixLocalname("http://example/foo#",           "http://example/foo#",  ""          ) ; }
+    @Test public void split_basic_04() { testPrefixLocalname("http://example/",               "http://example/",      ""          ) ; }
+    @Test public void split_basic_05() { testPrefixLocalname("http://example/1abc",           "http://example/",      "1abc"      ) ; }
+    @Test public void split_basic_06() { testPrefixLocalname("http://example/1.2.3.4",        "http://example/",      "1.2.3.4"   ) ; }
+    @Test public void split_basic_07() { testPrefixLocalname("http://example/xyz#1.2.3.4",    "http://example/xyz#",  "1.2.3.4"   ) ; }
+    @Test public void split_basic_08() { testPrefixLocalname("http://example/xyz#_abc",       "http://example/xyz#",  "_abc"      ) ; }
+    @Test public void split_basic_09() { testPrefixLocalname("http://example/xyz/_1.2.3.4",   "http://example/xyz/", "_1.2.3.4"   ) ; }
+
+    // Relative URIs
+    @Test public void split_rel_1() { testPrefixLocalname("xyz/_1.2.3.4",  "xyz/", "_1.2.3.4" ) ; }
+    @Test public void split_rel_2() { testPrefixLocalname("xyz",           "",     "xyz" ) ; }
+    @Test public void split_rel_3() { testPrefixLocalname("",              "",     "" ) ; }
+
+    // Bizarre but legal URIs
+    @Test public void split_weird_1() { testPrefixLocalname("abc:def",   "abc:", "def" ) ; }
+    @Test public void split_weird_2() { testPrefixLocalname("",          "",     ""    ) ; }
+
+    // Turtle details.
+    // "." leading dot is not legal.
+    @Test public void split_ttl_01() { testPrefixLocalname("http://example/foo#bar:baz",  "http://example/foo#",  "bar:baz"   ) ; }
+    @Test public void split_ttl_02() { testPrefixLocalname("http://example/a:b:c",        "http://example/",      "a:b:c"     ) ; }
+    @Test public void split_ttl_03() { testPrefixLocalname("http://example/.2.3.4",       "http://example/.",     "2.3.4"     ) ; }
+
+    // "." leading dot is not legal.
+    @Test public void split_ttl_04() { testPrefixLocalname("abc:xyz/.def",               "abc:xyz/.", "def" ) ; }
+    // "-" leading dash is not legal.
+    @Test public void split_ttl_05() { testPrefixLocalname("abc:xyz/-def",                 "abc:xyz/-", "def" ) ; }
+    @Test public void split_ttl_06() { testPrefixLocalname("abc:xyz/-.-.-def",             "abc:xyz/-.-.-", "def" ) ; }
+    @Test public void split_ttl_07() { testPrefixLocalname("http://example/id=89",         "http://example/",  "id=89"   ) ; }
+
+    // URNs split differently.
+    @Test public void split_urn_01() { testPrefixLocalname("urn:foo:bar",     "urn:foo:", "bar") ; }
+    @Test public void split_urn_02() { testPrefixLocalname("urn:example:bar/b",   "urn:example:", "bar/b"); }
+    @Test public void split_urn_03() { testPrefixLocalname("urn:example:bar#frag",   "urn:example:bar#", "frag"); }
+
+    private void testSplit(String string, int expected) {
+        int i = splitpoint(string) ;
+        Assert.assertEquals(expected, i) ;
+    }
+
+    private void testPrefixLocalnameNoSplit(String string) {
+        int i = splitpoint(string) ;
+        String msg = string ;
+        if ( i != -1 ) {
+            // Better error message.
+            String ns = namespaceTTL(string) ;
+            String ln = localnameTTL(string) ;
+            msg = "Unexpected split of '"+string+"' into ("+ns+", "+ln+") [index="+i+"]" ;
+        }
+        Assert.assertEquals(msg, -1, i) ;
+    }
+
+    // Don't worry about local name escaping.
+    private void testPrefixLocalname(String string, String expectedNamespace, String expectedLocalname) {
+        String actualNamespace = namespace(string) ;
+        String actualLocalName = localname(string) ;
+        checkPrefixLocalname(string,
+                             expectedNamespace, actualNamespace,
+                             expectedLocalname, actualLocalName) ;
+        if ( expectedNamespace != null && expectedLocalname != null ) {
+            String x = actualNamespace+actualLocalName ;
+            Assert.assertEquals(string, x) ;
+        }
+    }
+
+    private void checkPrefixLocalname(String string,
+                                      String expectedNamespace, String actualNamespace,
+                                      String expectedLocalname, String actualLocalName) {
+        if ( expectedNamespace != null )
+            Assert.assertEquals(expectedNamespace, actualNamespace);
+        if ( expectedLocalname != null )
+            Assert.assertEquals(expectedLocalname, actualLocalName);
+    }
+}

--- a/jena-core/src/test/java/org/apache/jena/util/TestSplitIRI_TTL.java
+++ b/jena-core/src/test/java/org/apache/jena/util/TestSplitIRI_TTL.java
@@ -20,8 +20,6 @@ package org.apache.jena.util;
 
 import static org.apache.jena.util.SplitIRI.* ;
 
-import java.util.Objects ;
-
 import junit.framework.JUnit4TestAdapter ;
 import org.junit.Assert ;
 import org.junit.Test ;
@@ -38,114 +36,77 @@ public class TestSplitIRI_TTL {
 
     // Basics
     @Test public void split_basic_00() { testSplit("http://example/foo", "http://example/".length()) ; }
-    @Test public void split_basic_01() { testPrefixLocalname("http://example/foo",            "http://example/",      "foo"       ) ; }
-    @Test public void split_basic_02() { testPrefixLocalname("http://example/foo#bar",        "http://example/foo#",  "bar"       ) ; }
-    @Test public void split_basic_03() { testPrefixLocalname("http://example/foo#",           "http://example/foo#",  ""          ) ; }
-    @Test public void split_basic_04() { testPrefixLocalname("http://example/",               "http://example/",      ""          ) ; }
-    @Test public void split_basic_05() { testPrefixLocalname("http://example/1abc",           "http://example/",      "1abc"      ) ; }
-    @Test public void split_basic_06() { testPrefixLocalname("http://example/1.2.3.4",        "http://example/",      "1.2.3.4"   ) ; }
-    @Test public void split_basic_07() { testPrefixLocalname("http://example/xyz#1.2.3.4",    "http://example/xyz#",  "1.2.3.4"   ) ; }
-    @Test public void split_basic_08() { testPrefixLocalname("http://example/xyz#_abc",       "http://example/xyz#",  "_abc"      ) ; }
-    @Test public void split_basic_09() { testPrefixLocalname("http://example/xyz/_1.2.3.4",   "http://example/xyz/", "_1.2.3.4"   ) ; }
+    @Test public void split_basic_01() { testPrefixLocalnameTTL("http://example/foo",            "http://example/",      "foo"       ) ; }
+    @Test public void split_basic_02() { testPrefixLocalnameTTL("http://example/foo#bar",        "http://example/foo#",  "bar"       ) ; }
+    @Test public void split_basic_03() { testPrefixLocalnameTTL("http://example/foo#",           "http://example/foo#",  ""          ) ; }
+    @Test public void split_basic_04() { testPrefixLocalnameTTL("http://example/",               "http://example/",      ""          ) ; }
+    @Test public void split_basic_05() { testPrefixLocalnameTTL("http://example/1abc",           "http://example/",      "1abc"      ) ; }
+    @Test public void split_basic_06() { testPrefixLocalnameTTL("http://example/1.2.3.4",        "http://example/",      "1.2.3.4"   ) ; }
+    @Test public void split_basic_07() { testPrefixLocalnameTTL("http://example/xyz#1.2.3.4",    "http://example/xyz#",  "1.2.3.4"   ) ; }
+    @Test public void split_basic_08() { testPrefixLocalnameTTL("http://example/xyz#_abc",       "http://example/xyz#",  "\\_abc"      ) ; }
+    @Test public void split_basic_09() { testPrefixLocalnameTTL("http://example/xyz/_1.2.3.4",   "http://example/xyz/",  "\\_1.2.3.4"   ) ; }
 
     // Relative URIs
-    @Test public void split_rel_1() { testPrefixLocalname("xyz/_1.2.3.4",  "xyz/", "_1.2.3.4" ) ; }
-    @Test public void split_rel_2() { testPrefixLocalname("xyz",           "",     "xyz" ) ; }
-    @Test public void split_rel_3() { testPrefixLocalname("",              "",     "" ) ; }
+    @Test public void split_rel_1() { testPrefixLocalnameTTL("xyz/_1.2.3.4",  "xyz/", "\\_1.2.3.4" ) ; }
+    @Test public void split_rel_2() { testPrefixLocalnameTTL("xyz",           "",     "xyz" ) ; }
+    @Test public void split_rel_3() { testPrefixLocalnameTTL("",              "",     "" ) ; }
 
     // Bizarre but legal URIs
-    @Test public void split_weird_1() { testPrefixLocalname("abc:def",       "abc:", "def" ) ; }
+    @Test public void split_weird_1() { testPrefixLocalnameTTL("abc:def",   "abc:", "def" ) ; }
+    @Test public void split_weird_2() { testPrefixLocalnameTTL("",          "",     ""    ) ; }
+    // Trailing '.' - split with escape.
+    @Test public void split_weird_3() { testPrefixLocalnameTTL("http://example/abc#x.",    "http://example/abc#", "x\\."  ) ; }
+    @Test public void split_weird_4() { testPrefixLocalnameTTL("http://example/",          "http://example/", ""  ) ; }
 
     // Turtle details.
     // "." leading dot is not legal.
-    @Test public void split_ttl_01() { testPrefixLocalname("http://example/foo#bar:baz",    "http://example/foo#",  "bar:baz"   ) ; }
-    @Test public void split_ttl_02() { testPrefixLocalname("http://example/a:b:c",          "http://example/",      "a:b:c"     ) ; }
-    @Test public void split_ttl_03() { testPrefixLocalname("http://example/.2.3.4",         "http://example/.",     "2.3.4"     ) ; }
+    @Test public void split_ttl_01() { testPrefixLocalnameTTL("http://example/foo#bar:baz",  "http://example/foo#",  "bar:baz"   ) ; }
+    @Test public void split_ttl_02() { testPrefixLocalnameTTL("http://example/a:b:c",        "http://example/",      "a:b:c"     ) ; }
+    @Test public void split_ttl_03() { testPrefixLocalnameTTL("http://example/.2.3.4",       "http://example/.",     "2.3.4"     ) ; }
 
     // "." leading dot is not legal.
-    @Test public void split_ttl_04() { testPrefixLocalname("abc:xyz/.def",       "abc:xyz/.", "def" ) ; }
+    @Test public void split_ttl_04() { testPrefixLocalnameTTL("abc:xyz/.def",               "abc:xyz/.", "def" ) ; }
     // "-" leading dash is not legal.
-    @Test public void split_ttl_05() { testPrefixLocalname("abc:xyz/-def",       "abc:xyz/-", "def" ) ; }
-    @Test public void split_ttl_06() { testPrefixLocalname("abc:xyz/-.-.-def",       "abc:xyz/-.-.-", "def" ) ; }
-    @Test public void split_ttl_07() { testPrefixLocalname("http://example/id=89",          "http://example/",      "id=89"   ) ; }
-    // Trailing '.'
-    @Test public void split_ttl_08() { testPrefixLocalname("http://example/2.3.",          "http://example/",  "2.3."    ) ; }
+    @Test public void split_ttl_05() { testPrefixLocalnameTTL("abc:xyz/-def",                 "abc:xyz/-", "def" ) ; }
+    @Test public void split_ttl_06() { testPrefixLocalnameTTL("abc:xyz/-.-.-def",             "abc:xyz/-.-.-", "def" ) ; }
+    // Turtle-escape.
+    @Test public void split_ttl_07() { testPrefixLocalnameTTL("http://example/id=89",         "http://example/",  "id\\=89"   ) ; }
 
     // Turtle details, including escaping.
     // Test for PrefixLocalnameEsc
-    @Test public void split_ttl_esc_01() { testPrefixLocalnameEsc("http://example/id=89",  "http://example/",  "id\\=89"  ) ; }
-    @Test public void split_ttl_esc_02() { testPrefixLocalnameEsc("http://example/a,b",  "http://example/", "a\\,b"       ) ; }
-    // Trailing '.'
-    @Test public void split_ttl_esc_03() { testPrefixLocalnameEsc("http://example/2.3.", "http://example/", "2.3\\."      ) ; }
+    @Test public void split_ttl_esc_01() { testPrefixLocalnameTTL("http://example/id=89",  "http://example/",  "id\\=89"  ) ; }
+    @Test public void split_ttl_esc_02() { testPrefixLocalnameTTL("http://example/a,b",  "http://example/", "a\\,b"       ) ; }
+    // Trailing '.' Legal if escaped.
+    @Test public void split_ttl_esc_03() { testPrefixLocalnameTTL("http://example/2.3.", "http://example/", "2.3\\." ) ; }
+    @Test public void split_ttl_esc_04() { testPrefixLocalnameTTL("http://example/abc#x.",    "http://example/abc#", "x\\."  ) ; }
 
     // URNs split differently.
-    @Test public void split_urn_01() { testPrefixLocalname("urn:foo:bar",     "urn:foo:", "bar") ; }
-    @Test public void split_urn_02() { testPrefixLocalname("urn:example:bar/b",   "urn:example:", "bar/b"); }
-    @Test public void split_urn_03() { testPrefixLocalname("urn:example:bar#frag",   "urn:example:bar#", "frag"); }
-
+    @Test public void split_urn_01() { testPrefixLocalnameTTL("urn:foo:bar",     "urn:foo:", "bar") ; }
+    @Test public void split_urn_02() { testPrefixLocalnameTTL("urn:example:bar/b",   "urn:example:", "bar\\/b"); }
+    @Test public void split_urn_03() { testPrefixLocalnameTTL("urn:example:bar#frag",   "urn:example:bar#", "frag"); }
 
     // Fragments, including Turtle escapes.
-    @Test public void split_frag_01() { testPrefixLocalname("http://example/foo#bar:baz", "http://example/foo#", "bar:baz"     ) ; }
-    @Test public void split_frag_02() { testPrefixLocalnameEsc("http://example/abc/def#ghi/jkl", "http://example/abc/def#", "ghi\\/jkl"); }
-    @Test public void split_frag_03() { testPrefixLocalnameEsc("urn:example:abc#ghi:jkl", "urn:example:abc#", "ghi:jkl"); }
-    @Test public void split_frag_04() { testPrefixLocalnameEsc("urn:example:abc#ghi/jkl", "urn:example:abc#", "ghi\\/jkl"); }
-    @Test public void split_frag_05() { testPrefixLocalnameEsc("urn:example:abc#ghi:jkl", "urn:example:abc#", "ghi:jkl"); }
+    @Test public void split_frag_01() { testPrefixLocalnameTTL("http://example/foo#bar:baz", "http://example/foo#", "bar:baz"     ) ; }
+    @Test public void split_frag_02() { testPrefixLocalnameTTL("http://example/abc/def#ghi/jkl", "http://example/abc/def#", "ghi\\/jkl"); }
+    @Test public void split_frag_03() { testPrefixLocalnameTTL("urn:example:abc#ghi:jkl", "urn:example:abc#", "ghi:jkl"); }
+    @Test public void split_frag_04() { testPrefixLocalnameTTL("urn:example:abc#ghi/jkl", "urn:example:abc#", "ghi\\/jkl"); }
+    @Test public void split_frag_05() { testPrefixLocalnameTTL("urn:example:abc#ghi:jkl", "urn:example:abc#", "ghi:jkl"); }
 
     private void testSplit(String string, int expected) {
         int i = splitpoint(string) ;
         Assert.assertEquals(expected, i) ;
     }
 
-    // ??
-    private void testTurtle(String string, String expectedPrefix, String expectedLocalname) {
-        int i = splitpoint(string) ;
-        String ns = string ;
-        String ln = "" ;
-        if ( i > 0 ) {
-            ns = string.substring(0, i) ;
-            ln = string.substring(i) ;
-        }
-
-        if ( expectedPrefix != null )
-            Assert.assertEquals(expectedPrefix, ns);
-        if ( expectedLocalname != null )
-            Assert.assertEquals(expectedLocalname, ln);
-        if (  expectedPrefix != null && expectedLocalname != null ) {
-            String x = ns+ln ;
-            Assert.assertEquals(string, x) ;
-        }
-    }
-
-    private void testPrefixLocalnameNoSplit(String string) {
-        int i = splitpoint(string) ;
-        String msg = string ;
-        if ( i != -1 ) {
-            // Better error message.
-            String ns = namespaceTTL(string) ;
-            String ln = localnameTTL(string) ;
-            msg = "Unexpected split of '"+string+"' into ("+ns+", "+ln+") [index="+i+"]" ;
-        }
-        Assert.assertEquals(msg, -1, i) ;
-    }
-
-    // Don't worry about local name escaping.
-    private void testPrefixLocalname(String string, String expectedNamespace, String expectedLocalname) {
-        String actualNamespace = namespace(string) ;
-        String actualLocalName = localname(string) ;
-        checkPrefixLocalname(string,
-                             expectedNamespace, actualNamespace,
-                             expectedLocalname, actualLocalName) ;
-        if ( expectedNamespace != null && expectedLocalname != null ) {
-            String x = actualNamespace+actualLocalName ;
-            Assert.assertEquals(string, x) ;
-        }
-    }
-
-    // Do worry about local name escaping.
-    private void testPrefixLocalnameEsc(String string, String expectedNamespace, String expectedLocalname) {
+    private void testPrefixLocalnameTTL(String string, String expectedNamespace, String expectedLocalname) {
         checkPrefixLocalname(string,
                              expectedNamespace, namespaceTTL(string),
                              expectedLocalname, localnameTTL(string)) ;
+    }
+
+    private void testPrefixLocalnameTTLnoESC(String string, String expectedNamespace, String expectedLocalname) {
+        checkPrefixLocalname(string,
+                             expectedNamespace, namespaceTTL(string),
+                             expectedLocalname, localnameTTLNoEsc(string)) ;
     }
 
     private void checkPrefixLocalname(String string,
@@ -155,19 +116,5 @@ public class TestSplitIRI_TTL {
             Assert.assertEquals(expectedNamespace, actualNamespace);
         if ( expectedLocalname != null )
             Assert.assertEquals(expectedLocalname, actualLocalName);
-    }
-
-    private void testPrefixLocalnameNot(String string, String expectedPrefix, String expectedLocalname) {
-        String ns = namespace(string) ;
-        String ln = localname(string) ;
-
-        boolean b1 = Objects.equals(expectedPrefix, ns) ;
-        boolean b2 = Objects.equals(expectedLocalname, ln) ;
-
-        // Test not both true.
-        Assert.assertFalse("Wrong: ("+ns+","+ln+")", b1&&b2);
-        // But it still combines.
-        String x = ns+ln ;
-        Assert.assertEquals(string, x) ;
     }
 }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandler.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/handlers/DatasetHandler.java
@@ -100,8 +100,8 @@ public class DatasetHandler implements Handler {
      * @see #asGraphName(Object)
      */
     private void processGraphName(Consumer<String> process, Object graphName) {
-        if (graphName instanceof Iterable iterGraphName) {
-            for (Object o : iterGraphName) {
+        if (graphName instanceof Iterable) {
+            for (Object o : (Iterable<?>)graphName) {
                 process.accept(asGraphName(o));
             }
         } else {

--- a/pom.xml
+++ b/pom.xml
@@ -980,12 +980,6 @@
                  https://maven.apache.org/guides/mini/guide-reproducible-builds.html
             -->
             <notimestamp>true</notimestamp>
-
-            <!-- Java11 javadoc: "syntax,html" fails on things that aren't 
-                 wrong and applies unrequested checks such as group "missing".
-                 Java17 has fixed these and behaves as expected:
-                 <doclint>syntax,html,reference</doclint>
-            -->
             <doclint>none</doclint>
             <quiet>true</quiet>
             <version>true</version>
@@ -1001,7 +995,6 @@
               <link>https://jena.apache.org/documentation/javadoc/text/</link>
               <link>https://jena.apache.org/documentation/javadoc/rdfconnection/</link>
               <link>https://jena.apache.org/documentation/javadoc/fuseki2/</link>
-              <link>https://jena.apache.org/documentation/javadoc/permissions/</link>
             </links>
             <!-- Settings for @apiNote, @implSpec and @implNote -->
             <tags>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
     <connection>scm:git:https://gitbox.apache.org/repos/asf/jena.git</connection>
     <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/jena.git</developerConnection>
     <url>https://gitbox.apache.org/repos/asf/jena.git</url>
-    <tag>jena-5.0.0-rc1</tag>
   </scm>
   
   <properties>
@@ -291,27 +290,13 @@
     <dependencies>
 
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
         <version>${ver.junit5}</version>
-        <scope>test</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-suite</artifactId>
-        <version>${ver.junit5-platform}</version>
-        <scope>test</scope>
-      </dependency>
-      
-      <!-- Includes JUnit 4 : Needed for older testing code. -->
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${ver.junit5}</version>
-        <scope>test</scope>
-      </dependency>
-
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>


### PR DESCRIPTION
A number of clean up changes, accumulated recently such as from investigating user questions.

* jena-querybuilder - fix compiler warning (this time, in a way that is compatible with javadoc production)
* `SplitIRI` - move XML related code into `SplitIRI`, split up display split tests
* Use Junit5 BOM
* White space normalization

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
