### PR TITLE
GH-2753: Improve customising Fuseki args

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -188,7 +188,7 @@ public class FusekiServer {
      * <p>
      * If http and https are in-use, this is the HTTPS port.
      * <p>
-     * If there multiple ports of the same schema, return any one port in use.
+     * If there are multiple ports of the same schema, return any one port in use.
      * <p>
      * See also {@link #getHttpPort} or Use {@link #getHttpsPort}.
      */

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -128,7 +128,7 @@ public class FusekiMain extends CmdARQ {
     // private static ModLocation modLocation = new ModLocation();
     private static ModDatasetAssembler modDataset      = new ModDatasetAssembler();
 
-    private final ServerConfig serverConfig  = new ServerConfig();
+    protected final ServerConfig serverConfig  = new ServerConfig();
     // Default
     private boolean useTDB2 = true;
 
@@ -142,7 +142,7 @@ public class FusekiMain extends CmdARQ {
 
     /**
      * Create a {@link org.apache.jena.fuseki.main.FusekiServer.Builder} which has
-     * been setup according to the command line arguments.
+     * been set up according to the command line arguments.
      * The builder can be further modified.
      */
     public static FusekiServer.Builder builder(String... args) {
@@ -152,7 +152,7 @@ public class FusekiMain extends CmdARQ {
         inner.process();
         // Apply command line/serverConfig to a builder.
         FusekiServer.Builder builder = inner.builder();
-        applyServerArgs(builder, inner.serverConfig);
+        inner.applyServerArgs(builder, inner.serverConfig);
         return builder;
     }
 
@@ -597,7 +597,7 @@ public class FusekiMain extends CmdARQ {
     }
 
     /**
-     * Take a {@link ServerConfig} and make a {@Link FusekiServer}.
+     * Take a {@link ServerConfig} and make a {@link FusekiServer}.
      * The server has not been started.
      */
     private FusekiServer makeServer(ServerConfig serverConfig) {
@@ -611,16 +611,13 @@ public class FusekiMain extends CmdARQ {
     }
 
     /**
-     * Process {@link ServerConfig} and build a server.
-     * The server has not been started.
+     * Apply {@link ServerConfig} to a {@link FusekiServer.Builder}.
+     * <p>
+     * Commands extended from this class can override this method if they are populating {@link ServerConfig#extra} from
+     * extra arguments and need to propagate that configuration onto the Server Builder somehow.
+     * </p>
      */
-    private static FusekiServer buildServer(FusekiServer.Builder builder, ServerConfig serverConfig) {
-        applyServerArgs(builder, serverConfig);
-        return builder.build();
-    }
-
-    /** Apply {@link ServerConfig} to a {@link FusekiServer.Builder}. */
-    private static void applyServerArgs(FusekiServer.Builder builder, ServerConfig serverConfig) {
+    protected void applyServerArgs(FusekiServer.Builder builder, ServerConfig serverConfig) {
         if ( serverConfig.jettyConfigFile != null )
             builder.jettyServerConfig(serverConfig.jettyConfigFile);
         builder.port(serverConfig.port);

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerConfig.java
@@ -23,12 +23,15 @@ import org.apache.jena.fuseki.main.sys.FusekiModules;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.sparql.core.DatasetGraph;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Setup details (command line, config file) from command line processing.
  * This is built by {@link FusekiMain#exec}.
  * This is processed by {@link FusekiMain#buildServer}.
  */
-class ServerConfig {
+public class ServerConfig {
     /** Server port. This is the http port when both http and https are active. */
     public int port                     = -1;
     /** Loopback */
@@ -81,4 +84,9 @@ class ServerConfig {
     public AuthScheme authScheme        = null;
     public String passwdFile            = null;
     public String realm                 = null;
+
+    /**
+     * Any extra configuration
+     */
+    public Map<String, Object> extra    = new HashMap<>();
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
@@ -35,6 +35,7 @@ import org.junit.platform.suite.api.Suite;
   , TestFusekiCustomOperation.class
   , TestFusekiMainCmd.class
   , TestFusekiMainCmdArguments.class
+  , TestFusekiMainCmdCustomArguments.class
   , TestFusekiStdSetup.class
   , TestFusekiStdReadOnlySetup.class
   , TestConfigFile.class

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
@@ -418,6 +418,14 @@ public class TestFusekiMainCmdArguments {
         assertNotNull(server);
     }
 
+    @Test
+    public void test_unrecognised_argument() {
+        // given
+        List<String> arguments = List.of("--port=0", "--mem", "--no-such-argument");
+        // when and then
+        testForCmdException(arguments, "Unknown argument: no-such-argument");
+    }
+
     private void testForCmdException(List<String> arguments, String expectedMessage) {
         // when
         Throwable actual = null;
@@ -440,7 +448,7 @@ public class TestFusekiMainCmdArguments {
     // Build and set the server
     private void buildServer(String... cmdline) {
         if ( server != null )
-            fail("Bad test - a server has aleardy been created");
+            fail("Bad test - a server has already been created");
         server = FusekiMain.build(cmdline);
         server.start();
     }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdCustomArguments.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdCustomArguments.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.fuseki.main;
+
+import org.apache.jena.atlas.logging.LogCtl;
+import org.apache.jena.cmd.CmdException;
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.main.cmds.CustomisedFusekiMain;
+import org.apache.jena.fuseki.system.FusekiLogging;
+import org.junit.*;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * NOTE: we will randomise the port (--port=0) on all happy paths in order to avoid conflict with existing runs.
+ */
+public class TestFusekiMainCmdCustomArguments {
+
+    private static String level = null;
+
+    @BeforeClass public static void beforeClass() {
+        // This is not reset by each running server.
+        FusekiLogging.setLogging();
+        level = LogCtl.getLevel(Fuseki.serverLog);
+        LogCtl.setLevel(Fuseki.serverLog, "WARN");
+    }
+
+    @AfterClass public static void afterClass() {
+        if ( level != null )
+            LogCtl.setLevel(Fuseki.serverLog, level);
+    }
+
+    private FusekiServer server = null;
+    @After public void after() {
+        if ( server != null )
+            server.stop();
+    }
+
+    @Test
+    public void test_custom_argument() {
+        // given
+        List<String> arguments = List.of("--port=0", "--mem", "--custom-flag", "--custom-arg", "test", "/ds");
+        // when
+        buildServer(buildCmdLineArguments(arguments));
+        // then
+        assertNotNull(server);
+        Assert.assertNotNull(server.getServletContext().getAttribute("flag"));
+        Assert.assertNotNull(server.getServletContext().getAttribute("arg"));
+    }
+
+    private void testForCmdException(List<String> arguments, String expectedMessage) {
+        // when
+        Throwable actual = null;
+        try {
+            buildServer(buildCmdLineArguments(arguments));
+        } catch (Exception e) {
+            actual = e;
+        }
+        // then
+        assertNotNull(actual);
+        assertTrue("Expecting correct exception", (actual instanceof CmdException));
+        assertEquals("Expecting correct message", expectedMessage, actual.getMessage());
+    }
+
+
+    private static String[] buildCmdLineArguments(List<String> listArgs) {
+        return listArgs.toArray(new String[0]);
+    }
+
+    // Build and set the server
+    private void buildServer(String... cmdline) {
+        if ( server != null )
+            fail("Bad test - a server has already been created");
+        server = CustomisedFusekiMain.buildCustom(cmdline);
+        server.start();
+    }
+}

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/cmds/CustomisedFusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/cmds/CustomisedFusekiMain.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.main.cmds;
+
+import org.apache.jena.cmd.ArgDecl;
+import org.apache.jena.fuseki.main.FusekiServer;
+
+public class CustomisedFusekiMain extends FusekiMain {
+
+    private final ArgDecl customFlag = new ArgDecl(ArgDecl.NoValue, "custom-flag");
+    private final ArgDecl customArg = new ArgDecl(ArgDecl.HasValue, "custom-arg");
+
+    public CustomisedFusekiMain(String[] args) {
+        super(args);
+
+        add(customFlag);
+        add(customArg);
+    }
+
+    public static FusekiServer buildCustom(String[] args) {
+        // Parses command line, sets arguments.
+        CustomisedFusekiMain inner = new CustomisedFusekiMain(args);
+        // Process command line args according to the argument specified.
+        inner.process();
+        // Apply command line/serverConfig to a builder.
+        FusekiServer.Builder builder = inner.builder();
+        inner.applyServerArgs(builder, inner.serverConfig);
+        return builder.build();
+    }
+
+    @Override
+    protected void processModulesAndArgs() {
+        super.processModulesAndArgs();
+
+        this.serverConfig.extra.put("flag", contains(customFlag));
+        this.serverConfig.extra.put("arg", getValue(customArg));
+    }
+
+    @Override
+    protected void applyServerArgs(FusekiServer.Builder builder, ServerConfig serverConfig) {
+        super.applyServerArgs(builder, serverConfig);
+
+        builder.addServletAttribute("flag", this.serverConfig.extra.get("flag"));
+        builder.addServletAttribute("arg", this.serverConfig.extra.get("arg"));
+    }
+}


### PR DESCRIPTION
Improves how Fuseki arguments are customised, in particular makes the `ServerConfig` class public adding the ability to store extra configuration on it.

It also changes the previously `private static applyServerArgs()` method into a protected instance method so users can extend `FusekiMain` and override it to use that to customise the `FusekiServer.Builder` further.

Unit tests are added that validate that custom arguments can now be passed through CLI inputs and used to influence the Server being built.

GitHub issue resolved #2753

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
