### PR TITLE
GH-2593: Fix JUnit dependency leaking to compile scope

### DIFF
--- a/jena-arq/pom.xml
+++ b/jena-arq/pom.xml
@@ -130,6 +130,7 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-suite-engine</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Explicitly declares the dependency as test scope to avoid it leaking into compile scope unneccesarily

GitHub issue resolved #2593

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
