### PR TITLE
JENA-2354 Make initial size of node caches configurable via StoreParams

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/CacheFactory.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/CacheFactory.java
@@ -45,6 +45,18 @@ public class CacheFactory {
         return new CacheCaffeine<>(maxSize, dropHandler) ;
     }
 
+    public static <Key, Value> Cache<Key, Value> createCache(int maxSize, double initialCapacityFactor) {
+        return new CacheCaffeine<>(maxSize, null, initialCapacityFactor) ;
+    }
+
+    /**
+     * Create a cache which has space for up to a certain number of objects and with a configurable initial capacity.
+     */
+    public static <Key, Value> Cache<Key, Value> createCache(int maxSize, BiConsumer<Key, Value> dropHandler,
+                                                             double initialCapacityFactor) {
+        return new CacheCaffeine<>(maxSize, dropHandler, initialCapacityFactor) ;
+    }
+
     /** Wrap an existing Caffeine cache */
     public static <Key, Value> Cache<Key, Value> wrap(com.github.benmanes.caffeine.cache.Cache<Key,Value> caffeine) {
         // Use a configured and built Caffeine cache with this API.

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheCaffeine.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheCaffeine.java
@@ -51,7 +51,7 @@ final public class CacheCaffeine<K,V> implements Cache<K, V>
         @SuppressWarnings("unchecked")
         Caffeine<K,V> builder = (Caffeine<K,V>)Caffeine.newBuilder()
             .maximumSize(size);
-        if (initialCapacityFactor > 0.0) {
+        if (initialCapacityFactor >= 0.0 && initialCapacityFactor <= 1.0) {
             builder.initialCapacity((int) Math.round(size * initialCapacityFactor));
         }
         // Eviction immediately using the caller thread.

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheCaffeine.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheCaffeine.java
@@ -44,12 +44,18 @@ final public class CacheCaffeine<K,V> implements Cache<K, V>
     }
 
     public CacheCaffeine(int size, BiConsumer<K, V> dropHandler) {
+        this(size, dropHandler, -1);
+    }
+
+    public CacheCaffeine(int size, BiConsumer<K, V> dropHandler, double initialCapacityFactor) {
         @SuppressWarnings("unchecked")
         Caffeine<K,V> builder = (Caffeine<K,V>)Caffeine.newBuilder()
-            .maximumSize(size)
-            .initialCapacity(size/4)
-            // Eviction immediately using the caller thread.
-            .executor(c->c.run());
+            .maximumSize(size);
+        if (initialCapacityFactor > 0.0) {
+            builder.initialCapacity((int) Math.round(size * initialCapacityFactor));
+        }
+        // Eviction immediately using the caller thread.
+        builder.executor(c->c.run());
 
         if ( dropHandler != null ) {
             RemovalListener<K,V> drop = (key, value, cause)-> {

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/DatasetBuilderStd.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/DatasetBuilderStd.java
@@ -351,7 +351,8 @@ public class DatasetBuilderStd {
         nodeTable = NodeTableCache.create(nodeTable,
                                           params.getNode2NodeIdCacheSize(),
                                           params.getNodeId2NodeCacheSize(),
-                                          params.getNodeMissCacheSize());
+                                          params.getNodeMissCacheSize(),
+                                          params.getNodeCacheInitialCapacityFactor());
         nodeTable = NodeTableInline.create(nodeTable);
         return nodeTable;
     }

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParams.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParams.java
@@ -50,6 +50,7 @@ public class StoreParams implements IndexParams, StoreParamsDynamic
     /*package*/ final Item<Integer>            Node2NodeIdCacheSize ;
     /*package*/ final Item<Integer>            NodeId2NodeCacheSize ;
     /*package*/ final Item<Integer>            NodeMissCacheSize ;
+    /*package*/ final Item<Double>             NodeCacheInitialCapacityFactor ;
 
     /* These are items affect database layout and
      * only can be applied when a database is created.
@@ -87,7 +88,8 @@ public class StoreParams implements IndexParams, StoreParamsDynamic
                             Item<Integer> blockReadCacheSize, Item<Integer> blockWriteCacheSize,
                             Item<Integer> node2NodeIdCacheSize, Item<Integer> nodeId2NodeCacheSize,
                             Item<Integer> nodeMissCacheSize,
-                            Item<String> indexNode2Id, Item<String> indexId2Node, 
+                            Item<Double> NodeCacheInitialCapacityFactor,
+                            Item<String> indexNode2Id, Item<String> indexId2Node,
                             Item<String> primaryIndexTriples, Item<String[]> tripleIndexes,
                             Item<String> primaryIndexQuads, Item<String[]> quadIndexes,
                             Item<String> primaryIndexPrefix, Item<String[]> prefixIndexes,
@@ -99,6 +101,7 @@ public class StoreParams implements IndexParams, StoreParamsDynamic
         this.Node2NodeIdCacheSize   = node2NodeIdCacheSize ;
         this.NodeId2NodeCacheSize   = nodeId2NodeCacheSize ;
         this.NodeMissCacheSize      = nodeMissCacheSize ;
+        this.NodeCacheInitialCapacityFactor = NodeCacheInitialCapacityFactor ;
 
         this.indexNode2Id           = indexNode2Id ;
         this.indexId2Node           = indexId2Node ;
@@ -199,6 +202,16 @@ public class StoreParams implements IndexParams, StoreParamsDynamic
         return NodeMissCacheSize.isSet ;
     }
 
+    @Override
+    public Double getNodeCacheInitialCapacityFactor() {
+        return NodeCacheInitialCapacityFactor.value ;
+    }
+
+    @Override
+    public boolean isSetNodeCacheInitialCapacityFactor() {
+        return NodeCacheInitialCapacityFactor.isSet ;
+    }
+
     public String getIndexNode2Id() {
         return indexNode2Id.value ;
     }
@@ -253,6 +266,7 @@ public class StoreParams implements IndexParams, StoreParamsDynamic
         fmt(buff, "Node2NodeIdCacheSize", getNode2NodeIdCacheSize(), Node2NodeIdCacheSize.isSet) ;
         fmt(buff, "NodeId2NodeCacheSize", getNodeId2NodeCacheSize(), NodeId2NodeCacheSize.isSet) ;
         fmt(buff, "NodeMissCacheSize", getNodeMissCacheSize(), NodeMissCacheSize.isSet) ;
+        fmt(buff, "NodeCacheInitialCapacityFactor", getNodeCacheInitialCapacityFactor(), NodeCacheInitialCapacityFactor.isSet) ;
 
         fmt(buff, "indexNode2Id", getIndexNode2Id(), indexNode2Id.isSet) ;
         fmt(buff, "indexId2Node", getIndexId2Node(), indexId2Node.isSet) ;
@@ -291,6 +305,13 @@ public class StoreParams implements IndexParams, StoreParamsDynamic
         buff.append(String.format("%-20s   %s%s\n", name, dftStr, value)) ;
     }
 
+    private void fmt(StringBuilder buff, String name, double value, boolean isSet) {
+        String dftStr = "" ;
+        if ( ! isSet )
+            dftStr = "dft:" ;
+        buff.append(String.format("%-20s   %s%s\n", name, dftStr, value)) ;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31 ;
@@ -298,6 +319,7 @@ public class StoreParams implements IndexParams, StoreParamsDynamic
         result = prime * result + ((Node2NodeIdCacheSize == null) ? 0 : Node2NodeIdCacheSize.hashCode()) ;
         result = prime * result + ((NodeId2NodeCacheSize == null) ? 0 : NodeId2NodeCacheSize.hashCode()) ;
         result = prime * result + ((NodeMissCacheSize == null) ? 0 : NodeMissCacheSize.hashCode()) ;
+        result = prime * result + ((NodeCacheInitialCapacityFactor == null) ? 0 : NodeCacheInitialCapacityFactor.hashCode()) ;
         result = prime * result + ((blockReadCacheSize == null) ? 0 : blockReadCacheSize.hashCode()) ;
         result = prime * result + ((blockSize == null) ? 0 : blockSize.hashCode()) ;
         result = prime * result + ((blockWriteCacheSize == null) ? 0 : blockWriteCacheSize.hashCode()) ;
@@ -335,6 +357,8 @@ public class StoreParams implements IndexParams, StoreParamsDynamic
         if ( !sameValues(params1.NodeId2NodeCacheSize, params2.NodeId2NodeCacheSize) )
             return false ;
         if ( !sameValues(params1.NodeMissCacheSize, params2.NodeMissCacheSize) )
+            return false ;
+        if ( !sameValues(params1.NodeCacheInitialCapacityFactor, params2.NodeCacheInitialCapacityFactor) )
             return false ;
         if ( !sameValues(params1.blockSize, params2.blockSize) )
             return false ;
@@ -390,6 +414,11 @@ public class StoreParams implements IndexParams, StoreParamsDynamic
             if ( other.NodeMissCacheSize != null )
                 return false ;
         } else if ( !NodeMissCacheSize.equals(other.NodeMissCacheSize) )
+            return false ;
+        if ( NodeCacheInitialCapacityFactor == null ) {
+            if ( other.NodeCacheInitialCapacityFactor != null )
+                return false ;
+        } else if ( !NodeCacheInitialCapacityFactor.equals(other.NodeCacheInitialCapacityFactor) )
             return false ;
         if ( blockReadCacheSize == null ) {
             if ( other.blockReadCacheSize != null )

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsBuilder.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsBuilder.java
@@ -74,6 +74,8 @@ public class StoreParamsBuilder {
 
     private Item<Integer>            NodeMissCacheSize     = new Item<>(StoreParamsConst.NodeMissCacheSize, false) ;
 
+    private Item<Double>             NodeCacheInitialCapacityFactor = new Item<>(StoreParamsConst.NodeCacheInitialCapacityFactor, false);
+
     /** Database layout - ignored after a database is created */
 
     private Item<Integer>            blockSize             = new Item<>(StoreParamsConst.blockSize, false) ;
@@ -136,6 +138,9 @@ public class StoreParamsBuilder {
         if ( additionalParams.isSetNodeMissCacheSize() )
             b.nodeMissCacheSize(additionalParams.getNodeMissCacheSize()) ;
 
+        if ( additionalParams.isSetNodeCacheInitialCapacityFactor() )
+            b.nodeCacheInitialCapacityFactor(additionalParams.getNodeCacheInitialCapacityFactor()) ;
+
         return b.build();
     }
     
@@ -151,6 +156,7 @@ public class StoreParamsBuilder {
         this.Node2NodeIdCacheSize   = other.Node2NodeIdCacheSize ; 
         this.NodeId2NodeCacheSize   = other.NodeId2NodeCacheSize ; 
         this.NodeMissCacheSize      = other.NodeMissCacheSize ; 
+        this.NodeCacheInitialCapacityFactor = other.NodeCacheInitialCapacityFactor ;
 
         this.indexNode2Id           = other.indexNode2Id ; 
         this.indexId2Node           = other.indexId2Node ; 
@@ -173,6 +179,7 @@ public class StoreParamsBuilder {
         return new StoreParams(
                  fileMode, blockSize, blockReadCacheSize, blockWriteCacheSize, 
                  Node2NodeIdCacheSize, NodeId2NodeCacheSize, NodeMissCacheSize,
+                 NodeCacheInitialCapacityFactor,
                  indexNode2Id, indexId2Node, primaryIndexTriples, tripleIndexes,
                  primaryIndexQuads, quadIndexes, primaryIndexPrefix,
                  prefixIndexes, indexPrefix,
@@ -239,6 +246,15 @@ public class StoreParamsBuilder {
 
    public StoreParamsBuilder nodeMissCacheSize(int nodeMissCacheSize) {
        NodeMissCacheSize = new Item<>(nodeMissCacheSize, true) ;
+       return this ;
+   }
+
+   public double getNodeCacheInitialCapacityFactor() {
+       return NodeCacheInitialCapacityFactor.value ;
+   }
+
+   public StoreParamsBuilder nodeCacheInitialCapacityFactor(double nodeCacheInitialCapacityFactor) {
+       NodeCacheInitialCapacityFactor = new Item<>(nodeCacheInitialCapacityFactor, true) ;
        return this ;
    }
 

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsCodec.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsCodec.java
@@ -84,24 +84,25 @@ public class StoreParamsCodec {
         JsonBuilder builder = new JsonBuilder() ;
         builder.startObject("StoreParams") ;    // "StoreParams" is an internal alignment marker - not in the JSON.
 
-        encode(builder, key(fFileMode),                 params.getFileMode().name()) ;
-        encode(builder, key(fBlockSize),                params.getBlockSize()) ;
-        encode(builder, key(fBlockReadCacheSize),       params.getBlockReadCacheSize()) ;
-        encode(builder, key(fBlockWriteCacheSize),      params.getBlockWriteCacheSize()) ;
-        encode(builder, key(fNode2NodeIdCacheSize),     params.getNode2NodeIdCacheSize()) ;
-        encode(builder, key(fNodeId2NodeCacheSize),     params.getNodeId2NodeCacheSize()) ;
-        encode(builder, key(fNodeMissCacheSize),        params.getNodeMissCacheSize()) ;
-        encode(builder, key(fIndexNode2Id),             params.getIndexNode2Id()) ;
-        encode(builder, key(fIndexId2Node),             params.getIndexId2Node()) ;
-        encode(builder, key(fPrimaryIndexTriples),      params.getPrimaryIndexTriples()) ;
-        encode(builder, key(fTripleIndexes),            params.getTripleIndexes()) ;
-        encode(builder, key(fPrimaryIndexQuads),        params.getPrimaryIndexQuads()) ;
-        encode(builder, key(fQuadIndexes),              params.getQuadIndexes()) ;
-        encode(builder, key(fPrimaryIndexPrefix),       params.getPrimaryIndexPrefix()) ;
-        encode(builder, key(fPrefixIndexes),            params.getPrefixIndexes()) ;
-        encode(builder, key(fIndexPrefix),              params.getIndexPrefix()) ;
-        encode(builder, key(fPrefixNode2Id),            params.getPrefixNode2Id()) ;
-        encode(builder, key(fPrefixId2Node),            params.getPrefixId2Node()) ;
+        encode(builder, key(fFileMode),                       params.getFileMode().name()) ;
+        encode(builder, key(fBlockSize),                      params.getBlockSize()) ;
+        encode(builder, key(fBlockReadCacheSize),             params.getBlockReadCacheSize()) ;
+        encode(builder, key(fBlockWriteCacheSize),            params.getBlockWriteCacheSize()) ;
+        encode(builder, key(fNode2NodeIdCacheSize),           params.getNode2NodeIdCacheSize()) ;
+        encode(builder, key(fNodeId2NodeCacheSize),           params.getNodeId2NodeCacheSize()) ;
+        encode(builder, key(fNodeMissCacheSize),              params.getNodeMissCacheSize()) ;
+        encode(builder, key(fNodeCacheInitialCapacityFactor), params.getNodeCacheInitialCapacityFactor());
+        encode(builder, key(fIndexNode2Id),                   params.getIndexNode2Id()) ;
+        encode(builder, key(fIndexId2Node),                   params.getIndexId2Node()) ;
+        encode(builder, key(fPrimaryIndexTriples),            params.getPrimaryIndexTriples()) ;
+        encode(builder, key(fTripleIndexes),                  params.getTripleIndexes()) ;
+        encode(builder, key(fPrimaryIndexQuads),              params.getPrimaryIndexQuads()) ;
+        encode(builder, key(fQuadIndexes),                    params.getQuadIndexes()) ;
+        encode(builder, key(fPrimaryIndexPrefix),             params.getPrimaryIndexPrefix()) ;
+        encode(builder, key(fPrefixIndexes),                  params.getPrefixIndexes()) ;
+        encode(builder, key(fIndexPrefix),                    params.getIndexPrefix()) ;
+        encode(builder, key(fPrefixNode2Id),                  params.getPrefixNode2Id()) ;
+        encode(builder, key(fPrefixId2Node),                  params.getPrefixId2Node()) ;
 
         builder.finishObject("StoreParams") ;
         return (JsonObject)builder.build() ;
@@ -127,24 +128,25 @@ public class StoreParamsCodec {
         for ( String key : json.keys() ) {
             String short_key = unkey(key) ;
             switch(short_key) {
-                case fFileMode :               builder.fileMode(FileMode.valueOf(getString(json, key))) ;   break ;
-                case fBlockSize:               builder.blockSize(getInt(json, key)) ;                       break ;
-                case fBlockReadCacheSize:      builder.blockReadCacheSize(getInt(json, key)) ;              break ;
-                case fBlockWriteCacheSize:     builder.blockWriteCacheSize(getInt(json, key)) ;             break ;
-                case fNode2NodeIdCacheSize:    builder.node2NodeIdCacheSize(getInt(json, key)) ;            break ;
-                case fNodeId2NodeCacheSize:    builder.nodeId2NodeCacheSize(getInt(json, key)) ;            break ;
-                case fNodeMissCacheSize:       builder.nodeMissCacheSize(getInt(json, key)) ;               break ;
-                case fIndexNode2Id:            builder.indexNode2Id(getString(json, key)) ;                 break ;
-                case fIndexId2Node:            builder.indexId2Node(getString(json, key)) ;                 break ;
-                case fPrimaryIndexTriples:     builder.primaryIndexTriples(getString(json, key)) ;          break ;
-                case fTripleIndexes:           builder.tripleIndexes(getStringArray(json, key)) ;           break ;
-                case fPrimaryIndexQuads:       builder.primaryIndexQuads(getString(json, key)) ;            break ;
-                case fQuadIndexes:             builder.quadIndexes(getStringArray(json, key)) ;             break ;
-                case fPrimaryIndexPrefix:      builder.primaryIndexPrefix(getString(json, key)) ;           break ;
-                case fPrefixIndexes:           builder.prefixIndexes(getStringArray(json, key)) ;           break ;
-                case fIndexPrefix:             builder.indexPrefix(getString(json, key)) ;                  break ;
-                case fPrefixNode2Id:           builder.prefixNode2Id(getString(json, key)) ;                break ;
-                case fPrefixId2Node:           builder.prefixId2Node(getString(json, key)) ;                break ;
+                case fFileMode :                      builder.fileMode(FileMode.valueOf(getString(json, key))) ;    break ;
+                case fBlockSize:                      builder.blockSize(getInt(json, key)) ;                        break ;
+                case fBlockReadCacheSize:             builder.blockReadCacheSize(getInt(json, key)) ;               break ;
+                case fBlockWriteCacheSize:            builder.blockWriteCacheSize(getInt(json, key)) ;              break ;
+                case fNode2NodeIdCacheSize:           builder.node2NodeIdCacheSize(getInt(json, key)) ;             break ;
+                case fNodeId2NodeCacheSize:           builder.nodeId2NodeCacheSize(getInt(json, key)) ;             break ;
+                case fNodeMissCacheSize:              builder.nodeMissCacheSize(getInt(json, key)) ;                break ;
+                case fNodeCacheInitialCapacityFactor: builder.nodeCacheInitialCapacityFactor(getDouble(json, key)); break ;
+                case fIndexNode2Id:                   builder.indexNode2Id(getString(json, key)) ;                  break ;
+                case fIndexId2Node:                   builder.indexId2Node(getString(json, key)) ;                  break ;
+                case fPrimaryIndexTriples:            builder.primaryIndexTriples(getString(json, key)) ;           break ;
+                case fTripleIndexes:                  builder.tripleIndexes(getStringArray(json, key)) ;            break ;
+                case fPrimaryIndexQuads:              builder.primaryIndexQuads(getString(json, key)) ;             break ;
+                case fQuadIndexes:                    builder.quadIndexes(getStringArray(json, key)) ;              break ;
+                case fPrimaryIndexPrefix:             builder.primaryIndexPrefix(getString(json, key)) ;            break ;
+                case fPrefixIndexes:                  builder.prefixIndexes(getStringArray(json, key)) ;            break ;
+                case fIndexPrefix:                    builder.indexPrefix(getString(json, key)) ;                   break ;
+                case fPrefixNode2Id:                  builder.prefixNode2Id(getString(json, key)) ;                 break ;
+                case fPrefixId2Node:                  builder.prefixId2Node(getString(json, key)) ;                 break ;
                 default:
                     throw new TDB1Exception("StoreParams key not recognized: "+key) ;
             }
@@ -168,6 +170,13 @@ public class StoreParamsCodec {
         return x ;
     }
 
+    private static Double getDouble(JsonObject json, String key) {
+        if ( ! json.hasKey(key) )
+            throw new TDB1Exception("StoreParamsCodec.getDouble: no such key: "+key);
+        Double x = json.get(key).getAsNumber().value().doubleValue();
+        return x;
+    }
+
     private static String[] getStringArray(JsonObject json, String key) {
         if ( ! json.hasKey(key) )
             throw new TDB1Exception("StoreParamsCodec.getStringArray: no such key: "+key) ;
@@ -181,6 +190,10 @@ public class StoreParamsCodec {
 
     // Encode helper.
     private static void encode(JsonBuilder builder, String name, Object value) {
+        if ( value instanceof Double number ) {
+            builder.key(name).value(number);
+            return;
+        }
         if ( value instanceof Number number ) {
             long x = number.longValue() ;
             builder.key(name).value(x) ;

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsConst.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsConst.java
@@ -51,6 +51,9 @@ public class StoreParamsConst {
     public static final String   fNodeMissCacheSize    = "node_miss_cache_size" ;
     public static final int      NodeMissCacheSize     = SystemTDB.NodeMissCacheSize ;
     
+    public static final String  fNodeCacheInitialCapacityFactor = "node_cache_initial_capacity_factor";
+    public static final double  NodeCacheInitialCapacityFactor  = SystemTDB.NodeCacheInitialCapacityFactor;
+
     /** Database layout - ignored after a database is created */
     public static final String   fBlockSize            = "block_size" ;
     public static final int      blockSize             = SystemTDB.BlockSize ;

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsDynamic.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsDynamic.java
@@ -50,5 +50,12 @@ public interface StoreParamsDynamic {
     /** Node cache for recording known misses */
     public Integer getNodeMissCacheSize() ;
     public boolean isSetNodeMissCacheSize() ;
-}
 
+    /**
+     * Initial capacity factor for node caches:
+     *   - if >= 0.0: initial capacity is set to the (maximum) size of the cache multiplied by the factor
+     *   - if < 0.0:  no initial capacity is set on the cache, i.e. its internal default is used
+     */
+    public Double getNodeCacheInitialCapacityFactor();
+    public boolean isSetNodeCacheInitialCapacityFactor();
+}

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/store/nodetable/NodeTableCache.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/store/nodetable/NodeTableCache.java
@@ -54,21 +54,24 @@ public class NodeTableCache implements NodeTable
         int idToNodeCacheSize = params.getNodeId2NodeCacheSize() ;
         if ( nodeToIdCacheSize <= 0 && idToNodeCacheSize <= 0 )
             return nodeTable ;
-        return new NodeTableCache(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, params.getNodeMissCacheSize()) ;
+        return new NodeTableCache(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, params.getNodeMissCacheSize(),
+                params.getNodeCacheInitialCapacityFactor()) ;
     }
 
-    public static NodeTable create(NodeTable nodeTable, int nodeToIdCacheSize, int idToNodeCacheSize, int nodeMissesCacheSize) {
+    public static NodeTable create(NodeTable nodeTable, int nodeToIdCacheSize, int idToNodeCacheSize, int nodeMissesCacheSize,
+                                   double nodeCacheInitialCapacityFactor) {
         if ( nodeToIdCacheSize <= 0 && idToNodeCacheSize <= 0 )
             return nodeTable ;
-        return new NodeTableCache(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, nodeMissesCacheSize) ;
+        return new NodeTableCache(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, nodeMissesCacheSize, nodeCacheInitialCapacityFactor) ;
     }
 
-    private NodeTableCache(NodeTable baseTable, int nodeToIdCacheSize, int idToNodeCacheSize, int nodeMissesCacheSize) {
+    private NodeTableCache(NodeTable baseTable, int nodeToIdCacheSize, int idToNodeCacheSize, int nodeMissesCacheSize,
+                           double nodeCacheInitialCapacityFactor) {
         this.baseTable = baseTable ;
         if ( nodeToIdCacheSize > 0 )
-            node2id_Cache = CacheFactory.createCache(nodeToIdCacheSize) ;
+            node2id_Cache = CacheFactory.createCache(nodeToIdCacheSize, nodeCacheInitialCapacityFactor) ;
         if ( idToNodeCacheSize > 0 )
-            id2node_Cache = CacheFactory.createCache(idToNodeCacheSize) ;
+            id2node_Cache = CacheFactory.createCache(idToNodeCacheSize, nodeCacheInitialCapacityFactor) ;
         if ( nodeMissesCacheSize > 0 )
             notPresent = CacheFactory.createCacheSet(nodeMissesCacheSize) ;
     }

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/sys/SystemTDB.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/sys/SystemTDB.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException ;
 import java.io.IOException ;
 import java.nio.ByteOrder ;
 import java.util.Properties ;
+import java.util.function.Function;
 
 import org.apache.jena.atlas.io.IO ;
 import org.apache.jena.atlas.lib.PropertyUtils ;
@@ -174,6 +175,9 @@ public class SystemTDB
     /** Size of Node lookup miss cache. */
     public static final int NodeMissCacheSize       = 100 ;
 
+    /** Initial capacity factor for node caches. */
+    public static final double NodeCacheInitialCapacityFactor = doubleValue("NodeCacheInitialCapacityFactor", 0.25);
+
     /** Size of the delayed-write block cache (32 bit systems only) (per file) */
     public static final int BlockWriteCacheSize     = intValue("BlockWriteCacheSize", 2*1000) ;
 
@@ -281,6 +285,16 @@ public class SystemTDB
 
     private static int intValue(String name, int defaultValue)
     {
+        return value(name, defaultValue, Integer::parseInt);
+    }
+
+    private static double doubleValue(String name, double defaultValue)
+    {
+        return value(name, defaultValue, Double::parseDouble);
+    }
+
+    private static <T> T value(String name, T defaultValue, Function<String, T> parse)
+    {
         if ( name == null ) return defaultValue ;
         if ( name.length() == 0 ) throw new TDB1Exception("Empty string for value name") ;
 
@@ -291,7 +305,7 @@ public class SystemTDB
         if ( x == null )
             return defaultValue ;
         TDB1.logInfo.info("Set: "+name+" = "+x) ;
-        int v = Integer.parseInt(x) ;
+        T v = parse.apply(x) ;
         return v ;
     }
 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TestStoreParams.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TestStoreParams.java
@@ -52,6 +52,24 @@ public class TestStoreParams {
         assertEqualsStoreParams(params,params2) ;
     }
     
+    @Test public void store_params_05() {
+        Double initialCapacityFactor = Double.valueOf(0.125);
+        StoreParams params = StoreParams.builder().nodeCacheInitialCapacityFactor(initialCapacityFactor).build();
+        StoreParams params2 = roundTrip(params);
+        assertEqualsStoreParams(params, params2);
+        assertEquals(params.getNodeCacheInitialCapacityFactor(), initialCapacityFactor);
+        assertEquals(params2.getNodeCacheInitialCapacityFactor(), initialCapacityFactor);
+    }
+
+    @Test public void store_params_06() {
+        Double initialCapacityFactor = Double.valueOf(0.33333);
+        String xs = "{ \"tdb.node_cache_initial_capacity_factor\": " + initialCapacityFactor + " }";
+        JsonObject x = JSON.parse(xs);
+        StoreParams paramsExpected = StoreParams.builder().nodeCacheInitialCapacityFactor(initialCapacityFactor).build();
+        StoreParams paramsActual = StoreParamsCodec.decode(x);
+        assertEqualsStoreParams(paramsExpected,paramsActual);
+    }
+
     // ----
     
     @Test public void store_params_10() {

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParams.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParams.java
@@ -251,27 +251,27 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
 
     @Override
     public boolean isSetPrefixNodeId2NodeCacheSize() {
-        return NodeId2NodeCacheSize.isSet;
+        return prefixNodeId2NodeCacheSize.isSet;
     }
 
     @Override
     public boolean isSetPrefixNode2NodeIdCacheSize() {
-        return Node2NodeIdCacheSize.isSet;
+        return prefixNode2NodeIdCacheSize.isSet;
     }
 
     @Override
     public Integer getPrefixNodeId2NodeCacheSize() {
-        return NodeId2NodeCacheSize.value;
+        return prefixNodeId2NodeCacheSize.value;
     }
 
     @Override
     public Integer getPrefixNodeMissCacheSize() {
-        return NodeMissCacheSize.value;
+        return prefixNodeMissCacheSize.value;
     }
 
     @Override
     public boolean isSetPrefixNodeMissCacheSize() {
-        return NodeMissCacheSize.isSet;
+        return prefixNodeMissCacheSize.isSet;
     }
 
     @Override
@@ -339,6 +339,9 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
         fmt(buff, "Node2NodeIdCacheSize", getNode2NodeIdCacheSize(), Node2NodeIdCacheSize.isSet);
         fmt(buff, "NodeId2NodeCacheSize", getNodeId2NodeCacheSize(), NodeId2NodeCacheSize.isSet);
         fmt(buff, "NodeMissCacheSize", getNodeMissCacheSize(), NodeMissCacheSize.isSet);
+        fmt(buff, "prefixNode2NodeIdCacheSize", getPrefixNode2NodeIdCacheSize(), prefixNode2NodeIdCacheSize.isSet);
+        fmt(buff, "prefixNodeId2NodeCacheSize", getPrefixNodeId2NodeCacheSize(), prefixNodeId2NodeCacheSize.isSet);
+        fmt(buff, "prefixNodeMissCacheSize", getPrefixNodeMissCacheSize(), prefixNodeMissCacheSize.isSet);
         fmt(buff, "nodeCacheInitialCapacityFactor", getNodeCacheInitialCapacityFactor(), nodeCacheInitialCapacityFactor.isSet);
 
         fmt(buff, "nodeTableBaseName", getNodeTableBaseName(), nodeTableBaseName.isSet);
@@ -404,6 +407,12 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
             return false;
         if ( !sameValues(params1.NodeMissCacheSize, params2.NodeMissCacheSize) )
             return false;
+        if ( !sameValues(params1.prefixNode2NodeIdCacheSize, params2.prefixNode2NodeIdCacheSize) )
+            return false;
+        if ( !sameValues(params1.prefixNodeId2NodeCacheSize, params2.prefixNodeId2NodeCacheSize) )
+            return false;
+        if ( !sameValues(params1.prefixNodeMissCacheSize, params2.prefixNodeMissCacheSize) )
+            return false;
         if ( !sameValues(params1.nodeCacheInitialCapacityFactor, params2.nodeCacheInitialCapacityFactor) )
             return false;
         if ( !sameValues(params1.nodeTableBaseName, params2.nodeTableBaseName) )
@@ -436,6 +445,9 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
         result = prime * result + ((Node2NodeIdCacheSize == null) ? 0 : Node2NodeIdCacheSize.hashCode());
         result = prime * result + ((NodeId2NodeCacheSize == null) ? 0 : NodeId2NodeCacheSize.hashCode());
         result = prime * result + ((NodeMissCacheSize == null) ? 0 : NodeMissCacheSize.hashCode());
+        result = prime * result + ((prefixNode2NodeIdCacheSize == null) ? 0 : prefixNode2NodeIdCacheSize.hashCode());
+        result = prime * result + ((prefixNodeId2NodeCacheSize == null) ? 0 : prefixNodeId2NodeCacheSize.hashCode());
+        result = prime * result + ((prefixNodeMissCacheSize == null) ? 0 : prefixNodeMissCacheSize.hashCode());
         result = prime * result + ((nodeCacheInitialCapacityFactor == null) ? 0 : nodeCacheInitialCapacityFactor.hashCode());
         result = prime * result + ((blockReadCacheSize == null) ? 0 : blockReadCacheSize.hashCode());
         result = prime * result + ((blockSize == null) ? 0 : blockSize.hashCode());
@@ -475,6 +487,21 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
             if ( other.NodeMissCacheSize != null )
                 return false;
         } else if ( !NodeMissCacheSize.equals(other.NodeMissCacheSize) )
+            return false;
+        if ( prefixNode2NodeIdCacheSize == null ) {
+            if ( other.prefixNode2NodeIdCacheSize != null )
+                return false;
+        } else if ( !prefixNode2NodeIdCacheSize.equals(other.prefixNode2NodeIdCacheSize) )
+            return false;
+        if ( prefixNodeId2NodeCacheSize == null ) {
+            if ( other.prefixNodeId2NodeCacheSize != null )
+                return false;
+        } else if ( !prefixNodeId2NodeCacheSize.equals(other.prefixNodeId2NodeCacheSize) )
+            return false;
+        if ( prefixNodeMissCacheSize == null ) {
+            if ( other.prefixNodeMissCacheSize != null )
+                return false;
+        } else if ( !prefixNodeMissCacheSize.equals(other.prefixNodeMissCacheSize) )
             return false;
         if ( nodeCacheInitialCapacityFactor == null ) {
             if ( other.nodeCacheInitialCapacityFactor != null )

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParams.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParams.java
@@ -56,6 +56,7 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
     /*package*/ final Item<Integer>            prefixNode2NodeIdCacheSize;
     /*package*/ final Item<Integer>            prefixNodeId2NodeCacheSize;
     /*package*/ final Item<Integer>            prefixNodeMissCacheSize;
+    /*package*/ final Item<Double>             nodeCacheInitialCapacityFactor;
 
     /*
      * These are items affect database layout and
@@ -112,6 +113,8 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
                             Item<Integer> prefixNode2NodeIdCacheSize, Item<Integer> prefixNodeId2NodeCacheSize,
                             Item<Integer> prefixNodeMissCacheSize,
 
+                            Item<Double> nodeCacheInitialCapacityFactor,
+
                             Item<String> nodeTableBaseName,
                             Item<String> primaryIndexTriples, Item<String[]> tripleIndexes,
                             Item<String> primaryIndexQuads, Item<String[]> quadIndexes,
@@ -131,6 +134,8 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
         this.prefixNode2NodeIdCacheSize   = prefixNode2NodeIdCacheSize;
         this.prefixNodeId2NodeCacheSize   = prefixNodeId2NodeCacheSize;
         this.prefixNodeMissCacheSize      = prefixNodeMissCacheSize;
+
+        this.nodeCacheInitialCapacityFactor = nodeCacheInitialCapacityFactor;
 
         this.nodeTableBaseName      = nodeTableBaseName;
 
@@ -269,6 +274,16 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
         return NodeMissCacheSize.isSet;
     }
 
+    @Override
+    public Double getNodeCacheInitialCapacityFactor() {
+        return nodeCacheInitialCapacityFactor.value;
+    }
+
+    @Override
+    public boolean isSetNodeCacheInitialCapacityFactor() {
+        return nodeCacheInitialCapacityFactor.isSet;
+    }
+
     public String getNodeTableBaseName() {
         return nodeTableBaseName.value;
     }
@@ -324,6 +339,7 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
         fmt(buff, "Node2NodeIdCacheSize", getNode2NodeIdCacheSize(), Node2NodeIdCacheSize.isSet);
         fmt(buff, "NodeId2NodeCacheSize", getNodeId2NodeCacheSize(), NodeId2NodeCacheSize.isSet);
         fmt(buff, "NodeMissCacheSize", getNodeMissCacheSize(), NodeMissCacheSize.isSet);
+        fmt(buff, "nodeCacheInitialCapacityFactor", getNodeCacheInitialCapacityFactor(), nodeCacheInitialCapacityFactor.isSet);
 
         fmt(buff, "nodeTableBaseName", getNodeTableBaseName(), nodeTableBaseName.isSet);
         fmt(buff, "primaryIndexTriples", getPrimaryIndexTriples(), primaryIndexTriples.isSet);
@@ -359,6 +375,13 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
         buff.append(String.format("%-20s   %s%s\n", name, dftStr, value));
     }
 
+    private void fmt(StringBuilder buff, String name, double value, boolean isSet) {
+        String dftStr = "";
+        if ( ! isSet )
+            dftStr = "dft:";
+        buff.append(String.format("%-20s   %s%s\n", name, dftStr, value));
+    }
+
     /** Equality but ignore "isSet" */
     public static boolean sameValues(StoreParams params1, StoreParams params2) {
         if ( params1 == null && params2 == null )
@@ -380,6 +403,8 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
         if ( !sameValues(params1.NodeId2NodeCacheSize, params2.NodeId2NodeCacheSize) )
             return false;
         if ( !sameValues(params1.NodeMissCacheSize, params2.NodeMissCacheSize) )
+            return false;
+        if ( !sameValues(params1.nodeCacheInitialCapacityFactor, params2.nodeCacheInitialCapacityFactor) )
             return false;
         if ( !sameValues(params1.nodeTableBaseName, params2.nodeTableBaseName) )
             return false;
@@ -411,6 +436,7 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
         result = prime * result + ((Node2NodeIdCacheSize == null) ? 0 : Node2NodeIdCacheSize.hashCode());
         result = prime * result + ((NodeId2NodeCacheSize == null) ? 0 : NodeId2NodeCacheSize.hashCode());
         result = prime * result + ((NodeMissCacheSize == null) ? 0 : NodeMissCacheSize.hashCode());
+        result = prime * result + ((nodeCacheInitialCapacityFactor == null) ? 0 : nodeCacheInitialCapacityFactor.hashCode());
         result = prime * result + ((blockReadCacheSize == null) ? 0 : blockReadCacheSize.hashCode());
         result = prime * result + ((blockSize == null) ? 0 : blockSize.hashCode());
         result = prime * result + ((blockWriteCacheSize == null) ? 0 : blockWriteCacheSize.hashCode());
@@ -449,6 +475,11 @@ public class StoreParams implements IndexParams, BlockParams, StoreParamsDynamic
             if ( other.NodeMissCacheSize != null )
                 return false;
         } else if ( !NodeMissCacheSize.equals(other.NodeMissCacheSize) )
+            return false;
+        if ( nodeCacheInitialCapacityFactor == null ) {
+            if ( other.nodeCacheInitialCapacityFactor != null )
+                return false;
+        } else if ( !nodeCacheInitialCapacityFactor.equals(other.nodeCacheInitialCapacityFactor) )
             return false;
         if ( blockReadCacheSize == null ) {
             if ( other.blockReadCacheSize != null )

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsBuilder.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsBuilder.java
@@ -83,6 +83,8 @@ public class StoreParamsBuilder {
 
     private Item<Integer>            prefixNodeMissCacheSize     = new Item<>(StoreParamsConst.NodeMissCacheSize, false);
 
+    private Item<Double>             nodeCacheInitialCapacityFactor = new Item<>(StoreParamsConst.NodeCacheInitialCapacityFactor, false);
+
     /** Database layout - ignored after a database is created */
 
     private Item<Integer>            blockSize             = new Item<>(StoreParamsConst.blockSize, false);
@@ -150,6 +152,9 @@ public class StoreParamsBuilder {
         if ( additionalParams.isSetNodeMissCacheSize() )
             b.nodeMissCacheSize(additionalParams.getNodeMissCacheSize());
 
+        if ( additionalParams.isSetNodeCacheInitialCapacityFactor() )
+            b.nodeCacheInitialCapacityFactor(additionalParams.getNodeCacheInitialCapacityFactor());
+
         return b.build();
     }
 
@@ -171,6 +176,8 @@ public class StoreParamsBuilder {
         this.prefixNodeId2NodeCacheSize   = other.prefixNodeId2NodeCacheSize;
         this.prefixNodeMissCacheSize      = other.prefixNodeMissCacheSize;
 
+        this.nodeCacheInitialCapacityFactor = other.nodeCacheInitialCapacityFactor;
+
         this.nodeTableBaseName      = other.nodeTableBaseName;
 
         this.primaryIndexTriples    = other.primaryIndexTriples;
@@ -189,6 +196,7 @@ public class StoreParamsBuilder {
                  label, fileMode, blockSize, blockReadCacheSize, blockWriteCacheSize,
                  Node2NodeIdCacheSize, NodeId2NodeCacheSize, NodeMissCacheSize,
                  prefixNode2NodeIdCacheSize, prefixNodeId2NodeCacheSize, prefixNodeMissCacheSize,
+                 nodeCacheInitialCapacityFactor,
                  nodeTableBaseName,
                  primaryIndexTriples, tripleIndexes,
                  primaryIndexQuads, quadIndexes,
@@ -292,6 +300,15 @@ public class StoreParamsBuilder {
 
     public StoreParamsBuilder prefixNodeMissCacheSize(int prefixNodeMissCacheSize) {
         this.prefixNodeMissCacheSize = new Item<>(prefixNodeMissCacheSize, true);
+        return this;
+    }
+
+    public double getNodeCacheInitialCapacityFactor() {
+        return nodeCacheInitialCapacityFactor.value;
+    }
+
+    public StoreParamsBuilder nodeCacheInitialCapacityFactor(double nodeCacheInitialCapacityFactor) {
+        this.nodeCacheInitialCapacityFactor = new Item<>(nodeCacheInitialCapacityFactor, true);
         return this;
     }
 

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsBuilder.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsBuilder.java
@@ -77,11 +77,11 @@ public class StoreParamsBuilder {
 
     private Item<Integer>            NodeMissCacheSize     = new Item<>(StoreParamsConst.NodeMissCacheSize, false);
 
-    private Item<Integer>            prefixNode2NodeIdCacheSize  = new Item<>(StoreParamsConst.Node2NodeIdCacheSize, false);
+    private Item<Integer>            prefixNode2NodeIdCacheSize  = new Item<>(StoreParamsConst.PrefixNode2NodeIdCacheSize, false);
 
-    private Item<Integer>            prefixNodeId2NodeCacheSize  = new Item<>(StoreParamsConst.NodeId2NodeCacheSize, false);
+    private Item<Integer>            prefixNodeId2NodeCacheSize  = new Item<>(StoreParamsConst.PrefixNodeId2NodeCacheSize, false);
 
-    private Item<Integer>            prefixNodeMissCacheSize     = new Item<>(StoreParamsConst.NodeMissCacheSize, false);
+    private Item<Integer>            prefixNodeMissCacheSize     = new Item<>(StoreParamsConst.PrefixNodeMissCacheSize, false);
 
     private Item<Double>             nodeCacheInitialCapacityFactor = new Item<>(StoreParamsConst.NodeCacheInitialCapacityFactor, false);
 
@@ -151,6 +151,15 @@ public class StoreParamsBuilder {
 
         if ( additionalParams.isSetNodeMissCacheSize() )
             b.nodeMissCacheSize(additionalParams.getNodeMissCacheSize());
+
+        if ( additionalParams.isSetPrefixNode2NodeIdCacheSize() )
+            b.prefixNode2NodeIdCacheSize(additionalParams.getPrefixNode2NodeIdCacheSize());
+
+        if ( additionalParams.isSetPrefixNodeId2NodeCacheSize() )
+            b.prefixNodeId2NodeCacheSize(additionalParams.getPrefixNodeId2NodeCacheSize());
+
+        if ( additionalParams.isSetPrefixNodeMissCacheSize() )
+            b.prefixNodeMissCacheSize(additionalParams.getPrefixNodeMissCacheSize());
 
         if ( additionalParams.isSetNodeCacheInitialCapacityFactor() )
             b.nodeCacheInitialCapacityFactor(additionalParams.getNodeCacheInitialCapacityFactor());
@@ -280,7 +289,7 @@ public class StoreParamsBuilder {
         return prefixNode2NodeIdCacheSize.value;
     }
 
-    public StoreParamsBuilder prefixnode2NodeIdCacheSize(int prefixNode2NodeIdCacheSize) {
+    public StoreParamsBuilder prefixNode2NodeIdCacheSize(int prefixNode2NodeIdCacheSize) {
         this.prefixNode2NodeIdCacheSize = new Item<>(prefixNode2NodeIdCacheSize, true);
         return this;
     }
@@ -289,7 +298,7 @@ public class StoreParamsBuilder {
         return prefixNodeId2NodeCacheSize.value;
     }
 
-    public StoreParamsBuilder prefixnodeId2NodeCacheSize(int prefixNodeId2NodeCacheSize) {
+    public StoreParamsBuilder prefixNodeId2NodeCacheSize(int prefixNodeId2NodeCacheSize) {
         this.prefixNodeId2NodeCacheSize = new Item<>(prefixNodeId2NodeCacheSize, true);
         return this;
     }

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsCodec.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsCodec.java
@@ -87,21 +87,22 @@ public class StoreParamsCodec {
 //        if ( params.label != null )
 //            encode(builder, key(fLabel),                params.getLabel());
 
-        encode(builder, key(fFileMode),                 params.getFileMode().name());
-        encode(builder, key(fBlockSize),                params.getBlockSize());
-        encode(builder, key(fBlockReadCacheSize),       params.getBlockReadCacheSize());
-        encode(builder, key(fBlockWriteCacheSize),      params.getBlockWriteCacheSize());
-        encode(builder, key(fNode2NodeIdCacheSize),     params.getNode2NodeIdCacheSize());
-        encode(builder, key(fNodeId2NodeCacheSize),     params.getNodeId2NodeCacheSize());
-        encode(builder, key(fNodeMissCacheSize),        params.getNodeMissCacheSize());
-        encode(builder, key(fNodeTableBaseName),        params.getNodeTableBaseName());
-        encode(builder, key(fPrimaryIndexTriples),      params.getPrimaryIndexTriples());
-        encode(builder, key(fTripleIndexes),            params.getTripleIndexes());
-        encode(builder, key(fPrimaryIndexQuads),        params.getPrimaryIndexQuads());
-        encode(builder, key(fQuadIndexes),              params.getQuadIndexes());
-        encode(builder, key(fPrefixTableBaseName),      params.getPrefixTableBaseName());
-        encode(builder, key(fPrimaryIndexPrefix),       params.getPrimaryIndexPrefix());
-        encode(builder, key(fPrefixIndexes),            params.getPrefixIndexes());
+        encode(builder, key(fFileMode),                       params.getFileMode().name());
+        encode(builder, key(fBlockSize),                      params.getBlockSize());
+        encode(builder, key(fBlockReadCacheSize),             params.getBlockReadCacheSize());
+        encode(builder, key(fBlockWriteCacheSize),            params.getBlockWriteCacheSize());
+        encode(builder, key(fNode2NodeIdCacheSize),           params.getNode2NodeIdCacheSize());
+        encode(builder, key(fNodeId2NodeCacheSize),           params.getNodeId2NodeCacheSize());
+        encode(builder, key(fNodeMissCacheSize),              params.getNodeMissCacheSize());
+        encode(builder, key(fNodeCacheInitialCapacityFactor), params.getNodeCacheInitialCapacityFactor());
+        encode(builder, key(fNodeTableBaseName),              params.getNodeTableBaseName());
+        encode(builder, key(fPrimaryIndexTriples),            params.getPrimaryIndexTriples());
+        encode(builder, key(fTripleIndexes),                  params.getTripleIndexes());
+        encode(builder, key(fPrimaryIndexQuads),              params.getPrimaryIndexQuads());
+        encode(builder, key(fQuadIndexes),                    params.getQuadIndexes());
+        encode(builder, key(fPrefixTableBaseName),            params.getPrefixTableBaseName());
+        encode(builder, key(fPrimaryIndexPrefix),             params.getPrimaryIndexPrefix());
+        encode(builder, key(fPrefixIndexes),                  params.getPrefixIndexes());
 
         builder.finishObject("StoreParams");
         return (JsonObject)builder.build();
@@ -128,25 +129,26 @@ public class StoreParamsCodec {
             String short_key = unkey(key);
             switch(short_key) {
                 // Optional (4.7.0 onwards)
-                case fLabel :                  builder.label(getString(json, key));                        break ;
+                case fLabel :                         builder.label(getString(json, key));                          break ;
                 // Expected.
-                case fFileMode :               builder.fileMode(FileMode.valueOf(getString(json, key)));   break ;
-                case fBlockSize:               builder.blockSize(getInt(json, key));                       break ;
-                case fBlockReadCacheSize:      builder.blockReadCacheSize(getInt(json, key));              break ;
-                case fBlockWriteCacheSize:     builder.blockWriteCacheSize(getInt(json, key));             break ;
-                case fNode2NodeIdCacheSize:    builder.node2NodeIdCacheSize(getInt(json, key));            break ;
-                case fNodeId2NodeCacheSize:    builder.nodeId2NodeCacheSize(getInt(json, key));            break ;
-                case fNodeMissCacheSize:       builder.nodeMissCacheSize(getInt(json, key));               break ;
+                case fFileMode :                      builder.fileMode(FileMode.valueOf(getString(json, key)));     break ;
+                case fBlockSize:                      builder.blockSize(getInt(json, key));                         break ;
+                case fBlockReadCacheSize:             builder.blockReadCacheSize(getInt(json, key));                break ;
+                case fBlockWriteCacheSize:            builder.blockWriteCacheSize(getInt(json, key));               break ;
+                case fNode2NodeIdCacheSize:           builder.node2NodeIdCacheSize(getInt(json, key));              break ;
+                case fNodeId2NodeCacheSize:           builder.nodeId2NodeCacheSize(getInt(json, key));              break ;
+                case fNodeMissCacheSize:              builder.nodeMissCacheSize(getInt(json, key));                 break ;
+                case fNodeCacheInitialCapacityFactor: builder.nodeCacheInitialCapacityFactor(getDouble(json, key)); break ;
 
-                case fNodeTableBaseName:       builder.nodeTableBaseName(getString(json, key));            break ;
-                case fPrimaryIndexTriples:     builder.primaryIndexTriples(getString(json, key));          break ;
-                case fTripleIndexes:           builder.tripleIndexes(getStringArray(json, key));           break ;
-                case fPrimaryIndexQuads:       builder.primaryIndexQuads(getString(json, key));            break ;
-                case fQuadIndexes:             builder.quadIndexes(getStringArray(json, key));             break ;
+                case fNodeTableBaseName:              builder.nodeTableBaseName(getString(json, key));              break ;
+                case fPrimaryIndexTriples:            builder.primaryIndexTriples(getString(json, key));            break ;
+                case fTripleIndexes:                  builder.tripleIndexes(getStringArray(json, key));             break ;
+                case fPrimaryIndexQuads:              builder.primaryIndexQuads(getString(json, key));              break ;
+                case fQuadIndexes:                    builder.quadIndexes(getStringArray(json, key));               break ;
 
-                case fPrefixTableBaseName:     builder.prefixTableBaseName(getString(json, key));          break ;
-                case fPrimaryIndexPrefix:      builder.primaryIndexPrefix(getString(json, key));           break ;
-                case fPrefixIndexes:           builder.prefixIndexes(getStringArray(json, key));           break ;
+                case fPrefixTableBaseName:            builder.prefixTableBaseName(getString(json, key));            break ;
+                case fPrimaryIndexPrefix:             builder.primaryIndexPrefix(getString(json, key));             break ;
+                case fPrefixIndexes:                  builder.prefixIndexes(getStringArray(json, key));             break ;
 
                 default:
                     throw new TDBException("StoreParams key not recognized: "+key);
@@ -171,6 +173,13 @@ public class StoreParamsCodec {
         return x;
     }
 
+    private static Double getDouble(JsonObject json, String key) {
+        if ( ! json.hasKey(key) )
+            throw new TDBException("StoreParamsCodec.getDouble: no such key: "+key);
+        Double x = json.get(key).getAsNumber().value().doubleValue();
+        return x;
+    }
+
     private static String[] getStringArray(JsonObject json, String key) {
         if ( ! json.hasKey(key) )
             throw new TDBException("StoreParamsCodec.getStringArray: no such key: "+key);
@@ -184,6 +193,10 @@ public class StoreParamsCodec {
 
     // Encode helper.
     private static void encode(JsonBuilder builder, String name, Object value) {
+        if ( value instanceof Double number ) {
+            builder.key(name).value(number);
+            return;
+        }
         if ( value instanceof Number number ) {
             long x = number.longValue();
             builder.key(name).value(x);

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsCodec.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsCodec.java
@@ -94,6 +94,9 @@ public class StoreParamsCodec {
         encode(builder, key(fNode2NodeIdCacheSize),           params.getNode2NodeIdCacheSize());
         encode(builder, key(fNodeId2NodeCacheSize),           params.getNodeId2NodeCacheSize());
         encode(builder, key(fNodeMissCacheSize),              params.getNodeMissCacheSize());
+        encode(builder, key(fPrefixNode2NodeIdCacheSize),     params.getPrefixNode2NodeIdCacheSize());
+        encode(builder, key(fPrefixNodeId2NodeCacheSize),     params.getPrefixNodeId2NodeCacheSize());
+        encode(builder, key(fPrefixNodeMissCacheSize),        params.getPrefixNodeMissCacheSize());
         encode(builder, key(fNodeCacheInitialCapacityFactor), params.getNodeCacheInitialCapacityFactor());
         encode(builder, key(fNodeTableBaseName),              params.getNodeTableBaseName());
         encode(builder, key(fPrimaryIndexTriples),            params.getPrimaryIndexTriples());
@@ -138,6 +141,9 @@ public class StoreParamsCodec {
                 case fNode2NodeIdCacheSize:           builder.node2NodeIdCacheSize(getInt(json, key));              break ;
                 case fNodeId2NodeCacheSize:           builder.nodeId2NodeCacheSize(getInt(json, key));              break ;
                 case fNodeMissCacheSize:              builder.nodeMissCacheSize(getInt(json, key));                 break ;
+                case fPrefixNode2NodeIdCacheSize:     builder.prefixNode2NodeIdCacheSize(getInt(json, key));        break ;
+                case fPrefixNodeId2NodeCacheSize:     builder.prefixNodeId2NodeCacheSize(getInt(json, key));        break ;
+                case fPrefixNodeMissCacheSize:        builder.prefixNodeMissCacheSize(getInt(json, key));           break ;
                 case fNodeCacheInitialCapacityFactor: builder.nodeCacheInitialCapacityFactor(getDouble(json, key)); break ;
 
                 case fNodeTableBaseName:              builder.nodeTableBaseName(getString(json, key));              break ;

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsConst.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsConst.java
@@ -58,6 +58,9 @@ public class StoreParamsConst {
     public static final String  fPrefixNodeMissCacheSize  = "prefix_node_miss_cache_size";
     public static final int     PrefixNodeMissCacheSize   = SystemTDB.PrefixNodeMissCacheSize;
 
+    public static final String  fNodeCacheInitialCapacityFactor = "node_cache_initial_capacity_factor";
+    public static final double  NodeCacheInitialCapacityFactor  = SystemTDB.NodeCacheInitialCapacityFactor;
+
     /** Database layout - ignored after a database is created */
     public static final String   fBlockSize            = "block_size";
     public static final int      blockSize             = SystemTDB.BlockSize;

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsDynamic.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsDynamic.java
@@ -67,4 +67,12 @@ public interface StoreParamsDynamic {
     /** Node cache for recording known misses */
     public Integer getPrefixNodeMissCacheSize();
     public boolean isSetPrefixNodeMissCacheSize();
+
+    /**
+     * Initial capacity factor for node caches:
+     *   - if >= 0.0: initial capacity is set to the (maximum) size of the cache multiplied by the factor
+     *   - if < 0.0:  no initial capacity is set on the cache, i.e. its internal default is used
+     */
+    public Double getNodeCacheInitialCapacityFactor();
+    public boolean isSetNodeCacheInitialCapacityFactor();
 }

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/TDB2StorageBuilder.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/TDB2StorageBuilder.java
@@ -297,7 +297,9 @@ public class TDB2StorageBuilder {
         int nodeToIdCacheSize   = isData ? params.getNode2NodeIdCacheSize() : params.getPrefixNode2NodeIdCacheSize();
         int idToNodeCacheSize   = isData ? params.getNodeId2NodeCacheSize() : params.getPrefixNodeId2NodeCacheSize();
         int missCacheSize       = isData ? params.getNodeMissCacheSize()    : params.getPrefixNodeMissCacheSize();
-        nodeTable = NodeTableCache.create(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, missCacheSize);
+        double nodeCacheInitialCapacityFactor = params.getNodeCacheInitialCapacityFactor();
+        nodeTable = NodeTableCache.create(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, missCacheSize,
+                nodeCacheInitialCapacityFactor);
         return nodeTable;
     }
 

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/nodetable/NodeTableCache.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/nodetable/NodeTableCache.java
@@ -77,28 +77,32 @@ public class NodeTableCache implements NodeTable, TransactionListener {
         int nodeToIdCacheSize   = isData ? params.getNode2NodeIdCacheSize() : params.getPrefixNode2NodeIdCacheSize();
         int idToNodeCacheSize   = isData ? params.getNodeId2NodeCacheSize() : params.getPrefixNodeId2NodeCacheSize();
         int missCacheSize       = isData ? params.getNodeMissCacheSize()    : params.getPrefixNodeMissCacheSize();
-        return create(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, missCacheSize);
+        return create(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, missCacheSize,
+                params.getNodeCacheInitialCapacityFactor());
     }
 
     /** Build a node table cache. */
-    public static NodeTable create(NodeTable nodeTable, int nodeToIdCacheSize, int idToNodeCacheSize, int nodeMissesCacheSize) {
+    public static NodeTable create(NodeTable nodeTable, int nodeToIdCacheSize, int idToNodeCacheSize, int nodeMissesCacheSize,
+                                   double nodeCacheInitialCapacityFactor) {
         if ( nodeToIdCacheSize <= 0 && idToNodeCacheSize <= 0 )
             return nodeTable;
-        return new NodeTableCache(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, nodeMissesCacheSize);
+        return new NodeTableCache(nodeTable, nodeToIdCacheSize, idToNodeCacheSize, nodeMissesCacheSize, nodeCacheInitialCapacityFactor);
     }
 
-    private NodeTableCache(NodeTable baseTable, int nodeToIdCacheSize, int idToNodeCacheSize, int nodeMissesCacheSize) {
+    private NodeTableCache(NodeTable baseTable, int nodeToIdCacheSize, int idToNodeCacheSize, int nodeMissesCacheSize,
+                           double nodeCacheInitialCapacityFactor) {
         this.baseTable = baseTable;
         if ( nodeToIdCacheSize > 0 )
-            node2id_Cache = createCache("nodeToId", nodeToIdCacheSize, 1000);
+            node2id_Cache = createCache("nodeToId", nodeToIdCacheSize, nodeCacheInitialCapacityFactor, 1000);
         if ( idToNodeCacheSize > 0 )
-            id2node_Cache = createCache("idToNode", idToNodeCacheSize, 1000);
+            id2node_Cache = createCache("idToNode", idToNodeCacheSize, nodeCacheInitialCapacityFactor, 1000);
         if ( nodeMissesCacheSize > 0 )
-            notPresent = CacheFactory.createCache(nodeMissesCacheSize);
+            notPresent = CacheFactory.createCache(nodeMissesCacheSize, nodeCacheInitialCapacityFactor);
     }
 
-    private static <Key, Value> ThreadBufferingCache<Key, Value> createCache(String label, int mainCachesize, int bufferSize) {
-        Cache<Key, Value> cache = CacheFactory.createCache(mainCachesize);
+    private static <Key, Value> ThreadBufferingCache<Key, Value> createCache(String label, int mainCachesize,
+                                                                             double initialCapacityFactor, int bufferSize) {
+        Cache<Key, Value> cache = CacheFactory.createCache(mainCachesize, initialCapacityFactor);
         return new ThreadBufferingCache<>(label, cache, bufferSize);
     }
 

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/SystemTDB.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/SystemTDB.java
@@ -21,6 +21,7 @@ package org.apache.jena.tdb2.sys;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.function.Function;
 
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.lib.PropertyUtils;
@@ -167,6 +168,9 @@ public class SystemTDB
     /** Size of Node lookup miss cache for prefixes. */
     public static final int PrefixNodeMissCacheSize       = 100;
 
+    /** Initial capacity factor for node caches. */
+    public static final double NodeCacheInitialCapacityFactor = doubleValue("NodeCacheInitialCapacityFactor", 0.25);
+
     /** Size of the delayed-write block cache (32 bit systems only). Per file. */
     public static final int BlockWriteCacheSize     = intValue("BlockWriteCacheSize", 1000);
 
@@ -261,6 +265,14 @@ public class SystemTDB
     }
 
     private static int intValue(String name, int defaultValue) {
+        return value(name, defaultValue, Integer::parseInt);
+    }
+
+    private static double doubleValue(String name, double defaultValue) {
+        return value(name, defaultValue, Double::parseDouble);
+    }
+
+    private static <T> T value(String name, T defaultValue, Function<String, T> parse) {
         if ( name == null )
             return defaultValue;
         if ( name.length() == 0 )
@@ -273,7 +285,7 @@ public class SystemTDB
         if ( x == null )
             return defaultValue;
         TDB2.logInfo.info("Set: " + name + " = " + x);
-        int v = Integer.parseInt(x);
+        T v = parse.apply(x);
         return v;
     }
 

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/setup/TestStoreParams.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/setup/TestStoreParams.java
@@ -55,6 +55,24 @@ public class TestStoreParams {
         assertEqualsStoreParams(params,params2);
     }
 
+    @Test public void store_params_05() {
+        Double initialCapacityFactor = Double.valueOf(0.125);
+        StoreParams params = StoreParams.builder(label()).nodeCacheInitialCapacityFactor(initialCapacityFactor).build();
+        StoreParams params2 = roundTrip(params);
+        assertEqualsStoreParams(params, params2);
+        assertEquals(params.getNodeCacheInitialCapacityFactor(), initialCapacityFactor);
+        assertEquals(params2.getNodeCacheInitialCapacityFactor(), initialCapacityFactor);
+    }
+
+    @Test public void store_params_06() {
+        Double initialCapacityFactor = Double.valueOf(0.33333);
+        String xs = "{ \"tdb.node_cache_initial_capacity_factor\": " + initialCapacityFactor + " }";
+        JsonObject x = JSON.parse(xs);
+        StoreParams paramsExpected = StoreParams.builder(label()).nodeCacheInitialCapacityFactor(initialCapacityFactor).build();
+        StoreParams paramsActual = StoreParamsCodec.decode(x);
+        assertEqualsStoreParams(paramsExpected,paramsActual);
+    }
+
     // ----
 
     @Test public void store_params_10() {


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/projects/JENA/issues/JENA-2354

Pull request Description:

With TDB 4.9.0, node caches change from Guava to Caffeine and are being assigned an initial capacity of 0.25 * their maximum size, increasing the memory footprint. This PR makes the initial capacity factor configurable via StoreParams.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
