### PR TITLE
GH-2783: [ontapi] do not allow OntDisjoints with no items

### DIFF
--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
@@ -965,8 +965,10 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
 
     @Override
     public OntDisjoint.Classes createDisjointClasses(Collection<OntClass> classes) {
+        if (classes.isEmpty()) {
+            throw new IllegalArgumentException("Empty list is specified");
+        }
         checkType(OntDisjoint.Classes.class);
-        checkType(OntClass.IntersectionOf.class);
         return checkCreate(model ->
                 OntDisjointImpl.createDisjointClasses(model, classes.stream()), OntDisjoint.Classes.class
         );
@@ -974,6 +976,9 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
 
     @Override
     public OntDisjoint.Individuals createDifferentIndividuals(Collection<OntIndividual> individuals) {
+        if (individuals.isEmpty()) {
+            throw new IllegalArgumentException("Empty list is specified");
+        }
         checkType(OntDisjoint.Individuals.class);
         return checkCreate(model ->
                 OntDisjointImpl.createDifferentIndividuals(model, individuals.stream()), OntDisjoint.Individuals.class
@@ -982,6 +987,9 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
 
     @Override
     public OntDisjoint.ObjectProperties createDisjointObjectProperties(Collection<OntObjectProperty> properties) {
+        if (properties.isEmpty()) {
+            throw new IllegalArgumentException("Empty list is specified");
+        }
         checkType(OntDisjoint.ObjectProperties.class);
         return checkCreate(model ->
                 OntDisjointImpl.createDisjointObjectProperties(model, properties.stream()), OntDisjoint.ObjectProperties.class
@@ -990,6 +998,9 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
 
     @Override
     public OntDisjoint.DataProperties createDisjointDataProperties(Collection<OntDataProperty> properties) {
+        if (properties.isEmpty()) {
+            throw new IllegalArgumentException("Empty list is specified");
+        }
         checkType(OntDisjoint.DataProperties.class);
         return checkCreate(model ->
                 OntDisjointImpl.createDisjointDataProperties(model, properties.stream()), OntDisjoint.DataProperties.class

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OWL2ObjectFactories.java
@@ -785,16 +785,16 @@ public final class OWL2ObjectFactories {
             OntFacetRestriction.LangRange.class
     );
 
-    public static final EnhNodeFactory CLASSES_DISJOINT = OntDisjoints.createDisjointClassesFactory(0);
+    public static final EnhNodeFactory CLASSES_DISJOINT = OntDisjoints.createDisjointClassesFactory(1);
     public static final EnhNodeFactory EL_CLASSES_DISJOINT = OntDisjoints.createDisjointClassesFactory(2);
     public static final EnhNodeFactory QL_RL_CLASSES_DISJOINT = OntDisjoints.createQLRLDisjointClassesFactory();
     public static final Function<OntConfig, EnhNodeFactory> DIFFERENT_INDIVIDUALS_DISJOINT =
             OntDisjoints::createDLFullDifferentIndividualsFactory;
     public static final EnhNodeFactory EL_QL_RL_DIFFERENT_INDIVIDUALS_DISJOINT =
             OntDisjoints.createELQLRLDifferentIndividualsFactory();
-    public static final EnhNodeFactory OBJECT_PROPERTIES_DISJOINT = OntDisjoints.createDisjointObjectPropertiesFactory(0);
+    public static final EnhNodeFactory OBJECT_PROPERTIES_DISJOINT = OntDisjoints.createDisjointObjectPropertiesFactory(1);
     public static final EnhNodeFactory QL_RL_OBJECT_PROPERTIES_DISJOINT = OntDisjoints.createDisjointObjectPropertiesFactory(2);
-    public static final EnhNodeFactory DATA_PROPERTIES_DISJOINT = OntDisjoints.createDisjointDataPropertiesFactory(0);
+    public static final EnhNodeFactory DATA_PROPERTIES_DISJOINT = OntDisjoints.createDisjointDataPropertiesFactory(1);
     public static final EnhNodeFactory QL_RL_DATA_PROPERTIES_DISJOINT = OntDisjoints.createDisjointDataPropertiesFactory(2);
 
     public static final EnhNodeFactory ANY_PROPERTIES_DISJOINT = OntEnhNodeFactories.createFrom(

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OntDisjoints.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/factories/OntDisjoints.java
@@ -68,7 +68,7 @@ final class OntDisjoints {
                 OWL2.AllDifferent,
                 OntIndividual.class,
                 it -> true,
-                0,
+                1,
                 predicates
         );
     }

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL1SpecsTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL1SpecsTest.java
@@ -189,21 +189,24 @@ public class OntModelOWL1SpecsTest {
         OntModel m = OntModelFactory.createModel(spec.inst);
         OntIndividual i1 = m.getOWLThing().createIndividual("A");
         OntIndividual i2 = m.getOWLThing().createIndividual("B");
+        OntClass c1 = m.createOntClass("C");
+        OntDataProperty p1 = m.createDataProperty("p1");
+        OntObjectProperty p2 = m.createObjectProperty("p2");
         OntDisjoint.Individuals d = m.createDifferentIndividuals(i1, i2);
         Assertions.assertEquals(
                 List.of("A", "B"),
                 d.members().map(Resource::getURI).sorted().collect(Collectors.toList())
         );
 
-        Assertions.assertEquals(8, m.statements().count());
+        Assertions.assertEquals(11, m.statements().count());
         Assertions.assertEquals(1, m.ontObjects(OntDisjoint.Individuals.class).count());
         Assertions.assertEquals(1, m.ontObjects(OntDisjoint.class).count());
 
-        Assertions.assertThrows(OntJenaException.Unsupported.class, m::createDisjointClasses);
-        Assertions.assertThrows(OntJenaException.Unsupported.class, m::createDisjointDataProperties);
-        Assertions.assertThrows(OntJenaException.Unsupported.class, m::createDisjointObjectProperties);
+        Assertions.assertThrows(OntJenaException.Unsupported.class, () -> m.createDisjointClasses(c1));
+        Assertions.assertThrows(OntJenaException.Unsupported.class, () -> m.createDisjointDataProperties(p1));
+        Assertions.assertThrows(OntJenaException.Unsupported.class, () -> m.createDisjointObjectProperties(p2));
 
-        Assertions.assertEquals(8, m.statements().count());
+        Assertions.assertEquals(11, m.statements().count());
         Assertions.assertEquals(1, m.ontObjects(OntDisjoint.Individuals.class).count());
         Assertions.assertEquals(1, m.ontObjects(OntDisjoint.class).count());
     }
@@ -244,6 +247,7 @@ public class OntModelOWL1SpecsTest {
     @ParameterizedTest
     @EnumSource(names = {
             "OWL1_MEM",
+            "OWL1_DL_MEM",
             "OWL1_LITE_MEM",
     })
     public void testDisabledFeaturesOWL1(TestSpec spec) {
@@ -259,7 +263,7 @@ public class OntModelOWL1SpecsTest {
                 );
         d.createDataProperty("dp1").addEquivalentProperty(d.createDataProperty("dp2"));
 
-        OntModel m = OntModelFactory.createModel(d.getGraph(), OntSpecification.OWL1_DL_MEM);
+        OntModel m = OntModelFactory.createModel(d.getGraph(), spec.inst);
         OntClass.Named x = m.getOntClass("X");
         OntClass.Named q = m.createOntClass("Q");
         OntDataProperty dp1 = m.createDataProperty("dp1");

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2ELSpecTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2ELSpecTest.java
@@ -316,7 +316,9 @@ public class OntModelOWL2ELSpecTest {
     public void testDifferentIndividuals(TestSpec spec) {
         OntModel data = OntModelFactory.createModel();
         data.createDifferentIndividuals(data.createIndividual("a"));
-        data.createDifferentIndividuals();
+        data.createResource()
+                .addProperty(RDF.type, OWL2.AllDifferent)
+                .addProperty(OWL2.members, data.createList());
         data.createDifferentIndividuals(data.createIndividual("b"), data.createIndividual("c"));
 
         OntModel m = OntModelFactory.createModel(data.getGraph(), spec.inst);
@@ -348,7 +350,9 @@ public class OntModelOWL2ELSpecTest {
     public void testDisjointClasses(TestSpec spec) {
         OntModel data = OntModelFactory.createModel();
         data.createDisjointClasses(data.createOntClass("a"));
-        data.createDisjointClasses();
+        data.createResource()
+                .addProperty(RDF.type, OWL2.AllDisjointClasses)
+                .addProperty(OWL2.members, data.createList());
         data.createDisjointClasses(data.createOntClass("b"), data.createOntClass("c"));
 
         OntModel m = OntModelFactory.createModel(data.getGraph(), spec.inst);

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2QLSpecTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2QLSpecTest.java
@@ -441,7 +441,9 @@ public class OntModelOWL2QLSpecTest {
     public void testDisjointDataProperties(TestSpec spec) {
         OntModel data = OntModelFactory.createModel();
         data.createDisjointDataProperties(data.createDataProperty("a"));
-        data.createDisjointDataProperties();
+        data.createResource()
+                .addProperty(RDF.type, OWL2.AllDisjointProperties)
+                .addProperty(OWL2.members, data.createList());
         data.createDisjointDataProperties(data.createDataProperty("b"), data.createDataProperty("c"));
 
         OntModel m = OntModelFactory.createModel(data.getGraph(), spec.inst);

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2RLSpecTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelOWL2RLSpecTest.java
@@ -644,7 +644,9 @@ public class OntModelOWL2RLSpecTest {
     public void testDisjointObjectProperties(TestSpec spec) {
         OntModel data = OntModelFactory.createModel();
         data.createDisjointObjectProperties(data.createObjectProperty("a"));
-        data.createDisjointObjectProperties();
+        data.createResource()
+                .addProperty(RDF.type, OWL2.AllDisjointProperties)
+                .addProperty(OWL2.members, data.createList());
         data.createDisjointObjectProperties(data.createObjectProperty("b"), data.createObjectProperty("c"));
 
         OntModel m = OntModelFactory.createModel(data.getGraph(), spec.inst);


### PR DESCRIPTION
GitHub issue resolved #2783

Pull request Description:
do not allow `OntDisjoint`s with no items


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
