### PR TITLE
GH-2497: Clean warnings in jena-ontapi

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/vocabulary/SWRLB.java
+++ b/jena-core/src/main/java/org/apache/jena/vocabulary/SWRLB.java
@@ -30,7 +30,6 @@ import org.apache.jena.rdf.model.ResourceFactory;
  * @see <a href="https://www.w3.org/Submission/SWRL/#8">8. Built-Ins</a>
  * @see SWRL
  */
-@SuppressWarnings("unused")
 public class SWRLB {
     public final static String URI = "http://www.w3.org/2003/11/swrlb";
     public final static String NS = URI + "#";

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntJenaException.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntJenaException.java
@@ -58,7 +58,7 @@ public class OntJenaException extends JenaException {
      *
      * @param message error description
      * @param <X>     any
-     * @return {@link X}
+     * @return X
      */
     public static <X> X TODO(String message) {
         throw new RuntimeException(message);
@@ -68,7 +68,7 @@ public class OntJenaException extends JenaException {
      * @param object any
      * @param <X>    any
      * @return the specified {@code object}
-     * @throws IllegalStateException if {@link X} is {@code null}
+     * @throws IllegalStateException if {@code X} is {@code null}
      * @see java.util.Objects#requireNonNull(Object)
      */
     public static <X> X checkNotNull(X object) {
@@ -83,7 +83,7 @@ public class OntJenaException extends JenaException {
      * @param message error description
      * @param <X>     any
      * @return the specified {@code object}
-     * @throws IllegalStateException if {@link X} is {@code null}
+     * @throws IllegalStateException if {@code X} is {@code null}
      * @see java.util.Objects#requireNonNull(Object)
      */
     public static <X> X checkNotNull(X object, String message) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelControls.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelControls.java
@@ -136,6 +136,7 @@ public enum OntModelControls {
      * {@link OntClass.Named#addDisjointUnion(OntClass...) OntClass.Named#addDisjointUnion(OntClass...)},
      * will throw {@link OntJenaException.Unsupported OntJenaException.Unsupported} exception.
      */
+    @SuppressWarnings("javadoc")
     USE_OWL2_NAMED_CLASS_DISJOINT_UNION_FEATURE,
     /**
      * Controls {@link OWL2#disjointWith owl:disjointWith} functionality.

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/UnionGraph.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/UnionGraph.java
@@ -151,7 +151,7 @@ public interface UnionGraph extends Graph {
         /**
          * Lists all encapsulated listeners for the given type.
          *
-         * @param type {@link L}
+         * @param type {@code L}
          * @return Stream of {@link GraphListener}s
          * @param <L> {@code Class}-type of {@link GraphListener}
          */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntEnhGraph.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntEnhGraph.java
@@ -39,7 +39,6 @@ import org.apache.jena.rdf.model.RDFNode;
  * More about this see in the description for
  * the method {@link OntObjectPersonalityBuilder#add(Class, EnhNodeFactory)}.
  */
-@SuppressWarnings("unused")
 public interface OntEnhGraph {
 
     /**
@@ -155,7 +154,7 @@ public interface OntEnhGraph {
     }
 
     /**
-     * @param type {@link X}
+     * @param type {@code X}
      * @param <X>  any {@link OntObject} type
      * @throws OntJenaException.Unsupported if the {@code type} is not supported by the configuration
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntObjectPersonalityBuilder.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntObjectPersonalityBuilder.java
@@ -40,8 +40,6 @@ import java.util.stream.Collectors;
 /**
  * An {@link OntPersonality} builder.
  * This must be the only place to create various {@code OntPersonality} objects.
- * <p>
- * Created by @szz on 17.01.2019.
  */
 @SuppressWarnings("WeakerAccess")
 public class OntObjectPersonalityBuilder {
@@ -129,6 +127,7 @@ public class OntObjectPersonalityBuilder {
      * @param factory {@link EnhNodeFactory} the factory to produce the instances of the {@code type}
      * @return this builder
      */
+    @SuppressWarnings("javadoc")
     public OntObjectPersonalityBuilder add(Class<? extends OntObject> type, EnhNodeFactory factory) {
         return add(type, config -> factory);
     }
@@ -149,6 +148,7 @@ public class OntObjectPersonalityBuilder {
      * @param factory {@code Function}, providing {@link EnhNodeFactory} by the {@link OntConfig}
      * @return this builder
      */
+    @SuppressWarnings("javadoc")
     public OntObjectPersonalityBuilder add(Class<? extends OntObject> type, Function<OntConfig, EnhNodeFactory> factory) {
         extFactories.put(type, factory);
         return this;

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalities.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalities.java
@@ -108,7 +108,7 @@ public class OntPersonalities {
     /**
      * For RDFS Ontologies, limited functionality.
      *
-     * @see <a href='https://www.w3.org/TR/rdf12-schema/'>RDF 1.2 Schema</a>
+     * @see <a href="https://www.w3.org/TR/rdf12-schema/">RDF 1.2 Schema</a>
      */
     private static final OntObjectPersonalityBuilder RDFS_OBJECT_FACTORIES = templatePersonalityBuilder()
             .setName("RDFS")
@@ -520,7 +520,7 @@ public class OntPersonalities {
     /**
      * For OWL1.1 Lite Ontologies, limited functionality.
      *
-     * @see <a href="https://www.w3.org/TR/2004/REC-owl-features-20040210/#s3>Language Description of OWL Lite</a>
+     * @see <a href="https://www.w3.org/TR/2004/REC-owl-features-20040210/#s3">Language Description of OWL Lite</a>
      */
     private static final OntObjectPersonalityBuilder OWL1_LITE_OBJECT_FACTORIES = templatePersonalityBuilder()
             .setName("OWL1-LITE")

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonality.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonality.java
@@ -61,10 +61,7 @@ import java.util.stream.Stream;
  * <p>
  * Instances of this class must be unmodifiable and
  * the {@link OntObjectPersonalityBuilder builder} should be used to create instances with different settings.
- * <p>
- * Created by @szz on 15.01.2019.
  */
-@SuppressWarnings("unused")
 public interface OntPersonality {
 
     /**
@@ -168,7 +165,7 @@ public interface OntPersonality {
      *
      * @param type {@code Class}-type of {@link OntObject}
      * @param <T>  any subtype of {@link OntObject}
-     * @return Stream of all types where each element extends {@link T} inclusive
+     * @return Stream of all types where each element extends {@code T} inclusive
      */
     @SuppressWarnings("unchecked")
     default <T extends OntObject> Stream<Class<? extends T>> types(Class<T> type) {
@@ -195,7 +192,7 @@ public interface OntPersonality {
      * <p>
      * Each node obtained from this class must be IRI (i.e. {@code node.isURI() = true}).
      *
-     * @see <a href='https://www.w3.org/TR/owl2-new-features/#F12:_Punning'>Punnings</a>
+     * @see <a href="https://www.w3.org/TR/owl2-new-features/#F12:_Punning">Punnings</a>
      * @see OntEntity#types()
      */
     interface Punnings extends ResourceVocabulary<OntObject> {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalityImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalityImpl.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  * A default implementation of {@link OntPersonality}.
  * Mappings from [interface] Class objects of RDFNode to {@link Implementation} factories.
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings("WeakerAccess")
 public class OntPersonalityImpl extends Personality<RDFNode> implements OntPersonality {
     private final String name;
     private final OntConfig config;

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntVocabulary.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntVocabulary.java
@@ -93,7 +93,7 @@ public interface OntVocabulary {
      *
      * @param uri a URI-{@link Resource}, not {@code null}
      * @param <X> either {@link Resource} or {@link Property}
-     * @return a {@code Set} of {@link X}s, not {@code null} but possibly empty
+     * @return a {@code Set} of {@code X}s, not {@code null} but possibly empty
      */
     @SuppressWarnings("unchecked")
     default <X extends Resource> Set<X> get(Resource uri) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/PunningsMode.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/PunningsMode.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 /**
  * A standard personality mode to manage punnings.
  *
- * @see <a href='https://www.w3.org/TR/owl2-new-features/#F12:_Punning'>2.4.1 F12: Punning</a>
+ * @see <a href="https://www.w3.org/TR/owl2-new-features/#F12:_Punning">2.4.1 F12: Punning</a>
  */
 public enum PunningsMode {
     /**

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/ResourceVocabulary.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/ResourceVocabulary.java
@@ -37,7 +37,7 @@ public interface ResourceVocabulary<T extends Resource> {
     /**
      * Returns a {@code Set} of {@link Node Jena Graph Node}s for the given {@code Class}-type.
      *
-     * @param type {@link Class}, any subtype of {@link T}
+     * @param type {@link Class}, any subtype of {@code T}
      * @return Set of {@link Node node}s (immutable!), can be empty (if no mapping or type is not supported)
      */
     Set<Node> get(Class<? extends T> type) throws OntJenaException;
@@ -45,7 +45,7 @@ public interface ResourceVocabulary<T extends Resource> {
     /**
      * Answers {@code true} if the given type is supported by the vocabulary.
      *
-     * @param type {@link Class}, any subtype of {@link T}
+     * @param type {@link Class}, any subtype of {@code T}
      * @return boolean
      */
     boolean supports(Class<? extends T> type);

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/HierarchySupport.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/HierarchySupport.java
@@ -92,10 +92,10 @@ public final class HierarchySupport {
      * For the given object returns a {@code Set} of objects the same type,
      * that are its children which is determined by the operation {@code listChildren}.
      *
-     * @param root         {@link X}
-     * @param listChildren a {@code Function} that returns {@code Iterator} for an object of type {@link X}
+     * @param root         {@code X}
+     * @param listChildren a {@code Function} that returns {@code Iterator} for an object of type {@code X}
      * @param <X>          any subtype of {@link Resource}
-     * @return {@code Set} of {@link X}, {@code root} is not included
+     * @return {@code Set} of {@code X}, {@code root} is not included
      */
     static <X extends Resource> Stream<X> allTreeNodes(X root, Function<X, Stream<X>> listChildren) {
         return Iterators.fromSet(() -> {
@@ -131,8 +131,8 @@ public final class HierarchySupport {
     /**
      * For the given object recursively collects all children determined by the operation {@code listChildren}.
      *
-     * @param root        {@link X}
-     * @param getChildren a {@code Function} that returns {@code Set} explicit children of an object of type {@link X}
+     * @param root        {@code X}
+     * @param getChildren a {@code Function} that returns {@code Set} explicit children of an object of type {@code X}
      * @param res         {@code Set} to store result
      * @param <X>         any subtype of {@link Resource}
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
@@ -116,7 +116,7 @@ import java.util.stream.Stream;
  *
  * @see UnionGraph
  */
-@SuppressWarnings({"WeakerAccess", "SameParameterValue", "unused"})
+@SuppressWarnings({"WeakerAccess", "SameParameterValue"})
 public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph, InfModel {
 
     // the model's types mapper
@@ -195,7 +195,7 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
     /**
      * Filters {@code OntIndividual}s from the specified {@code ExtendedIterator}.
      *
-     * @param model      {@link M}, not {@code null}
+     * @param model      {@code M}, not {@code null}
      * @param reserved   a {@code Set} of forbidden URIs,
      *                   that cannot be treated as {@link OntClass Ontology Class}es, not {@code null}
      * @param assertions {@link ExtendedIterator} of {@link Triple}s
@@ -288,7 +288,7 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
      * @param it       {@code ExtendedIterator} obtained from the {@code graph}
      * @param withSize if {@code true} attempts to include graph size as an estimated size of a future {@code Stream}
      * @param <X>      type of stream items
-     * @return {@code Stream} of {@link X}s
+     * @return {@code Stream} of {@code X}s
      */
     private static <X> Stream<X> asStream(Graph graph,
                                           ExtendedIterator<X> it,
@@ -854,7 +854,7 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
      * @param list      {@link RDFList}, not {@code null}
      * @param subject   {@link OntObject}, not {@code null}
      * @param predicate {@link Property}, not {@code null}
-     * @param type      a {@code Class}-type for list element {@link E}, not {@code null}
+     * @param type      a {@code Class}-type for list element {@code E}, not {@code null}
      * @param <E>       any {@link RDFNode}
      * @return {@code OntList}
      */
@@ -873,7 +873,7 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
      * @param predicate       {@link Property}, not {@code null}
      * @param checkRecursions boolean, if {@code true} more careful and expensive checking for list content is performed
      * @param listType        an uri-{@link Resource}, used as an archaic RDF-type, usually this parameter should be {@code null}
-     * @param elementType     a {@code Class}-type for list element {@link E}, not {@code null}
+     * @param elementType     a {@code Class}-type for list element {@code E}, not {@code null}
      * @param <E>             any {@link RDFNode}
      * @return {@code OntList}
      */
@@ -894,8 +894,8 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
      *
      * @param subject   {@link OntObject}, not {@code null}
      * @param predicate {@link Property}, not {@code null}
-     * @param type      a {@code Class}-type for element {@link E}, not {@code null}
-     * @param elements  and {@code Iterator} of {@link E}-elements (the order is preserved), not {@code null}
+     * @param type      a {@code Class}-type for element {@code E}, not {@code null}
+     * @param elements  and {@code Iterator} of {@code E}-elements (the order is preserved), not {@code null}
      * @param <E>       any {@link RDFNode}
      * @return {@code OntList}
      */
@@ -912,8 +912,8 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
      * @param subject     {@link OntObject}, not {@code null}
      * @param predicate   {@link Property}, not {@code null}
      * @param listType    an uri-{@link Resource}, used as an archaic RDF-type, usually this parameter should be {@code null}
-     * @param elementType a {@code Class}-type for element {@link E}, not {@code null}
-     * @param elements    and {@code Iterator} of {@link E}-elements (the order is preserved), not {@code null}
+     * @param elementType a {@code Class}-type for element {@code E}, not {@code null}
+     * @param elements    and {@code Iterator} of {@code E}-elements (the order is preserved), not {@code null}
      * @param <E>         any {@link RDFNode}
      * @return {@code OntList}
      */
@@ -1215,13 +1215,13 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
     }
 
     /**
-     * Creates an object of type {@link X} if it is possible;
+     * Creates an object of type {@code X} if it is possible;
      * otherwise throws {@link OntJenaException.Unsupported} exception.
      *
-     * @param creator {@link Function} to create {@link X}
-     * @param type    of {@link X}
+     * @param creator {@link Function} to create {@code X}
+     * @param type    of {@code X}
      * @param <X>     {@link OntObject}
-     * @return {@link X}
+     * @return {@code X}
      * @throws OntJenaException.Unsupported if no possible to create an object
      */
     protected <X extends OntObject> X checkCreate(Function<OntGraphModelImpl, X> creator, Class<X> type) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/UnionGraphImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/UnionGraphImpl.java
@@ -115,9 +115,10 @@ public class UnionGraphImpl extends CompositionBase implements UnionGraph {
      * Creates a graph for the given {@code base}.
      *
      * @param base         {@link Graph}, not {@code null}
-     * @param eventManager {@link EventManager} or {@code null} to use default fresh event manager
+     * @param eventManager {@link UnionGraph.EventManager} or {@code null} to use default fresh event manager
      * @param distinct     if {@code true} a distinct graph is created
      */
+    @SuppressWarnings("javadoc")
     public UnionGraphImpl(Graph base, EventManager eventManager, boolean distinct) {
         this(base, new SubGraphs(), eventManager, distinct);
     }

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
@@ -314,7 +314,7 @@ public final class OWL2ObjectFactories {
             OntClasses.RESTRICTION_FINDER,
             EnhNodeFilter.ANON.and(new OntClasses.HasSelfFilter())
     );
-    // see <a href='https://www.w3.org/TR/owl2-quick-reference/#Class_Expressions'>Restrictions Using n-ary Data Range</a>
+    // see <a href="https://www.w3.org/TR/owl2-quick-reference/#Class_Expressions">Restrictions Using n-ary Data Range</a>
     public static final EnhNodeFactory NARY_DATA_ALL_VALUES_FROM_CLASS = OntClasses.createNaryRestrictionFactory(
             OntClassImpl.NaryDataAllValuesFromImpl.class,
             OWL2.allValuesFrom

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntClassImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntClassImpl.java
@@ -1266,6 +1266,7 @@ public abstract class OntClassImpl extends OntObjectImpl implements OntClass {
     /**
      * Base for all {@link Restriction} impls.
      */
+    @SuppressWarnings("javadoc")
     public static class RestrictionImpl extends OntClassImpl implements Restriction {
 
         public RestrictionImpl(Node n, EnhGraph m) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntDisjointImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntDisjointImpl.java
@@ -67,8 +67,9 @@ public abstract class OntDisjointImpl<O extends OntObject> extends OntObjectImpl
      * @param model       {@link OntGraphModelImpl}
      * @param individuals stream of {@link OntIndividual}
      * @return {@link Individuals}
-     * @see <a href='https://www.w3.org/TR/owl2-quick-reference/#Additional_Vocabulary_in_OWL_2_RDF_Syntax'>4.2 Additional Vocabulary in OWL 2 RDF Syntax</a>
+     * @see <a href="https://www.w3.org/TR/owl2-quick-reference/#Additional_Vocabulary_in_OWL_2_RDF_Syntax">4.2 Additional Vocabulary in OWL 2 RDF Syntax</a>
      */
+    @SuppressWarnings("javadoc")
     public static Individuals createDifferentIndividuals(OntGraphModelImpl model, Stream<OntIndividual> individuals) {
         Property membersPredicate = OntGraphModelImpl.configValue(model, OntModelControls.USE_OWL1_DISTINCT_MEMBERS_PREDICATE_FEATURE) ?
                 OWL2.distinctMembers :

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntIndividualImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntIndividualImpl.java
@@ -260,6 +260,7 @@ public abstract class OntIndividualImpl extends OntObjectImpl implements OntIndi
      * <p>
      * for notations see <a href="https://www.w3.org/TR/owl2-quick-reference/">OWL2 Quick Refs</a>
      */
+    @SuppressWarnings("javadoc")
     public static class AnonymousImpl extends OntIndividualImpl implements Anonymous {
 
         public AnonymousImpl(Node n, EnhGraph m) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntListImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntListImpl.java
@@ -424,10 +424,10 @@ public abstract class OntListImpl<E extends RDFNode> extends ResourceImpl implem
     }
 
     /**
-     * Lists all elements of type {@link E} from this list.
+     * Lists all elements of type {@code E} from this list.
      * Note: the list may contain nodes with incompatible type, in this case they will be skipped.
      *
-     * @return {@link ExtendedIterator} of {@link E}-elements
+     * @return {@link ExtendedIterator} of {@code E}-elements
      */
     public ExtendedIterator<E> listMembers() {
         Iterator<List<Triple>> it = createRDFListIterator();
@@ -505,10 +505,10 @@ public abstract class OntListImpl<E extends RDFNode> extends ResourceImpl implem
     public abstract boolean isValid(RDFNode n);
 
     /**
-     * Makes an {@link E}-resource from the given {@link RDFNode RDF-Node}.
+     * Makes an {@code E}-resource from the given {@link RDFNode RDF-Node}.
      *
      * @param n {@link RDFNode}
-     * @return {@link RDFNode} of type {@link E}
+     * @return {@link RDFNode} of type {@code E}
      */
     public abstract E cast(RDFNode n);
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntObjectImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntObjectImpl.java
@@ -164,7 +164,7 @@ public class OntObjectImpl extends ResourceImpl implements OntObject {
      * @param node {@link RDFNode}, not {@code null}
      * @param view a {@code Class}-type of the desired RDF view (interface)
      * @param <X>  any subtype of {@link RDFNode}
-     * @return an instance of the type {@link X} or {@code null}
+     * @return an instance of the type {@code X} or {@code null}
      * @see OntGraphModelImpl#getNodeAs(Node, Class)
      */
     public static <X extends RDFNode> X getNodeAs(RDFNode node, Class<X> view) {
@@ -261,6 +261,7 @@ public class OntObjectImpl extends ResourceImpl implements OntObject {
      * that an {@code OntObject} can be also a {@code Literal}
      * (but in only single case when it is {@link OntSWRL.DArg}).
      */
+    @SuppressWarnings("javadoc")
     @Override
     public <X extends RDFNode> X getAs(Class<X> type) {
         return getNodeAs(this, type);
@@ -603,7 +604,7 @@ public class OntObjectImpl extends ResourceImpl implements OntObject {
      * @param predicate {@link Property}
      * @param type      subclass of {@link RDFNode}
      * @param <T>       any subtype of {@link RDFNode}
-     * @return Optional around {@link T}
+     * @return Optional around {@code T}
      */
     public <T extends RDFNode> Optional<T> object(Property predicate, Class<T> type) {
         return Iterators.findFirst(listObjects(predicate, type));
@@ -615,7 +616,7 @@ public class OntObjectImpl extends ResourceImpl implements OntObject {
      * @param predicate {@link Property} predicate, can be null
      * @param type      Interface to find and cast, not null
      * @param <O>       any subtype of {@link RDFNode}
-     * @return Stream of {@link RDFNode node}s of the {@link O} type
+     * @return Stream of {@link RDFNode node}s of the {@code O} type
      */
     @Override
     public <O extends RDFNode> Stream<O> objects(Property predicate, Class<O> type) {
@@ -628,7 +629,7 @@ public class OntObjectImpl extends ResourceImpl implements OntObject {
      * @param predicate {@link Property}, can be {@code null}
      * @param type      class-type of interface to find and cast, not {@code null}
      * @param <O>       subtype of {@link RDFNode rdf-node}
-     * @return {@link ExtendedIterator} of {@link RDFNode node}s of the type {@link O}
+     * @return {@link ExtendedIterator} of {@link RDFNode node}s of the type {@code O}
      * @see #object(Property, Class)
      * @see #listSubjects(Property, Class)
      */
@@ -645,7 +646,7 @@ public class OntObjectImpl extends ResourceImpl implements OntObject {
      * @param predicate {@link Property}, can be {@code null}
      * @param type      class-type of interface to find and cast, not {@code null}
      * @param <S>       subtype of {@link RDFNode rdf-node}
-     * @return {@link ExtendedIterator} of {@link RDFNode node}s of the type {@link S}
+     * @return {@link ExtendedIterator} of {@link RDFNode node}s of the type {@code S}
      * @see #listObjects(Property, Class)
      */
     public <S extends RDFNode> ExtendedIterator<S> listSubjects(Property predicate, Class<S> type) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntSimpleClassImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntSimpleClassImpl.java
@@ -207,6 +207,7 @@ public class OntSimpleClassImpl extends OntObjectImpl implements OntClass {
      * In jena OWL1, class expressions, such as {@link OntClass.ComplementOf}
      * can also be named.
      */
+    @SuppressWarnings("javadoc")
     public static class NamedImpl extends OntSimpleClassImpl implements OntClass.Named {
 
         public NamedImpl(Node n, EnhGraph eg) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntStatementImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntStatementImpl.java
@@ -399,7 +399,7 @@ public class OntStatementImpl extends StatementImpl implements OntStatement {
     /**
      * Returns the {@code rdf:type} of the attached annotation objects.
      *
-     * @return {@link OWL2#Axiom {@code owl:Axiom}} or {@link OWL2#Annotation {@code owl:Annotation}}
+     * @return {@link OWL2#Axiom} for {@code owl:Axiom} or {@link OWL2#Annotation} for {@code owl:Annotation}
      */
     protected Resource getAnnotationResourceType() {
         return getAnnotationRootType(subject);

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/AsNamed.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/AsNamed.java
@@ -30,7 +30,7 @@ interface AsNamed<E extends OntEntity> {
      * Represents this OWL expression as a named OWL entity if it is possible, otherwise throws an exception.
      * Effectively equivalent to the expression {@code this.as(Named.class)}.
      *
-     * @return {@link E}, never {@code null}
+     * @return {@code E}, never {@code null}
      * @throws org.apache.jena.enhanced.UnsupportedPolymorphismException if the expression is not named OWL entity
      * @see org.apache.jena.rdf.model.RDFNode#as(Class)
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/CreateClasses.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/CreateClasses.java
@@ -41,7 +41,7 @@ interface CreateClasses {
      * @param property {@link OntObjectProperty object property expression}, not {@code null}
      * @param ce       {@link OntClass class expression}, not {@code null}
      * @return {@link OntClass.ObjectSomeValuesFrom}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Existential_Quantification'>8.2.1 Existential Quantification</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Existential_Quantification">8.2.1 Existential Quantification</a>
      */
     OntClass.ObjectSomeValuesFrom createObjectSomeValuesFrom(OntObjectProperty property, OntClass ce);
 
@@ -57,7 +57,7 @@ interface CreateClasses {
      * @param property {@link OntDataProperty data property}, not {@code null}
      * @param dr       {@link OntDataRange data range}, not {@code null}
      * @return {@link OntClass.DataSomeValuesFrom}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Existential_Quantification_2'>8.4.1 Existential Quantification</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Existential_Quantification_2">8.4.1 Existential Quantification</a>
      */
     OntClass.DataSomeValuesFrom createDataSomeValuesFrom(OntDataProperty property, OntDataRange dr);
 
@@ -73,7 +73,7 @@ interface CreateClasses {
      * @param property {@link OntObjectProperty object property expression}, not {@code null}
      * @param ce       {@link OntClass class expression}, not {@code null}
      * @return {@link OntClass.ObjectAllValuesFrom}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Universal_Quantification'>8.2.2 Universal Quantification</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Universal_Quantification">8.2.2 Universal Quantification</a>
      */
     OntClass.ObjectAllValuesFrom createObjectAllValuesFrom(OntObjectProperty property, OntClass ce);
 
@@ -89,7 +89,7 @@ interface CreateClasses {
      * @param property {@link OntDataProperty data property}, not {@code null}
      * @param dr       {@link OntDataRange data range}, not {@code null}
      * @return {@link OntClass.DataAllValuesFrom}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Universal_Quantification_2'>8.4.2 Universal Quantification</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Universal_Quantification_2">8.4.2 Universal Quantification</a>
      */
     OntClass.DataAllValuesFrom createDataAllValuesFrom(OntDataProperty property, OntDataRange dr);
 
@@ -105,7 +105,7 @@ interface CreateClasses {
      * @param property   {@link OntObjectProperty object property expression}, not {@code null}
      * @param individual {@link OntIndividual}, not {@code null}
      * @return {@link OntClass.ObjectHasValue}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Individual_Value_Restriction'>8.2.3 Individual Value Restriction</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Individual_Value_Restriction">8.2.3 Individual Value Restriction</a>
      */
     OntClass.ObjectHasValue createObjectHasValue(OntObjectProperty property, OntIndividual individual);
 
@@ -121,7 +121,7 @@ interface CreateClasses {
      * @param property {@link OntDataProperty data property}, not {@code null}
      * @param literal  {@link Literal}, not {@code null}
      * @return {@link OntClass.DataHasValue}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Literal_Value_Restriction'>8.4.3 Literal Value Restriction</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Literal_Value_Restriction">8.4.3 Literal Value Restriction</a>
      */
     OntClass.DataHasValue createDataHasValue(OntDataProperty property, Literal literal);
 
@@ -146,7 +146,7 @@ interface CreateClasses {
      * @param cardinality {@code int}, non-negative number
      * @param ce          {@link OntClass class expression} or {@code null}
      * @return {@link OntClass.ObjectMinCardinality}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Minimum_Cardinality'>8.3.1 Minimum Cardinality</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Minimum_Cardinality">8.3.1 Minimum Cardinality</a>
      */
     OntClass.ObjectMinCardinality createObjectMinCardinality(OntObjectProperty property, int cardinality, OntClass ce);
 
@@ -170,7 +170,7 @@ interface CreateClasses {
      * @param cardinality {@code int}, non-negative number
      * @param dr          {@link OntDataRange data range} or {@code null}
      * @return {@link OntClass.DataMinCardinality}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Minimum_Cardinality_2'>8.5.1 Minimum Cardinality</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Minimum_Cardinality_2">8.5.1 Minimum Cardinality</a>
      */
     OntClass.DataMinCardinality createDataMinCardinality(OntDataProperty property, int cardinality, OntDataRange dr);
 
@@ -195,7 +195,7 @@ interface CreateClasses {
      * @param cardinality  {@code int}, non-negative number
      * @param ce           {@link OntClass class expression} or {@code null}
      * @return {@link OntClass.ObjectMaxCardinality}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Maximum_Cardinality'>8.3.2 Maximum Cardinality</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Maximum_Cardinality">8.3.2 Maximum Cardinality</a>
      */
     OntClass.ObjectMaxCardinality createObjectMaxCardinality(OntObjectProperty property, int cardinality, OntClass ce);
 
@@ -219,7 +219,7 @@ interface CreateClasses {
      * @param cardinality {@code int}, non-negative number
      * @param dr          {@link OntDataRange data range} or {@code null}
      * @return {@link OntClass.DataMaxCardinality}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Maximum_Cardinality_2'>8.5.2 Maximum Cardinality</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Maximum_Cardinality_2">8.5.2 Maximum Cardinality</a>
      */
     OntClass.DataMaxCardinality createDataMaxCardinality(OntDataProperty property, int cardinality, OntDataRange dr);
 
@@ -244,7 +244,7 @@ interface CreateClasses {
      * @param cardinality  {@code int}, non-negative number
      * @param ce           {@link OntClass class expression} or {@code null}
      * @return {@link OntClass.ObjectCardinality}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Exact_Cardinality'>8.3.3 Exact Cardinality</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Exact_Cardinality">8.3.3 Exact Cardinality</a>
      */
     OntClass.ObjectCardinality createObjectCardinality(OntObjectProperty property, int cardinality, OntClass ce);
 
@@ -268,7 +268,7 @@ interface CreateClasses {
      * @param cardinality {@code int}, non-negative number
      * @param dr          {@link OntDataRange data range} or {@code null}
      * @return {@link OntClass.DataCardinality}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Exact_Cardinality_2'>8.5.3 Exact Cardinality</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Exact_Cardinality_2">8.5.3 Exact Cardinality</a>
      */
     OntClass.DataCardinality createDataCardinality(OntDataProperty property, int cardinality, OntDataRange dr);
 
@@ -283,7 +283,7 @@ interface CreateClasses {
      *
      * @param property {@link OntObjectProperty object property expression}, not {@code null}
      * @return {@link OntClass.HasSelf}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Self-Restriction'>8.2.4 Self-Restriction</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Self-Restriction">8.2.4 Self-Restriction</a>
      */
     OntClass.HasSelf createHasSelf(OntObjectProperty property);
 
@@ -297,7 +297,7 @@ interface CreateClasses {
      *
      * @param classes {@code Collection} of {@link OntClass class expression}s without {@code null}s
      * @return {@link OntClass.UnionOf}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Union_of_Class_Expressions'>8.1.2 Union of Class Expressions</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Union_of_Class_Expressions">8.1.2 Union of Class Expressions</a>
      */
     OntClass.UnionOf createObjectUnionOf(Collection<OntClass> classes);
 
@@ -311,7 +311,7 @@ interface CreateClasses {
      *
      * @param classes {@code Collection} of {@link OntClass class expression}s without {@code null}s
      * @return {@link OntClass.IntersectionOf}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Intersection_of_Class_Expressions'>8.1.1 Intersection of Class Expressions</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Intersection_of_Class_Expressions">8.1.1 Intersection of Class Expressions</a>
      */
     OntClass.IntersectionOf createObjectIntersectionOf(Collection<OntClass> classes);
 
@@ -325,7 +325,7 @@ interface CreateClasses {
      *
      * @param individuals {@code Collection} of {@link OntIndividual individual}s without {@code null}s
      * @return {@link OntClass.OneOf}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Enumeration_of_Individuals'>8.1.4 Enumeration of Individuals</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Enumeration_of_Individuals">8.1.4 Enumeration of Individuals</a>
      */
     OntClass.OneOf createObjectOneOf(Collection<OntIndividual> individuals);
 
@@ -339,7 +339,7 @@ interface CreateClasses {
      *
      * @param ce {@link OntClass class expression} or {@code null}
      * @return {@link OntClass.ComplementOf}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Complement_of_Class_Expressions'>8.1.3 Complement of Class Expressions</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Complement_of_Class_Expressions">8.1.3 Complement of Class Expressions</a>
      */
     OntClass.ComplementOf createObjectComplementOf(OntClass ce);
 
@@ -358,7 +358,7 @@ interface CreateClasses {
      * @return {@link OntClass.NaryDataAllValuesFrom}
      * @see OntDataRange#arity()
      * @see #createDataAllValuesFrom(OntDataProperty, OntDataRange)
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Universal_Quantification_2'>8.4.2 Universal Quantification</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Universal_Quantification_2">8.4.2 Universal Quantification</a>
      */
     OntClass.NaryDataAllValuesFrom createDataAllValuesFrom(Collection<OntDataProperty> properties, OntDataRange dr);
 
@@ -377,7 +377,7 @@ interface CreateClasses {
      * @return {@link OntClass.NaryDataAllValuesFrom}
      * @see OntDataRange#arity()
      * @see #createDataSomeValuesFrom(OntDataProperty, OntDataRange)
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Existential_Quantification_2'>8.4.1 Existential Quantification</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Existential_Quantification_2">8.4.1 Existential Quantification</a>
      */
     OntClass.NaryDataSomeValuesFrom createDataSomeValuesFrom(Collection<OntDataProperty> properties, OntDataRange dr);
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/CreateDisjoint.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/CreateDisjoint.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 
 /**
  * A technical interface to generate {@link OntDisjoint Disjoint Resource}s.
- * Created by @szz on 14.05.2019.
  */
 interface CreateDisjoint {
 
@@ -39,7 +38,7 @@ interface CreateDisjoint {
      *
      * @param classes {@code Collection} of {@link OntClass Class Expression}s without {@code null}-elements
      * @return {@link OntDisjoint.Classes}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Disjoint_Classes'>9.1.3 Disjoint Classes</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Disjoint_Classes">9.1.3 Disjoint Classes</a>
      */
     OntDisjoint.Classes createDisjointClasses(Collection<OntClass> classes);
 
@@ -55,7 +54,7 @@ interface CreateDisjoint {
      *
      * @param individuals {@code Collection} of {@link OntIndividual Individual}s without {@code null}-elements
      * @return {@link OntDisjoint.Individuals}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Individual_Inequality'>9.6.2 Individual Inequality </a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Individual_Inequality">9.6.2 Individual Inequality </a>
      */
     OntDisjoint.Individuals createDifferentIndividuals(Collection<OntIndividual> individuals);
 
@@ -69,7 +68,7 @@ interface CreateDisjoint {
      *
      * @param properties {@code Collection} of {@link OntObjectProperty object property expression}s without {@code null}-elements
      * @return {@link OntDisjoint.ObjectProperties}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Disjoint_Object_Properties'>9.2.3 Disjoint Object Properties</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Disjoint_Object_Properties">9.2.3 Disjoint Object Properties</a>
      */
     OntDisjoint.ObjectProperties createDisjointObjectProperties(Collection<OntObjectProperty> properties);
 
@@ -83,7 +82,7 @@ interface CreateDisjoint {
      *
      * @param properties {@code Collection} of {@link OntDataProperty data properties} without {@code null}-elements
      * @return {@link OntDisjoint.DataProperties}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Disjoint_Data_Properties'>9.3.3 Disjoint Data Properties</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Disjoint_Data_Properties">9.3.3 Disjoint Data Properties</a>
      */
     OntDisjoint.DataProperties createDisjointDataProperties(Collection<OntDataProperty> properties);
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/CreateRanges.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/CreateRanges.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 
 /**
  * A technical interface to generate {@link OntDataRange Data Range Expression}s.
- * Created by @szz on 14.05.2019.
  */
 interface CreateRanges {
 
@@ -39,7 +38,7 @@ interface CreateRanges {
      *
      * @param values {@code Collection} of {@link Literal literal}s, without {@code null}s
      * @return {@link OntDataRange.OneOf}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Enumeration_of_Literals'>7.4 Enumeration of Literals</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Enumeration_of_Literals">7.4 Enumeration of Literals</a>
      */
     OntDataRange.OneOf createDataOneOf(Collection<Literal> values);
 
@@ -56,7 +55,7 @@ interface CreateRanges {
      * @param other  {@link OntDataRange.Named}, not {@code null}
      * @param values {@code Collection} of {@link OntFacetRestriction facet restriction}s, without {@code null}s
      * @return {@link OntDataRange.Restriction}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Datatype_Restrictions'>7.5 Datatype Restrictions</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Datatype_Restrictions">7.5 Datatype Restrictions</a>
      * @see OntFacetRestriction
      * @see OntModel#createFacetRestriction(Class, Literal)
      */
@@ -72,7 +71,7 @@ interface CreateRanges {
      *
      * @param other {@link OntDataRange}, not {@code null}
      * @return {@link OntDataRange.ComplementOf}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Complement_of_Data_Ranges'>7.3 Complement of Data Ranges</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Complement_of_Data_Ranges">7.3 Complement of Data Ranges</a>
      */
     OntDataRange.ComplementOf createDataComplementOf(OntDataRange other);
 
@@ -86,7 +85,7 @@ interface CreateRanges {
      *
      * @param values {@code Collection} of {@link OntDataRange data range}s, without {@code null}s
      * @return {@link OntDataRange.UnionOf}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Union_of_Data_Ranges'>7.2 Union of Data Ranges</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Union_of_Data_Ranges">7.2 Union of Data Ranges</a>
      */
     OntDataRange.UnionOf createDataUnionOf(Collection<OntDataRange> values);
 
@@ -100,7 +99,7 @@ interface CreateRanges {
      *
      * @param values {@code Collection} of {@link OntDataRange data range}s, without {@code null}s
      * @return {@link OntDataRange.IntersectionOf}
-     * @see <a href='https://www.w3.org/TR/owl-syntax/#Intersection_of_Data_Ranges'>7.1 Intersection of Data Ranges</a>
+     * @see <a href="https://www.w3.org/TR/owl-syntax/#Intersection_of_Data_Ranges">7.1 Intersection of Data Ranges</a>
      */
     OntDataRange.IntersectionOf createDataIntersectionOf(Collection<OntDataRange> values);
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/CreateSWRL.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/CreateSWRL.java
@@ -26,8 +26,6 @@ import java.util.Collection;
 
 /**
  * A technical interface to generate SWRL Objects (Variable, Atoms, Imp).
- * <p>
- * Created by @szz on 14.05.2019.
  */
 interface CreateSWRL {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/HasProperties.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/HasProperties.java
@@ -22,7 +22,7 @@ import org.apache.jena.ontapi.OntJenaException;
 import org.apache.jena.vocabulary.OWL2;
 
 /**
- * A technical interface to access {@link P} properties from a []-list
+ * A technical interface to access {@code P} properties from a []-list
  * on predicate {@link OWL2#onProperties owl:onProperties}.
  *
  * @param <P> - any subtype of {@link OntRelationalProperty} in general case,
@@ -35,7 +35,7 @@ interface HasProperties<P extends OntRelationalProperty> extends HasRDFNodeList<
      * Gets the first property from {@code owl:onProperties} []-list.
      * Currently, in OWL2, a []-list from n-ary Restrictions may contain one and only one (data) property.
      *
-     * @return {@link P}
+     * @return {@code P}
      * @see OntDataRange#arity()
      */
     @Override

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/HasProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/HasProperty.java
@@ -21,7 +21,7 @@ package org.apache.jena.ontapi.model;
 import org.apache.jena.vocabulary.OWL2;
 
 /**
- * A technical interface to access {@link P} property
+ * A technical interface to access {@code P} property
  * on predicate {@link OWL2#onProperty owl:onProperty}.
  *
  * @param <P> - {@link OntRelationalProperty Data or Object} property expression
@@ -33,7 +33,7 @@ interface HasProperty<P extends OntRelationalProperty> {
      * that this {@link OntClass.UnaryRestriction} has inside its RDF structure
      * on predicate {@link OWL2#onProperty owl:onProperty}.
      *
-     * @return {@link P}
+     * @return {@code P}
      */
     P getProperty();
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/HasRDFNodeList.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/HasRDFNodeList.java
@@ -30,7 +30,7 @@ import org.apache.jena.rdf.model.RDFNode;
 interface HasRDFNodeList<E extends RDFNode> {
 
     /**
-     * Gets an unmodifiable []-list with items of the type {@link E}
+     * Gets an unmodifiable []-list with items of the type {@code E}
      *
      * @return {@link RDFNodeList}
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/HasValue.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/HasValue.java
@@ -41,7 +41,7 @@ interface HasValue<V extends RDFNode> {
      * (the filler is expected to be either {@link OWL2#Thing owl:Thing}
      * for object restriction or {@link org.apache.jena.vocabulary.RDFS#Literal} for data restriction).
      *
-     * @return {@link V}, not {@code null}
+     * @return {@code V}, not {@code null}
      * @see SetValue#setValue(RDFNode)
      */
     V getValue();

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntAnnotation.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntAnnotation.java
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
  * <p>
  *
  * @see OntStatement
- * @see <a href='https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations'>2.2 Translation of Annotations</a>
+ * @see <a href="https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations">2.2 Translation of Annotations</a>
  */
 public interface OntAnnotation extends OntObject {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntAnnotationProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntAnnotationProperty.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
  * the {@link OntEntity OWL Entity} and the {@link OntProperty abstract property expression} interfaces.
  * In OWL2, an Annotation Property cannot be anonymous.
  *
- * @see <a href='https://www.w3.org/TR/owl2-syntax/#Annotation_Properties'>5.5 Annotation Properties</a>
+ * @see <a href="https://www.w3.org/TR/owl2-syntax/#Annotation_Properties">5.5 Annotation Properties</a>
  */
 public interface OntAnnotationProperty extends OntProperty, OntNamedProperty<OntAnnotationProperty> {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntClass.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntClass.java
@@ -248,6 +248,7 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
      * @return {@link OntList} of {@link OntRelationalProperty}s
      * @see #addHasKey(Collection, Collection)
      */
+    @SuppressWarnings("javadoc")
     OntList<OntRelationalProperty> createHasKey(Collection<OntObjectProperty> objectProperties,
                                                 Collection<OntDataProperty> dataProperties);
 
@@ -476,7 +477,7 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
      * @return {@link OntStatement} to allow the subsequent annotations addition
      * @see #addHasKeyStatement(OntRelationalProperty...)
      * @see #addHasKey(OntRelationalProperty...)
-     * @see <a href='https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations'>2.3.1 Axioms that Generate a Main Triple</a>
+     * @see <a href="https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations">2.3.1 Axioms that Generate a Main Triple</a>
      */
     default OntStatement addHasKeyStatement(Collection<OntObjectProperty> objectProperties,
                                             Collection<OntDataProperty> dataProperties) {
@@ -882,7 +883,7 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
      * An OWL Class {@link OntEntity Entity}, a named class expression.
      * This is an analogue of {@link org.apache.jena.ontology.OntClass}, but for OWL2.
      *
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Classes'>5.1 Classes</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Classes">5.1 Classes</a>
      */
     interface Named extends OntEntity, OntClass {
 
@@ -908,6 +909,7 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
          * @see #addDisjointUnionOfStatement(OntClass...)
          * @see #removeDisjointUnion(Resource)
          */
+        @SuppressWarnings("javadoc")
         OntList<OntClass> createDisjointUnion(Collection<OntClass> classes);
 
         /**
@@ -962,7 +964,7 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
          * @param classes a collection of {@link OntClass class expression}s without {@code null}s
          * @return {@link OntStatement} to allow the subsequent annotations addition
          * @see #createDisjointUnion(Collection)
-         * @see <a href='https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations'>2.3.1 Axioms that Generate a Main Triple</a>
+         * @see <a href="https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations">2.3.1 Axioms that Generate a Main Triple</a>
          * @see #createDisjointUnion(Collection)
          * @see #addDisjointUnion(Collection)
          * @see #addDisjointUnionOfStatement(Collection)
@@ -1233,7 +1235,7 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
          * Note that the returned values are not necessarily the same as {@link OntList#members()} output:
          * some profiles (e.g., OWL2 QL) impose some restrictions.
          *
-         * @return a {@code Stream} of {@link O}s
+         * @return a {@code Stream} of {@code O}s
          */
         default Stream<O> components() {
             return getList().members();

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntDataProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntDataProperty.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
  * (as distinct from object property expression valued {@link OntObjectProperty properties}).
  * In OWL2, a Data Property cannot be anonymous.
  *
- * @see <a href='https://www.w3.org/TR/owl2-syntax/#Data_Properties'>5.4 Data Properties</a>
+ * @see <a href="https://www.w3.org/TR/owl2-syntax/#Data_Properties">5.4 Data Properties</a>
  */
 public interface OntDataProperty extends OntRelationalProperty, OntNamedProperty<OntDataProperty>, HasDisjoint<OntDataProperty> {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntDataRange.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntDataRange.java
@@ -33,8 +33,8 @@ import java.util.stream.Stream;
  * A base abstraction for Ontology Data Range Expressions (both named and anonymous).
  *
  * @see Named - a named data range (i.e. OWL Datatype)
- * @see <a href='https://www.w3.org/TR/owl2-quick-reference/#Data_Ranges'>2.4 Data Ranges</a>
- * @see <a href='https://www.w3.org/TR/owl2-syntax/#Data_Ranges'>7 Data Ranges</a>
+ * @see <a href="https://www.w3.org/TR/owl2-quick-reference/#Data_Ranges">2.4 Data Ranges</a>
+ * @see <a href="https://www.w3.org/TR/owl2-syntax/#Data_Ranges">7 Data Ranges</a>
  */
 public interface OntDataRange extends OntObject, AsNamed<OntDataRange.Named> {
 
@@ -56,35 +56,35 @@ public interface OntDataRange extends OntObject, AsNamed<OntDataRange.Named> {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Complement_of_Data_Ranges'>7.3 Complement of Data Ranges</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Complement_of_Data_Ranges">7.3 Complement of Data Ranges</a>
      * @see OntModel#createDataComplementOf(OntDataRange)
      */
     interface ComplementOf extends OntDataRange, SetValue<OntDataRange, ComplementOf>, HasValue<OntDataRange> {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Intersection_of_Data_Ranges'>7.1 Intersection of Data Ranges</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Intersection_of_Data_Ranges">7.1 Intersection of Data Ranges</a>
      * @see OntModel#createDataIntersectionOf(Collection)
      */
     interface IntersectionOf extends Combination<OntDataRange>, SetComponents<OntDataRange, IntersectionOf> {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Union_of_Data_Ranges'>7.2 Union of Data Ranges</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Union_of_Data_Ranges">7.2 Union of Data Ranges</a>
      * @see OntModel#createDataUnionOf(Collection)
      */
     interface UnionOf extends Combination<OntDataRange>, SetComponents<OntDataRange, UnionOf> {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Enumeration_of_Literals'>7.4 Enumeration of Literals</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Enumeration_of_Literals">7.4 Enumeration of Literals</a>
      * @see OntModel#createDataOneOf(Collection)
      */
     interface OneOf extends Combination<Literal>, SetComponents<Literal, OneOf> {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Datatype_Restrictions'>7.5 Datatype Restrictions</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Datatype_Restrictions">7.5 Datatype Restrictions</a>
      * @see OntFacetRestriction
      * @see OntModel#createFacetRestriction(Class, Literal)
      * @see OntModel#createDataRestriction(Named, Collection)
@@ -126,7 +126,7 @@ public interface OntDataRange extends OntObject, AsNamed<OntDataRange.Named> {
      * Interface encapsulating an Ontology Datatype, {@link OntEntity OWL Entity},
      * a named {@link OntDataRange data range} expression.
      *
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Datatypes'>5.2 Datatypes</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Datatypes">5.2 Datatypes</a>
      */
     interface Named extends OntEntity, OntDataRange {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntDisjoint.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntDisjoint.java
@@ -45,14 +45,14 @@ public interface OntDisjoint<O extends OntObject> extends OntObject, HasRDFNodeL
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Disjoint_Classes'>9.1.3 Disjoint Classes</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Disjoint_Classes">9.1.3 Disjoint Classes</a>
      * @see OntModel#createDisjointClasses(Collection)
      */
     interface Classes extends OntDisjoint<OntClass>, SetComponents<OntClass, Classes> {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Individual_Inequality'>9.6.2 Individual Inequality</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Individual_Inequality">9.6.2 Individual Inequality</a>
      * @see OntModel#createDifferentIndividuals(Collection)
      */
     interface Individuals extends OntDisjoint<OntIndividual>, SetComponents<OntIndividual, Individuals> {
@@ -84,14 +84,14 @@ public interface OntDisjoint<O extends OntObject> extends OntObject, HasRDFNodeL
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Disjoint_Object_Properties'>9.2.3 Disjoint Object Properties</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Disjoint_Object_Properties">9.2.3 Disjoint Object Properties</a>
      * @see OntModel#createDisjointObjectProperties(Collection)
      */
     interface ObjectProperties extends Properties<OntObjectProperty>, SetComponents<OntObjectProperty, ObjectProperties> {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Disjoint_Data_Properties'>9.3.3 Disjoint Data Properties</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Disjoint_Data_Properties">9.3.3 Disjoint Data Properties</a>
      * @see OntModel#createDisjointDataProperties(Collection)
      */
     interface DataProperties extends Properties<OntDataProperty>, SetComponents<OntDataProperty, DataProperties> {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntEntity.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntEntity.java
@@ -98,6 +98,7 @@ public interface OntEntity extends OntObject {
      * @see OWL2
      * @see OntPersonality.Builtins
      */
+    @SuppressWarnings("javadoc")
     boolean isBuiltIn();
 
 }

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntFacetRestriction.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntFacetRestriction.java
@@ -24,8 +24,8 @@ import org.apache.jena.vocabulary.XSD;
 /**
  * Interface encapsulating an Ontology Facet Restriction abstraction.
  *
- * @see <a href='https://www.w3.org/TR/owl2-quick-reference/#Facets'>3.2 Facets</a>
- * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-facets'>4.3 Constraining Facets</a>
+ * @see <a href="https://www.w3.org/TR/owl2-quick-reference/#Facets">3.2 Facets</a>
+ * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-facets">4.3 Constraining Facets</a>
  * @see XSD
  * @see OntModel#createFacetRestriction(Class, Literal)
  */
@@ -38,67 +38,67 @@ public interface OntFacetRestriction extends OntObject {
     Literal getValue();
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-pattern'>4.3.4 pattern</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-pattern">4.3.4 pattern</a>
      */
     interface Pattern extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-length'>4.3.1 length</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-length">4.3.1 length</a>
      */
     interface Length extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-minLength'>4.3.2 minLength</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-minLength">4.3.2 minLength</a>
      */
     interface MinLength extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-maxLength'>4.3.3 maxLength</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-maxLength">4.3.3 maxLength</a>
      */
     interface MaxLength extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-minInclusive'>4.3.10 minInclusive</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-minInclusive">4.3.10 minInclusive</a>
      */
     interface MinInclusive extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-maxInclusive'>4.3.7 maxInclusive</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-maxInclusive">4.3.7 maxInclusive</a>
      */
     interface MaxInclusive extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-minExclusive'>4.3.9 minExclusive</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-minExclusive">4.3.9 minExclusive</a>
      */
     interface MinExclusive extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-maxExclusive'>4.3.8 maxExclusive</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-maxExclusive">4.3.8 maxExclusive</a>
      */
     interface MaxExclusive extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-totalDigits'>4.3.11 totalDigits</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-totalDigits">4.3.11 totalDigits</a>
      */
     interface TotalDigits extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/xmlschema11-2/#rf-fractionDigits'>4.3.12 fractionDigits</a>
+     * @see <a href="https://www.w3.org/TR/xmlschema11-2/#rf-fractionDigits">4.3.12 fractionDigits</a>
      */
     interface FractionDigits extends OntFacetRestriction {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/rdf-plain-literal/#langRange'>Table 1. The Facet Space of rdf:PlainLiteral</a>
+     * @see <a href="https://www.w3.org/TR/rdf-plain-literal/#langRange">Table 1. The Facet Space of rdf:PlainLiteral</a>
      */
     interface LangRange extends OntFacetRestriction {
     }

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntID.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntID.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  * from the main {@link UnionGraph Union Graph}.
  * Similar, calling the method {@link #addImport(String)} simply adds the corresponding triple to the base graph.
  *
- * @see <a href='https://www.w3.org/TR/owl-syntax/#Ontology_IRI_and_Version_IRI'>3.1 Ontology IRI and Version IRI</a>
+ * @see <a href="https://www.w3.org/TR/owl-syntax/#Ontology_IRI_and_Version_IRI">3.1 Ontology IRI and Version IRI</a>
  */
 public interface OntID extends OntObject {
 
@@ -99,7 +99,7 @@ public interface OntID extends OntObject {
      * According to the specification, a version IRI is primary.
      *
      * @return String or {@code null}
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Ontology_Documents'>3.2 Ontology Documents</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Ontology_Documents">3.2 Ontology Documents</a>
      */
     default String getImportsIRI() {
         String res = getVersionIRI();

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntIndividual.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntIndividual.java
@@ -182,10 +182,10 @@ public interface OntIndividual extends OntObject, AsNamed<OntIndividual.Named>, 
     /**
      * Lists all negative property assertions for this individual and the given property.
      *
-     * @param property {@link OntNamedProperty} or {@code null}
+     * @param property {@link OntRelationalProperty} or {@code null}
      * @return {@code Stream} of {@link OntNegativeAssertion negative property assertion}s
      */
-    default Stream<OntNegativeAssertion> negativeAssertions(OntNamedProperty property) {
+    default Stream<OntNegativeAssertion> negativeAssertions(OntRelationalProperty property) {
         Stream<OntNegativeAssertion> res = negativeAssertions();
         if (property == null) {
             return res;
@@ -225,7 +225,7 @@ public interface OntIndividual extends OntObject, AsNamed<OntIndividual.Named>, 
      * @return {@link OntStatement} to allow subsequent annotations adding
      * @see #addSameIndividual(OntIndividual)
      * @see #removeSameIndividual(Resource)
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Individual_Equality'>9.6.1 Individual Equality</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Individual_Equality">9.6.1 Individual Equality</a>
      */
     default OntStatement addSameAsStatement(OntIndividual other) {
         return addStatement(OWL2.sameAs, other);
@@ -253,7 +253,7 @@ public interface OntIndividual extends OntObject, AsNamed<OntIndividual.Named>, 
      * @see #addDifferentFromStatement(OntIndividual)
      * @see #removeDifferentIndividual(Resource)
      * @see OntDisjoint.Individuals
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Individual_Inequality'>9.6.2 Individual Inequality</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Individual_Inequality">9.6.2 Individual Inequality</a>
      */
     default OntIndividual addDifferentIndividual(OntIndividual other) {
         addDifferentFromStatement(other);
@@ -402,7 +402,7 @@ public interface OntIndividual extends OntObject, AsNamed<OntIndividual.Named>, 
      *                 can be {@code null} to remove all assertions for the predicate {@code property}
      * @return <b>this</b> instance to allow cascading calls
      */
-    default OntIndividual removeNegativeAssertion(OntNamedProperty property, RDFNode value) {
+    default OntIndividual removeNegativeAssertion(OntRelationalProperty property, RDFNode value) {
         negativeAssertions(property)
                 .filter(x -> value == null || value.equals(x.getTarget()))
                 .toList()
@@ -495,7 +495,7 @@ public interface OntIndividual extends OntObject, AsNamed<OntIndividual.Named>, 
     /**
      * An interface for <b>Named</b> Individual which is an {@link OWL2 Entity OntEntity}.
      *
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Named_Individuals'>5.6.1 Named Individuals</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Named_Individuals">5.6.1 Named Individuals</a>
      */
     interface Named extends OntIndividual, OntEntity {
 
@@ -530,7 +530,7 @@ public interface OntIndividual extends OntObject, AsNamed<OntIndividual.Named>, 
      * (where {@code PN} is a {@link OntObjectProperty.Named named object property}, and {@code _:ai} are individuals)</li>
      * </ul>
      *
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Anonymous_Individuals'>5.6.2 Anonymous Individuals</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Anonymous_Individuals">5.6.2 Anonymous Individuals</a>
      */
     interface Anonymous extends OntIndividual {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntList.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntList.java
@@ -61,12 +61,13 @@ import java.util.stream.Stream;
  * @param <E> the type of {@link RDFNode rdf-node}s in this list
  * @see RDFNodeList
  */
+@SuppressWarnings("javadoc")
 public interface OntList<E extends RDFNode> extends RDFNodeList<E>, OntResource {
 
     /**
      * Adds the given value to the end of the list.
      *
-     * @param e {@link E} rdf-node
+     * @param e {@code E} rdf-node
      * @return this list instance
      * @see #add(RDFNode)
      */
@@ -75,7 +76,7 @@ public interface OntList<E extends RDFNode> extends RDFNodeList<E>, OntResource 
     /**
      * Removes the last element from this list.
      * No-op in case of nil-list.
-     * Note: the removed element can be of any type, not necessarily of the type {@link E}.
+     * Note: the removed element can be of any type, not necessarily of the type {@code E}.
      *
      * @return this list instance
      * @see #remove()
@@ -87,7 +88,7 @@ public interface OntList<E extends RDFNode> extends RDFNodeList<E>, OntResource 
      * As a rule, this operation is faster than {@link #addLast(RDFNode)},
      * since it does not require iteration to the end of the list.
      *
-     * @param e {@link E} rdf-node
+     * @param e {@code E} rdf-node
      * @return this list instance
      */
     OntList<E> addFirst(E e);
@@ -95,7 +96,7 @@ public interface OntList<E extends RDFNode> extends RDFNodeList<E>, OntResource 
     /**
      * Removes and the first element from this list.
      * No-op in case of empty list.
-     * Note: the last element can be of any type, not necessarily of type {@link E}.
+     * Note: the last element can be of any type, not necessarily of type {@code E}.
      * As a rule, this operation is faster than {@link #removeLast()} ,
      * since the last one requires iteration to the end of the list.
      *
@@ -164,7 +165,7 @@ public interface OntList<E extends RDFNode> extends RDFNodeList<E>, OntResource 
      * Adds the given value to the end of the list.
      * This is a synonym for the {@code this.addLast(e)}.
      *
-     * @param e {@link E} rdf-node
+     * @param e {@code E} rdf-node
      * @return this list instance
      * @see #addLast(RDFNode)
      */
@@ -187,7 +188,7 @@ public interface OntList<E extends RDFNode> extends RDFNodeList<E>, OntResource 
      * Appends all the elements in the specified collection to the end of this list,
      * in the order that they are returned by the specified collection's iterator.
      *
-     * @param c Collection of {@link E}-elements
+     * @param c Collection of {@code E}-elements
      * @return this list instance
      */
     default OntList<E> addAll(Collection<? extends E> c) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntModel.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntModel.java
@@ -69,10 +69,10 @@ import java.util.stream.Stream;
  * If implementation does not provide inference support, the method will throw an exception.
  *
  * @see org.apache.jena.ontology.OntModel
- * @see <a href='https://www.w3.org/TR/owl2-mapping-to-rdf'>OWL2 RDF mapping</a>
- * @see <a href='https://www.w3.org/TR/owl2-quick-reference/'>A Quick Guide</a>
- * @see <a href='https://www.w3.org/TR/owl2-syntax/'>OWL 2 Web Ontology Language Structural Specification and Functional-Style Syntax (Second Edition)</a>
- * @see <a href='https://www.w3.org/Submission/SWRL/'>SWRL: A Semantic Web Rule Language Combining OWL and RuleML</a>
+ * @see <a href="https://www.w3.org/TR/owl2-mapping-to-rdf">OWL2 RDF mapping</a>
+ * @see <a href="https://www.w3.org/TR/owl2-quick-reference/">A Quick Guide</a>
+ * @see <a href="https://www.w3.org/TR/owl2-syntax/">OWL 2 Web Ontology Language Structural Specification and Functional-Style Syntax (Second Edition)</a>
+ * @see <a href="https://www.w3.org/Submission/SWRL/">SWRL: A Semantic Web Rule Language Combining OWL and RuleML</a>
  */
 public interface OntModel extends Model,
         MutableModel<OntModel>, PrefixedModel<OntModel>, IOModel<OntModel>,
@@ -188,7 +188,7 @@ public interface OntModel extends Model,
      *
      * @param type {@link Class} the concrete type of {@link OntObject}, not {@code null}
      * @param <O>  any ont-object subtype
-     * @return {@code Stream} of {@link OntObject}s of the type {@link O}
+     * @return {@code Stream} of {@link OntObject}s of the type {@code O}
      * @see #ontEntities()
      */
     <O extends OntObject> Stream<O> ontObjects(Class<? extends O> type);
@@ -244,6 +244,7 @@ public interface OntModel extends Model,
      * @return {@link OntEntity} or {@code null}
      * @see #fetchOntEntity(Class, String)
      */
+    @SuppressWarnings("javadoc")
     <E extends OntEntity> E getOntEntity(Class<E> type, String uri);
 
     /**
@@ -549,7 +550,7 @@ public interface OntModel extends Model,
      * @param type a class-type of entity
      * @param uri  String uri, not {@code null}
      * @param <E>  any subtype of {@link OntEntity}
-     * @return {@link E}
+     * @return {@code E}
      */
     default <E extends OntEntity> E fetchOntEntity(Class<E> type, String uri) {
         E res = getOntEntity(type, uri);
@@ -655,7 +656,7 @@ public interface OntModel extends Model,
      * @param type {@code Class}, not {@code null}
      * @param uri  {@link Resource}, must be URI, not {@code null}
      * @param <E>  any {@link OntEntity} subtype, not {@code null}
-     * @return a {@link E} instance
+     * @return a {@code E} instance
      */
     default <E extends OntEntity> E getOntEntity(Class<E> type, Resource uri) {
         return getOntEntity(type, uri.getURI());

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntNegativeAssertion.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntNegativeAssertion.java
@@ -68,13 +68,13 @@ public interface OntNegativeAssertion<P extends OntRelationalProperty, V extends
     V getTarget();
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Negative_Object_Property_Assertions'>9.6.5 Negative Object Property Assertions</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Negative_Object_Property_Assertions">9.6.5 Negative Object Property Assertions</a>
      */
     interface WithObjectProperty extends OntNegativeAssertion<OntObjectProperty, OntIndividual> {
     }
 
     /**
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Negative_Data_Property_Assertions'>9.6.7 Negative Data Property Assertions</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Negative_Data_Property_Assertions">9.6.7 Negative Data Property Assertions</a>
      */
     interface WithDataProperty extends OntNegativeAssertion<OntDataProperty, Literal> {
     }

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntObject.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntObject.java
@@ -169,7 +169,7 @@ public interface OntObject extends OntResource {
      * @param predicate {@link Property} predicate, can be {@code null} for wildcard searching
      * @param type      Interface to find and cast
      * @param <O>       a class-type of rdf-node
-     * @return {@code Stream} of {@link RDFNode RDF Node}s of the type {@link O}
+     * @return {@code Stream} of {@link RDFNode RDF Node}s of the type {@code O}
      */
     <O extends RDFNode> Stream<O> objects(Property predicate, Class<O> type);
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntObjectProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntObjectProperty.java
@@ -99,12 +99,13 @@ public interface OntObjectProperty extends OntRelationalProperty, AsNamed<OntObj
      *
      * @param properties {@link Collection} (preferably {@link List}) of {@link OntObjectProperty object property expression}s
      * @return {@link OntList} of {@link OntObjectProperty}s
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#a_SubObjectPropertyOfChain'>9.2.1 Object Subproperties</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#a_SubObjectPropertyOfChain">9.2.1 Object Subproperties</a>
      * @see #addPropertyChainAxiomStatement(Collection)
      * @see #addPropertyChain(Collection)
      * @see #propertyChains()
      * @see #findPropertyChain(RDFNode)
      */
+    @SuppressWarnings("javadoc")
     OntList<OntObjectProperty> createPropertyChain(Collection<OntObjectProperty> properties);
 
     /**
@@ -258,7 +259,7 @@ public interface OntObjectProperty extends OntRelationalProperty, AsNamed<OntObj
      * @param source {@link OntIndividual}
      * @return {@code Stream} of {@link OntNegativeAssertion.WithObjectProperty}s
      * @see OntDataProperty#negativeAssertions(OntIndividual)
-     * @see OntIndividual#negativeAssertions(OntNamedProperty)
+     * @see OntIndividual#negativeAssertions(OntRelationalProperty)
      */
     default Stream<OntNegativeAssertion.WithObjectProperty> negativeAssertions(OntIndividual source) {
         return negativeAssertions().filter(a -> a.getSource().equals(source));
@@ -328,7 +329,7 @@ public interface OntObjectProperty extends OntRelationalProperty, AsNamed<OntObj
      * to provide the ability to add annotations subsequently
      * @see #createPropertyChain(Collection)
      * @see #addPropertyChainAxiomStatement(OntObjectProperty...)
-     * @see <a href='https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations'>2.3.1 Axioms that Generate a Main Triple</a>
+     * @see <a href="https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations">2.3.1 Axioms that Generate a Main Triple</a>
      */
     default OntStatement addPropertyChainAxiomStatement(Collection<OntObjectProperty> properties) {
         return createPropertyChain(properties).getMainStatement();
@@ -811,7 +812,7 @@ public interface OntObjectProperty extends OntRelationalProperty, AsNamed<OntObj
      * It is a URI-{@link Resource Resource} and an extension to the standard jena {@link Property}.
      * Also, It is an {@link OntEntity OWL Entity} and {@link OntRelationalProperty real ontology property}.
      *
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Object_Properties'>5.3 Object Properties</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Object_Properties">5.3 Object Properties</a>
      */
     interface Named extends OntObjectProperty, OntNamedProperty<Named> {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntProperty.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * In OWL2 there are four such property expressions:
  * Data Property, Object Property (OWL Entity and InverseOf) and Annotation Property.
  *
- * @see <a href='https://www.w3.org/TR/owl2-quick-reference/'>2.2 Properties</a>
+ * @see <a href="https://www.w3.org/TR/owl2-quick-reference/">2.2 Properties</a>
  * @see OntObjectProperty
  * @see OntAnnotationProperty
  * @see OntDataProperty

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntRelationalProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntRelationalProperty.java
@@ -180,6 +180,7 @@ public interface OntRelationalProperty extends OntProperty {
      *
      * @return a {@code Stream} whose values are the restrictions from the local model that reference this property.
      */
+    @SuppressWarnings("unchecked")
     default Stream<OntClass.Restriction> referringRestrictions() {
         //noinspection unchecked
         return Stream.concat(

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntResource.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntResource.java
@@ -90,7 +90,7 @@ interface OntResource extends Resource {
      *
      * @param type a {@code Class}-type of the desired RDF view (interface)
      * @param <X>  any subtype of {@link RDFNode}
-     * @return an instance of the type {@link X} or {@code null}
+     * @return an instance of the type {@code X} or {@code null}
      * @see RDFNode#as(Class)
      * @see RDFNode#canAs(Class)
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntSWRL.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntSWRL.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * A base for SWRL addition.
  *
  * @see SWRL
- * @see <a href='https://www.w3.org/Submission/SWRL'>specification</a>
+ * @see <a href="https://www.w3.org/Submission/SWRL">specification</a>
  */
 public interface OntSWRL extends OntObject {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntStatement.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntStatement.java
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
  *
  * @see OntAnnotation
  * @see Statement
- * @see <a href='https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations'>2.2 Translation of Annotations</a>
+ * @see <a href="https://www.w3.org/TR/owl2-mapping-to-rdf/#Translation_of_Annotations">2.2 Translation of Annotations</a>
  */
 public interface OntStatement extends Statement {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/RDFNodeList.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/RDFNodeList.java
@@ -36,13 +36,13 @@ import java.util.stream.Stream;
 public interface RDFNodeList<E extends RDFNode> extends Resource {
 
     /**
-     * Lists all elements of the type {@link E} from this list.
+     * Lists all elements of the type {@code E} from this list.
      * Note: a real RDF-list may contain nodes with an incompatible type,
      * in this case they will not be included in the result {@code Stream}.
      * To get all {@link RDFNode RDF Node}s use the standard list representation:
      * the expression {@code Iter.asStream(this.as(RDFList.class).iterator())} will return a {@code Stream} of nodes.
      *
-     * @return {@code Stream} of {@link E}-elements
+     * @return {@code Stream} of {@code E}-elements
      * @see #as(Class)
      * @see Iterators#asStream(java.util.Iterator)
      */
@@ -51,9 +51,9 @@ public interface RDFNodeList<E extends RDFNode> extends Resource {
     /**
      * Answers {@code true} if the []-list contains the specified {@code element}.
      * More formally, returns {@code true} if and only if
-     * this RDF-list contains at least one element {@code e} of the type {@link E} such that {@code element.equals(e)}.
+     * this RDF-list contains at least one element {@code e} of the type {@code E} such that {@code element.equals(e)}.
      *
-     * @param element {@link E}, not {@code null}
+     * @param element {@code E}, not {@code null}
      * @return boolean
      */
     default boolean contains(E element) {
@@ -64,9 +64,9 @@ public interface RDFNodeList<E extends RDFNode> extends Resource {
     }
 
     /**
-     * Answers the first element of the type {@link E}.
+     * Answers the first element of the type {@code E}.
      *
-     * @return {@code Optional} around the {@link E}-item
+     * @return {@code Optional} around the {@code E}-item
      */
     default Optional<E> first() {
         try (Stream<E> members = members()) {
@@ -75,9 +75,9 @@ public interface RDFNodeList<E extends RDFNode> extends Resource {
     }
 
     /**
-     * Answers the last element of the type {@link E}.
+     * Answers the last element of the type {@code E}.
      *
-     * @return {@code Optional} around the {@link E}-item
+     * @return {@code Optional} around the {@code E}-item
      */
     default Optional<E> last() {
         return members().reduce((f, s) -> s);
@@ -96,7 +96,7 @@ public interface RDFNodeList<E extends RDFNode> extends Resource {
 
     /**
      * Answers {@code true} if it is a nil []-list.
-     * Please note: a non-nil list may also not contain elements of the type {@link E}
+     * Please note: a non-nil list may also not contain elements of the type {@code E}
      * and, therefore, be {@link #isEmpty()} empty.
      *
      * @return boolean
@@ -107,7 +107,7 @@ public interface RDFNodeList<E extends RDFNode> extends Resource {
     }
 
     /**
-     * Answers {@code true} if this list contains no elements of the type {@link E}.
+     * Answers {@code true} if this list contains no elements of the type {@code E}.
      * A {@link #isNil() nil}-list is always empty, but the reverse is not true.
      *
      * @return boolean

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/SetComponents.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/SetComponents.java
@@ -37,7 +37,7 @@ interface SetComponents<V extends RDFNode, R extends OntObject> extends WithOntL
     /**
      * Replaces the existing []-list content with the specified one, that is given in the form of vararg array.
      *
-     * @param values an {@code Array} of the type {@link V}
+     * @param values an {@code Array} of the type {@code V}
      * @return <b>this</b> instance to allow cascading calls
      */
     @SuppressWarnings("unchecked")
@@ -49,7 +49,7 @@ interface SetComponents<V extends RDFNode, R extends OntObject> extends WithOntL
      * Replaces the existing []-list content with the specified one, that is given in the form of {@link Collection}.
      * Nulls and self-references are not allowed.
      *
-     * @param components a {@code Collection} of the type {@link V}
+     * @param components a {@code Collection} of the type {@code V}
      * @return <b>this</b> instance to allow cascading calls
      * @throws OntJenaException in case of wrong input
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/SetProperties.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/SetProperties.java
@@ -35,7 +35,7 @@ interface SetProperties<P extends OntRelationalProperty, R extends OntClass.Nary
     /**
      * Sets the given property as the only member of the []-list.
      *
-     * @param property {@link P}, not {@code null}
+     * @param property {@code P}, not {@code null}
      * @return <b>this</b> instance to allow cascading calls
      * @see HasProperties#getProperty()
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/SetProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/SetProperty.java
@@ -35,7 +35,7 @@ interface SetProperty<P extends OntRelationalProperty, R extends OntClass.Restri
      * (as an object with predicate {@link OWL2#onProperty owl:onProperty}
      * if it is Unary Restriction).
      *
-     * @param property {@link P}, not {@code null}
+     * @param property {@code P}, not {@code null}
      * @return <b>this</b> instance to allow cascading calls
      */
     R setProperty(P property);

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/SetValue.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/SetValue.java
@@ -42,7 +42,7 @@ interface SetValue<V extends RDFNode, R extends OntObject> {
      * (the null-filler is considered as {@link OWL2#Thing owl:Thing}
      * for an object restriction and as {@link org.apache.jena.vocabulary.RDFS#Literal} for a data restriction).
      *
-     * @param value {@link V}, possible {@code null} in case of Cardinality Restriction
+     * @param value {@code V}, possible {@code null} in case of Cardinality Restriction
      * @return <b>this</b> instance to allow cascading calls
      * @see HasValue#getValue()
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/WithOntList.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/WithOntList.java
@@ -29,9 +29,9 @@ import org.apache.jena.rdf.model.RDFNode;
  */
 interface WithOntList<E extends RDFNode> extends HasRDFNodeList<E> {
     /**
-     * Gets a modifiable []-list with items of the type {@link E}.
+     * Gets a modifiable []-list with items of the type {@code E}.
      *
-     * @return {@link OntList Ontology []-list} with items of the type {@link E}
+     * @return {@link OntList Ontology []-list} with items of the type {@code E}
      */
     @Override
     OntList<E> getList();

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/utils/Graphs.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/utils/Graphs.java
@@ -65,7 +65,7 @@ import java.util.stream.Stream;
  * @see GraphUtil
  * @see GraphUtils
  */
-@SuppressWarnings({"WeakerAccess", "unused"})
+@SuppressWarnings({"WeakerAccess"})
 public class Graphs {
 
     static {
@@ -543,7 +543,7 @@ public class Graphs {
      * @param graph {@link Graph}
      * @return {@code Optional} with {@link Node} blank or URI,
      * or {@code Optional#empty} if the ontology Node cannot be uniquely defined or absent in the {@code graph}
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Ontology_Documents'>3.2 Ontology Documents</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Ontology_Documents">3.2 Ontology Documents</a>
      */
     public static Optional<Node> findOntologyNameNode(Graph graph) {
         return findOntologyNameNode(graph, false);
@@ -557,7 +557,7 @@ public class Graphs {
      * @param allowMultipleOntologyHeaders {@code boolean}, see {@link #ontologyNode(Graph, boolean)} for explanation
      * @return {@code Optional} with {@link Node} blank or URI,
      * or {@code Optional#empty} if the ontology Node cannot be uniquely defined or absent in the {@code graph}
-     * @see <a href='https://www.w3.org/TR/owl2-syntax/#Ontology_Documents'>3.2 Ontology Documents</a>
+     * @see <a href="https://www.w3.org/TR/owl2-syntax/#Ontology_Documents">3.2 Ontology Documents</a>
      */
     public static Optional<Node> findOntologyNameNode(Graph graph, boolean allowMultipleOntologyHeaders) {
         if (graph.isClosed()) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/utils/Iterators.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/utils/Iterators.java
@@ -59,9 +59,9 @@ public class Iterators {
      * Creates a new sequential {@code Stream} from the given {@code ExtendedIterator}.
      * Takes care about degenerate cases empty and single-element iterator.
      *
-     * @param iterator {@link ExtendedIterator} of {@link X}-elements
+     * @param iterator {@link ExtendedIterator} of {@code X}-elements
      * @param <X>      anything
-     * @return a {@code Stream} of {@link X}
+     * @return a {@code Stream} of {@code X}
      * @see #asStream(Iterator)
      */
     public static <X> Stream<X> asStream(ExtendedIterator<? extends X> iterator) {
@@ -152,7 +152,7 @@ public class Iterators {
      * Creates a {@code Stream} for a future {@code Set}, which is produced by the factory-parameter {@code getAsSet}.
      * The produced {@code Set} must not change and must not contain {@code null}.
      *
-     * @param getAsSet {@code Supplier} that produces a {@code Set} of {@link X}
+     * @param getAsSet {@code Supplier} that produces a {@code Set} of {@code X}
      * @param <X>      the type of items
      * @return <b>distinct</b> sequential {@code Stream}
      * @see Iterators#create(Supplier)
@@ -168,12 +168,12 @@ public class Iterators {
      * by applying the provided mapping function ({@code map}) to each element.
      * A functional equivalent of {@link Stream#flatMap(Function)}, but for {@link ExtendedIterator}s.
      *
-     * @param base   {@link ExtendedIterator} with elements of type {@link F}
-     * @param mapper {@link Function} map-function with Object of type of {@link F} (or any super type) as an input,
-     *               and an {@link Iterator} of type {@link T} (or any extended type) as an output
+     * @param base   {@link ExtendedIterator} with elements of type {@code F}
+     * @param mapper {@link Function} map-function with Object of type of {@code F} (or any super type) as an input,
+     *               and an {@link Iterator} of type {@code T} (or any extended type) as an output
      * @param <F>    the element type of the base iterator (from)
      * @param <T>    the element type of the new iterator (to)
-     * @return new {@link ExtendedIterator} of type {@link F}
+     * @return new {@link ExtendedIterator} of type {@code F}
      */
     @SuppressWarnings("unchecked")
     public static <T, F> ExtendedIterator<T> flatMap(ExtendedIterator<F> base,
@@ -207,7 +207,7 @@ public class Iterators {
      *
      * @param iterators Array of iterators
      * @param <X>       the type of iterator elements
-     * @return all input elements as a single {@link ExtendedIterator} of type {@link X}
+     * @return all input elements as a single {@link ExtendedIterator} of type {@code X}
      * @see Iterators#concat(ExtendedIterator, ExtendedIterator)
      */
     @SafeVarargs
@@ -224,7 +224,7 @@ public class Iterators {
      * that match the given predicate.
      * A functional equivalent of {@link Stream#filter(Predicate)}, but for {@link ExtendedIterator}s.
      *
-     * @param iterator  {@link ExtendedIterator} with elements of type {@link X}
+     * @param iterator  {@link ExtendedIterator} with elements of type {@code X}
      * @param predicate {@link Predicate} to apply to elements of the iterator
      * @param <X>       the element type of the input and output iterators
      * @return a new iterator
@@ -240,10 +240,10 @@ public class Iterators {
      * on each element as elements are consumed from the resulting iterator.
      * A functional equivalent of {@link Stream#peek(Consumer)}, but for {@link ExtendedIterator}s.
      *
-     * @param base   {@link ExtendedIterator} with elements of type {@link X}
+     * @param base   {@link ExtendedIterator} with elements of type {@code X}
      * @param action {@link Consumer} action
      * @param <X>    the element type of the input and output iterators
-     * @return new {@link ExtendedIterator} of type {@link X}
+     * @return new {@link ExtendedIterator} of type {@code X}
      */
     public static <X> ExtendedIterator<X> peek(ExtendedIterator<X> base, Consumer<? super X> action) {
         return base.mapWith(x -> {
@@ -258,9 +258,9 @@ public class Iterators {
      * A functional equivalent of {@link Stream#distinct()}, but for {@link ExtendedIterator}s.
      * Warning: the result is temporary stored in memory!
      *
-     * @param base {@link ExtendedIterator} with elements of type {@link X}
+     * @param base {@link ExtendedIterator} with elements of type {@code X}
      * @param <X>  the element type of the input and output iterators
-     * @return new {@link ExtendedIterator} of type {@link X} without duplicates
+     * @return new {@link ExtendedIterator} of type {@code X} without duplicates
      */
     public static <X> ExtendedIterator<X> distinct(ExtendedIterator<X> base) {
         return base.filterKeep(new FilterUnique<>());
@@ -270,7 +270,7 @@ public class Iterators {
      * Returns whether any elements of the given iterator match the provided predicate.
      * A functional equivalent of {@link Stream#anyMatch(Predicate)}, but for {@link Iterator}s.
      *
-     * @param iterator  {@link Iterator} with elements of type {@link X}
+     * @param iterator  {@link Iterator} with elements of type {@code X}
      * @param predicate {@link Predicate} to apply to elements of the iterator
      * @param <X>       the element type of the iterator
      * @return {@code true} if any elements of the stream match the provided predicate, otherwise {@code false}
@@ -293,7 +293,7 @@ public class Iterators {
      * Returns whether all elements of the given iterator match the provided predicate.
      * A functional equivalent of {@link Stream#allMatch(Predicate)}, but for {@link Iterator}s.
      *
-     * @param iterator  {@link Iterator} with elements of type {@link X}
+     * @param iterator  {@link Iterator} with elements of type {@code X}
      * @param predicate {@link Predicate} to apply to elements of the iterator
      * @param <X>       the element type of the iterator
      * @return {@code true} if either all elements of the iterator match the provided predicate
@@ -317,7 +317,7 @@ public class Iterators {
      * Returns whether no elements of the given iterator match the provided predicate.
      * A functional equivalent of {@link Stream#noneMatch(Predicate)}, but for {@link Iterator}s.
      *
-     * @param iterator  {@link Iterator} with elements of type {@link X}
+     * @param iterator  {@link Iterator} with elements of type {@code X}
      * @param predicate {@link Predicate} to apply to elements of the iterator
      * @param <X>       the element type of the iterator
      * @return {@code true} if either no elements of the iterator match the provided predicate
@@ -337,7 +337,7 @@ public class Iterators {
      *
      * @param iterator {@link Iterator}, not {@code null}
      * @param <X>      the element type of the iterator
-     * @return {@link Optional} of {@link X}
+     * @return {@link Optional} of {@code X}
      * @throws NullPointerException if the element selected is {@code null}
      */
     public static <X> Optional<X> findFirst(Iterator<X> iterator) {
@@ -427,7 +427,7 @@ public class Iterators {
      * On finish iteration, the iterator will be closed.
      *
      * @param iterator {@link Iterator}, not {@code null}
-     * @param action   {@link Consumer} accepting {@link X}
+     * @param action   {@link Consumer} accepting {@code X}
      * @param <X>      any
      */
     public static <X> void forEach(Iterator<X> iterator, Consumer<X> action) {
@@ -447,9 +447,9 @@ public class Iterators {
      *
      * @param <X>    the element type of the iterator, not {@code null}
      * @param <C>    the {@code Collection} type, not {@code null}
-     * @param source the {@code Iterator} with elements of type {@link X}
-     * @param target the collection of type {@link C}
-     * @return {@link C}, the same instance as specified
+     * @param source the {@code Iterator} with elements of type {@code X}
+     * @param target the collection of type {@code C}
+     * @return {@code C}, the same instance as specified
      */
     public static <X, C extends Collection<X>> C addAll(Iterator<? extends X> source, C target) {
         if (source instanceof NullIterator) {
@@ -491,7 +491,7 @@ public class Iterators {
     }
 
     /**
-     * Returns a {@code Map} (of the type of {@link M})
+     * Returns a {@code Map} (of the type of {@code M})
      * whose keys and values are the result of applying the provided mapping functions to the input elements.
      * A functional equivalent of {@code stream.collect(Collectors.toMap(...))}, but for plain {@link Iterator}s.
      * This method makes no guarantees about synchronization or atomicity properties of it.
@@ -540,7 +540,7 @@ public class Iterators {
     /**
      * Creates a new {@link ExtendedIterator Extended Iterator}} containing the specified elements.
      *
-     * @param members Array of elements of the type {@link X}
+     * @param members Array of elements of the type {@code X}
      * @param <X>     the element type of the new iterator
      * @return a fresh {@link ExtendedIterator} instance
      */
@@ -562,7 +562,7 @@ public class Iterators {
     /**
      * Creates a new {@link ExtendedIterator Extended Iterator}} containing a single specified element.
      *
-     * @param item - an object of type {@link X}
+     * @param item - an object of type {@code X}
      * @param <X>  the element type of the new iterator
      * @return a fresh {@link ExtendedIterator} instance
      */
@@ -573,7 +573,7 @@ public class Iterators {
     /**
      * Creates a new {@link ExtendedIterator Extended Iterator}} over all elements of the specified collection.
      *
-     * @param members {@code Collection} of elements of the type {@link X}
+     * @param members {@code Collection} of elements of the type {@code X}
      * @param <X>     the element type of the new iterator
      * @return a fresh {@link ExtendedIterator} instance
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/utils/OntModels.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/utils/OntModels.java
@@ -59,17 +59,15 @@ import java.util.stream.Stream;
  * {@link OntEntity Ontology Entity},
  * {@link RDFNodeList Node List},
  * {@link OntStatement Ontology Statement}.
- * <p>
- * Created by @szz on 11.06.2019.
  */
 public class OntModels {
 
     /**
      * Determines the actual ontology object type.
      *
-     * @param object instance of {@link O}
+     * @param object instance of {@code O}
      * @param <O>    any subtype of {@link OntObject}
-     * @return {@link Class}-type of {@link O}
+     * @return {@link Class}-type of {@code O}
      */
     @SuppressWarnings("unchecked")
     public static <O extends OntObject> Class<O> getOntType(O object) {
@@ -91,6 +89,7 @@ public class OntModels {
      * @return {@link OntIndividual.Anonymous}
      * @throws OntJenaException if the node cannot be present as anonymous individual
      */
+    @SuppressWarnings("javadoc")
     public static OntIndividual.Anonymous asAnonymousIndividual(RDFNode inModel) {
         return OntIndividualImpl.createAnonymousIndividual(inModel);
     }
@@ -119,7 +118,7 @@ public class OntModels {
      * @param model {@link OntModel}
      * @param type  {@link Class}-type
      * @param <O>   subclass of {@link OntObject}
-     * @return {@link ExtendedIterator} of ontology objects of the type {@link O} that are local to the base graph
+     * @return {@link ExtendedIterator} of ontology objects of the type {@code O} that are local to the base graph
      * @see OntModel#ontObjects(Class)
      */
     public static <O extends OntObject> ExtendedIterator<O> listLocalObjects(OntModel model, Class<? extends O> type) {
@@ -150,7 +149,7 @@ public class OntModels {
      *
      * @param list {@link RDFNodeList}
      * @param <R>  {@link RDFNode}, a type of list members
-     * @return {@link ExtendedIterator} of {@link R}
+     * @return {@link ExtendedIterator} of {@code R}
      */
     public static <R extends RDFNode> ExtendedIterator<R> listMembers(RDFNodeList<R> list) {
         if (list instanceof OntListImpl) {

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/GraphUtilsTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/GraphUtilsTest.java
@@ -50,7 +50,6 @@ import java.util.stream.Stream;
 
 /**
  * To test {@link Graphs} utility class.
- * Created by @szz on 11.06.2019.
  */
 @SuppressWarnings("deprecation")
 public class GraphUtilsTest {

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntPropertyTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntPropertyTest.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
  * {@link OntRelationalProperty},
  * {@link OntAnnotationProperty}.
  */
+@SuppressWarnings("javadoc")
 public class OntPropertyTest {
 
     @Test

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/TestOntPersonalities.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/TestOntPersonalities.java
@@ -28,12 +28,13 @@ import org.apache.jena.ontapi.model.OntDataProperty;
 import org.apache.jena.ontapi.model.OntDataRange;
 import org.apache.jena.ontapi.model.OntObjectProperty;
 
+@SuppressWarnings("javadoc")
 class TestOntPersonalities {
     /**
      * OWL2 Personality, that has default settings and does not care about the owl-entities "punnings"
      * (no restriction on the type declarations).
      *
-     * @see <a href='https://www.w3.org/TR/owl2-new-features/#F12:_Punning'>2.4.1 F12: Punning</a>
+     * @see <a href="https://www.w3.org/TR/owl2-new-features/#F12:_Punning">2.4.1 F12: Punning</a>
      * @see PunningsMode#FULL
      */
     public static final OntPersonality OWL2_PERSONALITY_LAX_PUNNS = OntPersonalities.OWL2_ONT_PERSONALITY()
@@ -51,7 +52,7 @@ class TestOntPersonalities {
      * <li>{@link OntObjectProperty.Named} &lt;-&gt; {@link OntDataProperty}</li>
      * </ul>
      *
-     * @see <a href='https://www.w3.org/TR/owl2-new-features/#F12:_Punning'>2.4.1 F12: Punning</a>
+     * @see <a href="https://www.w3.org/TR/owl2-new-features/#F12:_Punning">2.4.1 F12: Punning</a>
      * @see PunningsMode#DL_WEAK
      */
     public static final OntPersonality OWL2_PERSONALITY_MEDIUM_PUNNS = OntPersonalities.OWL2_ONT_PERSONALITY()
@@ -75,7 +76,7 @@ class TestOntPersonalities {
      * it requires that a name cannot be used for both a class and a datatype and
      * that a name can only be used for one kind of property."
      *
-     * @see <a href='https://www.w3.org/TR/owl2-new-features/#F12:_Punning'>2.4.1 F12: Punning</a>
+     * @see <a href="https://www.w3.org/TR/owl2-new-features/#F12:_Punning">2.4.1 F12: Punning</a>
      * @see PunningsMode#DL2
      */
     public static final OntPersonality OWL2_PERSONALITY_STRICT_PUNNS = OntPersonalities.OWL2_ONT_PERSONALITY()

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/UnionGraphTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/UnionGraphTest.java
@@ -23,7 +23,7 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.mem.GraphMem;
+import org.apache.jena.mem2.GraphMem2Fast;
 import org.apache.jena.ontapi.impl.UnionGraphImpl;
 import org.apache.jena.ontapi.model.OntModel;
 import org.apache.jena.ontapi.testutils.ModelTestUtils;
@@ -57,9 +57,8 @@ public class UnionGraphTest {
         return m.getBaseGraph();
     }
 
-    @SuppressWarnings("deprecation")
     static Graph createTestMemGraph(String name) {
-        return new GraphMem() {
+        return new GraphMem2Fast() {
             @Override
             public String toString() {
                 return String.format("[%s]", name);


### PR DESCRIPTION
GitHub issue resolved #2497

Continues from #2461.

There are  categories of chnage:

* `{@link Generic}` -> `{@code Generic}` -- there is no link for a generic. Fixed by regex.
* `href='...'` - Eclispe complains when this is in `@see` or `@param`. It accepts `"`.  Fixed by regex.
* Add `@SuppressWarnings("javadoc")` where a nested class is named. `Foo.Bar`. Despite the in-IDE javadoc seeming to work, it's warning and only correctable by incliding the full package name or suppression. This PR suppress the warning.
* Remove unnecessary `@SuppressWarnings("unused")`
* `Created by @szz` -- a few of these. `@` is not good! Jena does not have `@author` so these are removed inline with that.
* `UnionGraphTest` - extend `GraphMem2Fast` not deprecated `GraphMem`

@sszuev --
This one that look like a problem: 

```
Unlikely argument type for equals(): OntRelationalProperty seems to be unrelated to OntNamedProperty OntIndividual.java	/jena-ontapi/src/main/java/org/apache/jena/ontapi/model	line 193	Java Problem
```
The line is `return res.filter(x -> property.equals(x.getProperty()));`



----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
