### PR TITLE
Update CrossOriginFilter; remove dependency of jena-fuseki-core on Jetty artifacts.

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/pom.xml
+++ b/jena-fuseki2/jena-fuseki-core/pom.xml
@@ -76,20 +76,15 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
     </dependency>
-
+    
+    <!--
+        jena-fuseki-core is independent of Jetty.
+        This needs to be in-step with Jetty.
+        The version ismanaged in the top Jena POM.
+    -->
     <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-servlet</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-servlets</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-security</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <dependency>

--- a/jena-fuseki2/jena-fuseki-main/pom.xml
+++ b/jena-fuseki2/jena-fuseki-main/pom.xml
@@ -62,6 +62,21 @@
       <version>5.1.0-SNAPSHOT</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlets</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+    </dependency>
+    
     <!-- For parsing Jetty configuration files -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,10 @@
     <ver.titanium-json-ld>1.4.0</ver.titanium-json-ld>
     <ver.jakarta.json>2.0.1</ver.jakarta.json>
 
+    <!-- These two must be in-step -->
     <ver.jetty>12.0.8</ver.jetty>
+    <ver.jakarta-servlet>6.0.0</ver.jakarta-servlet>
+
     <ver.shiro>2.0.0</ver.shiro>
 
     <ver.protobuf>4.26.1</ver.protobuf>
@@ -473,6 +476,13 @@
         <version>${ver.jakarta.json}</version>
       </dependency>
       <!-- End JSON-LD 1.1 read support -->
+
+      <!-- Ensure the properties align the jakarta.servlet-api version to that of Jetty. -->
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>${ver.jakarta-servlet}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
This resolves #2443
This resolves #2444

Pull request Description:

Copy `CrossOriginFilter` from the source of the Eclipse Jetty 12.0.8 release.
Also copy some util code that `CrossOriginFilter` uses.

`CrossOriginFilter` tests continue to pass unchanged.

Change the dependency of `jena-fuseki-core` to be on `jakara-servlet-api` so that Jetty is not a dependency of `jena-fuseki-core`

----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
