### PR TITLE
GH-2673: [ontapi] OntDisjoints - require more than one member (for EL QL, RL)

### DIFF
--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalities.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalities.java
@@ -311,8 +311,8 @@ public class OntPersonalities {
             .add(OntNegativeAssertion.class, OWL2ObjectFactories.ANY_NEGATIVE_PROPERTY_ASSERTION)
 
             // disjoint anonymous collections:
-            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.CLASSES_DISJOINT)
-            .add(OntDisjoint.Individuals.class, OWL2ObjectFactories.DIFFERENT_INDIVIDUALS_DISJOINT)
+            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.EL_CLASSES_DISJOINT)
+            .add(OntDisjoint.Individuals.class, OWL2ObjectFactories.EL_QL_RL_DIFFERENT_INDIVIDUALS_DISJOINT)
             .add(OntDisjoint.class, OWL2ObjectFactories.EL_ANY_DISJOINT);
 
     /**
@@ -370,10 +370,10 @@ public class OntPersonalities {
             .add(OntDataRange.class, OWL2ObjectFactories.QL_ANY_DATARANGE)
 
             // disjoint anonymous collections:
-            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.QL_CLASSES_DISJOINT)
-            .add(OntDisjoint.Individuals.class, OWL2ObjectFactories.DIFFERENT_INDIVIDUALS_DISJOINT)
-            .add(OntDisjoint.ObjectProperties.class, OWL2ObjectFactories.OBJECT_PROPERTIES_DISJOINT)
-            .add(OntDisjoint.DataProperties.class, OWL2ObjectFactories.DATA_PROPERTIES_DISJOINT)
+            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.QL_RL_CLASSES_DISJOINT)
+            .add(OntDisjoint.Individuals.class, OWL2ObjectFactories.EL_QL_RL_DIFFERENT_INDIVIDUALS_DISJOINT)
+            .add(OntDisjoint.ObjectProperties.class, OWL2ObjectFactories.QL_RL_OBJECT_PROPERTIES_DISJOINT)
+            .add(OntDisjoint.DataProperties.class, OWL2ObjectFactories.QL_RL_DATA_PROPERTIES_DISJOINT)
             .add(OntDisjoint.Properties.class, OWL2ObjectFactories.ANY_PROPERTIES_DISJOINT)
             .add(OntDisjoint.class, OWL2ObjectFactories.ANY_DISJOINT);
 
@@ -445,10 +445,10 @@ public class OntPersonalities {
             .add(OntNegativeAssertion.class, OWL2ObjectFactories.ANY_NEGATIVE_PROPERTY_ASSERTION)
 
             // disjoint anonymous collections:
-            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.RL_CLASSES_DISJOINT)
-            .add(OntDisjoint.Individuals.class, OWL2ObjectFactories.DIFFERENT_INDIVIDUALS_DISJOINT)
-            .add(OntDisjoint.ObjectProperties.class, OWL2ObjectFactories.OBJECT_PROPERTIES_DISJOINT)
-            .add(OntDisjoint.DataProperties.class, OWL2ObjectFactories.DATA_PROPERTIES_DISJOINT)
+            .add(OntDisjoint.Classes.class, OWL2ObjectFactories.QL_RL_CLASSES_DISJOINT)
+            .add(OntDisjoint.Individuals.class, OWL2ObjectFactories.EL_QL_RL_DIFFERENT_INDIVIDUALS_DISJOINT)
+            .add(OntDisjoint.ObjectProperties.class, OWL2ObjectFactories.QL_RL_OBJECT_PROPERTIES_DISJOINT)
+            .add(OntDisjoint.DataProperties.class, OWL2ObjectFactories.QL_RL_DATA_PROPERTIES_DISJOINT)
             .add(OntDisjoint.Properties.class, OWL2ObjectFactories.ANY_PROPERTIES_DISJOINT)
             .add(OntDisjoint.class, OWL2ObjectFactories.ANY_DISJOINT);
     /**

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
@@ -967,25 +967,33 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
     public OntDisjoint.Classes createDisjointClasses(Collection<OntClass> classes) {
         checkType(OntDisjoint.Classes.class);
         checkType(OntClass.IntersectionOf.class);
-        return checkCreate(model -> OntDisjointImpl.createDisjointClasses(this, classes.stream()), OntDisjoint.Classes.class);
+        return checkCreate(model ->
+                OntDisjointImpl.createDisjointClasses(model, classes.stream()), OntDisjoint.Classes.class
+        );
     }
 
     @Override
     public OntDisjoint.Individuals createDifferentIndividuals(Collection<OntIndividual> individuals) {
         checkType(OntDisjoint.Individuals.class);
-        return OntDisjointImpl.createDifferentIndividuals(this, individuals.stream());
+        return checkCreate(model ->
+                OntDisjointImpl.createDifferentIndividuals(model, individuals.stream()), OntDisjoint.Individuals.class
+        );
     }
 
     @Override
     public OntDisjoint.ObjectProperties createDisjointObjectProperties(Collection<OntObjectProperty> properties) {
         checkType(OntDisjoint.ObjectProperties.class);
-        return OntDisjointImpl.createDisjointObjectProperties(this, properties.stream());
+        return checkCreate(model ->
+                OntDisjointImpl.createDisjointObjectProperties(model, properties.stream()), OntDisjoint.ObjectProperties.class
+        );
     }
 
     @Override
     public OntDisjoint.DataProperties createDisjointDataProperties(Collection<OntDataProperty> properties) {
         checkType(OntDisjoint.DataProperties.class);
-        return OntDisjointImpl.createDisjointDataProperties(this, properties.stream());
+        return checkCreate(model ->
+                OntDisjointImpl.createDisjointDataProperties(model, properties.stream()), OntDisjoint.DataProperties.class
+        );
     }
 
     @Override

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL1ObjectFactories.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL1ObjectFactories.java
@@ -369,7 +369,7 @@ public class OWL1ObjectFactories {
     );
 
     public static final Function<OntConfig, EnhNodeFactory> DIFFERENT_INDIVIDUALS_DISJOINT =
-            OntDisjoints::createDifferentIndividualsFactory;
+            OntDisjoints::createDLFullDifferentIndividualsFactory;
     public static final Function<OntConfig, EnhNodeFactory> ANY_DISJOINT = DIFFERENT_INDIVIDUALS_DISJOINT;
 
     private static boolean isNamedIndividual(Node n, EnhGraph eg) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
@@ -27,7 +27,6 @@ import org.apache.jena.ontapi.common.OntPersonality;
 import org.apache.jena.ontapi.impl.objects.OntAnnotationImpl;
 import org.apache.jena.ontapi.impl.objects.OntClassImpl;
 import org.apache.jena.ontapi.impl.objects.OntDataRangeImpl;
-import org.apache.jena.ontapi.impl.objects.OntDisjointImpl;
 import org.apache.jena.ontapi.impl.objects.OntFacetRestrictionImpl;
 import org.apache.jena.ontapi.impl.objects.OntIDImpl;
 import org.apache.jena.ontapi.impl.objects.OntIndividualImpl;
@@ -35,13 +34,11 @@ import org.apache.jena.ontapi.impl.objects.OntNegativePropertyAssertionImpl;
 import org.apache.jena.ontapi.impl.objects.OntObjectImpl;
 import org.apache.jena.ontapi.impl.objects.OntSimpleClassImpl;
 import org.apache.jena.ontapi.model.OntClass;
-import org.apache.jena.ontapi.model.OntDataProperty;
 import org.apache.jena.ontapi.model.OntDataRange;
 import org.apache.jena.ontapi.model.OntDisjoint;
 import org.apache.jena.ontapi.model.OntFacetRestriction;
 import org.apache.jena.ontapi.model.OntIndividual;
 import org.apache.jena.ontapi.model.OntNegativeAssertion;
-import org.apache.jena.ontapi.model.OntObjectProperty;
 import org.apache.jena.rdf.model.RDFList;
 import org.apache.jena.vocabulary.OWL2;
 import org.apache.jena.vocabulary.RDF;
@@ -788,34 +785,18 @@ public final class OWL2ObjectFactories {
             OntFacetRestriction.LangRange.class
     );
 
-    public static final EnhNodeFactory CLASSES_DISJOINT = OntDisjoints.createFactory(
-            OntDisjointImpl.ClassesImpl.class,
-            OntDisjointImpl.ClassesImpl::new,
-            OWL2.AllDisjointClasses,
-            OntClass.class,
-            true,
-            OWL2.members
-    );
-    public static final EnhNodeFactory QL_CLASSES_DISJOINT = OntDisjoints.createQLRLOntDisjointFactory();
-    public static final EnhNodeFactory RL_CLASSES_DISJOINT = OntDisjoints.createQLRLOntDisjointFactory();
+    public static final EnhNodeFactory CLASSES_DISJOINT = OntDisjoints.createDisjointClassesFactory(0);
+    public static final EnhNodeFactory EL_CLASSES_DISJOINT = OntDisjoints.createDisjointClassesFactory(2);
+    public static final EnhNodeFactory QL_RL_CLASSES_DISJOINT = OntDisjoints.createQLRLDisjointClassesFactory();
     public static final Function<OntConfig, EnhNodeFactory> DIFFERENT_INDIVIDUALS_DISJOINT =
-            OntDisjoints::createDifferentIndividualsFactory;
-    public static final EnhNodeFactory OBJECT_PROPERTIES_DISJOINT = OntDisjoints.createFactory(
-            OntDisjointImpl.ObjectPropertiesImpl.class,
-            OntDisjointImpl.ObjectPropertiesImpl::new,
-            OWL2.AllDisjointProperties,
-            OntObjectProperty.class,
-            false,
-            OWL2.members
-    );
-    public static final EnhNodeFactory DATA_PROPERTIES_DISJOINT = OntDisjoints.createFactory(
-            OntDisjointImpl.DataPropertiesImpl.class,
-            OntDisjointImpl.DataPropertiesImpl::new,
-            OWL2.AllDisjointProperties,
-            OntDataProperty.class,
-            false,
-            OWL2.members
-    );
+            OntDisjoints::createDLFullDifferentIndividualsFactory;
+    public static final EnhNodeFactory EL_QL_RL_DIFFERENT_INDIVIDUALS_DISJOINT =
+            OntDisjoints.createELQLRLDifferentIndividualsFactory();
+    public static final EnhNodeFactory OBJECT_PROPERTIES_DISJOINT = OntDisjoints.createDisjointObjectPropertiesFactory(0);
+    public static final EnhNodeFactory QL_RL_OBJECT_PROPERTIES_DISJOINT = OntDisjoints.createDisjointObjectPropertiesFactory(2);
+    public static final EnhNodeFactory DATA_PROPERTIES_DISJOINT = OntDisjoints.createDisjointDataPropertiesFactory(0);
+    public static final EnhNodeFactory QL_RL_DATA_PROPERTIES_DISJOINT = OntDisjoints.createDisjointDataPropertiesFactory(2);
+
     public static final EnhNodeFactory ANY_PROPERTIES_DISJOINT = OntEnhNodeFactories.createFrom(
             OntDisjoints.PROPERTIES_FINDER,
             OntDisjoint.ObjectProperties.class,

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OntDisjoints.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OntDisjoints.java
@@ -20,7 +20,6 @@ package org.apache.jena.ontapi.impl.factories;
 
 import org.apache.jena.enhanced.EnhGraph;
 import org.apache.jena.enhanced.EnhNode;
-import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.ontapi.OntModelControls;
@@ -33,7 +32,9 @@ import org.apache.jena.ontapi.common.OntEnhGraph;
 import org.apache.jena.ontapi.common.OntEnhNodeFactories;
 import org.apache.jena.ontapi.impl.objects.OntDisjointImpl;
 import org.apache.jena.ontapi.model.OntClass;
+import org.apache.jena.ontapi.model.OntDataProperty;
 import org.apache.jena.ontapi.model.OntIndividual;
+import org.apache.jena.ontapi.model.OntObjectProperty;
 import org.apache.jena.ontapi.utils.Iterators;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFList;
@@ -43,13 +44,14 @@ import org.apache.jena.util.iterator.ExtendedIterator;
 import org.apache.jena.vocabulary.OWL2;
 
 import java.util.function.BiFunction;
+import java.util.function.Predicate;
 
 final class OntDisjoints {
     public static final EnhNodeFinder PROPERTIES_FINDER = new EnhNodeFinder.ByType(OWL2.AllDisjointProperties);
     public static final EnhNodeFinder DISJOINT_FINDER = OntEnhNodeFactories.createFinder(OWL2.AllDisjointClasses,
             OWL2.AllDifferent, OWL2.AllDisjointProperties);
 
-    public static EnhNodeFactory createDifferentIndividualsFactory(OntConfig config) {
+    public static EnhNodeFactory createDLFullDifferentIndividualsFactory(OntConfig config) {
         boolean useDistinctMembers = config.getBoolean(OntModelControls.USE_OWL1_DISTINCT_MEMBERS_PREDICATE_FEATURE);
         boolean compatible = config.getBoolean(OntModelControls.USE_OWL2_DEPRECATED_VOCABULARY_FEATURE);
         Property[] predicates;
@@ -65,48 +67,106 @@ final class OntDisjoints {
                 (n, g) -> new OntDisjointImpl.IndividualsImpl(n, g, !compatible, useDistinctMembers),
                 OWL2.AllDifferent,
                 OntIndividual.class,
-                true,
+                it -> true,
+                0,
                 predicates
         );
     }
 
-    public static EnhNodeFactory createFactory(
-            Class<? extends OntDisjointImpl<?>> impl,
-            BiFunction<Node, EnhGraph, EnhNode> producer,
-            Resource type,
-            Class<? extends RDFNode> view,
-            boolean allowEmptyList,
-            Property... predicates) {
-        EnhNodeProducer maker = new EnhNodeProducer.WithType(impl, type, producer);
-        EnhNodeFinder finder = new EnhNodeFinder.ByType(type);
-        EnhNodeFilter filter = EnhNodeFilter.ANON.and(new EnhNodeFilter.HasType(type));
-        return OntEnhNodeFactories.createCommon(maker, finder, filter
-                .and(getHasPredicatesFilter(predicates))
-                .and(getHasMembersOfFilter(view, allowEmptyList, predicates)));
+    public static EnhNodeFactory createELQLRLDifferentIndividualsFactory() {
+        return createFactory(
+                OntDisjointImpl.IndividualsImpl.class,
+                (n, g) -> new OntDisjointImpl.IndividualsImpl(n, g, true, false),
+                OWL2.AllDifferent,
+                OntIndividual.class,
+                it -> true,
+                2,
+                OWL2.members
+        );
     }
 
-    public static EnhNodeFactory createQLRLOntDisjointFactory() {
-        EnhNodeProducer maker = new EnhNodeProducer.WithType(
-                OntDisjointImpl.QLRLClassesImpl.class,
-                OWL2.AllDisjointClasses,
-                OntDisjointImpl.QLRLClassesImpl::new
+    public static EnhNodeFactory createDisjointObjectPropertiesFactory(int atLeastN) {
+        return createFactory(
+                OntDisjointImpl.ObjectPropertiesImpl.class,
+                OntDisjointImpl.ObjectPropertiesImpl::new,
+                OWL2.AllDisjointProperties,
+                OntObjectProperty.class,
+                it -> true,
+                atLeastN,
+                OWL2.members
         );
-        EnhNodeFinder finder = new EnhNodeFinder.ByType(OWL2.AllDisjointClasses);
-        EnhNodeFilter filter = EnhNodeFilter.ANON.and(new EnhNodeFilter.HasType(OWL2.AllDisjointClasses)).and((n, g) -> {
-            ExtendedIterator<Triple> res = g.asGraph().find(n, OWL2.members.asNode(), Node.ANY);
+    }
+
+    public static EnhNodeFactory createDisjointDataPropertiesFactory(int atLeastN) {
+        return createFactory(
+                OntDisjointImpl.DataPropertiesImpl.class,
+                OntDisjointImpl.DataPropertiesImpl::new,
+                OWL2.AllDisjointProperties,
+                OntDataProperty.class,
+                it -> true,
+                atLeastN,
+                OWL2.members
+        );
+    }
+
+    public static EnhNodeFactory createDisjointClassesFactory(int atLeastN) {
+        return createFactory(
+                OntDisjointImpl.QLRLClassesImpl.class,
+                OntDisjointImpl.QLRLClassesImpl::new,
+                OWL2.AllDisjointClasses,
+                OntClass.class,
+                it -> true,
+                atLeastN,
+                OWL2.members
+        );
+    }
+
+    public static EnhNodeFactory createQLRLDisjointClassesFactory() {
+        return createFactory(
+                OntDisjointImpl.QLRLClassesImpl.class,
+                OntDisjointImpl.QLRLClassesImpl::new,
+                OWL2.AllDisjointClasses,
+                OntClass.class,
+                OntClass::canAsDisjointClass,
+                2,
+                OWL2.members
+        );
+    }
+
+    private static <X extends RDFNode> EnhNodeFactory createFactory(
+            Class<? extends OntDisjointImpl<?>> impl,
+            BiFunction<Node, EnhGraph, EnhNode> producer,
+            Resource rdfType,
+            Class<X> memberType,
+            Predicate<X> testMember,
+            int atLeastN,
+            Property... membersPredicates
+    ) {
+        EnhNodeProducer maker = new EnhNodeProducer.WithType(impl, rdfType, producer);
+        EnhNodeFinder finder = new EnhNodeFinder.ByType(rdfType);
+        EnhNodeFilter filter = EnhNodeFilter.ANON.and(new EnhNodeFilter.HasType(rdfType)).and((n, g) -> {
+            ExtendedIterator<Triple> res;
+            if (membersPredicates.length == 1) {
+                res = g.asGraph().find(n, membersPredicates[0].asNode(), Node.ANY);
+            } else {
+                res = Iterators.flatMap(Iterators.of(membersPredicates), it -> g.asGraph().find(n, it.asNode(), Node.ANY));
+            }
             try {
                 while (res.hasNext()) {
                     Node listNode = res.next().getObject();
                     if (!STDObjectFactories.RDF_LIST.canWrap(listNode, g)) {
                         return false;
                     }
+                    if (atLeastN == 0) {
+                        return true;
+                    }
                     RDFList list = (RDFList) STDObjectFactories.RDF_LIST.wrap(listNode, g);
                     if (Iterators.hasAtLeast(
                             list.iterator()
                                     .mapWith(it ->
-                                            OntEnhGraph.asPersonalityModel(g).findNodeAs(it.asNode(), OntClass.class)
+                                            OntEnhGraph.asPersonalityModel(g).findNodeAs(it.asNode(), memberType)
                                     )
-                                    .filterKeep(it -> it != null && it.canAsDisjointClass()), 2)) {
+                                    .filterKeep(it -> it != null && testMember.test(it)), atLeastN)) {
                         return true;
                     }
                 }
@@ -116,47 +176,5 @@ final class OntDisjoints {
             return false;
         });
         return OntEnhNodeFactories.createCommon(maker, finder, filter);
-    }
-
-    private static EnhNodeFilter getHasPredicatesFilter(Property... predicates) {
-        if (predicates.length == 0) {
-            throw new IllegalArgumentException();
-        }
-        EnhNodeFilter res = new EnhNodeFilter.HasPredicate(predicates[0]);
-        for (int i = 1; i < predicates.length; i++) {
-            res = res.or(new EnhNodeFilter.HasPredicate(predicates[i]));
-        }
-        return res;
-    }
-
-    private static EnhNodeFilter getHasMembersOfFilter(Class<? extends RDFNode> view,
-                                                       boolean allowEmptyList,
-                                                       Property... predicates) {
-        return (node, eg) -> {
-            ExtendedIterator<Node> res = listRoots(node, eg.asGraph(), predicates);
-            try {
-                while (res.hasNext()) {
-                    if (testList(res.next(), eg, view, allowEmptyList)) return true;
-                }
-            } finally {
-                res.close();
-            }
-            return false;
-        };
-    }
-
-    private static ExtendedIterator<Node> listRoots(Node node, Graph graph, Property... predicates) {
-        return Iterators.flatMap(Iterators.of(predicates),
-                p -> graph.find(node, p.asNode(), Node.ANY).mapWith(Triple::getObject));
-    }
-
-    private static boolean testList(Node node, EnhGraph graph, Class<? extends RDFNode> view, boolean allowEmptyList) {
-        if (!STDObjectFactories.RDF_LIST.canWrap(node, graph)) {
-            return false;
-        }
-        if (view == null) return true;
-        RDFList list = (RDFList) STDObjectFactories.RDF_LIST.wrap(node, graph);
-        return (list.isEmpty() && allowEmptyList) ||
-                Iterators.anyMatch(list.iterator().mapWith(RDFNode::asNode), n -> OntEnhGraph.canAs(view, n, graph));
     }
 }


### PR DESCRIPTION

GitHub issue resolved #2673

Pull request Description:

Now OntDisjoints does not allow less than two members for EL, QL, RL profiles, DL profile unchanged

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
