### PR TITLE
GH-2657: fix several defects in profiles support (RL, QL):

### DIFF
--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalities.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalities.java
@@ -371,7 +371,7 @@ public class OntPersonalities {
             .add(OntDataRange.class, OWL2ObjectFactories.QL_ANY_DATARANGE)
 
             // disjoint anonymous collections:
-            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.CLASSES_DISJOINT)
+            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.QL_CLASSES_DISJOINT)
             .add(OntDisjoint.Individuals.class, OWL2ObjectFactories.DIFFERENT_INDIVIDUALS_DISJOINT)
             .add(OntDisjoint.ObjectProperties.class, OWL2ObjectFactories.OBJECT_PROPERTIES_DISJOINT)
             .add(OntDisjoint.DataProperties.class, OWL2ObjectFactories.DATA_PROPERTIES_DISJOINT)
@@ -446,7 +446,7 @@ public class OntPersonalities {
             .add(OntNegativeAssertion.class, OWL2ObjectFactories.ANY_NEGATIVE_PROPERTY_ASSERTION)
 
             // disjoint anonymous collections:
-            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.CLASSES_DISJOINT)
+            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.RL_CLASSES_DISJOINT)
             .add(OntDisjoint.Individuals.class, OWL2ObjectFactories.DIFFERENT_INDIVIDUALS_DISJOINT)
             .add(OntDisjoint.ObjectProperties.class, OWL2ObjectFactories.OBJECT_PROPERTIES_DISJOINT)
             .add(OntDisjoint.DataProperties.class, OWL2ObjectFactories.DATA_PROPERTIES_DISJOINT)

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
@@ -966,7 +966,8 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
     @Override
     public OntDisjoint.Classes createDisjointClasses(Collection<OntClass> classes) {
         checkType(OntDisjoint.Classes.class);
-        return OntDisjointImpl.createDisjointClasses(this, classes.stream());
+        checkType(OntClass.IntersectionOf.class);
+        return checkCreate(model -> OntDisjointImpl.createDisjointClasses(this, classes.stream()), OntDisjoint.Classes.class);
     }
 
     @Override

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
@@ -795,6 +795,8 @@ public final class OWL2ObjectFactories {
             true,
             OWL2.members
     );
+    public static final EnhNodeFactory QL_CLASSES_DISJOINT = OntDisjoints.createQLRLOntDisjointFactory();
+    public static final EnhNodeFactory RL_CLASSES_DISJOINT = OntDisjoints.createQLRLOntDisjointFactory();
     public static final Function<OntConfig, EnhNodeFactory> DIFFERENT_INDIVIDUALS_DISJOINT =
             OntDisjoints::createDifferentIndividualsFactory;
     public static final EnhNodeFactory OBJECT_PROPERTIES_DISJOINT = OntDisjoints.createFactory(

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntDisjointImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntDisjointImpl.java
@@ -156,6 +156,35 @@ public abstract class OntDisjointImpl<O extends OntObject> extends OntObjectImpl
         }
     }
 
+    /**
+     * {@code DisjointClasses := 'DisjointClasses' '(' axiomAnnotations subClassExpression subClassExpression { subClassExpression } ')'}
+     */
+    public static class QLRLClassesImpl extends OntDisjointImpl<OntClass> implements Classes {
+        public QLRLClassesImpl(Node n, EnhGraph m) {
+            super(n, m);
+        }
+
+        @Override
+        public Class<? extends OntObject> objectType() {
+            return Classes.class;
+        }
+
+        @Override
+        protected Class<OntClass> getComponentType() {
+            return OntClass.class;
+        }
+
+        @Override
+        protected Resource getResourceType() {
+            return OWL2.AllDisjointClasses;
+        }
+
+        @Override
+        public Stream<OntClass> members() {
+            return getList().members().filter(OntClass::canAsDisjointClass).map(OntClass::asDisjointClass);
+        }
+    }
+
     public static class IndividualsImpl extends OntDisjointImpl<OntIndividual> implements Individuals {
         private final boolean useMembers;
         private final boolean useDistinctMembers;

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntClass.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntClass.java
@@ -258,9 +258,9 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
     /**
      * Deletes the given {@code HasKey} list including its annotations.
      *
-     * @param list {@link Resource} can be {@link OntList} or {@link RDFList}
+     * @param list {@link Resource} can be {@link OntList} or {@link RDFList};
+     *             if {@code null} the method will remove all hasKey's
      * @return <b>this</b> instance to allow cascading calls
-     * @throws OntJenaException if the list is not found
      */
     OntClass removeHasKey(Resource list);
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntDisjoint.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntDisjoint.java
@@ -36,7 +36,8 @@ public interface OntDisjoint<O extends OntObject> extends OntObject, HasRDFNodeL
 
     /**
      * Lists all pair-wise disjoint members holding by this {@link OntDisjoint Ontology Disjoint} resource.
-     * In general, this method is equivalent to the expression {@code this.getList().members()}.
+     * Note that the returned values are not necessarily the same as {@link OntList#members()} output:
+     * some profiles (e.g., OWL2 QL) impose some restrictions.
      *
      * @return Stream (<b>not distinct</b>) of {@link OntObject}s
      */

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2ELSpecTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2ELSpecTest.java
@@ -212,9 +212,9 @@ public class OntModelOWL2ELSpecTest {
         Resource c0 = m.createResource("C", OWL2.Class);
         Resource i1 = m.createResource("i1", c0);
         Resource i2 = m.createResource("i2", c0);
-        Resource c1 = m.createResource().addProperty(RDF.type, OWL2.Class).addProperty(OWL2.oneOf, m.createList());
-        Resource c2 = m.createResource().addProperty(RDF.type, OWL2.Class).addProperty(OWL2.oneOf, m.createList(i1));
-        Resource c3 = m.createResource().addProperty(RDF.type, OWL2.Class).addProperty(OWL2.oneOf, m.createList(i1, i2));
+        m.createResource().addProperty(RDF.type, OWL2.Class).addProperty(OWL2.oneOf, m.createList());
+        m.createResource().addProperty(RDF.type, OWL2.Class).addProperty(OWL2.oneOf, m.createList(i1));
+        m.createResource().addProperty(RDF.type, OWL2.Class).addProperty(OWL2.oneOf, m.createList(i1, i2));
 
         OntModel om = OntModelFactory.createModel(m.getGraph(), spec.inst);
         OntIndividual oi1 = Objects.requireNonNull(om.getIndividual("i1"));
@@ -237,9 +237,9 @@ public class OntModelOWL2ELSpecTest {
         Model m = ModelFactory.createDefaultModel();
         Literal v1 = m.createTypedLiteral(42);
         Literal v2 = m.createTypedLiteral("42");
-        Resource c1 = m.createResource().addProperty(RDF.type, RDFS.Datatype).addProperty(OWL2.oneOf, m.createList());
-        Resource c2 = m.createResource().addProperty(RDF.type, RDFS.Datatype).addProperty(OWL2.oneOf, m.createList(v1));
-        Resource c3 = m.createResource().addProperty(RDF.type, RDFS.Datatype).addProperty(OWL2.oneOf, m.createList(v1, v2));
+        m.createResource().addProperty(RDF.type, RDFS.Datatype).addProperty(OWL2.oneOf, m.createList());
+        m.createResource().addProperty(RDF.type, RDFS.Datatype).addProperty(OWL2.oneOf, m.createList(v1));
+        m.createResource().addProperty(RDF.type, RDFS.Datatype).addProperty(OWL2.oneOf, m.createList(v1, v2));
 
         OntModel om = OntModelFactory.createModel(m.getGraph(), spec.inst);
         OntDataRange.OneOf oc2 = om.ontObjects(OntDataRange.OneOf.class).findFirst().orElseThrow(AssertionError::new);
@@ -283,5 +283,22 @@ public class OntModelOWL2ELSpecTest {
                         () -> it.inModel(m).as(OntEntity.class),
                         "wrong result for " + it)
                 );
+    }
+
+    @ParameterizedTest
+    @EnumSource(names = {
+            "OWL2_EL_MEM",
+            "OWL2_EL_MEM_RDFS_INF",
+            "OWL2_EL_MEM_TRANS_INF",
+    })
+    public void testHasKey(TestSpec spec) {
+        OntModel m = OntModelFactory.createModel(spec.inst);
+        OntClass a = m.createOntClass("a");
+        OntDataProperty p1 = m.createDataProperty("p1");
+        OntDataProperty p2 = m.createDataProperty("p2");
+        a.addHasKey(p1, p2);
+        Assertions.assertEquals(1L, a.hasKeys().count());
+        a.removeHasKey(null);
+        Assertions.assertEquals(0L, a.hasKeys().count());
     }
 }

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2QLSpecTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2QLSpecTest.java
@@ -414,4 +414,19 @@ public class OntModelOWL2QLSpecTest {
         Assertions.assertThrows(OntJenaException.Unsupported.class, mc7::asDisjointClass);
         Assertions.assertThrows(OntJenaException.Unsupported.class, mc7::asEquivalentClass);
     }
+
+    @ParameterizedTest
+    @EnumSource(names = {
+            "OWL2_QL_MEM",
+            "OWL2_QL_MEM_RDFS_INF",
+            "OWL2_QL_MEM_TRANS_INF",
+    })
+    public void testHasKey(TestSpec spec) {
+        OntModel m = OntModelFactory.createModel(spec.inst);
+        OntClass a = m.createOntClass("a");
+        OntDataProperty p1 = m.createDataProperty("p1");
+        OntDataProperty p2 = m.createDataProperty("p2");
+        Assertions.assertThrows(OntJenaException.Unsupported.class, () -> a.addHasKey(p1, p2));
+        Assertions.assertThrows(OntJenaException.Unsupported.class, () -> a.removeHasKey(m.createList()));
+    }
 }


### PR DESCRIPTION
GitHub issue resolved #2657

Pull request Description:

- OntDisjoint.Classes should only contain subClassExpressions
- subject of hasKey axiom should be subClassExpression


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
