### PR TITLE
GH-2787: Deadlock in JenaSystem.init()

### DIFF
--- a/jena-integration-tests/src/test/java/org/apache/jena/sys/TS_Sys.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/sys/TS_Sys.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sys;
+
+import org.apache.jena.sparql.exec.http.*;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses(
+    { TestJenaSystem.class
+    })
+
+public class TS_Sys { }

--- a/jena-integration-tests/src/test/java/org/apache/jena/sys/TestJenaSystem.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/sys/TestJenaSystem.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.sys;
+
+import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.Test;
+
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestJenaSystem {
+
+    @Test
+    public void testInit() {
+        assertDoesNotThrow(() -> JenaSystem.init());
+    }
+
+    @Test
+    public void testInitParallel() {
+
+        // it is mandatory to init JenaSystem before running anything in parallel
+        JenaSystem.init();
+
+        var pool = Executors.newFixedThreadPool(8);
+
+        var futures = IntStream.range(0, 16)
+                .mapToObj(i -> pool.submit(() -> {
+                    if (i % 2 == 0)
+                        ModelFactory.createDefaultModel();
+                    else
+                        JenaSystem.init();
+
+                    return i;
+                }))
+                .toList();
+
+        var intSet = new HashSet<Integer>();
+        assertTimeoutPreemptively(
+                Duration.of(5, ChronoUnit.SECONDS),
+                () -> {
+                    for (var future : futures) {
+                        intSet.add(future.get());
+                    }
+                });
+
+        assertEquals(16, intSet.size());
+    }
+}


### PR DESCRIPTION
Added a fail-fast mechanism: now throwing an `ExceptionInInitializerError` when a thread attempts to enter `JenaSystem.init()` while another thread is in the initialization process.

Refactored `JenaSystem.init()` using the "Initialization-on-demand holder idiom" for simpler and safer initialization.

Additionally, I have added integration tests for `JenaSystem.init()`, including the parallel execution scenario from the issue, to ensure coverage of potential concurrency issues. 

GitHub issue resolved #2787

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
