### PR TITLE
GH-2802: Remove only if same key

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheSimple.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/cache/CacheSimple.java
@@ -115,19 +115,14 @@ public class CacheSimple<K, V> implements Cache<K, V> {
         }
     }
 
-
     @Override
     public void put(K key, V thing) {
         Objects.requireNonNull(key);
-        final int idx = calcIndex(key);
-        if(thing == null) { //null value causes removal of entry
-            if (keys[idx] != null) {
-                keys[idx] = null;
-                values[idx] = null;
-                currentSize--;
-            }
+        if (thing == null) {
+            remove(key);
             return;
         }
+        final int idx = calcIndex(key);
         if(!thing.equals(values[idx])) {
             values[idx] = thing;
         }

--- a/jena-base/src/test/java/org/apache/jena/atlas/lib/cache/TestCacheSimple.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/lib/cache/TestCacheSimple.java
@@ -32,7 +32,7 @@ public class TestCacheSimple {
 
     /**
      * Simple test to ensure that {@link CacheSimple} evidences
-     * the fixed-size behavior we desire.
+     * the fixed-size behaviour we desire.
      */
     @Test
     public void testFixedSize() {
@@ -209,6 +209,24 @@ public class TestCacheSimple {
     }
 
     @Test
+    public void testRemoveSameHash() {
+        CompoundKey key1 = new CompoundKey(1, 1);
+        CompoundKey key2 = new CompoundKey(1, 2);
+        String value1 = "v1";
+        String value2 = "v2";
+
+        Cache<CompoundKey, String> cache = new CacheSimple<>(10);
+
+        cache.put(key1, value1);
+        // Delete - different key
+        cache.put(key2, null);
+        String s = cache.getIfPresent(key1);
+
+        assertEquals(1, cache.size());
+        assertEquals(value1, s);
+    }
+
+    @Test
     public void testGet() {
         Cache<String, String> cache = new CacheSimple<>(10);
         assertEquals(0, cache.size());
@@ -325,7 +343,7 @@ public class TestCacheSimple {
         assertEquals(16, cache.getAllocatedSize());
     }
 
-    // Compound key for tests. 
+    // Compound key for tests.
     private static final class CompoundKey {
         private final int a;
         private final int b;


### PR DESCRIPTION
GitHub issue resolved #2802

Pull request Description:
Call `CacheSimple.remove` if the `put` value is null.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
