### PR TITLE
Javadoc fixes

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/mem/SparseArraySpliterator.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/SparseArraySpliterator.java
@@ -153,48 +153,46 @@ public class SparseArraySpliterator<E> implements Spliterator<E> {
     }
 
     /**
-     * Returns an estimate of the number of elements that would be
-     * encountered by a {@link #forEachRemaining} traversal, or returns {@link
-     * Long#MAX_VALUE} if infinite, unknown, or too expensive to compute.
+     * Returns an estimate of the number of elements that would be encountered by a
+     * {@link #forEachRemaining} traversal, or returns {@link Long#MAX_VALUE} if
+     * infinite, unknown, or too expensive to compute.
+     * <p>
+     * If this Spliterator is {@link #SIZED} and has not yet been partially traversed
+     * or split, or this Spliterator is {@link #SUBSIZED} and has not yet been
+     * partially traversed, this estimate must be an accurate count of elements that
+     * would be encountered by a complete traversal. Otherwise, this estimate may be
+     * arbitrarily inaccurate, but must decrease as specified across invocations of
+     * {@link #trySplit}.
      *
-     * <p>If this Spliterator is {@link #SIZED} and has not yet been partially
-     * traversed or split, or this Spliterator is {@link #SUBSIZED} and has
-     * not yet been partially traversed, this estimate must be an accurate
-     * count of elements that would be encountered by a complete traversal.
-     * Otherwise, this estimate may be arbitrarily inaccurate, but must decrease
-     * as specified across invocations of {@link #trySplit}.
-     *
-     * @return the estimated size, or {@code Long.MAX_VALUE} if infinite,
-     * unknown, or too expensive to compute.
+     * @return the estimated size, or {@code Long.MAX_VALUE} if infinite, unknown, or
+     *     too expensive to compute.
      * @apiNote Even an inexact estimate is often useful and inexpensive to compute.
-     * For example, a sub-spliterator of an approximately balanced binary tree
-     * may return a value that estimates the number of elements to be half of
-     * that of its parent; if the root Spliterator does not maintain an
-     * accurate count, it could estimate size to be the power of two
-     * corresponding to its maximum depth.
+     *     For example, a sub-spliterator of an approximately balanced binary tree
+     *     may return a value that estimates the number of elements to be half of
+     *     that of its parent; if the root Spliterator does not maintain an accurate
+     *     count, it could estimate size to be the power of two corresponding to its
+     *     maximum depth.
      */
     @Override
     public long estimateSize() { return ((long) (this.fillRatio  * pos)) + 1L; }
 
     /**
-     * Returns a set of characteristics of this Spliterator and its
-     * elements. The result is represented as ORed values from {@link
-     * #ORDERED}, {@link #DISTINCT}, {@link #SORTED}, {@link #SIZED},
-     * {@link #NONNULL}, {@link #IMMUTABLE}, {@link #CONCURRENT},
-     * {@link #SUBSIZED}.  Repeated calls to {@code characteristics()} on
-     * a given spliterator, prior to or in-between calls to {@code trySplit},
-     * should always return the same result.
-     *
-     * <p>If a Spliterator reports an inconsistent set of
-     * characteristics (either those returned from a single invocation
-     * or across multiple invocations), no guarantees can be made
-     * about any computation using this Spliterator.
+     * Returns a set of characteristics of this Spliterator and its elements. The
+     * result is represented as ORed values from {@link #ORDERED}, {@link #DISTINCT},
+     * {@link #SORTED}, {@link #SIZED}, {@link #NONNULL}, {@link #IMMUTABLE},
+     * {@link #CONCURRENT}, {@link #SUBSIZED}. Repeated calls to
+     * {@code characteristics()} on a given spliterator, prior to or in-between calls
+     * to {@code trySplit}, should always return the same result.
+     * <p>
+     * If a Spliterator reports an inconsistent set of characteristics (either those
+     * returned from a single invocation or across multiple invocations), no
+     * guarantees can be made about any computation using this Spliterator.
      *
      * @return a representation of characteristics
-     * @apiNote The characteristics of a given spliterator before splitting
-     * may differ from the characteristics after splitting.  For specific
-     * examples see the characteristic values {@link #SIZED}, {@link #SUBSIZED}
-     * and {@link #CONCURRENT}.
+     * @apiNote The characteristics of a given spliterator before splitting may
+     *     differ from the characteristics after splitting. For specific examples see
+     *     the characteristic values {@link #SIZED}, {@link #SUBSIZED} and
+     *     {@link #CONCURRENT}.
      */
     @Override
     public int characteristics() {

--- a/jena-core/src/main/java/org/apache/jena/mem/SparseArraySubSpliterator.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/SparseArraySubSpliterator.java
@@ -169,49 +169,47 @@ public class SparseArraySubSpliterator<E> implements Spliterator<E> {
     }
 
     /**
-     * Returns an estimate of the number of elements that would be
-     * encountered by a {@link #forEachRemaining} traversal, or returns {@link
-     * Long#MAX_VALUE} if infinite, unknown, or too expensive to compute.
+     * Returns an estimate of the number of elements that would be encountered by a
+     * {@link #forEachRemaining} traversal, or returns {@link Long#MAX_VALUE} if
+     * infinite, unknown, or too expensive to compute.
+     * <p>
+     * If this Spliterator is {@link #SIZED} and has not yet been partially traversed
+     * or split, or this Spliterator is {@link #SUBSIZED} and has not yet been
+     * partially traversed, this estimate must be an accurate count of elements that
+     * would be encountered by a complete traversal. Otherwise, this estimate may be
+     * arbitrarily inaccurate, but must decrease as specified across invocations of
+     * {@link #trySplit}.
      *
-     * <p>If this Spliterator is {@link #SIZED} and has not yet been partially
-     * traversed or split, or this Spliterator is {@link #SUBSIZED} and has
-     * not yet been partially traversed, this estimate must be an accurate
-     * count of elements that would be encountered by a complete traversal.
-     * Otherwise, this estimate may be arbitrarily inaccurate, but must decrease
-     * as specified across invocations of {@link #trySplit}.
-     *
-     * @return the estimated size, or {@code Long.MAX_VALUE} if infinite,
-     * unknown, or too expensive to compute.
+     * @return the estimated size, or {@code Long.MAX_VALUE} if infinite, unknown, or
+     *     too expensive to compute.
      * @apiNote Even an inexact estimate is often useful and inexpensive to compute.
-     * For example, a sub-spliterator of an approximately balanced binary tree
-     * may return a value that estimates the number of elements to be half of
-     * that of its parent; if the root Spliterator does not maintain an
-     * accurate count, it could estimate size to be the power of two
-     * corresponding to its maximum depth.
+     *     For example, a sub-spliterator of an approximately balanced binary tree
+     *     may return a value that estimates the number of elements to be half of
+     *     that of its parent; if the root Spliterator does not maintain an accurate
+     *     count, it could estimate size to be the power of two corresponding to its
+     *     maximum depth.
      */
     @Override
     public long estimateSize() { return ((long) (fillRatio * (pos - fromIndex))) + 1L; }
 
 
     /**
-     * Returns a set of characteristics of this Spliterator and its
-     * elements. The result is represented as ORed values from {@link
-     * #ORDERED}, {@link #DISTINCT}, {@link #SORTED}, {@link #SIZED},
-     * {@link #NONNULL}, {@link #IMMUTABLE}, {@link #CONCURRENT},
-     * {@link #SUBSIZED}.  Repeated calls to {@code characteristics()} on
-     * a given spliterator, prior to or in-between calls to {@code trySplit},
-     * should always return the same result.
-     *
-     * <p>If a Spliterator reports an inconsistent set of
-     * characteristics (either those returned from a single invocation
-     * or across multiple invocations), no guarantees can be made
-     * about any computation using this Spliterator.
+     * Returns a set of characteristics of this Spliterator and its elements. The
+     * result is represented as ORed values from {@link #ORDERED}, {@link #DISTINCT},
+     * {@link #SORTED}, {@link #SIZED}, {@link #NONNULL}, {@link #IMMUTABLE},
+     * {@link #CONCURRENT}, {@link #SUBSIZED}. Repeated calls to
+     * {@code characteristics()} on a given spliterator, prior to or in-between calls
+     * to {@code trySplit}, should always return the same result.
+     * <p>
+     * If a Spliterator reports an inconsistent set of characteristics (either those
+     * returned from a single invocation or across multiple invocations), no
+     * guarantees can be made about any computation using this Spliterator.
      *
      * @return a representation of characteristics
-     * @apiNote The characteristics of a given spliterator before splitting
-     * may differ from the characteristics after splitting.  For specific
-     * examples see the characteristic values {@link #SIZED}, {@link #SUBSIZED}
-     * and {@link #CONCURRENT}.
+     * @apiNote The characteristics of a given spliterator before splitting may
+     *     differ from the characteristics after splitting. For specific examples see
+     *     the characteristic values {@link #SIZED}, {@link #SUBSIZED} and
+     *     {@link #CONCURRENT}.
      */
     @Override
     public int characteristics() {

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/RDFList.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/RDFList.java
@@ -192,8 +192,8 @@ public interface RDFList
     /**
      * <p>
      * Replace the value at the i'th position in the list with the given value.
-     * If the list is too short to have an i'th element, throws a {@link
-     * ListIndexException}.
+     * If the list is too short to have an i'th element, throws
+     * a {@link ListIndexException}.
      * </p>
      *
      * @param i The index into the list, from 0
@@ -252,8 +252,8 @@ public interface RDFList
      * Answer a new list that is formed by adding each element of this list to
      * the head of the given <code>list</code>. This is a non side-effecting
      * operation on either this list or the given list, but generates a copy
-     * of this list.  For a more storage efficient alternative, see {@link
-     * #concatenate concatenate}.
+     * of this list.  For a more storage efficient alternative, see
+     * {@link #concatenate concatenate}.
      * </p>
      *
      * @param list The argument list
@@ -269,8 +269,8 @@ public interface RDFList
      * the head of the the list formed from the
      * given <code>nodes</code>. This is a non side-effecting
      * operation on either this list or the given list, but generates a copy
-     * of this list.  For a more storage efficient alternative, see {@link
-     * #concatenate concatenate}.
+     * of this list.  For a more storage efficient alternative,
+     * see {@link #concatenate concatenate}.
      * </p>
      *
      * @param nodes An iterator whose range is RDFNode
@@ -407,8 +407,8 @@ public interface RDFList
      * Answer an iterator over the elements of the list. Note that this iterator
      * does not take a snapshot of the list, so changes to the list statements
      * in the model while iterating will affect the behaviour of the iterator.
-     * To get an iterator that is not affected by model changes, use {@link
-     * #asJavaList}.
+     * To get an iterator that is not affected by model changes,
+     * use {@link #asJavaList}.
      * </p>
      *
      * @return A closable iterator over the elements of the list.
@@ -470,8 +470,8 @@ public interface RDFList
      * <p>
      * Answer true if the list is well-formed, by checking that each node is
      * correctly typed, and has a head and tail pointer from the correct
-     * vocabulary. If the list is invalid, the reason is available via {@link
-     * #getValidityErrorMessage}.
+     * vocabulary. If the list is invalid, the reason is available
+     * via {@link #getValidityErrorMessage}.
      * </p>
      *
      * @return True if the list is well-formed.

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFListImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFListImpl.java
@@ -402,8 +402,8 @@ public class RDFListImpl
     /**
      * <p>
      * Replace the value at the i'th position in the list with the given value.
-     * If the list is too short to have an i'th element, throws a {@link
-     * ListIndexException}.
+     * If the list is too short to have an i'th element, throws
+     * a {@link ListIndexException}.
      * </p>
      *
      * @param i The index into the list, from 0
@@ -502,8 +502,8 @@ public class RDFListImpl
      * the head of the the list formed from the
      * given <code>nodes</code>. This is a non side-effecting
      * operation on either this list or the given list, but generates a copy
-     * of this list.  For a more storage efficient alternative, see {@link
-     * #concatenate concatenate}.
+     * of this list.  For a more storage efficient alternative,
+     * see {@link #concatenate concatenate}.
      * </p>
      *
      * @param nodes An iterator whose range is RDFNode
@@ -521,8 +521,8 @@ public class RDFListImpl
      * Answer a new list that is formed by adding each element of this list to
      * the head of the given <code>list</code>. This is a non side-effecting
      * operation on either this list or the given list, but generates a copy
-     * of this list.  For a more storage efficient alternative, see {@link
-     * #concatenate concatenate}.
+     * of this list.  For a more storage efficient alternative,
+     * see {@link #concatenate concatenate}.
      * </p>
      *
      * @param list The argument list
@@ -798,8 +798,8 @@ public class RDFListImpl
      * Answer an iterator over the elements of the list. Note that this iterator
      * does not take a snapshot of the list, so changes to the list statements
      * in the model while iterating will affect the behaviour of the iterator.
-     * To get an iterator that is not affected by model changes, use {@link
-     * #asJavaList}.
+     * To get an iterator that is not affected by model changes,
+     * use {@link #asJavaList}.
      * </p>
      *
      * @return A closable iterator over the elements of the list.

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput0/NTriple.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmlinput0/NTriple.java
@@ -83,7 +83,7 @@ import org.xml.sax.SAXParseException;
  * </dt><dd>
  * Ignores numbered error/warning conditions.
  * </dl>
- * @deprecate Legacy. To be removed.
+ * @deprecated Legacy. To be removed.
  */
 @Deprecated
 public class NTriple implements ARPErrorNumbers {

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/UpdateBuilder.java
@@ -262,7 +262,7 @@ public class UpdateBuilder {
      * @param p the predicate object
      * @param o the object object.
      * @return a TriplePath
-     * @deprecatd use {@link #makeTriplePaths(Object, Object, Object)}
+     * @deprecated use {@link #makeTriplePaths(Object, Object, Object)}
      */
     @Deprecated(since="5.0.0")
     public TriplePath makeTriplePath(Object s, Object p, Object o) {
@@ -272,7 +272,7 @@ public class UpdateBuilder {
         }
         return new TriplePath(Triple.create(makeNode(s), (Node) po, makeNode(o)));
     }
-   
+
     /**
      * Make a collection of one or more {@code TriplePath} objects from the objects.
      *
@@ -346,7 +346,7 @@ public class UpdateBuilder {
     private List<Triple> makeTriples(Object s, Object p, Object o) {
         return Converters.makeTriples(s, p, o, prefixHandler.getPrefixes());
     }
-    
+
     /**
      * Add a quad to the insert statement.
      *
@@ -900,7 +900,7 @@ public class UpdateBuilder {
         whereProcessor.addOptional(collection);
         return this;
     }
-    
+
     /**
      * Add the contents of a where handler as an optional statement.
      *
@@ -1015,7 +1015,7 @@ public class UpdateBuilder {
 
         return retval;
     }
-    
+
     /**
      * Create a list node from a list of objects as per RDF Collections.
      *

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/auth/Auth.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/auth/Auth.java
@@ -86,8 +86,8 @@ public class Auth {
      * Test whether a user (principal) is allowed by a authorization policy.
      * The policy can be null, meaning no restrictions, and the function returns true.
      * {@code user} maybe null, meaning unauthenticated and any policy must deal with this.
-     * @param user
-     * @param policy
+     * @param user User
+     * @param policy Policy
      * @return boolean True if the policy is null or allows the user.
      */
     public static boolean allow(String user, AuthPolicy policy) {
@@ -103,8 +103,8 @@ public class Auth {
      * Additional, return true/false - see {@link #allow(String, AuthPolicy)}.
      * The policy can be null, meaning no restrictions, and the function returns true.
      * {@code user} maybe null, meaning unauthenticated and any policy must deal with this.
-     * @param user
-     * @param policy
+     * @param user User
+     * @param policy Policy
      * @param notAllowed Runnable to execute if the policy does not allow the user.
      */
     public static boolean allow(String user, AuthPolicy policy, Runnable notAllowed) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
@@ -143,7 +143,6 @@ public class FusekiConfig {
     /** Get the allowed users on a resource.
      *  Returns null if the resource is null or if there were no settings.
      *
-     * @param resource
      * @return RequestAuthorization
      */
     public static AuthPolicy allowedUsers(Resource resource) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionExecLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionExecLib.java
@@ -49,7 +49,7 @@ public class ActionExecLib {
 
     /**
      * Returns a fresh HTTP Action for this request.
-     * @param dap
+     * @param dap DataAccessPoint
      * @param request HTTP request
      * @param response HTTP response
      * @return a new HTTP Action
@@ -82,9 +82,6 @@ public class ActionExecLib {
      * and {@link ServletProcessor} for administration actions.
      * <p>
      * Return false if the ActionProcessor is null.
-     *
-     * @param action
-     * @param processor
      */
     public static void execAction(HttpAction action, ActionProcessor processor) {
         boolean b = execAction(action, ()->processor);

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionLib.java
@@ -202,7 +202,7 @@ public class ActionLib {
      * Parse RDF content from the body of the request of the action, ends the
      * request, and sends a 400 if there is a parse error.
      *
-     * @throws ActionErrorException
+     * @throws ActionErrorException ActionErrorException
      */
     public static void parseOrError(HttpAction action, StreamRDF dest, Lang lang, String base) {
         try {
@@ -216,7 +216,7 @@ public class ActionLib {
     /**
      * Parse RDF content. This wraps up the parse step reading from an action.
      * It includes handling compression if the {@code Content-Encoding} header is present
-     * @throws RiotParseException
+     * @throws RiotParseException RiotParseException
      */
     public static void parse(HttpAction action, StreamRDF dest, Lang lang, String base) {
         try {
@@ -227,7 +227,7 @@ public class ActionLib {
 
     /**
      * Parse RDF content. This wraps up the parse step reading from an input stream.
-     * @throws RiotParseException
+     * @throws RiotParseException RiotParseException
      */
     public static void parse(HttpAction action, StreamRDF dest, InputStream input, Lang lang, String base) {
         try {
@@ -389,7 +389,7 @@ public class ActionLib {
 
     /**
      * Get the content type of an action.
-     * @param  action
+     * @param  action HttpAction
      * @return ContentType
      */
     public static ContentType getContentType(HttpAction action) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionServicePlaceholder.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionServicePlaceholder.java
@@ -22,7 +22,7 @@ import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.server.Endpoint;
 
 /**
- * A NoOp implementation of {@ActionService}.
+ * A NoOp implementation of {@link ActionService}.
  * <p>
  * This is only for use as a placeholder during configuration. It must be replaced in
  * an {@link Endpoint} during server building with another implementation.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
@@ -673,7 +673,6 @@ public class HttpAction
      * Get the request input stream, bypassing any compression.
      * The state of the input stream is unknown.
      * Only useful for skipping a body on a connection.
-     * @throws IOException
      */
     public InputStream getRequestInputStreamRaw() throws IOException {
         return request.getInputStream();

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryDataset.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/SPARQL_QueryDataset.java
@@ -43,9 +43,6 @@ public class SPARQL_QueryDataset extends SPARQLQueryProcessor {
      * Function to return the {@code Pair<DatasetGraph, Query>} based on processing any dataset description as {@link DynamicDatasets a dynamic dataset}.
      * The query is modified to remove any dataset description.
      *
-     * @param action
-     * @param query
-     * @param queryStringLog
      * @return Pair&lt;DatasetGraph, Query&gt;
      */
     public Pair<DatasetGraph, Query> decideDatasetDynamic(HttpAction action, Query query, String queryStringLog) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServletOps.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServletOps.java
@@ -50,10 +50,6 @@ public class ServletOps {
      *  Note that we do not set a custom Reason Phrase.
      *  <br/>
      *  HTTPS/2 does not have a "Reason Phrase".
-     *
-     * @param response
-     * @param statusCode
-     * @param message
      */
     public static void responseSendError(HttpServletResponse response, int statusCode, String message) {
         response.setStatus(statusCode);

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/prefixes/ActionProcPrefixes.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/prefixes/ActionProcPrefixes.java
@@ -19,10 +19,11 @@
 package org.apache.jena.fuseki.servlets.prefixes;
 
 import org.apache.jena.fuseki.servlets.ActionPrefixesRW;
+import org.apache.jena.fuseki.servlets.ActionREST;
 import org.apache.jena.fuseki.servlets.HttpAction;
 
 /**
- * An {@linkActionREST} that provides a all the HTTP services over a fixed {@link PrefixesAccess}.
+ * An {@link ActionREST} that provides a all the HTTP services over a fixed {@link PrefixesAccess}.
  * <p>
  * This is in support of testing.
  * Instead of taking the prefixes from the action, this classes uses a provided {@link PrefixesAccess}.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/DataUploader.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/DataUploader.java
@@ -62,7 +62,7 @@ public class DataUploader {
      * {@code multipart/mixed} (<a href="https://tools.ietf.org/html/rfc204">RFC 2046</a>) and
      * {@code multipart/form-data} (<a href="https://tools.ietf.org/html/rfc1867">RFC 1867</a>)
      * with a file part.
-     * @throws RiotParseException
+     * @throws RiotParseException RiotParseException
      */
     public static UploadDetails incomingData(HttpAction action, StreamRDF dest) {
         ContentType ct = ActionLib.getContentType(action);

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
@@ -116,8 +116,6 @@ public class FusekiLogging
 
     /**
      * Set up logging. Allow an extra location. This may be null.
-     *
-     * @param extraDir
      */
     public static synchronized void setLogging(Path extraDir) {
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiNetLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiNetLib.java
@@ -41,7 +41,7 @@ import org.apache.jena.sparql.util.Convert;
 public class FusekiNetLib {
     /**
      * Get the content type of an action or return the default.
-     * @param  request
+     * @param  request Request
      * @return ContentType
      */
     public static ContentType getContentType(HttpServletRequest request) {
@@ -53,7 +53,7 @@ public class FusekiNetLib {
 
     /**
      * Get the incoming {@link Lang} based on Content-Type of an action.
-     * @param  action
+     * @param  action HttpAction
      * @param  dft Default if no "Content-Type:" found.
      * @return ContentType
      */

--- a/jena-iri3986/pom.xml
+++ b/jena-iri3986/pom.xml
@@ -73,6 +73,12 @@
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
 
+     <plugin>
+       <groupId>org.apache.maven.plugins</groupId>
+       <artifactId>maven-jar-plugin</artifactId>
+       <inherited>false</inherited>
+     </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -95,7 +101,6 @@
           </execution>
         </executions>
         <configuration>
-          <doclint>none</doclint>
           <windowtitle>Apache Jena IRI3986</windowtitle>
           <doctitle>Apache Jena IRI3986 ${project.version}</doctitle>
         </configuration>

--- a/jena-iri3986/src/main/java/module-info.java
+++ b/jena-iri3986/src/main/java/module-info.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-module org.seaborne.iri4ld {
+module org.apache.jena.iri3986 {
     exports org.apache.jena.rfc3986;
     exports org.apache.jena.rfc3986.cmd;
 }

--- a/jena-iri3986/src/main/java/org/apache/jena/rfc3986/IRI3986.java
+++ b/jena-iri3986/src/main/java/org/apache/jena/rfc3986/IRI3986.java
@@ -324,7 +324,7 @@ public class IRI3986 implements IRI {
 
     /**
      * Return an immutable list of the violations for this IRI.
-     * @See {@link #forEachViolation(Consumer)}.
+     * See {@link #forEachViolation(Consumer)}.
      */
     public List<Violation> violations() {
         if ( reports == null )
@@ -754,7 +754,7 @@ public class IRI3986 implements IRI {
         return iri;
     }
 
-    /** Build a {@linkIRI3986} from components. */
+    /** Build a {@link IRI3986} from components. */
     public static IRI3986 build(String scheme, String authority, String path, String query, String fragment) {
         String s = rebuild(scheme, authority, path, query, fragment);
         return newAndParseEx(s);

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/loader/LoaderFactory.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/loader/LoaderFactory.java
@@ -66,7 +66,7 @@ public class LoaderFactory {
      * other quad data is discarded.
      * <p>
      * For other behaviours, use {@link #basicLoader(DatasetGraph, MonitorOutput)}
-     * and wrap the {@linkStreamRDF} from {@link DataLoader#stream()}) with the required
+     * and wrap the {@link StreamRDF} from {@link DataLoader#stream()}) with the required
      * transformation.
      *
      * @see #basicLoader(DatasetGraph, MonitorOutput)
@@ -104,7 +104,7 @@ public class LoaderFactory {
      * other quad data is discarded.
      * <p>
      * For other behaviours, use {@link #basicLoader(DatasetGraph, MonitorOutput)}
-     * and wrap the {@linkStreamRDF} from {@link DataLoader#stream()}) with the required
+     * and wrap the {@link StreamRDF} from {@link DataLoader#stream()}) with the required
      * transformation.
      *
      * @see #sequentialLoader(DatasetGraph, MonitorOutput)

--- a/pom.xml
+++ b/pom.xml
@@ -1056,7 +1056,7 @@
                  https://maven.apache.org/guides/mini/guide-reproducible-builds.html
             -->
             <notimestamp>true</notimestamp>
-            <doclint>none</doclint>
+            <doclint>-missing</doclint>
             <quiet>true</quiet>
             <version>true</version>
             <show>public</show>


### PR DESCRIPTION
Based on the output of the java23 build on Jenkins, there are some errors in the javadoc which this PR fixes.

The change in jena-iri3986 about maven-jar-plugin is to have both `automatic.module.name` and a module-info.java file ...
and avoid a javadoc error about mixed aggregation javadoc!

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
