### PR TITLE
Ensure tests stop any FusekiServer

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
@@ -30,6 +30,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
   // This tests modules and modifies the system state.
   , TestFusekiModules.class
+
   , TestMultipleEmbedded.class
   , TestFusekiCustomOperation.class
   , TestFusekiMainCmd.class

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestCrossOriginFilter.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestCrossOriginFilter.java
@@ -224,7 +224,7 @@ public class TestCrossOriginFilter {
         String unrecognisedHeader = "Content-Type, unknown-header";
         String[] headersToPass = {"Access-Control-Request-Method", "POST",
                                   "Access-Control-Request-Headers", unrecognisedHeader};
-        FusekiServer server = server("--mem", "/ds");
+        FusekiServer server = server("--port=0", "--mem", "/ds");
         executeWithServer(server, "/ds", URL->{
             // when
             HttpResponse<InputStream> response = httpOptions(URL, headersToPass);
@@ -244,7 +244,7 @@ public class TestCrossOriginFilter {
                                   "Origin", "http://localhost:5173",
                                   "Access-Control-Request-Headers", nonDefaultAllowedHeader};
         String expectedAllowedHeaders = "X-Requested-With,Content-Type,Accept,Origin,Last-Modified,Authorization,Custom-Header";
-        FusekiServer server = server("--mem", "--CORS=testing/Config/cors.properties","/ds");
+        FusekiServer server = server("--port=0", "--mem", "--CORS=testing/Config/cors.properties","/ds");
         executeWithServer(server, "/ds", URL->{
             // when
             HttpResponse<InputStream> response = httpOptions(URL, headersToPass);
@@ -263,7 +263,7 @@ public class TestCrossOriginFilter {
         String defaultHeader = "Content-Type";
         String[] headersToPass = {"Access-Control-Request-Method", "POST",
                                   "Access-Control-Request-Headers", defaultHeader};
-        FusekiServer server = server("--mem", "--noCORS", "/ds");
+        FusekiServer server = server("--port=0", "--mem", "--noCORS", "/ds");
         executeWithServer(server, "/ds", URL->{
             // when
             HttpResponse<InputStream> response = httpOptions(URL, headersToPass);

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
@@ -17,26 +17,36 @@
  */
 package org.apache.jena.fuseki.main;
 
-import org.apache.jena.cmd.CmdException;
-import org.apache.jena.fuseki.main.cmds.FusekiMain;
-import org.junit.Test;
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.List;
 
-import static java.util.Collections.emptyList;
-import static org.junit.Assert.*;
+import org.apache.jena.cmd.CmdException;
+import org.apache.jena.fuseki.main.cmds.FusekiMain;
+import org.junit.After;
+import org.junit.Test;
 
 /**
  * NOTE: we will randomise the port (--port=0) on all happy paths in order to avoid conflict with existing runs.
  */
 public class TestFusekiMainCmdArguments {
 
+    private FusekiServer server = null;
+    @After public void after() {
+        if ( server != null )
+            server.stop();
+    }
+
     @Test
     public void test_happy_empty() {
         // given
         List<String> arguments = List.of("--port=0", "--empty", "/dataset");
         // when
-        FusekiServer server = buildServer(buildCmdLineArguments(arguments));
+        buildServer(buildCmdLineArguments(arguments));
         // then
         assertNotNull(server);
     }
@@ -46,7 +56,7 @@ public class TestFusekiMainCmdArguments {
         // given
         List<String> arguments = List.of("--port=0", "--localhost", "--mem", "/dataset");
         // when
-        FusekiServer server = buildServer(buildCmdLineArguments(arguments));
+        buildServer(buildCmdLineArguments(arguments));
         // then
         assertNotNull(server);
     }
@@ -338,14 +348,14 @@ public class TestFusekiMainCmdArguments {
     @Test
     public void test_happy_corsConfig() {
         // given
-        List<String> arguments = List.of("--mem", "--CORS=testing/Config/cors.properties", "--localhost", "/path");
+        List<String> arguments = List.of("--port=0", "--mem", "--CORS=testing/Config/cors.properties", "--localhost", "/path");
         // when
-        FusekiServer server = buildServer(buildCmdLineArguments(arguments));
+        buildServer(buildCmdLineArguments(arguments));
         // then
         assertNotNull(server);
     }
 
-    private static void testForCmdException(List<String> arguments, String expectedMessage) {
+    private void testForCmdException(List<String> arguments, String expectedMessage) {
         // when
         Throwable actual = null;
         try {
@@ -364,10 +374,12 @@ public class TestFusekiMainCmdArguments {
         return listArgs.toArray(new String[0]);
     }
 
-    private static FusekiServer buildServer(String... cmdline) {
-        FusekiServer server = FusekiMain.build(cmdline);
+    // Build and set the server
+    private void buildServer(String... cmdline) {
+        if ( server != null )
+            fail("Bad test - a server has aleardy been created");
+        server = FusekiMain.build(cmdline);
         server.start();
-        return server;
     }
 
 }


### PR DESCRIPTION
This is a build fix.

There was a hidden problem with some tests (failing to release an allocated server on a fixed port) that 3cdc8cf9487b triggers.

This PR corrects the tests failing to clearup completely and also makes the tests that found this issue robust.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
