### PR TITLE
Unwrap Titanium exceptions

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LangJSONLD11.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LangJSONLD11.java
@@ -81,11 +81,15 @@ public class LangJSONLD11 implements ReaderRIOT {
     }
 
     private void handleJsonLdError(JsonLdError ex) {
-        if (ex.getCause() instanceof jakarta.json.stream.JsonParsingException exp) {
+        Throwable cause = ex.getCause();
+
+        if (cause instanceof jakarta.json.stream.JsonParsingException exp) {
             JsonLocation loc = exp.getLocation();
             errorHandler.error(ex.getMessage(), loc.getLineNumber(), loc.getColumnNumber());
-        } else {
-            errorHandler.error(ex.getMessage(), -1, -1);
+        } else if ( cause instanceof JsonLdError ex2) {
+            // Avoid seemingly circular causes.
+            if ( ex != ex2 )
+                errorHandler.error(ex2.getMessage(), -1, -1);
         }
         throw new RiotException(ex);
     }


### PR DESCRIPTION
While investigating #2739, I found that errors from Titanium can be wrapped exceptions with where the cause is also a Titanium exception and more meaningful.

This PR adds unwrapping the cause in that case.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
