### PR TITLE
Registry for ResultSetLang

### DIFF
--- a/jena-arq/pom.xml
+++ b/jena-arq/pom.xml
@@ -122,6 +122,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFLanguages.java
@@ -197,6 +197,7 @@ public class RDFLanguages
     private static Map<String, Lang> mapFileExtToLang                  = new HashMap<>();
 
     // ----------------------
+    /** System initialization function. */
     public static void init() {}
     static { init$(); }
 

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFWriterRegistry.java
@@ -279,9 +279,10 @@ public class RDFWriterRegistry
     }
 
     /** Is the RDFFormat registered for use? */
-    public static boolean contains(RDFFormat format)
-    { return langToFormat.containsKey(format.getLang()) && (registryGraph.containsKey(format) || registryDataset.containsKey(format)); }
-
+    public static boolean contains(RDFFormat format) {
+        return langToFormat.containsKey(format.getLang()) &&
+                (registryGraph.containsKey(format) || registryDataset.containsKey(format));
+    }
 
     /** All registered graph formats */
     public static Collection<RDFFormat> registeredGraphFormats() {

--- a/jena-arq/src/main/java/org/apache/jena/riot/resultset/ResultSetLang.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/resultset/ResultSetLang.java
@@ -18,6 +18,9 @@
 
 package org.apache.jena.riot.resultset;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.LangBuilder;
 import org.apache.jena.riot.RDFLanguages;
@@ -25,7 +28,10 @@ import org.apache.jena.riot.WebContent;
 import org.apache.jena.riot.rowset.RowSetReaderRegistry;
 import org.apache.jena.riot.rowset.RowSetWriterRegistry;
 
+/** {@link Lang} related to SPARQL result sets. */
 public class ResultSetLang {
+
+    private ResultSetLang() {}
 
     /** SPARQL results in XML syntax */
     public static final Lang RS_XML = LangBuilder.create("SPARQL-Results-XML", WebContent.contentTypeResultsXML)
@@ -59,22 +65,40 @@ public class ResultSetLang {
     public static final Lang RS_None = LangBuilder.create("SPARQL-Results-None", "application/sparql-results+none").build();
 
     private static boolean initialized = false;
+
+    /** System initialization function */
     public static void init() {
         if ( initialized )
             return;
         initialized = true;
-        RDFLanguages.register(RS_XML);
-        RDFLanguages.register(RS_JSON);
-        RDFLanguages.register(RS_CSV);
-        RDFLanguages.register(RS_TSV);
-        RDFLanguages.register(RS_Thrift);
+        registerResultSetLang(RS_XML);
+        registerResultSetLang(RS_JSON);
+        registerResultSetLang(RS_CSV);
+        registerResultSetLang(RS_TSV);
+        registerResultSetLang(RS_Thrift);
+        registerResultSetLang(RS_Protobuf);
         // Not output-only text.
-        RDFLanguages.register(RS_None);
+        registerResultSetLang(RS_None);
 
         RowSetReaderRegistry.init();
         RowSetWriterRegistry.init();
 
         ResultSetReaderRegistry.init();
         ResultSetWriterRegistry.init();
+        registered = Set.copyOf(registered);
+    }
+
+    /**
+     * Is a lang a registered {@link ResultSetLang}?
+     * @param lang
+     */
+    public static boolean isRegistered(Lang lang) {
+        return registered.contains(lang);
+    }
+
+    private static Set<Lang> registered = new HashSet<>();
+    private static void registerResultSetLang(Lang rsLang)  {
+        registered.add(rsLang);
+        RDFLanguages.register(rsLang);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/resultset/ResultSetReaderRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/resultset/ResultSetReaderRegistry.java
@@ -75,10 +75,10 @@ public class ResultSetReaderRegistry {
         register(RS_Thrift,   factory) ;
         register(RS_Protobuf, factory) ;
     }
-    
+
     /** Return registered result set languages. */
     public static Set<Lang> registered() {
-        return Collections.unmodifiableSet(registry.keySet());
+        return Set.copyOf(registry.keySet());
     }
 
     private static class ResultSetReaderAdapter implements ResultSetReader {

--- a/jena-arq/src/main/java/org/apache/jena/riot/resultset/ResultSetWriterRegistry.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/resultset/ResultSetWriterRegistry.java
@@ -22,7 +22,6 @@ import static org.apache.jena.riot.resultset.ResultSetLang.*;
 
 import java.io.OutputStream;
 import java.io.Writer;
-import java.util.Collection;
 import java.util.Map ;
 import java.util.Objects ;
 import java.util.Set;
@@ -60,10 +59,10 @@ public class ResultSetWriterRegistry {
     }
 
     /** All registered languages */
-    public static Collection<Lang> registered() {
+    public static Set<Lang> registered() {
         return Set.copyOf(registry.keySet());
     }
-    
+
     private static boolean initialized = false ;
     public static void init() {
         if ( initialized )

--- a/jena-arq/src/test/java/org/apache/jena/riot/resultset/TS_ResultSetRIOT.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/resultset/TS_ResultSetRIOT.java
@@ -28,7 +28,7 @@ import org.junit.runners.Suite ;
     TestResultSetIO.class
     , TestResultSetWriterCSV.class
     , TestResultSetWriterTSV.class
+    , TestResultSetLang.class
 })
 
 public class TS_ResultSetRIOT { }
-

--- a/jena-arq/src/test/java/org/apache/jena/riot/resultset/TestResultSetLang.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/resultset/TestResultSetLang.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.resultset;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.stream.Stream;
+
+import org.apache.jena.riot.Lang;
+import org.apache.jena.sys.JenaSystem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestResultSetLang {
+
+    // Testing assumes JenaSystem.init() has run.
+    // Call here for a standalone test suite.
+    static { JenaSystem.init(); }
+
+    @DisplayName("ResultSetLang registration")
+    @ParameterizedTest(name="{index} - {1}")
+    @MethodSource("provideLangs")
+    void registrationResultSetLang(Lang rsLang, String label) {
+        boolean b = ResultSetLang.isRegistered(rsLang);
+        assertTrue(label+" : not registered", b);
+    }
+
+    private static Stream<Arguments> provideLangs() {
+        return Stream.of
+                (Arguments.of(ResultSetLang.RS_JSON, "SPARQL JSON results"),
+                 Arguments.of(ResultSetLang.RS_XML, "SPARQL XML results"),
+                 Arguments.of(ResultSetLang.RS_CSV, "SPARQL CSV results"),
+                 Arguments.of(ResultSetLang.RS_TSV, "SPARQL TSV results"),
+                 Arguments.of(ResultSetLang.RS_Thrift, "SPARQL RDF-Thrift results"),
+                 Arguments.of(ResultSetLang.RS_Protobuf, "SPARQL RDF-Protobuf results"),
+                 // Not a readable format -- ResultSetLang.RS_Text
+                 Arguments.of(ResultSetLang.RS_None, "SPARQL None results"));
+    }
+}


### PR DESCRIPTION
Adds registry functionality to ResultSetLang

----

 - [x] Tests are included.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
