### PR TITLE
GH-2740: Faster parsing of RDF/XML

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/SysRRX.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/rdfxml/SysRRX.java
@@ -29,8 +29,21 @@ import org.apache.jena.util.JenaXMLInput;
  */
 public class SysRRX {
 
+    /**
+     * Creates and initializes a javax.xml.stream.XMLInputFactory#newInstance().
+     * @return XMLInputFactory
+     */
     public static XMLInputFactory createXMLInputFactory() {
-        XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+        return initAndConfigure(XMLInputFactory.newInstance());
+    }
+
+    /**
+     * Configures the parser to be safe and sets necessary properties.
+     * This method should be called when a factory other than
+     * javax.xml.stream.XMLInputFactory#newInstance() is used.
+     * @param xmlInputFactory
+     */
+    public static <E extends XMLInputFactory> E initAndConfigure(final E xmlInputFactory) {
         JenaXMLInput.initXMLInputFactory(xmlInputFactory);
         // Additional features. Enable character entity support.
         xmlInputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.TRUE);

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfile.java
@@ -22,6 +22,7 @@ import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.irix.IRIx;
 import org.apache.jena.riot.tokens.Token;
 import org.apache.jena.sparql.core.Quad;
 
@@ -49,8 +50,11 @@ public interface ParserProfile {
     /** Create a quad */
     public Quad createQuad(Node graph, Node subject, Node predicate, Node object, long line, long col);
 
-    /** Create a URI Node */
+    /** Create a URI Node, where 'uriStr' could also be a blank node. */
     public Node createURI(String uriStr, long line, long col);
+
+    /** Create a URI Node */
+    public Node createURI(IRIx iriX, long line, long col);
 
     /** Create a literal for a string+datatype */
     public Node createTypedLiteral(String lexical, RDFDatatype datatype, long line, long col);

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileStd.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileStd.java
@@ -200,6 +200,11 @@ public class ParserProfileStd implements ParserProfile {
     }
 
     @Override
+    public Node createURI(IRIx iriX, long line, long col) {
+        return factory.createURI(iriX.str());
+    }
+
+    @Override
     public Node createTypedLiteral(String lexical, RDFDatatype datatype, long line, long col) {
         if ( checking )
             Checker.checkLiteral(lexical, datatype, errorHandler, line, col);

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileWrapper.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/ParserProfileWrapper.java
@@ -22,6 +22,7 @@ import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.irix.IRIx;
 import org.apache.jena.riot.tokens.Token;
 import org.apache.jena.sparql.core.Quad;
 
@@ -60,6 +61,11 @@ public class ParserProfileWrapper implements ParserProfile
     @Override
     public Node createURI(String uriStr, long line, long col) {
         return get().createURI(uriStr, line, col);
+    }
+
+    @Override
+    public Node createURI(IRIx iriX, long line, long col) {
+        return get().createURI(iriX, line, col);
     }
 
     @Override

--- a/jena-arq/src/test/java/org/apache/jena/system/TestReadXML.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestReadXML.java
@@ -72,10 +72,19 @@ public class TestReadXML {
         assertEquals("XMLInputFactory.SUPPORT_DTD",
                      Boolean.FALSE, xf.getProperty(XMLInputFactory.SUPPORT_DTD));
 
-        // Java19. Setting ACCESS_EXTERNAL_DTD to "" now returns "" whereas it was returning null.
-        Object obj = xf.getProperty(XMLConstants.ACCESS_EXTERNAL_DTD);
-        boolean noAccessExternalDTD = ( (obj == null) || ((obj instanceof String) && ((String)obj).isEmpty()) );
-        assertTrue("XMLConstants.ACCESS_EXTERNAL_DTD", noAccessExternalDTD);
+
+        String name = xf.getClass().getName();
+        boolean isWoodstox = name.startsWith("com.ctc.wstx.stax.");
+        boolean isAalto = name.startsWith("com.fasterxml.aalto.");
+        if(!isWoodstox && !isAalto) {
+            // Not supported by Woodstox or Aalto. IS_SUPPORTING_EXTERNAL_ENTITIES = false is enough.
+            // Disable external DTDs (files and HTTP) - errors unless SUPPORT_DTD is false.
+
+            // Java19. Setting ACCESS_EXTERNAL_DTD to "" now returns "" whereas it was returning null.
+            Object obj = xf.getProperty(XMLConstants.ACCESS_EXTERNAL_DTD);
+            boolean noAccessExternalDTD = ( (obj == null) || ((obj instanceof String) && ((String)obj).isEmpty()) );
+            assertTrue("XMLConstants.ACCESS_EXTERNAL_DTD", noAccessExternalDTD);
+        }
 
         assertEquals("javax.xml.stream.isSupportingExternalEntities",
                      Boolean.FALSE,xf.getProperty("javax.xml.stream.isSupportingExternalEntities"));

--- a/jena-benchmarks/jena-benchmarks-jmh/src/test/java/org/apache/jena/riot/lang/rdfxml/TestXMLParser.java
+++ b/jena-benchmarks/jena-benchmarks-jmh/src/test/java/org/apache/jena/riot/lang/rdfxml/TestXMLParser.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.riot.lang.rdfxml;
+
+import org.apache.commons.io.input.BufferedFileChannelInputStream;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.mem.graph.helper.JMHDefaultOptions;
+import org.apache.jena.mem2.GraphMem2Fast;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+
+import java.nio.file.StandardOpenOption;
+
+@State(Scope.Benchmark)
+public class TestXMLParser {
+
+    @Param({
+            "../testing/pizza.owl.rdf",
+//            "../testing/citations.rdf",
+//            "../testing/BSBM/bsbm-5m.xml",
+
+    })
+    public String param0_GraphUri;
+
+    @Param({
+            "RRX.RDFXML_SAX",
+            "RRX.RDFXML_StAX_ev",
+            "RRX.RDFXML_StAX_sr",
+
+//            "RRX.RDFXML_ARP0",
+            "RRX.RDFXML_ARP1"
+    })
+    public String param1_ParserLang;
+
+
+    private static Lang getLang(String langName) {
+        switch (langName) {
+            case "RRX.RDFXML_SAX":
+                return RRX.RDFXML_SAX;
+            case "RRX.RDFXML_StAX_ev":
+                return RRX.RDFXML_StAX_ev;
+            case "RRX.RDFXML_StAX_sr":
+                return RRX.RDFXML_StAX_sr;
+
+            case "RRX.RDFXML_ARP0":
+                return RRX.RDFXML_ARP0;
+            case "RRX.RDFXML_ARP1":
+                return RRX.RDFXML_ARP1;
+
+            default:
+                throw new IllegalArgumentException("Unknown lang: " + langName);
+        }
+    }
+
+    private static org.apache.shadedJena510.riot.Lang getLangJena510(String langName) {
+        switch (langName) {
+            case "RRX.RDFXML_SAX":
+                return org.apache.shadedJena510.riot.lang.rdfxml.RRX.RDFXML_SAX;
+            case "RRX.RDFXML_StAX_ev":
+                return org.apache.shadedJena510.riot.lang.rdfxml.RRX.RDFXML_StAX_ev;
+            case "RRX.RDFXML_StAX_sr":
+                return org.apache.shadedJena510.riot.lang.rdfxml.RRX.RDFXML_StAX_sr;
+
+            case "RRX.RDFXML_ARP0":
+                return org.apache.shadedJena510.riot.lang.rdfxml.RRX.RDFXML_ARP0;
+            case "RRX.RDFXML_ARP1":
+                return org.apache.shadedJena510.riot.lang.rdfxml.RRX.RDFXML_ARP1;
+
+            default:
+                throw new IllegalArgumentException("Unknown lang: " + langName);
+        }
+    }
+
+    @Benchmark
+    public Graph parseXML() throws Exception {
+        final var graph = new GraphMem2Fast();
+        try(final var is = new BufferedFileChannelInputStream.Builder()
+                .setFile(this.param0_GraphUri)
+                .setOpenOptions(StandardOpenOption.READ)
+                .setBufferSize(64*4096)
+                .get()) {
+            RDFParser.source(is)
+                    .base("xx:")
+                    .forceLang(getLang(this.param1_ParserLang))
+                    .checking(false)
+                    .parse(graph);
+        }
+        return graph;
+    }
+
+    @Benchmark
+    public org.apache.shadedJena510.graph.Graph parseXMLJena510() throws Exception {
+        final var graph = new org.apache.shadedJena510.mem2.GraphMem2Fast();
+        try(final var is = new BufferedFileChannelInputStream.Builder()
+                .setFile(this.param0_GraphUri)
+                .setOpenOptions(StandardOpenOption.READ)
+                .setBufferSize(64*4096)
+                .get()) {
+            org.apache.shadedJena510.riot.RDFParser.source(is)
+                    .base("xx:")
+                    .forceLang(getLangJena510(this.param1_ParserLang))
+                    .checking(false)
+                    .parse(graph);
+        }
+        return graph;
+    }
+
+    @Setup(Level.Trial)
+    public void setup() {
+        org.apache.shadedJena510.riot.lang.rdfxml.RRX.register();
+    }
+
+    @Test
+    public void benchmark() throws Exception {
+        var opt = JMHDefaultOptions.getDefaults(this.getClass())
+                .warmupIterations(2)
+                .measurementIterations(4)
+                .build();
+        var results = new Runner(opt).run();
+        Assert.assertNotNull(results);
+    }
+
+}

--- a/jena-core/src/main/java/org/apache/jena/util/JenaXMLInput.java
+++ b/jena-core/src/main/java/org/apache/jena/util/JenaXMLInput.java
@@ -134,6 +134,7 @@ public class JenaXMLInput {
 
         String name = xmlInputFactory.getClass().getName();
         boolean isWoodstox = name.startsWith("com.ctc.wstx.stax.");
+        boolean isAalto = name.startsWith("com.fasterxml.aalto.");
         boolean isJDK = name.contains("sun.xml.internal");
         boolean isXerces = name.startsWith("org.apache.xerces");
 
@@ -146,9 +147,9 @@ public class JenaXMLInput {
         // disable external entities (silently ignore)
         setXMLInputFactoryProperty(xmlInputFactory, XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
 
-        // Not supported by Woodstox. IS_SUPPORTING_EXTERNAL_ENTITIES = false is enough.
+        // Not supported by Woodstox or Aalto. IS_SUPPORTING_EXTERNAL_ENTITIES = false is enough.
         // Disable external DTDs (files and HTTP) - errors unless SUPPORT_DTD is false.
-        if ( ! isWoodstox )
+        if ( ! isWoodstox && ! isAalto)
             setXMLInputFactoryProperty(xmlInputFactory, XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
         return xmlInputFactory;


### PR DESCRIPTION
Faster parsing of RDF/XML by avoiding duplicated resolving of IRIs and adding cache for IRIx in parsers
(Parsers: RRX.RDFXML_SAX, RRX.RDFXML_StAX_ev, RRX.RDFXML_StAX_sr )

GitHub issue resolved #2740

Pull request Description:
- added "public Node createURI(IRIx iriX, ...);" to the ParserProfile, which simply uses the given IRI instead of resolving it again.
- adding general IRIx caching (org.apache.jena.atlas.lib.cache.CacheSimple) in the parsers where the already cached org.apache.jena.riot.system.ParserProfileStd#resolver is not applicable
- removed unused code and variables from ParserRRX_StAX_SR and ParserRRX_StAX_EV
- added `org.apache.jena.riot.lang.rdfxml.TestXMLParser` in jena-benchmarks-jmh


Benchmark results:
```
Benchmark                                                       (param0_GraphUri)  (param1_ParserLang)  Mode  Cnt   Score   Error  Units
TestXMLParser.parseXML                                   ../testing/citations.rdf       RRX.RDFXML_SAX  avgt    5  47,232 ± 0,778   s/op
TestXMLParser.parseXML                                   ../testing/citations.rdf   RRX.RDFXML_StAX_ev  avgt    5  76,502 ± 4,390   s/op
TestXMLParser.parseXML                                   ../testing/citations.rdf   RRX.RDFXML_StAX_sr  avgt    5  48,689 ± 2,224   s/op
TestXMLParser.parseXML                                   ../testing/citations.rdf      RRX.RDFXML_ARP1  avgt    5  86,298 ± 2,440   s/op
TestXMLParser.parseXML                                ../testing/BSBM/bsbm-5m.xml       RRX.RDFXML_SAX  avgt    5   9,576 ± 0,402   s/op
TestXMLParser.parseXML                                ../testing/BSBM/bsbm-5m.xml   RRX.RDFXML_StAX_ev  avgt    5  11,562 ± 0,535   s/op
TestXMLParser.parseXML                                ../testing/BSBM/bsbm-5m.xml   RRX.RDFXML_StAX_sr  avgt    5   9,406 ± 0,465   s/op
TestXMLParser.parseXML                                ../testing/BSBM/bsbm-5m.xml      RRX.RDFXML_ARP1  avgt    5  19,738 ± 1,526   s/op
TestXMLParser.parseXML          CGMES_v2.4.15_RealGridTestConfiguration_EQ_V2.xml       RRX.RDFXML_SAX  avgt    5   0,998 ± 0,223   s/op
TestXMLParser.parseXML          CGMES_v2.4.15_RealGridTestConfiguration_EQ_V2.xml   RRX.RDFXML_StAX_ev  avgt    5   1,325 ± 0,093   s/op
TestXMLParser.parseXML          CGMES_v2.4.15_RealGridTestConfiguration_EQ_V2.xml   RRX.RDFXML_StAX_sr  avgt    5   0,985 ± 0,018   s/op
TestXMLParser.parseXML          CGMES_v2.4.15_RealGridTestConfiguration_EQ_V2.xml      RRX.RDFXML_ARP1  avgt    5   2,357 ± 0,163   s/op
TestXMLParser.parseXML         CGMES_v2.4.15_RealGridTestConfiguration_SSH_V2.xml       RRX.RDFXML_SAX  avgt    5   0,146 ± 0,029   s/op
TestXMLParser.parseXML         CGMES_v2.4.15_RealGridTestConfiguration_SSH_V2.xml   RRX.RDFXML_StAX_ev  avgt    5   0,192 ± 0,007   s/op
TestXMLParser.parseXML         CGMES_v2.4.15_RealGridTestConfiguration_SSH_V2.xml   RRX.RDFXML_StAX_sr  avgt    5   0,140 ± 0,016   s/op
TestXMLParser.parseXML         CGMES_v2.4.15_RealGridTestConfiguration_SSH_V2.xml      RRX.RDFXML_ARP1  avgt    5   0,309 ± 0,098   s/op
TestXMLParser.parseXMLJena510                            ../testing/citations.rdf       RRX.RDFXML_SAX  avgt    5  57,690 ± 0,932   s/op
TestXMLParser.parseXMLJena510                            ../testing/citations.rdf   RRX.RDFXML_StAX_ev  avgt    5  84,579 ± 4,109   s/op
TestXMLParser.parseXMLJena510                            ../testing/citations.rdf   RRX.RDFXML_StAX_sr  avgt    5  56,949 ± 0,815   s/op
TestXMLParser.parseXMLJena510                            ../testing/citations.rdf      RRX.RDFXML_ARP1  avgt    5  82,940 ± 0,815   s/op
TestXMLParser.parseXMLJena510                         ../testing/BSBM/bsbm-5m.xml       RRX.RDFXML_SAX  avgt    5  13,280 ± 0,458   s/op
TestXMLParser.parseXMLJena510                         ../testing/BSBM/bsbm-5m.xml   RRX.RDFXML_StAX_ev  avgt    5  14,994 ± 0,803   s/op
TestXMLParser.parseXMLJena510                         ../testing/BSBM/bsbm-5m.xml   RRX.RDFXML_StAX_sr  avgt    5  13,132 ± 0,166   s/op
TestXMLParser.parseXMLJena510                         ../testing/BSBM/bsbm-5m.xml      RRX.RDFXML_ARP1  avgt    5  19,125 ± 1,044   s/op
TestXMLParser.parseXMLJena510   CGMES_v2.4.15_RealGridTestConfiguration_EQ_V2.xml       RRX.RDFXML_SAX  avgt    5   1,311 ± 0,018   s/op
TestXMLParser.parseXMLJena510   CGMES_v2.4.15_RealGridTestConfiguration_EQ_V2.xml   RRX.RDFXML_StAX_ev  avgt    5   1,693 ± 0,021   s/op
TestXMLParser.parseXMLJena510   CGMES_v2.4.15_RealGridTestConfiguration_EQ_V2.xml   RRX.RDFXML_StAX_sr  avgt    5   1,332 ± 0,179   s/op
TestXMLParser.parseXMLJena510   CGMES_v2.4.15_RealGridTestConfiguration_EQ_V2.xml      RRX.RDFXML_ARP1  avgt    5   2,305 ± 0,280   s/op
TestXMLParser.parseXMLJena510  CGMES_v2.4.15_RealGridTestConfiguration_SSH_V2.xml       RRX.RDFXML_SAX  avgt    5   0,194 ± 0,028   s/op
TestXMLParser.parseXMLJena510  CGMES_v2.4.15_RealGridTestConfiguration_SSH_V2.xml   RRX.RDFXML_StAX_ev  avgt    5   0,227 ± 0,016   s/op
TestXMLParser.parseXMLJena510  CGMES_v2.4.15_RealGridTestConfiguration_SSH_V2.xml   RRX.RDFXML_StAX_sr  avgt    5   0,194 ± 0,025   s/op
TestXMLParser.parseXMLJena510  CGMES_v2.4.15_RealGridTestConfiguration_SSH_V2.xml      RRX.RDFXML_ARP1  avgt    5   0,291 ± 0,039   s/op
```

----

 - [x] Tests are included.
 -  no Documentation change and updates needed
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
