### PR TITLE
GH-2494: Remove unnecessary <relativePath> in POMs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ pom.xml.next
 release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
+.flattened-pom.xml
 
 # Eclipse
 .classpath

--- a/apache-jena-libs/pom.xml
+++ b/apache-jena-libs/pom.xml
@@ -29,7 +29,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <description>

--- a/apache-jena/pom.xml
+++ b/apache-jena/pom.xml
@@ -36,7 +36,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <organization>

--- a/jena-arq/pom.xml
+++ b/jena-arq/pom.xml
@@ -25,7 +25,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <description>SPARQL 1.1 query engine and RDF parsers for Apache Jena</description>

--- a/jena-base/pom.xml
+++ b/jena-base/pom.xml
@@ -23,7 +23,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   <artifactId>jena-base</artifactId>
   <name>Apache Jena - Base</name>

--- a/jena-benchmarks/jena-benchmarks-jmh/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-jmh/pom.xml
@@ -22,7 +22,6 @@
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-benchmarks</artifactId>
         <version>5.1.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <name>Apache Jena - Benchmarks JMH</name>

--- a/jena-benchmarks/jena-benchmarks-shadedJena480/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena480/pom.xml
@@ -22,7 +22,6 @@
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-benchmarks</artifactId>
         <version>5.1.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <name>Apache Jena - Benchmarks Shaded Jena 4.8.0</name>

--- a/jena-benchmarks/pom.xml
+++ b/jena-benchmarks/pom.xml
@@ -22,7 +22,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <name>Apache Jena - Benchmark Suite</name>

--- a/jena-bom/pom.xml
+++ b/jena-bom/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <dependencyManagement>

--- a/jena-cmds/pom.xml
+++ b/jena-cmds/pom.xml
@@ -22,7 +22,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <name>Apache Jena - Command line tools</name>

--- a/jena-core/pom.xml
+++ b/jena-core/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <description>Jena is a Java framework for building Semantic Web applications. It provides a programmatic environment for RDF, RDFS and OWL, SPARQL and includes a rule-based inference engine.</description>

--- a/jena-db/jena-dboe-base/pom.xml
+++ b/jena-db/jena-dboe-base/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-db</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <properties>

--- a/jena-db/jena-dboe-index-test/pom.xml
+++ b/jena-db/jena-dboe-index-test/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-db</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <properties>

--- a/jena-db/jena-dboe-index/pom.xml
+++ b/jena-db/jena-dboe-index/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-db</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <properties>

--- a/jena-db/jena-dboe-storage/pom.xml
+++ b/jena-db/jena-dboe-storage/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-db</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <description>Triplestore database storage</description>

--- a/jena-db/jena-dboe-trans-data/pom.xml
+++ b/jena-db/jena-dboe-trans-data/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-db</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <properties>

--- a/jena-db/jena-dboe-transaction/pom.xml
+++ b/jena-db/jena-dboe-transaction/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-db</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <properties>

--- a/jena-db/pom.xml
+++ b/jena-db/pom.xml
@@ -30,7 +30,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <licenses>

--- a/jena-examples/pom.xml
+++ b/jena-examples/pom.xml
@@ -21,7 +21,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/jena-extras/jena-commonsrdf/pom.xml
+++ b/jena-extras/jena-commonsrdf/pom.xml
@@ -24,9 +24,8 @@
 
   <parent>
     <groupId>org.apache.jena</groupId>
-    <artifactId>jena</artifactId>
+    <artifactId>jena-extras</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>../..</relativePath>
   </parent>
 
   <name>Apache Jena - CommonsRDF for Jena</name>

--- a/jena-extras/jena-querybuilder/pom.xml
+++ b/jena-extras/jena-querybuilder/pom.xml
@@ -25,7 +25,6 @@
   <parent>
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-extras</artifactId>
-    <relativePath>..</relativePath>
     <version>5.1.0-SNAPSHOT</version>
   </parent>
 

--- a/jena-extras/jena-serviceenhancer/pom.xml
+++ b/jena-extras/jena-serviceenhancer/pom.xml
@@ -25,7 +25,6 @@
   <parent>
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-extras</artifactId>
-    <relativePath>..</relativePath>
     <version>5.1.0-SNAPSHOT</version>
   </parent>
 

--- a/jena-extras/pom.xml
+++ b/jena-extras/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <modules>

--- a/jena-fuseki2/apache-jena-fuseki/pom.xml
+++ b/jena-fuseki2/apache-jena-fuseki/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-fuseki</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
   
   <description>Fuseki distribution</description>

--- a/jena-fuseki2/jena-fuseki-core/pom.xml
+++ b/jena-fuseki2/jena-fuseki-core/pom.xml
@@ -22,7 +22,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-fuseki</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <name>Apache Jena - Fuseki Core Engine</name>

--- a/jena-fuseki2/jena-fuseki-docker/pom.xml
+++ b/jena-fuseki2/jena-fuseki-docker/pom.xml
@@ -28,7 +28,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-fuseki</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
   
   <description>Fuseki Docker</description>

--- a/jena-fuseki2/jena-fuseki-fulljar/pom.xml
+++ b/jena-fuseki2/jena-fuseki-fulljar/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-fuseki</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent> 
 
   <packaging>jar</packaging>

--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -24,7 +24,6 @@
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-fuseki</artifactId>
       <version>5.1.0-SNAPSHOT</version>
-      <relativePath>../</relativePath>
     </parent>
     
     <description>GeoSPARQL with Fuseki</description>

--- a/jena-fuseki2/jena-fuseki-server/pom.xml
+++ b/jena-fuseki2/jena-fuseki-server/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-fuseki</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent> 
 
   <packaging>jar</packaging>

--- a/jena-fuseki2/jena-fuseki-ui/pom.xml
+++ b/jena-fuseki2/jena-fuseki-ui/pom.xml
@@ -26,7 +26,6 @@
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-fuseki</artifactId>
         <version>5.1.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <properties>

--- a/jena-fuseki2/jena-fuseki-war/pom.xml
+++ b/jena-fuseki2/jena-fuseki-war/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-fuseki</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <packaging>war</packaging>

--- a/jena-fuseki2/jena-fuseki-webapp/pom.xml
+++ b/jena-fuseki2/jena-fuseki-webapp/pom.xml
@@ -22,7 +22,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena-fuseki</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <name>Apache Jena - Fuseki Webapp</name>

--- a/jena-fuseki2/pom.xml
+++ b/jena-fuseki2/pom.xml
@@ -22,7 +22,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <name>Apache Jena - Fuseki - A SPARQL 1.1 Server</name>

--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -24,7 +24,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <description>GeoSPARQL implementation for Apache Jena</description>

--- a/jena-integration-tests/pom.xml
+++ b/jena-integration-tests/pom.xml
@@ -30,7 +30,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <properties>

--- a/jena-iri/pom.xml
+++ b/jena-iri/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
   
   <description>

--- a/jena-ontapi/pom.xml
+++ b/jena-ontapi/pom.xml
@@ -28,7 +28,6 @@
         <groupId>org.apache.jena</groupId>
         <artifactId>jena</artifactId>
         <version>5.1.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <description>Ontology API for Apache Jena</description>

--- a/jena-permissions/pom.xml
+++ b/jena-permissions/pom.xml
@@ -30,7 +30,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
   
   <organization>

--- a/jena-rdfconnection/pom.xml
+++ b/jena-rdfconnection/pom.xml
@@ -30,7 +30,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <licenses>

--- a/jena-rdfpatch/pom.xml
+++ b/jena-rdfpatch/pom.xml
@@ -27,7 +27,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <properties>

--- a/jena-shacl/pom.xml
+++ b/jena-shacl/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <description>SHACL engine for Apache Jena</description>

--- a/jena-tdb1/pom.xml
+++ b/jena-tdb1/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <description>TDB is a storage subsystem for Jena and ARQ, it is a native triple store providing persistent storage of triples/quads.</description>

--- a/jena-tdb2/pom.xml
+++ b/jena-tdb2/pom.xml
@@ -29,7 +29,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent> 
 
   <properties>

--- a/jena-text/pom.xml
+++ b/jena-text/pom.xml
@@ -26,7 +26,6 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>5.1.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <properties>


### PR DESCRIPTION
GitHub issue resolved #2494

And also gitignore another maven generated file.

Tested with maven 3.9.6 (latest) and 3.8.1, which is the declared in the POM as the minimum version.

----
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

