### PR TITLE
GH-2841: Align naming of assembler constants for TDB1 and TDB2

### DIFF
--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/assembler/DatasetAssemblerTDB1.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/assembler/DatasetAssemblerTDB1.java
@@ -45,6 +45,8 @@ public class DatasetAssemblerTDB1 extends DatasetAssembler
 
     static { JenaSystem.init(); }
 
+    public DatasetAssemblerTDB1() {}
+
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {
         return make(a, root);

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/assembler/VocabTDB1.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/assembler/VocabTDB1.java
@@ -33,8 +33,11 @@ public class VocabTDB1
     // Types
     public static final Resource tDatasetTDB        = Vocab.type(NS, "DatasetTDB") ;
     public static final Resource tGraphTDB          = Vocab.type(NS, "GraphTDB") ;
-//    public static final Resource tGraphBDB          = Vocab.type(NS, "GraphBDB") ;
-//    public static final Resource tTupleIndex        = Vocab.type(NS, "TupleIndex") ;
+
+    // Alternative type names.
+    public static final Resource tDatasetTDB1       = Vocab.type(NS, "DatasetTDB1") ;
+    public static final Resource tGraphTDB1         = Vocab.type(NS, "GraphTDB1") ;
+
     public static final Resource tNodeTable         = Vocab.type(NS, "NodeTable") ;
 
     public static final Property pLocation          = Vocab.property(NS, "location") ;
@@ -51,9 +54,9 @@ public class VocabTDB1
     public static final Property pDescription       = Vocab.property(getURI(), "description") ;
     public static final Property pFile              = Vocab.property(getURI(), "file") ;
 
-    // Nodes
-    public static final Property pNodeIndex         = Vocab.property(getURI(), "nodeIndex") ;
-    public static final Property pNodeData          = Vocab.property(getURI(), "nodeData") ;
+//    // Nodes
+//    public static final Property pNodeIndex         = Vocab.property(getURI(), "nodeIndex") ;
+//    public static final Property pNodeData          = Vocab.property(getURI(), "nodeData") ;
 
     // Setting
     public static final Property pSetting           = Vocab.property(getURI(), "setting") ;
@@ -68,7 +71,9 @@ public class VocabTDB1
         if ( initialized )
             return;
         initialized = true;
-        AssemblerUtils.registerDataset(tDatasetTDB, new DatasetAssemblerTDB1());
-        AssemblerUtils.registerModel(tGraphTDB, new TDB1GraphAssembler());
+        AssemblerUtils.registerDataset(tDatasetTDB,     new DatasetAssemblerTDB1());
+        AssemblerUtils.registerDataset(tDatasetTDB1,    new DatasetAssemblerTDB1());
+        AssemblerUtils.registerModel(tGraphTDB,         new TDB1GraphAssembler());
+        AssemblerUtils.registerModel(tGraphTDB1,        new TDB1GraphAssembler());
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/assembler/TestTDBAssembler.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/assembler/TestTDBAssembler.java
@@ -20,126 +20,123 @@ package org.apache.jena.tdb1.assembler;
 
 import static org.junit.Assert.assertTrue;
 
-import org.apache.jena.assembler.JA ;
-import org.apache.jena.assembler.exceptions.AssemblerException ;
-import org.apache.jena.atlas.lib.FileOps ;
-import org.apache.jena.graph.Graph ;
-import org.apache.jena.query.Dataset ;
-import org.apache.jena.rdf.model.Model ;
-import org.apache.jena.rdf.model.Resource ;
-import org.apache.jena.sparql.core.assembler.AssemblerUtils ;
-import org.apache.jena.sparql.core.assembler.DatasetAssemblerVocab ;
+import org.apache.jena.assembler.JA;
+import org.apache.jena.assembler.exceptions.AssemblerException;
+import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.sparql.core.assembler.AssemblerUtils;
+import org.apache.jena.sparql.core.assembler.DatasetAssemblerVocab;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.store.DatasetGraphTDB;
 import org.apache.jena.tdb1.store.GraphTDB;
 import org.apache.jena.tdb1.sys.TDBInternal;
 import org.apache.jena.tdb1.transaction.DatasetGraphTransaction;
-import org.junit.AfterClass ;
-import org.junit.Before ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
-public class TestTDBAssembler
-{
+public class TestTDBAssembler {
     // Can be slow - explicitly closes the dataset.
-    static String dirAssem      = null ;
-    static final String dirDB   = ConfigTest.getTestingDir()+"/DB" ;
+    static String dirAssem = null;
+    static final String dirDB = ConfigTest.getTestingDir() + "/DB";
 
-    @BeforeClass static public void beforeClass()
-    {
-        dirAssem = ConfigTest.getTestingDataRoot()+"/Assembler" ;
-        FileOps.ensureDir(dirDB) ;
+    @BeforeClass
+    static public void beforeClass() {
+        dirAssem = ConfigTest.getTestingDataRoot() + "/Assembler";
+        FileOps.ensureDir(dirDB);
     }
 
-    @Before public void before()
-    {
-        TDBInternal.reset() ;
-        FileOps.clearDirectory(dirDB) ;
+    @Before
+    public void before() {
+        TDBInternal.reset();
+        FileOps.clearDirectory(dirDB);
     }
 
-    @AfterClass static public void afterClass()
-    {
-        TDBInternal.reset() ;
-        FileOps.clearDirectory(dirDB) ;
+    @AfterClass
+    static public void afterClass() {
+        TDBInternal.reset();
+        FileOps.clearDirectory(dirDB);
     }
 
-    @Test public void createDatasetDirect()
-    {
-        createTest(dirAssem+"/tdb-dataset.ttl", VocabTDB1.tDatasetTDB) ;
+    @Test
+    public void createDatasetDirect() {
+        createTest(dirAssem + "/tdb-dataset.ttl", VocabTDB1.tDatasetTDB);
     }
 
-    @Test public void createDatasetEmbed()
-    {
-        createTest(dirAssem+"/tdb-dataset-embed.ttl", DatasetAssemblerVocab.tDataset) ;
+    @Test
+    public void createDatasetEmbed() {
+        createTest(dirAssem + "/tdb-dataset-embed.ttl", DatasetAssemblerVocab.tDataset);
     }
 
-    private void createTest(String filename, Resource type)
-    {
-        Object thing = AssemblerUtils.build(filename, type) ;
-        assertTrue(thing instanceof Dataset) ;
-        Dataset ds = (Dataset)thing ;
-        assertTrue(ds.asDatasetGraph() instanceof DatasetGraphTransaction) ;
-        assertTrue(ds.supportsTransactions()) ;
+    private void createTest(String filename, Resource type) {
+        Object thing = AssemblerUtils.build(filename, type);
+        assertTrue(thing instanceof Dataset);
+        Dataset ds = (Dataset)thing;
+        assertTrue(ds.asDatasetGraph() instanceof DatasetGraphTransaction);
+        assertTrue(ds.supportsTransactions());
         ds.close();
 
     }
 
-    @Test public void createGraphDirect()
-    {
-        testGraph(dirAssem+"/tdb-graph.ttl", false) ;
+    @Test
+    public void createGraphDirect() {
+        testGraph(dirAssem + "/tdb-graph.ttl", false);
     }
 
-    @Test public void createGraphEmbed()
-    {
-        String f = dirAssem+"/tdb-graph-embed.ttl" ;
-        Object thing = null ;
-        try { thing = AssemblerUtils.build( f, JA.Model) ; }
-        catch (AssemblerException e)
-        {
-            e.getCause().printStackTrace(System.err) ;
-            throw e ;
+    @Test
+    public void createGraphEmbed() {
+        String f = dirAssem + "/tdb-graph-embed.ttl";
+        Object thing = null;
+        try {
+            thing = AssemblerUtils.build(f, JA.Model);
+        } catch (AssemblerException e) {
+            e.getCause().printStackTrace(System.err);
+            throw e;
         }
 
-        assertTrue(thing instanceof Model) ;
-        Graph graph = ((Model)thing).getGraph() ;
-        assertTrue(graph instanceof GraphTDB) ;
+        assertTrue(thing instanceof Model);
+        Graph graph = ((Model)thing).getGraph();
+        assertTrue(graph instanceof GraphTDB);
 
-        DatasetGraphTDB ds = ((GraphTDB)graph).getDatasetGraphTDB() ;
+        DatasetGraphTDB ds = ((GraphTDB)graph).getDatasetGraphTDB();
         if ( ds != null )
             ds.close();
     }
 
-    @Test public void createNamedGraph1()
-    {
-        testGraph(dirAssem+"/tdb-named-graph-1.ttl", true) ;
+    @Test
+    public void createNamedGraph1() {
+        testGraph(dirAssem + "/tdb-named-graph-1.ttl", true);
     }
 
-    @Test public void createNamedGraph2()
-    {
-        testGraph(dirAssem+"/tdb-named-graph-2.ttl", true) ;
+    @Test
+    public void createNamedGraph2() {
+        testGraph(dirAssem + "/tdb-named-graph-2.ttl", true);
     }
 
-    @Test public void createNamedGraphViaDataset()
-    {
-        testGraph(dirAssem+"/tdb-graph-ref-dataset.ttl",false) ;
+    @Test
+    public void createNamedGraphViaDataset() {
+        testGraph(dirAssem + "/tdb-graph-ref-dataset.ttl", false);
     }
 
-    private static void testGraph(String assemblerFile, boolean named)
-    {
-        Object thing = null ;
-        try { thing = AssemblerUtils.build( assemblerFile, VocabTDB1.tGraphTDB) ; }
-        catch (AssemblerException e)
-        {
-            e.getCause().printStackTrace(System.err) ;
-            throw e ;
+    private static void testGraph(String assemblerFile, boolean named) {
+        Object thing = null;
+        try {
+            thing = AssemblerUtils.build(assemblerFile, VocabTDB1.tGraphTDB);
+        } catch (AssemblerException e) {
+            e.getCause().printStackTrace(System.err);
+            throw e;
         }
 
-        assertTrue(thing instanceof Model) ;
-        Graph graph = ((Model)thing).getGraph() ;
+        assertTrue(thing instanceof Model);
+        Graph graph = ((Model)thing).getGraph();
 
-        assertTrue(graph instanceof GraphTDB) ;
+        assertTrue(graph instanceof GraphTDB);
 
-        DatasetGraphTDB ds = ((GraphTDB)graph).getDatasetGraphTDB() ;
+        DatasetGraphTDB ds = ((GraphTDB)graph).getDatasetGraphTDB();
         if ( ds != null )
             ds.close();
     }

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/assembler/VocabTDB2.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/assembler/VocabTDB2.java
@@ -20,8 +20,6 @@ package org.apache.jena.tdb2.assembler;
 
 
 import org.apache.jena.assembler.Assembler;
-import org.apache.jena.assembler.ConstAssembler;
-import org.apache.jena.assembler.JA;
 import org.apache.jena.assembler.assemblers.AssemblerGroup;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
@@ -36,12 +34,21 @@ public class VocabTDB2
     public static String getURI() { return NS; }
 
     // Types
-    public static final Resource tDatasetTDB        = Vocab.type(NS, "DatasetTDB2");
+
+    public static final Resource tDatasetTDB        = Vocab.type(NS, "DatasetTDB");
+    public static final Resource tDatasetTDB2       = Vocab.type(NS, "DatasetTDB2");
+    /** @deprecated Use {@link #tDatasetTDB} */
+    @Deprecated(forRemoval = true)
     public static final Resource tDatasetTDB_alt    = Vocab.type(NS, "DatasetTDB");
-    public static final Resource tGraphTDB          = Vocab.type(NS, "GraphTDB2");
+
+    public static final Resource tGraphTDB          = Vocab.type(NS, "GraphTDB");
+    public static final Resource tGraphTDB2         = Vocab.type(NS, "GraphTDB2");
+    /** @deprecated Use {@link #tGraphTDB} */
+    @Deprecated
     public static final Resource tGraphTDB_alt      = Vocab.type(NS, "GraphTDB");
+
 //    public static final Resource tTupleIndex        = Vocab.type(NS, "TupleIndex");
-    public static final Resource tNodeTable         = Vocab.type(NS, "NodeTable");
+//    public static final Resource tNodeTable         = Vocab.type(NS, "NodeTable");
 
     public static final Property pLocation          = Vocab.property(NS, "location");
     public static final Property pUnionDefaultGraph = Vocab.property(NS, "unionDefaultGraph");
@@ -51,15 +58,16 @@ public class VocabTDB2
     public static final Property pGraphName2        = Vocab.property(NS, "namedGraph");
     public static final Property pDataset           = Vocab.property(NS, "dataset");
 
-    public static final Property pNodes             = Vocab.property(NS, "nodes");
-
-    // Indexes
-    public static final Property pDescription       = Vocab.property(getURI(), "description");
-    public static final Property pFile              = Vocab.property(getURI(), "file");
-
-    // Nodes
-    public static final Property pNodeIndex         = Vocab.property(getURI(), "nodeIndex");
-    public static final Property pNodeData          = Vocab.property(getURI(), "nodeData");
+    // Not implemented.
+//    public static final Property pNodes             = Vocab.property(NS, "nodes");
+//
+//    // Indexes
+//    public static final Property pDescription       = Vocab.property(getURI(), "description");
+//    public static final Property pFile              = Vocab.property(getURI(), "file");
+//
+//    // Nodes
+//    public static final Property pNodeIndex         = Vocab.property(getURI(), "nodeIndex");
+//    public static final Property pNodeData          = Vocab.property(getURI(), "nodeData");
 
     // Setting
     public static final Property pSetting           = Vocab.property(getURI(), "setting");
@@ -79,10 +87,9 @@ public class VocabTDB2
 
     static void registerWith(AssemblerGroup g) {
         // Wire in the assemblers.
-        AssemblerUtils.registerDataset(tDatasetTDB, new DatasetAssemblerTDB2());
-        AssemblerUtils.registerDataset(tDatasetTDB_alt, new DatasetAssemblerTDB2());
-        AssemblerUtils.register(ConstAssembler.general(), tGraphTDB, new TDB2GraphAssembler(), JA.Model);
-        AssemblerUtils.register(ConstAssembler.general(), tGraphTDB_alt, new TDB2GraphAssembler(), JA.Model);
-
+        AssemblerUtils.registerDataset(tDatasetTDB,  new DatasetAssemblerTDB2());
+        AssemblerUtils.registerDataset(tDatasetTDB2, new DatasetAssemblerTDB2());
+        AssemblerUtils.registerModel(tGraphTDB,      new TDB2GraphAssembler());
+        AssemblerUtils.registerModel(tGraphTDB2,     new TDB2GraphAssembler());
     }
 }

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/assembler/TestTDBAssembler.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/assembler/TestTDBAssembler.java
@@ -63,7 +63,7 @@ public class TestTDBAssembler
 
     @Test
     public void createDatasetDirect() {
-        createTest(dirAssem + "/tdb-dataset.ttl", VocabTDB2.tDatasetTDB);
+        createTest(dirAssem + "/tdb-dataset.ttl", VocabTDB2.tDatasetTDB2);
     }
 
     @Test
@@ -124,7 +124,7 @@ public class TestTDBAssembler
     private static void testGraph(String assemblerFile, boolean named) {
         Object thing = null;
         try {
-            thing = AssemblerUtils.build(assemblerFile, VocabTDB2.tGraphTDB);
+            thing = AssemblerUtils.build(assemblerFile, VocabTDB2.tGraphTDB2);
         }
         catch (AssemblerException e) {
             e.getCause().printStackTrace(System.err);


### PR DESCRIPTION
GitHub issue resolved #2841

Pull request Description: 
Tidy up assembler constants in TDB1 and TDB2.

----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
