### PR TITLE
GH-2346: Fix warning during first yarn install

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/package.json
+++ b/jena-fuseki2/jena-fuseki-ui/package.json
@@ -13,7 +13,7 @@
     "test:unit": "vitest run --pool=threads --environment jsdom",
     "test:e2e": "run-script-os",
     "test:e2e:nix": "cross-env FUSEKI_PORT=\"${FUSEKI_PORT:=3030}\" PORT=\"${PORT:=8080}\" concurrently  --names 'SERVER,CLIENT,TESTS' --prefix-colors 'yellow,blue,green' --success 'first' --kill-others \"yarn run serve:fuseki\" \"yarn wait-on http://localhost:${FUSEKI_PORT}/$/ping && yarn run dev\" \"yarn wait-on http-get://localhost:${PORT}/index.html && cypress run $@\"",
-    "test:e2e:win32" : "SET /a (FUSEKI_PORT=FUSEKI_PORT ^ 3030) & SET /a (PORT=PORT ^ 8080) & cross-env concurrently --names 'SERVER,CLIENT,TESTS' --prefix-colors 'yellow,blue,green' --success 'first' --kill-others \"yarn run serve:fuseki\" \"yarn wait-on http://localhost:${FUSEKI_PORT}/$/ping && yarn run dev\" \"yarn wait-on http-get://localhost:${PORT}/index.html && cypress run $@\"",
+    "test:e2e:win32": "SET /a (FUSEKI_PORT=FUSEKI_PORT ^ 3030) & SET /a (PORT=PORT ^ 8080) & cross-env concurrently --names 'SERVER,CLIENT,TESTS' --prefix-colors 'yellow,blue,green' --success 'first' --kill-others \"yarn run serve:fuseki\" \"yarn wait-on http://localhost:${FUSEKI_PORT}/$/ping && yarn run dev\" \"yarn wait-on http-get://localhost:${PORT}/index.html && cypress run $@\"",
     "lint": "eslint --fix src",
     "coverage:unit": "yarn run test:unit --coverage",
     "coverage:e2e": "cross-env-shell CYPRESS_COVERAGE=true yarn run test:e2e",
@@ -74,5 +74,6 @@
     "loader-utils": "^1.4.2",
     "cookiejar": "^2.1.4",
     "json5": "^1.0.2"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
GitHub issue resolved #2346

Pull request Description:

Hi,

My old old thinkpad finally started to have some issues, so I'm setting up a new laptop, and thought it'd be good to clean up some older UI issues like this one.

I installed Node LTS (20) with nvm, then enabled corepack (to get yarn), and did a yarn install. Very first project I am building on this new framework laptop. Did not get the yarn test:unit tests (I think someone updated vite and now the issue is gone :pray:).

![Screenshot_2024-08-03_16-27-38](https://github.com/user-attachments/assets/6ae6530a-a3e2-445e-88b6-80d653f1469f)


The warning was fixed automatically by yarn install, so I just committed it.

It also fixed the spaces around the colon for the windows script command.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
