### PR TITLE
GH-2462: Fuseki reload configuration

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
@@ -65,8 +65,8 @@ public class AssemblerUtils
         initialized = true ;
         registerDataset(tDataset,         new DatasetAssemblerGeneral());
         registerDataset(tDatasetOne,      new DatasetOneAssembler());
-        registerDataset(tDatasetZero,     new DatasetNullAssembler(tDatasetZero));
-        registerDataset(tDatasetSink,     new DatasetNullAssembler(tDatasetSink));
+        registerDataset(tDatasetZero,     new DatasetZeroAssembler());
+        registerDataset(tDatasetSink,     new DatasetSinkAssembler());
         registerDataset(tMemoryDataset,   new InMemDatasetAssembler());
         registerDataset(tDatasetTxnMem,   new InMemDatasetAssembler());
         registerDataset(tDatasetView,     new ViewDatasetAssembler());

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetAssemblerGeneral.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetAssemblerGeneral.java
@@ -19,7 +19,6 @@
 package org.apache.jena.sparql.core.assembler ;
 
 import java.util.List ;
-import java.util.Map;
 
 import org.apache.jena.assembler.Assembler ;
 import org.apache.jena.atlas.logging.Log ;
@@ -40,11 +39,6 @@ public class DatasetAssemblerGeneral extends NamedDatasetAssembler {
     }
 
     public DatasetAssemblerGeneral() {}
-
-    @Override
-    public Map<String, DatasetGraph> pool() {
-        return sharedDatasetPool;
-    }
 
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetOneAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetOneAssembler.java
@@ -19,7 +19,6 @@
 package org.apache.jena.sparql.core.assembler;
 
 import java.util.List;
-import java.util.Map;
 
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.assembler.exceptions.AssemblerException;
@@ -50,11 +49,6 @@ public class DatasetOneAssembler extends NamedDatasetAssembler  {
     }
 
     public DatasetOneAssembler() {}
-
-    @Override
-    public Map<String, DatasetGraph> pool() {
-        return sharedDatasetPool;
-    }
 
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetSinkAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetSinkAssembler.java
@@ -21,25 +21,25 @@ package org.apache.jena.sparql.core.assembler;
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphWrapper;
+import org.apache.jena.sparql.core.DatasetGraphSink;
+import org.apache.jena.sparql.core.DatasetGraphZero;
 
 /**
- * An assembler that layers on top of another dataset given by {@code ja:dataset}.
- * <p>
- * It enables adding extra context settings.
- * <p>
- * It can be used as a super class, where the subclass overrides {@link #createBaseDataset}.
+ * An assembler that creates datasets that do nothing, either a sink or an always empty one.
+
+ * @see DatasetGraphSink
+ * @see DatasetGraphZero
  */
-public class ViewDatasetAssembler extends NamedDatasetAssembler  {
 
-    public static Resource getType() { return DatasetAssemblerVocab.tDatasetView; }
+public class DatasetSinkAssembler extends NamedDatasetAssembler {
 
-    public ViewDatasetAssembler() {}
+    public static Resource getType() { return DatasetAssemblerVocab.tDatasetSink; }
+
+    public DatasetSinkAssembler() {}
 
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {
-        DatasetGraph sub = createBaseDataset(root, DatasetAssemblerVocab.pDataset);
-        DatasetGraph dsg = new DatasetGraphWrapper(sub);
+        DatasetGraph dsg = DatasetGraphSink.create();
         AssemblerUtils.mergeContext(root, dsg.getContext());
         return dsg;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetZeroAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetZeroAssembler.java
@@ -18,45 +18,27 @@
 
 package org.apache.jena.sparql.core.assembler;
 
-import java.util.Map;
-
 import org.apache.jena.assembler.Assembler;
-import org.apache.jena.atlas.lib.InternalErrorException;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphSink;
 import org.apache.jena.sparql.core.DatasetGraphZero;
 
 /**
- * An assembler that creates datasets that do nothing, either a sink or a always empty one.
-
- * @see DatasetGraphSink
+ * An assembler that creates datasets that do nothing, either a sink or an always empty one.
+ *
  * @see DatasetGraphZero
  */
 
-public class DatasetNullAssembler extends NamedDatasetAssembler {
+public class DatasetZeroAssembler extends NamedDatasetAssembler {
 
-    private final Resource tDataset;
+    public static Resource getType() { return DatasetAssemblerVocab.tDatasetZero; }
 
-    public DatasetNullAssembler(Resource tDataset) {
-        this.tDataset = tDataset;
-    }
+    public DatasetZeroAssembler() {}
 
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {
-        DatasetGraph dsg;
-        if ( DatasetAssemblerVocab.tDatasetSink.equals(tDataset) )
-            dsg = DatasetGraphSink.create();
-        else if ( DatasetAssemblerVocab.tDatasetZero.equals(tDataset) )
-            dsg = DatasetGraphZero.create();
-        else
-            throw new InternalErrorException();
+        DatasetGraph dsg = DatasetGraphZero.create();
         AssemblerUtils.mergeContext(root, dsg.getContext());
         return dsg;
-    }
-
-    @Override
-    public Map<String, DatasetGraph> pool() {
-        return sharedDatasetPool;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
@@ -21,8 +21,6 @@ package org.apache.jena.sparql.core.assembler;
 import static org.apache.jena.sparql.core.assembler.AssemblerUtils.loadData;
 import static org.apache.jena.sparql.core.assembler.AssemblerUtils.mergeContext;
 
-import java.util.Map;
-
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
@@ -38,11 +36,6 @@ import org.apache.jena.vocabulary.RDF;
 public class InMemDatasetAssembler extends NamedDatasetAssembler {
 
     public InMemDatasetAssembler() {}
-
-    @Override
-    public Map<String, DatasetGraph> pool() {
-        return sharedDatasetPool;
-    }
 
     public static Resource getType() {
         return DatasetAssemblerVocab.tMemoryDataset ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/NamedDatasetAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/NamedDatasetAssembler.java
@@ -49,6 +49,11 @@ public abstract class NamedDatasetAssembler extends DatasetAssembler {
         return createDataset(a, root);
     }
 
-    /** Shared {@link DatasetGraph} objects */
-    public abstract Map<String, DatasetGraph> pool();
+    /**
+     * Shared {@link DatasetGraph} objects.
+     * Subclasses may override for a different policy, or return null for "don't pool".
+     * Pools only affect {@link #createNamedDataset} and then only when {@code ja:name}
+     * ({@code DatasetAssemblerVocab.pDatasetName}) is present.
+     */
+    public Map<String, DatasetGraph> pool() { return sharedDatasetPool; }
 }

--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
@@ -38,10 +38,11 @@ import org.slf4j.Logger;
  * This needs access to log4j2 binaries including log4j-core, which is encapsulated in LogCtlLog4j2.
  */
 public class LogCtl {
-    private static final boolean hasLog4j2 = hasClass("org.apache.logging.slf4j.Log4jLoggerFactory");
-    private static final boolean hasLog4j1 = hasClass("org.slf4j.impl.Log4jLoggerFactory");
-    private static final boolean hasJUL    = hasClass("org.slf4j.impl.JDK14LoggerFactory");
+    private static final boolean hasLog4j2   = hasClass("org.apache.logging.slf4j.Log4jLoggerFactory");
+    private static final boolean hasLog4j1   = hasClass("org.slf4j.impl.Log4jLoggerFactory");
     // JUL always present but needs slf4j adapter.
+    private static final boolean hasJUL      = hasClass("org.slf4j.impl.JDK14LoggerFactory");
+    private static final boolean hasLogback  = hasClass("ch.qos.logback.core.LogbackException");
     // Put per-logging system code in separate classes to avoid needing them on the classpath.
 
     private static boolean hasClass(String className) {
@@ -83,67 +84,34 @@ public class LogCtl {
         String s2 = getLevelLog4j2(logger);
         if ( s2 != null )
             return s2;
-        // Always present.
         String s3 = getLevelJUL(logger);
         if ( s3 != null )
             return s3;
         return null;
     }
 
-    static private String getLevelJUL(String logger) {
-        java.util.logging.Level level = java.util.logging.Logger.getLogger(logger).getLevel();
-        if ( level == null )
-            return null;
-        if ( level == java.util.logging.Level.SEVERE )
-            return "ERROR";
-        return level.getName();
-    }
-
     static private String getLevelLog4j2(String logger) {
         if ( !hasLog4j2 )
             return null;
-        org.apache.logging.log4j.Level level = org.apache.logging.log4j.LogManager.getLogger(logger).getLevel();
-        if ( level != null )
-            return level.toString();
-        return null;
+        return LogCtlLog4j2.getLoggerlevel(logger);
+    }
+
+    static private String getLevelJUL(String logger) {
+        if ( ! hasJUL )
+            return null;
+        return LogCtlJUL.getLevelJUL(logger);
     }
 
     private static void setLevelJUL(String logger, String levelName) {
-        java.util.logging.Level level = java.util.logging.Level.ALL;
-        if ( levelName == null )
-            level = null;
-        else if ( levelName.equalsIgnoreCase("info") )
-            level = java.util.logging.Level.INFO;
-        else if ( levelName.equalsIgnoreCase("debug") )
-            level = java.util.logging.Level.FINE;
-        else if ( levelName.equalsIgnoreCase("warn") || levelName.equalsIgnoreCase("warning") )
-            level = java.util.logging.Level.WARNING;
-        else if ( levelName.equalsIgnoreCase("error") || levelName.equalsIgnoreCase("severe") )
-            level = java.util.logging.Level.SEVERE;
-        else if ( levelName.equalsIgnoreCase("OFF") )
-            level = java.util.logging.Level.OFF;
-        java.util.logging.Logger.getLogger(logger).setLevel(level);
+        if ( ! hasJUL )
+            return ;
+        LogCtlJUL.setLevelJUL(logger, levelName);
     }
 
     private static void setLevelLog4j2(String logger, String levelName) {
         if ( !hasLog4j2 )
             return;
-        org.apache.logging.log4j.Level level = org.apache.logging.log4j.Level.ALL;
-        if ( levelName == null )
-            level = null;
-        else if ( levelName.equalsIgnoreCase("info") )
-            level = org.apache.logging.log4j.Level.INFO;
-        else if ( levelName.equalsIgnoreCase("debug") )
-            level = org.apache.logging.log4j.Level.DEBUG;
-        else if ( levelName.equalsIgnoreCase("warn") || levelName.equalsIgnoreCase("warning") )
-            level = org.apache.logging.log4j.Level.WARN;
-        else if ( levelName.equalsIgnoreCase("error") || levelName.equalsIgnoreCase("severe") )
-            level = org.apache.logging.log4j.Level.ERROR;
-        else if ( levelName.equalsIgnoreCase("fatal") )
-            level = org.apache.logging.log4j.Level.FATAL;
-        else if ( levelName.equalsIgnoreCase("OFF") )
-            level = org.apache.logging.log4j.Level.OFF;
-        LogCtlLog4j2.setLoggerlevel(logger, level);
+        LogCtlLog4j2.setLoggerlevel(logger, levelName);
     }
 
     /**

--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlJUL.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlJUL.java
@@ -54,6 +54,32 @@ public class LogCtlJUL {
 
     private LogCtlJUL() {}
 
+    /*package*/ static String getLevelJUL(String logger) {
+        java.util.logging.Level level = java.util.logging.Logger.getLogger(logger).getLevel();
+        if ( level == null )
+            return null;
+        if ( level == java.util.logging.Level.SEVERE )
+            return "ERROR";
+        return level.getName();
+    }
+
+    /*package*/ static void setLevelJUL(String logger, String levelName) {
+        java.util.logging.Level level = java.util.logging.Level.ALL;
+        if ( levelName == null )
+            level = null;
+        else if ( levelName.equalsIgnoreCase("info") )
+            level = java.util.logging.Level.INFO;
+        else if ( levelName.equalsIgnoreCase("debug") )
+            level = java.util.logging.Level.FINE;
+        else if ( levelName.equalsIgnoreCase("warn") || levelName.equalsIgnoreCase("warning") )
+            level = java.util.logging.Level.WARNING;
+        else if ( levelName.equalsIgnoreCase("error") || levelName.equalsIgnoreCase("severe") )
+            level = java.util.logging.Level.SEVERE;
+        else if ( levelName.equalsIgnoreCase("OFF") )
+            level = java.util.logging.Level.OFF;
+        java.util.logging.Logger.getLogger(logger).setLevel(level);
+    }
+
     /**
      * Reset java.util.logging - this overrides the previous configuration, if any.
      */

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -202,8 +202,6 @@ public class Fuseki {
     // HTTP response header inserted to aid tracking.
     public static String FusekiRequestIdHeader = "Fuseki-Request-Id";
 
-    private static boolean            initialized       = false;
-
     // Server start time and uptime.
     private static final long startMillis = System.currentTimeMillis();
     // Hide server locale
@@ -228,12 +226,14 @@ public class Fuseki {
         return startDateTime;
     }
 
+    private static boolean initialized = false;
     /**
      * Initialize an instance of the Fuseki server stack.
      * This is not done via Jena's initialization mechanism
      * but done explicitly to give more control.
-     * Touching this class causes this to happen
-     * (see static block at the end of this class).
+     * It is done after Jena initializes.
+     * Fuseki-main adds a Fuseki specific custom initialization
+     * round after this is run.
      */
     public synchronized static void init() {
         if ( initialized )

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -26,15 +26,12 @@ import jakarta.servlet.ServletContext;
 
 import org.apache.jena.atlas.lib.DateTimeUtils;
 import org.apache.jena.atlas.lib.Version;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.riot.system.stream.LocatorFTP;
 import org.apache.jena.riot.system.stream.LocatorHTTP;
 import org.apache.jena.riot.system.stream.StreamManager;
 import org.apache.jena.sparql.util.Context;
-import org.apache.jena.sparql.util.MappingRegistry;
-import org.apache.jena.sys.JenaSystem;
-import org.apache.jena.tdb1.TDB1;
-import org.apache.jena.tdb1.transaction.TransactionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,6 +99,12 @@ public class Fuseki {
 
     public static boolean   outputJettyServerHeader     = developmentMode;
     public static boolean   outputFusekiServerHeader    = developmentMode;
+
+    /**
+     * Initialize is class.
+     * See also {@link FusekiCore} for Fuseki core initialization.
+     */
+    public static void initConsts() {}
 
     /** An identifier for the HTTP Fuseki server instance */
     static public final String  serverHttpName          = NAME + " (" + VERSION + ")";
@@ -224,28 +227,6 @@ public class Fuseki {
     /** XSD DateTime for when the server started */
     public static String serverStartedAt() {
         return startDateTime;
-    }
-
-    private static boolean initialized = false;
-    /**
-     * Initialize an instance of the Fuseki server stack.
-     * This is not done via Jena's initialization mechanism
-     * but done explicitly to give more control.
-     * It is done after Jena initializes.
-     * Fuseki-main adds a Fuseki specific custom initialization
-     * round after this is run.
-     */
-    public synchronized static void init() {
-        if ( initialized )
-            return;
-        initialized = true;
-        JenaSystem.init();
-        MappingRegistry.addPrefixMapping("fuseki", FusekiSymbolIRI);
-
-        TDB1.setOptimizerWarningFlag(false);
-        // Don't use TDB1 batch commits.
-        // This can be slower, but it less memory hungry and more predictable.
-        TransactionManager.QueueBatchSize = 0;
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -40,37 +40,33 @@ import org.slf4j.LoggerFactory;
 
 public class Fuseki {
     // General fixed constants.
-    // See also FusekiServer for the naming on the filesystem
 
     /** Path as package name */
-    static public String    PATH                         = "org.apache.jena.fuseki";
+    static public final String PATH               = "org.apache.jena.fuseki";
 
     /** a unique IRI for the Fuseki namespace */
-    static public String    FusekiIRI                    = "http://jena.apache.org/Fuseki";
+    static public final String FusekiIRI          = "http://jena.apache.org/Fuseki";
 
     /**
      * a unique IRI including the symbol notation for which properties should be
      * appended
      */
-    static public String    FusekiSymbolIRI              = "http://jena.apache.org/fuseki#";
+    static public final String FusekiSymbolIRI    = "http://jena.apache.org/fuseki#";
 
     /** Default location of the pages for the Fuseki UI  */
-    static public String    PagesStatic                  = "pages";
+    static public final String PagesStatic        = "pages";
 
     /** Dummy base URi string for parsing SPARQL Query and Update requests */
-    static public final String BaseParserSPARQL          = "http://server/unset-base/";
+    static public final String BaseParserSPARQL   = "http://server/unset-base/";
 
     /** Dummy base URi string for parsing SPARQL Query and Update requests */
-    static public final String BaseUpload                = "http://server/unset-base/";
-
-    /** Add CORS header */
-    static public final boolean CORS_ENABLED = false;
+    static public final String BaseUpload         = "http://server/unset-base/";
 
     /** The name of the Fuseki server.*/
-    static public final String        NAME              = "Apache Jena Fuseki";
+    static public final String  NAME              = "Apache Jena Fuseki";
 
     /** Version of this Fuseki instance */
-    static public final String        VERSION           = Version.versionForClass(Fuseki.class).orElse("<development>");
+    static public final String  VERSION           = Version.versionForClass(Fuseki.class).orElse("<development>");
 
     /** Supporting Graph Store Protocol direct naming.
      * <p>
@@ -175,6 +171,7 @@ public class Fuseki {
     public static final String attrNameRegistry            = "org.apache.jena.fuseki:DataAccessPointRegistry";
     public static final String attrOperationRegistry       = "org.apache.jena.fuseki:OperationRegistry";
     public static final String attrAuthorizationService    = "org.apache.jena.fuseki:AuthorizationService";
+    public static final String attrFusekiServer            = "org.apache.jena.fuseki:Server";
 
     public static void setVerbose(ServletContext cxt, boolean verbose) {
         cxt.setAttribute(attrVerbose, Boolean.valueOf(verbose));

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
@@ -322,9 +322,6 @@ public class FusekiConfig {
         // ---- Services
         // Server to services.
         RowSet rs = BuildLib.query("SELECT * { ?s fu:services [ list:member ?service ] }", configuration, "s", server);
-
-        List<Node> services = rs.stream().map(b->b.get("service")).toList();
-
         List<DataAccessPoint> accessPoints = new ArrayList<>();
 
         // If none, look for services by type.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
@@ -95,8 +95,6 @@ public class FusekiConfig {
                    Operation.GSP_RW,
                    Operation.Patch);
 
-    static { Fuseki.init(); }
-
     /** Convenience operation to populate a {@link DataService} with the conventional default services. */
     public static DataService.Builder populateStdServices(DataService.Builder dataServiceBuilder, boolean allowUpdate) {
         Set<Endpoint> endpoints = new HashSet<>();

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionStatsText.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionStatsText.java
@@ -38,12 +38,12 @@ public class ActionStatsText extends ActionCtl
 
     @Override
     public void validate(HttpAction action) {
-        switch(action.getMethod() ) {
+        switch(action.getRequestMethod() ) {
             case HttpNames.METHOD_GET:
             case HttpNames.METHOD_POST:
                 return;
             default:
-                ServletOps.errorMethodNotAllowed(action.getMethod());
+                ServletOps.errorMethodNotAllowed(action.getRequestMethod());
         }
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPointRegistry.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPointRegistry.java
@@ -27,6 +27,7 @@ import org.apache.jena.atlas.lib.Registry;
 import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiException;
+import org.apache.jena.fuseki.servlets.HttpAction;
 
 /**
  * Registry of (dataset name, {@link DataAccessPoint}).
@@ -59,7 +60,7 @@ public class DataAccessPointRegistry extends Registry<String, DataAccessPoint>
      */
     public List<DataAccessPoint> accessPoints() {
         List<DataAccessPoint> accessPoints = new ArrayList<>(size());
-        // Make a copy for safety.
+        // Copy for safety.
         forEach((_name, accessPoint) -> accessPoints.add(accessPoint));
         return accessPoints;
     }
@@ -90,7 +91,14 @@ public class DataAccessPointRegistry extends Registry<String, DataAccessPoint>
         });
     }
 
-    // The server DataAccessPointRegistry is held in the ServletContext for the server.
+    /** The server DataAccessPointRegistry is held in the ServletContext.
+     * <p>
+     * Reload may change this object for another one. Therefore, code should obtain the
+     * DataAccessPointRegistry once per operation.
+     * <p>
+     * Each request, has a stable {@link HttpAction#getDataAccessPointRegistry()}.
+     * <p>Getting the {@link DataAccessPointRegistry} is atomic.
+     */
     public static DataAccessPointRegistry get(ServletContext cxt) {
         DataAccessPointRegistry registry = (DataAccessPointRegistry)cxt.getAttribute(Fuseki.attrNameRegistry);
         if ( registry == null )
@@ -98,6 +106,10 @@ public class DataAccessPointRegistry extends Registry<String, DataAccessPoint>
         return registry;
     }
 
+    /**
+     * Set or change the {@link DataAccessPointRegistry}.
+     * This is atomic. (In Jetty, it is backed by a ConcurrentHashMap).
+     */
     public static void set(ServletContext cxt, DataAccessPointRegistry registry) {
         cxt.setAttribute(Fuseki.attrNameRegistry, registry);
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Dispatcher.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Dispatcher.java
@@ -388,11 +388,11 @@ public class Dispatcher {
             } else if ( GSP_RW.equals(operation) ) {
                 // If asking for GSP_RW, but only GSP_R is available ...
                 // ... if OPTIONS, use GSP_R.
-                if ( action.getMethod().equals(HttpNames.METHOD_OPTIONS) && epSet.contains(GSP_R) )
+                if ( action.getRequestMethod().equals(HttpNames.METHOD_OPTIONS) && epSet.contains(GSP_R) )
                         return GSP_R;
                 // ... else 405
                 if ( epSet.contains(GSP_R) )
-                    ServletOps.errorMethodNotAllowed(action.getMethod());
+                    ServletOps.errorMethodNotAllowed(action.getRequestMethod());
             }
         }
         return operation;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionLib.java
@@ -401,8 +401,6 @@ public class ActionLib {
     }
 
     private static void setCommonHeadersForOptions(HttpServletResponse httpResponse) {
-        if ( Fuseki.CORS_ENABLED )
-            httpResponse.setHeader(HttpNames.hAccessControlAllowHeaders, "X-Requested-With, Content-Type, Authorization");
         setCommonHeaders(httpResponse);
     }
 
@@ -411,8 +409,6 @@ public class ActionLib {
     }
 
     private static void setCommonHeaders(HttpServletResponse httpResponse) {
-        if ( Fuseki.CORS_ENABLED )
-            httpResponse.setHeader(HttpNames.hAccessControlAllowOrigin, "*");
         if ( Fuseki.outputFusekiServerHeader )
             httpResponse.setHeader(HttpNames.hServer, Fuseki.serverHttpName);
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionProcessor.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionProcessor.java
@@ -29,7 +29,7 @@ public interface ActionProcessor {
      * @param action   HTTP Action
      */
     public default void process(HttpAction action) {
-        switch ( action.getMethod() ) {
+        switch ( action.getRequestMethod() ) {
             case METHOD_GET ->       execGet(action);
             case METHOD_POST ->      execPost(action);
             case METHOD_PATCH ->     execPatch(action);
@@ -38,7 +38,7 @@ public interface ActionProcessor {
             case METHOD_HEAD ->      execHead(action);
             case METHOD_OPTIONS->    execOptions(action);
             case METHOD_TRACE ->     execTrace(action);
-            default -> execAny(action.getMethod(), action);
+            default -> execAny(action.getRequestMethod(), action);
         }
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/BaseActionREST.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/BaseActionREST.java
@@ -46,6 +46,6 @@ public class BaseActionREST extends ActionREST {
     public void validate(HttpAction action) { }
 
     private void notSupported(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod()+" "+action.getDatasetName());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod()+" "+action.getDatasetName());
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
  * for any service.
  */
 public class FusekiFilter implements Filter {
-    private static Logger log = Fuseki.serverLog;
+    private static final Logger LOG = Fuseki.serverLog;
 
     @Override
     public void init(FilterConfig filterConfig) {}
@@ -50,7 +50,7 @@ public class FusekiFilter implements Filter {
             if ( handled )
                 return;
         } catch (Throwable ex) {
-            log.info("Filter: unexpected exception: "+ex.getMessage(),ex);
+            LOG.info("Filter: unexpected exception: "+ex.getMessage(),ex);
         }
 
         // Not found - continue.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
@@ -316,6 +316,7 @@ public class HttpAction
             transactional.begin(txnType);
         activeDSG = dsg;
         if ( dataService != null )
+            // Paired with finishTxn in end()
             dataService.startTxn(txnType);
         startActionTxn();
     }
@@ -491,6 +492,7 @@ public class HttpAction
     // ----
 
     public void commit() {
+//dataService.finishTxn();
         if ( transactional != null )
             transactional.commit();
         endInternal();
@@ -616,6 +618,8 @@ public class HttpAction
 
     // ---- Request - response abstraction.
 
+    /** @deprecated Use {@link #getRequestMethod}. */
+    @Deprecated(since="5.1.0", forRemoval=true)
     public String getMethod()                           { return request.getMethod(); }
 
     public HttpServletRequest getRequest()              { return request; }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServletOps.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServletOps.java
@@ -248,11 +248,11 @@ public class ServletOps {
     }
 
     public static void error(int statusCode) {
-        throw new ActionErrorException(statusCode, null, null);
+        throw actionErrorException(statusCode, null, null);
     }
 
     public static void error(int statusCode, String string) {
-        throw new ActionErrorException(statusCode, string, null);
+        throw actionErrorException(statusCode, string, null);
     }
 
     public static void errorOccurred(String message) {
@@ -266,7 +266,12 @@ public class ServletOps {
     public static void errorOccurred(String message, Throwable ex) {
         if ( ex instanceof ActionErrorException actionErr )
             throw actionErr;
-        throw new ActionErrorException(HttpSC.INTERNAL_SERVER_ERROR_500, message, ex);
+        throw actionErrorException(HttpSC.INTERNAL_SERVER_ERROR_500, message, ex);
+        /* Does not return */
+    }
+
+    private static ActionErrorException actionErrorException(int statusCode, String message, Throwable ex) {
+        return new ActionErrorException(statusCode, message, ex);
     }
 
     public static String formatForLog(String string) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/UploadRDF.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/UploadRDF.java
@@ -54,7 +54,7 @@ public class UploadRDF extends ActionREST {
     @Override protected void doPatch(HttpAction action)     { unsupported(action); }
 
     private void unsupported(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod());
     }
 
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiCore.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiCore.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.system;
+
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.sparql.util.MappingRegistry;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.tdb1.TDB1;
+import org.apache.jena.tdb1.transaction.TransactionManager;
+
+/**
+ * Fuseki core initialization.
+ * <p>
+ * Initialize an instance of the Fuseki server core code.
+ * This is not done via Jena's initialization mechanism
+ * but done explicitly to give control.
+ * <p>
+ * It is done after Jena initializes.
+ * <p>
+ * {@code InitFusekiMain} is the code for Jena's initialization mechanism.
+ * It calls this class.
+ */
+public class FusekiCore {
+
+    private static boolean initialized = false;
+
+    public synchronized static void init() {
+        if ( initialized )
+            return;
+
+        // Avoid re-entrancy.
+        initialized = true;
+
+        JenaSystem.init();
+        // Touch the Fuseki class to make sure statics get initialized.
+        Fuseki.initConsts();
+        MappingRegistry.addPrefixMapping("fuseki", Fuseki.FusekiSymbolIRI);
+
+        // TDB1
+        TDB1.setOptimizerWarningFlag(false);
+        // Don't use TDB1 batch commits.
+        // This can be slower, but it less memory hungry and more predictable.
+        TransactionManager.QueueBatchSize = 0;
+    }
+}

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
@@ -34,7 +34,7 @@ import org.apache.jena.fuseki.Fuseki;
 /**
  * FusekiLogging.
  * <p>
- * This applies to Fuseki run from the command line and embedded.
+ * This applies to Fuseki run from the command line, as a combined jar and as an embedded server.
  * <p>
  * This does not apply to Fuseki running in Tomcat where it uses the
  * servlet 3.0 mechanism described in
@@ -49,10 +49,9 @@ public class FusekiLogging
 
     // Set logging.
     // 1/ Use system property log4j2.configurationFile if defined.
-    // 2/ Use file:log4j2.properties if exists
+    // 2/ Use file:log4j2.properties if exists [Jena extension]
     // 3/ Use log4j2.properties on the classpath.
-    // 4/ Use org/apache/jena/fuseki/log4j2.properties on the classpath.
-    // 5/ Use built in string
+    // 4/ Use built in string
 
     /**
      * Places for the log4j properties file at (3).

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
@@ -70,7 +70,7 @@ public class FusekiLib {
         OperationRegistry operationRegistry = server.getOperationRegistry();
 
         try {
-            List<DataAccessPoint> newDAPs = FusekiConfig.servicesAndDatasets(configuration);
+            List<DataAccessPoint> newDAPs = FusekiConfig.servicesAndDatasets(configuration.getGraph());
             newDAPs.forEach(dap->newRegistry.register(dap));
             FusekiServer.Builder.prepareDataServices(newRegistry, operationRegistry);
             // Reload : switch DataAccessPointRegistry

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
@@ -21,20 +21,24 @@ package org.apache.jena.fuseki.main;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.servlet.ServletContext;
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.access.AccessCtl_AllowGET;
 import org.apache.jena.fuseki.access.AccessCtl_Deny;
 import org.apache.jena.fuseki.access.AccessCtl_GSP_R;
 import org.apache.jena.fuseki.access.AccessCtl_SPARQL_QueryDataset;
-import org.apache.jena.fuseki.server.DataAccessPointRegistry;
-import org.apache.jena.fuseki.server.Endpoint;
-import org.apache.jena.fuseki.server.Operation;
+import org.apache.jena.fuseki.build.FusekiConfig;
+import org.apache.jena.fuseki.server.*;
 import org.apache.jena.fuseki.servlets.ActionService;
 import org.apache.jena.fuseki.servlets.GSP_RW;
 import org.apache.jena.fuseki.servlets.HttpAction;
+import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.WebContent;
 
 /** Actions on and about a {@link FusekiServer} */
@@ -50,6 +54,34 @@ public class FusekiLib {
         // Correct size, no reallocate.
         List<String> names = stream.collect(Collectors.toCollection(() -> new ArrayList<>(N)));
         return names;
+    }
+
+    /**
+     * Process a configuration mode to find the DataServices and reset the server
+     * {@link DataAccessPointRegistry}. The only server-level setting processed is
+     * the {@code fuseki:services} list. Other settings are ignored.
+     */
+    public static void reload(FusekiServer server, Model configuration) {
+        DataAccessPointRegistry newRegistry = new DataAccessPointRegistry();
+        OperationRegistry operationRegistry = server.getOperationRegistry();
+
+        try {
+            List<DataAccessPoint> newDAPs = FusekiConfig.servicesAndDatasets(configuration);
+            newDAPs.forEach(dap->newRegistry.register(dap));
+            FusekiServer.Builder.prepareDataServices(newRegistry, operationRegistry);
+            // Reload : switch DataAccessPointRegistry
+            setDataAccessPointRegistry(server, newRegistry);
+        } catch (RuntimeException ex) {
+            Log.error(Fuseki.serverLog,  "Failed to load a new configuration", ex);
+        }
+    }
+
+    public static void setDataAccessPointRegistry(FusekiServer server,  DataAccessPointRegistry newRegistry) {
+        Objects.requireNonNull(server, "server");
+        Objects.requireNonNull(newRegistry, "newRegistry");
+        ServletContext cxt = server.getServletContext();
+        // This is atomic (in Jetty, it is backed by a ConcurrentHashMap).
+        DataAccessPointRegistry.set(cxt, newRegistry);
     }
 
     /**
@@ -82,7 +114,6 @@ public class FusekiLib {
     public static void modifyForAccessCtl(DataAccessPointRegistry dapRegistry, Function<HttpAction, String> determineUser) {
         dapRegistry.forEach((name, dap) -> {
             dap.getDataService().forEachEndpoint(ep->{
-                Operation op = ep.getOperation();
                 modifyForAccessCtl(ep, determineUser);
             });
         });

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
@@ -59,9 +59,13 @@ public class FusekiLib {
     /**
      * Process a configuration mode to find the DataServices and reset the server
      * {@link DataAccessPointRegistry}. The only server-level setting processed is
-     * the {@code fuseki:services} list. Other settings are ignored.
+     * the {@code fuseki:services} list; other settings are ignored.
      */
     public static void reload(FusekiServer server, Model configuration) {
+        // See also FusekiServer.applyDatabaseSetup
+        //      prepareDataServices(dapRegistry, operationReg);
+        //      OperationRegistry.set(servletContext, operationReg);
+        //      DataAccessPointRegistry.set(servletContext, dapRegistry);
         DataAccessPointRegistry newRegistry = new DataAccessPointRegistry();
         OperationRegistry operationRegistry = server.getOperationRegistry();
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -112,7 +112,10 @@ import org.slf4j.Logger;
  */
 
 public class FusekiServer {
-    static { JenaSystem.init(); }
+    static {
+        JenaSystem.init();
+        Fuseki.init();
+    }
 
     /**
      * Construct a Fuseki server from command line arguments.
@@ -1400,7 +1403,6 @@ public class FusekiServer {
                 boolean hasFusekiSecurityHandler = applySecurityHandler(handler);
                 // Prepare the DataAccessPointRegistry.
                 // Put it in the servlet context.
-                // This would be the reload operation.
                 applyDatabaseSetup(handler.getServletContext(), dapRegistry, operationReg);
 
                 // Must be after the DataAccessPointRegistry is in the servlet context.
@@ -1492,8 +1494,8 @@ public class FusekiServer {
                                                DataAccessPointRegistry dapRegistry,
                                                OperationRegistry operationReg) {
             // Final wiring up of DataAccessPointRegistry
+            // See also FusekiLib.reload()
             prepareDataServices(dapRegistry, operationReg);
-
             OperationRegistry.set(servletContext, operationReg);
             DataAccessPointRegistry.set(servletContext, dapRegistry);
         }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -28,7 +28,6 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-
 import jakarta.servlet.Filter;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServlet;
@@ -59,11 +58,12 @@ import org.apache.jena.fuseki.servlets.*;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Dataset;
-import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sparql.util.Context;
-import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.G;
 import org.apache.jena.system.RDFDataException;
 import org.apache.jena.web.HttpSC;
@@ -113,8 +113,7 @@ import org.slf4j.Logger;
 
 public class FusekiServer {
     static {
-        JenaSystem.init();
-        Fuseki.init();
+        InitFusekiMain.init();
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -393,6 +393,7 @@ public class JettyServer {
             try {
                 Fuseki.setVerbose(cxt, verbose);
                 OperationRegistry.set(cxt, OperationRegistry.createEmpty());
+                // Empty DataAccessPointRegistry, no nulls!
                 DataAccessPointRegistry.set(cxt, new DataAccessPointRegistry());
             } catch (NoClassDefFoundError err) {
                 LOG.info("Fuseki classes not found");

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -157,6 +157,7 @@ public class FusekiMain extends CmdARQ {
      */
     public static void run(String... argv) {
         JenaSystem.init();
+        Fuseki.init();
         new FusekiMain(argv).mainRun();
     }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -42,6 +42,7 @@ import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.sys.FusekiAutoModules;
 import org.apache.jena.fuseki.main.sys.FusekiModules;
 import org.apache.jena.fuseki.main.sys.FusekiServerArgsCustomiser;
+import org.apache.jena.fuseki.main.sys.InitFusekiMain;
 import org.apache.jena.fuseki.server.DataAccessPoint;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.FusekiCoreInfo;
@@ -157,7 +158,7 @@ public class FusekiMain extends CmdARQ {
      */
     public static void run(String... argv) {
         JenaSystem.init();
-        Fuseki.init();
+        InitFusekiMain.init();
         new FusekiMain(argv).mainRun();
     }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/mgt/ActionReload.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/mgt/ActionReload.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.main.mgt;
+
+import org.apache.jena.atlas.logging.FmtLog;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.ctl.ActionCtl;
+import org.apache.jena.fuseki.main.FusekiLib;
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.servlets.HttpAction;
+import org.apache.jena.fuseki.servlets.ServletOps;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.web.HttpNames;
+
+/**
+ * Administration action to reload the server's dataset configuration.
+ * <p>
+ * This is done by reading the configuration file which may have changed since server startup.
+ * <p>
+ * If the server does not have a configuration file (e.g. command line or programmatic configuration)
+ */
+public class ActionReload extends ActionCtl {
+
+    @Override
+    public void validate(HttpAction action) {
+        if ( action.getRequestMethod() != HttpNames.METHOD_POST ) {
+            ServletOps.errorMethodNotAllowed(action.getRequestMethod());
+        }
+    }
+
+    @Override
+    public void execute(HttpAction action) {
+        FusekiServer server = FusekiServer.get(action.getRequest().getServletContext());
+        if ( server == null ) {
+            ServletOps.errorOccurred("Failed to find the server for this action");
+            return;
+        }
+
+        String configFilename = server.getConfigFilename();
+        if ( configFilename == null ) {
+            FmtLog.warn(Fuseki.serverLog, "[%d] Server does not have an associated configuration file", action.id);
+            ServletOps.errorBadRequest("Server does not have an associated configuration file");
+            return;
+        }
+        Model model = RDFParser.source(configFilename).toModel();
+        FmtLog.info(Fuseki.serverLog, "[%d] Reload configuration", action.id);
+        FusekiLib.reload(server, model);
+    }
+}
+

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/mgt/ActionReload.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/mgt/ActionReload.java
@@ -64,4 +64,3 @@ public class ActionReload extends ActionCtl {
         FusekiLib.reload(server, model);
     }
 }
-

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiAutoModules.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiAutoModules.java
@@ -26,17 +26,19 @@ import java.util.function.Function;
 import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.atlas.lib.Version;
 import org.apache.jena.atlas.logging.FmtLog;
-import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiConfigException;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Management of {@link FusekiAutoModule automatically loaded modules} found via {@link ServiceLoader}.
  */
 public class FusekiAutoModules {
 
-    private static final Logger LOG = Fuseki.serverLog;
+    // Separate from Fuseki.serverLog;
+    private static final Logger LOG = LoggerFactory.getLogger(FusekiAutoModules.class);
+
     private static final Object lock = new Object();
 
     public static final String logLoadingProperty = "fuseki.logLoading";
@@ -173,7 +175,7 @@ public class FusekiAutoModules {
             try {
                 ServiceLoader<FusekiModule> newServiceLoader = ServiceLoader.load(moduleClass, this.getClass().getClassLoader());
                 newServiceLoader.stream().forEach(provider->{
-                    FmtLog.warn(FusekiAutoModules.class, "Ignored: \"%s\" : legacy use of interface FusekiModule which has changed to FusekiAutoModule", provider.type().getSimpleName());
+                    FmtLog.warn(LOG, "Ignored: \"%s\" : legacy use of interface FusekiModule which has changed to FusekiAutoModule", provider.type().getSimpleName());
                 });
             } catch (ServiceConfigurationError ex) {
                 // Ignore - we were only checking.
@@ -218,7 +220,7 @@ public class FusekiAutoModules {
                 String name = m.name();
                 if ( name == null )
                     name = m.getClass().getSimpleName();
-                FmtLog.info(LOG, "Module: %s (%s)",
+                FmtLog.debug(LOG, "Module: %s (%s)",
                                  name,
                                  Version.versionForClass(m.getClass()).orElse("unknown"));
             });

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiLifecycle.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiLifecycle.java
@@ -24,7 +24,7 @@ import org.apache.jena.base.module.SubsystemLifecycle;
  * A {@link SubsystemLifecycle} for Fuseki.
  * This lifecycle is run after Jena system initialization.
  * Jena system initialization includes system initialization of Fuseki itself
- * in {@link InitFuseki}.
+ * in {@link InitFusekiMain}.
  * This lifecycle is for extensions to an initialized Fuseki server
  * and is used via {@link FusekiAutoModule}.
  */

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModuleStep.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModuleStep.java
@@ -77,7 +77,7 @@ public class FusekiModuleStep {
     }
 
     /**
-     * Sever reload.
+     * Server reload.
      * Return true if reload happened, else false.
      * @see FusekiBuildCycle#serverConfirmReload
      * @see FusekiBuildCycle#serverReload

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/InitFusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/InitFusekiMain.java
@@ -20,6 +20,7 @@ package org.apache.jena.fuseki.main.sys;
 
 import org.apache.jena.cmd.Cmds;
 import org.apache.jena.fuseki.main.cmds.FusekiMainCmd;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.sys.JenaSubsystemLifecycle;
 import org.apache.jena.sys.JenaSystem;
 
@@ -28,7 +29,7 @@ import org.apache.jena.sys.JenaSystem;
  * Level 101 - called during Jena system initialization
  * and after Jena itself has initialized.
  */
-public class InitFuseki implements JenaSubsystemLifecycle {
+public class InitFusekiMain implements JenaSubsystemLifecycle {
 
     private static volatile boolean initialized = false;
 
@@ -45,7 +46,8 @@ public class InitFuseki implements JenaSubsystemLifecycle {
         if ( initialized ) {
             return;
         }
-        synchronized (InitFuseki.class) {
+
+        synchronized (InitFusekiMain.class) {
             if ( initialized ) {
                 JenaSystem.logLifecycle("Fuseki.init - skip");
                 return;
@@ -53,7 +55,12 @@ public class InitFuseki implements JenaSubsystemLifecycle {
             initialized = true;
             JenaSystem.logLifecycle("Fuseki.init - start");
 
+            // Ensure core constants are initialized first.
+            FusekiCore.init();
             FusekiModules.init();
+
+            // Leave until known to be needed FusekiServer build with no specific FusekikModules given.
+            // FusekiModulesCtl.setup();
             try {
                 Cmds.injectCmd("fuseki", a->FusekiMainCmd.main(a));
             } catch (NoClassDefFoundError ex) {

--- a/jena-fuseki2/jena-fuseki-main/src/main/resources/META-INF/services/org.apache.jena.sys.JenaSubsystemLifecycle
+++ b/jena-fuseki2/jena-fuseki-main/src/main/resources/META-INF/services/org.apache.jena.sys.JenaSubsystemLifecycle
@@ -1,1 +1,1 @@
-org.apache.jena.fuseki.main.sys.InitFuseki
+org.apache.jena.fuseki.main.sys.InitFusekiMain

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/CustomTestService.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/CustomTestService.java
@@ -76,6 +76,6 @@ public class CustomTestService extends ActionREST {
     public void validate(HttpAction action) { }
 
     private void notSupported(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod()+" "+action.getDatasetName());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod()+" "+action.getDatasetName());
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
@@ -55,9 +55,11 @@ import org.junit.platform.suite.api.Suite;
   , TestFusekiCustomScriptFunc.class
 
   , PrefixesServiceTests.class
-
   , TestMetrics.class
   , TestFusekiShaclValidation.class
+
+  , TestFusekiMainAdmin.class
+
 })
 public class TS_FusekiMain {}
 

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainAdmin.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainAdmin.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.main;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.apache.jena.atlas.io.IOX;
+import org.apache.jena.atlas.logging.LogCtl;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.main.mgt.ActionReload;
+import org.apache.jena.http.HttpOp;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.exec.RowSetOps;
+import org.apache.jena.sparql.exec.http.QueryExecHTTP;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestFusekiMainAdmin {
+
+    private static Path fConfigServer  = Path.of("target/config-reload.ttl");
+    private static Path DIR            = Path.of("testing/Config/");
+    private static Path fConfig1       = DIR.resolve("reload-config1.ttl");
+    private static Path fConfig2       = DIR.resolve("reload-config2.ttl");
+
+    @Before public void before() {
+        // Initial state
+        copyFile(fConfig1, fConfigServer);
+    }
+
+    @AfterClass public static void after() {
+        try {
+            Files.delete(fConfigServer);
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+
+    @Test public void serverReload_1() {
+        FusekiServer server = server(fConfigServer);
+        try {
+            server.start();
+
+            serverBeforeReload(server);
+
+            // Change configuration file.
+            copyFile(fConfig2, fConfigServer);
+            Model newConfig = RDFParser.source(fConfigServer).toModel();
+
+            // Reload operation on the server
+            HttpOp.httpPost("http://localhost:"+server.getPort()+"/$/reload");
+
+            serverAfterReload(server);
+        }
+        finally { server.stop(); }
+    }
+
+    @Test public void serverReload_2() {
+        FusekiServer server = serverNoConfigFile();
+        try {
+            server.start();
+
+            serverBeforeReload(server);
+
+            // Change configuration file.
+            // Error!
+            copyFile(fConfig2, fConfigServer);
+            Model newConfig = RDFParser.source(fConfigServer).toModel();
+
+            LogCtl.withLevel(Fuseki.serverLog, "ERROR", ()->
+                // Poke server - Operation denied - no configuration file.
+                FusekiTestLib.expect400(()->HttpOp.httpPost("http://localhost:"+server.getPort()+"/$/reload"))
+            );
+
+            // No change
+            serverBeforeReload(server);
+        }
+        finally { server.stop(); }
+    }
+
+    private static void copyFile(Path pathSrc, Path pathDest) {
+        try {
+            Files.copy(pathSrc, pathDest, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException ex) { throw IOX.exception(ex); }
+    }
+
+    private static void serverBeforeReload(FusekiServer server) {
+        String URL = "http://localhost:"+server.getPort()+"/$/ping";
+        String x = HttpOp.httpGetString(URL);
+        query(server, "/ds", "SELECT * { }", 200);
+        query(server, "/dataset2", "SELECT * { ?s ?p ?o }", 404);
+        query(server, "/zero", "SELECT * { }", 404);
+        query(server, "/codedsg", "SELECT * { }", 200);
+    }
+
+    private static void serverAfterReload(FusekiServer server) {
+        String URL = "http://localhost:"+server.getPort()+"/$/ping";
+        String x = HttpOp.httpGetString(URL);
+        query(server, "/ds", "SELECT * { }", 404);
+        query(server, "/dataset2", "SELECT * { ?s ?p ?o }", 200);
+        query(server, "/zero", "SELECT * { }", 404);
+        // Replaced.
+        query(server, "/codedsg", "SELECT * { }", 404);
+    }
+
+    private static void query(FusekiServer server, String datasetName, String queryString, int expectedStatusCode) {
+        QueryExec qExec = QueryExecHTTP.service(server.datasetURL(datasetName)).query(queryString).build();
+        try {
+            RowSetOps.consume(qExec.select());
+            assertEquals(datasetName, expectedStatusCode, 200);
+        } catch (QueryExceptionHTTP ex) {
+            assertEquals(datasetName, expectedStatusCode, ex.getStatusCode());
+        }
+    }
+
+    private static FusekiServer serverNoConfigFile() {
+        DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
+        FusekiServer server = FusekiServer.create().port(0)
+                                          // .verbose(true)
+                                          .addServlet("/$/reload", new ActionReload())
+                                          .add("/ds", dsg)
+                                          .add("/codedsg", dsg)
+                                          .build();
+        return server;
+    }
+
+
+    private static FusekiServer server(Path fConfig) {
+        DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
+        FusekiServer server = FusekiServer.create().port(0)
+                                          // .verbose(true)
+                                          .addServlet("/$/reload", new ActionReload())
+                                          .parseConfigFile(fConfig)
+                                          .add("/codedsg", dsg)
+                                          .build();
+        return server;
+    }
+}

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
@@ -339,7 +339,7 @@ public class TestFusekiMainCmdArguments {
         List<String> arguments = List.of("--file=testing/Config/invalid.ttl", "/dataset");
         String expectedMessage = "Failed to load file: testing/Config/invalid.ttl";
         // when, then
-        LogCtl.withLevel(SysRIOT.getLogger(), "fatal",
+        LogCtl.withLevel(SysRIOT.getLogger(), "FATAL",
                          ()-> testForCmdException(arguments, expectedMessage)
                          );
     }
@@ -458,7 +458,6 @@ public class TestFusekiMainCmdArguments {
         assertTrue("Expecting correct exception", (actual instanceof CmdException));
         assertEquals("Expecting correct message", expectedMessage, actual.getMessage());
     }
-
 
     private static String[] buildCmdLineArguments(List<String> listArgs) {
         return listArgs.toArray(new String[0]);

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.util.function.Consumer;
 
+import jakarta.servlet.ServletContext;
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.atlas.logging.LogCtl;
@@ -60,9 +61,13 @@ public class TestFusekiServerBuild {
 
     @Test public void fuseki_build_1() {
         FusekiServer server = FusekiServer.create().port(3456).build();
-        // Not started. Port not assigned.
         assertTrue(server.getHttpPort() == 3456 );
         assertTrue(server.getHttpsPort() == -1 );
+
+        ServletContext cxt = server.getServletContext();
+        FusekiServer server2 = FusekiServer.get(cxt);
+        assertNotNull(server2);
+        assertEquals(server, server2);
     }
 
     @Test public void fuseki_build_2() {

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestPlainServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestPlainServer.java
@@ -109,7 +109,7 @@ public class TestPlainServer {
     }
 
     @Test public void plainFile3() {
-        String x = HttpOp.httpGetString(serverURL+"/file-top.txt");
+        String x = HttpOp.httpGetString(serverURL+"/exists.txt");
         assertNotNull(x);
         assertTrue(x.contains("CONTENT"));
     }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestFusekiSecurityAssembler.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestFusekiSecurityAssembler.java
@@ -36,6 +36,7 @@ import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.main.FusekiLib;
 import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.InitFusekiMain;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.QuerySolution;
@@ -46,7 +47,6 @@ import org.apache.jena.rdfconnection.RDFConnection;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.sse.SSE;
-import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.Txn;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -63,7 +63,7 @@ import org.junit.Test;
  */
 
 public abstract class AbstractTestFusekiSecurityAssembler {
-    static { JenaSystem.init(); }
+    static { InitFusekiMain.init(); }
     static final String DIR = "testing/Access/";
 
     private final String assemblerFile;

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/DemoService.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/DemoService.java
@@ -79,6 +79,6 @@ public class DemoService extends ActionREST {
     public void validate(HttpAction action) { }
 
     private void notSupported(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod()+" "+action.getActionURI());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod()+" "+action.getActionURI());
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExFuseki_04_CustomOperation_Inline.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExFuseki_04_CustomOperation_Inline.java
@@ -25,6 +25,7 @@ import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.build.FusekiExt;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.sys.FusekiModule;
+import org.apache.jena.fuseki.main.sys.InitFusekiMain;
 import org.apache.jena.fuseki.server.Operation;
 import org.apache.jena.fuseki.servlets.ActionService;
 import org.apache.jena.fuseki.servlets.HttpAction;
@@ -32,7 +33,6 @@ import org.apache.jena.fuseki.system.FusekiLogging;
 import org.apache.jena.http.HttpOp;
 import org.apache.jena.riot.WebContent;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.web.HttpSC;
 
 /**
@@ -46,8 +46,8 @@ import org.apache.jena.web.HttpSC;
 public class ExFuseki_04_CustomOperation_Inline {
 
     static {
-        JenaSystem.init();
         FusekiLogging.setLogging();
+        InitFusekiMain.init();
     }
 
     public static void main(String...args) {

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExFuseki_04_CustomOperation_Module.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExFuseki_04_CustomOperation_Module.java
@@ -27,6 +27,7 @@ import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.sys.FusekiModule;
 import org.apache.jena.fuseki.main.sys.FusekiModules;
+import org.apache.jena.fuseki.main.sys.InitFusekiMain;
 import org.apache.jena.fuseki.server.Operation;
 import org.apache.jena.fuseki.servlets.ActionService;
 import org.apache.jena.fuseki.servlets.HttpAction;
@@ -35,7 +36,6 @@ import org.apache.jena.http.HttpOp;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.WebContent;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.web.HttpSC;
 
 /**
@@ -48,8 +48,8 @@ import org.apache.jena.web.HttpSC;
 public class ExFuseki_04_CustomOperation_Module {
 
     static {
-        JenaSystem.init();
         FusekiLogging.setLogging();
+        InitFusekiMain.init();
     }
 
     // Example usage.

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/reload-config1.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/reload-config1.ttl
@@ -1,0 +1,16 @@
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+:service rdf:type fuseki:Service ;
+    fuseki:name "ds" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:patch ; ] ;
+    fuseki:dataset :dataset ;
+.
+
+:dataset rdf:type ja:MemoryDataset .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/reload-config2.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/reload-config2.ttl
@@ -1,0 +1,25 @@
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+:service rdf:type fuseki:Service ;
+    fuseki:name "dataset2" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:patch ; ] ;
+    fuseki:dataset :dataset ;
+.
+
+:dataset rdf:type ja:MemoryDataset ;
+     #ja:data "data.trig";
+.
+
+:service2 rdf:type fuseki:Service ;
+    fuseki:name "null" ;
+    ## No operations.
+    ## Always empty dataset.
+    fuseki:dataset [ rdf:type ja:RDFDatasetZero ] ;
+    .

--- a/jena-fuseki2/jena-fuseki-main/testing/Files/exists.txt
+++ b/jena-fuseki2/jena-fuseki-main/testing/Files/exists.txt
@@ -1,0 +1,2 @@
+This file is used by the plain server static resource tests.
+CONTENT

--- a/jena-fuseki2/jena-fuseki-main/testing/Files/file-top.txt
+++ b/jena-fuseki2/jena-fuseki-main/testing/Files/file-top.txt
@@ -1,2 +1,0 @@
-# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
-CONTENT

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiWebappCmd.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiWebappCmd.java
@@ -31,6 +31,7 @@ import org.apache.jena.cmd.TerminationException;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.mgt.Template;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.fuseki.system.FusekiLogging;
 import org.apache.jena.fuseki.webapp.FusekiEnv;
 import org.apache.jena.fuseki.webapp.FusekiServerListener;
@@ -96,7 +97,7 @@ public class FusekiWebappCmd {
         static public void innerMain(String... argv) {
             JenaSystem.init();
             // Do explicitly so it happens after subsystem initialization.
-            Fuseki.init();
+            FusekiCore.init();
             new FusekiCmdInner(argv).mainRun();
         }
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
@@ -31,7 +31,9 @@ import org.apache.jena.fuseki.FusekiConfigException;
 import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.FusekiCoreInfo;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.fuseki.webapp.FusekiEnv;
+import org.apache.jena.sys.JenaSystem;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
@@ -59,7 +61,10 @@ public class JettyFusekiWebapp {
     // This class is becoming less important - it now sets up a Jetty server for in-process use
     // either for the command line in development
     // and in testing but not direct webapp deployments.
-    static { Fuseki.init(); }
+    static {
+        JenaSystem.init();
+        FusekiCore.init();
+    }
 
     public static JettyFusekiWebapp  instance    = null;
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerEnvironmentInit.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerEnvironmentInit.java
@@ -22,6 +22,7 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
 import org.apache.jena.fuseki.system.FusekiLogging;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.sys.JenaSystem;
 
 /** Setup the environment and logging.
@@ -49,6 +50,8 @@ public class FusekiServerEnvironmentInit implements ServletContextListener {
             }
         }
         JenaSystem.init();
+        FusekiCore.init();
+
     }
 
     @Override

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiWebapp.java
@@ -46,6 +46,7 @@ import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.DataService;
 import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.fuseki.servlets.ServletOps;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.rdfs.RDFSFactory;
@@ -55,6 +56,7 @@ import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.riot.RDFParser;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
+import org.apache.jena.sys.JenaSystem;
 
 public class FusekiWebapp
 {
@@ -122,7 +124,8 @@ public class FusekiWebapp
             Path FUSEKI_HOME = FusekiEnv.FUSEKI_HOME;
             Path FUSEKI_BASE = FusekiEnv.FUSEKI_BASE;
 
-            Fuseki.init();
+            JenaSystem.init();
+            FusekiCore.init();
             Fuseki.configLog.info("FUSEKI_HOME="+ ((FUSEKI_HOME==null) ? "unset" : FUSEKI_HOME.toString()));
             Fuseki.configLog.info("FUSEKI_BASE="+FUSEKI_BASE.toString());
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/ShiroEnvironmentLoader.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/ShiroEnvironmentLoader.java
@@ -26,7 +26,9 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
 import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.irix.IRIs;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.shiro.lang.io.ResourceUtils;
 import org.apache.shiro.web.env.EnvironmentLoader;
 import org.apache.shiro.web.env.ResourceBasedWebEnvironment;
@@ -86,8 +88,9 @@ public class ShiroEnvironmentLoader extends EnvironmentLoader implements Servlet
 
     /** Look for a Shiro ini file, or return null */
     private static String huntForShiroIni(String[] locations) {
+        JenaSystem.init();
+        FusekiCore.init();
         FusekiEnv.setEnvironment();
-        Fuseki.init();
         for ( String loc : locations ) {
             // If file:, look for that file.
             // If a relative name without scheme, look in FUSEKI_BASE, FUSEKI_HOME, webapp.

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/ServerCtl.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/ServerCtl.java
@@ -30,6 +30,7 @@ import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.cmd.FusekiArgs;
 import org.apache.jena.fuseki.cmd.JettyFusekiWebapp;
 import org.apache.jena.fuseki.cmd.JettyServerConfig;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.fuseki.webapp.FusekiEnv;
 import org.apache.jena.fuseki.webapp.FusekiServerListener;
 import org.apache.jena.fuseki.webapp.FusekiWebapp;
@@ -37,6 +38,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.modify.request.Target;
 import org.apache.jena.sparql.modify.request.UpdateDrop;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.Txn;
 import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateExecutionFactory;
@@ -83,7 +85,10 @@ import org.apache.jena.update.UpdateProcessor;
  * </pre>
  */
 public class ServerCtl {
-    static { Fuseki.init(); }
+    static {
+        JenaSystem.init();
+        FusekiCore.init();
+    }
 
     /* Cut&Paste versions:
 


### PR DESCRIPTION
GitHub issue resolved #2462

Pull request Description: Provide reload of the config.ttl with zero interruption of service.

+ some clean-up done while working on this PR.
The logging support code changes better isolate the logging implementation specific functions.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
