### PR TITLE
Bump org.apache.apache parent POM from 31 to 32

### DIFF
--- a/jena-extras/jena-querybuilder/pom.xml
+++ b/jena-extras/jena-querybuilder/pom.xml
@@ -36,9 +36,8 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>apache-jena-libs</artifactId>
+      <artifactId>jena-arq</artifactId>
       <version>5.1.0-SNAPSHOT</version>
-      <type>pom</type>
     </dependency>
 
     <dependency>
@@ -95,9 +94,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <detectJavaApiLink>false</detectJavaApiLink>
-          <source>8</source>
-          <doclint>none</doclint>
           <windowtitle>Apache Jena Query Builder</windowtitle>
           <doctitle>Apache Jena - Query Builder ${project.version}</doctitle>
         </configuration>

--- a/jena-iri/pom.xml
+++ b/jena-iri/pom.xml
@@ -83,10 +83,6 @@
           </execution>
         </executions>
         <configuration>
-          <!-- 
-               OK for Java17 (compiling to Java11); not OK for Java11
-               <doclint>syntax</doclint>
-          -->
           <doclint>none</doclint>
           <windowtitle>Apache Jena IRI </windowtitle>
           <doctitle>Apache Jena IRI ${project.version}</doctitle>

--- a/jena-permissions/pom.xml
+++ b/jena-permissions/pom.xml
@@ -84,13 +84,11 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <detectJavaApiLink>false</detectJavaApiLink>
-          <source>8</source>
-          <doclint>none</doclint>
           <excludePackageNames>org.apache.jena.security.example:org.apache.jena.security.example.*</excludePackageNames>
           <tags>
             <tag>
@@ -109,6 +107,7 @@
           <overview>${basedir}/src/main/overview.html</overview>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -192,9 +191,21 @@
 
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>apache-jena-libs</artifactId>
+      <artifactId>jena-arq</artifactId>
       <version>${project.version}</version>
-      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-tdb1</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-tdb2</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>31</version>
+    <version>32</version>
   </parent>
 
   <licenses>
@@ -53,6 +53,7 @@
   <properties>
     <!-- Build -->
     <java.version>17</java.version>
+
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>2024-03-16T16:17:59Z</project.build.outputTimestamp>
 
@@ -970,9 +971,8 @@
             </execution>
           </executions>
           <configuration>
+            <release>${java.version}</release>
             <detectJavaApiLink>false</detectJavaApiLink>
-            <source>${java.version}</source>
-
             <!-- To allow the build to keep going despite javadoc problems:
                  <failOnError>false</failOnError>
             -->


### PR DESCRIPTION
Update the project parent Apache POM from v31 to v32.

This requires fixes in jena-permissions and jena-querybuilder around the "attach-javadocs" step.

The fix is to switch from depending on apache-jena-libs:pom to jena-arq:jar. The "pom" part triggers an error:

```
...
apache-jena-libs-5.1.0-SNAPSHOT.pom' not allowed on the path, only outputDirectories and jars are accepted 
```

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
