### PR TITLE
GH-2435: Suppress both 'deprecation' and 'removal' warnings

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionFactory.java
@@ -260,7 +260,7 @@ public class QueryExecutionFactory
 
     // This form of "make" has support for "initialBinding" (seed the execution)
     // The preferred approach is to use "substitution" )(replace variables with RDF terms).
-    @SuppressWarnings("removal")
+    @SuppressWarnings("all")
     private static QueryExecution make$(Query query, Dataset dataset, DatasetGraph datasetGraph, Binding initialBinding) {
         QueryExecDatasetBuilder builder = QueryExecDataset.newBuilder().query(query);
         if ( initialBinding != null )

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngineWorker.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngineWorker.java
@@ -522,7 +522,7 @@ public class UpdateEngineWorker implements UpdateVisitor
         return evalBindings(query, datasetGraph, inputBinding, context);
     }
 
-    @SuppressWarnings("removal")
+    @SuppressWarnings("all")
     protected static Iterator<Binding> evalBindings(Query query, DatasetGraph dsg, Binding inputBinding, Context context) {
         // The UpdateProcessorBase already copied the context and made it safe
         // ... but that's going to happen again :-(

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateAction.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateAction.java
@@ -247,7 +247,7 @@ public class UpdateAction {
     // All non-streaming updates come through here.
 
     private static void execute$(UpdateRequest request, DatasetGraph datasetGraph, Binding inputBinding) {
-        @SuppressWarnings("removal")
+        @SuppressWarnings("all")
         UpdateExec uProc = UpdateExec.newBuilder().update(request).dataset(datasetGraph).initialBinding(inputBinding).build();
         if ( uProc == null )
             throw new ARQException("No suitable update procesors are registered/able to execute your updates");


### PR DESCRIPTION
Fix places where the "suppress warnings" has changed.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
