### PR TITLE
GH-2631: cleanup javadocs (remove references to legacy OntModel)

### DIFF
--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/GraphRepository.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/GraphRepository.java
@@ -32,8 +32,6 @@ import java.util.stream.Stream;
  * Graph repository.
  * Each {@link Graph} is associated with ID.
  * For OWL Ontology Graphs, Graph ID can be {@link OntID#getImportsIRI()}.
- *
- * @see org.apache.jena.ontology.OntDocumentManager
  */
 public interface GraphRepository {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelControls.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelControls.java
@@ -75,7 +75,7 @@ public enum OntModelControls {
     USE_OWL1_DISTINCT_MEMBERS_PREDICATE_FEATURE,
     /**
      * If this key is set to {@code true}, all class expressions are allowed to be named (can have URI).
-     * This option is for compatibility with {@link org.apache.jena.ontology.OntModel}.
+     * This option is for compatibility with legacy {@code org.apache.jena.ontology.OntModel}.
      * In OWL2, complex class expression should be anonymous.
      */
     ALLOW_NAMED_CLASS_EXPRESSIONS,
@@ -86,7 +86,7 @@ public enum OntModelControls {
      * Casting such a construction to a particular class type
      * (e.g. {@code generic.as(OntClass.OneOf.class)}) will result in an exception,
      * but as a class expression, it can a type of the individual, can be a domain for property, etc.
-     * This option is for compatibility with {@link org.apache.jena.ontology.OntModel}.
+     * This option is for compatibility with legacy {@code org.apache.jena.ontology.OntModel}.
      */
     ALLOW_GENERIC_CLASS_EXPRESSIONS,
     /**
@@ -103,14 +103,14 @@ public enum OntModelControls {
     USE_SIMPLIFIED_TYPE_CHECKING_WHILE_LIST_INDIVIDUALS,
     /**
      * If {@code true},
-     * named class testing is compatible with the legacy {@link org.apache.jena.ontology.OntModel Jena OntModel},
+     * named class testing is compatible with the legacy {@code org.apache.jena.ontology.OntModel},
      * otherwise, a strict check against the specification for the class declaration is performed
      * ({@code owl:Class} for OWL &amp; {@code rdfs:Class} for RDFS types are required).
      * Note that this only applies to
      * {@link org.apache.jena.enhanced.EnhNode#canAs EnhNode#canAs} and {@link org.apache.jena.enhanced.EnhNode#as EnhNode#as} methods;
      * iteration (e.g., methods {@code OntModel.ontObjects(OntClass.class)})
      * still does not take into account classes with incorrect or missing declarations.
-     * For legacy Jena's casting rules see {@link org.apache.jena.ontology.Profile} impls.
+     * For legacy Jena's casting rules see {@code org.apache.jena.ontology.Profile} impls.
      */
     USE_LEGACY_COMPATIBLE_NAMED_CLASS_FACTORY,
     /**

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelFactory.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelFactory.java
@@ -47,9 +47,7 @@ import org.apache.jena.vocabulary.XSD;
 import java.util.Objects;
 
 /**
- * A factory to produce {@link OntModel OWL2 model}s, {@link Model Common model}s and {@link Graph graph}s.
- * Currently, OWL2 models support only direct semantic with no additional entailment reasoning.
- * This corresponds to {@link org.apache.jena.ontology.OntModelSpec#OWL_MEM OWL_MEM spec} for {@link org.apache.jena.ontology.OntModel Jena OWL model}.
+ * A factory to produce {@link OntModel Ontolofy model}s.
  */
 public class OntModelFactory {
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntSpecification.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntSpecification.java
@@ -53,7 +53,6 @@ import java.util.Objects;
  * @see <a href="https://www.w3.org/TR/2008/WD-owl11-syntax-20080108/">OWL v1.1</a>
  * @see <a href="https://www.w3.org/TR/owl-guide/">OWL v1</a>
  * @see <a href="https://www.w3.org/TR/2004/REC-owl-features-20040210/#s3">OWL1 Lite</a>
- * @see org.apache.jena.ontology.OntModelSpec OntModelSpec - legacy Jena's OWL1 specifications
  */
 @SuppressWarnings("ClassCanBeRecord")
 public class OntSpecification {
@@ -142,8 +141,6 @@ public class OntSpecification {
      * that handles hierarchy.
      * It supports {@code rdfs:subClassOf}, {@code rdfs:subPropertyOf} and class-individuals hierarchy,
      * otherwise it behaves like a regular {@link #OWL2_DL_MEM}.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_DL_MEM_RDFS_INF
      */
     public static final OntSpecification OWL2_DL_MEM_BUILTIN_RDFS_INF = new OntSpecification(
             OntPersonalities.OWL2_ONT_PERSONALITY()
@@ -158,8 +155,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 DL ontology models
      * that are stored in memory and do no additional entailment reasoning.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_DL_MEM
      */
     public static final OntSpecification OWL2_DL_MEM = new OntSpecification(
             OWL2_DL_PERSONALITY, null
@@ -168,8 +163,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 DL ontology models
      * that are stored in memory and use the RDFS inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_DL_MEM_RDFS_INF
      */
     public static final OntSpecification OWL2_DL_MEM_RDFS_INF = new OntSpecification(
             OWL2_DL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
@@ -178,8 +171,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 DL ontology models
      * that are stored in memory and use the transitive inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_DL_MEM_TRANS_INF
      */
     public static final OntSpecification OWL2_DL_MEM_TRANS_INF = new OntSpecification(
             OWL2_DL_PERSONALITY, TransitiveReasonerFactory.theInstance()
@@ -188,8 +179,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 DL ontology models
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_DL_MEM_RULE_INF
      */
     public static final OntSpecification OWL2_DL_MEM_RULES_INF = new OntSpecification(
             OWL2_DL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
@@ -204,8 +193,6 @@ public class OntSpecification {
     /**
      * A specification for Ontology models that are stored in memory and do no additional entailment reasoning.
      * Full support for the OWL v2 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM
      */
     public static final OntSpecification OWL2_FULL_MEM = new OntSpecification(
             OWL2_FULL_PERSONALITY, null
@@ -213,8 +200,6 @@ public class OntSpecification {
 
     /**
      * A specification for OWL2 models that are stored in memory and use the RDFS inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RDFS_INF
      */
     public static final OntSpecification OWL2_FULL_MEM_RDFS_INF = new OntSpecification(
             OWL2_FULL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
@@ -222,8 +207,6 @@ public class OntSpecification {
 
     /**
      * A specification for OWL2 models that are stored in memory and use the transitive inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_TRANS_INF
      */
     public static final OntSpecification OWL2_FULL_MEM_TRANS_INF = new OntSpecification(
             OWL2_FULL_PERSONALITY, TransitiveReasonerFactory.theInstance()
@@ -232,8 +215,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 ontology models
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RULE_INF
      */
     public static final OntSpecification OWL2_FULL_MEM_RULES_INF = new OntSpecification(
             OWL2_FULL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
@@ -242,8 +223,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 ontology models
      * that are stored in memory and use the micro OWL rules inference engine for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_MICRO_RULE_INF
      */
     public static final OntSpecification OWL2_FULL_MEM_MICRO_RULES_INF = new OntSpecification(
             OWL2_FULL_PERSONALITY, OWLMicroReasonerFactory.theInstance()
@@ -252,8 +231,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 ontology models
      * that are stored in memory and use the mini OWL rules inference engine for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_MINI_RULE_INF
      */
     public static final OntSpecification OWL2_FULL_MEM_MINI_RULES_INF = new OntSpecification(
             OWL2_FULL_PERSONALITY, OWLMiniReasonerFactory.theInstance()
@@ -267,8 +244,6 @@ public class OntSpecification {
 
     /**
      * A specification for OWL2 EL Ontology models that are stored in memory and do no additional entailment reasoning.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM
      */
     public static final OntSpecification OWL2_EL_MEM = new OntSpecification(
             OWL2_EL_PERSONALITY, null
@@ -277,8 +252,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 EL models that are stored in memory
      * and use the RDFS inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RDFS_INF
      */
     public static final OntSpecification OWL2_EL_MEM_RDFS_INF = new OntSpecification(
             OWL2_EL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
@@ -287,8 +260,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 EL models that are stored in memory
      * and use the transitive inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_TRANS_INF
      */
     public static final OntSpecification OWL2_EL_MEM_TRANS_INF = new OntSpecification(
             OWL2_EL_PERSONALITY, TransitiveReasonerFactory.theInstance()
@@ -297,8 +268,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 EL ontology models
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RULE_INF
      */
     public static final OntSpecification OWL2_EL_MEM_RULES_INF = new OntSpecification(
             OWL2_EL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
@@ -312,8 +281,6 @@ public class OntSpecification {
 
     /**
      * A specification for OWL2 QL Ontology models that are stored in memory and do no additional entailment reasoning.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM
      */
     public static final OntSpecification OWL2_QL_MEM = new OntSpecification(
             OWL2_QL_PERSONALITY, null
@@ -322,8 +289,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 QL models that are stored in memory
      * and use the RDFS inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RDFS_INF
      */
     public static final OntSpecification OWL2_QL_MEM_RDFS_INF = new OntSpecification(
             OWL2_QL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
@@ -332,8 +297,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 QL models that are stored in memory
      * and use the transitive inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_TRANS_INF
      */
     public static final OntSpecification OWL2_QL_MEM_TRANS_INF = new OntSpecification(
             OWL2_QL_PERSONALITY, TransitiveReasonerFactory.theInstance()
@@ -342,8 +305,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 QL ontology models
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RULE_INF
      */
     public static final OntSpecification OWL2_QL_MEM_RULES_INF = new OntSpecification(
             OWL2_QL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
@@ -357,8 +318,6 @@ public class OntSpecification {
 
     /**
      * A specification for OWL2 RL Ontology models that are stored in memory and do no additional entailment reasoning.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM
      */
     public static final OntSpecification OWL2_RL_MEM = new OntSpecification(
             OWL2_RL_PERSONALITY, null
@@ -367,8 +326,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 RL models that are stored in memory
      * and use the RDFS inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RDFS_INF
      */
     public static final OntSpecification OWL2_RL_MEM_RDFS_INF = new OntSpecification(
             OWL2_RL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
@@ -377,8 +334,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 RL models that are stored in memory
      * and use the transitive inferencer for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_TRANS_INF
      */
     public static final OntSpecification OWL2_RL_MEM_TRANS_INF = new OntSpecification(
             OWL2_RL_PERSONALITY, TransitiveReasonerFactory.theInstance()
@@ -387,8 +342,6 @@ public class OntSpecification {
     /**
      * A specification for OWL2 RL ontology models
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RULE_INF
      */
     public static final OntSpecification OWL2_RL_MEM_RULES_INF = new OntSpecification(
             OWL2_RL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
@@ -404,8 +357,6 @@ public class OntSpecification {
      * A specification for OWL1 DL ontology models
      * that are stored in memory and do no additional entailment reasoning.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL DL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_DL_MEM
      */
     public static final OntSpecification OWL1_DL_MEM = new OntSpecification(
             OWL1_DL_PERSONALITY, null
@@ -415,8 +366,6 @@ public class OntSpecification {
      * A specification for OWL1 DL ontology models
      * that are stored in memory and use the RDFS inferencer for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_DL_MEM_RDFS_INF
      */
     public static final OntSpecification OWL1_DL_MEM_RDFS_INF = new OntSpecification(
             OWL1_DL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
@@ -426,8 +375,6 @@ public class OntSpecification {
      * A specification for OWL1 DL ontology models
      * that are stored in memory and use the transitive inferencer for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_DL_MEM_TRANS_INF
      */
     public static final OntSpecification OWL1_DL_MEM_TRANS_INF = new OntSpecification(
             OWL1_DL_PERSONALITY, TransitiveReasonerFactory.theInstance()
@@ -437,8 +384,6 @@ public class OntSpecification {
      * A specification for OWL1 DL ontology models
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_DL_MEM_RULE_INF
      */
     public static final OntSpecification OWL1_DL_MEM_RULES_INF = new OntSpecification(
             OWL1_DL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
@@ -454,8 +399,6 @@ public class OntSpecification {
      * A specification for OWL1 ontology models
      * that are stored in memory and do no additional entailment reasoning.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM
      */
     public static final OntSpecification OWL1_FULL_MEM = new OntSpecification(
             OWL1_FULL_PERSONALITY, null
@@ -465,8 +408,6 @@ public class OntSpecification {
      * A specification for OWL1 ontology models
      * that are stored in memory and use the RDFS inferencer for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RDFS_INF
      */
     public static final OntSpecification OWL1_FULL_MEM_RDFS_INF = new OntSpecification(
             OWL1_FULL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
@@ -476,8 +417,6 @@ public class OntSpecification {
      * A specification for OWL1 ontology models
      * that are stored in memory and use the transitive inferencer for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_TRANS_INF
      */
     public static final OntSpecification OWL1_FULL_MEM_TRANS_INF = new OntSpecification(
             OWL1_FULL_PERSONALITY, TransitiveReasonerFactory.theInstance()
@@ -487,8 +426,6 @@ public class OntSpecification {
      * A specification for OWL1 ontology models
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_RULE_INF
      */
     public static final OntSpecification OWL1_FULL_MEM_RULES_INF = new OntSpecification(
             OWL1_FULL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
@@ -498,8 +435,6 @@ public class OntSpecification {
      * A specification for OWL1 ontology models
      * that are stored in memory and use the micro OWL rules inference engine for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_MICRO_RULE_INF
      */
     public static final OntSpecification OWL1_FULL_MEM_MICRO_RULES_INF = new OntSpecification(
             OWL1_FULL_PERSONALITY, OWLMicroReasonerFactory.theInstance()
@@ -509,8 +444,6 @@ public class OntSpecification {
      * A specification for OWL1 ontology models
      * that are stored in memory and use the mini OWL rules inference engine for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_MEM_MINI_RULE_INF
      */
     public static final OntSpecification OWL1_FULL_MEM_MINI_RULES_INF = new OntSpecification(
             OWL1_FULL_PERSONALITY, OWLMiniReasonerFactory.theInstance()
@@ -526,8 +459,6 @@ public class OntSpecification {
      * A specification for OWL1 Lite ontology models
      * that are stored in memory and do no additional entailment reasoning.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1 Lite specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_LITE_MEM
      */
     public static final OntSpecification OWL1_LITE_MEM = new OntSpecification(
             OWL1_LITE_PERSONALITY, null
@@ -537,8 +468,6 @@ public class OntSpecification {
      * A specification for OWL1 Lite ontology models
      * that are stored in memory and use the RDFS inferencer for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1 Lite specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_LITE_MEM_RDFS_INF
      */
     public static final OntSpecification OWL1_LITE_MEM_RDFS_INF = new OntSpecification(
             OWL1_LITE_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
@@ -548,8 +477,6 @@ public class OntSpecification {
      * A specification for OWL1 Lite ontology models
      * that are stored in memory and use the transitive inferencer for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1 Lite specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_LITE_MEM_TRANS_INF
      */
     public static final OntSpecification OWL1_LITE_MEM_TRANS_INF = new OntSpecification(
             OWL1_LITE_PERSONALITY, TransitiveReasonerFactory.theInstance()
@@ -559,8 +486,6 @@ public class OntSpecification {
      * A specification for OWL1 Lite ontology models
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1 Lite specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#OWL_LITE_MEM_RULES_INF
      */
     public static final OntSpecification OWL1_LITE_MEM_RULES_INF = new OntSpecification(
             OWL1_LITE_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
@@ -575,8 +500,6 @@ public class OntSpecification {
     /**
      * A specification for RDFS models that are stored in memory and do no additional entailment reasoning.
      * Supposed to be a replacement for the original legacy Jena interpretation of RDFS specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#RDFS_MEM
      */
     public static final OntSpecification RDFS_MEM = new OntSpecification(
             RDFS_PERSONALITY, null
@@ -586,8 +509,6 @@ public class OntSpecification {
      * A specification for RDFS ontology models that are stored in memory
      * and use the RDFS inferencer for additional entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of RDFS specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#RDFS_MEM_RDFS_INF
      */
     public static final OntSpecification RDFS_MEM_RDFS_INF = new OntSpecification(
             RDFS_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
@@ -597,8 +518,6 @@ public class OntSpecification {
      * A specification for RDFS ontology models that are stored in memory
      * and use the transitive reasoner for entailments.
      * Supposed to be a replacement for the original legacy Jena interpretation of RDFS specification.
-     *
-     * @see org.apache.jena.ontology.OntModelSpec#RDFS_MEM_TRANS_INF
      */
     public static final OntSpecification RDFS_MEM_TRANS_INF = new OntSpecification(
             RDFS_PERSONALITY, TransitiveReasonerFactory.theInstance()

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/HierarchySupport.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/HierarchySupport.java
@@ -68,8 +68,6 @@ public final class HierarchySupport {
 
     /**
      * Lists tree nodes for the given root using {@code listChildren} function, which provides child nodes.
-     * This is an analogy of
-     * {@code org.apache.jena.ontology.impl.OntResourceImpl#listDirectPropertyValues(Property, String, Class, Property, boolean, boolean)}
      *
      * @param root                       the root of tree
      * @param listChildren               a {@link Function} that provides {@code Stream} of child nodes for the given parent node

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
@@ -111,8 +111,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Base model ONT-API implementation to work through jena only.
- * This is an analogue of {@link org.apache.jena.ontology.impl.OntModelImpl} to work in accordance with OWL2 DL specification.
+ * Implementation of a model that can process general ontologies in OWL and similar languages.
+ * Class {@link OntPersonality} is responsible for the configuration of the model.
+ * Also see {@link OntModelControls} - a set of settings,
+ * that can be accessed through {@link OntPersonality#getConfig()}.
  *
  * @see UnionGraph
  */
@@ -670,10 +672,6 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
     /**
      * Returns an {@code ExtendedIterator} over all individuals
      * that participate in class assertion statement {@code a rdf:type C}.
-     * <b>Note:</b> this method behaves differently than
-     * the method {@link org.apache.jena.ontology.impl.OntModelImpl#listIndividuals()}!
-     * The Jena's method does not verify that the right side of the class-assertion is indeed a valid class expression;
-     * it checks only several well-known cases.
      *
      * @return {@link ExtendedIterator} of {@link OntIndividual}s
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntObjectImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntObjectImpl.java
@@ -189,7 +189,6 @@ public class OntObjectImpl extends ResourceImpl implements OntObject {
     /**
      * Returns {@code true} if the given object is from reserved vocabulary
      * (e.g. {@code rdf:rest} is reserved in system settings).
-     * This is the equivalent of {@link org.apache.jena.ontology.OntResource#isOntLanguageTerm()}, but more accurate.
      *
      * @param object {@link OntObject}
      * @return boolean

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntClass.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntClass.java
@@ -20,7 +20,6 @@ package org.apache.jena.ontapi.model;
 
 import org.apache.jena.ontapi.OntJenaException;
 import org.apache.jena.rdf.model.Literal;
-import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFList;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
@@ -40,7 +39,7 @@ import java.util.stream.Stream;
 /**
  * A base abstraction for any Class Expressions (both named and anonymous).
  *
- * @see Named - an OWL Class
+ * @see Named an OWL Class
  * @see <a href="https://www.w3.org/TR/owl2-quick-reference/#Class_Expressions">2.1 Class Expressions</a>
  * @see <a href="https://www.w3.org/TR/owl2-syntax/#Class_Expressions">8 Class Expressions</a>
  */
@@ -89,7 +88,6 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
      * @return <b>distinct</b> {@code Stream} of sub {@link OntClass class expression}s
      * @see #subClasses()
      * @see #superClasses(boolean)
-     * @see org.apache.jena.ontology.OntClass#listSubClasses(boolean)
      */
     Stream<OntClass> subClasses(boolean direct);
 
@@ -134,7 +132,6 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
      * @return <b>distinct</b> {@code Stream} of super {@link OntClass class expression}s
      * @see #superClasses()
      * @see #subClasses(boolean)
-     * @see org.apache.jena.ontology.OntClass#listSuperClasses(boolean)
      */
     Stream<OntClass> superClasses(boolean direct);
 
@@ -159,15 +156,11 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
      * This method may therefore return complete results only in models that have an attached reasoner.
      * For built-in properties the method returns always {@code false}.
      * If there are no domains for the property, then it is considered as global and is attached to root classes.
-     * <p>
-     * The behavior of this method must be identical to the behavior of the Jena method
-     * {@link org.apache.jena.ontology.OntClass#hasDeclaredProperty(Property, boolean)}.
      *
      * @param property {@link OntProperty}, not {@code null}
      * @param direct   {@code boolean}: if {@code true} analyses only the directly adjacent domains in the subclass relation,
      *                 otherwise takes into account the class hierarchy
      * @return {@code boolean}, {@code true} if the property is associated with this class by its domain, otherwise {@code false}
-     * @see org.apache.jena.ontology.OntClass#hasDeclaredProperty(Property, boolean)
      */
     boolean hasDeclaredProperty(OntProperty property, boolean direct);
 
@@ -179,9 +172,6 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
      * The properties in the frame-like view of the class are determined by comparing
      * the domain of properties in this class's {@link OntModel} with the class itself.
      * See: <a href="https://jena.apache.org/documentation/notes/rdf-frames.html">Apache Jena: Presenting RDF as frames</a> for more details.
-     * <p>
-     * The behavior of this method must be identical to the behavior of the Jena method
-     * {@link org.apache.jena.ontology.OntClass#listDeclaredProperties(boolean)}}.
      *
      * @param direct {@code boolean}: if {@code true} analyses only the directly adjacent domains in the subclass relation,
      *               otherwise takes into account the class hierarchy
@@ -196,9 +186,6 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
      * or (ii) it has no declared superclasses.
      * <p>
      * {@code owl:Nothing} cannot be root.
-     * <p>
-     * The behavior of this method must be identical to the behavior of the Jena method
-     * {@link org.apache.jena.ontology.OntClass#isHierarchyRoot()}.
      *
      * @return {@code true} if this class is the root of the class hierarchy in the model it is attached to
      */
@@ -1012,8 +999,7 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
     }
 
     /**
-     * An OWL Class {@link OntEntity Entity}, a named class expression.
-     * This is an analogue of {@link org.apache.jena.ontology.OntClass}, but for OWL2.
+     * An Ontology Class {@link OntEntity Entity}, a named class expression.
      *
      * @see <a href="https://www.w3.org/TR/owl2-syntax/#Classes">5.1 Classes</a>
      */

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntModel.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntModel.java
@@ -21,7 +21,6 @@ package org.apache.jena.ontapi.model;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.ontapi.OntJenaException;
-import org.apache.jena.ontapi.common.OntPersonality;
 import org.apache.jena.ontapi.utils.Graphs;
 import org.apache.jena.rdf.model.InfModel;
 import org.apache.jena.rdf.model.Literal;
@@ -44,9 +43,8 @@ import java.util.stream.Stream;
 /**
  * An enhanced view of a {@link Model Jena Model} about which is known
  * to contain <b>OWL</b> or <b>RDFS</b> ontology data.
- * The view supports OWL2 DL specification,
- * and is an analogue of {@link org.apache.jena.ontology.OntModel Apache Jena OntModel},
- * which only covers the OWL1 syntax.
+ * The view supports OWL2 DL specification and all its dialects, including OWL1.
+ * The model also has a component-level support of Semantic Web Rule Language (SWRL).
  * <p>
  * In addition to the standard {@link Resource Jena Resource}s and {@link Statement Jena Statement}s
  * this model provides access to different ontological components in the form of {@link OntObject Object}s
@@ -54,21 +52,15 @@ import java.util.stream.Stream;
  * Some of the {@link OntObject}s can be constructed using another kind of resource -
  * {@link OntList}, which is an extended analogue of the standard {@link RDFList Jena RDFList}.
  * <p>
- * The model also has a component-level support of Semantic Web Rule Language (SWRL).
- * <p>
  * In additional to native Jena {@link org.apache.jena.util.iterator.ExtendedIterator Extended Iterator}s,
  * this model also provides access to RDF in the form of {@link Stream}s, that obey the same rules:
  * both {@code Stream} and {@code ExtendedIterator} must be closed explicitly
  * if they are no longer needed but not yet exhausted, see {@link org.apache.jena.util.iterator.ClosableIterator}.
  * <p>
- * Impl note: this model does not support {@link org.apache.jena.ontology.Profile Jena Profile}s mechanism,
- * and model configuration is delegated directly to the extended {@link OntPersonality Personality}.
- * <p>
  * The interface does not extend {@link InfModel},
  * but the inference model can be accessed via {@link OntModel#asInferenceModel()}.
  * If implementation does not provide inference support, the method will throw an exception.
  *
- * @see org.apache.jena.ontology.OntModel
  * @see <a href="https://www.w3.org/TR/owl2-mapping-to-rdf">OWL2 RDF mapping</a>
  * @see <a href="https://www.w3.org/TR/owl2-quick-reference/">A Quick Guide</a>
  * @see <a href="https://www.w3.org/TR/owl2-syntax/">OWL 2 Web Ontology Language Structural Specification and Functional-Style Syntax (Second Edition)</a>
@@ -235,12 +227,12 @@ public interface OntModel extends Model,
      * This method can also be used to wrap builtin entities, which, in fact, do not belong to the RDF graph,
      * but can be considered as belonged to the OWL model.
      * An IRI for such a built-in entity must be in
-     * the {@link OntPersonality.Builtins Builtins Vocabulary},
+     * the {@link org.apache.jena.ontapi.common.OntPersonality.Builtins Builtins Vocabulary},
      * otherwise the method returns {@code null}.
      *
-     * @param type {@link Class}, the type of {@link OntEntity}, not {@code null}.
-     * @param uri String, not {@code null}.
-     * @param <E>  type of ont-entity
+     * @param type {@link Class}, the type of {@link OntEntity}, not {@code null}
+     * @param uri String, not {@code null}
+     * @param <E>  type of OntEntity
      * @return {@link OntEntity} or {@code null}
      * @see #fetchOntEntity(Class, String)
      */
@@ -591,7 +583,6 @@ public interface OntModel extends Model,
      * }.
      * If you need all named properties, use {@code this.ontEntities(OntNamedProperty.class)}
      * <p>
-     * This is analogous of {@link org.apache.jena.ontology.OntModel#listAllOntProperties()}.
      * Note that this method does not care about punnings: it will return property
      * even if it has both {@code owl:ObjectProperty} and {@code owl:DatatypeProperty} declarations
      * and such punning is prohibited in the model settings.

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntProperty.java
@@ -148,9 +148,6 @@ public interface OntProperty extends OntObject {
      * This simulates a frame-like view of properties and classes;
      * for more details see the
      * <a href="https://jena.apache.org/documentation/notes/rdf-frames.html">Apache Jena: Presenting RDF as frames</a>
-     * <p>
-     * The behavior of this method must be identical to the behavior of the Jena method
-     * {@link org.apache.jena.ontology.OntProperty#listDeclaringClasses(boolean)}.
      *
      * @param direct {@code boolean} if {@code true}, use only <em>direct</em> associations between classes and properties
      * @return a {@code Stream} of the classes having this property as one of their declared properties

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntResource.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntResource.java
@@ -26,8 +26,6 @@ import java.util.stream.Stream;
 
 /**
  * A common super-type for all the abstractions in this ontology representation package.
- * This is an analogue of the {@link org.apache.jena.ontology.OntResource Jena OntResource} interface,
- * but for {@link OntModel OWL2 Ontology RDF Graph Model}.
  */
 interface OntResource extends Resource {
 

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntClassDeclaredPropertiesTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntClassDeclaredPropertiesTest.java
@@ -500,10 +500,6 @@ public class OntClassDeclaredPropertiesTest {
         );
         OntClass A = m.getOntClass(NS + "A");
 
-        // Legacy Jena OWL (org.apache.jena.ontology.OntModel) no need to add explicit rdf:Property declarations,
-        // since Jena OWL for RDFS spec allow casting everything to everything.
-        // This OWL model follows more strict rules,
-        // so it is needed to add corresponding declarations to object properties to be able to get them as OntProperty
         OntProperty pA = m.createResource(NS + "pA", RDF.Property).as(OntProperty.class);
         OntProperty pB = m.createResource(NS + "pB", RDF.Property).as(OntProperty.class);
 


### PR DESCRIPTION
GitHub issue resolved #2631

Pull request Description:

javadocs cleanup

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
