### PR TITLE
GH-2800: Include jena-iri3986 in maven modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
 
       <modules>
         <module>jena-iri</module>
+        <module>jena-iri3986</module>
         <module>jena-base</module>
         
         <module>jena-core</module>
@@ -258,6 +259,7 @@
       <modules>
         <!-- Basic modules -->
         <module>jena-iri</module>
+        <module>jena-iri3986</module>
         <module>jena-base</module>
 
         <!-- Main modules -->


### PR DESCRIPTION
Add `jena-iri3986` to the `<modules>`
(got lost in a rebase preparing for the merge)

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
