### PR TITLE
GH-2580: Added parseCheck flag to query and update exec builders.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionBuilder.java
@@ -42,6 +42,9 @@ public interface QueryExecutionBuilder {
 
     public QueryExecutionBuilder query(String queryString, Syntax syntax);
 
+    /** Hint whether to immediately parse query strings passed to {@link #query(String)} */
+    public QueryExecutionBuilder parseCheck(boolean parseCheck);
+
     public QueryExecutionBuilder set(Symbol symbol, Object value);
 
     public QueryExecutionBuilder set(Symbol symbol, boolean value);

--- a/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionDatasetBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryExecutionDatasetBuilder.java
@@ -67,6 +67,12 @@ public class QueryExecutionDatasetBuilder implements QueryExecutionBuilder {
         return this;
     }
 
+    @Override
+    public QueryExecutionBuilder parseCheck(boolean parseCheck) {
+        builder.parseCheck(parseCheck);
+        return this;
+    }
+
     public QueryExecutionDatasetBuilder dataset(Dataset dataset) {
         this.dataset = dataset;
         builder.dataset(dataset.asDatasetGraph());

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecBuilder.java
@@ -42,6 +42,9 @@ public interface QueryExecBuilder extends QueryExecMod {
     /** Set the query. */
     public QueryExecBuilder query(String queryString, Syntax syntax);
 
+    /** Hint whether to immediately parse query strings passed to {@link #query(String)} */
+    public QueryExecBuilder parseCheck(boolean parseCheck);
+
     /** Set a context entry. */
     public QueryExecBuilder set(Symbol symbol, Object value);
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecBuilderAdapter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecBuilderAdapter.java
@@ -107,6 +107,12 @@ public class QueryExecBuilderAdapter
     }
 
     @Override
+    public QueryExecBuilder parseCheck(boolean parseCheck) {
+        builder = builder.parseCheck(parseCheck);
+        return this;
+    }
+
+    @Override
     public QueryExecBuilder set(Symbol symbol, Object value) {
         builder = builder.set(symbol, value);
         return this;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDatasetBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDatasetBuilder.java
@@ -91,6 +91,12 @@ public class QueryExecDatasetBuilder implements QueryExecMod, QueryExecBuilder {
         return this;
     }
 
+    /** The parse-check flag has no effect for query execs over datasets. */
+    @Override
+    public QueryExecDatasetBuilder parseCheck(boolean parseCheck) {
+        return this;
+    }
+
     @Override
     public QueryExecDatasetBuilder query(String queryString, Syntax syntax) {
         this.queryString = queryString;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecutionBuilderAdapter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecutionBuilderAdapter.java
@@ -81,6 +81,12 @@ public class QueryExecutionBuilderAdapter implements QueryExecutionBuilder {
     }
 
     @Override
+    public QueryExecutionBuilderAdapter parseCheck(boolean parseCheck) {
+        builder.parseCheck(parseCheck);
+        return this;
+    }
+
+    @Override
     public QueryExecutionBuilderAdapter set(Symbol symbol, Object value) {
         builder.set(symbol, value);
         return this;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecBuilder.java
@@ -29,14 +29,18 @@ import org.apache.jena.update.UpdateRequest;
 
 public interface UpdateExecBuilder {
 
-    /** Set the update. */
+    /** Append the updates in an {@link UpdateRequest} to the {@link UpdateRequest} being built. */
     public UpdateExecBuilder update(UpdateRequest request);
 
-    /** Set the update. */
+    /** Add the {@link Update} to the {@link UpdateRequest} being built. */
     public UpdateExecBuilder update(Update update);
 
-    /** Set the update. */
+    /** Add the string to the {@link UpdateRequest} being built.
+     *  Implementations may support the {@link #parseCheck(boolean)} hint to control whether or not to parse the given strings. */
     public UpdateExecBuilder update(String updateString);
+
+    /** Hint whether to immediately parse strings passed to {@link #update(String)}. */
+    public UpdateExecBuilder parseCheck(boolean parseCheck);
 
     /** Set a context entry. */
     public UpdateExecBuilder set(Symbol symbol, Object value);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecBuilderAdapter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecBuilderAdapter.java
@@ -77,6 +77,12 @@ public class UpdateExecBuilderAdapter
     }
 
     @Override
+    public UpdateExecBuilder parseCheck(boolean parseCheck) {
+        builder = builder.parseCheck(parseCheck);
+        return this;
+    }
+
+    @Override
     public UpdateExecBuilder set(Symbol symbol, Object value) {
         builder = builder.set(symbol, value);
         return this;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecDatasetBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecDatasetBuilder.java
@@ -77,6 +77,12 @@ public class UpdateExecDatasetBuilder implements UpdateExecBuilder {
         return this;
     }
 
+    /** Hint has no effect on update execs over datasets. */
+    @Override
+    public UpdateExecBuilder parseCheck(boolean parseCheck) {
+        return this;
+    }
+
     public UpdateExecDatasetBuilder dataset(DatasetGraph dsg) {
         this.dataset = dsg;
         return this;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecutionBuilderAdapter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecutionBuilderAdapter.java
@@ -67,6 +67,12 @@ public class UpdateExecutionBuilderAdapter implements UpdateExecutionBuilder {
     }
 
     @Override
+    public UpdateExecutionBuilder parseCheck(boolean parseCheck) {
+        builder.parseCheck(parseCheck);
+        return this;
+    }
+
+    @Override
     public UpdateExecutionBuilder set(Symbol symbol, Object value) {
         builder.set(symbol, value);
         return this;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecHTTPBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecHTTPBuilder.java
@@ -40,8 +40,8 @@ public class UpdateExecHTTPBuilder extends ExecUpdateHTTPBuilder<UpdateExecHTTP,
     }
 
     @Override
-    protected UpdateExecHTTP buildX(HttpClient hClient, UpdateRequest updateActual, Context cxt) {
-        return new UpdateExecHTTP(serviceURL, updateActual, updateString, hClient, params,
+    protected UpdateExecHTTP buildX(HttpClient hClient, UpdateRequest updateActual, String updateStringActual, Context cxt) {
+        return new UpdateExecHTTP(serviceURL, updateActual, updateStringActual, hClient, params,
                                   copyArray(usingGraphURIs),
                                   copyArray(usingNamedGraphURIs),
                                   new HashMap<>(httpHeaders),

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecutionHTTPBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecutionHTTPBuilder.java
@@ -47,8 +47,8 @@ public class UpdateExecutionHTTPBuilder
     }
 
     @Override
-    protected UpdateExecutionHTTP buildX(HttpClient hClient, UpdateRequest updateActual, Context cxt) {
-        UpdateExecHTTP uExec = new UpdateExecHTTP(serviceURL, updateActual, updateString, hClient, params,
+    protected UpdateExecutionHTTP buildX(HttpClient hClient, UpdateRequest updateActual, String updateStringActual, Context cxt) {
+        UpdateExecHTTP uExec = new UpdateExecHTTP(serviceURL, updateActual, updateStringActual, hClient, params,
                                                   copyArray(usingGraphURIs),
                                                   copyArray(usingNamedGraphURIs),
                                                   new HashMap<>(httpHeaders),

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionBuilder.java
@@ -34,6 +34,9 @@ public interface UpdateExecutionBuilder {
     /** Parse and update operations to the {@link UpdateRequest} being built. */
     public UpdateExecutionBuilder update(String updateRequestString);
 
+    /** Hint whether to immediately parse update strings passed to {@link #update(String)}. */
+    public UpdateExecutionBuilder parseCheck(boolean parseCheck);
+
     public UpdateExecutionBuilder set(Symbol symbol, Object value);
 
     public UpdateExecutionBuilder set(Symbol symbol, boolean value);

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionDatasetBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionDatasetBuilder.java
@@ -66,6 +66,12 @@ public class UpdateExecutionDatasetBuilder implements UpdateExecutionBuilder {
         return this;
     }
 
+    @Override
+    public UpdateExecutionBuilder parseCheck(boolean parseCheck) {
+        builder.parseCheck(parseCheck);
+        return this;
+    }
+
     public UpdateExecutionDatasetBuilder dataset(Dataset dataset) {
         builder.dataset(dataset.asDatasetGraph());
         return this;

--- a/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionRemote.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/rdfconnection/TestRDFConnectionRemote.java
@@ -34,6 +34,8 @@ import org.apache.jena.rdfconnection.RDFConnectionRemote;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.core.DatasetGraphFactory ;
 import org.apache.jena.system.Txn ;
+import org.apache.jena.update.UpdateException;
+import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.web.HttpSC.Code;
 import org.junit.AfterClass ;
 import org.junit.Before ;
@@ -132,6 +134,105 @@ public class TestRDFConnectionRemote extends AbstractTestRDFConnection {
             } finally {
                 LogCtl.setLevel(Fuseki.actionLog, level);
             }
+        }
+    }
+
+    /** Non-standard query syntax on remote connection with parse check enabled is expected to fail. */
+    @Test(expected = QueryParseException.class)
+    public void non_standard_syntax_query_remote_1a() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(true).build() ) {
+            try (QueryExecution qe = conn.newQuery().query("FOOBAR").build()) { }
+        }
+    }
+
+    /** Non-standard query syntax on remote connection with parse flag overridden on the builder is expected to work. */
+    @Test
+    public void non_standard_syntax_query_remote_1b() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(true).build() ) {
+            try (QueryExecution qe = conn.newQuery().parseCheck(false).query("FOOBAR").build()) { }
+        }
+    }
+
+    /** Non-standard query syntax on remote connection with parse check disabled is expected to work. */
+    @Test
+    public void non_standard_syntax_query_remote_2a() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(false).build() ) {
+            try (QueryExecution qe = conn.newQuery().query("FOOBAR").build()) { }
+        }
+    }
+
+    /** Non-standard query syntax on remote connection with parse flag overridden on the builder is expected to fail. */
+    @Test(expected = QueryParseException.class)
+    public void non_standard_syntax_query_remote_2b() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(false).build() ) {
+            try (QueryExecution qe = conn.newQuery().parseCheck(true).query("FOOBAR").build()) { }
+        }
+    }
+
+    /** Non-standard update syntax on remote connection with parse check enabled is expected to fail. */
+    @Test(expected = QueryParseException.class)
+    public void non_standard_syntax_update_remote_1a() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(true).build() ) {
+            conn.newUpdate().update("FOOBAR").build();
+        }
+    }
+
+    /** Non-standard update syntax on remote connection with parse flag overridden on the builder is expected to work. */
+    @Test
+    public void non_standard_syntax_update_remote_1b() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(true).build() ) {
+            conn.newUpdate().parseCheck(false).update("FOOBAR").build();
+        }
+    }
+
+    /** Non-standard update syntax on remote connection with parse check disabled is expected to work. */
+    @Test
+    public void non_standard_syntax_update_remote_2a() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(false).build() ) {
+            conn.newUpdate().update("FOOBAR").build();
+        }
+    }
+
+    /** Non-standard update syntax on remote connection with parse flag overridden on the builder is expected to fail. */
+    @Test(expected = QueryParseException.class)
+    public void non_standard_syntax_update_remote_2b() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(false).build() ) {
+            conn.newUpdate().parseCheck(true).update("FOOBAR").build();
+        }
+    }
+
+    /** Non-standard update syntax on remote connection with parse check disabled is expected to work. */
+    @Test
+    public void non_standard_syntax_update_remote_3a() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(false).build() ) {
+            conn.newUpdate().update("FOO").update("BAR").build();
+        }
+    }
+
+    /** Non-standard update syntax on remote connection with parse flag disabled on the builder is expected to work. */
+    public void non_standard_syntax_update_remote_3b() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(true).build() ) {
+            conn.newUpdate().parseCheck(false).update("FOO").update("BAR").build();
+        }
+    }
+
+    /** Non-standard update syntax with substitution should fail on build. */
+    @Test(expected = UpdateException.class)
+    public void non_standard_syntax_update_remote_3c() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(false).build() ) {
+            conn.newUpdate().parseCheck(false).update("FOO").update("BAR")
+                .substitution("foo", RDF.type).build();
+        }
+    }
+
+    /** Standard update syntax with substitution should work. */
+    @Test
+    public void standard_syntax_update_remote_1a() {
+        try ( RDFConnection conn = RDFConnectionRemote.service(server.datasetURL("/ds")).parseCheckSPARQL(false).build() ) {
+            conn.newUpdate()
+                .update("INSERT DATA { <a> <b> <c> }")
+                .update("INSERT DATA { <x> <y> <z> }")
+                .substitution("foo", RDF.type).build();
         }
     }
 

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionWrapper.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdfconnection/RDFConnectionWrapper.java
@@ -50,6 +50,11 @@ public class RDFConnectionWrapper implements RDFConnection {
     }
 
     @Override
+    public QueryExecution query(String queryString) {
+        return get().query(queryString);
+    }
+
+    @Override
     public QueryExecutionBuilder newQuery() {
         return get().newQuery();
     }

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTP.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTP.java
@@ -300,7 +300,7 @@ public class RDFLinkHTTP implements RDFLink {
 
         /** This method is far only called from RDFLinkHTTP. It validates the query string if parseCheckQueries is enabled.  */
         protected QueryExecHTTPBuilder queryStringValidated(String queryString, Syntax syntax, QueryType fallbackQueryType) {
-            Query parsedQuery = RDFLinkHTTP.this.parseCheckQueries
+            Query parsedQuery = parseCheck
                     ? QueryFactory.create(queryString, syntax)
                     : null;
 
@@ -373,7 +373,7 @@ public class RDFLinkHTTP implements RDFLink {
     private QueryExecHTTPBuilderOverRDFLinkHTTP createQExecBuilder() {
         checkQuery();
         QueryExecHTTPBuilderOverRDFLinkHTTP builder = new QueryExecHTTPBuilderOverRDFLinkHTTP();
-        builder.endpoint(svcQuery).httpClient(httpClient).sendMode(querySendMode);
+        builder.endpoint(svcQuery).httpClient(httpClient).sendMode(querySendMode).parseCheck(parseCheckQueries);
         return builder;
     }
 
@@ -400,7 +400,7 @@ public class RDFLinkHTTP implements RDFLink {
     /** Create a builder, configured with the link setup. */
     private UpdateExecHTTPBuilder createUExecBuilder() {
         return UpdateExecHTTPBuilder.create().endpoint(svcUpdate).httpClient(httpClient)
-                .sendMode(updateSendMode);
+                .sendMode(updateSendMode).parseCheck(parseCheckUpdates);
     }
 
     @Override

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTPBuilder.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTPBuilder.java
@@ -91,6 +91,7 @@ public class RDFLinkHTTPBuilder {
         parseCheckUpdates   = base.parseCheckUpdates;
 
         querySendMode       = base.querySendMode;
+        updateSendMode      = base.updateSendMode;
     }
 
     /** URL of the remote SPARQL endpoint.

--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkModular.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkModular.java
@@ -102,6 +102,11 @@ public class RDFLinkModular implements RDFLink {
     }
 
     @Override
+    public QueryExec query(String queryString) {
+        return queryConnection().query(queryString);
+    }
+
+    @Override
     public QueryExecBuilder newQuery() {
         return queryConnection().newQuery();
     }

--- a/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/AbstractTestRDFConnection.java
+++ b/jena-rdfconnection/src/test/java/org/apache/jena/rdfconnection/AbstractTestRDFConnection.java
@@ -390,16 +390,16 @@ public abstract class AbstractTestRDFConnection {
     }
 
     @Test public void update_03() {
-    	UpdateRequest update = new UpdateRequest();
-    	update.add("INSERT DATA { <urn:ex:s> <urn:ex:p> <urn:ex:o>}");
+        UpdateRequest update = new UpdateRequest();
+        update.add("INSERT DATA { <urn:ex:s> <urn:ex:p> <urn:ex:o>}");
         try ( RDFConnection conn = connection() ) {
             conn.update(update);
         }
     }
 
     @Test public void update_04() {
-    	UpdateRequest update = new UpdateRequest();
-    	update.add("INSERT DATA { <urn:ex:s> <urn:ex:p> <urn:ex:o>}");
+        UpdateRequest update = new UpdateRequest();
+        update.add("INSERT DATA { <urn:ex:s> <urn:ex:p> <urn:ex:o>}");
         try ( RDFConnection conn = connection() ) {
             Txn.executeWrite(conn, ()->conn.update(update));
         }
@@ -455,6 +455,38 @@ public abstract class AbstractTestRDFConnection {
             conn.begin(ReadWrite.WRITE);
             // Should have conn.commit();
             conn.end();
+        }
+    }
+
+    /** Non-standard query syntax on local connection is expected to fail (regardless of syntax checking hint) */
+    @Test(expected = QueryParseException.class)
+    public void non_standard_syntax_query_local_1a() {
+        try ( RDFConnection conn = RDFConnection.connect(DatasetFactory.empty()) ) {
+            try (QueryExecution qe = conn.newQuery().parseCheck(false).query("FOOBAR").build()) { }
+        }
+    }
+
+    /** Non-standard query syntax on local connection is expected to fail (regardless of syntax checking hint) */
+    @Test(expected = QueryParseException.class)
+    public void non_standard_syntax_query_local_1b() {
+        try ( RDFConnection conn = RDFConnection.connect(DatasetFactory.empty()) ) {
+            try (QueryExecution qe = conn.newQuery().parseCheck(true).query("FOOBAR").build()) { }
+        }
+    }
+
+    /** Non-standard update syntax on local connection is expected to fail (regardless of syntax checking hint) */
+    @Test(expected = QueryParseException.class)
+    public void non_standard_syntax_update_local_1a() {
+        try ( RDFConnection conn = RDFConnection.connect(DatasetFactory.empty()) ) {
+            conn.newUpdate().parseCheck(false).update("FOOBAR").build();
+        }
+    }
+
+    /** Non-standard update syntax on local connection is expected to fail (regardless of syntax checking hint) */
+    @Test(expected = QueryParseException.class)
+    public void non_standard_syntax_update_local_1b() {
+        try ( RDFConnection conn = RDFConnection.connect(DatasetFactory.empty()) ) {
+            conn.newUpdate().parseCheck(true).update("FOOBAR").build();
         }
     }
 }


### PR DESCRIPTION
GitHub issue resolved #2580 

Pull request Description: Added `parseCheck` flag to query and update exec builders in order to give users control over how to deal with strings passed to `QueryExecBuilder.query(String)` and `UpdateExecBuilder.update(String)`.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
