### PR TITLE
Profile to skip UI tests

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/pom.xml
+++ b/jena-fuseki2/jena-fuseki-ui/pom.xml
@@ -32,7 +32,26 @@
         <node.version>v20.11.0</node.version>
         <yarn.version>v1.22.17</yarn.version>
         <automatic.module.name>org.apache.jena.fuseki.ui</automatic.module.name>
+
+        <!-- 
+             Allow for skipping the tests.
+             The test frameworks need various software compoents to 
+             be available on the host running maven. This isn't always 
+             practical. This property allows the UI to be built on such machines
+             by skipping the tests.
+             It is set "true" by profile "ui-skip-tests"
+        -->
+        <skip.ui.tests>false</skip.ui.tests>
+
     </properties>
+    <profiles>
+      <profile>
+        <id>ui-skip-tests</id>
+        <properties>
+          <skip.ui.tests>true</skip.ui.tests>
+        </properties>
+    </profile>
+    </profiles>
 
     <build>
         <plugins>
@@ -98,6 +117,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <skip>${skip.ui.tests}</skip>
                             <arguments>run test:unit</arguments>
                         </configuration>
                     </execution>
@@ -108,7 +128,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
-                            <testFailureIgnore>false</testFailureIgnore>
+                            <skip>${skip.ui.tests}</skip>
                             <environmentVariables>
                                 <PORT>${org.apache.jena.fuseki.ui.port}</PORT>
                                 <FUSEKI_PORT>${org.apache.jena.fuseki.port}</FUSEKI_PORT>


### PR DESCRIPTION
This adds a profile that skips the UI tests.

Currently, the build fails on ASF Jenkins because many AFS Jenkins host nodes are older LTS Ubuntu and don't have the necessary dependencies installed + some dependencies also need updated system libraries.

I haven't made progress on a containerized build. 

The advantage of the ASF builds is that that have all the Java versions. There are changes  in the java world where it would be good to have builds running on the latest (non-LTS) java.

A hopefully temporary profile that builds the UI but does not run the tests would help keeping the development snapshot current and give builds using latest Java.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
