### PR TITLE
Convert RRX parser classes to package visible

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/RRX.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/RRX.java
@@ -38,13 +38,13 @@ public class RRX {
     /** <a href="http://www.w3.org/TR/rdf-xml/">RDF/XML</a> implemented by RRX-StAXev */
     public static final Lang RDFXML_StAX_ev = LangBuilder.create("RDFXML-StAX-EV", "application/rdf+stax-ev")
             .addAltNames("RRX-StAX-ev", "rrxstaxev")
-            .addFileExtensions("rdfstax")
+            .addFileExtensions("rdfstaxev")
             .build();
 
     /** <a href="http://www.w3.org/TR/rdf-xml/">RDF/XML</a> implemented by RRX-StAXsr */
     public static final Lang RDFXML_StAX_sr = LangBuilder.create("RDFXML-StAX-SR", "application/rdf+stax-sr")
             .addAltNames("RRX-StAX-sr", "rrxstaxsr")
-            .addFileExtensions("rdfstaxev")
+            .addFileExtensions("rdfstaxsr")
             .build();
 
     /**

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx/ParserRDFXML_SAX.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx/ParserRDFXML_SAX.java
@@ -53,7 +53,7 @@ import org.xml.sax.ext.DeclHandler;
 import org.xml.sax.ext.EntityResolver2;
 import org.xml.sax.ext.LexicalHandler;
 
-public class ParserRDFXML_SAX
+class ParserRDFXML_SAX
         implements
             ContentHandler,
             ErrorHandler,
@@ -62,7 +62,6 @@ public class ParserRDFXML_SAX
             LexicalHandler,
             DeclHandler,
             EntityResolver2 {
-    public static boolean TRACE = false;
     private static boolean VERBOSE = false;
     // Addition tracing for SAX events we don't care about.
     private static boolean EVENTS = false;
@@ -281,7 +280,7 @@ public class ParserRDFXML_SAX
 
     // Called directly when ObjectLex turns out to be a resource object after all.
     private void pushParserFrame(ParserMode frameParserMode) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("Push frame: S: %s P: %s -- mode=%s\n",
                          str(currentSubject), str(currentProperty), frameParserMode);
 
@@ -297,7 +296,7 @@ public class ParserRDFXML_SAX
     private void popParserFrame() {
         ParserFrame frame = parserStack.pop();
 
-        if ( TRACE ) {
+        if ( ReaderRDFXML_SAX.TRACE ) {
             trace.printf("Pop frame: S: %s -> %s : P: %s -> %s\n", str(currentSubject), frame.subject,
                          str(currentProperty), frame.property);
         }
@@ -389,13 +388,13 @@ public class ParserRDFXML_SAX
     // the beginning of "endElement". Used for collecting XML Literals.
     private int elementDepth = 0;
     private void incElementDepth() {
-        if ( TRACE && VERBOSE )
+        if ( ReaderRDFXML_SAX.TRACE && VERBOSE )
             trace.printf("~~ incElementDepth %d -> %d\n", elementDepth, elementDepth + 1);
         elementDepth++;
     }
 
     private void decElementDepth() {
-        if ( TRACE && VERBOSE )
+        if ( ReaderRDFXML_SAX.TRACE && VERBOSE )
             trace.printf("~~ decElementDepth %d -> %d\n", elementDepth, elementDepth - 1);
         --elementDepth;
     }
@@ -420,9 +419,9 @@ public class ParserRDFXML_SAX
 
 // // Forming objects.
 // private ParseType parseType = null;
-    public ParserRDFXML_SAX(String xmlBase, ParserProfile parserProfile, StreamRDF destination, Context context) {
+    ParserRDFXML_SAX(String xmlBase, ParserProfile parserProfile, StreamRDF destination, Context context) {
         // Debug
-        if ( TRACE ) {
+        if ( ReaderRDFXML_SAX.TRACE ) {
             IndentedWriter out1 = IndentedWriter.stdout.clone();
             out1.setFlushOnNewline(true);
             out1.setUnitIndent(4);
@@ -433,7 +432,7 @@ public class ParserRDFXML_SAX
             this.trace = null;
         }
         this.traceXML = this.trace;
-        EVENTS = TRACE;
+        EVENTS = ReaderRDFXML_SAX.TRACE;
         // Debug
 
         this.parserProfile = parserProfile;
@@ -456,27 +455,27 @@ public class ParserRDFXML_SAX
 
     @Override
     public void startDocument() throws SAXException {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             traceXML.println("Doc start");
         hasDocument = true;
     }
 
     @Override
     public void endDocument() throws SAXException {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             traceXML.println("Doc end");
     }
 
     @Override
     public void startElement(final String namespaceURI, final String localName, String qName, Attributes attributes) {
         if ( xmlLiteralCollecting() ) {
-            if ( TRACE )
+            if ( ReaderRDFXML_SAX.TRACE )
                 trace.printf("startElement: XML Literal[%s]: depth = %d\n", qName, elementDepth);
             xmlLiteralCollectStartElement(namespaceURI, localName, qName, attributes);
             return;
         }
 
-        if ( TRACE ) {
+        if ( ReaderRDFXML_SAX.TRACE ) {
             trace.printf("%s StartElement(%s", here(), qName);
             for ( int i = 0 ; i < attributes.getLength() ; i++ ) {
                 String x = attributes.getQName(i);
@@ -488,7 +487,7 @@ public class ParserRDFXML_SAX
         incIndent();
         Position position = position();
 
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("StartElement parserMode=%s\n", parserMode);
 
         // Special case.
@@ -560,7 +559,7 @@ public class ParserRDFXML_SAX
             return;
         }
 
-        if ( TRACE ) {
+        if ( ReaderRDFXML_SAX.TRACE ) {
             decIndent();
             trace.printf("%s enter endElement(%s) mode = %s\n", here(), qName, parserMode);
             incIndent();
@@ -568,16 +567,16 @@ public class ParserRDFXML_SAX
 
         Position position = position();
         if ( xmlLiteralCollecting() ) {
-            if ( TRACE )
+            if ( ReaderRDFXML_SAX.TRACE )
                 trace.printf("Collecting: elementDepth=%d / xmlLiteralStartDepth=%s\n", elementDepth, xmlLiteralStartDepth);
             if ( elementDepth-1 > xmlLiteralStartDepth ) {
-                if ( TRACE )
+                if ( ReaderRDFXML_SAX.TRACE )
                     trace.print("Continue collecting\n");
                 xmlLiteralCollectEndElement(namespaceURI, localName, qName);
                 return;
             }
             endXMLLiteral(position);
-            if ( TRACE )
+            if ( ReaderRDFXML_SAX.TRACE )
                 trace.printf("**** End XML Literal[%s]: elementDepth=%d / xmlLiteralStartDepth=%s\n", qName, elementDepth, xmlLiteralStartDepth);
             // Keep going to finish the end tag.
         }
@@ -612,12 +611,12 @@ public class ParserRDFXML_SAX
 
         decIndent();
         decElementDepth();
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("%s EndElement(%s) mode = %s\n", here(), qName, parserMode);
     }
 
     private void rdfRDF(String namespaceURI, String localName, String qName, Attributes attributes, Position position) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.println("rdf:RDF");
         if ( hasRDF )
             throw RDFXMLparseError("Nested rdf:RDF", position);
@@ -668,7 +667,7 @@ public class ParserRDFXML_SAX
     private void startNodeElementWithSubject(Node thisSubject,
                                              String namespaceURI, String localName, String qName, Attributes attributes,
                                              Position position) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("Start nodeElement: subject = %s\n", str(thisSubject));
 
         currentSubject = thisSubject;
@@ -696,12 +695,12 @@ public class ParserRDFXML_SAX
     }
 
     private void endNodeElement(Position position) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.println("endNodeElement. ParserMode = "+parserMode);
     }
 
     private void startPropertyElement(String namespaceURI, String localName, String qName, Attributes attributes, Position position) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("Start propertyElement: subject = %s\n", str(currentSubject));
 
         if ( ! allowedPropertyElementURIs(namespaceURI, localName) )
@@ -717,7 +716,7 @@ public class ParserRDFXML_SAX
         } else
             currentProperty = qNameToIRI(namespaceURI, localName, position);
 
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("Property = %s\n", str(currentProperty));
 
         String dt = attributes.getValue(rdfNS, rdfDatatype);
@@ -780,7 +779,7 @@ public class ParserRDFXML_SAX
             case Resource:
                 // Change of subject to a blank node subject.
                 Node nested = blankNode(position);
-                if ( TRACE )
+                if ( ReaderRDFXML_SAX.TRACE )
                     trace.printf("Subject = %s\n", str(nested));
                 currentEmitter.emit(currentSubject, currentProperty, nested, position);
                 // Clear property now it's been used.
@@ -808,7 +807,7 @@ public class ParserRDFXML_SAX
     }
 
     private void endPropertyElement(Position position) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.println("endPropertyElement");
     }
 
@@ -826,7 +825,7 @@ public class ParserRDFXML_SAX
         // Start element encountered when expecting a ObjectCollection
         private void startCollectionItem(String namespaceURI, String localName, String qName, Attributes attributes, Position position) {
             // Finish last list cell, start new one.
-            if ( TRACE )
+            if ( ReaderRDFXML_SAX.TRACE )
                 trace.println("Generate list cell");
             // Preceding cell in list.
             Node previousCollectionNode = collectionNode.node;
@@ -846,7 +845,7 @@ public class ParserRDFXML_SAX
         }
 
     private void endCollectionItem(Position position) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.println("endObjectCollectionItem");
         if ( collectionNode.node != null ) {
             emit(collectionNode.node, Nodes.rest, Nodes.nil, position);
@@ -857,7 +856,7 @@ public class ParserRDFXML_SAX
     }
 
     private void endObjectLexical(Position position) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.println("endObjectLexical");
         Node object = generateLiteral(position);
         currentEmitter.emit(currentSubject, currentProperty, object, position);
@@ -866,7 +865,7 @@ public class ParserRDFXML_SAX
     }
 
     private void endObjectXMLLiteral(Position position) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.println("endObjectXMLLiteral");
         Node object = generateXMLLiteral(position);
         currentEmitter.emit(currentSubject, currentProperty, object, position);
@@ -1111,7 +1110,7 @@ public class ParserRDFXML_SAX
     // These happen before startElement.
     @Override
     public void startPrefixMapping(String prefix, String uri) throws SAXException {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("startPrefixMapping: %s: <%s>\n", prefix, uri);
         // Output only the top level prefix mappings.
         // Done in startElement to test for rdf:RDF
@@ -1119,7 +1118,7 @@ public class ParserRDFXML_SAX
 
     @Override
     public void endPrefixMapping(String prefix) throws SAXException {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("endPrefixMapping: %s\n", prefix);
     }
 
@@ -1168,7 +1167,7 @@ public class ParserRDFXML_SAX
 
     @Override
     public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             traceXML.println("ignorableWhitespace");
     }
 
@@ -1441,19 +1440,19 @@ public class ParserRDFXML_SAX
     // ---- Development
 
     private void incIndent() {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.incIndent();
     }
 
     private void decIndent() {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.decIndent();
     }
 
     // ---- RDF XML Literal
 
     private void startXMLLiteral(Position position) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("Start XML Literal : depth=%d\n", elementDepth);
         incIndent();
         parserMode(ParserMode.ObjectParseTypeLiteral);
@@ -1463,7 +1462,7 @@ public class ParserRDFXML_SAX
 
     private void endXMLLiteral(Position position) {
         decIndent();
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("End XML Literal : depth=%d\n", elementDepth);
         xmlLiteralStartDepth = -1;
     }
@@ -1495,7 +1494,7 @@ public class ParserRDFXML_SAX
      private Deque<Map<String, String>> stackNamespaces = new ArrayDeque<>();
 
      private void xmlLiteralCollectStartElement(String namespaceURI, String localName, String qName, Attributes attributes) {
-         if ( TRACE )
+         if ( ReaderRDFXML_SAX.TRACE )
              trace.printf("XML Literal[%s]: depth=%d\n", qName, elementDepth);
          incIndent();
          incElementDepth();
@@ -1588,12 +1587,12 @@ public class ParserRDFXML_SAX
         namespaces = stackNamespaces.pop();
         decElementDepth();
         decIndent();
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("XML Literal[/%s]: depth=%d\n", qName, elementDepth);
     }
 
     private void xmlLiteralCollectCharacters(char[] ch, int start, int length) {
-        if ( TRACE )
+        if ( ReaderRDFXML_SAX.TRACE )
             trace.printf("XML Literal Characters: depth=%d\n", elementDepth);
         String s = new String(ch, start, length);
         s = xmlLiteralEscapeText(s);

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx/ReaderRDFXML_SAX.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx/ReaderRDFXML_SAX.java
@@ -47,6 +47,8 @@ public class ReaderRDFXML_SAX implements ReaderRIOT
 
     private final ParserProfile parserProfile;
 
+    public static boolean TRACE = false;
+
     public ReaderRDFXML_SAX(ParserProfile parserProfile) {
         this.parserProfile = parserProfile;
     }

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx_stax_ev/ParserRDFXML_StAX_EV.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx_stax_ev/ParserRDFXML_StAX_EV.java
@@ -51,8 +51,8 @@ import org.apache.jena.util.XML11Char;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDF.Nodes;
 
-public class ParserRDFXML_StAX_EV {
-    public static boolean TRACE = false;
+/** StAX events */
+class ParserRDFXML_StAX_EV {
     private static boolean EVENTS = false;
     private final IndentedWriter trace;
 
@@ -155,7 +155,7 @@ public class ParserRDFXML_StAX_EV {
         out.setUnitIndent(4);
         out.setLinePrefix("# ");
         this.trace = out;
-        EVENTS = TRACE;
+        EVENTS = ReaderRDFXML_StAX_EV.TRACE;
         // Debug
 
         this.xmlEventReader = reader;
@@ -298,13 +298,13 @@ public class ParserRDFXML_StAX_EV {
     // doc or production nodeElement.
     // start:
     //  6.2.9 Production RDF
-    public void parse() {
+    void parse() {
         boolean hasDocument = false;
 
         XMLEvent event = nextEventAny();
 
         if ( event.isStartDocument() ) {
-            if ( TRACE )
+            if ( ReaderRDFXML_StAX_EV.TRACE )
                 trace.println("Start document");
             hasDocument = true;
             event = nextEventTag();
@@ -323,7 +323,7 @@ public class ParserRDFXML_StAX_EV {
 
         // <rdf:RDF>
         if ( qNameMatches(rdfRDF, rdfStartElt.getName()) ) {
-            if ( TRACE )
+            if ( ReaderRDFXML_StAX_EV.TRACE )
                 trace.println("rdf:RDF");
             // Not necessary to track this element when parsing.
             hasFrame = startElement(rdfStartElt);
@@ -346,7 +346,7 @@ public class ParserRDFXML_StAX_EV {
             if ( !qNameMatches(rdfRDF, event.asEndElement().getName()) )
                 throw RDFXMLparseError("Expected </"+rdfStartElt.getName().getPrefix()+":RDF>  got "+str(event), event);
             endElement(hasFrame);
-            if ( TRACE )
+            if ( ReaderRDFXML_StAX_EV.TRACE )
                 trace.println("/rdf:RDF");
             event = nextEventAny();
         }
@@ -358,7 +358,7 @@ public class ParserRDFXML_StAX_EV {
         if ( hasDocument ) {
             if ( !event.isEndDocument() )
                 throw RDFXMLparseError("Expected end of document: got "+str(event), event);
-            if ( TRACE )
+            if ( ReaderRDFXML_StAX_EV.TRACE )
                 trace.println("End document");
         }
     }
@@ -413,7 +413,7 @@ public class ParserRDFXML_StAX_EV {
      */
     private void nodeElement(Node subject, StartElement startElt) {
 
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_EV.TRACE )
             trace.println(">> nodeElement: "+str(startElt.getLocation())+" "+str(startElt));
 
         if ( ! allowedNodeElementURIs(startElt.getName()) )
@@ -427,7 +427,7 @@ public class ParserRDFXML_StAX_EV {
         endElement(hasFrame);
         decIndent();
 
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_EV.TRACE )
             trace.println("<< nodeElement: "+str(endElt.getLocation())+" "+str(endElt));
     }
 
@@ -557,7 +557,7 @@ public class ParserRDFXML_StAX_EV {
      */
     private void propertyElement(Node subject, StartElement startElt, Counter listElementCounter) {
         // Move logging inside?
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_EV.TRACE )
             trace.println(">> propertyElement: "+str(startElt.getLocation())+" "+str(startElt));
 
         incIndent();
@@ -574,7 +574,7 @@ public class ParserRDFXML_StAX_EV {
         endElement(hasFrame);
         decIndent();
 
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_EV.TRACE )
             trace.println("<< propertyElement: "+str(event.getLocation())+" "+str(event));
     }
 
@@ -646,19 +646,19 @@ public class ParserRDFXML_StAX_EV {
         switch(parseTypeName) {
             case parseTypeResource -> {
                 // Implicit <rdf:Description><rdf:Description> i.e. fresh blank node
-                if ( TRACE )
+                if ( ReaderRDFXML_StAX_EV.TRACE )
                     trace.println("rdfParseType=Resource");
                 XMLEvent event = parseTypeResource(subject, property, emitter, startElt);
                 return event;
             }
             case parseTypeLiteral -> {
-                if ( TRACE )
+                if ( ReaderRDFXML_StAX_EV.TRACE )
                     trace.println("rdfParseType=Literal");
                 XMLEvent event = parseTypeLiteral(subject, property, emitter, startElt);
                 return event;
             }
             case parseTypeCollection -> {
-                if ( TRACE )
+                if ( ReaderRDFXML_StAX_EV.TRACE )
                     trace.println("rdfParseType=Collection");
                 XMLEvent event = parseTypeCollection(subject, property, emitter, startElt);
                 return event;
@@ -1265,7 +1265,7 @@ public class ParserRDFXML_StAX_EV {
         //Object x = startElt.getNamespaceContext();
         Iterator<Namespace> iter = startElt.getNamespaces();
         boolean result = iter.hasNext();
-        if ( TRACE ) {
+        if ( ReaderRDFXML_StAX_EV.TRACE ) {
             iter.forEachRemaining(namespace->{
                 String prefix = namespace.getPrefix();
                 String iriStr = namespace.getValue();
@@ -1286,7 +1286,7 @@ public class ParserRDFXML_StAX_EV {
 
         String xmlBase = attribute(startElt, xmlQNameBase);
         String xmlLang = attribute(startElt, xmlQNameLang);
-        if ( TRACE ) {
+        if ( ReaderRDFXML_StAX_EV.TRACE ) {
             if ( xmlBase != null )
                 trace.printf("+ BASE <%s>\n", xmlBase);
             if ( xmlLang != null )
@@ -1550,12 +1550,12 @@ public class ParserRDFXML_StAX_EV {
     }
 
     private void incIndent() {
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_EV.TRACE )
             trace.incIndent();
     }
 
     private void decIndent() {
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_EV.TRACE )
             trace.decIndent();
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx_stax_ev/ReaderRDFXML_StAX_EV.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx_stax_ev/ReaderRDFXML_StAX_EV.java
@@ -38,7 +38,7 @@ import org.apache.jena.sparql.util.Context;
 /**
  * RDF/XML parser.
  * <p>
- * This implementation uses StAX events vi {@link XMLEventReader}.
+ * This implementation uses StAX events via {@link XMLEventReader}.
  *
  * @see <a href="https://www.w3.org/TR/rdf-xml/">https://www.w3.org/TR/rdf-xml/</a>
  */
@@ -50,6 +50,8 @@ public class ReaderRDFXML_StAX_EV implements ReaderRIOT
 
     private static final XMLInputFactory xmlInputFactory = SysRRX.createXMLInputFactory();
     private final ParserProfile parserProfile;
+
+    public static boolean TRACE = false;
 
     public ReaderRDFXML_StAX_EV(ParserProfile parserProfile) {
         this.parserProfile = parserProfile;

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx_stax_sr/ParserRDFXML_StAX_SR.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx_stax_sr/ParserRDFXML_StAX_SR.java
@@ -55,9 +55,9 @@ import org.apache.jena.util.XML11Char;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDF.Nodes;
 
-public class ParserRDFXML_StAX_SR {
-    public static boolean TRACE = false;
-    private static boolean EVENTS = true;
+/* StAX - stream reader */
+class ParserRDFXML_StAX_SR {
+    private static boolean EVENTS = false;
     private final IndentedWriter trace;
 
     private final XMLStreamReader xmlSource;
@@ -156,7 +156,7 @@ public class ParserRDFXML_StAX_SR {
         out.setUnitIndent(4);
         out.setLinePrefix("# ");
         this.trace = out;
-        EVENTS = TRACE;
+        EVENTS = ReaderRDFXML_StAX_SR.TRACE;
         // Debug
 
         this.xmlSource = reader;
@@ -299,7 +299,7 @@ public class ParserRDFXML_StAX_SR {
     // doc or production nodeElement.
     // start:
     //  6.2.9 Production RDF
-    public void parse() {
+    void parse() {
 
         int eventType = nextEventAny();
 
@@ -321,7 +321,7 @@ public class ParserRDFXML_StAX_SR {
 
         // <rdf:RDF>
         if ( qNameMatches(rdfRDF, qName()) ) {
-            if ( TRACE )
+            if ( ReaderRDFXML_StAX_SR.TRACE )
                 trace.println("rdf:RDF");
             // Not necessary to track this element when parsing.
             hasFrame = startElement();
@@ -341,7 +341,7 @@ public class ParserRDFXML_StAX_SR {
         // Possible </rdf:RDF>
         if ( hasRDF ) {
             endElement(hasFrame);
-            if ( TRACE )
+            if ( ReaderRDFXML_StAX_SR.TRACE )
                 trace.println("/rdf:RDF");
             eventType = nextEventAny();
         }
@@ -393,7 +393,7 @@ public class ParserRDFXML_StAX_SR {
     private void nodeElement(Node subject) {
         QName qName = qName();
 
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_SR.TRACE )
             trace.println(">> nodeElement: "+str(location())+" "+str(qName));
 
         if ( ! allowedNodeElementURIs(qName) )
@@ -407,7 +407,7 @@ public class ParserRDFXML_StAX_SR {
         endElement(hasFrame);
         decIndent();
 
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_SR.TRACE )
             trace.println("<< nodeElement: "+str(location())+" "+strEventType(eventType()));
     }
 
@@ -531,7 +531,7 @@ public class ParserRDFXML_StAX_SR {
      */
     private void propertyElement(Node subject, Counter listElementCounter, Location location) {
         // Pass in location?
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_SR.TRACE )
             trace.println(">> propertyElement: "+str(location())+" "+str(qName()));
 
         incIndent();
@@ -548,7 +548,7 @@ public class ParserRDFXML_StAX_SR {
         endElement(hasFrame);
         decIndent();
 
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_SR.TRACE )
             trace.println("<< propertyElement: "+str(location())+" "+str(qName));
     }
 
@@ -621,19 +621,19 @@ public class ParserRDFXML_StAX_SR {
         switch(parseTypeName) {
             case parseTypeResource -> {
                 // Implicit <rdf:Description><rdf:Description> i.e. fresh blank node
-                if ( TRACE )
+                if ( ReaderRDFXML_StAX_SR.TRACE )
                     trace.println("rdfParseType=Resource");
                 int event = parseTypeResource(subject, property, emitter, location);
                 return event;
             }
             case parseTypeLiteral -> {
-                if ( TRACE )
+                if ( ReaderRDFXML_StAX_SR.TRACE )
                     trace.println("rdfParseType=Literal");
                 int event = parseTypeLiteral(subject, property, emitter, location);
                 return event;
             }
             case parseTypeCollection -> {
-                if ( TRACE )
+                if ( ReaderRDFXML_StAX_SR.TRACE )
                     trace.println("rdfParseType=Collection");
                 int event = parseTypeCollection(subject, property, emitter, location);
                 return event;
@@ -1252,7 +1252,7 @@ public class ParserRDFXML_StAX_SR {
     private boolean processBaseAndLang() {
         String xmlBase = attribute(xmlQNameBase);
         String xmlLang = attribute(xmlQNameLang);
-        if ( TRACE ) {
+        if ( ReaderRDFXML_StAX_SR.TRACE ) {
             if ( xmlBase != null )
                 trace.printf("+ BASE <%s>\n", xmlBase);
             if ( xmlLang != null )
@@ -1280,7 +1280,7 @@ public class ParserRDFXML_StAX_SR {
      * Return true if there is a namespace declaration.
      */
     private void processNamespaces() {
-        if ( TRACE ) {
+        if ( ReaderRDFXML_StAX_SR.TRACE ) {
             int numNS = xmlSource.getNamespaceCount();
             for ( int i = 0 ; i < numNS ; i++ ) {
                 String prefix = xmlSource.getNamespacePrefix(i);
@@ -1535,12 +1535,12 @@ public class ParserRDFXML_StAX_SR {
     }
 
     private void incIndent() {
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_SR.TRACE )
             trace.incIndent();
     }
 
     private void decIndent() {
-        if ( TRACE )
+        if ( ReaderRDFXML_StAX_SR.TRACE )
             trace.decIndent();
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx_stax_sr/ReaderRDFXML_StAX_SR.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/rrx_stax_sr/ReaderRDFXML_StAX_SR.java
@@ -42,7 +42,6 @@ import org.apache.jena.sparql.util.Context;
  *
  * @see <a href="https://www.w3.org/TR/rdf-xml/">https://www.w3.org/TR/rdf-xml/</a>
  */
-
 public class ReaderRDFXML_StAX_SR implements ReaderRIOT
 {
     public static ReaderRIOTFactory factory = (Lang language, ParserProfile parserProfile) -> {
@@ -51,6 +50,8 @@ public class ReaderRDFXML_StAX_SR implements ReaderRIOT
 
     private static final XMLInputFactory xmlInputFactory = SysRRX.createXMLInputFactory();
     private final ParserProfile parserProfile;
+
+    public static boolean TRACE = false;
 
     public ReaderRDFXML_StAX_SR(ParserProfile parserProfile) {
         this.parserProfile = parserProfile;


### PR DESCRIPTION
The RIOT RRX Readers are public - the parsers themselves should be package scoped. 

`ReaderRDFXML_SAX` is the RRX parser used for RDF/XML.

Also - fix some " internal" file extensions.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
