### PR TITLE
GH-2755: DatasetGraphText call operations in correct order

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionPrefixesR.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionPrefixesR.java
@@ -215,6 +215,5 @@ public class ActionPrefixesR extends ActionPrefixesBase {
         }
         action.commit();
         ServletOps.success(action);
-        action.endRead();
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionPrefixesRW.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionPrefixesRW.java
@@ -58,7 +58,7 @@ public class ActionPrefixesRW extends ActionPrefixesR {
             action.abortSilent();
             ServletOps.errorOccurred(ex);
         } finally {
-            action.end();
+            action.endWrite();
         }
     }
 
@@ -101,7 +101,7 @@ public class ActionPrefixesRW extends ActionPrefixesR {
                 ServletOps.errorOccurred(ex);
             }
         } finally {
-            action.end();
+            action.endWrite();
         }
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQLQueryProcessor.java
@@ -283,14 +283,20 @@ public abstract class SPARQLQueryProcessor extends ActionService
             }
         }
         catch (QueryParseException ex) {
+            abortSilent(action);
             // Late stage static error (e.g. bad fixed Lucene query string).
             ServletOps.errorBadRequest("Query parse error: \n" + queryString + "\n" + SPARQLProtocol.messageForException(ex));
         }
         catch (QueryCancelledException ex) {
+            abortSilent(action);
             // Additional counter information.
             incCounter(action.getEndpoint().getCounters(), QueryTimeouts);
             throw ex;
         } finally { action.endRead(); }
+    }
+
+    private static void abortSilent(HttpAction action) {
+        action.abortSilent();
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/GraphLoadUtils.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/GraphLoadUtils.java
@@ -22,8 +22,6 @@ package org.apache.jena.fuseki.system;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFParser;
 import org.apache.jena.riot.system.StreamRDF;
 import org.apache.jena.riot.system.StreamRDFLib;
@@ -32,19 +30,6 @@ import org.apache.jena.riot.system.StreamRDFLib;
 
 public class GraphLoadUtils
 {
-    // ---- Model level
-
-    public static Model readModel(String uri, int limit) {
-        Graph g = GraphMemFactory.createDefaultGraphSameTerm();
-        readUtil(g, uri, limit);
-        return ModelFactory.createModelForGraph(g);
-    }
-
-    public static void loadModel(Model model, String uri, int limit) {
-        Graph g = model.getGraph();
-        readUtil(g, uri, limit);
-    }
-
     // ---- Graph level
 
     public static Graph readGraph(String uri, int limit) {

--- a/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/DatasetGraphText.java
@@ -255,14 +255,22 @@ public class DatasetGraphText extends DatasetGraphTextMonitor implements Transac
             super.end();
             return;
         }
-        if ( readWriteMode.get() == ReadWrite.WRITE ) {
-            // If we are still in a write transaction at this point, then commit
-            // was never called, so rollback the TextIndex and the dataset.
-            abortAction.run();
+        ReadWrite rwMode = readWriteMode.get();
+        switch(rwMode) {
+            case READ ->{
+                super.getMonitor().finish();
+                super.end();
+                readWriteMode.set(null);
+            }
+            case WRITE ->{
+                // If we are still in a write transaction at this point, then commit
+                // was never called, so rollback the TextIndex and the dataset.
+                super.getMonitor().finish();
+                abortAction.run();
+                super.end();
+                readWriteMode.set(null);
+            }
         }
-        super.end();
-        super.getMonitor().finish();
-        readWriteMode.set(null);
     }
 
     @Override

--- a/jena-text/src/main/java/org/apache/jena/query/text/changes/DatasetGraphTextMonitor.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/changes/DatasetGraphTextMonitor.java
@@ -16,192 +16,186 @@
  * limitations under the License.
  */
 
-package org.apache.jena.query.text.changes ;
+package org.apache.jena.query.text.changes;
 
-import static org.apache.jena.atlas.iterator.Iter.take ;
+import static org.apache.jena.atlas.iterator.Iter.take;
 import static org.apache.jena.sparql.core.GraphView.createDefaultGraph;
 import static org.apache.jena.sparql.core.GraphView.createNamedGraph;
 
-import java.util.Iterator ;
-import java.util.List ;
+import java.util.Iterator;
+import java.util.List;
 
-import org.apache.jena.graph.Graph ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.sparql.SystemARQ ;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.SystemARQ;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphWrapper;
 import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.util.iterator.ExtendedIterator ;
+import org.apache.jena.util.iterator.ExtendedIterator;
 
-/** Connect a DatasetGraph to a DatasetChanges monitor.
- *  Any add or delete to the DatasetGraph is notified to the
- *  monitoring object with a {@link TextQuadAction} to indicate
- *  the change made.
+/**
+ * Connect a DatasetGraph to a DatasetChanges monitor. Any add or delete to the
+ * DatasetGraph is notified to the monitoring object with a {@link TextQuadAction} to
+ * indicate the change made.
  */
-public class DatasetGraphTextMonitor extends DatasetGraphWrapper
-{
-    /** Whether to see if a quad action will change the dataset - test before add for existence, test before delete for absence */
-    private boolean CheckFirst = true ;
+public class DatasetGraphTextMonitor extends DatasetGraphWrapper {
+    /**
+     * Whether to see if a quad action will change the dataset - test before add for
+     * existence, test before delete for absence
+     */
+    private boolean CheckFirst = true;
     /** Whether to record a no-op (maybe as a comment) */
-    private boolean RecordNoAction = true ;
+    private boolean RecordNoAction = true;
     /** Where to send the notifications */
-    private final TextDatasetChanges monitor ;
+    private final TextDatasetChanges monitor;
 
     /**
-     * Create a DatasetGraph wrapper that monitors the dataset for changes (add or delete quads).
-     * Use this DatasetGraph for all operations in order to record changes.
-     * Note whether additions of deletions cause an actual change to the dataset or not.
-     * @param dsg       The DatasetGraph to monitor
-     * @param monitor   The handler for a change
+     * Create a DatasetGraph wrapper that monitors the dataset for changes (add or
+     * delete quads). Use this DatasetGraph for all operations in order to record
+     * changes. Note whether additions of deletions cause an actual change to the
+     * dataset or not.
      *
+     * @param dsg The DatasetGraph to monitor
+     * @param monitor The handler for a change
      * @see TextDatasetChanges
      * @see TextQuadAction
      */
-    public DatasetGraphTextMonitor(DatasetGraph dsg, TextDatasetChanges monitor)
-    {
-        super(dsg) ;
-        this.monitor = monitor ;
+    public DatasetGraphTextMonitor(DatasetGraph dsg, TextDatasetChanges monitor) {
+        super(dsg);
+        this.monitor = monitor;
     }
 
     /**
-     * Create a DatasetGraph wrapper that monitors the dataset for changes (add or delete quads).
-     * Use this DatasetGraph for all operations in order to record changes.
-     * @param dsg       The DatasetGraph to monitor
-     * @param monitor   The handler for a change
-     * @param recordOnlyIfRealChange
-     *         If true, check to see if the change would have an effect (e.g. add is a new quad).
-     *         If false, log changes as ADD/DELETE regardless of whether the dataset actually changes.
+     * Create a DatasetGraph wrapper that monitors the dataset for changes (add or
+     * delete quads). Use this DatasetGraph for all operations in order to record
+     * changes.
      *
+     * @param dsg The DatasetGraph to monitor
+     * @param monitor The handler for a change
+     * @param recordOnlyIfRealChange If true, check to see if the change would have
+     *     an effect (e.g. add is a new quad). If false, log changes as ADD/DELETE
+     *     regardless of whether the dataset actually changes.
      * @see TextDatasetChanges
      * @see TextQuadAction
      */
-    public DatasetGraphTextMonitor(DatasetGraph dsg, TextDatasetChanges monitor, boolean recordOnlyIfRealChange)
-    {
-        super(dsg) ;
-        CheckFirst = recordOnlyIfRealChange ;
-        this.monitor = monitor ;
+    public DatasetGraphTextMonitor(DatasetGraph dsg, TextDatasetChanges monitor, boolean recordOnlyIfRealChange) {
+        super(dsg);
+        CheckFirst = recordOnlyIfRealChange;
+        this.monitor = monitor;
     }
 
     /** Return the monitor */
-    public TextDatasetChanges getMonitor()      { return monitor ; }
+    public TextDatasetChanges getMonitor() {
+        return monitor;
+    }
 
     /** Return the monitored DatasetGraph */
-    public DatasetGraph   monitored()       { return getWrapped() ; }
-
-    @Override public void add(Quad quad)
-    {
-        if ( CheckFirst && contains(quad) )
-        {
-            if ( RecordNoAction )
-                record(TextQuadAction.NO_ADD, quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject()) ;
-            return ;
-        }
-        add$(quad) ;
+    public DatasetGraph monitored() {
+        return getWrapped();
     }
-
-    @Override public void add(Node g, Node s, Node p, Node o)
-    {
-        if ( CheckFirst && contains(g,s,p,o) )
-        {
-            if ( RecordNoAction )
-                record(TextQuadAction.NO_ADD,g,s,p,o) ;
-            return ;
-        }
-
-        add$(g,s,p,o) ;
-    }
-
-    private void add$(Node g, Node s, Node p, Node o)
-    {
-        super.add(g,s,p,o) ;
-        record(TextQuadAction.ADD,g,s,p,o) ;
-    }
-
-    private void add$(Quad quad)
-    {
-        super.add(quad) ;
-        record(TextQuadAction.ADD, quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject()) ;
-    }
-
-    @Override public void delete(Quad quad)
-    {
-        if ( CheckFirst && ! contains(quad) )
-        {
-            if ( RecordNoAction )
-                record(TextQuadAction.NO_DELETE, quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject()) ;
-            return ;
-        }
-        delete$(quad) ;
-    }
-
-    @Override public void delete(Node g, Node s, Node p, Node o)
-    {
-        if ( CheckFirst && ! contains(g,s,p,o) )
-        {
-            if ( RecordNoAction )
-                record(TextQuadAction.NO_DELETE, g,s,p,o) ;
-            return ;
-        }
-        delete$(g,s,p,o) ;
-    }
-
-    private void delete$(Quad quad)
-    {
-        super.delete(quad) ;
-        record(TextQuadAction.DELETE, quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject()) ;
-    }
-
-    private void delete$(Node g, Node s, Node p, Node o)
-    {
-        super.delete(g,s,p,o) ;
-        record(TextQuadAction.DELETE,g,s,p,o) ;
-    }
-
-
-    private static int SLICE = 1000 ;
 
     @Override
-    public void deleteAny(Node g, Node s, Node p, Node o)
-    {
-        while (true)
-        {
-            Iterator<Quad> iter = find(g, s, p, o) ;
+    public void add(Quad quad) {
+        if ( CheckFirst && contains(quad) ) {
+            if ( RecordNoAction )
+                record(TextQuadAction.NO_ADD, quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject());
+            return;
+        }
+        add$(quad);
+    }
+
+    @Override
+    public void add(Node g, Node s, Node p, Node o) {
+        if ( CheckFirst && contains(g, s, p, o) ) {
+            if ( RecordNoAction )
+                record(TextQuadAction.NO_ADD, g, s, p, o);
+            return;
+        }
+
+        add$(g, s, p, o);
+    }
+
+    private void add$(Node g, Node s, Node p, Node o) {
+        super.add(g, s, p, o);
+        record(TextQuadAction.ADD, g, s, p, o);
+    }
+
+    private void add$(Quad quad) {
+        super.add(quad);
+        record(TextQuadAction.ADD, quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject());
+    }
+
+    @Override
+    public void delete(Quad quad) {
+        if ( CheckFirst && !contains(quad) ) {
+            if ( RecordNoAction )
+                record(TextQuadAction.NO_DELETE, quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject());
+            return;
+        }
+        delete$(quad);
+    }
+
+    @Override
+    public void delete(Node g, Node s, Node p, Node o) {
+        if ( CheckFirst && !contains(g, s, p, o) ) {
+            if ( RecordNoAction )
+                record(TextQuadAction.NO_DELETE, g, s, p, o);
+            return;
+        }
+        delete$(g, s, p, o);
+    }
+
+    private void delete$(Quad quad) {
+        super.delete(quad);
+        record(TextQuadAction.DELETE, quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject());
+    }
+
+    private void delete$(Node g, Node s, Node p, Node o) {
+        super.delete(g, s, p, o);
+        record(TextQuadAction.DELETE, g, s, p, o);
+    }
+
+    private static int SLICE = 1000;
+
+    @Override
+    public void deleteAny(Node g, Node s, Node p, Node o) {
+        while (true) {
+            Iterator<Quad> iter = find(g, s, p, o);
             // Materialize - stops possible ConcurrentModificationExceptions
-            List<Quad> some = take(iter, SLICE) ;
-            for (Quad q : some)
-                delete$(q) ;
-            if (some.size() < SLICE) break ;
+            List<Quad> some = take(iter, SLICE);
+            for ( Quad q : some )
+                delete$(q);
+            if ( some.size() < SLICE )
+                break;
         }
     }
 
-    @Override public void addGraph(Node gn, Graph g)
-    {
+    @Override
+    public void addGraph(Node gn, Graph g) {
         // Convert to quads.
-        //super.addGraph(gn, g) ;
-        ExtendedIterator<Triple> iter = g.find(Node.ANY, Node.ANY, Node.ANY) ;
-        for ( ; iter.hasNext(); )
-        {
-            Triple t = iter.next() ;
-            add(gn, t.getSubject(), t.getPredicate(), t.getObject()) ;
+        // super.addGraph(gn, g) ;
+        ExtendedIterator<Triple> iter = g.find(Node.ANY, Node.ANY, Node.ANY);
+        for ( ; iter.hasNext() ; ) {
+            Triple t = iter.next();
+            add(gn, t.getSubject(), t.getPredicate(), t.getObject());
         }
     }
 
-    @Override public void removeGraph(Node gn)
-    {
-        //super.removeGraph(gn) ;
-        deleteAny(gn, Node.ANY, Node.ANY, Node.ANY) ;
+    @Override
+    public void removeGraph(Node gn) {
+        // super.removeGraph(gn) ;
+        deleteAny(gn, Node.ANY, Node.ANY, Node.ANY);
     }
 
-    private void record(TextQuadAction action, Node g, Node s, Node p, Node o)
-    {
-        monitor.change(action, g, s, p, o) ;
+    private void record(TextQuadAction action, Node g, Node s, Node p, Node o) {
+        monitor.change(action, g, s, p, o);
     }
 
     @Override
     public void sync() {
-        SystemARQ.syncObject(monitor) ;
-        super.sync() ;
+        SystemARQ.syncObject(monitor);
+        super.sync();
     }
 
     @Override
@@ -214,4 +208,3 @@ public class DatasetGraphTextMonitor extends DatasetGraphWrapper
         return createNamedGraph(this, graphNode);
     }
 }
-


### PR DESCRIPTION
I've done a code review and testing for the report #2755. I haven't been able to reproduced the situation. 

In a code review, I did find one weak area of DatasetGraphText where it was not following the correct code pattern but I can't get it to reproduce the report. This is commit c7f61a3ef1 "DatasetGraphText call operations in correct order".

The other changes are rewrite for clarity and general clean-up because of reviewing many areas.

----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
