### PR TITLE
Correct the entry point to run in the combined jar

### DIFF
--- a/jena-fuseki2/jena-fuseki-fulljar/pom.xml
+++ b/jena-fuseki2/jena-fuseki-fulljar/pom.xml
@@ -91,7 +91,7 @@
                  If it becomes necessary, see: https://github.com/edwgiz/maven-shaded-log4j-transformer
             -->
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-              <mainClass>org.apache.jena.fuseki.cmd.FusekiCmd</mainClass>
+              <mainClass>org.apache.jena.fuseki.cmd.FusekiWebappCmd</mainClass>
               <!-- https://issues.apache.org/jira/browse/LOG4J2-2537  -->
               <manifestEntries>
                 <Multi-Release>true</Multi-Release>

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiCmd.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiCmd.java
@@ -22,7 +22,7 @@ package org.apache.jena.fuseki.cmd;
  * @deprecated Use {@link FusekiWebappCmd}.
  */
 @Deprecated(since="5.1.0", forRemoval = true)
-public class FusekiMain {
+public class FusekiCmd {
     static public void main(String... argv) {
         FusekiWebappCmd.main(argv);
     }


### PR DESCRIPTION
The first release attempt for jena 5.1.0 failed in the checking.

The fuseki-server script (the combined jar) failed because the jar file had the wrong entry point name.

Some clean-up during 5.1.0 development wrongly renamed a class.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
