### PR TITLE
Add -proc:none to call of Java compiler (Test_schemagen)

### DIFF
--- a/jena-cmds/src/test/java/jena/Test_schemagen.java
+++ b/jena-cmds/src/test/java/jena/Test_schemagen.java
@@ -789,8 +789,10 @@ public class Test_schemagen
 
             if (sjc != null && jcRun != null) {
                 // build the args list for javac
-                String[] args = new String[] {"-classpath", getClassPath( tmpDir ), "-d", tmpDir.getPath(), srcFile.getPath()};
-
+                String[] args = new String[] {"-classpath", getClassPath( tmpDir ),
+                                              "-d", tmpDir.getPath(), srcFile.getPath(),
+                                              // Otherwise the build has warnings (Java21)
+                                              "-proc:none" };
                 int success = (Integer) jcRun.invoke( sjc, null, null, null, args );
                 assertEquals( "Errors reported from compilation of schemagen output", 0, success );
             }


### PR DESCRIPTION
This stops calls of the compiler printing

```
Note: Annotation processing is enabled because one or more processors were found
  on the class path. A future release of javac may disable annotation processing
  unless at least one processor is specified by name (-processor), or a search
  path is specified (--processor-path, --processor-module-path), or annotation
  processing is enabled explicitly (-proc:only, -proc:full).
  Use -Xlint:-options to suppress this message.
  Use -proc:none to disable annotation processing.
```
numerous time in the jena-cmds tests when using Java21 as the build compiler.

`Test_schemagen` invokes the java compiler to check output is correct Java

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
