### PR TITLE
Improve HttpAction lifecycle

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/Transactional.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/Transactional.java
@@ -190,7 +190,8 @@ public interface Transactional
     /** Finish the transaction - if a write transaction and commit() has not been called, then abort */
     public void end() ;
 
-    /** Return the current mode of the transaction - "read" or "write".
+    /**
+     * Return the current mode of the transaction - "read" or "write".
      * If the caller is not in a transaction, this method returns null.
      */
     public ReadWrite transactionMode();

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataService.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataService.java
@@ -239,15 +239,15 @@ public class DataService {
         totalTxn.getAndIncrement();
     }
 
+    public void finishTxn() {
+        activeTxn.decrementAndGet();
+    }
+
     private void check(DataServiceStatus status) {
         if ( state != status ) {
             String msg = format("DataService %s: Expected=%s, Actual=%s", label(), status, state);
             throw new FusekiException(msg);
         }
-    }
-
-    public void finishTxn() {
-        activeTxn.decrementAndGet();
     }
 
     /** Shutdown and never use again. */

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/OperationRegistry.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/OperationRegistry.java
@@ -26,7 +26,6 @@ import jakarta.servlet.ServletContext;
 
 import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.fuseki.Fuseki;
-import org.apache.jena.fuseki.patch.PatchApplyService;
 import org.apache.jena.fuseki.servlets.*;
 import org.apache.jena.riot.WebContent;
 
@@ -47,7 +46,7 @@ public class OperationRegistry {
     private static final ActionService uploadServlet   = new UploadRDF();
     private static final ActionService gspServlet_R    = new GSP_R();
     private static final ActionService gspServlet_RW   = new GSP_RW();
-    private static final ActionService rdfPatch        = new PatchApplyService();
+    private static final ActionService rdfPatch        = new PatchApply();
     private static final ActionService noOperation     = new NoOpActionService();
     private static final ActionService shaclValidation = new SHACL_Validation();
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSP_RW.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/GSP_RW.java
@@ -105,7 +105,7 @@ public class GSP_RW extends GSP_R {
         }
         catch (ActionErrorException ex) { throw ex; }
         catch (Exception ex) { action.abortSilent(); }
-        finally { action.end(); }
+        finally { action.endWrite(); }
         ServletOps.successNoContent(action);
     }
 
@@ -215,7 +215,7 @@ public class GSP_RW extends GSP_R {
             ServletOps.errorOccurred(ex.getMessage());
             return null;
         } finally {
-            action.end();
+            action.endWrite();
         }
     }
 
@@ -261,6 +261,6 @@ public class GSP_RW extends GSP_R {
             action.abortSilent();
             ServletOps.errorOccurred(ex.getMessage());
             return null;
-        } finally { action.end(); }
+        } finally { action.endWrite(); }
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/PatchApply.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/PatchApply.java
@@ -15,7 +15,7 @@
  *  information regarding copyright ownership.
  */
 
-package org.apache.jena.fuseki.patch;
+package org.apache.jena.fuseki.servlets;
 
 import static java.lang.String.format;
 import static org.apache.jena.fuseki.servlets.ActionExecLib.incCounter;
@@ -25,7 +25,6 @@ import java.io.InputStream;
 
 import org.apache.jena.atlas.web.ContentType;
 import org.apache.jena.fuseki.server.CounterName;
-import org.apache.jena.fuseki.servlets.*;
 import org.apache.jena.rdfpatch.PatchException;
 import org.apache.jena.rdfpatch.RDFChanges;
 import org.apache.jena.rdfpatch.changes.*;
@@ -37,7 +36,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.web.HttpSC;
 
 /** A Fuseki service to receive and apply a patch. */
-public class PatchApplyService extends ActionREST {
+public class PatchApply extends ActionREST {
     static CounterName counterPatches     = CounterName.register("RDFpatch-apply", "rdf-patch.apply.requests");
     static CounterName counterPatchesGood = CounterName.register("RDFpatch-apply", "rdf-patch.apply.good");
     static CounterName counterPatchesBad  = CounterName.register("RDFpatch-apply", "rdf-patch.apply.bad");
@@ -46,7 +45,7 @@ public class PatchApplyService extends ActionREST {
     private ContentType ctPatchText   = WebContent.ctPatch;
     private ContentType ctPatchBinary = WebContent.ctPatchThrift;
 
-    public PatchApplyService() {
+    public PatchApply() {
         // Counters: the standard ActionREST counters per operation are enough.
     }
 
@@ -111,7 +110,10 @@ public class PatchApplyService extends ActionREST {
         catch (Exception ex) {
             action.abort();
             throw ex;
-        } finally { action.end(); }
+        }
+        finally {
+            action.endWrite();
+        }
         ServletOps.success(action);
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_Update.java
@@ -258,7 +258,7 @@ public class SPARQL_Update extends ActionService
                 abortSilent(action);
                 ServletOps.errorOccurred(ex.getMessage(), ex);
             }
-        } finally { action.end(); }
+        } finally { action.endWrite(); }
     }
 
     /* [It is an error to supply the using-graph-uri or using-named-graph-uri parameters

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/UploadRDF.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/UploadRDF.java
@@ -138,7 +138,7 @@ public class UploadRDF extends ActionREST {
             action.abortSilent();
             ServletOps.errorOccurred(ex.getMessage());
         } finally {
-            action.end();
+            action.endWrite();
         }
         return details;
     }
@@ -192,7 +192,7 @@ public class UploadRDF extends ActionREST {
             action.abortSilent();
             ServletOps.errorOccurred(ex.getMessage());
         } finally {
-            action.end();
+            action.endWrite();
         }
         return details;
     }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiCustomOperation.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiCustomOperation.java
@@ -182,7 +182,7 @@ public class TestFusekiCustomOperation {
         // .build();
     }
 
-    // Bad test: no MIME type must match.
+    // Bad test: MIME type must match.
     @Test
     public void cfg_bad_ct_not_enabled_here_1() {
         FusekiServer server = FusekiServer.create().port(port)

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiStdSetup.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiStdSetup.java
@@ -112,11 +112,6 @@ public class TestFusekiStdSetup {
     }
 
     @Test
-    public void stdSetup_endpoint_8() {
-        HttpTest.expect404( () -> exec(URL, "/nonsense", conn -> conn.putDataset(dataset)) );
-    }
-
-    @Test
     public void stdSetup_dataset_1() {
         exec(URL, conn -> conn.queryAsk("ASK{}"));
     }
@@ -164,6 +159,10 @@ public class TestFusekiStdSetup {
 
     @Test public void stdSetup_endpoint_bad_5() {
         HttpTest.expect404( () -> exec(URL+"2", "", (RDFConnection conn)->conn.queryAsk("ASK{}")) );
+    }
+
+    @Test public void stdSetup_endpoint_bad_6() {
+        HttpTest.expect404( () -> exec(URL, "/nonsense", conn -> conn.putDataset(dataset)) );
     }
 
     private static void exec(String url, Consumer<RDFConnection> action) {

--- a/jena-rdfpatch/src/main/java/org/apache/jena/rdfpatch/system/DatasetGraphChanges.java
+++ b/jena-rdfpatch/src/main/java/org/apache/jena/rdfpatch/system/DatasetGraphChanges.java
@@ -263,7 +263,7 @@ public class DatasetGraphChanges extends DatasetGraphWrapper {
     public void commit() {
         // Assume local commit will work - so signal first.
         // If the monitor.txnCommit fails, the commit should not happen
-        if ( isWriteMode() ) {
+        if ( isInWriteMode() ) {
             try {
                 changesMonitor.txnCommit();
             } catch (Exception ex) {
@@ -279,12 +279,12 @@ public class DatasetGraphChanges extends DatasetGraphWrapper {
     @Override
     public void abort() {
         // Assume abort will work - signal first.
-        if ( isWriteMode() )
+        if ( isInWriteMode() )
             changesMonitor.txnAbort();
         super.abort();
     }
 
-    private boolean isWriteMode() {
+    private boolean isInWriteMode() {
         return super.transactionMode() == ReadWrite.WRITE;
     }
 


### PR DESCRIPTION
GitHub issue resolved #2506

Pull request Description:

To keep the server stable and running, implementations of Fuseki operations must follow the HttpAction lifecycle for transactions.

This PR fixes one problem (found in code review, not as a live bug), and puts in consistency checking.

The consistency checks did show some incorrect use of the  HttpAction lifecycle.

There are also changes to remove other, unrelated logging messages output during Fuseki tests.

The function to apply a patch is moved to the Fuseki servlet package.

----

 - [x] Tests are included 
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
