### PR TITLE
Warnings lucene

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,13 +21,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
+        java_version: ['17', '21']
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK ${{ matrix.java_version }}
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: ${{ matrix.java_version }}
     - name: Build with Maven
       run: mvn -B --file pom.xml -Dmaven.javadoc.skip=true install

--- a/jena-text/pom.xml
+++ b/jena-text/pom.xml
@@ -27,8 +27,20 @@
     <artifactId>jena</artifactId>
     <version>5.3.0-SNAPSHOT</version>
   </parent>
-
+  <profiles>
+   <!-- apache lucene emits warnings for native access and for the vector module for java version >= 21 -->
+   <profile><id>enable-native-and-incubator-vector</id>
+   <activation>
+     <jdk>[21,22,23]</jdk>
+   </activation>
+     <properties>
+       <jena.text.test.argLine>--enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector</jena.text.test.argLine>
+     </properties>
+   </profile>
+ </profiles>
   <properties>
+    <jena.text.test.argLine></jena.text.test.argLine>
+    <argLine></argLine>
     <automatic.module.name>org.apache.jena.text</automatic.module.name>
   </properties>
 
@@ -122,6 +134,7 @@
           <includes>
             <include>**/TS_*.java</include>
           </includes>
+          <argLine>@{argLine} ${jena.text.test.argLine}</argLine>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
GitHub issue resolved #2533

Pull request Description:

Add different build arguments based on the running JVM version to minimize lucene warnings during build
This is based on how tests are being run in Apache Lucene (in gradle) where they check for java version and add args if >=21
but translated-ish to maven.

https://github.com/apache/lucene/blob/1faf33a02afd610c90ffa8685b1675f9d1c24b0e/gradle/testing/defaults-tests.gradle#L131

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
