### PR TITLE
GH-2766: Don't warn on surrogates in IRIs

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizerText.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizerText.java
@@ -573,35 +573,9 @@ public final class TokenizerText implements Tokenizer
                 default:
                     if ( ch <= 0x19 )
                         warning("Illegal character in IRI (control char 0x%02X): <%s[0x%02X]...>", ch, stringBuilder.toString(), ch);
-
             }
-            // JENA-1924: jena-iri does not catch this.
-            if ( ! VeryVeryLaxIRI && ch >= 0xA0 && ! isUcsChar(ch) )
-                warning("Illegal character in IRI (Not a ucschar: 0x%04X): <%s[U+%04X]...>", ch, stringBuilder.toString(), ch);
             insertCodepoint(stringBuilder, ch);
         }
-    }
-
-    private static boolean isUcsChar(int ch) {
-        // RFC 3987
-        // ucschar    = %xA0-D7FF / %xF900-FDCF / %xFDF0-FFEF
-        //            / %x10000-1FFFD / %x20000-2FFFD / %x30000-3FFFD
-        //            / %x40000-4FFFD / %x50000-5FFFD / %x60000-6FFFD
-        //            / %x70000-7FFFD / %x80000-8FFFD / %x90000-9FFFD
-        //            / %xA0000-AFFFD / %xB0000-BFFFD / %xC0000-CFFFD
-        //            / %xD0000-DFFFD / %xE1000-EFFFD
-        boolean b = range(ch, 0xA0, 0xD7FF)  || range(ch, 0xF900, 0xFDCF)  || range(ch, 0xFDF0, 0xFFEF);
-        if ( b )
-            return true;
-        if ( ch < 0x1000 )
-            return false;
-        // 32 bit checks.
-        return
-            range(ch, 0x10000, 0x1FFFD) || range(ch, 0x20000, 0x2FFFD) || range(ch, 0x30000, 0x3FFFD) ||
-            range(ch, 0x40000, 0x4FFFD) || range(ch, 0x50000, 0x5FFFD) || range(ch, 0x60000, 0x6FFFD) ||
-            range(ch, 0x70000, 0x7FFFD) || range(ch, 0x80000, 0x8FFFD) || range(ch, 0x90000, 0x9FFFD) ||
-            range(ch, 0xA0000, 0xAFFFD) || range(ch, 0xB0000, 0xBFFFD) || range(ch, 0xC0000, 0xCFFFD) ||
-            range(ch, 0xD0000, 0xDFFFD) || range(ch, 0xE1000, 0xEFFFD);
     }
 
     // Read a unicode escape : does not allow \\ bypass

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestTurtleWriterPretty.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestTurtleWriterPretty.java
@@ -42,9 +42,9 @@ public class TestTurtleWriterPretty {
         x.add(new Object[]{"Turtle/Long", RDFFormat.TURTLE_LONG});
         x.add(new Object[]{"Trig/Pretty", RDFFormat.TRIG_PRETTY});
         x.add(new Object[]{"Trig/Long", RDFFormat.TRIG_LONG});
-        return x ; 
+        return x ;
     }
-    
+
     private static String DIR = "testing/RIOT/Writer/";
 
     private static String BASE = "http://BASE/";
@@ -60,7 +60,7 @@ public class TestTurtleWriterPretty {
         else
             this.filename = DIR+"rdfwriter-01.ttl";
     }
-    
+
     // read file, with external base URI
     private static Graph data(String fn, String baseURI) {
         Graph g1 = GraphFactory.createDefaultGraph();
@@ -72,13 +72,16 @@ public class TestTurtleWriterPretty {
     }
 
     // Stream writer (BLOCKS and FLAT) don't print a base URI unless explicitly given one in the data.
-   
+
     @Test public void writer_parse_base_2() {
-        assumeTrue(format.getVariant().equals(RDFFormat.PRETTY));
-        
+        RDFFormatVariant fmtVariant = format.getVariant();
+        boolean isPretty = ( fmtVariant == RDFFormat.PRETTY || fmtVariant == RDFFormat.LONG ) ;
+
+        assumeTrue(isPretty);
+
         Graph g = data(filename, BASE);
 
-        String written = 
+        String written =
             RDFWriter.create()
                 .base(BASE)
                 .source(g)

--- a/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizerText.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizerText.java
@@ -996,64 +996,62 @@ public class TestTokenizerText {
         });
     }
 
-    @Test(expected=RiotParseException.class)
-    public void token_replacmentChar_uri_1() {
+    public void token_replacementChar_uri_1() {
         Tokenizer tokenizer = tokenizer("<a\uFFFDz>");
         testNextToken(tokenizer, TokenType.IRI);
     }
 
-    @Test(expected=RiotParseException.class)
-    public void token_replacmentChar_uri_2() {
+    public void token_replacementChar_uri_2() {
         Tokenizer tokenizer = tokenizer("<a\\uFFFDz>");
         testNextToken(tokenizer, TokenType.IRI);
     }
 
     @Test(expected=RiotParseException.class)
-    public void token_replacmentChar_bnode_1() {
+    public void token_replacementChar_bnode_1() {
         Tokenizer tokenizer = tokenizer("ns\uFFFD:xyz");
         testNextToken(tokenizer, TokenType.PREFIXED_NAME);
         //assertFalse(tokenizer.hasNext());
     }
 
     @Test(expected=RiotParseException.class)
-    public void token_replacmentChar_bnode_2() {
+    public void token_replacementChar_bnode_2() {
         Tokenizer tokenizer = tokenizer("ns:\uFFFDabc");
         testNextToken(tokenizer, TokenType.PREFIXED_NAME);
         //assertFalse(tokenizer.hasNext());
     }
 
-    private final int CountWaringsOnReplacmeentChar = 0;
+    private static final int CountWaringsOnReplacementChar = 0;
 
     // Test for warnings
     @Test
-    public void tokenStr_replacmentChar_str_1() {
-        testExpectWarning("'\uFFFD'", TokenType.STRING, CountWaringsOnReplacmeentChar);
+    public void tokenStr_replacementChar_str_1() {
+        testExpectWarning("'\uFFFD'", TokenType.STRING, CountWaringsOnReplacementChar);
     }
 
     @Test
-    public void tokenStr_replacmentChar_str_2() {
+    public void tokenStr_replacementChar_str_2() {
         // As unicode escape.
         testExpectWarning("'\\uFFFD'", TokenType.STRING, 0);
     }
 
     @Test
-    public void tokenStr_replacmentChar_str_3() {
-        testExpectWarning("'''\uFFFD'''", TokenType.STRING, CountWaringsOnReplacmeentChar);
+    public void tokenStr_replacementChar_str_3() {
+        testExpectWarning("'''\uFFFD'''", TokenType.STRING, CountWaringsOnReplacementChar);
     }
 
     @Test
-    public void tokenStr_replacmentChar_str_4() {
+    public void tokenStr_replacementChar_str_4() {
         // As unicode escape.
         testExpectWarning("'''\\uFFFD'''", TokenType.STRING, 0);
     }
 
     @Test
-    public void tokenStr_replacmentChar_str_5() {
-        testExpectWarning("'abc\uFFFDdef'", TokenType.STRING, CountWaringsOnReplacmeentChar);
+    public void tokenStr_replacementChar_str_5() {
+        testExpectWarning("'abc\uFFFDdef'", TokenType.STRING, CountWaringsOnReplacementChar);
     }
 
     @Test
-    public void tokenStr_replacmentChar_str_6() {
+    public void tokenStr_replacementChar_str_6() {
         // Illegal encoding.
         // 0xDF is ß (lower case) in ISO-8859-1.
         // Here it is an illegal encoding (high set, next byte should have the high bit set but does not).
@@ -1063,35 +1061,35 @@ public class TestTokenizerText {
         byte[] bytes = {(byte)0x22, (byte)0xDF, (byte)0x22};
         Reader r = IO.asUTF8(new ByteArrayInputStream(bytes));
         PeekReader pr = PeekReader.make(r);
-        Token t = testExpectWarning(pr, TokenType.STRING, CountWaringsOnReplacmeentChar);
+        Token t = testExpectWarning(pr, TokenType.STRING, CountWaringsOnReplacementChar);
         int char0 = t.getImage().codePointAt(0);
         assertEquals("Expected Unicode REPLACEMENT CHARACTER", 0xFFFD, char0);
     }
 
     @Test
-    public void tokenStr_replacmentChar_IRI_1() {
-        testExpectWarning("<http://example/\uFFFD>", TokenType.IRI, 1);
+    public void tokenStr_replacementChar_IRI_1() {
+        testExpectWarning("<http://example/\uFFFD>", TokenType.IRI, 0);
     }
 
     @Test
-    public void tokenStr_replacmentChar_IRI_2() {
+    public void tokenStr_replacementChar_IRI_2() {
         // As unicode escape. Still bad in a URI.
-        testExpectWarning("<http://example/\\uFFFD>", TokenType.IRI, 1);
+        testExpectWarning("<http://example/\\uFFFD>", TokenType.IRI, 0);
     }
 
     @Test
-    public void tokenStr_replacmentChar_prefixedName_1() {
+    public void tokenStr_replacementChar_prefixedName_1() {
         testExpectWarning("ex:abc\uFFFD", TokenType.PREFIXED_NAME, 1);
     }
 
     @Test(expected=RiotException.class)
-    public void tokenStr_replacmentChar_prefixedName_2() {
+    public void tokenStr_replacementChar_prefixedName_2() {
         // Unicode escape
         testExpectWarning("ex:abc\\uFFFD", TokenType.PREFIXED_NAME, 0);
     }
 
     @Test
-    public void tokenStr_replacmentChar_blankNode_1() {
+    public void tokenStr_replacementChar_blankNode_1() {
         testExpectWarning("_:b\uFFFD", TokenType.BNODE, 1);
         // and no escaped characters for blank node labels.
     }

--- a/jena-core/src/main/java/org/apache/jena/irix/Chars3986.java
+++ b/jena-core/src/main/java/org/apache/jena/irix/Chars3986.java
@@ -44,7 +44,7 @@ public class Chars3986 {
 
     /** RFC3987 ipchar */
     public static boolean isIPChar(char ch, String str, int posn) {
-        return isPChar(ch, str, posn) || isUcsChar(ch);
+        return isPChar(ch, str, posn) || ch_isUcsChar(ch);
     }
 
     /**
@@ -69,7 +69,7 @@ public class Chars3986 {
 
     /** RFC3987: International alphabetic. */
     public static boolean isIAlpha(char ch) {
-        return isAlpha(ch) || isUcsChar(ch);
+        return isAlpha(ch) || ch_isUcsChar(ch);
     }
 
     // RFC 3987
@@ -83,7 +83,13 @@ public class Chars3986 {
     // Surrogates are "hi-lo" : DC000-DFFF and D800-DFFF
     // We assume the java string is valid and surrogates are correctly in high-low pairs.
 
+    /** @deprecated Prefer {@link #int_isUcsChar(int)} */
+    @Deprecated(forRemoval = true)
     public static boolean isUcsChar(char ch) {
+        return ch_isUcsChar(ch);
+    }
+
+    private static boolean ch_isUcsChar(char ch) {
             return range(ch, 0xA0, 0xD7FF)  || range(ch, 0xF900, 0xFDCF)  || range(ch, 0xFDF0, 0xFFEF)
                     // Allow surrogates.
                     || Character.isSurrogate(ch);


### PR DESCRIPTION
GitHub issue resolved #2766

Pull request Description:

Due to Java bytes to string conversion using the JDK conversion, Jena can't tell the difference between multibyte characters translated to surrogates (legal) and surrogates actually in the in UTF-8 (illegal - UTF-8 does not allow surrogates).

The test changes are bug fixes. They are detecting warnings on the replacement character but that is explicitly handled, and allowed, controlled by a flag, further up.

A deep fix might be possible - but it involves our own UTF-8 decoder and will need careful assessment of the performance impact. 

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
