### PR TITLE
Tidy dependencies

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
@@ -55,7 +55,6 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.sparql.util.Context;
-import org.apache.jena.system.Txn;
 
 /**
  * An {@link RDFParser} is a process that will generate triples and quads;

--- a/jena-arq/src/test/java/org/apache/jena/riot/TS_RiotGeneral.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TS_RiotGeneral.java
@@ -31,10 +31,9 @@ import org.junit.runners.Suite.SuiteClasses ;
     , TestJenaReaderRIOT.class
     , TestReadData.class
     , TestRiotReader.class
-    , TestRDFParser.class
     , TestParserRegistry.class
-    , TestRDFWriter.class
     , TestRDFParser.class
+    , TestRDFWriter.class
     , TestParseURISchemeBases.class
 
     , TestTurtleTrigWriter.class

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Map;
 
+import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -313,7 +314,8 @@ public class TestRDFParser {
         RDFParserBuilder builder = RDFParserBuilder.create().lang(Lang.TRIG).fromString(testdata + "\njunk data goes here");
         DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
         try {
-            Txn.executeWrite(dsg, () -> builder.parse(dsg));
+            LogCtl.withLevel(SysRIOT.getLogger(), "FATAL", ()->
+                Txn.executeWrite(dsg, () -> builder.parse(dsg)));
             Assert.fail("Parsing should have produced an error");
         } catch (RiotException e) {
             // Size should be zero as failure to parse should abort the transaction and produce an empty dataset
@@ -322,11 +324,12 @@ public class TestRDFParser {
     }
 
     @Test
-    public void parse_to_dataset_malformed_01a() {
+    public void parse_to_dataset_malformed_02() {
         RDFParserBuilder builder = RDFParserBuilder.create().lang(Lang.TRIG).fromString(testdata + "\njunk data goes here");
         DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
         try {
-            builder.parse(dsg);
+            LogCtl.withLevel(SysRIOT.getLogger(), "FATAL", ()->
+                 builder.parse(dsg));
             Assert.fail("Parsing should have produced an error");
         } catch (RiotException e) {
             // Without a transaction the valid quad would have gone into the dataset prior to the error occurring
@@ -335,14 +338,16 @@ public class TestRDFParser {
     }
 
     @Test
-    public void parse_to_dataset_malformed_02() {
+    public void parse_to_dataset_malformed_03() {
         RDFParserBuilder builder = RDFParserBuilder.create().lang(Lang.TRIG).fromString(testdata + "\njunk data goes here");
-        DatasetGraph dsg = null;
-        try {
-            dsg = builder.toDatasetGraph();
-            Assert.fail("Parsing should have produced an error");
-        } catch (RiotException e) {
-            assertNull(dsg);
-        }
+        LogCtl.withLevel(SysRIOT.getLogger(), "FATAL", ()-> {
+            DatasetGraph dsg = null;
+            try {
+                dsg = builder.toDatasetGraph();
+                Assert.fail("Parsing should have produced an error");
+            } catch (RiotException e) {
+                assertNull(dsg);
+            }
+        });
     }
 }

--- a/jena-cmds/pom.xml
+++ b/jena-cmds/pom.xml
@@ -55,7 +55,6 @@
         This works ... 
         except it breaks javadoc:javadoc building with Java11.
         But it does work if Java17 is used for the build
-        
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>apache-jena-libs</artifactId>
@@ -101,6 +100,11 @@
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-rdfconnection</artifactId>
       <version>5.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <artifactId>commons-cli</artifactId>
+      <groupId>commons-cli</groupId>
     </dependency>
 
     <!-- Pull test code into scope -->

--- a/jena-core/pom.xml
+++ b/jena-core/pom.xml
@@ -59,36 +59,21 @@
     </dependency>
     
     <dependency>
-      <artifactId>commons-cli</artifactId>
-      <groupId>commons-cli</groupId>
+      <groupId>org.roaringbitmap</groupId>
+      <artifactId>RoaringBitmap</artifactId>
     </dependency>
-    
-      <dependency>
-        <groupId>org.roaringbitmap</groupId>
-        <artifactId>RoaringBitmap</artifactId>
-      </dependency>
 
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <scope>test</scope>
-      </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
 
-      <dependency>
-        <groupId>org.xenei</groupId>
-        <artifactId>junit-contracts</artifactId>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <artifactId>commons-cli</artifactId>
-            <groupId>commons-cli</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>commons-logging</artifactId>
-            <groupId>commons-logging</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
+    <dependency>
+      <groupId>org.xenei</groupId>
+      <artifactId>junit-contracts</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jena-extras/jena-querybuilder/pom.xml
+++ b/jena-extras/jena-querybuilder/pom.xml
@@ -44,16 +44,6 @@
       <groupId>org.xenei</groupId>
       <artifactId>junit-contracts</artifactId> 
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-cli</artifactId>
-          <groupId>commons-cli</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>commons-logging</artifactId>
-          <groupId>commons-logging</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/jena-fuseki2/jena-fuseki-main/sparqler/pages/data-validator.html
+++ b/jena-fuseki2/jena-fuseki-main/sparqler/pages/data-validator.html
@@ -25,35 +25,25 @@
       <form action="$/validate/data" method="post" accept-charset="UTF-8" >
 	    <textarea name="data" cols="70" rows="30">
 # Prefixes for Turtle or TriG - these can be edited or removed.
-@base          &lt;http://example.org/base/> .
-@prefix :      &lt;http://example.org/> .
-@prefix xsd:   &lt;http://www.w3.org/2001/XMLSchema#> .
-@prefix rdf:   &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#> .
-@prefix owl:   &lt;http://www.w3.org/2002/07/owl#> .
-
+BASE          &lt;http://example.org/base/&gt;
+PREFIX :      &lt;http://example.org/&gt;
+PREFIX xsd:   &lt;http://www.w3.org/2001/XMLSchema#&gt;
+PREFIX rdf:   &lt;http://www.w3.org/1999/02/22-rdf-syntax-ns#&gt;
+PREFIX rdfs:  &lt;http://www.w3.org/2000/01/rdf-schema#&gt;
+PREFIX owl:   &lt;http://www.w3.org/2002/07/owl#&gt;
+PREFIX sh:    &lt;http://www.w3.org/ns/shacl#&gt;
 
 </textarea>
 <br/>
 Input syntax:
+<p>
 <input type="radio" name="languageSyntax" value="Turtle" checked="checked"/>Turtle
 <input type="radio" name="languageSyntax" value="TriG"/>TriG
 <input type="radio" name="languageSyntax" value="N-Triples"/>N-Triples
 <input type="radio" name="languageSyntax" value="N-Quads"/>N-Quad
-  <br/>
-      <!--
-Output syntax:
-  <input type="checkbox" name="outputFormat" value="sparql" checked="checked"/>SPARQL
-  <input type="checkbox" name="outputFormat" value="algebra"/>SPARQL algebra
-  <input type="checkbox" name="outputFormat" value="quads"/>SPARQL algebra (quads)
-  <br/>
-
-  Line numbers:
-  <input type="radio" name="linenumbers" value="true" checked="checked"/>Yes
-  <input type="radio" name="linenumbers" value="false"/>No
-  <br/>
-      -->
-        <input type="submit" value="Validate RDF Data" />
+<input type="radio" name="languageSyntax" value="RDF/XML"/>RDF-XML
+</p>
+<input type="submit" value="Validate RDF Data"/>
       </form>
       <hr/>
 Parsing provided by <a href="http://jena.apache.org/documentation/io/">Jena/RIOT</a>.

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,12 @@
         <artifactId>commons-io</artifactId>
         <version>${ver.commons-io}</version>
       </dependency>
+
+       <dependency>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-</artifactId>
+        <version>${ver.commons-io}</version>
+      </dependency>
       
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -328,6 +334,12 @@
             <artifactId>org.osgi.core</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-rdf-api</artifactId>
+        <version>${ver.commons-rdf}</version>
       </dependency>
 
       <!-- Protobuf only, not gRPC -->
@@ -595,18 +607,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>jul-to-slf4j</artifactId>
         <version>${ver.slf4j}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>commons-cli</groupId>
-        <artifactId>commons-cli</artifactId>
-        <version>${ver.commons-cli}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-rdf-api</artifactId>
-        <version>${ver.commons-rdf}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
GitHub issue resolved #2433

and other POM tidying

+ TestRDFParser - avoid output tests; run test suite only once.

----
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
