### PR TITLE
GH-2383: Protect GraphUnionRead against unacceptable prefix mappings

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/StreamRDFLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/StreamRDFLib.java
@@ -215,7 +215,7 @@ public class StreamRDFLib
 
         @Override
         public void prefix(String prefix, String uri) {
-            try { // Some graphs applies XML rules to prefixes.
+            try { // Some graphs apply XML rules to prefixes.
                 graph.getPrefixMapping().setNsPrefix(prefix, uri);
             } catch (JenaException ex) {}
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphUnionRead.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphUnionRead.java
@@ -20,6 +20,8 @@ package org.apache.jena.sparql.graph;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Consumer;
 
 import org.apache.jena.atlas.iterator.Iter;
@@ -81,8 +83,13 @@ public class GraphUnionRead extends GraphBase {
     protected PrefixMapping createPrefixMapping() {
         PrefixMapping pmap = new PrefixMappingImpl();
         forEachGraph((g) -> {
-            PrefixMapping pmapNamedGraph = g.getPrefixMapping();
-            pmap.setNsPrefixes(pmapNamedGraph);
+            Map<String, String> map = g.getPrefixMapping().getNsPrefixMap();
+            for (Entry<String, String> e: map.entrySet()) {
+                try {
+                    // PrefixMapping protects against RDF/XML illegal prefixes.
+                    pmap.setNsPrefix( e.getKey(), e.getValue() );
+                } catch (PrefixMapping.IllegalPrefixException ex) { /* ignore unacceptable prefixes */ }
+            }
         });
         return pmap;
     }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/graph/TestGraphUnionRead.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/graph/TestGraphUnionRead.java
@@ -19,6 +19,9 @@
 package org.apache.jena.sparql.graph;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +32,7 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.sse.Item;
 import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.sparql.sse.builders.BuilderGraph;
@@ -46,7 +50,7 @@ public class TestGraphUnionRead
       "   (triple <http://example/s> <http://example/p> 'g1')",
       "   (triple <http://example/s> <http://example/p> <http://example/o>)",
       " )",
-      " (graph <http://example/g2>", 
+      " (graph <http://example/g2>",
       "   (triple <http://example/s> <http://example/p> 'g2')",
       "   (triple <http://example/s> <http://example/p> <http://example/o>)",
       " )",
@@ -63,7 +67,7 @@ public class TestGraphUnionRead
     private static Node gn2 = SSE.parseNode("<http://example/g2>");
     private static Node gn3 = SSE.parseNode("<http://example/g3>");
     private static Node gn9 = SSE.parseNode("<http://example/g9>");
-    
+
     @Test
     public void gr_union_01() {
         List<Node> gnodes = list(gn1, gn2);
@@ -123,6 +127,44 @@ public class TestGraphUnionRead
         Node o = NodeFactory.createLiteralString("g2");
         long x2 = Iter.count(g.find(null, null, o));
         assertEquals(1, x2);
+    }
+
+    @Test
+    public void gr_union_prefixes() {
+        Graph graph = setupPrefixGraph("ex", "http://example/");
+
+        DatasetGraph dsg = DatasetGraphFactory.createGeneral();
+        dsg.addGraph(gn1, graph);
+
+        GraphUnionRead gUnionRead = new GraphUnionRead(dsg, List.of(gn1));
+        assertNotNull(gUnionRead.getPrefixMapping().getNsPrefixURI("ex"));
+    }
+
+    @Test
+    public void gr_union_prefixes_bad_PrefixMapping() {
+        // Turtle-valid, RDF/XML invalid prefix.
+        Graph graph = setupPrefixGraph("😀", "http://example/");
+
+        // Test : Must be createGeneral
+        DatasetGraph dsg = DatasetGraphFactory.createGeneral();
+        dsg.addGraph(gn1, graph);
+
+        // Builds a PrefixMapping when created.
+        GraphUnionRead gUnionRead = new GraphUnionRead(dsg, List.of(gn1));
+        // .. but skips the unacceptable prefix.
+        assertTrue(gUnionRead.getPrefixMapping().hasNoMappings());
+    }
+
+    private static Graph setupPrefixGraph(String prefix, String uriStr) {
+        // Must be createTxnMem
+        DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
+        dsg.prefixes().add(prefix, uriStr);
+        Graph graph = dsg.getDefaultGraph();
+        // Check it has the prefix.
+        assertFalse(graph.getPrefixMapping().hasNoMappings());
+        assertTrue(graph.getPrefixMapping().getNsPrefixURI(prefix) != null);
+        assertTrue(graph.getPrefixMapping().getNsPrefixMap().containsKey(prefix));
+        return graph;
     }
 
     static List<Node> list(Node...x) {


### PR DESCRIPTION
GitHub issue resolved #2383

Pull request Description:
Protect `GraphUnionRead` against unacceptable prefix mappings.


----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
