### PR TITLE
Resolve the base directory for static content

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -523,7 +523,9 @@ public class FusekiServer {
             requireNonNull(directory, "directory");
             if ( ! FileOps.exists(directory) )
                 Fuseki.configLog.warn("File area not found: "+directory);
-            this.staticContentDir = directory;
+            // Resolve path.
+            String dir = Path.of(directory).toAbsolutePath().toString();
+            this.staticContentDir = dir;
             return this;
         }
 

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestFusekiSecurityAssembler.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestFusekiSecurityAssembler.java
@@ -71,13 +71,13 @@ public abstract class AbstractTestFusekiSecurityAssembler {
 
     private boolean sharedDatabase;
 
-    // Parameterized tests don't provide a convenient way to run code at the start and end of each parameter run and access the parameters.
     private static FusekiServer server;
     private FusekiServer getServer() {
         if ( server == null )
             server = setup(assemblerFile, false);
         return server;
     }
+
     @AfterClass public static void afterClass() {
         server.stop();
         server = null;

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestServiceDatasetAuth.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestServiceDatasetAuth.java
@@ -38,10 +38,11 @@ import org.junit.Test;
  */
 public abstract class AbstractTestServiceDatasetAuth {
 
-    protected static int port = WebLib.choosePort();
-    private static AuthSetup auth1 = new AuthSetup("localhost", port, "user1", "pw1", null);
-    private static AuthSetup auth2 = new AuthSetup("localhost", port, "user2", "pw2", null);
-    private static AuthSetup auth3 = new AuthSetup("localhost", port, "user3", "pw3", null);
+    // Need the port for server and for the AuthSetup.
+    protected int port = WebLib.choosePort();
+    private AuthSetup auth1 = new AuthSetup("localhost", port, "user1", "pw1", null);
+    private AuthSetup auth2 = new AuthSetup("localhost", port, "user2", "pw2", null);
+    private AuthSetup auth3 = new AuthSetup("localhost", port, "user3", "pw3", null);
 
     @Test public void no_auth() {
         // No user -> fails login

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthBuild.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthBuild.java
@@ -29,7 +29,7 @@ public class TestServiceDataAuthBuild extends AbstractTestServiceDatasetAuth {
 
     private FusekiServer server;
 
-    @Before public void before () {
+    @Before public void before() {
         server = FusekiServer.create()
             //.verbose(true)
             .port(port)
@@ -38,7 +38,7 @@ public class TestServiceDataAuthBuild extends AbstractTestServiceDatasetAuth {
         server.start();
     }
 
-    @After public void afterClass () {
+    @After public void after () {
         server.stop();
     }
 

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthConfig.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestServiceDataAuthConfig.java
@@ -26,22 +26,22 @@ import org.apache.jena.fuseki.server.Endpoint;
 import org.apache.jena.fuseki.server.Operation;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 
 /**
  * AbstractTestServiceDatasetAuth with a programmatically built server which should be
  * the same as the {@link TestServiceDataAuthConfig configuration file version}.
  */
 public class TestServiceDataAuthConfig extends AbstractTestServiceDatasetAuth {
-    private static FusekiServer server;
+    private FusekiServer server;
 
-    @BeforeClass public static void beforeClass () {
+    @Before public void before() {
         server = build(port, null);
         server.start();
     }
 
-    @AfterClass public static void afterClass () {
+    @After public void after () {
         server.stop();
     }
 


### PR DESCRIPTION
This is a precursor for #2399 - an incremental Jetty update. That PR triggers a problem, caught by the Fuseki main test suite, with relative filenames for serving static content. Solution: resolve the filename. This works the previous Jetty as well. This work on windows - Jetty adapts to `c:` style file names.

This PR also changes the test suite for better stability on MS Windows by avoiding a Fuseki server shared between tests in the same suite (found via running the GH Windows build).

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
