### PR TITLE
GH-2402: RDF Patch Binary handles malformed inputs better

### DIFF
--- a/jena-rdfpatch/src/main/java/org/apache/jena/rdfpatch/binary/RDFPatchReaderBinary.java
+++ b/jena-rdfpatch/src/main/java/org/apache/jena/rdfpatch/binary/RDFPatchReaderBinary.java
@@ -42,7 +42,7 @@ import org.apache.thrift.transport.TTransportException;
  * @see PatchProcessor
  */
 public class RDFPatchReaderBinary implements PatchProcessor {
-    private static final RDF_Patch_Row EMPTY_ROW = new RDF_Patch_Row();
+
     private static final String TPROTOCOL_UTIL = TProtocolUtil.class.getCanonicalName();
     private static final String TUNION = TUnion.class.getCanonicalName();
     private static final String SKIP = "skip";
@@ -130,6 +130,7 @@ public class RDFPatchReaderBinary implements PatchProcessor {
         changes.start();
         for (;;) {
             row.clear();
+
             try { row.read(protocol) ; }
             catch (TTransportException e) {
                 if ( e.getType() == TTransportException.END_OF_FILE) {

--- a/jena-rdfpatch/src/main/java/org/apache/jena/rdfpatch/changes/PatchSummary.java
+++ b/jena-rdfpatch/src/main/java/org/apache/jena/rdfpatch/changes/PatchSummary.java
@@ -111,5 +111,9 @@ public class PatchSummary {
     public long getCountSegment() {
         return countSegment;
     }
+
+    public boolean isEmpty() {
+        return (this.countStart +  this.countFinish + this.countHeader +  this.countAddData + this.countDeleteData + this.countAddPrefix + this.countDeletePrefix + this.countTxnBegin + this.countTxnCommit + this.countTxnAbort + this.countSegment) == 0;
+    }
 }
 

--- a/jena-rdfpatch/src/test/java/org/apache/jena/rdfpatch/TestPatchIO_Binary.java
+++ b/jena-rdfpatch/src/test/java/org/apache/jena/rdfpatch/TestPatchIO_Binary.java
@@ -18,8 +18,17 @@
 
 package org.apache.jena.rdfpatch;
 
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.rdfpatch.changes.RDFChangesCollector;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 public class TestPatchIO_Binary extends AbstractTestPatchIO {
 
@@ -31,5 +40,29 @@ public class TestPatchIO_Binary extends AbstractTestPatchIO {
     @Override
     protected RDFPatch read(InputStream in) {
         return RDFPatchOps.readBinary(in);
+    }
+
+    @Test(expected = PatchException.class)
+    public void junk_01() {
+        byte[] junkData = "junk".getBytes(StandardCharsets.UTF_8);
+        read(new ByteArrayInputStream(junkData));
+    }
+
+    @Test(expected = PatchException.class)
+    public void junk_02() {
+        byte[] junkData = "aaaa".getBytes(StandardCharsets.UTF_8);
+        read(new ByteArrayInputStream(junkData));
+    }
+
+    @Test(expected = PatchException.class)
+    public void junk_03() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        RDFChangesCollector collector = new RDFChangesCollector();
+        collector.add(NodeFactory.createURI("http://g"), NodeFactory.createURI("http://s"),
+                      NodeFactory.createURI("http://p"), NodeFactory.createURI("http://o"));
+        write(output, collector.getRDFPatch());
+        // Intentionally truncating a valid binary patch
+        byte[] junkData = Arrays.copyOfRange(output.toByteArray(), 0, output.size() - 10);
+        read(new ByteArrayInputStream(junkData));
     }
 }


### PR DESCRIPTION
Discovered in $dayjob work that `RDFPatchReaderBinary` would silently accept malformed inputs in some cases.  Started by adding several test cases, some of which failed, to demonstrate that the RDF Patch Binary reader can silently accept invalid streams.  Then debugged from there are introduced additional logic which makes a best effort attempt to distinguish between genuine EOF and EOF due to malformed input that should produce an error.

Unfortunately the Thrift API doesn't have a clean way to detect that you've genuinely reached the EOF so we just have to attempt to read the next row from the patch, and detect the obvious cases of malformed input:

1. `TProtocolUtil.skip()` getting called, this indicates that Thrift recognised a Field ID but that the Type ID was not the expected type for that field.  So if we hit a EOF while skipping over such a field we're definitely reading malformed input.
2. `TUnion.read()` getting called multiple times.  This means that we're partway through reading an otherwise valid data structure at the point where we encounter the EOF so again is a clear indicator of malformed input.

I appreciate that this solution is somewhat hacky, if anyone has a more robust solution please feel free to suggest it

GitHub issue resolved #2402

----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
