### PR TITLE
GH-2578: Fix Quad.isTriple() handling in JenaTitanium

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/JenaTitanium.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/JenaTitanium.java
@@ -51,7 +51,7 @@ public class JenaTitanium {
             RdfResource predicate = resource(provider, labelMapping, quad.getPredicate());
             RdfValue object = nodeToValue(provider, labelMapping, quad.getObject());
 
-            if ( quad.isDefaultGraph() ) {
+            if ( quad.isTriple() || quad.isDefaultGraph() ) {
                 RdfTriple t = provider.createTriple(subject, predicate, object);
                 rdfDataset.add(t);
             }


### PR DESCRIPTION
GitHub issue resolved #2578

Pull request Description: This commit adds a `Quad.isTriple()` check when writing JSON-LD files, to cover the case where we have a "triple in quad". I've also added a test to check if this works. The test fails on the current main branch version of Jena.



----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
