### PR TITLE
GH-2160: Include jena-ontapi in distributions

### DIFF
--- a/apache-jena-libs/pom.xml
+++ b/apache-jena-libs/pom.xml
@@ -51,6 +51,12 @@
 
     <dependency>
       <groupId>org.apache.jena</groupId>
+      <artifactId>jena-ontapi</artifactId>
+      <version>5.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
       <artifactId>jena-shacl</artifactId>
       <version>5.1.0-SNAPSHOT</version>
     </dependency>

--- a/apache-jena/pom.xml
+++ b/apache-jena/pom.xml
@@ -56,13 +56,27 @@
     -->
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>jena-arq</artifactId>
+      <artifactId>jena-core</artifactId>
       <version>5.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>jena-arq</artifactId>
+      <artifactId>jena-core</artifactId>
+      <version>5.1.0-SNAPSHOT</version>
+      <classifier>sources</classifier>
+      <optional>true</optional>
+    </dependency>
+
+     <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-ontapi</artifactId>
+      <version>5.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-ontapi</artifactId>
       <version>5.1.0-SNAPSHOT</version>
       <classifier>sources</classifier>
       <optional>true</optional>
@@ -70,13 +84,13 @@
 
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>jena-core</artifactId>
+      <artifactId>jena-arq</artifactId>
       <version>5.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>jena-core</artifactId>
+      <artifactId>jena-arq</artifactId>
       <version>5.1.0-SNAPSHOT</version>
       <classifier>sources</classifier>
       <optional>true</optional>

--- a/jena-bom/pom.xml
+++ b/jena-bom/pom.xml
@@ -56,6 +56,12 @@
 
       <dependency>
         <groupId>org.apache.jena</groupId>
+        <artifactId>jena-ontapi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.jena</groupId>
         <artifactId>jena-arq</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/jena-cmds/pom.xml
+++ b/jena-cmds/pom.xml
@@ -51,26 +51,39 @@
   <dependencies>
 
     <!--
-        This works ... 
-        except it breaks javadoc:javadoc building with Java11.
-        But it does work if Java17 is used for the build
+        Does not work.
+        Breaks javadoc production in modules like jena-text
+        This makes the downstream brittle because it requires
+        downstream to adapt.
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>apache-jena-libs</artifactId>
-      <version>4.7.0-SNAPSHOT</version>
+      <version>VERSION</version>
       <type>pom</type>
     </dependency>
     -->
+    <!-- 
+         Places with commands.
+         Avoids depending on apache-jena-libs with its <type>pom</type>
+     -->
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-core</artifactId>
+       <version>5.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-arq</artifactId>
+       <version>5.1.0-SNAPSHOT</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-rdfpatch</artifactId>
-      <version>5.1.0-SNAPSHOT</version>
+       <version>5.1.0-SNAPSHOT</version>
     </dependency>
 
-    <!-- Copied from apache-jena-libs
-         to avoid <type>pom</type>
-    -->
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-shacl</artifactId>
@@ -100,6 +113,8 @@
       <artifactId>jena-rdfconnection</artifactId>
       <version>5.1.0-SNAPSHOT</version>
     </dependency>
+
+    <!-- End places with commands -->
 
     <dependency>
       <artifactId>commons-cli</artifactId>

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsDynamic.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/setup/StoreParamsDynamic.java
@@ -21,16 +21,16 @@ package org.apache.jena.tdb1.setup;
 import org.apache.jena.tdb1.base.block.FileMode;
 
 /** Store parameters that can be adjusted after a store has been created,
- *  and given different values when the JVM attaches to a store area. 
- *  (They are still fixed for any given database once created in a JVM.) 
+ *  and given different values when the JVM attaches to a store area.
+ *  (They are still fixed for any given database once created in a JVM.)
  */
 
 public interface StoreParamsDynamic {
-    
-    /** Store-wide file access mode */ 
+
+    /** Store-wide file access mode */
     public FileMode getFileMode() ;
     public boolean isSetFileMode() ;
-    
+
     /** Block read cache (note: mapped files do not have a block cache) */
     public Integer getBlockReadCacheSize() ;
     public boolean isSetBlockReadCacheSize() ;
@@ -38,11 +38,11 @@ public interface StoreParamsDynamic {
     /** Block write cache (note: mapped files do not have a block cache) */
     public Integer getBlockWriteCacheSize() ;
     public boolean isSetBlockWriteCacheSize() ;
-    
+
     /** Node cache for Node{@literal ->}NodeId. */
     public Integer getNode2NodeIdCacheSize() ;
     public boolean isSetNode2NodeIdCacheSize() ;
-    
+
     /** Node cache for NodeId{@literal ->}Node. Important for SPARQL results. */
     public Integer getNodeId2NodeCacheSize() ;
     public boolean isSetNodeId2NodeCacheSize() ;
@@ -53,8 +53,10 @@ public interface StoreParamsDynamic {
 
     /**
      * Initial capacity factor for node caches:
-     *   - if >= 0.0: initial capacity is set to the (maximum) size of the cache multiplied by the factor
-     *   - if < 0.0:  no initial capacity is set on the cache, i.e. its internal default is used
+     * <ul>
+     * <li>if &gt;= 0.0: initial capacity is set to the (maximum) size of the cache multiplied by the factor</li>
+     * <li>if &lt; 0.0:  no initial capacity is set on the cache, i.e. its internal default is used</li>
+     * </ul>
      */
     public Double getNodeCacheInitialCapacityFactor();
     public boolean isSetNodeCacheInitialCapacityFactor();

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsDynamic.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/params/StoreParamsDynamic.java
@@ -70,8 +70,10 @@ public interface StoreParamsDynamic {
 
     /**
      * Initial capacity factor for node caches:
-     *   - if >= 0.0: initial capacity is set to the (maximum) size of the cache multiplied by the factor
-     *   - if < 0.0:  no initial capacity is set on the cache, i.e. its internal default is used
+     * <ul>
+     * <li>if &gt;= 0.0: initial capacity is set to the (maximum) size of the cache multiplied by the factor</li>
+     * <li>if &lt; 0.0:  no initial capacity is set on the cache, i.e. its internal default is used</li>
+     * </ul>
      */
     public Double getNodeCacheInitialCapacityFactor();
     public boolean isSetNodeCacheInitialCapacityFactor();


### PR DESCRIPTION
Pull request Description:

Put `jena-ontapi` in the `apache-jena-libs` and `apache-jena` binary distributions. 
Include in `jena-bom`.

Fix a javadoc warning.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
