### PR TITLE
Update slf4j to 2.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <project.build.outputTimestamp>2024-03-16T16:17:59Z</project.build.outputTimestamp>
 
     <!-- Logging -->
-    <ver.slf4j>2.0.7</ver.slf4j>
+    <ver.slf4j>2.0.13</ver.slf4j>
     <ver.log4j2>2.23.1</ver.log4j2>
 
     <!-- JSON-LD 1.1 -->


### PR DESCRIPTION
The dependabot update for v2 got turned off while waiting for v2.0.x to stabilise and wasn't turned back on again.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
