### PR TITLE
GH-2487: add OntClass#canAs*Class methods + fix some mistakes

### DIFF
--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntJenaException.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntJenaException.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.ontapi;
 
-import org.apache.jena.ontapi.common.EnhNodeFactory;
 import org.apache.jena.shared.JenaException;
 
 /**
@@ -134,10 +133,8 @@ public class OntJenaException extends JenaException {
 
     /**
      * Exception that is thrown when an ontology resource is converted to another facet,
-     * using {@link org.apache.jena.rdf.model.RDFNode#as as()},
+     * usually using {@link org.apache.jena.rdf.model.RDFNode#as as()},
      * and the requested conversion is not possible.
-     * This is an analogue of {@link org.apache.jena.ontology.ConversionException},
-     * and it is used mostly by {@link EnhNodeFactory}.
      */
     public static class Conversion extends OntJenaException {
         public Conversion(String message, Throwable cause) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
@@ -264,7 +264,7 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
             return testIsOWLClass(model, candidate);
         }
         OntClass clazz = model.safeFindNodeAs(candidate, OntClass.class);
-        return clazz != null && clazz.asAssertionClass() != null;
+        return clazz != null && clazz.canAsAssertionClass();
     }
 
     private static <M extends OntModel & OntEnhGraph> boolean testIsOWLClass(M model, Node candidate) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
@@ -176,8 +176,8 @@ public final class OWL2ObjectFactories {
                     OntClass.class,
                     OntClassImpl.ComplementOfImpl::new,
                     config);
-    public static final Function<OntConfig, EnhNodeFactory> QL_COMPLEMENT_OF_CLASS = OntClasses::createOWL2RLQLComplementOfFactory;
-    public static final Function<OntConfig, EnhNodeFactory> RL_COMPLEMENT_OF_CLASS = OntClasses::createOWL2RLQLComplementOfFactory;
+    public static final Function<OntConfig, EnhNodeFactory> QL_COMPLEMENT_OF_CLASS = OntClasses::createOWL2QLComplementOfFactory;
+    public static final Function<OntConfig, EnhNodeFactory> RL_COMPLEMENT_OF_CLASS = OntClasses::createOWL2RLComplementOfFactory;
 
     public static final Function<OntConfig, EnhNodeFactory> OBJECT_SOME_VALUES_FROM_CLASS =
             config -> OntClasses.createComponentRestrictionFactory(

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntSimpleClassImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntSimpleClassImpl.java
@@ -186,22 +186,54 @@ public class OntSimpleClassImpl extends OntObjectImpl implements OntClass {
 
         @Override
         public OntClass asSubClass() {
-            return OWL2.Thing.equals(this) ? null : this;
+            if (OWL2.Thing.equals(this)) {
+                throw new OntJenaException.Unsupported("Specification does not allow this class to be a subclass");
+            }
+            return this;
+        }
+
+        @Override
+        public boolean canAsSubClass() {
+            return !OWL2.Thing.equals(this);
         }
 
         @Override
         public OntClass asSuperClass() {
-            return OWL2.Thing.equals(this) ? null : this;
+            if (OWL2.Thing.equals(this)) {
+                throw new OntJenaException.Unsupported("Specification does not allow this class to be a superclass");
+            }
+            return this;
+        }
+
+        @Override
+        public boolean canAsSuperClass() {
+            return !OWL2.Thing.equals(this);
         }
 
         @Override
         public OntClass asEquivalentClass() {
-            return OWL2.Thing.equals(this) ? null : this;
+            if (OWL2.Thing.equals(this)) {
+                throw new OntJenaException.Unsupported("Specification does not allow this class to be an equivalent class");
+            }
+            return this;
+        }
+
+        @Override
+        public boolean canAsEquivalentClass() {
+            return !OWL2.Thing.equals(this);
         }
 
         @Override
         public OntClass asDisjointClass() {
-            return OWL2.Thing.equals(this) ? null : this;
+            if (OWL2.Thing.equals(this)) {
+                throw new OntJenaException.Unsupported("Specification does not allow this class to be a disjoint class");
+            }
+            return this;
+        }
+
+        @Override
+        public boolean canAsDisjointClass() {
+            return !OWL2.Thing.equals(this);
         }
     }
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntIndividual.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntIndividual.java
@@ -100,6 +100,9 @@ public interface OntIndividual extends OntObject, AsNamed<OntIndividual.Named>, 
      */
     default boolean hasOntClass(OntClass clazz, boolean direct) {
         Objects.requireNonNull(clazz);
+        if (!clazz.canAsAssertionClass()) {
+            return false;
+        }
         try (Stream<OntClass> classes = classes(direct)) {
             return classes.anyMatch(clazz::equals);
         }

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntObjectProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntObjectProperty.java
@@ -133,7 +133,7 @@ public interface OntObjectProperty extends OntRelationalProperty, AsNamed<OntObj
      */
     @Override
     default Stream<OntClass> ranges() {
-        return objects(RDFS.range, OntClass.class).map(OntClass::asSuperClass).filter(Objects::nonNull);
+        return objects(RDFS.range, OntClass.class).filter(OntClass::canAsSuperClass).map(OntClass::asSuperClass);
     }
 
     /**

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntRelationalProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntRelationalProperty.java
@@ -203,7 +203,7 @@ public interface OntRelationalProperty extends OntProperty {
      */
     @Override
     default Stream<OntClass> domains() {
-        return objects(RDFS.domain, OntClass.class).map(OntClass::asSuperClass).filter(Objects::nonNull);
+        return objects(RDFS.domain, OntClass.class).filter(OntClass::canAsSuperClass).map(OntClass::asSuperClass);
     }
 
     /**

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2QLSpecTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2QLSpecTest.java
@@ -123,14 +123,15 @@ public class OntModelOWL2QLSpecTest {
         OntClass oc1 = c1.inModel(m).as(OntClass.ObjectSomeValuesFrom.class);
         OntClass oc3 = c3.inModel(m).as(OntClass.ObjectSomeValuesFrom.class);
 
-        Assertions.assertNull(oc1.asSubClass());
+        Assertions.assertFalse(oc1.canAsSubClass());
+        Assertions.assertThrows(OntJenaException.Unsupported.class, oc1::asSubClass);
         Assertions.assertSame(oc3, oc3.asSubClass());
         Assertions.assertSame(oc1, oc1.asSuperClass());
         Assertions.assertSame(oc3, oc3.asSuperClass());
 
         Assertions.assertThrows(OntJenaException.Unsupported.class, () -> m.createObjectSomeValuesFrom(p, oc1));
 
-        Assertions.assertNull(m.createObjectSomeValuesFrom(p, c0).asSubClass());
+        Assertions.assertThrows(OntJenaException.Unsupported.class, () -> m.createObjectSomeValuesFrom(p, c0).asSubClass());
         Assertions.assertEquals(4, m.ontObjects(OntClass.class).count());
         Assertions.assertEquals(3, m.ontObjects(OntClass.ObjectSomeValuesFrom.class).count());
     }
@@ -249,6 +250,7 @@ public class OntModelOWL2QLSpecTest {
             "OWL2_QL_MEM_TRANS_INF",
     })
     public void testIndividuals(TestSpec spec) {
+        // class assertions in OWL 2 QL can involve only atomic classes
         OntModel m = OntModelFactory.createModel(spec.inst);
         OntObjectProperty op = m.createObjectProperty("p");
         OntDataProperty dp = m.createDataProperty("d");
@@ -279,7 +281,7 @@ public class OntModelOWL2QLSpecTest {
         Assertions.assertEquals(List.of(), c4.individuals().collect(Collectors.toList()));
         Assertions.assertEquals(List.of(), c5.individuals().collect(Collectors.toList()));
 
-        Assertions.assertEquals(List.of(c0), i0.classes().collect(Collectors.toList()));
+        Assertions.assertEquals(Set.of(c0), i0.classes().collect(Collectors.toSet()));
         Assertions.assertEquals(List.of(), i1.classes().collect(Collectors.toList()));
         Assertions.assertEquals(List.of(), i2.classes().collect(Collectors.toList()));
         Assertions.assertEquals(List.of(), i3.classes().collect(Collectors.toList()));
@@ -343,5 +345,73 @@ public class OntModelOWL2QLSpecTest {
         c1.addProperty(OWL2.equivalentClass, c2);
         Assertions.assertEquals(List.of(c0), c1.equivalentClasses().collect(Collectors.toList()));
         Assertions.assertEquals(List.of(), c2.equivalentClasses().collect(Collectors.toList()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {
+            "OWL2_QL_MEM",
+            "OWL2_QL_MEM_RDFS_INF",
+            "OWL2_QL_MEM_TRANS_INF",
+    })
+    public void testDisjointEquivalentAxioms(TestSpec spec) {
+        OntModel data = OntModelFactory.createModel();
+        OntObjectProperty p0 = data.createObjectProperty("p0");
+        OntDataProperty p1 = data.createDataProperty("p1");
+
+        OntClass c0 = data.createOntClass("c0");
+        OntClass c1 = data.createDataHasValue(p1, data.createTypedLiteral(42));
+        OntClass c2 = data.createObjectOneOf(data.createIndividual("X"));
+
+        OntClass c3 = data.createObjectSomeValuesFrom(p0, c0);
+        OntClass c4 = data.createObjectAllValuesFrom(p0, c2);
+        OntClass c5 = data.createDataMinCardinality(p1, 42, data.getDatatype(XSD.xstring));
+        OntClass c6 = data.createDataMaxCardinality(p1, 0, data.getDatatype(XSD.xstring));
+
+        OntClass c7 = data.createObjectIntersectionOf(c3, c0);
+        OntClass c8 = data.createObjectIntersectionOf(c1, c2);
+
+        OntClass c9 = data.createObjectComplementOf(c2);
+        OntClass c10 = data.createObjectComplementOf(c9);
+
+        OntClass c11 = data.createObjectSomeValuesFrom(p0, data.getOWLThing());
+        OntClass c12 = data.createDataSomeValuesFrom(p1, data.getDatatype(XSD.xstring));
+
+        OntModel m = OntModelFactory.createModel(data.getGraph(), spec.inst);
+
+        OntClass mc0 = c0.inModel(m).as(OntClass.class);
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c1.inModel(m).as(OntClass.class));
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c2.inModel(m).as(OntClass.class));
+        OntClass mc3 = c3.inModel(m).as(OntClass.class);
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c4.inModel(m).as(OntClass.class));
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c5.inModel(m).as(OntClass.class));
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c6.inModel(m).as(OntClass.class));
+        OntClass mc7 = c7.inModel(m).as(OntClass.class);
+        Assertions.assertThrows(OntJenaException.Conversion.class, () ->  c8.inModel(m).as(OntClass.class));
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c9.inModel(m).as(OntClass.class));
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c10.inModel(m).as(OntClass.class));
+        OntClass mc11 = c11.inModel(m).as(OntClass.class);
+        OntClass mc12 = c12.inModel(m).as(OntClass.class);
+
+        Assertions.assertTrue(mc0.canAsEquivalentClass());
+        Assertions.assertTrue(mc0.canAsDisjointClass());
+        Assertions.assertFalse(mc3.canAsEquivalentClass());
+        Assertions.assertFalse(mc3.canAsDisjointClass());
+        Assertions.assertFalse(mc7.canAsEquivalentClass());
+        Assertions.assertFalse(mc7.canAsDisjointClass());
+        Assertions.assertTrue(mc11.canAsEquivalentClass());
+        Assertions.assertTrue(mc11.canAsDisjointClass());
+        Assertions.assertTrue(mc12.canAsEquivalentClass());
+        Assertions.assertTrue(mc12.canAsDisjointClass());
+
+        Assertions.assertSame(mc0, mc0.asEquivalentClass());
+        Assertions.assertSame(mc0, mc0.asDisjointClass());
+        Assertions.assertSame(mc11, mc11.asEquivalentClass());
+        Assertions.assertSame(mc11, mc11.asDisjointClass());
+        Assertions.assertSame(mc12, mc12.asEquivalentClass());
+        Assertions.assertSame(mc12, mc12.asDisjointClass());
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc3::asDisjointClass);
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc3::asEquivalentClass);
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc7::asDisjointClass);
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc7::asEquivalentClass);
     }
 }

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2RLSpecTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2RLSpecTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.jena.ontapi.OntModelOWLSpecsTest.testListObjects;
@@ -343,6 +344,177 @@ public class OntModelOWL2RLSpecTest {
         Assertions.assertEquals(4, m.ontObjects(OntClass.ValueRestriction.class).count());
         Assertions.assertEquals(4, m.ontObjects(OntClass.ComponentRestriction.class).count());
         Assertions.assertEquals(3, m.ontObjects(OntClass.ObjectAllValuesFrom.class).count());
+    }
+
+
+    @ParameterizedTest
+    @EnumSource(names = {
+            "OWL2_RL_MEM",
+            "OWL2_RL_MEM_RDFS_INF",
+            "OWL2_RL_MEM_TRANS_INF",
+    })
+    public void testClassAssertions(TestSpec spec) {
+        // OWL 2 RL restricts class expressions in positive assertions to superClassExpression.
+        // All other assertions are the same as in the structural specification
+
+        OntModel data = OntModelFactory.createModel();
+        OntObjectProperty p0 = data.createObjectProperty("p0");
+        OntDataProperty p1 = data.createDataProperty("p1");
+
+        OntClass c0 = data.createOntClass("c0"); // can be super
+        OntClass c1 = data.createDataHasValue(p1, data.createTypedLiteral(42)); // can be super
+        OntClass c2 = data.createObjectOneOf(data.createIndividual("X")); // cannot be super, can be sub
+
+        OntClass c3 = data.createObjectSomeValuesFrom(p0, c0); // cannot be super
+        OntClass c4 = data.createObjectAllValuesFrom(p0, c2); // cannot be super, cannot be sub
+        OntClass c5 = data.createDataMinCardinality(p1, 42, data.getDatatype(XSD.xstring)); // cannot be super and sub
+        OntClass c6 = data.createDataMaxCardinality(p1, 0, data.getDatatype(XSD.xstring)); // can be super
+
+        OntClass c7 = data.createObjectIntersectionOf(c1, c0); // can be supper, can be sub
+        OntClass c8 = data.createObjectIntersectionOf(c1, c2); // cannot be supper, can be sub
+
+        OntClass c9 = data.createObjectComplementOf(c2); // can be super, cannot be sub
+        OntClass c10 = data.createObjectComplementOf(c9); // cannot be super, cannot be sub
+
+        data.createIndividual("i1").attachClass(c3).attachClass(c4).attachClass(c5).attachClass(c7);
+        data.createIndividual("i2").attachClass(c1).attachClass(c2).attachClass(c6);
+        data.createIndividual("i3").attachClass(c9).attachClass(c10).attachClass(c8);
+
+        OntModel m = OntModelFactory.createModel(data.getGraph(), spec.inst);
+
+        Assertions.assertEquals(List.of(c7), m.getIndividual("i1").classes().toList());
+        Assertions.assertEquals(Set.of(c1, c6), m.getIndividual("i2").classes().collect(Collectors.toSet()));
+        Assertions.assertEquals(List.of(c9), m.getIndividual("i3").classes().toList());
+
+        Assertions.assertTrue(c0.inModel(m).as(OntClass.class).canAsAssertionClass());
+        Assertions.assertTrue(c1.inModel(m).as(OntClass.class).canAsAssertionClass());
+        Assertions.assertFalse(c2.inModel(m).as(OntClass.class).canAsAssertionClass());
+        Assertions.assertThrows(OntJenaException.Unsupported.class, c2.inModel(m).as(OntClass.class)::asAssertionClass);
+        Assertions.assertFalse(c3.inModel(m).as(OntClass.class).canAsAssertionClass());
+        Assertions.assertThrows(OntJenaException.Unsupported.class, c3.inModel(m).as(OntClass.class)::asAssertionClass);
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c4.inModel(m).as(OntClass.class));
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c5.inModel(m).as(OntClass.class));
+        Assertions.assertTrue(c6.inModel(m).as(OntClass.class).canAsAssertionClass());
+        Assertions.assertTrue(c7.inModel(m).as(OntClass.class).canAsAssertionClass());
+        Assertions.assertFalse(c8.inModel(m).as(OntClass.class).canAsAssertionClass());
+        Assertions.assertThrows(OntJenaException.Unsupported.class, c8.inModel(m).as(OntClass.class)::asAssertionClass);
+        Assertions.assertTrue(c9.inModel(m).as(OntClass.class).canAsAssertionClass());
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c10.inModel(m).as(OntClass.class));
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {
+            "OWL2_RL_MEM",
+            "OWL2_RL_MEM_RDFS_INF",
+            "OWL2_RL_MEM_TRANS_INF",
+    })
+    public void testDisjointAxiom(TestSpec spec) {
+        OntModel data = OntModelFactory.createModel();
+        OntObjectProperty p0 = data.createObjectProperty("p0");
+        OntDataProperty p1 = data.createDataProperty("p1");
+
+        OntClass c0 = data.createOntClass("c0"); // can be super, can be sub
+        OntClass c1 = data.createDataHasValue(p1, data.createTypedLiteral(42)); // can be super, can be sub
+        OntClass c2 = data.createObjectOneOf(data.createIndividual("X")); // cannot be super, can be sub
+
+        OntClass c3 = data.createObjectSomeValuesFrom(p0, c0); // cannot be super, can be sub
+        OntClass c4 = data.createObjectAllValuesFrom(p0, c2); // cannot be super, cannot be sub
+        OntClass c5 = data.createDataMinCardinality(p1, 42, data.getDatatype(XSD.xstring)); // cannot be super and sub
+        OntClass c6 = data.createDataMaxCardinality(p1, 0, data.getDatatype(XSD.xstring)); // can be super, cannot be sub
+
+        OntClass c7 = data.createObjectIntersectionOf(c1, c0); // can be supper, can be sub
+        OntClass c8 = data.createObjectIntersectionOf(c1, c2); // cannot be supper, can be sub
+
+        OntClass c9 = data.createObjectComplementOf(c2); // can be super, cannot be sub
+        OntClass c10 = data.createObjectComplementOf(c9); // cannot be super, cannot be sub
+
+        OntModel m = OntModelFactory.createModel(data.getGraph(), spec.inst);
+
+        OntClass mc0 = c0.inModel(m).as(OntClass.class);
+        OntClass mc1 = c1.inModel(m).as(OntClass.class);
+        OntClass mc2 = c2.inModel(m).as(OntClass.class);
+        OntClass mc3 = c3.inModel(m).as(OntClass.class);
+        OntClass mc6 = c6.inModel(m).as(OntClass.class);
+        OntClass mc7 = c7.inModel(m).as(OntClass.class);
+        OntClass mc8 = c8.inModel(m).as(OntClass.class);
+        OntClass mc9 = c9.inModel(m).as(OntClass.class);
+
+        Assertions.assertTrue(mc0.canAsDisjointClass());
+        Assertions.assertTrue(mc1.canAsDisjointClass());
+        Assertions.assertTrue(mc2.canAsDisjointClass());
+        Assertions.assertTrue(mc3.canAsDisjointClass());
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c4.inModel(m).as(OntClass.class));
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c5.inModel(m).as(OntClass.class));
+        Assertions.assertFalse(mc6.canAsDisjointClass());
+        Assertions.assertTrue(mc7.canAsDisjointClass());
+        Assertions.assertTrue(mc8.canAsDisjointClass());
+        Assertions.assertFalse(mc9.canAsDisjointClass());
+        Assertions.assertThrows(OntJenaException.Conversion.class, () -> c10.inModel(m).as(OntClass.class));
+
+        Assertions.assertSame(mc0, mc0.asDisjointClass());
+        Assertions.assertSame(mc1, mc1.asDisjointClass());
+        Assertions.assertSame(mc2, mc2.asDisjointClass());
+        Assertions.assertSame(mc3, mc3.asDisjointClass());
+        Assertions.assertNotSame(mc7, mc7.asDisjointClass());
+        Assertions.assertEquals(mc7, mc7.asDisjointClass());
+        Assertions.assertNotSame(mc8, mc8.asDisjointClass());
+        Assertions.assertEquals(mc8, mc8.asDisjointClass());
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc6::asDisjointClass);
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc9::asDisjointClass);
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {
+            "OWL2_RL_MEM",
+            "OWL2_RL_MEM_RDFS_INF",
+            "OWL2_RL_MEM_TRANS_INF",
+    })
+    public void testEquivalentAxiom(TestSpec spec) {
+        OntModel data = OntModelFactory.createModel();
+        OntObjectProperty p0 = data.createObjectProperty("p0");
+        OntDataProperty p1 = data.createDataProperty("p1");
+
+        OntClass c0 = data.createOntClass("c0"); // can be super, can be sub, can be equiv
+        OntClass c1 = data.createDataHasValue(p1, data.createTypedLiteral(42)); // can be super, can be sub, can be equiv
+        OntClass c2 = data.createObjectOneOf(data.createIndividual("X")); // cannot be super, can be sub, cannot be equiv
+
+        OntClass c3 = data.createObjectSomeValuesFrom(p0, c0); // cannot be super, can be sub, cannot be equiv
+        OntClass c6 = data.createDataMaxCardinality(p1, 0, data.getDatatype(XSD.xstring)); // can be super, cannot be sub, cannot be equiv
+
+        OntClass c7 = data.createObjectIntersectionOf(c1, c0); // can be supper, can be sub, can be equiv
+        OntClass c8 = data.createObjectIntersectionOf(c1, c2); // cannot be supper, can be sub, cannot be equiv
+        OntClass c9 = data.createObjectComplementOf(c2); // can be super, cannot be sub, cannot be equiv
+
+        OntModel m = OntModelFactory.createModel(data.getGraph(), spec.inst);
+
+        OntClass mc0 = c0.inModel(m).as(OntClass.class);
+        OntClass mc1 = c1.inModel(m).as(OntClass.class);
+        OntClass mc2 = c2.inModel(m).as(OntClass.class);
+        OntClass mc3 = c3.inModel(m).as(OntClass.class);
+        OntClass mc6 = c6.inModel(m).as(OntClass.class);
+        OntClass mc7 = c7.inModel(m).as(OntClass.class);
+        OntClass mc8 = c8.inModel(m).as(OntClass.class);
+        OntClass mc9 = c9.inModel(m).as(OntClass.class);
+
+        Assertions.assertFalse(m.getOWLThing().canAsEquivalentClass());
+        Assertions.assertTrue(mc0.canAsEquivalentClass());
+        Assertions.assertTrue(mc1.canAsEquivalentClass());
+        Assertions.assertFalse(mc2.canAsEquivalentClass());
+        Assertions.assertFalse(mc3.canAsEquivalentClass());
+        Assertions.assertFalse(mc6.canAsEquivalentClass());
+        Assertions.assertTrue(mc7.canAsEquivalentClass());
+        Assertions.assertFalse(mc8.canAsEquivalentClass());
+        Assertions.assertFalse(mc9.canAsEquivalentClass());
+
+        Assertions.assertSame(mc0, mc0.asEquivalentClass());
+        Assertions.assertSame(mc1, mc1.asEquivalentClass());
+        Assertions.assertNotSame(mc7, mc7.asEquivalentClass());
+        Assertions.assertEquals(mc7, mc7.asEquivalentClass());
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc2::asEquivalentClass);
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc3::asEquivalentClass);
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc6::asEquivalentClass);
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc8::asEquivalentClass);
+        Assertions.assertThrows(OntJenaException.Unsupported.class, mc9::asEquivalentClass);
     }
 
     @ParameterizedTest

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/StreamsTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/StreamsTest.java
@@ -22,7 +22,6 @@ import org.apache.jena.ontapi.impl.UnionGraphImpl;
 import org.apache.jena.ontapi.model.OntAnnotationProperty;
 import org.apache.jena.ontapi.model.OntClass;
 import org.apache.jena.ontapi.model.OntDataProperty;
-import org.apache.jena.ontapi.model.OntIndividual;
 import org.apache.jena.ontapi.model.OntModel;
 import org.apache.jena.ontapi.model.OntObject;
 import org.apache.jena.sparql.graph.GraphFactory;
@@ -91,8 +90,6 @@ public class StreamsTest {
     public void testSetBasedMethods() {
         OntModel m = OntModelFactory.createModel();
         OntClass.Named a = m.createOntClass("C1");
-        OntIndividual i = a.addSuperClass(m.createOntClass("C2").addSuperClass(m.getOWLThing()))
-                .createIndividual("I");
         OntDataProperty p = m.createDataProperty("D1")
                 .addSuperProperty(m.createDataProperty("D2").addSuperProperty(m.getOWLBottomDataProperty()));
 
@@ -101,9 +98,6 @@ public class StreamsTest {
         Supplier<Stream<?>> s3 = () -> a.subClasses(true);
         Supplier<Stream<?>> s4 = () -> a.superClasses(true);
 
-        Supplier<Stream<?>> s5 = () -> i.classes(false);
-        Supplier<Stream<?>> s6 = () -> i.classes(true);
-
         Supplier<Stream<?>> s7 = () -> p.superProperties(false);
         Supplier<Stream<?>> s8 = () -> p.subProperties(false);
         Supplier<Stream<?>> s9 = () -> p.superProperties(true);
@@ -111,7 +105,7 @@ public class StreamsTest {
 
         Supplier<Stream<?>> s11 = p::content;
 
-        Stream.of(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11).forEach(s -> {
+        Stream.of(s1, s2, s3, s4, s7, s8, s9, s10, s11).forEach(s -> {
             assertTrueConstant(s.get(), Spliterator.NONNULL);
             assertTrueConstant(s.get(), Spliterator.DISTINCT);
             assertTrueConstant(s.get(), Spliterator.IMMUTABLE);


### PR DESCRIPTION
- add `OntClass#canAsSubClass`, `OntClass#canAsSuperClass`, `OntClass#canAsAssertionClass`, `OntClass#canAsDisjointClass`, `OntClass#canAsEquivalentClass`
- make `OntClass#as*Class` throw exception if corresponding `OntClass#canAs*Class` returns false
- fix few mistakes related to RL/QL profiles

GitHub issue resolved #

Pull request Description:



----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
