### PR TITLE
GH-2578: Fix for null graph name in DatasetGraphMap and TriGWriter

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/TriGWriter.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/TriGWriter.java
@@ -64,7 +64,8 @@ public class TriGWriter extends TriGWriterBase
 
         /** Return true if anything written */
         private boolean writeGraphTriG(DatasetGraph dsg, Node name, Set<Node> graphNames) {
-            boolean dftGraph = ( name == null || name == Quad.defaultGraphNodeGenerated  );
+            //boolean dftGraph = ( name == Quad.tripleInQuad || Quad.isDefaultGraph(name) );
+            boolean dftGraph = ( name == Quad.tripleInQuad || Quad.isDefaultGraph(name) );
 
             if ( dftGraph && dsg.getDefaultGraph().isEmpty() )
                 return false;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphMap.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphMap.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.apache.jena.atlas.iterator.IteratorConcat;
 import org.apache.jena.graph.Graph;
@@ -174,11 +175,16 @@ public class DatasetGraphMap extends DatasetGraphTriplesQuads
         return defaultGraph;
     }
 
+    private static boolean isDefaultGraph(Node graphNode) {
+        // Include null (Quad.tripleInQuad)
+        return Objects.equals(graphNode, Quad.tripleInQuad) || Quad.isDefaultGraph(graphNode);
+    }
+
     @Override
     public Graph getGraph(Node graphNode) {
         if ( Quad.isUnionGraph(graphNode) )
             return GraphOps.unionGraph(this);
-        if ( Quad.isDefaultGraph(graphNode))
+        if ( isDefaultGraph(graphNode) )
             return getDefaultGraph();
         // Not a special case.
         Graph g = graphs.get(graphNode);
@@ -196,9 +202,10 @@ public class DatasetGraphMap extends DatasetGraphTriplesQuads
         graphs.clear();
     }
 
-    /** Called from getGraph when a nonexistent graph is asked for.
+    /**
+     * Called from getGraph when a nonexistent named graph is asked for.
      * Return null for "nothing created as a graph".
-     * Sub classes can reimplement this.
+     * Sub classes can re-implement this.
      */
     protected Graph getGraphCreate(Node graphNode) {
         Graph g = graphMaker.create(graphNode);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphTriplesQuads.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/DatasetGraphTriplesQuads.java
@@ -43,7 +43,7 @@ public abstract class DatasetGraphTriplesQuads extends DatasetGraphBaseFind
     final public void add(Node g, Node s, Node p, Node o) {
         if ( Quad.isUnionGraph(g))
             throw new AddDeniedException("Can't add to the union graph");
-        if ( Quad.isDefaultGraph(g) )
+        if ( g == null || Quad.isDefaultGraph(g) )
             addToDftGraph(s, p, o) ;
         else
             addToNamedGraph(g, s, p, o) ;
@@ -53,7 +53,7 @@ public abstract class DatasetGraphTriplesQuads extends DatasetGraphBaseFind
     final public void delete(Node g, Node s, Node p, Node o) {
         if ( Quad.isUnionGraph(g))
             throw new DeleteDeniedException("Can't remove from the union graph");
-        if ( Quad.isDefaultGraph(g) )
+        if ( g == null || Quad.isDefaultGraph(g) )
             deleteFromDftGraph(s, p, o) ;
         else
             deleteFromNamedGraph(g, s, p, o) ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphTests.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphTests.java
@@ -17,28 +17,28 @@
  */
 
 package org.apache.jena.sparql.core;
-import static org.junit.Assert.assertEquals ;
-import static org.junit.Assert.assertFalse ;
-import static org.junit.Assert.assertNotNull ;
-import static org.junit.Assert.assertTrue ;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.Iterator ;
-import java.util.List ;
-import java.util.Set ;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
-import org.apache.jena.atlas.iterator.Iter ;
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.ListUtils;
-import org.apache.jena.graph.Graph ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.graph.NodeFactory ;
-import org.apache.jena.graph.Triple ;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.shared.AddDeniedException;
 import org.apache.jena.shared.DeleteDeniedException;
-import org.apache.jena.sparql.graph.GraphFactory ;
-import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.system.Txn;
-import org.junit.Test ;
+import org.junit.Test;
 
 /** Test basic operations on a DatasetGraph
  *
@@ -48,14 +48,14 @@ import org.junit.Test ;
  */
 public abstract class AbstractDatasetGraphTests
 {
-    protected abstract DatasetGraph emptyDataset() ;
+    protected abstract DatasetGraph emptyDataset();
 
     @Test public void create_1()
     {
-        DatasetGraph dsg = emptyDataset() ;
-        assertNotNull(dsg) ;
-        assertNotNull(dsg.getDefaultGraph()) ;
-        assertTrue(dsg.getDefaultGraph().isEmpty()) ;
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        assertNotNull(dsg.getDefaultGraph());
+        assertTrue(dsg.getDefaultGraph().isEmpty());
     }
 
     // Quad operations
@@ -68,88 +68,142 @@ public abstract class AbstractDatasetGraphTests
      * boolean contains(Node g, Node s, Node p , Node o)
      * boolean contains(Quad quad)
      */
-    @Test public void quad_01()
-    {
-        DatasetGraph dsg = emptyDataset() ;
-        assertNotNull(dsg) ;
-        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)") ;
-        dsg.add(quad) ;
-        assertTrue(dsg.contains(quad)) ;
+    @Test
+    public void quad_01() {
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)");
+        dsg.add(quad);
+        assertTrue(dsg.contains(quad));
 
-        Iterator<Quad> iter = dsg.find(quad) ;
-        assertTrue(iter.hasNext()) ;
+        Iterator<Quad> iter = dsg.find(quad);
+        assertTrue(iter.hasNext());
         Quad quad2 = iter.next();
-        assertFalse(iter.hasNext()) ;
-        assertEquals(quad, quad2) ;
+        assertFalse(iter.hasNext());
+        assertEquals(quad, quad2);
 
         // and the graph view.
-        assertTrue(dsg.getDefaultGraph().isEmpty()) ;
-        assertFalse(dsg.getGraph(NodeFactory.createURI("g")).isEmpty()) ;
+        assertTrue(dsg.getDefaultGraph().isEmpty());
+        assertFalse(dsg.getGraph(NodeFactory.createURI("g")).isEmpty());
     }
 
-    @Test public void quad_02()
-    {
-        DatasetGraph dsg = emptyDataset() ;
-        assertNotNull(dsg) ;
-        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)") ;
-        dsg.add(quad) ;
-        dsg.containsGraph(NodeFactory.createURI("g")) ;
+    @Test
+    public void quad_02() {
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)");
+        dsg.add(quad);
+        dsg.containsGraph(NodeFactory.createURI("g"));
 
-        dsg.delete(quad) ;
-        assertTrue(dsg.isEmpty()) ;
-        assertTrue(dsg.getDefaultGraph().isEmpty()) ;
-        assertTrue(dsg.getGraph(NodeFactory.createURI("g")).isEmpty()) ;
+        dsg.delete(quad);
+        assertTrue(dsg.isEmpty());
+        assertTrue(dsg.getDefaultGraph().isEmpty());
+        assertTrue(dsg.getGraph(NodeFactory.createURI("g")).isEmpty());
     }
 
-    @Test public void quad_03()
-    {
-        DatasetGraph dsg = emptyDataset() ;
-        assertNotNull(dsg) ;
-        Quad quad1 = SSE.parseQuad("(quad <g> <s> <p> <o1>)") ;
-        Quad quad2 = SSE.parseQuad("(quad <g> <s> <p> <o2>)") ;
-        dsg.add(quad1) ;
-        dsg.add(quad2) ;
+    @Test
+    public void quad_03() {
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        Quad quad1 = SSE.parseQuad("(quad <g> <s> <p> <o1>)");
+        Quad quad2 = SSE.parseQuad("(quad <g> <s> <p> <o2>)");
+        dsg.add(quad1);
+        dsg.add(quad2);
 
-        dsg.deleteAny(NodeFactory.createURI("g"), NodeFactory.createURI("s"), null, null) ;
-        assertFalse(dsg.contains(quad1)) ;
-        assertFalse(dsg.contains(quad2)) ;
+        dsg.deleteAny(NodeFactory.createURI("g"), NodeFactory.createURI("s"), null, null);
+        assertFalse(dsg.contains(quad1));
+        assertFalse(dsg.contains(quad2));
     }
 
-    @Test public void quad_04()
-    {
-        DatasetGraph dsg = emptyDataset() ;
-        assertNotNull(dsg) ;
-        Quad quad1 = SSE.parseQuad("(quad <g> <s> <p> <o1>)") ;
-        Quad quad2 = SSE.parseQuad("(quad <g> <s> <p> <o2>)") ;
-        dsg.add(quad1) ;
-        dsg.add(quad2) ;
-        Iterator<Quad> iter = dsg.find(NodeFactory.createURI("g"), NodeFactory.createURI("s"), null, null) ;
+    @Test
+    public void quad_04() {
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        Quad quad1 = SSE.parseQuad("(quad <g> <s> <p> <o1>)");
+        Quad quad2 = SSE.parseQuad("(quad <g> <s> <p> <o2>)");
+        dsg.add(quad1);
+        dsg.add(quad2);
+        Iterator<Quad> iter = dsg.find(NodeFactory.createURI("g"), NodeFactory.createURI("s"), null, null);
 
-        assertTrue(iter.hasNext()) ;
-        Set<Quad> x = Iter.iter(iter).toSet() ;
-        assertEquals(2, x.size()) ;
-        assertTrue(x.contains(quad1)) ;
-        assertTrue(x.contains(quad2)) ;
+        assertTrue(iter.hasNext());
+        Set<Quad> x = Iter.iter(iter).toSet();
+        assertEquals(2, x.size());
+        assertTrue(x.contains(quad1));
+        assertTrue(x.contains(quad2));
     }
 
-    @Test public void quad_05()
-    {
-        DatasetGraph dsg = emptyDataset() ;
-        assertNotNull(dsg) ;
-        Quad quad1 = SSE.parseQuad("(quad <g> <s> <p> <o1>)") ;
-        Quad quad2 = SSE.parseQuad("(quad <g> <s> <p> <o2>)") ;
-        Node g  = SSE.parseNode("<g>") ;
-        Node s  = SSE.parseNode("<s>") ;
-        Node p  = SSE.parseNode("<p>") ;
-        Node o1 = SSE.parseNode("<o1>") ;
-        Node o2 = SSE.parseNode("<o2>") ;
+    @Test
+    public void quad_05() {
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        Quad quad1 = SSE.parseQuad("(quad <g> <s> <p> <o1>)");
+        Quad quad2 = SSE.parseQuad("(quad <g> <s> <p> <o2>)");
+        Node g = SSE.parseNode("<g>");
+        Node s = SSE.parseNode("<s>");
+        Node p = SSE.parseNode("<p>");
+        Node o1 = SSE.parseNode("<o1>");
+        Node o2 = SSE.parseNode("<o2>");
 
-        dsg.add(g,s,p,o1) ;
-        assertTrue(dsg.contains(quad1)) ;
-        assertTrue(dsg.contains(g,s,p,o1)) ;
-        assertFalse(dsg.contains(g,s,p,o2)) ;
+        dsg.add(g, s, p, o1);
+        assertTrue(dsg.contains(quad1));
+        assertTrue(dsg.contains(g, s, p, o1));
+        assertFalse(dsg.contains(g, s, p, o2));
     }
 
+    // The ways to write "default graph"
+
+    @Test
+    public void quadDftTerm1() {
+        testDftGraphTerms(null);
+    }
+
+    @Test
+    public void quadDftTerm2() {
+        testDftGraphTerms(Quad.defaultGraphIRI);
+    }
+
+    @Test
+    public void quadDftTerm3() {
+        testDftGraphTerms(Quad.defaultGraphNodeGenerated);
+    }
+
+    @Test
+    public void quadDftQuad1() {
+        testDftGraphQuad(null);
+    }
+
+    @Test
+    public void quadDftQuad2() {
+        testDftGraphQuad(Quad.defaultGraphIRI);
+    }
+
+    @Test
+    public void quadDftQuad3() {
+        testDftGraphQuad(Quad.defaultGraphNodeGenerated);
+    }
+
+    private static Node s = SSE.parseNode("<s>");
+    private static Node p = SSE.parseNode("<p>");
+    private static Node o = SSE.parseNode("<o>");
+
+    private void testDftGraphTerms(Node graphName) {
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        dsg.add(graphName, s, p, o);
+        assertFalse(dsg.getDefaultGraph().isEmpty());
+        dsg.delete(graphName, s, p, o);
+        assertTrue(dsg.getDefaultGraph().isEmpty());
+    }
+
+    private void testDftGraphQuad(Node graphName) {
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        Quad quad = Quad.create(graphName, s, p, o);
+        dsg.add(quad);
+        assertFalse(dsg.getDefaultGraph().isEmpty());
+        dsg.delete(quad);
+        assertTrue(dsg.getDefaultGraph().isEmpty());
+    }
 
     /*
      * getDefaultGraph()
@@ -164,82 +218,82 @@ public abstract class AbstractDatasetGraphTests
     // Graph centric operations
     @Test public void graph_00()
     {
-        DatasetGraph dsg = emptyDataset() ;
-        assertNotNull(dsg) ;
-        Node gn = NodeFactory.createURI("g") ;
-        Graph g = GraphFactory.createDefaultGraph() ;
-        g.add(SSE.parseTriple("(<s> <p> <o>)")) ;   // So the graph is not empty.
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        Node gn = NodeFactory.createURI("g");
+        Graph g = GraphFactory.createDefaultGraph();
+        g.add(SSE.parseTriple("(<s> <p> <o>)"));   // So the graph is not empty.
         dsg.addGraph(gn, g);
-        assertTrue(dsg.containsGraph(gn)) ;
+        assertTrue(dsg.containsGraph(gn));
     }
 
     // Graph centric operations
     @Test public void graph_01()
     {
-        DatasetGraph dsg = emptyDataset() ;
-        assertNotNull(dsg) ;
-        Node g = NodeFactory.createURI("g") ;
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        Node g = NodeFactory.createURI("g");
 
-        Triple t = SSE.parseTriple("(<s> <p> <o>)") ;
+        Triple t = SSE.parseTriple("(<s> <p> <o>)");
 
-        dsg.getGraph(g).add(t) ;
-        assertTrue(dsg.getGraph(g).contains(t)) ;
+        dsg.getGraph(g).add(t);
+        assertTrue(dsg.getGraph(g).contains(t));
 
-        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)") ;
-        Iterator<Quad> iter = dsg.find(null, null, null, null) ;
+        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)");
+        Iterator<Quad> iter = dsg.find(null, null, null, null);
 
-        assertTrue(iter.hasNext()) ;
+        assertTrue(iter.hasNext());
         Quad quad2 = iter.next();
-        assertFalse(iter.hasNext()) ;
-        assertEquals(quad, quad2) ;
+        assertFalse(iter.hasNext());
+        assertEquals(quad, quad2);
 
-        assertTrue(dsg.getDefaultGraph().isEmpty()) ;
-        assertFalse(dsg.getGraph(NodeFactory.createURI("g")).isEmpty()) ;
+        assertTrue(dsg.getDefaultGraph().isEmpty());
+        assertFalse(dsg.getGraph(NodeFactory.createURI("g")).isEmpty());
     }
 
     @Test public void graph_02()
     {
-        Node g = NodeFactory.createURI("g") ;
-        DatasetGraph dsg = emptyDataset() ;
-        assertNotNull(dsg) ;
-        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)") ;
-        dsg.add(quad) ;
+        Node g = NodeFactory.createURI("g");
+        DatasetGraph dsg = emptyDataset();
+        assertNotNull(dsg);
+        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)");
+        dsg.add(quad);
 
-        Triple t = SSE.parseTriple("(<s> <p> <o>)") ;
-        dsg.getGraph(g).delete(t) ;
-        assertTrue(dsg.getDefaultGraph().isEmpty()) ;
-        assertTrue(dsg.getGraph(NodeFactory.createURI("g")).isEmpty()) ;
-        assertFalse(dsg.find(Node.ANY, Node.ANY, Node.ANY, Node.ANY).hasNext()) ;
+        Triple t = SSE.parseTriple("(<s> <p> <o>)");
+        dsg.getGraph(g).delete(t);
+        assertTrue(dsg.getDefaultGraph().isEmpty());
+        assertTrue(dsg.getGraph(NodeFactory.createURI("g")).isEmpty());
+        assertFalse(dsg.find(Node.ANY, Node.ANY, Node.ANY, Node.ANY).hasNext());
     }
 
     @Test public void graph_03()
     {
-        Node g = NodeFactory.createURI("g") ;
-        DatasetGraph dsg = emptyDataset() ;
-        Graph data = SSE.parseGraph("(graph (<s> <p> <o>))") ;
-        dsg.addGraph(g, data) ;
-        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)") ;
-        assertTrue(dsg.contains(quad)) ;
+        Node g = NodeFactory.createURI("g");
+        DatasetGraph dsg = emptyDataset();
+        Graph data = SSE.parseGraph("(graph (<s> <p> <o>))");
+        dsg.addGraph(g, data);
+        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)");
+        assertTrue(dsg.contains(quad));
     }
 
     @Test public void find_01()
     {
-        Node g1 = NodeFactory.createURI("g1") ;
-        DatasetGraph dsg = emptyDataset() ;
-        Quad quad1 = SSE.parseQuad("(quad <g1> <s1> <p1> <o1>)") ;
-        Quad quad2 = SSE.parseQuad("(quad <g2> <s2> <p2> <o2>)") ;
-        dsg.add(quad1) ;
-        dsg.add(quad2) ;
+        Node g1 = NodeFactory.createURI("g1");
+        DatasetGraph dsg = emptyDataset();
+        Quad quad1 = SSE.parseQuad("(quad <g1> <s1> <p1> <o1>)");
+        Quad quad2 = SSE.parseQuad("(quad <g2> <s2> <p2> <o2>)");
+        dsg.add(quad1);
+        dsg.add(quad2);
 
-        List<Quad> quads = Iter.toList(dsg.find(g1, null, null, null)) ;
-        assertEquals(1, quads.size()) ;
-        Quad q = quads.get(0) ;
-        assertEquals(quad1, q) ;
+        List<Quad> quads = Iter.toList(dsg.find(g1, null, null, null));
+        assertEquals(1, quads.size());
+        Quad q = quads.get(0);
+        assertEquals(quad1, q);
     }
 
     @Test public void deleteAny_01()
     {
-        DatasetGraph dsg = emptyDataset() ;
+        DatasetGraph dsg = emptyDataset();
         Node subject = NodeFactory.createURI("http://example/s");
         Node predicate = NodeFactory.createURI("http://example/p");
         Node object = NodeFactory.createBlankNode();
@@ -249,83 +303,83 @@ public abstract class AbstractDatasetGraphTests
 
     @Test public void deleteAny_02()
     {
-        DatasetGraph dsg = emptyDataset() ;
+        DatasetGraph dsg = emptyDataset();
         Node subject = NodeFactory.createURI("http://example/s");
         Node predicate = NodeFactory.createURI("http://example/p");
         Node object1 = NodeFactory.createBlankNode();
         Node object2 = NodeFactory.createBlankNode();
-        Node graph = NodeFactory.createURI("http://example/g") ;
+        Node graph = NodeFactory.createURI("http://example/g");
 
         dsg.add(graph, subject, predicate, object1);
         dsg.add(graph, subject, predicate, object2);
 
         dsg.deleteAny(Quad.defaultGraphIRI, null, null, null);
-        List<Quad> quads = Iter.toList(dsg.find(graph, null, null, null)) ;
-        assertEquals(2, quads.size()) ;
+        List<Quad> quads = Iter.toList(dsg.find(graph, null, null, null));
+        assertEquals(2, quads.size());
 
         dsg.deleteAny(graph, null, null, null);
-        quads = Iter.toList(dsg.find(graph, null, null, null)) ;
-        assertEquals(0, quads.size()) ;
+        quads = Iter.toList(dsg.find(graph, null, null, null));
+        assertEquals(0, quads.size());
     }
     @Test public void deleteAny_03()
     {
-        DatasetGraph dsg = emptyDataset() ;
+        DatasetGraph dsg = emptyDataset();
         Node subject = NodeFactory.createURI("http://example/s");
         Node predicate = NodeFactory.createURI("http://example/p");
         Node object1 = NodeFactory.createBlankNode();
         Node object2 = NodeFactory.createBlankNode();
-        Node graph = NodeFactory.createURI("http://example/g") ;
+        Node graph = NodeFactory.createURI("http://example/g");
 
         dsg.getDefaultGraph().add(Triple.create(subject, predicate, object1));
         dsg.getGraph(graph).add(Triple.create(subject, predicate, object2));
 
         dsg.deleteAny(Quad.defaultGraphIRI, null, null, null);
-        List<Quad> quads = Iter.toList(dsg.find(Quad.defaultGraphIRI, null, null, null)) ;
-        assertEquals(0, quads.size()) ;
+        List<Quad> quads = Iter.toList(dsg.find(Quad.defaultGraphIRI, null, null, null));
+        assertEquals(0, quads.size());
 
         dsg.deleteAny(graph, null, null, null);
-        quads = Iter.toList(dsg.find(graph, null, null, null)) ;
-        assertEquals(0, quads.size()) ;
+        quads = Iter.toList(dsg.find(graph, null, null, null));
+        assertEquals(0, quads.size());
     }
 
     @Test public void deleteAny_04()
     {
-        DatasetGraph dsg = emptyDataset() ;
+        DatasetGraph dsg = emptyDataset();
 
         Node subject = NodeFactory.createURI("http://example/s");
         Node predicate = NodeFactory.createURI("http://example/p");
         Node object1 = NodeFactory.createBlankNode();
         Node object2 = NodeFactory.createBlankNode();
-        Node graph = NodeFactory.createURI("http://example/g") ;
-        Node graph2 = NodeFactory.createURI("http://example/abc") ;
+        Node graph = NodeFactory.createURI("http://example/g");
+        Node graph2 = NodeFactory.createURI("http://example/abc");
 
         dsg.add(graph, subject, predicate, object1);
         dsg.add(graph, subject, predicate, object2);
 
         dsg.deleteAny(graph2, null, null, null);
 
-        List<Quad> quads = Iter.toList(dsg.find(graph, null, null, null)) ;
-        assertEquals(2, quads.size()) ;
+        List<Quad> quads = Iter.toList(dsg.find(graph, null, null, null));
+        assertEquals(2, quads.size());
 
         dsg.deleteAny(graph, null, null, null);
 
-        quads = Iter.toList(dsg.find(graph, null, null, null)) ;
-        assertEquals(0, quads.size()) ;
+        quads = Iter.toList(dsg.find(graph, null, null, null));
+        assertEquals(0, quads.size());
     }
 
     @Test public void clear_01() {
-        DatasetGraph dsg = emptyDataset() ;
-        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)") ;
-        Node gn = SSE.parseNode("<g>") ;
-        assertTrue(dsg.isEmpty()) ;
-        dsg.add(quad) ;
-        assertFalse(dsg.isEmpty()) ;
-        assertTrue(dsg.containsGraph(gn)) ;
+        DatasetGraph dsg = emptyDataset();
+        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)");
+        Node gn = SSE.parseNode("<g>");
+        assertTrue(dsg.isEmpty());
+        dsg.add(quad);
+        assertFalse(dsg.isEmpty());
+        assertTrue(dsg.containsGraph(gn));
 
-        dsg.clear() ;
+        dsg.clear();
 
-        assertTrue(dsg.isEmpty()) ;
-        assertFalse(dsg.containsGraph(gn)) ;
+        assertTrue(dsg.isEmpty());
+        assertFalse(dsg.containsGraph(gn));
     }
 
     @Test public void clear_02() {
@@ -346,10 +400,10 @@ public abstract class AbstractDatasetGraphTests
     }
 
     @Test public void graph_clear_1() {
-        DatasetGraph dsg = emptyDataset() ;
+        DatasetGraph dsg = emptyDataset();
         if ( ! dsg.supportsTransactions() )
             return;
-        Quad quad = SSE.parseQuad("(<g> <s> <p> 0)") ;
+        Quad quad = SSE.parseQuad("(<g> <s> <p> 0)");
         Node gn = quad.getGraph();
         Txn.executeWrite(dsg, ()->{
             dsg.add(quad);
@@ -360,10 +414,10 @@ public abstract class AbstractDatasetGraphTests
 
     // Check that clear does not leak.
     @Test public void graph_clear_2() {
-        DatasetGraph dsg = emptyDataset() ;
+        DatasetGraph dsg = emptyDataset();
         if ( ! dsg.supportsTransactions() )
             return;
-        Quad quad = SSE.parseQuad("(<g> <s> <p> 0)") ;
+        Quad quad = SSE.parseQuad("(<g> <s> <p> 0)");
         Node gn = quad.getGraph();
         Node gnx = NodeFactory.createURI("xyz");
         Txn.executeWrite(dsg, ()->{
@@ -377,8 +431,8 @@ public abstract class AbstractDatasetGraphTests
     // Quad delete causes graph to not be visible.
     // Not valid for all datasets (e.g. DatasetGraphMapLink)
     @Test public void emptyGraph_1() {
-        DatasetGraph dsg = emptyDataset() ;
-        Node gn = NodeFactory.createURI("http://example/g") ;
+        DatasetGraph dsg = emptyDataset();
+        Node gn = NodeFactory.createURI("http://example/g");
         Quad q = SSE.parseQuad("(:g :s :p :o)");
 
         dsg.add(q);
@@ -390,8 +444,8 @@ public abstract class AbstractDatasetGraphTests
     }
 
     @Test public void emptyGraph_2() {
-        DatasetGraph dsg = emptyDataset() ;
-        Node gn = NodeFactory.createURI("http://example/g") ;
+        DatasetGraph dsg = emptyDataset();
+        Node gn = NodeFactory.createURI("http://example/g");
         Quad q = SSE.parseQuad("(:g :s :p :o)");
 
         dsg.add(q);
@@ -403,9 +457,9 @@ public abstract class AbstractDatasetGraphTests
 
     @Test public void listGraphNodes_1() {
         DatasetGraph dsg = emptyDataset();
-        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)") ;
-        Node gn = SSE.parseNode("<g>") ;
-        dsg.add(quad) ;
+        Quad quad = SSE.parseQuad("(quad <g> <s> <p> <o>)");
+        Node gn = SSE.parseNode("<g>");
+        dsg.add(quad);
         List<Node> x = Iter.toList(dsg.listGraphNodes());
         assertEquals(1,x.size());
         Node gn2 = x.get(0);
@@ -414,12 +468,12 @@ public abstract class AbstractDatasetGraphTests
 
     @Test public void listGraphNodes_2() {
         DatasetGraph dsg = emptyDataset();
-        Quad quad1 = SSE.parseQuad("(quad <g1> <s> <p> <o>)") ;
-        Quad quad2 = SSE.parseQuad("(quad <g2> <s> <p> <o>)") ;
-        Node gn1 = SSE.parseNode("<g1>") ;
-        Node gn2 = SSE.parseNode("<g2>") ;
-        dsg.add(quad1) ;
-        dsg.add(quad2) ;
+        Quad quad1 = SSE.parseQuad("(quad <g1> <s> <p> <o>)");
+        Quad quad2 = SSE.parseQuad("(quad <g2> <s> <p> <o>)");
+        Node gn1 = SSE.parseNode("<g1>");
+        Node gn2 = SSE.parseNode("<g2>");
+        dsg.add(quad1);
+        dsg.add(quad2);
         List<Node> x = Iter.toList(dsg.listGraphNodes());
         List<Node> e = Arrays.asList(gn1, gn2);
         assertEquals(2,x.size());
@@ -429,11 +483,11 @@ public abstract class AbstractDatasetGraphTests
 
     @Test public void listGraphNodes_3() {
         DatasetGraph dsg = emptyDataset();
-        Quad quad1 = SSE.parseQuad("(quad _ <s> <p> <o>)") ;
-        Quad quad2 = SSE.parseQuad("(quad <g> <s> <p> <o>)") ;
-        Node gn = SSE.parseNode("<g>") ;
-        dsg.add(quad1) ;
-        dsg.add(quad2) ;
+        Quad quad1 = SSE.parseQuad("(quad _ <s> <p> <o>)");
+        Quad quad2 = SSE.parseQuad("(quad <g> <s> <p> <o>)");
+        Node gn = SSE.parseNode("<g>");
+        dsg.add(quad1);
+        dsg.add(quad2);
         List<Node> x = Iter.toList(dsg.listGraphNodes());
         List<Node> e = Arrays.asList(gn);
         boolean b = ListUtils.equalsUnordered(e, x);
@@ -442,13 +496,13 @@ public abstract class AbstractDatasetGraphTests
 
     @Test(expected=AddDeniedException.class) public void updateUnionGraph_1() {
         DatasetGraph dsg = emptyDataset();
-        Quad quad = SSE.parseQuad("(quad :g :s :p :o)") ;
+        Quad quad = SSE.parseQuad("(quad :g :s :p :o)");
         dsg.add(Quad.unionGraph, quad.getSubject(), quad.getPredicate(), quad.getObject());
     }
 
     @Test(expected=DeleteDeniedException.class) public void updateUnionGraph_2() {
         DatasetGraph dsg = emptyDataset();
-        Quad quad = SSE.parseQuad("(quad :g :s :p :o)") ;
+        Quad quad = SSE.parseQuad("(quad :g :s :p :o)");
         dsg.delete(Quad.unionGraph, quad.getSubject(), quad.getPredicate(), quad.getObject());
     }
 }

--- a/jena-db/jena-dboe-storage/src/main/java/org/apache/jena/dboe/storage/system/DatasetGraphStorage.java
+++ b/jena-db/jena-dboe-storage/src/main/java/org/apache/jena/dboe/storage/system/DatasetGraphStorage.java
@@ -159,7 +159,7 @@ public class DatasetGraphStorage extends DatasetGraphBaseFind implements Databas
 
     @Override
     public void add(Quad quad) {
-        if ( Quad.isDefaultGraph(quad.getGraph()) )
+        if ( quad.getGraph() == Quad.tripleInQuad || Quad.isDefaultGraph(quad.getGraph()) )
             storage.add(quad.getSubject(), quad.getPredicate(), quad.getObject());
         else
             storage.add(quad);
@@ -167,7 +167,7 @@ public class DatasetGraphStorage extends DatasetGraphBaseFind implements Databas
 
     @Override
     public void delete(Quad quad) {
-        if ( Quad.isDefaultGraph(quad.getGraph()) )
+        if ( quad.getGraph() == Quad.tripleInQuad || Quad.isDefaultGraph(quad.getGraph()) )
             storage.delete(quad.getSubject(), quad.getPredicate(), quad.getObject());
         else
             storage.delete(quad);
@@ -177,7 +177,7 @@ public class DatasetGraphStorage extends DatasetGraphBaseFind implements Databas
     public void add(Node g, Node s, Node p, Node o) {
         if ( Quad.isUnionGraph(g))
             throw new AddDeniedException("Can't add to the union graph");
-        if ( g == null || Quad.isDefaultGraph(g) )
+        if ( g == Quad.tripleInQuad || Quad.isDefaultGraph(g) )
             storage.add(s,p,o);
         else
             storage.add(g,s,p,o);
@@ -187,7 +187,7 @@ public class DatasetGraphStorage extends DatasetGraphBaseFind implements Databas
     public void delete(Node g, Node s, Node p, Node o) {
         if ( Quad.isUnionGraph(g))
             throw new DeleteDeniedException("Can't remove from the union graph");
-        if ( g == null || Quad.isDefaultGraph(g) )
+        if ( g == Quad.tripleInQuad || Quad.isDefaultGraph(g) )
             storage.delete(s,p,o);
         else
             storage.delete(g,s,p,o);
@@ -209,7 +209,7 @@ public class DatasetGraphStorage extends DatasetGraphBaseFind implements Databas
     public long size() {
         // Slow!
         return stream()
-                .map(Quad::getGraph).filter(gn->!Quad.isDefaultGraph(gn)).distinct().count();
+                .map(Quad::getGraph).filter(gn->gn != null && !Quad.isDefaultGraph(gn)).distinct().count();
     }
 
     @Override


### PR DESCRIPTION
Adds to issue #2578

Pull request Description:
Fixes for:
* `TriGWriter` -- NPE when the graph name is null.
* `DatasetGraphMap` -- map null graph name to the default graph.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
