### PR TITLE
Clear-up same-term/same-value graphs for the Model API

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
@@ -61,7 +61,7 @@ public class GraphFactory {
      * @see #createDefaultGraph
      */
     public static Graph createGraphMem() {
-        return GraphMemFactory.createGraphMem();
+        return GraphMemFactory.createDefaultGraphSameTerm();
     }
 
     /**
@@ -76,14 +76,18 @@ public class GraphFactory {
         return new GraphTxn();
     }
 
-    /** Create a graph - ARQ-wide default type */
+    /**
+     * Create a graph - ARQ-wide default type.
+     *
+     * In Jena5, this is "same-term"
+     */
     public static Graph createDefaultGraph() {
         // Normal usage is SystemARQ.UsePlainGraph = false and use
         // createJenaDefaultGraph
         return SystemARQ.UsePlainGraph ? createPlainGraph() : createJenaDefaultGraph();
     }
 
-    /** Create a graph - always the Jena default graph type */
+    /** Create a graph - the Jena default graph for ARQ and RIOT */
     public static Graph createJenaDefaultGraph() {
         return GraphMemFactory.createDefaultGraph();
     }

--- a/jena-cmds/src/main/java/arq/rdfdiff.java
+++ b/jena-cmds/src/main/java/arq/rdfdiff.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.io.FileInputStream;
 
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.sparql.util.Closure;
 
@@ -93,8 +94,9 @@ public class rdfdiff extends java.lang.Object {
 
         //System.out.println(in1 + " " + in2 + " " + lang1 + " " + lang2 + " " + base1 + " " + base2);
         try {
-            Model m1 = ModelFactory.createDefaultModel();
-            Model m2 = ModelFactory.createDefaultModel();
+            // Term-equality.
+            Model m1 = ModelFactory.createModelForGraph(GraphMemFactory.createDefaultGraphSameTerm());
+            Model m2 = ModelFactory.createModelForGraph(GraphMemFactory.createDefaultGraphSameTerm());
 
             read(m1, in1, lang1, base1);
             read(m2, in2, lang2, base2);

--- a/jena-core/src/main/java/org/apache/jena/graph/GraphMemFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/GraphMemFactory.java
@@ -98,12 +98,13 @@ public class GraphMemFactory
     }
 
     /**
-     * This function will track the preferred general purpose graph.
-     * It will switch from "same value" to "same term"
+     * This function will track the preferred general purpose graph for the Model API.
      */
-    @SuppressWarnings("deprecation")
-    public static Graph createGraphMem()
-    { return new org.apache.jena.mem.GraphMem(); }
+    public static Graph createGraphMem() {
+        @SuppressWarnings("deprecation")
+        Graph g = new org.apache.jena.mem.GraphMem();
+        return g;
+    }
 
     /**
      * Answer a memory-based graph with "same value" semantics
@@ -111,9 +112,11 @@ public class GraphMemFactory
      * Jena5 changed to "same term" semantics.
      * This method will continue to provide a "same value" graph.
      */
-    @SuppressWarnings("deprecation")
-    public static Graph createDefaultGraphSameValue()
-    { return new org.apache.jena.mem.GraphMem(); }
+    public static Graph createDefaultGraphSameValue() {
+        @SuppressWarnings("deprecation")
+        Graph g = new org.apache.jena.mem.GraphMem();
+        return g;
+    }
 
     /**
      * Answer a memory-based graph with "same term" semantics

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
@@ -62,8 +62,9 @@ public class ModelFactory extends ModelFactoryBase
         roots in a description, and <code>assemblerModelFrom(Resource)</code>
         for assembling a model from its single description.
     */
-    public static Model assembleModelFrom( Model singleRoot )
-        { return assembleModelFrom( AssemblerHelp.singleModelRoot( singleRoot ) ); }
+    public static Model assembleModelFrom(Model singleRoot) {
+        return assembleModelFrom(AssemblerHelp.singleModelRoot(singleRoot));
+    }
 
     /**
         Answer a Set of resources present in <code>m</code> that are
@@ -73,8 +74,9 @@ public class ModelFactory extends ModelFactoryBase
         their <code>getModel()</code> - they may be members of an
         extended constructed model.
     */
-    public static Set<Resource> findAssemblerRoots( Model m )
-        { return AssemblerHelp.findAssemblerRoots( m ); }
+    public static Set<Resource> findAssemblerRoots(Model m) {
+        return AssemblerHelp.findAssemblerRoots(m);
+    }
 
     /**
         Answer a Model as described the Assembler specification rooted
@@ -82,14 +84,35 @@ public class ModelFactory extends ModelFactoryBase
         must be of rdf:type <code>ja:Object</code>, where <code>ja</code>
         is the prefix of Jena Assembler objects.
     */
-    public static Model assembleModelFrom( Resource root )
-        { return Assembler.general.openModel( root ); }
+    public static Model assembleModelFrom(Resource root) {
+        return Assembler.general.openModel(root);
+    }
 
     /**
-        Answer a fresh Model with the default specification.
-    */
-    public static Model createDefaultModel()
-        { return new ModelCom( GraphMemFactory.createGraphMem( ) ); }
+     * Answer a fresh Model for use with the Model API.
+     * <p>
+     * This model is "same value" for Model API compatibility.
+     *
+     * @see #createModelSameTerm() for a same-term equality Model.
+     */
+    public static Model createDefaultModel() {
+        return createModelForGraph(GraphMemFactory.createDefaultGraphSameValue());
+    }
+
+    /**
+     * Answer a fresh Model with "same term" semantics.
+     */
+    public static Model createModelSameTerm() {
+        return createModelForGraph(GraphMemFactory.createDefaultGraphSameTerm());
+    }
+
+    /**
+     * Answer a fresh Model with "same value" semantics.
+     */
+    public static Model createModelSameValue() {
+        return createModelForGraph(GraphMemFactory.createDefaultGraphSameValue());
+    }
+
 
     /**
         Answer a model that encapsulates the given graph. Existing prefixes are
@@ -143,7 +166,7 @@ public class ModelFactory extends ModelFactoryBase
      * Build an inferred model by attaching the given RDF model to the given reasoner.
      *
      * @param reasoner the reasoner to use to process the data
-     * @param model the Model containing both instance data and schema assertions to be inferenced over, 
+     * @param model the Model containing both instance data and schema assertions to be inferenced over,
      * any statements added to the InfModel will be added to this underlying data model.
      */
     public static InfModel createInfModel( Reasoner reasoner, Model model ) {
@@ -201,7 +224,6 @@ public class ModelFactory extends ModelFactoryBase
         return createOntologyModel( ProfileRegistry.OWL_LANG );
     }
 
-
     /**
      * <p>
      * Answer a new ontology model which will process in-memory models of
@@ -217,7 +239,6 @@ public class ModelFactory extends ModelFactoryBase
     public static OntModel createOntologyModel( String languageURI ) {
         return createOntologyModel( OntModelSpec.getDefaultSpec( languageURI ), null );
     }
-
 
     /**
      * <p>
@@ -242,7 +263,6 @@ public class ModelFactory extends ModelFactoryBase
         return createOntologyModel( _spec, base );
     }
 
-
     /**
      * <p>
      * Answer a new ontology model, constructed according to the given ontology model specification,
@@ -263,9 +283,9 @@ public class ModelFactory extends ModelFactoryBase
      * Answer a new ontology model constructed according to the specification, which includes
      * a ModelMaker which will create the necessary base model.
     */
-    public static OntModel createOntologyModel( OntModelSpec spec )
-        { return new OntModelImpl( spec ); }
-
+    public static OntModel createOntologyModel(OntModelSpec spec) {
+        return new OntModelImpl(spec);
+    }
 
     /**
          Answer a new model that is the dynamic union of two other models. By
@@ -278,7 +298,7 @@ public class ModelFactory extends ModelFactoryBase
      <p>
         <code>createUnion</code> only creates two-element unions.
     */
-    public static Model createUnion(Model m1, Model m2)
-        { return createModelForGraph( new Union( m1.getGraph(), m2.getGraph() ) );   }
-
+    public static Model createUnion(Model m1, Model m2) {
+        return createModelForGraph(new Union(m1.getGraph(), m2.getGraph()));
     }
+}

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/GraphLoadUtils.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/GraphLoadUtils.java
@@ -35,7 +35,7 @@ public class GraphLoadUtils
     // ---- Model level
 
     public static Model readModel(String uri, int limit) {
-        Graph g = GraphMemFactory.createGraphMem();
+        Graph g = GraphMemFactory.createDefaultGraphSameTerm();
         readUtil(g, uri, limit);
         return ModelFactory.createModelForGraph(g);
     }
@@ -48,7 +48,7 @@ public class GraphLoadUtils
     // ---- Graph level
 
     public static Graph readGraph(String uri, int limit) {
-        Graph g = GraphMemFactory.createGraphMem();
+        Graph g = GraphMemFactory.createDefaultGraphSameTerm();
         readUtil(g, uri, limit);
         return g;
     }


### PR DESCRIPTION

Pull request Description:

Better handling of the same term/same value choices of graph. This not a change, it is cleaning up around the Jena5 changes to be clearer.

The Model API, via ModelFactory.createDefault Model, is same-value which gives the most legacy compatibility.

"same-term" is the default at the graph level including use in Fuseki .

`rdfdiff` is same-term, as is `Graph.isIsomorphic`.

----

 - [ ] Tests are included.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
