### PR TITLE
GH-2821: Support for Timeouts on Updates

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -244,7 +244,21 @@ public class HttpLib {
      * @return String
      */
     public static String handleResponseRtnString(HttpResponse<InputStream> response) {
+        return handleResponseRtnString(response, null);
+    }
+
+    /**
+     * Handle the HTTP response and read the body to produce a string if a 200.
+     * Otherwise, throw an {@link HttpException}.
+     * @param response
+     * @param callback A callback that receives the opened input stream.
+     * @return String
+     */
+    public static String handleResponseRtnString(HttpResponse<InputStream> response, Consumer<InputStream> callback) {
         InputStream input = handleResponseInputStream(response);
+        if (callback != null) {
+            callback.accept(input);
+        }
         try {
             return IO.readWholeFileAsUTF8(input);
         } catch (RuntimeIOException e) { throw new HttpException(e); }

--- a/jena-arq/src/main/java/org/apache/jena/http/sys/ExecHTTPBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/sys/ExecHTTPBuilder.java
@@ -280,29 +280,18 @@ public abstract class ExecHTTPBuilder<X, Y> {
     public Y context(Context context) {
         if ( context == null )
             return thisBuilder();
-        ensureContext();
         contextAcc.context(context);
-        //this.context.putAll(context);
         return thisBuilder();
     }
 
     public Y set(Symbol symbol, Object value) {
-        ensureContext();
         contextAcc.set(symbol, value);
-        //context.set(symbol, value);
         return thisBuilder();
     }
 
     public Y set(Symbol symbol, boolean value) {
-        ensureContext();
         contextAcc.set(symbol, value);
-        //context.set(symbol, value);
         return thisBuilder();
-    }
-
-    private void ensureContext() {
-//        if ( context == null )
-//            context = new Context();
     }
 
     /**

--- a/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ARQ.java
@@ -198,6 +198,17 @@ public class ARQ
      */
     public static final Symbol queryTimeout = SystemARQ.allocSymbol("queryTimeout");
 
+    /**
+     * Set timeout.  The value of this symbol gives the value of the timeout in milliseconds
+     * <ul>
+     * <li>A Number; the long value is used</li>
+     * <li>A string, e.g. "1000", parsed as a number</li>
+     * <li>A string, as two numbers separated by a comma, e.g. "500,10000" parsed as two numbers</li>
+     * </ul>
+     * @see org.apache.jena.update.UpdateExecutionBuilder#timeout(long, TimeUnit)
+     */
+    public static final Symbol updateTimeout = SystemARQ.allocSymbol("updateTimeout");
+
     // This can't be a context constant because NodeValues don't look in the context.
 //    /**
 //     * Context symbol controlling Roman Numerals in Filters.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/ExecutionContext.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/ExecutionContext.java
@@ -24,10 +24,8 @@ import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.jena.atlas.iterator.Iter;
-import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.query.ARQ;
-import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.engine.main.OpExecutor;
 import org.apache.jena.sparql.engine.main.OpExecutorFactory;
@@ -78,18 +76,7 @@ public class ExecutionContext implements FunctionEnv
     }
 
     public ExecutionContext(Context params, Graph activeGraph, DatasetGraph dataset, OpExecutorFactory factory) {
-        this(params, activeGraph, dataset, factory, cancellationSignal(params));
-    }
-
-    private static AtomicBoolean cancellationSignal(Context cxt) {
-        if ( cxt == null )
-            return null;
-        try {
-            return cxt.get(ARQConstants.symCancelQuery);
-        } catch (ClassCastException ex) {
-            Log.error(ExecutionContext.class, "Class cast exception: Expected AtomicBoolean for cancel control: "+ex.getMessage());
-            return null;
-        }
+        this(params, activeGraph, dataset, factory, Context.getCancelSignal(params));
     }
 
     private ExecutionContext(Context params, Graph activeGraph, DatasetGraph dataset, OpExecutorFactory factory, AtomicBoolean cancelSignal) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/Timeouts.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/Timeouts.java
@@ -22,9 +22,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.jena.atlas.lib.Pair;
 import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.query.ARQ;
+import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sparql.util.Symbol;
 
 /** Processing timeout strings. */
 public class Timeouts {
+
+    private static final long UNSET_AMOUNT       = -1;
 
     public static Pair<Long, Long> parseTimeoutStr(String str, TimeUnit unit) {
         try {
@@ -48,5 +53,195 @@ public class Timeouts {
             Log.warn(Timeouts.class, "Failed to parse timeout string: "+str+": "+ex.getMessage());
             return null;
         }
+    }
+
+    public static record DurationWithUnit(long amount, TimeUnit unit) {
+        public static DurationWithUnit UNSET = new DurationWithUnit(UNSET_AMOUNT, TimeUnit.MILLISECONDS);
+
+        public boolean isSet() {
+            return amount >= 0;
+        }
+
+        public long asMillis() {
+            return (amount < 0) ? amount : unit.toMillis(amount);
+        }
+
+        /** Create an instance with normalized values: negative amounts become -1 and a null unit is turned into milliseconds. */
+        public static DurationWithUnit of(long amount, TimeUnit unit) {
+            return new DurationWithUnit(amount < 0 ? -1 : amount, nullToMillis(unit));
+        }
+    }
+
+    public static record Timeout(DurationWithUnit initialTimeout, DurationWithUnit overallTimeout) {
+        public static Timeout UNSET = new Timeout(UNSET_AMOUNT, UNSET_AMOUNT);
+
+        public Timeout(long initialTimeout, TimeUnit initialTimeoutUnit, long overallTimeout, TimeUnit overallTimeoutUnit) {
+            this(DurationWithUnit.of(initialTimeout, initialTimeoutUnit), DurationWithUnit.of(overallTimeout, overallTimeoutUnit));
+        }
+
+        public Timeout(long initialTimeout, long overallTimeout) {
+            this(initialTimeout, TimeUnit.MILLISECONDS, overallTimeout, TimeUnit.MILLISECONDS);
+        }
+
+        public boolean hasInitialTimeout() {
+            return initialTimeout().isSet();
+        }
+
+        public long initialTimeoutMillis() {
+            return initialTimeout().asMillis();
+        }
+
+        public boolean hasOverallTimeout() {
+            return overallTimeout().isSet();
+        }
+
+        public long overallTimeoutMillis() {
+            return overallTimeout().asMillis();
+        }
+
+        public boolean hasTimeout() {
+            return hasInitialTimeout() || hasOverallTimeout();
+        }
+    }
+
+    // TimeoutBuilder reserved as a possible super-interface for {Query, Update}Exec(ution)Builder.
+    public static class TimeoutBuilderImpl {
+        protected long     initialTimeout     = UNSET_AMOUNT;
+        protected TimeUnit initialTimeoutUnit = null;
+        protected long     overallTimeout     = UNSET_AMOUNT;
+        protected TimeUnit overallTimeoutUnit = null;
+
+        /** Overwrite this builder's state with that of the argument. */
+        public TimeoutBuilderImpl timeout(Timeout timeout) {
+            initialTimeout(timeout.initialTimeout().amount(), timeout.initialTimeout().unit());
+            overallTimeout(timeout.overallTimeout().amount(), timeout.overallTimeout().unit());
+            return this;
+        }
+
+        public TimeoutBuilderImpl timeout(long value, TimeUnit timeUnit) {
+            initialTimeout(UNSET_AMOUNT, null);
+            overallTimeout(value, timeUnit);
+            return this;
+        }
+
+        public TimeoutBuilderImpl initialTimeout(long value, TimeUnit timeUnit) {
+            this.initialTimeout = value < 0 ? UNSET_AMOUNT : value ;
+            this.initialTimeoutUnit = timeUnit;
+            return this;
+        }
+
+        public boolean hasInitialTimeout() {
+            return initialTimeout >= 0;
+        }
+
+        public TimeoutBuilderImpl overallTimeout(long value, TimeUnit timeUnit) {
+            this.overallTimeout = value;
+            this.overallTimeoutUnit = timeUnit;
+            return this;
+        }
+
+        public boolean hasOverallTimeout() {
+            return overallTimeout >= 0;
+        }
+
+        public Timeout build() {
+            return new Timeout(initialTimeout, nullToMillis(initialTimeoutUnit), overallTimeout, nullToMillis(overallTimeoutUnit));
+        }
+    }
+
+    /** Update any unset timeout in the builder from the specification object. */
+    public static void applyDefaultTimeout(TimeoutBuilderImpl builder, Timeout timeout) {
+        if (timeout != null) {
+            if ( !builder.hasInitialTimeout() )
+                builder.initialTimeout(timeout.initialTimeout().amount(), timeout.initialTimeout().unit());
+            if ( !builder.hasOverallTimeout() )
+                builder.overallTimeout(timeout.overallTimeout().amount(), timeout.overallTimeout().unit());
+        }
+    }
+
+    public static Timeout extractQueryTimeout(Context cxt) {
+        return extractTimeout(cxt, ARQ.queryTimeout);
+    }
+
+    public static Timeout extractUpdateTimeout(Context cxt) {
+        return extractTimeout(cxt, ARQ.updateTimeout);
+    }
+
+    public static Timeout extractTimeout(Context cxt, Symbol symbol) {
+        Object obj = cxt.get(symbol);
+        return parseTimeout(obj);
+    }
+
+    /** Creates a timeout instance from the object. Never returns null. */
+    public static Timeout parseTimeout(Object obj) {
+        Timeout result = Timeout.UNSET;
+        if ( obj != null ) {
+            try {
+                if ( obj instanceof Timeout to ) {
+                    result = to;
+                } else if ( obj instanceof Number n ) {
+                    long x = n.longValue();
+                    result = new Timeout(UNSET_AMOUNT, x);
+                } else if ( obj instanceof String str ) {
+                    Pair<Long, Long> pair = Timeouts.parseTimeoutStr(str, TimeUnit.MILLISECONDS);
+                    if ( pair == null ) {
+                        Log.warn(Timeouts.class, "Bad timeout string: "+str);
+                        return result;
+                    }
+                    result = new Timeout(pair.getLeft(), pair.getRight());
+                } else
+                    Log.warn(Timeouts.class, "Can't interpret timeout: " + obj);
+            } catch (Exception ex) {
+                Log.warn(Timeouts.class, "Exception setting timeouts (context) from: "+obj, ex);
+            }
+        }
+        return result;
+    }
+
+    public static void setQueryTimeout(Context cxt, Timeout timeout) {
+        setTimeout(cxt, ARQ.queryTimeout, timeout);
+    }
+
+    public static void setUpdateTimeout(Context cxt, Timeout timeout) {
+        setTimeout(cxt, ARQ.updateTimeout, timeout);
+    }
+
+    public static void setTimeout(Context cxt, Symbol symbol, Timeout timeout) {
+        Object obj = toContextValue(timeout);
+        cxt.set(symbol, obj);
+    }
+
+    /** Inverse function of {@link #parseTimeout(Object)}. */
+    public static Object toContextValue(Timeout timeout) {
+        Object result = timeout == null
+            ? null
+            : timeout.hasInitialTimeout()
+                ? toString(timeout)
+                : timeout.hasOverallTimeout()
+                    ? timeout.overallTimeoutMillis()
+                    : null;
+        return result;
+    }
+
+    /** Inverse function of {@link #parseTimeout(Object)}. */
+    public static String toString(Timeout timeout) {
+       String result = timeout.hasInitialTimeout()
+            ? timeout.initialTimeoutMillis() + "," + timeout.overallTimeoutMillis()
+            : timeout.hasOverallTimeout()
+                ? Long.toString(timeout.overallTimeoutMillis())
+                : null;
+       return result;
+    }
+
+    // Set times from context if not set directly. e..g Context provides default values.
+    // Contrast with SPARQLQueryProcessor where the context is limiting values of the protocol parameter.
+    public static void applyDefaultQueryTimeoutFromContext(TimeoutBuilderImpl builder, Context cxt) {
+        Timeout queryTimeout = extractQueryTimeout(cxt);
+        applyDefaultTimeout(builder, queryTimeout);
+    }
+
+    /** Returns milliseconds if the given time unit is null. */
+    private static TimeUnit nullToMillis(TimeUnit unit) {
+        return unit != null ? unit : TimeUnit.MILLISECONDS;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterProcessBinding.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterProcessBinding.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.jena.atlas.lib.Lib ;
 import org.apache.jena.query.QueryCancelledException;
-import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.ARQInternalErrorException ;
 import org.apache.jena.sparql.engine.ExecutionContext ;
 import org.apache.jena.sparql.engine.QueryIterator ;
@@ -49,7 +48,7 @@ public abstract class QueryIterProcessBinding extends QueryIter1 {
         nextBinding = null ;
         AtomicBoolean signal;
         try {
-            signal = context.getContext().get(ARQConstants.symCancelQuery);
+            signal = context.getCancelSignal();
         } catch(Exception ex) {
             signal = null;
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIteratorBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIteratorBase.java
@@ -70,7 +70,7 @@ public abstract class QueryIteratorBase
     }
 
     private boolean requestingCancel() {
-        return requestingCancel != null && requestingCancel.get() ;
+        return (requestingCancel != null && requestingCancel.get()) || Thread.interrupted() ;
     }
 
     private void haveCancelled() {}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecAdapter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecAdapter.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.sparql.exec;
 
+import org.apache.jena.sparql.util.Context;
 import org.apache.jena.update.UpdateExecution;
 
 public class UpdateExecAdapter implements UpdateExec {
@@ -39,4 +40,14 @@ public class UpdateExecAdapter implements UpdateExec {
 
     @Override
     public void execute() { updateProc.execute(); }
+
+    @Override
+    public Context getContext() {
+        return updateProc.getContext();
+    }
+
+    @Override
+    public void abort() {
+        updateProc.abort();
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecBuilder.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.sparql.exec;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.core.Var;
@@ -64,6 +66,8 @@ public interface UpdateExecBuilder {
     public default UpdateExecBuilder substitution(String var, Node value) {
         return substitution(Var.alloc(var), value);
     }
+
+    public UpdateExecBuilder timeout(long value, TimeUnit timeUnit);
 
     public UpdateExec build();
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecBuilderAdapter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecBuilderAdapter.java
@@ -19,6 +19,7 @@
 package org.apache.jena.sparql.exec;
 
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.ResultBinding;
@@ -115,6 +116,12 @@ public class UpdateExecBuilderAdapter
     @Override
     public UpdateExecBuilder substitution(Var var, Node value) {
         builder = builder.substitution(var.getName(), ModelUtils.convertGraphNodeToRDFNode(value));
+        return this;
+    }
+
+    @Override
+    public UpdateExecBuilder timeout(long timeout, TimeUnit timeoutUnit) {
+        builder = builder.timeout(timeout, timeoutUnit);
         return this;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecDataset.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecDataset.java
@@ -20,6 +20,7 @@ package org.apache.jena.sparql.exec;
 
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.Timeouts.Timeout;
 import org.apache.jena.sparql.modify.UpdateEngineFactory;
 import org.apache.jena.sparql.modify.UpdateProcessorBase;
 import org.apache.jena.sparql.util.Context;
@@ -28,8 +29,8 @@ import org.apache.jena.update.UpdateRequest;
 public class UpdateExecDataset extends UpdateProcessorBase implements UpdateExec {
 
     protected UpdateExecDataset(UpdateRequest request, DatasetGraph datasetGraph,
-                                Binding inputBinding, Context context, UpdateEngineFactory factory) {
-        super(request, datasetGraph, inputBinding, context, factory);
+                                Binding inputBinding, Context context, UpdateEngineFactory factory, Timeout timeout) {
+        super(request, datasetGraph, inputBinding, context, factory, timeout);
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecutionAdapter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecutionAdapter.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.sparql.exec;
 
+import org.apache.jena.sparql.util.Context;
 import org.apache.jena.update.UpdateExecution;
 
 public class UpdateExecutionAdapter implements UpdateExecution {
@@ -40,4 +41,13 @@ public class UpdateExecutionAdapter implements UpdateExecution {
     @Override
     public void execute() { updateExec.execute(); }
 
+    @Override
+    public Context getContext() {
+        return updateExec.getContext();
+    }
+
+    @Override
+    public void abort() {
+        updateExec.abort();
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecutionBuilderAdapter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExecutionBuilderAdapter.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.sparql.exec;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.sparql.engine.binding.Binding;
@@ -100,6 +102,12 @@ public class UpdateExecutionBuilderAdapter implements UpdateExecutionBuilder {
     @Override
     public UpdateExecutionBuilder substitution(String varName, RDFNode value) {
         builder.substitution(varName, value.asNode());
+        return this;
+    }
+
+    @Override
+    public UpdateExecutionBuilder timeout(long value, TimeUnit timeUnit) {
+        builder.timeout(value, timeUnit);
         return this;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTP.java
@@ -114,7 +114,7 @@ public class QueryExecHTTP implements QueryExec {
     private String httpResponseContentType = null;
     // Releasing HTTP input streams is important. We remember this for SELECT result
     // set streaming, and will close it when the execution is closed
-    private InputStream retainedConnection = null;
+    private volatile InputStream retainedConnection = null;
 
     private HttpClient httpClient = HttpEnv.getDftHttpClient();
     private Map<String, String> httpHeaders;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecHTTPBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecHTTPBuilder.java
@@ -45,6 +45,6 @@ public class UpdateExecHTTPBuilder extends ExecUpdateHTTPBuilder<UpdateExecHTTP,
                                   copyArray(usingGraphURIs),
                                   copyArray(usingNamedGraphURIs),
                                   new HashMap<>(httpHeaders),
-                                  sendMode, cxt);
+                                  sendMode, cxt, timeout, timeoutUnit);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecutionHTTPBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecutionHTTPBuilder.java
@@ -52,7 +52,8 @@ public class UpdateExecutionHTTPBuilder
                                                   copyArray(usingGraphURIs),
                                                   copyArray(usingNamedGraphURIs),
                                                   new HashMap<>(httpHeaders),
-                                                  sendMode, cxt);
+                                                  sendMode, cxt,
+                                                  timeout, timeoutUnit);
         return new UpdateExecutionHTTP(uExec);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngine.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngine.java
@@ -30,12 +30,12 @@ public interface UpdateEngine
      *  Signal start of a request being executed
      */
     public void startRequest();
-    
+
     /**
-     * Signal end of a request being executed 
+     * Signal end of a request being executed
      */
     public void finishRequest();
-    
+
     /**
      * Returns an {@link UpdateSink} that accepts Update operations
      */

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngineBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngineBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.jena.sparql.modify;
 
-import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.ARQConstants ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.engine.binding.Binding ;
@@ -39,18 +38,16 @@ public abstract class UpdateEngineBase implements UpdateEngine
         this.inputBinding = inputBinding ;
         this.context = setupContext(context, datasetGraph) ;
     }
-    
-    private static Context setupContext(Context context, DatasetGraph dataset)
-    {
-        // To many copies?
-        if ( context == null )      // Copy of global context to protect against change.
-            context = ARQ.getContext() ;
-        context = context.copy() ;
 
-        if ( dataset.getContext() != null )
-            context.putAll(dataset.getContext()) ;
-        
-        context.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime()) ;
-        return context ; 
+    private Context setupContext(Context cxt, DatasetGraph dataset)
+    {
+        // The following setup is effectively the same as in QueryEngineBase
+        Context result = cxt;
+
+        if ( result == null )
+            result = Context.setupContextForDataset(cxt, dataset);
+
+        result.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime()) ;
+        return result ;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngineMain.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngineMain.java
@@ -38,7 +38,7 @@ import org.apache.jena.sparql.util.Context ;
  * See {@link UpdateEngineNonStreaming} for a subclass that accumulates updates, including  during
  * parsing then executes the operation.
  */
-public class UpdateEngineMain extends UpdateEngineBase 
+public class UpdateEngineMain extends UpdateEngineBase
 {
     /**
      * Creates a new Update Engine
@@ -53,12 +53,12 @@ public class UpdateEngineMain extends UpdateEngineBase
 
     @Override
     public void startRequest() {}
-    
+
     @Override
     public void finishRequest() {}
-    
+
     private UpdateSink updateSink = null ;
-    
+
     /*
      * Returns the {@link UpdateSink}. In this implementation, this is done by with
      * an {@link UpdateVisitor} which will visit each update operation and send the
@@ -71,11 +71,11 @@ public class UpdateEngineMain extends UpdateEngineBase
     {
         if ( updateSink == null )
             updateSink = new UpdateVisitorSink(this.prepareWorker(),
-                                               sink(q->datasetGraph.add(q)), 
+                                               sink(q->datasetGraph.add(q)),
                                                sink(q->datasetGraph.delete(q)));
         return updateSink ;
     }
-    
+
     /**
      * Creates the {@link UpdateVisitor} which will do the work of applying the updates
      * @return The update visitor to be used to apply the updates
@@ -84,18 +84,18 @@ public class UpdateEngineMain extends UpdateEngineBase
         return new UpdateEngineWorker(datasetGraph, inputBinding, context) ;
     }
 
-    /** Direct a sink to a Consumer. */ 
+    /** Direct a sink to a Consumer. */
     private <X> Sink<X> sink(Consumer<X> action) {
         return new Sink<X>() {
             @Override
             public void send(X item) { action.accept(item); }
 
-            @Override public void close() {} 
+            @Override public void close() {}
 
             @Override public void flush() {}
-        }; 
+        };
     }
-    
+
     private static UpdateEngineFactory factory = new UpdateEngineFactory()
     {
         @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/Context.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/Context.java
@@ -20,9 +20,11 @@ package org.apache.jena.sparql.util;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 
 import org.apache.jena.atlas.lib.Lib;
+import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.ARQException;
@@ -416,6 +418,26 @@ public class Context {
 
     public static void setCurrentDateTime(Context context) {
         context.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime());
+    }
+
+    public static AtomicBoolean getCancelSignal(Context context) {
+        if ( context == null )
+            return null;
+        try {
+            return context.get(ARQConstants.symCancelQuery);
+        } catch (ClassCastException ex) {
+            Log.error(Context.class, "Class cast exception: Expected AtomicBoolean for cancel control: "+ex.getMessage());
+            return null;
+        }
+    }
+
+    public static AtomicBoolean getOrSetCancelSignal(Context context) {
+        AtomicBoolean cancelSignal = getCancelSignal(context);
+        if (cancelSignal == null) {
+            cancelSignal = new AtomicBoolean(false);
+            context.set(ARQConstants.symCancelQuery, cancelSignal);
+        }
+        return cancelSignal;
     }
 
     /** Merge an outer (defaults to the system global context)

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionBuilder.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.update;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.sparql.util.Context;
@@ -46,6 +48,10 @@ public interface UpdateExecutionBuilder {
     public UpdateExecutionBuilder substitution(QuerySolution querySolution);
 
     public UpdateExecutionBuilder substitution(String varName, RDFNode value);
+
+    public UpdateExecutionBuilder timeout(long value, TimeUnit timeUnit);
+
+    public default UpdateExecutionBuilder timeout(long value) { return timeout(value, TimeUnit.MILLISECONDS); }
 
     public UpdateExecution build();
 

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionDatasetBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateExecutionDatasetBuilder.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.update;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.QueryExecution;
@@ -128,6 +130,12 @@ public class UpdateExecutionDatasetBuilder implements UpdateExecutionBuilder {
         Var var = Var.alloc(varName);
         Node val = value.asNode();
         builder.substitution(var, val);
+        return this;
+    }
+
+    @Override
+    public UpdateExecutionBuilder timeout(long value, TimeUnit timeUnit) {
+        builder.timeout(value, timeUnit);
         return this;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateProcessor.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateProcessor.java
@@ -18,6 +18,8 @@
 
 package org.apache.jena.update;
 
+import org.apache.jena.sparql.util.Context;
+
 /**
  * An instance of a execution of an UpdateRequest.
  * Applies to UpdateExec (GPI) and UpdateExecution (API).
@@ -26,4 +28,10 @@ public interface UpdateProcessor
 {
     /** Execute */
     public void execute() ;
+
+    /** Attempt to asynchronously abort an update execution. */
+    public default void abort() { }
+
+    /** Returns the processor's context. Null if there is none. */
+    public default Context getContext() { return null ; }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestTimeouts.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestTimeouts.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.api;
+
+import org.apache.jena.sparql.engine.Timeouts;
+import org.apache.jena.sparql.engine.Timeouts.Timeout;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTimeouts {
+    @Test
+    public void testUnset() {
+        Timeout timeout = roundtrip(Timeout.UNSET);
+        String str = Timeouts.toString(timeout);
+        Assert.assertNull(str);
+    }
+
+    @Test
+    public void testInitialTimeout() {
+        Timeout timeout = roundtrip(new Timeout(6, -1));
+        String str = Timeouts.toString(timeout);
+        Assert.assertEquals("6,-1", str);
+    }
+
+    @Test
+    public void testOverallTimeout() {
+        Timeout timeout = roundtrip(new Timeout(-1, 6));
+        String str = Timeouts.toString(timeout);
+        Assert.assertEquals("6", str);
+    }
+
+    @Test
+    public void testInitialAndOverallTimeout() {
+        Timeout timeout = roundtrip(new Timeout(6, 6));
+        String str = Timeouts.toString(timeout);
+        Assert.assertEquals("6,6", str);
+    }
+
+    public static Timeout roundtrip(Timeout timeout) {
+        Object obj = Timeouts.toContextValue(timeout);
+        Timeout result = Timeouts.parseTimeout(obj);
+        Assert.assertEquals(timeout, result);
+        return result;
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestUpdateExecutionCancel.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestUpdateExecutionCancel.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.api;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.query.ARQ;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.QueryCancelledException;
+import org.apache.jena.sparql.ARQConstants;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.exec.UpdateExec;
+import org.apache.jena.sparql.exec.UpdateExecBuilder;
+import org.apache.jena.sparql.function.FunctionRegistry;
+import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sparql.util.Symbol;
+import org.apache.jena.update.UpdateExecutionFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateProcessor;
+import org.apache.jena.update.UpdateRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestUpdateExecutionCancel {
+
+    /** Set cancel signal function via {@link UpdateExecBuilder#set(Symbol, Object)}. */
+    @Test
+    public void test_cancel_signal_1() {
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        FunctionRegistry fnReg = TestQueryExecutionCancel.registerCancelSignalFunction(new FunctionRegistry());
+        UpdateExec ue = UpdateExec.dataset(dsg)
+                .update("INSERT { <s> <p> ?o } WHERE { BIND(<urn:cancelSignal>() AS ?o) }")
+                .set(ARQConstants.registryFunctions, fnReg)
+                .build();
+        ue.execute();
+        Assert.assertEquals(1, Iter.count(dsg.find()));
+    }
+
+    /** Set cancel signal function via {@link UpdateExecBuilder#context(Context)}. */
+    @Test
+    public void test_cancel_signal_2() {
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        Context cxt = ARQ.getContext().copy();
+        FunctionRegistry fnReg = TestQueryExecutionCancel.registerCancelSignalFunction(new FunctionRegistry());
+        FunctionRegistry.set(cxt, fnReg);
+        UpdateExec ue = UpdateExec.dataset(dsg)
+                .update("INSERT { <s> <p> ?o } WHERE { BIND(<urn:cancelSignal>() AS ?o) }")
+                .context(cxt)
+                .build();
+        ue.execute();
+        Assert.assertEquals(1, Iter.count(dsg.find()));
+    }
+
+    /** Set cancel signal function via {@link UpdateExec#getContext()}. */
+    @Test
+    public void test_cancel_signal_3() {
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        UpdateExec ue = UpdateExec.dataset(dsg)
+                .update("INSERT { <s> <p> ?o } WHERE { BIND(<urn:cancelSignal>() AS ?o) }")
+                .build();
+        Context cxt = ue.getContext();
+        FunctionRegistry fnReg = TestQueryExecutionCancel.registerCancelSignalFunction(new FunctionRegistry());
+        FunctionRegistry.set(cxt, fnReg);
+        ue.execute();
+        Assert.assertEquals(1, Iter.count(dsg.find()));
+    }
+
+    @Test(expected = QueryCancelledException.class, timeout = 5000)
+    public void test_update_cancel_1() {
+        Graph graph = TestQueryExecutionCancel.createTestGraph();
+        // Create an insert whose WHERE clause creates 3 cross joins a 1000 triples/bindings.
+        // This would result in one billion result rows.
+        UpdateExec
+            .dataset(graph)
+            // No-op delete followed by insert indirectly tests that timeout is applied to overall update request.
+            .update("DELETE { <s> <p> <o> } WHERE { ?a ?b ?c } ; INSERT { <s> <p> <o> } WHERE { ?a ?b ?c . ?d ?e ?f . ?g ?h ?i . }")
+            .timeout(50, TimeUnit.MILLISECONDS)
+            .build()
+            .execute();
+    }
+
+    /** Test that creates iterators over a billion result rows and attempts to cancel them.
+     *  If this test hangs then it is likely that something went wrong in the cancellation machinery. */
+    @Test(timeout = 10000)
+    public void test_cancel_concurrent_1() {
+        int maxCancelDelayInMillis = 100;
+
+        int cpuCount = Runtime.getRuntime().availableProcessors();
+        // Spend at most roughly 1 second per cpu (10 tasks a max 100ms)
+        int taskCount = cpuCount * 10;
+
+        // Create a model with 1000 triples
+        Dataset dataset = DatasetFactory.wrap(DatasetGraphFactory.wrap(TestQueryExecutionCancel.createTestGraph()));
+
+        // Create a query that creates 3 cross joins - resulting in one billion result rows
+        UpdateRequest updateRequest = UpdateFactory.create("INSERT { <s> <p> <o> } WHERE { ?a ?b ?c . ?d ?e ?f . ?g ?h ?i . }");
+        Callable<UpdateProcessor> qeFactory = () -> UpdateExecutionFactory.create(updateRequest, dataset);
+
+        runConcurrentAbort(taskCount, maxCancelDelayInMillis, qeFactory);
+    }
+
+    /** Reusable method that creates a parallel stream that starts query executions
+     *  and schedules cancel tasks on a separate thread pool. */
+    public static void runConcurrentAbort(int taskCount, int maxCancelDelay, Callable<UpdateProcessor> upFactory) {
+        Random cancelDelayRandom = new Random();
+        ExecutorService executorService = Executors.newCachedThreadPool();
+        try {
+            List<Integer> list = IntStream.range(0, taskCount).boxed().collect(Collectors.toList());
+            list
+                .parallelStream()
+                .forEach(i -> {
+                    UpdateProcessor up;
+                    try {
+                        up = upFactory.call();
+                    } catch (Exception e) {
+                        throw new RuntimeException("Failed to build a query execution", e);
+                    }
+                    Future<?> future = executorService.submit(() -> up.execute());
+                    int delayToAbort = cancelDelayRandom.nextInt(maxCancelDelay);
+                    try {
+                        Thread.sleep(delayToAbort);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    // System.out.println("Abort: " + qe);
+                    up.abort();
+                    try {
+                        // System.out.println("Waiting for: " + qe);
+                        future.get();
+                    } catch (ExecutionException e) {
+                        Throwable cause = e.getCause();
+                        if (!(cause instanceof QueryCancelledException)) {
+                            // Unexpected exception - print out the stack trace
+                            e.printStackTrace();
+                        }
+                        Assert.assertEquals(QueryCancelledException.class, cause.getClass());
+                    } catch (InterruptedException e) {
+                        // Ignored
+                    } finally {
+                        // System.out.println("Completed: " + qe);
+                    }
+                });
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+}

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestSPARQLProtocolTimeout.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestSPARQLProtocolTimeout.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.main;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.apache.jena.atlas.web.HttpException;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.exec.http.GSP;
+import org.apache.jena.sparql.graph.GraphFactory;
+import org.apache.jena.sparql.util.Convert;
+import org.apache.jena.update.UpdateExecution;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSPARQLProtocolTimeout extends AbstractFusekiTest
+{
+    @Before
+    public void before() {
+        Graph graph = createTestGraph();
+        GSP.service(serviceGSP()).defaultGraph().PUT(graph);
+    }
+
+    /** Create a model with 1000 triples. Same method as in {@link org.apache.jena.sparql.api.TestQueryExecutionCancel}. */
+    static Graph createTestGraph() {
+        Graph graph = GraphFactory.createDefaultGraph();
+        IntStream.range(0, 1000)
+            .mapToObj(i -> NodeFactory.createURI("http://www.example.org/r" + i))
+            .forEach(node -> graph.add(node, node, node));
+        return graph;
+    }
+
+    static String query(String base, String queryString) {
+        return base + "?query=" + Convert.encWWWForm(queryString);
+    }
+
+    /** If the HTTP client reaches its timeout and disconnects from the server then it is up
+     *  to the server whether it will cancel or complete the started SPARQL update execution. */
+    @Test(expected = HttpException.class)
+    public void update_timeout_01() {
+        UpdateExecution.service(serviceUpdate())
+            .update("INSERT { } WHERE { ?a ?b ?c . ?d ?e ?f . ?g ?h ?i . }")
+            .timeout(500, TimeUnit.MILLISECONDS)
+            .execute();
+    }
+}


### PR DESCRIPTION
GitHub issue resolved #2821

Pull request Description:
* Fixed inconsistent context handling in the update builder machinery and made it consistent with that in the query builder machinery.
* The context of update requests is now forwarded to the query execution
* `UpdateEngineWorker` sets the remaining query timeout if the newly introduced `ARQ.updateTimeout` has been set. Note, that it is possible to set an initial timeout via the `ARQ.updateTimeout` from which internally an `ARQ.queryTimeout` setting is derived: An update request would abort if the corresponding query execution timed out on the initial timeout - so only updates with a `WHERE` clause are affected.
* I did not add `initialTimeout` methods to the update exec builders because perhaps initial timeout on updates are a bit to specific for the general interface - opinions?
* Added `UpdateProcessor.getContext()` for consistency with `QueryExec`. This is for discussion.
* Added `UpdateProcessor.abort()` which can abort the underlying query execution if it is based on `QueryIterator`.
* Added test cases to the `TestUpdateExecutionCancel` class.
* For HTTP-based updates, the overall update timeout is forwarded to the existing HTTP machinery.
* There is now a class `TestSPARQLProtocolTimeout` which tests setting the timeout on the update builder.
* `QueryIteratorBase.requestingCancel` was updated to check the `Thread.interrupted()` so that when Fuseki gets shut down (e.g. during unit testing) then any threads still busy executing queries can cancel execution in a timely manner.


* Added query/update tests that register a local function that checks for the availability of the cancel signal. Please also see the [test cases](https://github.com/apache/jena/pull/2822/files#diff-6463c230248848118801cb3a1a78ab22f0f9103de53bd812c87e916d1bfc1805R240) which register the function that checks for the cancel signal in three ways for both queries and updates:

    1. via query/update builder.set
    2. via query/update builder.context
    3. via query/update exec.getContext()

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
