### PR TITLE
GH-2465: Produce jena-cmds source jar. Correct dependencies

### DIFF
--- a/jena-cmds/pom.xml
+++ b/jena-cmds/pom.xml
@@ -180,6 +180,11 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+
     </plugins>
   </build>
   

--- a/jena-integration-tests/pom.xml
+++ b/jena-integration-tests/pom.xml
@@ -70,14 +70,6 @@
 
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>jena-cmds</artifactId>
-      <version>5.1.0-SNAPSHOT</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.jena</groupId>
       <artifactId>jena-geosparql</artifactId>
       <version>5.1.0-SNAPSHOT</version>
     </dependency>


### PR DESCRIPTION
GitHub issue resolved #2465

Pull request Description:
Fixes a problem introduced in a5638d2371

* jena-cmds to produce a sources jar (for the download)
* jena-intregation-tests does not use jena-cmds:test  - remove from dependencies

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
