### PR TITLE
Update Grammar/.gitignore

### DIFF
--- a/jena-arq/Grammar/.gitignore
+++ b/jena-arq/Grammar/.gitignore
@@ -1,5 +1,13 @@
 # Intermediate files
 arq.txt
 sparql_11.txt
+sparql_12.txt
+# Older files
 X12.html
 Y12.html
+# Grammar in HTML 
+sparql-grammar.html
+# Grammar in BNF text
+sparql.bnf
+# Grammar in HTML as a standalone web page.
+sparql-html.html


### PR DESCRIPTION
Update the .gitignore for jena-arq/Grammar.

Ongoing RDF 1.2 work improves the production of BNF HTML and BNF text for the SPARQL specification. It may be sometime before the working group achieves sufficient stability of syntax for this to go into a Jena release even as "experimental, subject to change".

There are intermediate work files when generating spec material. This PR updates .gitignore to ignore these files to stop accidentally committing them when switch branches. 

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
