### PR TITLE
GH-2535: Always use hash joins when joining VALUES blocks

### DIFF
--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestClassify.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestClassify.java
@@ -179,10 +179,10 @@ public class TestClassify
         TestClassify.classifyJ(x1, false);
     }
 
-    /** Can linearize because rhs binds ?x*/
+    /** Could linearize because rhs binds ?x, however, tables on both sides prefers hash join */
     @Test public void testClassify_Join_70b() {
         String x1 = "{ VALUES ?x { UNDEF } VALUES ?x { 0 } }";
-        TestClassify.classifyJ(x1, true);
+        TestClassify.classifyJ(x1, false);
     }
 
     /** Can't linearize because rhs does not bind ?x */
@@ -203,9 +203,33 @@ public class TestClassify
         TestClassify.classifyJ(x1, false);
     }
 
-    /** Can linearize because rhs binds ?x*/
+    /** Could linearize because rhs binds ?x, however, unit tables (beneath BIND) on both sides prefers hash join */
     @Test public void testClassify_Join_82() {
         String x1 = "{ BIND('x' AS ?x) { BIND('y' AS ?x) FILTER(?x < 1) } }";
+        TestClassify.classifyJ(x1, false);
+    }
+
+    /** Can linearize because rhs binds ?z */
+    @Test public void testClassify_Join_90a() {
+        String x1 = "{ ?x ?y ?z VALUES ?z { 0 } }";
+        TestClassify.classifyJ(x1, true);
+    }
+
+    /** Can linearize because rhs binds ?z (bgps must bind mentioned variables) */
+    @Test public void testClassify_Join_90b() {
+        String x1 = "{ VALUES ?z { 0 } ?x ?y ?z }";
+        TestClassify.classifyJ(x1, true);
+    }
+
+    /** Can't linearize because rhs does not bind ?z */
+    @Test public void testClassify_Join_91a() {
+        String x1 = "{ ?x ?y ?z  VALUES ?z { UNDEF } }";
+        TestClassify.classifyJ(x1, false);
+    }
+
+    /** Can linearize because rhs binds ?z */
+    @Test public void testClassify_Join_91b() {
+        String x1 = "{ VALUES ?z { UNDEF } ?x ?y ?z }";
         TestClassify.classifyJ(x1, true);
     }
 


### PR DESCRIPTION
GitHub issue resolved #2535 

Pull request Description: Update to JoinClassifier such that joins between tables are not linearized.
The downside is, that this PR adds extra passes over the algebra tree to JoinClassifier in order to check for the operand types.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
