### PR TITLE
Add GH Actions for UI tests

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -1,0 +1,90 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+name: Apache Jena UI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Unit tests, faster, only run on GH for the ASF repository.
+  unit-test-and-build:
+    if: github.repository == 'apache/jena'
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        java_version: [ '21' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          working-directory: jena-fuseki2/jena-fuseki-ui
+          node-version: 'lts/*'
+
+      - name: Set up JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java_version }}
+
+      - name: Build with Maven
+        run: mvn -B --file pom.xml --projects jena-fuseki2/jena-fuseki-ui --also-make-dependents test install
+
+      - name: Lint
+        working-directory: jena-fuseki2/jena-fuseki-ui
+        run: yarn lint
+
+  cypress-run:
+    # End-to-end tests, only run on GH for the ASF repository.
+    if: github.repository == 'apache/jena'
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [ firefox, chrome, electron ]
+        os: [ ubuntu-latest ]
+
+    env:
+      COVERAGE: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          working-directory: jena-fuseki2/jena-fuseki-ui
+          node-version: 'lts/*'
+
+      - name: Test (E2E)
+        uses: cypress-io/github-action@v6
+        env:
+          BASE_URL: http://localhost:8080/
+          FUSEKI_URL: http://localhost:3030/
+        with:
+          working-directory: jena-fuseki2/jena-fuseki-ui
+          config-file: cypress.config.mjs
+          browser: ${{ matrix.browser }}
+          build: yarn run build
+          start: yarn run serve:offline
+          config: baseUrl=${{ env.BASE_URL }}
+          wait-on: '${{ env.FUSEKI_URL }}$/ping, ${{ env.BASE_URL }}index.html'
+          wait-on-timeout: 120


### PR DESCRIPTION
Ref: https://github.com/apache/jena/pull/2830#issuecomment-2466641867

Pull request Description:

This PR adds GitHub Actions for the UI tests.

Tested on my fork:

- Created a quick YAML version (knew it was probably broken, doesn't matter as I wanted to add it to my `main`)
- Pushed it to `kinow/jena`'s `main`
- Then [created  PR](https://github.com/kinow/jena/pull/36) to fix it, which now could be used to validate it worked
- 8 commits later, got it to work, tests took 1 min e2e, and 2 min the unit (because e2e is pure `yarn`, but for unit I used `mvn` -- just to make sure UI is not broken when Maven is used?)
- Squashed, cherry-picked the commit from this PR to prepare this PR
- Added the `if` to check for `apache/jena` as the repository

Now once this is merged we can rebase a dependabot or some other UI PR and :crossed_fingers: it will work.

![image](https://github.com/user-attachments/assets/34809fcf-a7f4-4e68-9a04-829f71016be7)


----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
