### PR TITLE
Integration tests for CORS

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -578,7 +578,26 @@ public class HttpLib {
     }
 
     /**
-     * Execute request and return a response without authentication challenge handling.
+     * Execute request and return a {@code HttpResponse<InputStream>} response.
+     * Status codes have not been handled. The response can be passed to
+     * {@link #handleResponseInputStream(HttpResponse)} which will convert non-2xx
+     * status code to {@link HttpException HttpExceptions}.
+     *
+     * @param httpClient
+     * @param httpRequest
+     * @return HttpResponse
+     */
+    public static HttpResponse<InputStream> executeJDK(HttpClient httpClient, HttpRequest httpRequest) {
+        return execute(httpClient, httpRequest, BodyHandlers.ofInputStream());
+    }
+
+    /**
+     * Execute request and return a response without authentication challenge
+     * handling. Status codes have not been handled. This is a call to
+     * {@code HttpClient.send} converting exceptions to {@link HttpException}.
+     * request and responses are logged as "debug" to logger
+     * {@code org.apache.jena.http.HTTP}.
+     *
      * @param httpClient
      * @param httpRequest
      * @param bodyHandler

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TS_FusekiCore.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/TS_FusekiCore.java
@@ -19,7 +19,7 @@
 package org.apache.jena.fuseki;
 
 import org.apache.jena.fuseki.server.TestDispatchOnURI;
-import org.apache.jena.fuseki.servlets.TestCrossOriginFilter;
+import org.apache.jena.fuseki.servlets.TestCrossOriginFilterMock;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -29,7 +29,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
     TestValidators.class,
     TestDispatchOnURI.class,
-    TestCrossOriginFilter.class
+    TestCrossOriginFilterMock.class
 })
 public class TS_FusekiCore {}
 

--- a/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/servlets/TestCrossOriginFilterMock.java
+++ b/jena-fuseki2/jena-fuseki-core/src/test/java/org/apache/jena/fuseki/servlets/TestCrossOriginFilterMock.java
@@ -36,7 +36,7 @@ import static java.util.Collections.emptyMap;
 import static org.apache.jena.fuseki.servlets.CrossOriginFilter.*;
 import static org.mockito.Mockito.*;
 
-public class TestCrossOriginFilter {
+public class TestCrossOriginFilterMock {
     private static class TestFilterConfig implements FilterConfig {
         Map<String,String> parameterMap;
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -555,16 +555,25 @@ public class FusekiServer {
             return this;
         }
 
-        /** Add the Cross Origin (CORS) filter.
-         * {@link CrossOriginFilter}.
+        /**
+         * Enable or disable a Cross Origin (CORS) filter with default settings.
+         * @see CrossOriginFilter
+         */
+        public Builder enableCors(boolean withCORS) {
+            return enableCors(withCORS, null);
+
+        }
+        /**
+         * Enable a Cross Origin (CORS) filter with a specific configuration,
+         * or disable CORS processing.
+         *
+         * @see CrossOriginFilter
          */
         public Builder enableCors(boolean withCORS, String corsConfigFile) {
-            if (withCORS) {
-                if(null == corsConfigFile) {
-                    corsInitParams = corsInitParamsDft;
-                } else {
-                    corsInitParams = parseCORSConfigFile(corsConfigFile);
-                }
+            if ( withCORS ) {
+                corsInitParams = (corsConfigFile == null)
+                        ? corsInitParamsDft
+                        : parseCORSConfigFile(corsConfigFile);
             } else {
                 corsInitParams = null;
             }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
@@ -37,6 +37,7 @@ import org.junit.runners.Suite.SuiteClasses;
   , TestFusekiStdSetup.class
   , TestFusekiStdReadOnlySetup.class
   , TestConfigFile.class
+  , TestCrossOriginFilter.class
   , TestFusekiServerBuild.class
   , TestFusekiDatasetSharing.class
 

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestCrossOriginFilter.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestCrossOriginFilter.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.fuseki.main;
+
+import static org.apache.jena.fuseki.servlets.CrossOriginFilter.*;
+import static org.apache.jena.http.HttpLib.handleResponseNoBody;
+import static org.apache.jena.riot.web.HttpNames.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.fuseki.system.FusekiLogging;
+import org.apache.jena.http.HttpLib;
+import org.apache.jena.riot.web.HttpNames;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Integration tests for CORS handling.
+ * Mock unit testing: {@code TestCrossOriginFilterMock} (in jena-fuseki-core)
+ */
+public class TestCrossOriginFilter {
+    static { FusekiLogging.setLogging(); }
+
+    /** System property that allows "Host" to be set. */
+    private static String jdkAllowRestrictedHeaders = "jdk.httpclient.allowRestrictedHeaders";
+
+//    private static FusekiServer server = null;
+//    private static String URL = null;
+    private static Optional<String> systemValue = null;
+
+    @BeforeClass
+    public static void beforeClass() {
+        // Allow pretending to be another host
+        systemValue = Optional.ofNullable(System.setProperty(jdkAllowRestrictedHeaders, "host"));
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if ( systemValue != null ) {
+            if ( systemValue.isPresent() )
+                System.setProperty(jdkAllowRestrictedHeaders, systemValue.get());
+            else
+                System.clearProperty(jdkAllowRestrictedHeaders);
+        }
+    }
+
+    private static FusekiServer server(String ...args) {
+        return FusekiServer.construct(args);
+    }
+
+    private static void executeWithServer(FusekiServer server, String datasetName, Consumer<String> action) {
+        server.start();
+        String URL = server.datasetURL(datasetName);
+        try {
+            action.accept(URL);
+        } finally { server.stop(); }
+    }
+
+    @Test
+    public void test_corsWithOrigin() {
+        FusekiServer server = FusekiServer.construct("-v", "--port=0", "--mem", "/ds");
+        executeWithServer(server, "/ds", URL->{
+            // Default responses.
+            String originString = "https://test.example.org/";
+            HttpResponse<InputStream> response = httpOptions(URL,
+                                                             // "Host", "test.example.com"
+                                                             "Access-Control-Request-Method", "GET",
+                                                             "Origin", originString);
+            //print(response);
+
+            String allowCreds = getHeader(response, ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER);
+            assertNotNull(allowCreds);
+            assertEqualsIgnoreCase(allowCreds, "true");
+
+            Set<String> allowHeaders = getHeaderSet(response, ACCESS_CONTROL_ALLOW_HEADERS_HEADER);
+            Set<String> expectedHeaders = Set.of("X-Requested-With", "Content-Type", "Accept", "Origin", "Last-Modified", "Authorization");
+            assertSetEquals(allowHeaders, expectedHeaders);
+
+            Set<String> allowMethods = getHeaderSet(response, ACCESS_CONTROL_ALLOW_METHODS_HEADER);
+            Set<String> expectedMethods = Set.of(METHOD_GET, METHOD_POST, METHOD_PUT, METHOD_DELETE, METHOD_HEAD, METHOD_PATCH, METHOD_OPTIONS);
+            assertSetEquals(allowMethods, expectedMethods);
+
+            String allowOriginHeader = getHeader(response, ACCESS_CONTROL_ALLOW_ORIGIN_HEADER);
+            assertEqualsIgnoreCase(allowOriginHeader, originString);
+
+            String allowMaxAge = getHeader(response, ACCESS_CONTROL_MAX_AGE_HEADER);
+            assertNotNull(allowMaxAge);
+            handleResponseNoBody(response);
+        });
+    }
+
+    @Test
+    public void test_corsLocalhost() {
+        FusekiServer server = FusekiServer.construct("-v", "--port=0", "--mem", "/ds");
+        executeWithServer(server, "/ds", URL->{
+            HttpResponse<InputStream> response = httpOptions(URL,
+                                                            //"Host", "test.example.com"
+                                                            "Access-Control-Request-Method", "GET"
+                                                            //,"Origin", "localhost"
+                    );
+            //print(response);
+
+            // Nothing expected.
+            String h1 = getHeader(response, ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER);
+            assertNull(h1);
+
+            String h2 = getHeader(response, ACCESS_CONTROL_ALLOW_HEADERS_HEADER);
+            assertNull(h2);
+
+            String h3 = getHeader(response, ACCESS_CONTROL_ALLOW_METHODS_HEADER);
+            assertNull(h3);
+
+            String h4 = getHeader(response, ACCESS_CONTROL_ALLOW_ORIGIN_HEADER);
+            assertNull(h4);
+
+            String h5 = getHeader(response, ACCESS_CONTROL_MAX_AGE_HEADER);
+            assertNull(h5);
+            handleResponseNoBody(response);
+        });
+    }
+
+    private static String getHeader(HttpResponse<?> response, String header) {
+        Map<String, List<String>> map = response.headers().map();
+        List<String> x = map.get(Lib.lowercase(header));
+        if ( x == null )
+            return null;
+        assertEquals(1, x.size());
+        return x.get(0);
+    }
+
+    private static Set<String> getHeaderSet(HttpResponse<?> response, String header) {
+        Map<String, List<String>> map = response.headers().map();
+        List<String> x = map.get(Lib.lowercase(header));
+        if ( x == null )
+            return null;
+        assertEquals(1, x.size());
+        String s = x.get(0);
+        String[] elts = s.split(" *, *");
+        return Set.of(elts);
+    }
+
+    private static void assertEqualsIgnoreCase(String allowCreds, String string) {
+        assertEquals("Not equals (ignoring case)",
+                     Lib.lowercase(allowCreds), Lib.lowercase(string));
+    }
+
+    // Assumes no repeated but different case.
+    // Case insensitive
+    private static void assertSetEquals(Set<String> set, Set<String> expected) {
+        if ( set.size() != expected.size() ) {
+            fail("Different size: "+set+ " -- "+expected);
+        }
+        for ( String val : expected ) {
+            assertSetContains(set, val);
+        }
+    }
+
+    // Case insensitive
+    private static void assertSetContains(Set<String> set, String value) {
+        String x = Lib.lowercase(value);
+        for ( String s : set ) {
+            if ( s.equalsIgnoreCase(value))
+                return;
+        }
+        fail("Not found: "+value+" in set "+set);
+    }
+
+    @Test public void test_CORS_default_success() {
+        // given
+        String defaultHeaders = "X-Requested-With, Content-Type, Accept, Origin, Last-Modified, Authorization";
+        String[] headersToPass = {"Access-Control-Request-Method", "POST",
+                                  "Origin", "localhost:12345",
+                                  "Access-Control-Request-Headers", defaultHeaders};
+        String expectedAllowedHeaders = "X-Requested-With,Content-Type,Accept,Origin,Last-Modified,Authorization";
+        FusekiServer server = server("--mem", "/ds");
+        executeWithServer(server, "/ds", URL->{
+            // when
+            HttpResponse<InputStream> response = httpOptions(URL, headersToPass);
+            // then
+            assertNotNull(response);
+            assertEquals(response.statusCode(), 200);
+            String actualAllowedHeaders = HttpLib.responseHeader(response, HttpNames.hAccessControlAllowHeaders);
+            assertNotNull("Expecting valid headers", actualAllowedHeaders);
+            assertEquals(expectedAllowedHeaders, actualAllowedHeaders);
+            handleResponseNoBody(response);
+        });
+    }
+
+    @Test public void test_CORS_default_fail() {
+        // given
+        String unrecognisedHeader = "Content-Type, unknown-header";
+        String[] headersToPass = {"Access-Control-Request-Method", "POST",
+                                  "Access-Control-Request-Headers", unrecognisedHeader};
+        FusekiServer server = server("--mem", "/ds");
+        executeWithServer(server, "/ds", URL->{
+            // when
+            HttpResponse<InputStream> response = httpOptions(URL, headersToPass);
+            // then
+            assertNotNull(response);
+            assertEquals(response.statusCode(), 200);
+            String actualAllowedHeaders = HttpLib.responseHeader(response, HttpNames.hAccessControlAllowHeaders);
+            assertNull("No headers expected given invalid request", actualAllowedHeaders);
+            handleResponseNoBody(response);
+        });
+    }
+
+    @Test public void test_CORS_config_success() {
+        // given
+        String nonDefaultAllowedHeader = "Content-Type, Custom-Header";
+        String[] headersToPass = {"Access-Control-Request-Method", "POST",
+                                  "Origin", "http://localhost:5173",
+                                  "Access-Control-Request-Headers", nonDefaultAllowedHeader};
+        String expectedAllowedHeaders = "X-Requested-With,Content-Type,Accept,Origin,Last-Modified,Authorization,Custom-Header";
+        FusekiServer server = server("--mem", "--CORS=testing/Config/cors.properties","/ds");
+        executeWithServer(server, "/ds", URL->{
+            // when
+            HttpResponse<InputStream> response = httpOptions(URL, headersToPass);
+            // then
+            assertNotNull(response);
+            assertEquals(response.statusCode(), 200);
+            String actualAllowedHeaders = HttpLib.responseHeader(response, HttpNames.hAccessControlAllowHeaders);
+            assertNotNull("Expecting valid headers", actualAllowedHeaders);
+            assertEquals(expectedAllowedHeaders, actualAllowedHeaders);
+            handleResponseNoBody(response);
+        });
+    }
+
+    @Test public void test_CORS_noConfig() {
+        // given
+        String defaultHeader = "Content-Type";
+        String[] headersToPass = {"Access-Control-Request-Method", "POST",
+                                  "Access-Control-Request-Headers", defaultHeader};
+        FusekiServer server = server("--mem", "--noCORS", "/ds");
+        executeWithServer(server, "/ds", URL->{
+            // when
+            HttpResponse<InputStream> response = httpOptions(URL, headersToPass);
+            // then
+            assertNotNull(response);
+            assertEquals(response.statusCode(), 200);
+            String actualAllowedHeaders = HttpLib.responseHeader(response, HttpNames.hAccessControlAllowHeaders);
+            assertNull("No headers expected given invalid request", actualAllowedHeaders);
+            handleResponseNoBody(response);
+        });
+    }
+
+    private static HttpResponse<InputStream> httpOptions(String URL, String...headers) {
+        HttpClient httpClient = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(URL))
+                .method(METHOD_OPTIONS, BodyPublishers.noBody())
+                .headers(headers)
+                .build();
+        try {
+            return httpClient.send(request, BodyHandlers.ofInputStream());
+        } catch (IOException | InterruptedException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    private static void print(HttpResponse<?> response) {
+        response.headers().map().forEach((h,v) -> System.out.printf("%s : %s\n", h, v));
+    }
+}


### PR DESCRIPTION
Put in integration tests for the CORS filter in one place. The integration tests capture embedded use and default settings.

Keep the jena-fuseki-core mocked tests in place (renamed). 

Put back `FusekiServer.Builder. enableCors(boolean withCORS)`

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
