### PR TITLE
GH-2475: Specify the day for weekly schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
     groups:
       maven-patch-group:
         update-types:
@@ -15,11 +16,13 @@ updates:
     directory: "/"
     schedule: 
       interval: monthly
+      day: "tuesday"
     open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/jena-fuseki2/jena-fuseki-ui"
     schedule:
       interval: "weekly"
+      day: "wednesday"
     versioning-strategy: increase-if-necessary
     groups:
       npm-patch-group:


### PR DESCRIPTION
GitHub issue resolved #2475

Assuming naming the day means "run very early morning":

Monday: maven
Tuesday: github actions
Wednesday: npm

----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
