### PR TITLE
GH-2382 - Track engine instances in a Set rather than a List

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/LPBRuleEngine.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/LPBRuleEngine.java
@@ -59,8 +59,8 @@ public class LPBRuleEngine {
     /** Set to true to flag that derivations should be logged */
     protected boolean recordDerivations;
 
-    /** List of engine instances which are still processing queries */
-    protected List<LPInterpreter> activeInterpreters = new LinkedList<>();
+    /** Set of engine instances which are still processing queries */
+    protected Collection<LPInterpreter> activeInterpreters = new HashSet<>();
 
     protected final int MAX_CACHED_TABLED_GOALS = Integer.parseInt(
     		JenaRuntime.getSystemProperty("jena.rulesys.lp.max_cached_tabled_goals", "524288"));


### PR DESCRIPTION
The collection of active interpreters is removed from randomly - as each one completes. This results in random removals from the linked list, a O(n) operation.

As the number of active interpreters grows, so does this time. This happens within a synchronized block, which can stall the work of other threads when a model is shared across threads for reads.

GitHub issue resolved #2382 

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [X] Commits have been squashed to remove intermediate development commit messages.
 - [X] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
