### PR TITLE
Clean warnings

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/cdt/parser/JavaCharStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/cdt/parser/JavaCharStream.java
@@ -31,7 +31,7 @@ public
 class JavaCharStream
 {
   /** Whether parser is static. */
-  
+
 @SuppressWarnings("all")
 public static final boolean staticFlag = false;
 
@@ -83,7 +83,7 @@ public static final boolean staticFlag = false;
   }
 
 /* Position in buffer. */
-  
+
 @SuppressWarnings("all")
 public int bufpos = -1;
   int bufsize;
@@ -108,10 +108,10 @@ public int bufpos = -1;
   protected int tabSize = 1;
   protected boolean trackLineColumn = true;
 
-  
+
 @SuppressWarnings("all")
 public void setTabSize(int i) { tabSize = i; }
-  
+
 @SuppressWarnings("all")
 public int getTabSize() { return tabSize; }
 
@@ -203,7 +203,7 @@ public int getTabSize() { return tabSize; }
   }
 
 /* @return starting character for token. */
-  
+
 @SuppressWarnings("all")
 public char BeginToken() throws java.io.IOException
   {
@@ -285,7 +285,7 @@ public char BeginToken() throws java.io.IOException
   }
 
 /* Read a character. */
-  
+
 @SuppressWarnings("all")
 public char readChar() throws java.io.IOException
   {
@@ -385,7 +385,7 @@ public char readChar() throws java.io.IOException
    * @see #getEndColumn
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getColumn() {
     return bufcolumn[bufpos];
@@ -397,7 +397,7 @@ public int getColumn() {
    * @return the line number.
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getLine() {
     return bufline[bufpos];
@@ -406,7 +406,7 @@ public int getLine() {
 /** Get end column.
  * @return the end column or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndColumn() {
     return bufcolumn[bufpos];
@@ -415,7 +415,7 @@ public int getEndColumn() {
 /** Get end line.
  * @return the end line number or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndLine() {
     return bufline[bufpos];
@@ -423,21 +423,21 @@ public int getEndLine() {
 
 /** Get the beginning column.
  * @return column of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginColumn() {
     return bufcolumn[tokenBegin];
   }
 
 /** @return line number of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginLine() {
     return bufline[tokenBegin];
   }
 
 /** Retreat. */
-  
+
 @SuppressWarnings("all")
 public void backup(int amount) {
 
@@ -452,7 +452,7 @@ public void backup(int amount) {
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -473,7 +473,7 @@ public JavaCharStream(java.io.Reader dstream,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -483,16 +483,15 @@ public JavaCharStream(java.io.Reader dstream,
 
 /** Constructor.
  * @param dstream the underlying data source.
- * @param startline line number of the first character of the stream, mostly for error messages.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream)
   {
     this(dstream, 1, 1, 4096);
   }
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -515,7 +514,7 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -524,14 +523,14 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream)
   {
     ReInit(dstream, 1, 1, 4096);
   }
 /** Constructor. */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -545,7 +544,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -558,9 +557,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
                         int startcolumn) throws java.io.UnsupportedEncodingException
@@ -573,7 +572,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
                         int startcolumn)
@@ -584,9 +583,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
 /** Constructor.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -596,7 +595,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.
   /** Constructor.
    * @param dstream the underlying data source.
    */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream)
   {
@@ -610,7 +609,7 @@ public JavaCharStream(java.io.InputStream dstream)
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -624,7 +623,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -636,9 +635,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
                      int startcolumn) throws java.io.UnsupportedEncodingException
@@ -650,7 +649,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
                      int startcolumn)
@@ -660,9 +659,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
 /** Reinitialise.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -672,7 +671,7 @@ public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.
 /** Reinitialise.
  * @param dstream the underlying data source.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream)
   {
@@ -681,7 +680,7 @@ public void ReInit(java.io.InputStream dstream)
 
   /** Get the token timage.
    * @return token image as String */
-  
+
 @SuppressWarnings("all")
 public String GetImage()
   {
@@ -695,7 +694,7 @@ public String GetImage()
   /** Get the suffix as an array of characters.
    * @param len the length of the array to return.
    * @return suffix */
-  
+
 @SuppressWarnings("all")
 public char[] GetSuffix(int len)
   {
@@ -714,7 +713,7 @@ public char[] GetSuffix(int len)
   }
 
   /** Set buffers back to null when finished. */
-  
+
 @SuppressWarnings("all")
 public void Done()
   {
@@ -730,7 +729,7 @@ public void Done()
    * @param newLine the new line number.
    * @param newCol the new column number.
    */
-  
+
 @SuppressWarnings("all")
 public void adjustBeginLineColumn(int newLine, int newCol)
   {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/JavaCharStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/JavaCharStream.java
@@ -13,7 +13,7 @@ public
 class JavaCharStream
 {
   /** Whether parser is static. */
-  
+
 @SuppressWarnings("all")
 public static final boolean staticFlag = false;
 
@@ -65,7 +65,7 @@ public static final boolean staticFlag = false;
   }
 
 /* Position in buffer. */
-  
+
 @SuppressWarnings("all")
 public int bufpos = -1;
   int bufsize;
@@ -90,10 +90,10 @@ public int bufpos = -1;
   protected int tabSize = 1;
   protected boolean trackLineColumn = true;
 
-  
+
 @SuppressWarnings("all")
 public void setTabSize(int i) { tabSize = i; }
-  
+
 @SuppressWarnings("all")
 public int getTabSize() { return tabSize; }
 
@@ -185,7 +185,7 @@ public int getTabSize() { return tabSize; }
   }
 
 /* @return starting character for token. */
-  
+
 @SuppressWarnings("all")
 public char BeginToken() throws java.io.IOException
   {
@@ -267,7 +267,7 @@ public char BeginToken() throws java.io.IOException
   }
 
 /* Read a character. */
-  
+
 @SuppressWarnings("all")
 public char readChar() throws java.io.IOException
   {
@@ -367,7 +367,7 @@ public char readChar() throws java.io.IOException
    * @see #getEndColumn
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getColumn() {
     return bufcolumn[bufpos];
@@ -379,7 +379,7 @@ public int getColumn() {
    * @return the line number.
    */
   @Deprecated
-  
+
 @SuppressWarnings("all")
 public int getLine() {
     return bufline[bufpos];
@@ -388,7 +388,7 @@ public int getLine() {
 /** Get end column.
  * @return the end column or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndColumn() {
     return bufcolumn[bufpos];
@@ -397,7 +397,7 @@ public int getEndColumn() {
 /** Get end line.
  * @return the end line number or -1
  */
-  
+
 @SuppressWarnings("all")
 public int getEndLine() {
     return bufline[bufpos];
@@ -405,21 +405,21 @@ public int getEndLine() {
 
 /** Get the beginning column.
  * @return column of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginColumn() {
     return bufcolumn[tokenBegin];
   }
 
 /** @return line number of token start */
-  
+
 @SuppressWarnings("all")
 public int getBeginLine() {
     return bufline[tokenBegin];
   }
 
 /** Retreat. */
-  
+
 @SuppressWarnings("all")
 public void backup(int amount) {
 
@@ -434,7 +434,7 @@ public void backup(int amount) {
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -455,7 +455,7 @@ public JavaCharStream(java.io.Reader dstream,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -465,16 +465,15 @@ public JavaCharStream(java.io.Reader dstream,
 
 /** Constructor.
  * @param dstream the underlying data source.
- * @param startline line number of the first character of the stream, mostly for error messages.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream)
   {
     this(dstream, 1, 1, 4096);
   }
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -497,7 +496,7 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -506,14 +505,14 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream)
   {
     ReInit(dstream, 1, 1, 4096);
   }
 /** Constructor. */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -527,7 +526,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -540,9 +539,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
                         int startcolumn) throws java.io.UnsupportedEncodingException
@@ -555,7 +554,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
                         int startcolumn)
@@ -566,9 +565,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
 /** Constructor.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -578,7 +577,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.
   /** Constructor.
    * @param dstream the underlying data source.
    */
-  
+
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream)
   {
@@ -592,7 +591,7 @@ public JavaCharStream(java.io.InputStream dstream)
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -606,7 +605,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -618,9 +617,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
                      int startcolumn) throws java.io.UnsupportedEncodingException
@@ -632,7 +631,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
                      int startcolumn)
@@ -642,9 +641,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
 /** Reinitialise.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -654,7 +653,7 @@ public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.
 /** Reinitialise.
  * @param dstream the underlying data source.
  */
-  
+
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream)
   {
@@ -663,7 +662,7 @@ public void ReInit(java.io.InputStream dstream)
 
   /** Get the token timage.
    * @return token image as String */
-  
+
 @SuppressWarnings("all")
 public String GetImage()
   {
@@ -677,7 +676,7 @@ public String GetImage()
   /** Get the suffix as an array of characters.
    * @param len the length of the array to return.
    * @return suffix */
-  
+
 @SuppressWarnings("all")
 public char[] GetSuffix(int len)
   {
@@ -696,7 +695,7 @@ public char[] GetSuffix(int len)
   }
 
   /** Set buffers back to null when finished. */
-  
+
 @SuppressWarnings("all")
 public void Done()
   {
@@ -712,7 +711,7 @@ public void Done()
    * @param newLine the new line number.
    * @param newCol the new column number.
    */
-  
+
 @SuppressWarnings("all")
 public void adjustBeginLineColumn(int newLine, int newCol)
   {

--- a/jena-cmds/src/main/java/jena/schemagen.java
+++ b/jena-cmds/src/main/java/jena/schemagen.java
@@ -1038,7 +1038,7 @@ public class schemagen {
         String template = m_options.hasIndividualTemplateOption() ?  m_options.getIndividualTemplateOption() : DEFAULT_INDIVIDUAL_TEMPLATE;
 
         for (Iterator<? extends RDFNode> i = selectIndividuals(); i.hasNext(); ) {
-            Individual ind = ((Resource) i.next()).as( Individual.class );
+            Individual ind = i.next().as( Individual.class );
 
             // do we have a local class resource
             Resource cls = ind.getOntClass();

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/AllDifferentImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/AllDifferentImpl.java
@@ -148,7 +148,7 @@ public class AllDifferentImpl
      */
     @Override
     public ExtendedIterator<? extends OntResource> listDistinctMembers() {
-        return getDistinctMembers().mapWith( o -> ((Resource) o).as( OntResource.class ));
+        return getDistinctMembers().mapWith( o -> o.as( OntResource.class ));
     }
 
     /**

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OntResourceImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OntResourceImpl.java
@@ -1533,7 +1533,7 @@ public class OntResourceImpl
         }
         else {
             // create a new list to hold the only value we know so far
-            addProperty( p, ((OntModel) getModel()).createList( new RDFNode[] {value} ) );
+            addProperty( p, getModel().createList( new RDFNode[] {value} ) );
         }
     }
 

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFListImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFListImpl.java
@@ -58,10 +58,10 @@ public class RDFListImpl
      */
     @SuppressWarnings("hiding")
     public static Implementation factory = new Implementation() {
-        @Override public EnhNode wrap( Node n, EnhGraph eg ) { 
+        @Override public EnhNode wrap( Node n, EnhGraph eg ) {
             if (canWrap( n, eg )) {
                 RDFListImpl impl = new RDFListImpl( n, eg );
-                
+
                 // pass on the vocabulary terms, if available
                 if (eg instanceof OntModel) {
                     Profile prof = ((OntModel) eg).getProfile();
@@ -70,32 +70,32 @@ public class RDFListImpl
                     impl.m_listNil = prof.NIL();
                     impl.m_listType = prof.LIST();
                 }
-                
+
                 return impl;
             }
             else {
                 throw new JenaException( "Cannot convert node " + n + " to RDFList");
-            } 
+            }
         }
-            
+
         @Override public boolean canWrap( Node node, EnhGraph eg ) {
             Graph g = eg.asGraph();
-            
+
             // if we are using a language profile, get the first, rest and next resources from there
             Resource first = RDF.first;
             Resource rest = RDF.rest;
             Resource nil = RDF.nil;
-            
+
             if (eg instanceof OntModel) {
                 Profile prof = ((OntModel) eg).getProfile();
                 first = prof.FIRST();
                 rest = prof.REST();
                 nil = prof.NIL();
             }
-            
+
             // node will support being an RDFList facet if it has rdf:type rdf:List, is nil, or is in the domain of a list property
-            return  
-                node.equals( nil.asNode() ) || 
+            return
+                node.equals( nil.asNode() ) ||
                 g.contains( node, first.asNode(), Node.ANY ) ||
                 g.contains( node, rest.asNode(), Node.ANY ) ||
                 g.contains( node, RDF.type.asNode(), RDF.List.asNode() );
@@ -104,33 +104,32 @@ public class RDFListImpl
 
     /** Flag to indicate whether we are checking for valid lists during list operations. Default false. */
     protected static boolean s_checkValid = false;
-    
+
     private static final Logger log = LoggerFactory.getLogger( RDFListImpl.class );
-    
+
 
     // Instance variables
     //////////////////////////////////
 
     /** Error message if validity check fails */
     protected String m_errorMsg = null;
-    
+
     /** Pointer to the node that is the tail of the list */
     protected RDFList m_tail = null;
-    
+
     /** The URI for the 'first' property in this list */
     protected Property m_listFirst = RDF.first;
-    
+
     /** The URI for the 'rest' property in this list */
     protected Property m_listRest = RDF.rest;
-    
+
     /** The URI for the 'nil' Resource in this list */
     protected Resource m_listNil = RDF.nil;
-    
+
     /** The URI for the rdf:type of this list */
     protected Resource m_listType = RDF.List;
-    
-    
-    
+
+
     // Constructors
     //////////////////////////////////
 
@@ -139,15 +138,15 @@ public class RDFListImpl
      * Construct an implementation of RDFList in the given graph, where the
      * given node is the head of the list.
      * </p>
-     * 
+     *
      * @param n The node that is the head of the list, currently
      * @param g The enh graph that contains n
      */
     public RDFListImpl( Node n, EnhGraph g ) {
         super( n, g );
     }
-    
-    
+
+
     // External signature methods
     //////////////////////////////////
 
@@ -157,13 +156,13 @@ public class RDFListImpl
     public Property listFirst()         { return m_listFirst; }
     public Property listRest()          { return m_listRest; }
     public Class<? extends RDFList> listAbstractionClass() { return RDFList.class; }
-    
-    
+
+
     /**
      * <p>
      * Answer the number of elements in the list.
      * </p>
-     * 
+     *
      * @return The length of the list as an integer
      */
     @Override
@@ -171,21 +170,21 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         int size = 0;
-        
+
         for (Iterator<RDFNode> i = iterator(); i.hasNext(); i.next()) {
             size++;
-        } 
+        }
         return size;
     }
-    
-    
+
+
     /**
      * <p>
      * Answer the value that is at the head of the list.
      * </p>
-     * 
+     *
      * @return The value that is associated with the head of the list.
      * @exception EmptyListException if this list is the empty list
      */
@@ -194,19 +193,19 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         checkNotNil( "Tried to get the head of an empty list" );
-        
+
         return getRequiredProperty( listFirst() ).getObject();
     }
-    
-    
+
+
     /**
      * <p>
      * Update the head of the list to have the given value, and return the
      * previous value.
      * </p>
-     * 
+     *
      * @param value The value that will become the value of the list head
      * @exception EmptyListException if this list is the empty list
      */
@@ -215,26 +214,26 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         checkNotNil( "Tried to set the head of an empty list" );
-        
+
         // first remove the existing head
         Statement current = getRequiredProperty( listFirst() );
         RDFNode n = current.getObject();
         current.remove();
-        
+
         // now add the new head value to the graph
         addProperty( listFirst(), value );
-        
+
         return n;
     }
-    
-    
+
+
     /**
      * <p>
      * Answer the list that is the tail of this list.
      * </p>
-     * 
+     *
      * @return The tail of the list, as a list
      * @exception EmptyListException if this list is the empty list
      */
@@ -243,20 +242,20 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         checkNotNil( "Tried to get the tail of an empty list" );
-        
+
         Resource tail = getRequiredProperty( listRest() ).getResource();
         return tail.as( listAbstractionClass() );
     }
-    
-    
+
+
     /**
      * <p>
      * Update the list cell at the front of the list to have the given list as
      * tail. The old tail is returned, and remains in the model.
      * </p>
-     * 
+     *
      * @param tail The new tail for this list.
      * @return The old tail.
      */
@@ -265,16 +264,16 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         checkNotNil( "Tried to set the tail of an empty list" );
 
         return (setTailAux( this, tail, listRest() )).as( listAbstractionClass() );
     }
-    
-    
+
+
     /**
      * Answer true if this list is the empty list.
-     * 
+     *
      * @return True if this is the empty (nil) list, otherwise false.
      */
     @Override
@@ -282,17 +281,17 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         return equals( listNil() );
     }
-    
-    
+
+
     /**
      * <p>
      * Return a reference to a new list cell whose head is <code>value</code>
      * and whose tail is this list.
      * </p>
-     * 
+     *
      * @param value A new value to add to the head of the list
      * @return The new list, whose head is <code>value</code>
      */
@@ -301,27 +300,27 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         // create a new, anonymous typed resource to be the list cell
         // map to a list facet
         return (newListCell( value, this )).as( listAbstractionClass() );
     }
-    
-    
+
+
     /**
      * <p>
-     * Add the given value to the end of the list. This is a side-effecting 
+     * Add the given value to the end of the list. This is a side-effecting
      * operation on the underlying model that is only defined if this is not the
-     * empty list.  If this list is the empty (nil) list, we cannot perform a 
+     * empty list.  If this list is the empty (nil) list, we cannot perform a
      * side-effecting update without changing the URI of this node (from <code>rdf:nil</code>)
      * to a blank-node for the new list cell) without violating a Jena invariant.
      * Therefore, this update operation will throw an exception if an attempt is
      * made to add to the nil list.  Safe ways to add to an empty list include
      * {@link #with} and {@link #cons}.
      * </p>
-     * 
+     *
      * @param value A value to add to the end of the list
-     * @exception EmptyListUpdateException if an attempt is made to 
+     * @exception EmptyListUpdateException if an attempt is made to
      * <code>add</code> to the empty list.
      */
     @Override
@@ -329,20 +328,20 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         // if this is the empty list, we have to barf
         if (isEmpty()) {
             throw new EmptyListUpdateException( "Attempt to add() to the empty list (rdf:nil)" );
         }
-        
+
         // get the tail of the list (which may be cached)
         RDFList tail = findElement( true, 0 );
-        
+
         // now do the concatenate
         setTailAux( tail, newListCell( value, listNil() ), listRest() );
     }
-    
-    
+
+
     /**
      * <p>
      * Answer the list that is this list with the given value added to the end
@@ -353,37 +352,37 @@ public class RDFListImpl
      * not assume that this is an in-place update, but should ensure that the resulting
      * list is asserted back into the graph into the appropriate relationships.</strong>
      * </p>
-     * 
+     *
      * @param value A value to add to the end of the list
-     * @return The list that results from adding a value to the end of this list 
+     * @return The list that results from adding a value to the end of this list
      */
     @Override
     public RDFList with( RDFNode value ) {
         if (s_checkValid) {
             checkValid();
         }
-        
+
         // if this is the empty list, we create a new node containing value - i.e. cons
         if (isEmpty()) {
             return cons( value );
         }
-        
+
         // get the tail of the list (which may be cached)
         RDFList tail = findElement( true, 0 );
-        
+
         // now do the concatenate
         setTailAux( tail, newListCell( value, listNil() ), listRest() );
         return this;
     }
-    
-    
+
+
     /**
      * <p>
-     * Answer the node that is the i'th element of the list, assuming that the 
+     * Answer the node that is the i'th element of the list, assuming that the
      * head is item zero.  If the list is too short to have an i'th element,
      * throws a {@link ListIndexException}.
      * </p>
-     * 
+     *
      * @param i The index into the list, from 0
      * @return The list value at index i, or null
      * @exception ListIndexException if the list has fewer than (i + 1)
@@ -394,19 +393,19 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         checkNotNil( "Tried to get an element from the empty list" );
         return findElement( false, i ).getHead();
     }
-    
-    
+
+
     /**
      * <p>
      * Replace the value at the i'th position in the list with the given value.
      * If the list is too short to have an i'th element, throws a {@link
      * ListIndexException}.
      * </p>
-     * 
+     *
      * @param i The index into the list, from 0
      * @param value The new value to associate with the i'th list element
      * @return The value that was previously at position i in the list
@@ -418,18 +417,18 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         checkNotNil( "Tried to replace a value in the empty list" );
         return findElement( false, i ).setHead( value );
     }
-    
-    
+
+
     /**
      * <p>
      * Answer true if the given node appears as the value of a value of any
      * of the cells of this list.
      * </p>
-     * 
+     *
      * @param value A value to test for
      * @return True if the list contains value.
      */
@@ -437,14 +436,14 @@ public class RDFListImpl
     public boolean contains( RDFNode value ) {
         return indexOf( value, 0 ) >= 0;
     }
-    
-    
+
+
     /**
      * <p>
      * Answer the index of the first occurrence of the given value in the list,
      * or -1 if the value is not in the list.
      * </p>
-     * 
+     *
      * @param value The value to search for
      * @return The index of the first occurrence of value in the list, or
      * <code>-1</code> if not found.
@@ -453,15 +452,15 @@ public class RDFListImpl
     public int indexOf( RDFNode value ) {
         return indexOf( value, 0 );
     }
-    
-    
+
+
     /**
      * <p>
      * Answer the index of the first occurrence of the given value in the list
      * after index <code>start</code>, or -1 if the value is not in the list
      * after the given start point.
      * </p>
-     * 
+     *
      * @param value The value to search for
      * @param start The index into the list to start searching from
      * @return The index (from zero, the front of the list) of the first
@@ -475,17 +474,17 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         // first get to where we start
         Resource l = findElement( false, start );
         int index = start;
-        
+
         Property head = listFirst();
         Property tail = listRest();
         Resource nil = listNil();
-        
+
         boolean found = l.hasProperty( head, value );
-        
+
         // search for the element whose value is, er, value
         while (!found  &&  !l.equals( nil )) {
             l = l.getRequiredProperty( tail ).getResource();
@@ -495,18 +494,18 @@ public class RDFListImpl
 
         return found ? index : -1;
     }
-    
-    
+
+
     /**
      * <p>
      * Answer a new list that is formed by adding each element of this list to
-     * the head of the the list formed from the 
+     * the head of the the list formed from the
      * given <code>nodes</code>. This is a non side-effecting
      * operation on either this list or the given list, but generates a copy
      * of this list.  For a more storage efficient alternative, see {@link
      * #concatenate concatenate}.
      * </p>
-     * 
+     *
      * @param nodes An iterator whose range is RDFNode
      * @return A new RDFList that contains all of this elements of this list,
      * followed by all of the elements of the given iterator.
@@ -515,8 +514,8 @@ public class RDFListImpl
     public RDFList append( Iterator<? extends RDFNode> nodes ) {
         return append( copy( nodes) );
     }
-            
-            
+
+
     /**
      * <p>
      * Answer a new list that is formed by adding each element of this list to
@@ -525,7 +524,7 @@ public class RDFListImpl
      * of this list.  For a more storage efficient alternative, see {@link
      * #concatenate concatenate}.
      * </p>
-     * 
+     *
      * @param list The argument list
      * @return A new RDFList that contains all of this elements of this list,
      * followed by all of the elements of the given list.
@@ -535,7 +534,7 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         if (isEmpty()) {
             // special case
             return list;
@@ -548,8 +547,8 @@ public class RDFListImpl
             return copy;
         }
     }
-    
-    
+
+
     /**
      * <p>
      * Change the tail of this list to point to the given list, so that this
@@ -562,7 +561,7 @@ public class RDFListImpl
      * proceed with the concatenate as usual.  An alternative solution is to use
      * {@link #append} and replace the original list with the return value.
      * </p>
-     * 
+     *
      * @param list The argument list to concatenate to this list
      * @exception EmptyListUpdateException if this list is the nil list
      */
@@ -571,7 +570,7 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         if (isEmpty()) {
             // concatenating list onto the empty list is an error
             throw new EmptyListUpdateException( "Tried to concatenate onto the empty list" );
@@ -581,13 +580,13 @@ public class RDFListImpl
             findElement( true, 0 ).setTail( list );
         }
     }
-    
-    
+
+
     /**
      * <p>
      * Add the nodes returned by the given iterator to the end of this list.
      * </p>
-     * 
+     *
      * @param nodes An iterator whose range is RDFNode
      * @exception EmptyListUpdateException if this list is the nil list
      * @see #concatenate(RDFList) for details on avoiding the empty list update exception.
@@ -597,14 +596,14 @@ public class RDFListImpl
         // make a list of the nodes and add to the end of this
         concatenate( copy( nodes ) );
     }
-            
-        
+
+
     /**
      * <p>
      * Answer a list that contains all of the elements of this list in the same
      * order, but is a duplicate copy in the underlying model.
      * </p>
-     * 
+     *
      * @return A copy of the current list
      */
     @Override
@@ -612,16 +611,16 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         return copy( iterator() );
     }
-    
-    
+
+
     /**
      * <p>
      * Apply a function to each value in the list in turn.
      * </p>
-     * 
+     *
      * @param fn The function to apply to each list node.
      */
     @Override
@@ -629,20 +628,20 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         for (Iterator<RDFNode> i = iterator();  i.hasNext(); ) {
             fn.apply( i.next() );
         }
     }
-    
-    
+
+
     /**
      * <p>
      * Apply a function to each value in the list in turn, accumulating the
      * results in an accumulator. The final value of the accumulator is returned
      * as the value of <code>reduce()</code>.
      * </p>
-     * 
+     *
      * @param fn The reduction function to apply
      * @param initial The initial value for the accumulator
      * @return The final value of the accumulator.
@@ -652,17 +651,17 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         Object acc = initial;
-        
+
         for (Iterator<RDFNode> i = iterator();  i.hasNext();  ) {
             acc = fn.reduce( i.next(), acc );
         }
-        
+
         return acc;
     }
-    
-    
+
+
     /**
      * <p>Answer an iterator of the elements of this list, to each of which
      * the given map function has been applied.</p>
@@ -673,7 +672,7 @@ public class RDFListImpl
     public <T> ExtendedIterator<T> mapWith( Function<RDFNode, T> fn ) {
         return iterator().mapWith( fn );
     }
-        
+
     /**
      * <p>
      * Remove the value from the head of the list.  The tail of the list remains
@@ -682,7 +681,7 @@ public class RDFListImpl
      * <code>removeHead</code> operation, such lists will be in a non-valid
      * state.
      * </p>
-     * 
+     *
      * @return The remainder of the list after the head is removed (i&#046;e&#046; the
      * pre-removal list tail)
      */
@@ -691,23 +690,23 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         checkNotNil( "Attempted to delete the head of a nil list" );
-        
+
         RDFList tail = getTail();
         removeProperties();
-        
+
         return tail;
     }
-    
-    
+
+
     /**
      * <p>Remove the given value from this list. If <code>val</code> does not occur in
      * the list, no action is taken.  Since removing the head of the list will invalidate
      * the list head cell, in general the list must return the list that results from this
      * operation. However, in many cases the return value will be the same as the object
      * that this method is invoked on</p>
-     * 
+     *
      * @param val The value to be removed from the list
      * @return The resulting list, which will be the same as the current list in most
      * cases, except when <code>val</code> occurs at the head of the list.
@@ -717,11 +716,11 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         RDFList prev = null;
         RDFList cell = this;
         boolean searching = true;
-        
+
         while (searching && !cell.isEmpty()) {
             if (cell.getHead().equals( val )) {
                 // found the value to be removed
@@ -729,9 +728,9 @@ public class RDFListImpl
                 if (prev != null) {
                     prev.setTail( tail );
                 }
-                
+
                 cell.removeProperties();
-                
+
                 // return this unless we have removed the head element
                 return (prev == null) ? tail : this;
             }
@@ -741,11 +740,11 @@ public class RDFListImpl
                 cell = cell.getTail();
             }
         }
-        
+
         // not found
         return this;
     }
-    
+
     /**
      * <p>Remove all of the components of this list from the model. Once this operation
      * has completed, the {@link RDFList} resource on which it was called will no
@@ -753,10 +752,10 @@ public class RDFListImpl
      * (for example, {@link #size} will fail.  Due to restrictions on the encoding
      * of lists in RDF, it is not possible to perform an operation which empties a list
      * and then adds further values to that list. Client code wishing to perform
-     * such an operation should do so in two steps: first remove the old list, then 
+     * such an operation should do so in two steps: first remove the old list, then
      * create a new list with the new contents. It is important that RDF statements
-     * that reference the old list (in the object position) be updated to point 
-     * to the newly created list.  
+     * that reference the old list (in the object position) be updated to point
+     * to the newly created list.
      * Note that this
      * is operation is only removing the list cells themselves, not the resources
      * referenced by the list - unless being the object of an <code>rdf:first</code>
@@ -769,8 +768,8 @@ public class RDFListImpl
             statement.remove();
         }
     }
-    
-    
+
+
     /**
      * <p>Answer a set of all of the RDF statements whose subject is one of the cells
      * of this list.</p>
@@ -779,21 +778,21 @@ public class RDFListImpl
     public Set<Statement> collectStatements() {
         Set<Statement> stmts = new HashSet<>();
         RDFList l = this;
-        
+
         do {
             // collect all statements of this list cell
             for (Iterator<Statement> i = l.listProperties(); i.hasNext(); ) {
                 stmts.add( i.next() );
             }
-            
+
             // move on to next cell
             l = l.getTail();
         } while (!l.isEmpty());
-        
+
         return stmts;
     }
-    
-    
+
+
     /**
      * <p>
      * Answer an iterator over the elements of the list. Note that this iterator
@@ -802,34 +801,34 @@ public class RDFListImpl
      * To get an iterator that is not affected by model changes, use {@link
      * #asJavaList}.
      * </p>
-     * 
+     *
      * @return A closable iterator over the elements of the list.
      */
     @Override
     public ExtendedIterator<RDFNode> iterator() {
         return new RDFListIterator( this );
     }
-    
-    
+
+
     /**
      * <p>
      * Answer the contents of this RDF list as a Java list of RDFNode values.
      * </p>
-     * 
+     *
      * @return The contents of this list as a Java List.
      */
     @Override
     public List<RDFNode> asJavaList() {
         List<RDFNode> l = new ArrayList<>();
-        
+
         for (Iterator<RDFNode> i = iterator();  i.hasNext(); ) {
             l.add( i.next() );
         }
-        
+
         return l;
     }
-    
-    
+
+
     /**
      * <p>
      * Answer true if this list has the same elements in the same order as the
@@ -838,7 +837,7 @@ public class RDFListImpl
      * for many purposes, this test provides a broader equality definition, but
      * is correspondingly more expensive to test.
      * </p>
-     * 
+     *
      * @param list The list to test against
      * @return True if the given list and this list are the same length, and
      * contain equal elements in the same order.
@@ -848,19 +847,19 @@ public class RDFListImpl
         if (s_checkValid) {
             checkValid();
         }
-        
+
         Resource r0 = this;
         Resource r1 = list;
-        
+
         Property head = listFirst();
         Property tail = listRest();
         Resource nil = listNil();
-        
+
         // iterate through to the end of the list
         while (!(r0.equals( nil ) || r1.equals( nil ))) {
             RDFNode n0 = r0.getRequiredProperty( head ).getObject();
             RDFNode n1 = r1.getRequiredProperty( head ).getObject();
-            
+
             if (n0 == null || !n0.equals( n1 )) {
                 // not equal at this position
                 return false;
@@ -871,26 +870,26 @@ public class RDFListImpl
                 r1 = r1.getRequiredProperty( tail ).getResource();
             }
         }
-        
+
         // lists are equal if they terminate together
         return r0.equals( nil ) && r1.equals( nil );
     }
-    
-    
+
+
     /**
      * <p>
      * Answer true lists are operating in strict mode, in which the
      * well- formedness of the list is checked at every operation.
      * </p>
-     * 
+     *
      * @return True lists are being strictly checked.
      */
     @Override
     public boolean getStrict() {
         return s_checkValid;
     }
-    
-    
+
+
     /**
      * <p>
      * Set a flag to indicate whether to strictly check the well-formedness of
@@ -898,35 +897,35 @@ public class RDFListImpl
      * manipulated is actually a static: it applies to all lists. However, RDFList
      * is a Java interface, and Java does not permit static methods in interfaces.
      * </p>
-     * 
+     *
      * @param strict The <b>static</b> flag for whether lists will be checked strictly.
      */
     @Override
     public void setStrict( boolean strict ) {
         s_checkValid = strict;
     }
-    
-    
+
+
     /**
      * <p>
      * Answer true if the list is well-formed, by checking that each node is
      * correctly typed, and has a head and tail pointer from the correct
      * vocabulary.
      * </p>
-     * 
+     *
      * @return True if the list is well-formed.
      */
     @Override
     public boolean isValid() {
         m_errorMsg = null;
-        
+
         try {
             checkValid();
         }
         catch (InvalidListException e) {
             m_errorMsg = e.getMessage();
         }
-        
+
         return (m_errorMsg == null);
     }
 
@@ -936,20 +935,20 @@ public class RDFListImpl
      * Answer the error message returned by the last failed validity check,
      * if any.
      * </p>
-     * 
+     *
      * @return The most recent error message, or null.
      */
     @Override
     public String getValidityErrorMessage() {
         return m_errorMsg;
     }
-    
-    
+
+
     /**
      * <p>
      * Construct a new list cell with the given value and tail.
      * </p>
-     * 
+     *
      * @param value The value at the head of the new list cell
      * @param tail The tail of the list cell
      * @return A new list cell as a resource
@@ -957,15 +956,15 @@ public class RDFListImpl
     public Resource newListCell( RDFNode value, Resource tail ) {
         // Note: following the RDF WG decision, we no longer assert rdf:type rdf:List for list cells
         Resource cell = getModel().createResource();
-        
+
         // set the head and tail
         cell.addProperty( listFirst(), value );
         cell.addProperty( listRest(), tail );
-        
-        return cell;        
+
+        return cell;
     }
-    
-    
+
+
     // Internal implementation methods
     //////////////////////////////////
 
@@ -978,7 +977,7 @@ public class RDFListImpl
      * and rdf:rest, so no longer needs to be asserted directly.  The test
      * for rdf:type has therefore been removed.
      * </p>
-     * 
+     *
      * @returns True if this list cell passes basic validity checks
      */
     protected void checkValid() {
@@ -986,19 +985,19 @@ public class RDFListImpl
             // note that the rdf:type of list cells is now implied by the RDF M&S
             // so we don't check explicitly
             // checkValidProperty( RDF.type, listType() );
-            
+
             checkValidProperty( listFirst(), null );
             checkValidProperty( listRest(), null );
         }
     }
-    
+
     private void checkValidProperty( Property p, RDFNode expected ) {
         int count = 0;
-        
-        for (StmtIterator j = getModel().listStatements( this, p, expected );  j.hasNext();  j.next()) { 
+
+        for (StmtIterator j = getModel().listStatements( this, p, expected );  j.hasNext();  j.next()) {
             count++;
         }
-        
+
         // exactly one value is expected
         if (count == 0) {
             if (log.isDebugEnabled()) {
@@ -1011,7 +1010,7 @@ public class RDFListImpl
                 }
             }
             throw new InvalidListException( "List node " + toString() + " is not valid: it should have property " +
-                                            p.toString() + 
+                                            p.toString() +
                                             (expected == null ? "" : ( " with value " + expected )) );
         }
         else if (count > 1) {
@@ -1019,15 +1018,15 @@ public class RDFListImpl
                                             p.toString() );
         }
     }
-    
-    
-    
+
+
+
     /**
      * <p>
      * Check that the current list cell is not the nil list, and throw an empty
      * list exception if it is.
      * </p>
-     * 
+     *
      * @param msg The context message for the empty list exception
      * @exception EmptyListException if the list is the nil list
      */
@@ -1036,8 +1035,8 @@ public class RDFListImpl
             throw new EmptyListException( msg );
         }
     }
-    
-    
+
+
     /**
      * <p>
      * Find and return an element of this list - either the last element before
@@ -1045,7 +1044,7 @@ public class RDFListImpl
      * zero).  Note that this method assumes the pre-condition that
      * <code>this</code> is not the empty list.
      * </p>
-     * 
+     *
      * @param last If true, find the element whose tail is nil
      * @param index If <code>last</code> is false, find the index'th element
      * from the head of the list
@@ -1058,17 +1057,17 @@ public class RDFListImpl
     protected RDFList findElement( boolean last, int index ) {
         Property tail = listRest();
         Resource nil = listNil();
-        
+
         Resource l = this;
         int i = index;
         boolean found = (last && l.hasProperty( tail, nil )) || (!last && (i == 0));
-        
+
         // search for the element whose tail is nil, or whose index is now zero
         while (!found  &&  !l.equals( nil )) {
             l = l.getRequiredProperty( tail ).getResource();
             found = (last && l.hasProperty( tail, nil )) || (!last && (--i == 0));
         }
-        
+
         if (!found) {
             // premature end of list
             if (!last) {
@@ -1082,43 +1081,43 @@ public class RDFListImpl
             return l.as( listAbstractionClass() );
         }
     }
-    
+
 
     /**
      * <p>
      * Create a copy of the list of nodes returned by an iterator.
      * </p>
-     * 
+     *
      * @param i An iterator of RDFNodes
      * @return A list formed from all of the nodes of i, in sequence
      */
     protected RDFList copy( Iterator<? extends RDFNode> i ) {
         Resource list = null;
         Resource start = null;
-        
+
         Property head = listFirst();
         Property tail = listRest();
         Resource cellType = listType();
-        
+
         if (i.hasNext())
         {
 	        while (i.hasNext()){
 	            // create a list cell to hold the next value from the existing list
 	            Resource cell = getModel().createResource( cellType );
 	            cell.addProperty( head, i.next() );
-	                
+
 	            // point the previous list cell to this one
 	            if (list != null) {
-	                list.addProperty( tail, cell ); 
+	                list.addProperty( tail, cell );
 	            }
 	            else {
 	                // must be the first cell we're adding
 	                start = cell;
 	            }
-	                
+
 	            list = cell;
 	        }
-	            
+
 	        // finally close the list
 	        list.addProperty( tail, listNil() );
         }
@@ -1127,17 +1126,17 @@ public class RDFListImpl
         	// create an empty list
         	start = getModel().createList();
         }
-            
+
         return start.as( listAbstractionClass() );
     }
-    
-    
+
+
     /**
      * <p>
      * Helper method for setting the list tail, that assumes we have
      * a resource that is a list.
      * </p>
-     * 
+     *
      * @param root The resource representing the list cell we're setting the
      * tail of
      * @param tail The new tail for this list, as a resource.
@@ -1146,16 +1145,16 @@ public class RDFListImpl
     protected static Resource setTailAux( Resource root, Resource tail, Property pTail ) {
         Statement current = root.getRequiredProperty( pTail );
         Resource oldTail = current.getResource();
-            
+
         // out with the old, in with the new
         current.remove();
         root.addProperty( pTail, tail );
-            
+
         return oldTail;
     }
-        
-        
-    
+
+
+
     //==============================================================================
     // Inner class definitions
     //==============================================================================
@@ -1169,28 +1168,28 @@ public class RDFListImpl
     protected class RDFListIterator extends NiceIterator<RDFNode>
     {
         // Instance variables
-        
+
         /** The current list node */
         protected RDFList m_head;
-        
+
         /** The most recently seen node */
         protected RDFList m_seen = null;
-        
-        
+
+
         // Constructor
         //////////////
-        
+
         /**
          * Construct an iterator for walking the list starting at head
          */
         protected RDFListIterator( RDFList head ) {
             m_head = head;
         }
-        
-        
+
+
         // External contract methods
         ////////////////////////////
-        
+
         /**
          * @see Iterator#hasNext
          */
@@ -1204,7 +1203,7 @@ public class RDFListImpl
         @Override public RDFNode next() {
             m_seen = m_head;
             m_head = m_head.getTail();
-            
+
             return m_seen.getHead();
         }
 
@@ -1215,9 +1214,9 @@ public class RDFListImpl
             if (m_seen == null) {
                 throw new IllegalStateException( "Illegal remove from list operator" );
             }
-            
+
             // will remove three statements in a well-formed list
-            ((Resource) m_seen).removeProperties();
+            m_seen.removeProperties();
             m_seen = null;
         }
     }

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmloutput/impl/Unparser.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmloutput/impl/Unparser.java
@@ -1496,7 +1496,7 @@ class Unparser {
 
         if (!(n instanceof Resource))
             return -1;
-        if (((Resource) n).isAnon())
+        if ( n.isAnon() )
             return -1;
         // Only allow resources with namespace and fragment ID
         String uri = ((Resource) n).getURI();

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BBRuleContext.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BBRuleContext.java
@@ -26,20 +26,20 @@ import org.apache.jena.util.iterator.ClosableIterator ;
 
 /**
  * Implementation of RuleContext for use in the backward chaining
- * interpreter. The RuleContext allows builtin predicates to 
+ * interpreter. The RuleContext allows builtin predicates to
  * interpret variable bindings to access the static triple data.
  */
 public class BBRuleContext implements RuleContext {
-    
+
     /** The binding environment which represents the state of the current rule execution. */
     protected BindingEnvironment env;
-    
+
     /** The rule current being executed. */
     protected Rule rule;
-    
+
     /** The enclosing inference graph. */
     protected BackwardRuleInfGraphI graph;
-    
+
     /**
      * Construct an empty context. It can't be used until
      * the rule and environment have been set.
@@ -90,7 +90,7 @@ public class BBRuleContext implements RuleContext {
     public void setEnv(BindingEnvironment env) {
         this.env = env;
     }
-    
+
     /**
      * @see org.apache.jena.reasoner.rulesys.RuleContext#getGraph()
      */
@@ -114,13 +114,13 @@ public class BBRuleContext implements RuleContext {
     public void setRule(Rule rule) {
         this.rule = rule;
     }
-    
+
     /**
      * Assert a new triple in the deduction graph, bypassing any processing machinery.
      */
     @Override
     public void silentAdd(Triple t) {
-        ((SilentAddI)graph).silentAdd(t);
+        graph.silentAdd(t);
     }
 
     /**
@@ -129,7 +129,7 @@ public class BBRuleContext implements RuleContext {
      */
     @Override
     public void add(Triple t) {
-        ((SilentAddI)graph).silentAdd(t);
+        graph.silentAdd(t);
     }
 
     /**
@@ -142,12 +142,12 @@ public class BBRuleContext implements RuleContext {
 
     /**
      * Retrieve or create a bNode representing an inferred property value.
-     * This is currently only available on backward contexts and not part of the 
+     * This is currently only available on backward contexts and not part of the
      * normal RuleContext interface.
      * @param instance the base instance node to which the property applies
      * @param prop the property node whose value is being inferred
      * @param pclass the (optional, can be null) class for the inferred value.
-     * @return the bNode representing the property value 
+     * @return the bNode representing the property value
      */
     public Node getTemp(Node instance, Node prop, Node pclass) {
         return graph.getTemp(instance, prop, pclass);

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BFRuleContext.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/BFRuleContext.java
@@ -36,16 +36,16 @@ import org.slf4j.LoggerFactory;
 public class BFRuleContext implements RuleContext {
     /** The binding environment which represents the state of the current rule execution. */
     protected BindingStack env;
-    
+
     /** The rule current being executed. */
     protected Rule rule;
-    
+
     /** The enclosing inference graph. */
     protected ForwardRuleInfGraphI graph;
-    
+
     /** A stack of triples which have been added to the graph but haven't yet been processed. */
     protected List<Triple> stack;
-    
+
     /** A temporary list of Triples which will be added to the stack and triples at the end of a rule scan */
     protected List<Triple> pending;
 
@@ -54,9 +54,9 @@ public class BFRuleContext implements RuleContext {
 
     /** A searchable index into the pending triples */
     protected Graph pendingCache;
-    
+
     protected static Logger logger = LoggerFactory.getLogger(BFRuleContext.class);
-    
+
     /**
      * Constructor.
      * @param graph the inference graph which owns this context.
@@ -68,7 +68,7 @@ public class BFRuleContext implements RuleContext {
         pending = new ArrayList<>();
         pendingCache = GraphMemFactory.createGraphMem();
     }
-    
+
     /**
      * Returns the current variable binding environment for the current rule.
      * @return BindingEnvironment
@@ -77,7 +77,7 @@ public class BFRuleContext implements RuleContext {
     public BindingEnvironment getEnv() {
         return env;
     }
-    
+
     /**
      * Variant of the generic getEnv interface specific to the basic
      * forward rule system.
@@ -128,7 +128,7 @@ public class BFRuleContext implements RuleContext {
         }
         stack.add(t);
     }
-    
+
     /**
      * Add a triple to a temporary "pending" store, ready to be added to added to the
      * deductions graph and the processing stack later.
@@ -147,7 +147,7 @@ public class BFRuleContext implements RuleContext {
         pending.add(t);
         //pendingCache.add(t);
     }
-            
+
     /**
      * Take all the pending triples and add them to both the given graph and
      * to the processing stack.
@@ -168,7 +168,7 @@ public class BFRuleContext implements RuleContext {
         }
         deletesPending.clear();
     }
-    
+
     /**
      * Return true if the triple is already in either the graph or the stack.
      * I.e. it has already been deduced.
@@ -178,7 +178,7 @@ public class BFRuleContext implements RuleContext {
         // Can't use stackCache.contains because that does not do semantic equality
         return contains(t.getSubject(), t.getPredicate(), t.getObject());
     }
-    
+
     /**
      * Return true if the triple pattern is already in either the graph or the stack.
      * I.e. it has already been deduced.
@@ -191,7 +191,7 @@ public class BFRuleContext implements RuleContext {
         it.close();
         return result;
     }
-    
+
     /**
      * In some formulations the context includes deductions that are not yet
      * visible to the underlying graph but need to be checked for.
@@ -202,7 +202,7 @@ public class BFRuleContext implements RuleContext {
         //return graph.find(s, p, o).andThen(pendingCache.find(s, p, o));
         return graph.findDataMatches(s, p, o);
     }
-    
+
     /**
      * Return the next triple to be added to the graph, removing it from
      * the stack.
@@ -214,9 +214,9 @@ public class BFRuleContext implements RuleContext {
             return t;
         } else {
             return null;
-        } 
+        }
     }
-    
+
     /**
      * Reset the binding environment back to empty.
      * @param newSize the number of variables needed for processing the new rule
@@ -224,13 +224,13 @@ public class BFRuleContext implements RuleContext {
     public void resetEnv(int newSize) {
         env.reset(newSize);
     }
-    
+
     /**
      * Assert a new triple in the deduction graph, bypassing any processing machinery.
      */
     @Override
     public void silentAdd(Triple t) {
-        ((SilentAddI)graph).silentAdd(t);
+        graph.silentAdd(t);
     }
 
     /**

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/RETERuleContext.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/impl/RETERuleContext.java
@@ -28,19 +28,19 @@ import org.apache.jena.util.iterator.ClosableIterator ;
  * The RuleContext is used to supply context information to the builtin operations.
  */
 public class RETERuleContext implements RuleContext {
-    
+
     /** The binding environment which represents the state of the current rule execution. */
     protected BindingEnvironment env;
-    
+
     /** The rule current being executed. */
     protected Rule rule;
-    
+
     /** The enclosing inference graph. */
     protected ForwardRuleInfGraphI graph;
-    
+
     /** The RETE engine associated with the inference graph */
     protected RETEEngine engine;
-    
+
     /**
      * Constructor.
      * @param graph the inference graph which owns this context.
@@ -49,7 +49,7 @@ public class RETERuleContext implements RuleContext {
         this.graph = graph;
         this.engine = engine;
     }
-    
+
     /**
      * Returns the current variable binding environment for the current rule.
      * @return BindingEnvironment
@@ -67,7 +67,7 @@ public class RETERuleContext implements RuleContext {
     public InfGraph getGraph() {
         return graph;
     }
-    
+
     /**
      * Returns the RETE engine associated with this context.
      */
@@ -100,7 +100,7 @@ public class RETERuleContext implements RuleContext {
     public void setEnv(BindingEnvironment env) {
         this.env = env;
     }
-    
+
     /**
      * Return true if the triple is already in either the graph or the stack.
      * I.e. it has already been deduced.
@@ -110,7 +110,7 @@ public class RETERuleContext implements RuleContext {
         // Can't use stackCache.contains because that does not do semantic equality
         return contains(t.getSubject(), t.getPredicate(), t.getObject());
     }
-    
+
     /**
      * Return true if the triple pattern is already in either the graph or the stack.
      * I.e. it has already been deduced.
@@ -122,7 +122,7 @@ public class RETERuleContext implements RuleContext {
         it.close();
         return result;
     }
-    
+
     /**
      * In some formulations the context includes deductions that are not yet
      * visible to the underlying graph but need to be checked for.
@@ -133,13 +133,13 @@ public class RETERuleContext implements RuleContext {
         //return graph.find(s, p, o).andThen(pendingCache.find(s, p, o));
         return graph.findDataMatches(s, p, o);
     }
-    
+
     /**
      * Assert a new triple in the deduction graph, bypassing any processing machinery.
      */
     @Override
     public void silentAdd(Triple t) {
-        ((SilentAddI)graph).silentAdd(t);
+        graph.silentAdd(t);
     }
 
     /**
@@ -163,7 +163,7 @@ public class RETERuleContext implements RuleContext {
      * Check whether the rule should fire in this context.
      */
     public boolean shouldFire(boolean allowUnsafe) {
-        // Check any non-pattern clauses 
+        // Check any non-pattern clauses
         for (int i = 0; i < rule.bodyLength(); i++) {
             Object clause = rule.getBodyElement(i);
             if (clause instanceof Functor) {
@@ -184,13 +184,13 @@ public class RETERuleContext implements RuleContext {
         }
         return true;
     }
-    
+
     /**
      * Check if a rule from the conflict set is still OK to fire.
      * Just checks the non-monotonic guards such as noValue.
      */
     public boolean shouldStillFire() {
-        // Check any non-pattern clauses 
+        // Check any non-pattern clauses
         for (int i = 0; i < rule.bodyLength(); i++) {
             Object clause = rule.getBodyElement(i);
             if (clause instanceof Functor) {
@@ -204,5 +204,5 @@ public class RETERuleContext implements RuleContext {
         }
         return true;
     }
-    
+
 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestRDFNodes.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestRDFNodes.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -113,14 +113,14 @@ public class TestRDFNodes extends AbstractModelTestBase
 	{
 		final Model m = ModelHelper.modelWithStatements(this, "");
 		final Literal l = m.createLiteral("hello, world");
-		Assert.assertSame(l, ((RDFNode) l).asLiteral());
+		Assert.assertSame(l, l.asLiteral());
 	}
 
 	public void testRDFNodeAsResource()
 	{
 		final Model m = ModelHelper.modelWithStatements(this, "");
 		final Resource r = m.createResource("eh:/spoo");
-		Assert.assertSame(r, ((RDFNode) r).asResource());
+		Assert.assertSame(r, r.asResource());
 	}
 
 	public void testRDFVisitor()

--- a/jena-iri/src/main/java/org/apache/jena/iri/impl/IRIFactoryImpl.java
+++ b/jena-iri/src/main/java/org/apache/jena/iri/impl/IRIFactoryImpl.java
@@ -32,7 +32,7 @@ import org.apache.jena.iri.IRIComponents ;
 import org.apache.jena.iri.ViolationCodes ;
 
 
-public class IRIFactoryImpl 
+public class IRIFactoryImpl
   extends AbsIRIFactoryImpl
   implements ViolationCodes, Force, IRIComponents {
 
@@ -41,7 +41,7 @@ public static final int UNKNOWN_SYNTAX = -4;
     /*
     static final long conformanceMasks[] = {
             // RFC3986
-              (1l<<ILLEGAL_CHAR) 
+              (1l<<ILLEGAL_CHAR)
               |(1l<<ILLEGAL_PERCENT_ENCODING)
               |(1l<<EMPTY_SCHEME)
               |(1l<<IP_V4_HAS_FOUR_COMPONENTS)
@@ -56,7 +56,7 @@ public static final int UNKNOWN_SYNTAX = -4;
               |(1l<<ARBITRARY_CHAR)
               ,
             // RFC3987
-              (1l<<ILLEGAL_CHAR) 
+              (1l<<ILLEGAL_CHAR)
               |(1l<<ILLEGAL_PERCENT_ENCODING)
               |(1l<<EMPTY_SCHEME)
               |(1l<<IP_V4_HAS_FOUR_COMPONENTS)
@@ -70,7 +70,7 @@ public static final int UNKNOWN_SYNTAX = -4;
               |(1l<<ARBITRARY_CHAR)
               ,
             // RDF
-              (1l<<ILLEGAL_CHAR) 
+              (1l<<ILLEGAL_CHAR)
               |(1l<<ILLEGAL_PERCENT_ENCODING)
               |(1l<<EMPTY_SCHEME)
               |(1l<<IP_V4_HAS_FOUR_COMPONENTS)
@@ -80,7 +80,7 @@ public static final int UNKNOWN_SYNTAX = -4;
               |(1l<<RELATIVE_URI)
               ,
             // XLink
-              (1l<<ILLEGAL_CHAR) 
+              (1l<<ILLEGAL_CHAR)
               |(1l<<ILLEGAL_PERCENT_ENCODING)
               |(1l<<EMPTY_SCHEME)
               |(1l<<IP_V4_HAS_FOUR_COMPONENTS)
@@ -90,7 +90,7 @@ public static final int UNKNOWN_SYNTAX = -4;
               |(1l<<NON_XML_CHARACTER)
               ,
             // XMLSchema
-              (1l<<ILLEGAL_CHAR) 
+              (1l<<ILLEGAL_CHAR)
               |(1l<<ILLEGAL_PERCENT_ENCODING)
               |(1l<<EMPTY_SCHEME)
               |(1l<<IP_V4_HAS_FOUR_COMPONENTS)
@@ -105,7 +105,7 @@ public static final int UNKNOWN_SYNTAX = -4;
               0
               ,
             // Should
-              (1l<<LOWERCASE_PREFERRED) 
+              (1l<<LOWERCASE_PREFERRED)
               |(1l<<PORT_SHOULD_NOT_BE_EMPTY)
               |(1l<<PORT_SHOULD_NOT_START_IN_ZERO)
     //          |(1l<<SCHEME_NAMES_SHOULD_BE_LOWER_CASE)
@@ -116,10 +116,10 @@ public static final int UNKNOWN_SYNTAX = -4;
             // Minting
       /* consider HAS_PASSWORD vs LOWER_CASE_PREFERRED
        * The former should be an error unless switched
-       * off (but it can be, unlike a MUST), whereas the 
+       * off (but it can be, unlike a MUST), whereas the
        * latter should be a warning by default.
        * /
-              (1l<<LOWERCASE_PREFERRED) 
+              (1l<<LOWERCASE_PREFERRED)
               |(1l<<PORT_SHOULD_NOT_BE_EMPTY)
               |(1l<<PORT_SHOULD_NOT_START_IN_ZERO)
     //          |(1l<<SCHEME_NAMES_SHOULD_BE_LOWER_CASE)
@@ -134,7 +134,7 @@ public static final int UNKNOWN_SYNTAX = -4;
         */
     protected long errors;
     protected long warnings;
-    
+
     protected Set<Specification> specs = new HashSet<>();
 
     public IRIFactoryImpl() {
@@ -143,7 +143,7 @@ public static final int UNKNOWN_SYNTAX = -4;
     public IRIFactoryImpl(IRIFactoryImpl template) {
         if (backwardCompatibleRelativeRefs.size()==Integer.MAX_VALUE)
     	   backwardCompatibleRelativeRefs = template.backwardCompatibleRelativeRefs;
-        else 
+        else
         	backwardCompatibleRelativeRefs = new HashSet<>(backwardCompatibleRelativeRefs);
         encoding = template.encoding;
         errors = template.errors;
@@ -179,7 +179,7 @@ public static final int UNKNOWN_SYNTAX = -4;
     }
 */
     private final long getMask(boolean includeWarnings) {
-        
+
         return includeWarnings?(errors|warnings):errors;
     }
 
@@ -187,20 +187,19 @@ public static final int UNKNOWN_SYNTAX = -4;
     protected IRIFactoryImpl getFactory() {
         return this;
     }
-    
+
     @Override
     public IRI create(IRI i) {
-        if (i instanceof AbsIRIImpl && 
-                ((AbsIRIImpl)i).getFactory()==this)
+        if (i instanceof AbsIRIImpl && i.getFactory()==this)
             return i;
-        return 
+        return
             create(i.toString());
     }
 
     boolean getSameSchemaRelativeReferences(String scheme) {
         return backwardCompatibleRelativeRefs.contains(scheme.toLowerCase());
     }
-    
+
     private String encoding = "utf-8";
     String getEncoding() {
         return encoding;
@@ -210,8 +209,8 @@ public static final int UNKNOWN_SYNTAX = -4;
         "".getBytes(enc);
         encoding = enc;
     }
-    
-   
+
+
     boolean asErrors[] = new boolean[]{
             true,
             true,
@@ -219,7 +218,7 @@ public static final int UNKNOWN_SYNTAX = -4;
             true,
             true,
             true,
-            
+
     };
     boolean asWarnings[] = new boolean[]{
       false,
@@ -229,16 +228,16 @@ public static final int UNKNOWN_SYNTAX = -4;
       false,
       false
     };
-    
+
     protected void setViolation(int ix, boolean e, boolean w){
         if (e && w)
             throw new IllegalArgumentException("xxxViolation(true,true) is not permitted.");
         initializing();
         asErrors[ix]=e;
         asWarnings[ix]=w;
-        
+
     }
-    
+
     protected boolean getAsWarnings(int ix) {
         return asWarnings[ix];
     }
@@ -255,9 +254,9 @@ private Set<String> backwardCompatibleRelativeRefs = new HashSet<>();
     protected void initializing() {
         if (!initializing)
             throw new IllegalStateException("Cannot reinitialize IRIFactory after first use.");
-        
+
     }
-    
+
     @Override
     public IRI create(String s) {
         initializing = false;
@@ -287,7 +286,7 @@ private Set<String> backwardCompatibleRelativeRefs = new HashSet<>();
                 return true;
             }
         };
-        else 
+        else
             backwardCompatibleRelativeRefs.add(scheme.toLowerCase());
     }
 
@@ -306,11 +305,11 @@ private Set<String> backwardCompatibleRelativeRefs = new HashSet<>();
         prohibited |= spec.getProhibited();
         required |= spec.getRequired();
         warnings &= ~errors;
-        
+
     }
 
     public SchemeSpecificPart getScheme(String scheme, Parser parser) {
-        
+
         scheme = scheme.toLowerCase();
         SchemeSpecificPart p = schemes.get(scheme);
         if (p!=null) {
@@ -349,7 +348,7 @@ private Set<String> backwardCompatibleRelativeRefs = new HashSet<>();
           schemes.put(scheme,p);
         return p;
     }
-    
+
     private NoScheme unregisteredScheme=null;
     private NoScheme nonIETFScheme=null;
 
@@ -381,7 +380,7 @@ private Set<String> backwardCompatibleRelativeRefs = new HashSet<>();
                     zwarnings |= spec.getErrors(i);
                 }
             }
-            
+
         }
         @Override void usedBy(Parser parser) {
             if (!inited) {
@@ -392,7 +391,7 @@ private Set<String> backwardCompatibleRelativeRefs = new HashSet<>();
                 zrequired = scheme.getRequired() | required;
                 zprohibited = scheme.getProhibited() | prohibited;
             }
-            
+
         }
         @Override
         public long getMask(boolean includeWarnings) {
@@ -418,10 +417,10 @@ private Set<String> backwardCompatibleRelativeRefs = new HashSet<>();
         public boolean withScheme() {
             return true;
         }
-        
+
     }
     private class NoScheme extends SchemeSpecificPart {
-        
+
         NoScheme() {
             this(-1);
         }
@@ -453,9 +452,9 @@ private Set<String> backwardCompatibleRelativeRefs = new HashSet<>();
         public boolean withScheme() {
             return false;
         }
-        
+
     }
-    
+
     final private NoScheme noScheme = new NoScheme();
     private int required = 0;
     private int prohibited = 0;
@@ -469,7 +468,7 @@ private Set<String> backwardCompatibleRelativeRefs = new HashSet<>();
     }
 
     final private Map<String, SchemeSpecificPart> schemes = new HashMap<>();
-    
+
     public void useSchemeSpecificRules(String scheme, boolean asErr)
     {
         if (scheme.equals("*"))


### PR DESCRIPTION
Clean warnings due to:
- Eclipse warning detection has been imporved/fixed. The code has some unnecessary casts.
- Rebuilt JavaCharStream (from JavaCC) has some javadoc warnings in the maven build.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
