### PR TITLE
Migrating Base 64 operations from Apache Commons Codec to Util package.

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/datatypes/xsd/XSDbase64Binary.java
+++ b/jena-core/src/main/java/org/apache/jena/datatypes/xsd/XSDbase64Binary.java
@@ -18,8 +18,9 @@
 
 package org.apache.jena.datatypes.xsd;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.jena.datatypes.DatatypeFormatException ;
+
+import java.util.Base64;
 
 /**
  * Implement base64binary type. Most of the work is done in the superclass.
@@ -38,7 +39,7 @@ public class XSDbase64Binary extends XSDbinary {
     @Override
     public String unparse(Object value) {
         if (value instanceof byte[]) {
-            return Base64.encodeBase64String((byte[])value);
+            return Base64.getEncoder().encodeToString((byte[])value);
         } else {
             throw new DatatypeFormatException("base64 asked to encode an unwrapped byte array");
         }

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/builtins/MakeSkolem.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/builtins/MakeSkolem.java
@@ -20,8 +20,8 @@ package org.apache.jena.reasoner.rulesys.builtins;
 
 import java.security.MessageDigest ;
 import java.security.NoSuchAlgorithmException ;
+import java.util.Base64;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.reasoner.rulesys.RuleContext ;
@@ -75,7 +75,7 @@ public class MakeSkolem extends BaseBuiltin {
             MessageDigest digester = MessageDigest.getInstance("MD5");
             digester.reset();
             byte[] digest = digester.digest(key.toString().getBytes());
-            String label = Base64.encodeBase64String(digest);
+            String label = Base64.getEncoder().encodeToString(digest);
             Node skolem = NodeFactory.createBlankNode(label);
             return context.getEnv().bind(args[0], skolem); 
         } catch (NoSuchAlgorithmException e) {

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/AuthBearerTestLib.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/AuthBearerTestLib.java
@@ -80,7 +80,7 @@ public class AuthBearerTestLib {
     private static String enc64(String x) {
         byte[] bytes = x.getBytes(StandardCharsets.UTF_8);
         // URL encoding, no padding, no chunking line breaks.
-        String s = Base64.getUrlEncoder().encodeToString(bytes);
+        String s = Base64.getEncoder().encodeToString(bytes);
         return s;
     }
 

--- a/jena-integration-tests/src/test/java/org/apache/jena/http/AuthBearerTestLib.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/http/AuthBearerTestLib.java
@@ -19,9 +19,8 @@
 package org.apache.jena.http;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Objects;
-
-import org.apache.commons.codec.binary.Base64;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -49,7 +48,7 @@ public class AuthBearerTestLib {
                 log.warn("Bad token: '"+token+"'");
                 return null;
             }
-            byte[] jsonBytes = Base64.decodeBase64(parts[1]);
+            byte[] jsonBytes = Base64.getDecoder().decode(parts[1]);
             String jsonStr = new String(jsonBytes, StandardCharsets.UTF_8);
             JsonObject obj = new Gson().fromJson(jsonStr, JsonObject.class);
             JsonElement field = obj.get("sub");
@@ -81,7 +80,7 @@ public class AuthBearerTestLib {
     private static String enc64(String x) {
         byte[] bytes = x.getBytes(StandardCharsets.UTF_8);
         // URL encoding, no padding, no chunking line breaks.
-        String s = org.apache.commons.codec.binary.Base64.encodeBase64URLSafeString(bytes);
+        String s = Base64.getUrlEncoder().encodeToString(bytes);
         return s;
     }
 


### PR DESCRIPTION
GitHub issue resolved # N/A

Pull request Description:

Updating repo to use the Util's Base 64 class (introduced in JDK 8) which has greater performance than Apache Commons Codec.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
