### PR TITLE
GH-2787: Use lazy holder pattern for system initialization

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/sys/JenaSystem.java
+++ b/jena-core/src/main/java/org/apache/jena/sys/JenaSystem.java
@@ -77,20 +77,23 @@ public class JenaSystem {
     }
 
     public static void init() {
-        // Once jena is initialized, all calls are an immediate return.
         if ( initialized )
             return ;
-        // Overlapping attempts to perform initialization will block on the synchronized.
-        synchronized(JenaSystem.class) {
-            if ( initialized )
-                return ;
+        // Access the initialized flag to trigger class loading
+        var unused = LazyInitializer.IS_INITIALIZED;
+    }
+
+    private static class LazyInitializer {
+        static final boolean IS_INITIALIZED = jenaSystemInitialization();
+
+        private static boolean jenaSystemInitialization() {
+            JenaSystem.initialized = true; // Set early to avoid blocking on static initialization.
             setup();
             if ( DEBUG_INIT )
                 singleton.debug(DEBUG_INIT);
             singleton.initialize();
             singleton.debug(false);
-            // Last so overlapping initialization waits on the synchronized
-            initialized = true;
+            return true;
         }
     }
 


### PR DESCRIPTION
Use the lazy holder pattern to perform system initialization.
Set `JenaSystem.initialized" flag early to avoid deadlocks.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
