### PR TITLE
Use Stream.toList directly

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/AsyncParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/AsyncParser.java
@@ -28,8 +28,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import org.apache.jena.atlas.iterator.IteratorCloseable;
 import org.apache.jena.atlas.iterator.IteratorSlotted;
 import org.apache.jena.atlas.lib.InternalErrorException;
@@ -189,7 +187,7 @@ public class AsyncParser {
     private static List<RDFParserBuilder> urlsToSource(List<String> filesOrURLs) {
         return filesOrURLs.stream().map(
                     uriOrFile -> RDFParser.source(uriOrFile).errorHandler(dftErrorHandler))
-            .collect(Collectors.toList());
+            .toList();
     }
 
     /** Create a source object from the given arguments that is suitable for use with

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpAsQuery.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpAsQuery.java
@@ -20,8 +20,6 @@ package org.apache.jena.sparql.algebra ;
 
 import java.util.* ;
 import java.util.function.BiConsumer ;
-import java.util.stream.Collectors ;
-
 import org.apache.jena.atlas.lib.NotImplemented ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -116,12 +114,12 @@ public class OpAsQuery {
             if ( opHaving != null )
                 System.out.printf("having: %s\n", opHaving.getExprs()) ;
             if ( opExtends != null && !opExtends.isEmpty() ) {
-                List<VarExprList> z = opExtends.stream().map(x -> x.getVarExprList()).collect(Collectors.toList()) ;
+                List<VarExprList> z = opExtends.stream().map(x -> x.getVarExprList()).toList() ;
                 System.out.printf("assigns: %s\n", z) ;
             }
             if ( opGroup != null ) {
                 List<ExprAggregator> aggregators = opGroup.getAggregators() ;
-                List<Var> aggVars = aggregators.stream().map(x -> x.getAggVar().asVar()).collect(Collectors.toList()) ;
+                List<Var> aggVars = aggregators.stream().map(x -> x.getAggVar().asVar()).toList() ;
                 System.out.printf("group: %s |-| %s\n", opGroup.getGroupVars(), opGroup.getAggregators()) ;
                 System.out.printf("group agg vars: %s\n", aggVars) ;
             }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterPlacement.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformFilterPlacement.java
@@ -666,7 +666,7 @@ public class TransformFilterPlacement extends TransformCopy {
 
         if ( false ) {
             // Push everything, always
-            // Left as a safty fall back.
+            // Left as a safety fall back.
             List<Op> x = new ArrayList<>() ;
             input.getElements().forEach(op->{
                 Placement p = transform(exprs, op) ;
@@ -683,7 +683,6 @@ public class TransformFilterPlacement extends TransformCopy {
         // Don't push any expressions that aren't used in any of the arms of the disjunction.
         // This is more about being tidy.
         List<Expr> unplaced = new ArrayList<>(exprs.getList()) ;
-        //List<Placement> x = input.getElements().stream().map(op->transform(exprs, op)).collect(Collectors.toList()) ;
         List<Placement> placements = new ArrayList<>(exprs.size()) ;
         Boolean someChange = Boolean.FALSE ;
         for ( Op op : input.getElements() ) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDataset.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDataset.java
@@ -22,8 +22,6 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.json.JsonArray;
 import org.apache.jena.atlas.json.JsonObject;
@@ -169,7 +167,7 @@ public class QueryExecDataset implements QueryExec
 
     private RowSet execute() {
         startQueryIterator();
-        List<Var> vars = query.getResultVars().stream().map(Var::alloc).collect(Collectors.toList());
+        List<Var> vars = query.getResultVars().stream().map(Var::alloc).toList();
         return RowSetStream.create(vars, queryIterator);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/TemplateLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/TemplateLib.java
@@ -20,7 +20,6 @@ package org.apache.jena.sparql.modify;
 
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream ;
 
 import org.apache.jena.atlas.iterator.Iter;
@@ -64,7 +63,7 @@ public class TemplateLib {
         Stream<Quad> remappedStream = quads.stream().map(q->
             !q.isDefaultGraph() ? q : new Quad(dftGraph, q.getSubject(), q.getPredicate(), q.getObject())
         ) ;
-        return remappedStream.collect(Collectors.toList());
+        return remappedStream.toList();
     }
 
     /** Substitute into triple patterns */

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/NodeUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/NodeUtils.java
@@ -20,7 +20,6 @@ package org.apache.jena.sparql.util;
 
 import java.util.*;
 
-import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.atlas.lib.SetUtils;
 import org.apache.jena.datatypes.RDFDatatype ;
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
@@ -107,9 +106,7 @@ public class NodeUtils
 
     /** Convert strings to a List of {@link Node Nodes}. */
     public static List<Node> convertToListNodes(List<String> namedGraphs) {
-        List<Node> nodes = ListUtils.toList(
-            namedGraphs.stream().map(NodeFactory::createURI)
-            );
+        List<Node> nodes = namedGraphs.stream().map(NodeFactory::createURI).toList();
         return nodes;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/graph/GraphUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/graph/GraphUtils.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.IRILib;
-import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
@@ -301,8 +300,7 @@ public class GraphUtils {
         QuerySolutionMap qsm = new QuerySolutionMap();
         qsm.add("ATYPE", atype);
         try(QueryExecution qExec = QueryExecution.model(model).query(q).initialBinding(qsm).build() ) {
-            return ListUtils.toList(
-                    QueryExecUtils.getAll(qExec, "root").stream().map(r->(Resource)r));
+            return QueryExecUtils.getAll(qExec, "root").stream().map(r->(Resource)r).toList();
         }
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/rdfs/LibTestRDFS.java
+++ b/jena-arq/src/test/java/org/apache/jena/rdfs/LibTestRDFS.java
@@ -26,7 +26,6 @@ import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.atlas.lib.Pair;
-import org.apache.jena.atlas.lib.StreamOps;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -43,7 +42,7 @@ public class LibTestRDFS {
      * Remove triples with a predicate which is RDFS schema vocabulary.
      */
     public static List<Triple> removeRDFS(List<Triple> x) {
-        return StreamOps.toList(x.stream().filter(ConstRDFS.filterNotRDFS));
+        return x.stream().filter(ConstRDFS.filterNotRDFS).toList();
     }
 
     /** Create a Jena-rules backed graph */

--- a/jena-arq/src/test/java/org/apache/jena/rdfs/TestMatchVocab.java
+++ b/jena-arq/src/test/java/org/apache/jena/rdfs/TestMatchVocab.java
@@ -24,16 +24,16 @@ import static org.apache.jena.rdfs.LibTestRDFS.node;
 import java.io.PrintStream;
 import java.util.List;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import org.apache.jena.atlas.lib.ListUtils;
-import org.apache.jena.atlas.lib.StreamOps;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.rdfs.engine.ConstRDFS;
 import org.apache.jena.rdfs.setup.MatchVocabRDFS;
 import org.apache.jena.riot.RDFDataMgr;
-import org.junit.Assert;
-import org.junit.Test;
 
 /** Test the setup matcher that provides access to a setup as a (s,p,o) access */
 public class TestMatchVocab {
@@ -100,6 +100,6 @@ public class TestMatchVocab {
     }
 
     private List<Triple> match(Node s, Node p, Node o) {
-        return StreamOps.toList(matchVocab.match(s, p, o));
+        return matchVocab.match(s, p, o).toList();
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/rdfxml/rrx/RunTestRDFXML.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/rdfxml/rrx/RunTestRDFXML.java
@@ -65,7 +65,7 @@ public class RunTestRDFXML {
                 .filter(Files::isRegularFile)
                 .map(Path::toString)
                 .filter(fn->fn.endsWith(".rdf"))
-                .collect(Collectors.toList());
+                .toList();
         } catch (IOException ex) {
             throw IOX.exception(ex);
         }
@@ -207,7 +207,7 @@ public class RunTestRDFXML {
                 // If not enabling entity support in StAX
                 //.filter(fn-> ( xmlParserType != XMLParser.StAX || !fn.startsWith("entities") ) )
                 .map(fn->LOCAL_DIR.resolve(fn).toString())
-                .collect(Collectors.toList());
+                .toList();
 
         return testfilesAbs;
     }

--- a/jena-arq/src/test/java/org/apache/jena/riot/system/TestAsyncParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/system/TestAsyncParser.java
@@ -35,7 +35,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.jena.atlas.iterator.IteratorCloseable;
@@ -210,7 +209,7 @@ public class TestAsyncParser {
 
         List<EltStreamRDF> expected;
         try (Stream<EltStreamRDF> s = AsyncParser.of(new ByteArrayInputStream(goodInputStr.getBytes()), Lang.TURTLE, null).streamElements()) {
-            expected = s.collect(Collectors.toList());
+            expected = s.toList();
         }
 
         // Validate parser on the good data
@@ -225,7 +224,7 @@ public class TestAsyncParser {
             try (Stream<EltStreamRDF> s = AsyncParser.of(new ByteArrayInputStream(badInputStr.getBytes()), Lang.TURTLE, null)
                     .setChunkSize(chunkSize)
                     .streamElements()) {
-                List<EltStreamRDF> actual = s.collect(Collectors.toList());
+                List<EltStreamRDF> actual = s.toList();
                 Assert.assertEquals(expectedGoodEventCount + 1, actual.size());
                 Assert.assertEquals(expected, actual.subList(0, expectedGoodEventCount));
                 Assert.assertTrue(actual.get(actual.size() - 1).isException());
@@ -250,7 +249,7 @@ public class TestAsyncParser {
             })
             .streamElements()
             .limit(1000)) { // The limit is just a safety net to prevent infinite parsing in case of malfunction
-            actual = stream.collect(Collectors.toList());
+            actual = stream.toList();
         }
 
         // Check that only the expected number of elements were dispatched

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestQueryExecutionCancel.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestQueryExecutionCancel.java
@@ -33,7 +33,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.jena.graph.Graph;
@@ -298,7 +297,7 @@ public class TestQueryExecutionCancel {
         Random cancelDelayRandom = new Random();
         ExecutorService executorService = Executors.newCachedThreadPool();
         try {
-            List<Integer> list = IntStream.range(0, taskCount).boxed().collect(Collectors.toList());
+            List<Integer> list = IntStream.range(0, taskCount).boxed().toList();
             list
                 .parallelStream()
                 .forEach(i -> {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphFind.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/AbstractDatasetGraphFind.java
@@ -21,7 +21,6 @@ package org.apache.jena.sparql.core;
 import static org.apache.jena.atlas.iterator.Iter.asStream ;
 import static org.apache.jena.atlas.iterator.Iter.toList;
 import static org.apache.jena.atlas.iterator.Iter.toSet;
-import static org.apache.jena.atlas.lib.StreamOps.toList;
 import static org.junit.Assert.assertEquals ;
 import static org.junit.Assert.assertFalse ;
 import static org.junit.Assert.assertNotNull;
@@ -29,8 +28,6 @@ import static org.junit.Assert.assertTrue ;
 import static org.junit.Assert.fail;
 
 import java.util.*;
-import java.util.stream.Collectors ;
-
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.graph.Node ;
@@ -205,7 +202,7 @@ public abstract class AbstractDatasetGraphFind {
         assertEquals(3, x.size()) ;
         x.stream().allMatch(q->q.getGraph().equals(Quad.unionGraph)) ;
 
-        List<Triple> z = x.stream().map(Quad::asTriple).collect(Collectors.toList()) ;
+        List<Triple> z = x.stream().map(Quad::asTriple).toList();
         assertTrue(z.contains(q4.asTriple())) ;
         assertTrue(z.contains(q5.asTriple())) ;
         Quad qx = Quad.create(Quad.unionGraph, q4.asTriple()) ;
@@ -286,14 +283,14 @@ public abstract class AbstractDatasetGraphFind {
     }
 
     @Test public void stream_dsg_01() {
-        List<Quad> x = toList(dsg.stream());
+        List<Quad> x = dsg.stream().toList();
         assertEquals(10, x.size()) ;
         assertTrue(x.contains(q1)) ;
         assertTrue(x.contains(q5)) ;
     }
 
     @Test public void stream_dsg_02() {
-        List<Quad> x = toList(dsg.stream(null, s,p,o)) ;
+        List<Quad> x = dsg.stream(null, s,p,o).toList();
         assertEquals(4, x.size()) ;
         assertFalse(x.contains(q2)) ;
         assertFalse(x.contains(q4)) ;
@@ -312,7 +309,7 @@ public abstract class AbstractDatasetGraphFind {
     }
 
     static List<Triple> quadsToDistinctTriples(Iterator<Quad> iter) {
-        return asStream(iter).map(Quad::asTriple).distinct().collect(Collectors.toList()) ;
+        return asStream(iter).map(Quad::asTriple).distinct().toList() ;
     }
 
     static void print(List<Quad> x) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/AbstractTestDistinctReduced.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/AbstractTestDistinctReduced.java
@@ -21,8 +21,6 @@ package org.apache.jena.sparql.engine.iterator;
 import static org.junit.Assert.assertEquals;
 
 import java.util.*;
-import java.util.stream.Collectors ;
-
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.sparql.core.Var ;
@@ -44,7 +42,7 @@ public abstract class AbstractTestDistinctReduced {
     private static List<Binding> build(List<String> items) {
         return items.stream().sequential()
                 .map((s)-> BindingFactory.binding(var_a, NodeFactory.createLiteralString(s)))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     protected abstract QueryIterator createQueryIter(List<Binding> data) ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestDataBagDistinctOrder.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestDataBagDistinctOrder.java
@@ -21,8 +21,6 @@ package org.apache.jena.sparql.engine.iterator;
 import static org.junit.Assert.fail;
 
 import java.util.List ;
-import java.util.stream.Collectors;
-
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
@@ -50,7 +48,7 @@ public class TestDataBagDistinctOrder  {
         cxt.set(ARQ.spillToDiskThreshold, 2L);
 
         List<QuerySolution> x = ResultSetFormatter.toList(qExec.execSelect());
-        List<Integer> z = x.stream().map(qsoln->qsoln.getLiteral("v").getInt()).collect(Collectors.toList());
+        List<Integer> z = x.stream().map(qsoln->qsoln.getLiteral("v").getInt()).toList();
         for ( int i = 0 ; i < z.size()-1; i++ ) {
             int v1 = z.get(i);
             int v2 = z.get(i+1);

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/Lib.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/Lib.java
@@ -20,7 +20,6 @@ package org.apache.jena.atlas.lib;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.stream.Stream;
 import java.util.zip.Adler32;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
@@ -52,12 +51,6 @@ public class Lib
             return directory+path;
         else
             return directory+"/"+path;
-    }
-
-    /** Stream to {@link List} */
-    public static <X> List<X> toList(Stream<X> stream) {
-        // Findability.
-        return StreamOps.toList(stream);
     }
 
     /** "ConcurrentHashSet" */

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/ListUtils.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/ListUtils.java
@@ -23,8 +23,7 @@ import static java.util.stream.Collectors.joining;
 
 import java.util.ArrayList ;
 import java.util.List ;
-import java.util.stream.Collectors ;
-import java.util.stream.Stream ;
+import java.util.stream.Stream;
 
 import org.apache.jena.atlas.io.IndentedWriter ;
 import org.apache.jena.atlas.logging.Log ;
@@ -35,7 +34,7 @@ public class ListUtils
     private ListUtils() {}
 
     public static <T> List<T> unique(List<T> list) {
-        return toList(list.stream().distinct());
+        return list.stream().distinct().toList();
     }
 
     public static List<Integer> asList(int...values) {
@@ -51,9 +50,10 @@ public class ListUtils
         return list.get(list.size()-1);
     }
 
-    // This is commonly needed
+    /** @deprecated Call {@link Stream#toList} */
+    @Deprecated(forRemoval = true)
     public static <T> List<T> toList(Stream<T> stream) {
-        return stream.collect(Collectors.toList()) ;
+        return stream.toList() ;
     }
 
     public static <T> String str(T[] array) {

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/StrUtils.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/StrUtils.java
@@ -20,7 +20,6 @@ package org.apache.jena.atlas.lib;
 
 import static java.lang.String.format;
 import static java.util.Arrays.stream ;
-import static java.util.stream.Collectors.toList;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -154,7 +153,7 @@ public class StrUtils //extends StringUtils
     }
 
     public static List<Character> toCharList(String str) {
-        return str.codePoints().mapToObj(i -> (char) i).map(Character::valueOf).collect(toList());
+        return str.codePoints().mapToObj(i -> (char) i).map(Character::valueOf).toList();
     }
 
     // ==== Encoding and decoding strings based on a marker character (e.g. %)

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/StreamOps.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/StreamOps.java
@@ -39,10 +39,10 @@ public class StreamOps {
         return Iter.asStream(iter);
     }
 
-    /** Stream to {@link List} */
-    public static <X> List<X> toList(Stream<X> stream) {
-        return stream.collect(Collectors.toList());
-    }
+//    /** Stream to {@link List} */
+//    public static <X> List<X> toList(Stream<X> stream) {
+//        return stream.toList();
+//    }
 
     /** Stream to {@link Set} */
     public static <X> Set<X> toSet(Stream<X> stream) {
@@ -69,19 +69,19 @@ public class StreamOps {
 
     public static <X> Stream<X> print(PrintStream out, Stream<X> stream) {
         stream = stream.map(item -> { out.println(item); return item; });
-        return toList(stream).stream();
+        return stream.toList().stream();
     }
 
     public static <X> Stream<X> print(PrintStream out, String leader, Stream<X> stream) {
         String prefix = (leader==null) ? "" : leader;
         stream = stream.map(item -> { out.print(prefix); out.println(item); return item; });
-        return toList(stream).stream();
+        return stream.toList().stream();
     }
 
 
     /** Print immediate, noting empty streams */
     public static <X> Stream<X> debug(Stream<X> stream) {
-        List<X> elts = StreamOps.toList(stream);
+        List<X> elts = stream.toList();
         if ( elts.isEmpty() )
             System.out.println("[empty]");
         else {
@@ -91,5 +91,4 @@ public class StreamOps {
         }
         return elts.stream();
     }
-
 }

--- a/jena-cmds/src/main/java/arq/cmdline/ModDatasetGeneral.java
+++ b/jena-cmds/src/main/java/arq/cmdline/ModDatasetGeneral.java
@@ -21,7 +21,6 @@ package arq.cmdline;
 import java.util.List ;
 
 import org.apache.jena.atlas.lib.IRILib;
-import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdArgModule;
 import org.apache.jena.cmd.CmdException;
@@ -105,7 +104,7 @@ public class ModDatasetGeneral extends ModDataset
             }
             if ( hasEntries(graphURLs) ||  hasEntries(namedGraphURLs) ) {
                 // Resolve named graph URLs so the graphname is an absolute IRI.
-                List<String> x = ListUtils.toList(namedGraphURLs.stream().map(IRILib::filenameToIRI));
+                List<String> x = namedGraphURLs.stream().map(IRILib::filenameToIRI).toList();
                 DatasetUtils.addInGraphs(ds, graphURLs, x, null) ;
             }
         }

--- a/jena-cmds/src/main/java/shacl/shacl_parse.java
+++ b/jena-cmds/src/main/java/shacl/shacl_parse.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.io.IndentedWriter;
-import org.apache.jena.atlas.lib.StreamOps;
 import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdException;
@@ -97,11 +96,10 @@ public class shacl_parse extends CmdGeneral {
                  String[] a = x.split(",");
                  return Arrays.stream(a);
              };
-             List<String> values =
-                 StreamOps.toList(getValues(argOutput).stream()
+             List<String> values = getValues(argOutput).stream()
                      .flatMap(f)
                      .map(s->s.toLowerCase())
-                     );
+                     .toList();
              printText = values.remove("text") || values.remove("t");
              printCompact = values.remove("compact") || values.remove("c");
              printRDF = values.remove("rdf") || values.remove("r") || values.remove("ttl");

--- a/jena-cmds/src/main/java/shex/shex_parse.java
+++ b/jena-cmds/src/main/java/shex/shex_parse.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 
 import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.atlas.lib.FileOps;
-import org.apache.jena.atlas.lib.StreamOps;
 import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdException;
@@ -90,11 +89,10 @@ public class shex_parse extends CmdGeneral {
                  String[] a = x.split(",");
                  return Arrays.stream(a);
              };
-             List<String> values =
-                 StreamOps.toList(getValues(argOutput).stream()
+             List<String> values = getValues(argOutput).stream()
                      .flatMap(f)
                      .map(s->s.toLowerCase())
-                     );
+                     .toList();
              printText = values.remove("text") || values.remove("t");
              printCompact = values.remove("compact") || values.remove("c");
              printRDF = values.remove("rdf") || values.remove("r");

--- a/jena-cmds/src/main/java/tdb/tdbloader.java
+++ b/jena-cmds/src/main/java/tdb/tdbloader.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdException;
 import org.apache.jena.query.ARQ;
@@ -127,13 +126,13 @@ public class tdbloader extends CmdTDBGraph {
 
     // Check files exists before starting.
     private void checkFiles(List<String> urls) {
-        List<String> problemFiles = ListUtils.toList(urls.stream().filter(u -> FileUtils.isFile(u))
+        List<String> problemFiles = urls.stream().filter(u -> FileUtils.isFile(u))
                                                          // Only check local files.
                                                          .map(Paths::get)
-                                                         .filter(p -> !Files.exists(p) || !Files.isRegularFile(p /* follow
-                                                                                                                  * links */)
-                                                                      || !Files.isReadable(p))
-                                                         .map(Path::toString));
+                                                         /* follows links */
+                                                         .filter(p -> !Files.exists(p) || !Files.isRegularFile(p) || !Files.isReadable(p))
+                                                         .map(Path::toString)
+                                                         .toList();
         if ( !problemFiles.isEmpty() ) {
             String str = String.join(", ", problemFiles);
             throw new CmdException("Can't read files : " + str);

--- a/jena-cmds/src/main/java/tdb2/tdbloader.java
+++ b/jena-cmds/src/main/java/tdb2/tdbloader.java
@@ -18,8 +18,6 @@
 
 package tdb2;
 
-import static org.apache.jena.atlas.lib.ListUtils.toList;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -160,14 +158,15 @@ public class tdbloader extends CmdTDBGraph {
 
     // Check files exists before starting.
     private void checkFiles(List<String> urls) {
-        List<String> problemFiles = toList(urls.stream()
+        List<String> problemFiles = urls.stream()
                                            // Local files.
                                            .filter(u -> FileUtils.isFile(u))
                                            .map(Paths::get)
                                            .filter(p -> !Files.exists(p) ||
                                                         !Files.isRegularFile(p /* this follows links */) ||
                                                         !Files.isReadable(p))
-                                           .map(Path::toString));
+                                           .map(Path::toString)
+                                           .toList();
         if ( !problemFiles.isEmpty() ) {
             if ( problemFiles.size() == 1 )
                 throw new CmdException("Can't read file : " + problemFiles.get(0));

--- a/jena-core/src/test/java/org/apache/jena/mem2/AbstractGraphMem2Test.java
+++ b/jena-core/src/test/java/org/apache/jena/mem2/AbstractGraphMem2Test.java
@@ -18,20 +18,21 @@
 
 package org.apache.jena.mem2;
 
+import static org.apache.jena.testing_framework.GraphHelper.node;
+import static org.apache.jena.testing_framework.GraphHelper.triple;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
 import org.apache.jena.datatypes.xsd.impl.XSDDouble;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.stream.Collectors;
-
-import static org.apache.jena.testing_framework.GraphHelper.node;
-import static org.apache.jena.testing_framework.GraphHelper.triple;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 
 public abstract class AbstractGraphMem2Test {
 
@@ -379,7 +380,7 @@ public abstract class AbstractGraphMem2Test {
 
         var t = triple("x R y");
         sut.add(t);
-        var findings = sut.stream(t.getSubject(), t.getPredicate(), t.getObject()).collect(Collectors.toList());
+        var findings = sut.stream(t.getSubject(), t.getPredicate(), t.getObject()).toList();
         assertEquals(1, findings.size());
         assertEquals(findings.get(0), t);
     }
@@ -408,7 +409,7 @@ public abstract class AbstractGraphMem2Test {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(null, null, null).collect(Collectors.toList());
+        var findings = sut.stream(null, null, null).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, aAb, aAc, bAa, bAb, bAc, cBa, cBb, cBc));
     }
 
@@ -436,16 +437,16 @@ public abstract class AbstractGraphMem2Test {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(aAa.getSubject(), null, null).collect(Collectors.toList());
+        var findings = sut.stream(aAa.getSubject(), null, null).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, aAb, aAc));
 
-        findings = sut.stream(bAa.getSubject(), null, null).collect(Collectors.toList());
+        findings = sut.stream(bAa.getSubject(), null, null).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(bAa, bAb, bAc));
 
-        findings = sut.stream(cBa.getSubject(), null, null).collect(Collectors.toList());
+        findings = sut.stream(cBa.getSubject(), null, null).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa, cBb, cBc));
 
-        findings = sut.stream(node("d"), null, null).collect(Collectors.toList());
+        findings = sut.stream(node("d"), null, null).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -473,13 +474,13 @@ public abstract class AbstractGraphMem2Test {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(null, aAa.getPredicate(), null).collect(Collectors.toList());
+        var findings = sut.stream(null, aAa.getPredicate(), null).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, aAb, aAc, bAa, bAb, bAc));
 
-        findings = sut.stream(null, cBa.getPredicate(), null).collect(Collectors.toList());
+        findings = sut.stream(null, cBa.getPredicate(), null).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa, cBb, cBc));
 
-        findings = sut.stream(null, node("C"), null).collect(Collectors.toList());
+        findings = sut.stream(null, node("C"), null).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -507,16 +508,16 @@ public abstract class AbstractGraphMem2Test {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(null, null, aAa.getObject()).collect(Collectors.toList());
+        var findings = sut.stream(null, null, aAa.getObject()).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, bAa, cBa));
 
-        findings = sut.stream(null, null, aAb.getObject()).collect(Collectors.toList());
+        findings = sut.stream(null, null, aAb.getObject()).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAb, bAb, cBb));
 
-        findings = sut.stream(null, null, aAc.getObject()).collect(Collectors.toList());
+        findings = sut.stream(null, null, aAc.getObject()).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAc, bAc, cBc));
 
-        findings = sut.stream(null, null, node("d")).collect(Collectors.toList());
+        findings = sut.stream(null, null, node("d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -544,19 +545,19 @@ public abstract class AbstractGraphMem2Test {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(aAa.getSubject(), aAa.getPredicate(), null).collect(Collectors.toList());
+        var findings = sut.stream(aAa.getSubject(), aAa.getPredicate(), null).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, aAb, aAc));
 
-        findings = sut.stream(bAa.getSubject(), bAa.getPredicate(), null).collect(Collectors.toList());
+        findings = sut.stream(bAa.getSubject(), bAa.getPredicate(), null).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(bAa, bAb, bAc));
 
-        findings = sut.stream(cBa.getSubject(), cBa.getPredicate(), null).collect(Collectors.toList());
+        findings = sut.stream(cBa.getSubject(), cBa.getPredicate(), null).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa, cBb, cBc));
 
-        findings = sut.stream(node("a"), node("C"), null).collect(Collectors.toList());
+        findings = sut.stream(node("a"), node("C"), null).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(node("d"), node("D"), null).collect(Collectors.toList());
+        findings = sut.stream(node("d"), node("D"), null).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -584,22 +585,22 @@ public abstract class AbstractGraphMem2Test {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(aAa.getSubject(), null, aAa.getObject()).collect(Collectors.toList());
+        var findings = sut.stream(aAa.getSubject(), null, aAa.getObject()).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa));
 
-        findings = sut.stream(bAa.getSubject(), null, bAa.getObject()).collect(Collectors.toList());
+        findings = sut.stream(bAa.getSubject(), null, bAa.getObject()).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(bAa));
 
-        findings = sut.stream(cBa.getSubject(), null, cBa.getObject()).collect(Collectors.toList());
+        findings = sut.stream(cBa.getSubject(), null, cBa.getObject()).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa));
 
-        findings = sut.stream(node("d"), null, node("d")).collect(Collectors.toList());
+        findings = sut.stream(node("d"), null, node("d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(node("d"), null, node("a")).collect(Collectors.toList());
+        findings = sut.stream(node("d"), null, node("a")).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(node("a"), null, node("d")).collect(Collectors.toList());
+        findings = sut.stream(node("a"), null, node("d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -627,22 +628,22 @@ public abstract class AbstractGraphMem2Test {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(null, aAa.getPredicate(), aAa.getObject()).collect(Collectors.toList());
+        var findings = sut.stream(null, aAa.getPredicate(), aAa.getObject()).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, bAa));
 
-        findings = sut.stream(null, bAa.getPredicate(), bAa.getObject()).collect(Collectors.toList());
+        findings = sut.stream(null, bAa.getPredicate(), bAa.getObject()).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, bAa));
 
-        findings = sut.stream(null, cBa.getPredicate(), cBa.getObject()).collect(Collectors.toList());
+        findings = sut.stream(null, cBa.getPredicate(), cBa.getObject()).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa));
 
-        findings = sut.stream(null, node("C"), node("a")).collect(Collectors.toList());
+        findings = sut.stream(null, node("C"), node("a")).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(null, node("A"), node("d")).collect(Collectors.toList());
+        findings = sut.stream(null, node("A"), node("d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(null, node("D"), node("d")).collect(Collectors.toList());
+        findings = sut.stream(null, node("D"), node("d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 

--- a/jena-core/src/test/java/org/apache/jena/mem2/collection/AbstractJenaMapNodeTest.java
+++ b/jena-core/src/test/java/org/apache/jena/mem2/collection/AbstractJenaMapNodeTest.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.apache.jena.testing_framework.GraphHelper.node;
@@ -305,7 +304,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(n0, null);
 
         final var spliterator = sut.keySpliterator();
-        final var list = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+        final var list = StreamSupport.stream(spliterator, false).toList();
         assertThat(list, IsIterableContainingInAnyOrder.containsInAnyOrder(n0));
     }
 
@@ -314,7 +313,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(node("s"), 1);
 
         final var spliterator = sut.valueSpliterator();
-        final var list = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+        final var list = StreamSupport.stream(spliterator, false).toList();
         assertThat(list, IsIterableContainingInAnyOrder.containsInAnyOrder(1));
     }
 
@@ -327,7 +326,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(n1, null);
 
         final var spliterator = sut.keySpliterator();
-        final var list = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+        final var list = StreamSupport.stream(spliterator, false).toList();
         assertThat(list, IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1));
     }
 
@@ -337,7 +336,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(node("s2"), 2);
 
         final var spliterator = sut.valueSpliterator();
-        final var list = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+        final var list = StreamSupport.stream(spliterator, false).toList();
         assertThat(list, IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2));
     }
 
@@ -352,7 +351,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(n2, null);
 
         final var spliterator = sut.keySpliterator();
-        final var list = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+        final var list = StreamSupport.stream(spliterator, false).toList();
         assertThat(list, IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1, n2));
     }
 
@@ -363,20 +362,20 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(node("s3"), 3);
 
         final var spliterator = sut.valueSpliterator();
-        final var list = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+        final var list = StreamSupport.stream(spliterator, false).toList();
         assertThat(list, IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2, 3));
     }
 
     @Test
     public void testKeyStreamEmpty() {
         var stream = sut.keyStream();
-        assertThat(stream.collect(Collectors.toList()), IsEmptyCollection.empty());
+        assertThat(stream.toList(), IsEmptyCollection.empty());
     }
 
     @Test
     public void testValueStreamEmpty() {
         var stream = sut.valueStream();
-        assertThat(stream.collect(Collectors.toList()), IsEmptyCollection.empty());
+        assertThat(stream.toList(), IsEmptyCollection.empty());
     }
 
     @Test
@@ -386,7 +385,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(n0, null);
 
         final var stream = sut.keyStream();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(n0));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0));
     }
 
     @Test
@@ -394,7 +393,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(node("s"), 1);
 
         final var stream = sut.valueStream();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(1));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(1));
     }
 
     @Test
@@ -406,7 +405,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(n1, null);
 
         final var stream = sut.keyStream();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1));
     }
 
     @Test
@@ -415,7 +414,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(node("s2"), 2);
 
         final var stream = sut.valueStream();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2));
     }
 
     @Test
@@ -429,7 +428,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(n2, null);
 
         final var stream = sut.keyStream();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1, n2));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1, n2));
     }
 
     @Test
@@ -439,19 +438,19 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(node("s3"), 3);
 
         final var stream = sut.valueStream();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2, 3));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2, 3));
     }
 
     @Test
     public void testKeyStreamParallelEmpty() {
         var stream = sut.keyStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsEmptyCollection.empty());
+        assertThat(stream.toList(), IsEmptyCollection.empty());
     }
 
     @Test
     public void testValueStreamParallelEmpty() {
         var stream = sut.valueStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsEmptyCollection.empty());
+        assertThat(stream.toList(), IsEmptyCollection.empty());
     }
 
     @Test
@@ -461,7 +460,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(n0, null);
 
         final var stream = sut.keyStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(n0));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0));
     }
 
     @Test
@@ -469,7 +468,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(node("s"), 1);
 
         final var stream = sut.valueStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(1));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(1));
     }
 
     @Test
@@ -481,7 +480,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(n1, null);
 
         final var stream = sut.keyStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1));
     }
 
     @Test
@@ -490,7 +489,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(node("s2"), 2);
 
         final var stream = sut.valueStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2));
     }
 
     @Test
@@ -504,7 +503,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(n2, null);
 
         final var stream = sut.keyStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1, n2));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1, n2));
     }
 
     @Test
@@ -514,7 +513,7 @@ public abstract class AbstractJenaMapNodeTest {
         sut.put(node("s3"), 3);
 
         final var stream = sut.valueStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2, 3));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(1, 2, 3));
     }
 
     @Test

--- a/jena-core/src/test/java/org/apache/jena/mem2/collection/AbstractJenaSetTripleTest.java
+++ b/jena-core/src/test/java/org/apache/jena/mem2/collection/AbstractJenaSetTripleTest.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static org.apache.jena.testing_framework.GraphHelper.triple;
@@ -174,7 +173,7 @@ public abstract class AbstractJenaSetTripleTest {
         sut.tryAdd(t0);
 
         final var spliterator = sut.keySpliterator();
-        final var list = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+        final var list = StreamSupport.stream(spliterator, false).toList();
         assertThat(list, IsIterableContainingInAnyOrder.containsInAnyOrder(t0));
     }
 
@@ -187,7 +186,7 @@ public abstract class AbstractJenaSetTripleTest {
         sut.tryAdd(t1);
 
         final var spliterator = sut.keySpliterator();
-        final var list = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+        final var list = StreamSupport.stream(spliterator, false).toList();
         assertThat(list, IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1));
     }
 
@@ -202,14 +201,14 @@ public abstract class AbstractJenaSetTripleTest {
         sut.tryAdd(t2);
 
         final var spliterator = sut.keySpliterator();
-        final var list = StreamSupport.stream(spliterator, false).collect(Collectors.toList());
+        final var list = StreamSupport.stream(spliterator, false).toList();
         assertThat(list, IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1, t2));
     }
 
     @Test
     public void testKeyStreamEmpty() {
         var stream = sut.keyStream();
-        assertThat(stream.collect(Collectors.toList()), IsEmptyCollection.empty());
+        assertThat(stream.toList(), IsEmptyCollection.empty());
     }
 
     @Test
@@ -219,7 +218,7 @@ public abstract class AbstractJenaSetTripleTest {
         sut.tryAdd(t0);
 
         final var stream = sut.keyStream();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(t0));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(t0));
     }
 
     @Test
@@ -231,7 +230,7 @@ public abstract class AbstractJenaSetTripleTest {
         sut.tryAdd(t1);
 
         final var stream = sut.keyStream();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1));
     }
 
     @Test
@@ -245,13 +244,13 @@ public abstract class AbstractJenaSetTripleTest {
         sut.tryAdd(t2);
 
         final var stream = sut.keyStream();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1, t2));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1, t2));
     }
 
     @Test
     public void testKeyStreamParallelEmpty() {
         var stream = sut.keyStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsEmptyCollection.empty());
+        assertThat(stream.toList(), IsEmptyCollection.empty());
     }
 
     @Test
@@ -261,7 +260,7 @@ public abstract class AbstractJenaSetTripleTest {
         sut.tryAdd(t0);
 
         final var stream = sut.keyStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(t0));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(t0));
     }
 
     @Test
@@ -273,7 +272,7 @@ public abstract class AbstractJenaSetTripleTest {
         sut.tryAdd(t1);
 
         final var stream = sut.keyStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1));
     }
 
     @Test
@@ -287,7 +286,7 @@ public abstract class AbstractJenaSetTripleTest {
         sut.tryAdd(t2);
 
         final var stream = sut.keyStreamParallel();
-        assertThat(stream.collect(Collectors.toList()), IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1, t2));
+        assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(t0, t1, t2));
     }
 
     @Test

--- a/jena-core/src/test/java/org/apache/jena/mem2/store/AbstractTripleStoreTest.java
+++ b/jena-core/src/test/java/org/apache/jena/mem2/store/AbstractTripleStoreTest.java
@@ -26,8 +26,6 @@ import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.stream.Collectors;
-
 import static org.apache.jena.testing_framework.GraphHelper.node;
 import static org.apache.jena.testing_framework.GraphHelper.triple;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -380,7 +378,7 @@ public abstract class AbstractTripleStoreTest {
 
         var t = triple("x R y");
         sut.add(t);
-        var findings = sut.stream(t).collect(Collectors.toList());
+        var findings = sut.stream(t).toList();
         assertEquals(1, findings.size());
         assertEquals(findings.get(0), t);
     }
@@ -409,7 +407,7 @@ public abstract class AbstractTripleStoreTest {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(triple("?? ?? ??")).collect(Collectors.toList());
+        var findings = sut.stream(triple("?? ?? ??")).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, aAb, aAc, bAa, bAb, bAc, cBa, cBb, cBc));
     }
 
@@ -437,16 +435,16 @@ public abstract class AbstractTripleStoreTest {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(Triple.createMatch(aAa.getSubject(), null, null)).collect(Collectors.toList());
+        var findings = sut.stream(Triple.createMatch(aAa.getSubject(), null, null)).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, aAb, aAc));
 
-        findings = sut.stream(Triple.createMatch(bAa.getSubject(), null, null)).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(bAa.getSubject(), null, null)).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(bAa, bAb, bAc));
 
-        findings = sut.stream(Triple.createMatch(cBa.getSubject(), null, null)).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(cBa.getSubject(), null, null)).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa, cBb, cBc));
 
-        findings = sut.stream(triple("d ?? ??")).collect(Collectors.toList());
+        findings = sut.stream(triple("d ?? ??")).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -474,13 +472,13 @@ public abstract class AbstractTripleStoreTest {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(Triple.createMatch(null, aAa.getPredicate(), null)).collect(Collectors.toList());
+        var findings = sut.stream(Triple.createMatch(null, aAa.getPredicate(), null)).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, aAb, aAc, bAa, bAb, bAc));
 
-        findings = sut.stream(Triple.createMatch(null, cBa.getPredicate(), null)).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(null, cBa.getPredicate(), null)).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa, cBb, cBc));
 
-        findings = sut.stream(triple("?? C ??")).collect(Collectors.toList());
+        findings = sut.stream(triple("?? C ??")).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -508,16 +506,16 @@ public abstract class AbstractTripleStoreTest {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(Triple.createMatch(null, null, aAa.getObject())).collect(Collectors.toList());
+        var findings = sut.stream(Triple.createMatch(null, null, aAa.getObject())).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, bAa, cBa));
 
-        findings = sut.stream(Triple.createMatch(null, null, aAb.getObject())).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(null, null, aAb.getObject())).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAb, bAb, cBb));
 
-        findings = sut.stream(Triple.createMatch(null, null, aAc.getObject())).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(null, null, aAc.getObject())).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAc, bAc, cBc));
 
-        findings = sut.stream(triple("?? ?? d")).collect(Collectors.toList());
+        findings = sut.stream(triple("?? ?? d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -545,19 +543,19 @@ public abstract class AbstractTripleStoreTest {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(Triple.createMatch(aAa.getSubject(), aAa.getPredicate(), null)).collect(Collectors.toList());
+        var findings = sut.stream(Triple.createMatch(aAa.getSubject(), aAa.getPredicate(), null)).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, aAb, aAc));
 
-        findings = sut.stream(Triple.createMatch(bAa.getSubject(), bAa.getPredicate(), null)).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(bAa.getSubject(), bAa.getPredicate(), null)).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(bAa, bAb, bAc));
 
-        findings = sut.stream(Triple.createMatch(cBa.getSubject(), cBa.getPredicate(), null)).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(cBa.getSubject(), cBa.getPredicate(), null)).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa, cBb, cBc));
 
-        findings = sut.stream(triple("a C ??")).collect(Collectors.toList());
+        findings = sut.stream(triple("a C ??")).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(triple("d D ??")).collect(Collectors.toList());
+        findings = sut.stream(triple("d D ??")).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -585,22 +583,22 @@ public abstract class AbstractTripleStoreTest {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(Triple.createMatch(aAa.getSubject(), null, aAa.getObject())).collect(Collectors.toList());
+        var findings = sut.stream(Triple.createMatch(aAa.getSubject(), null, aAa.getObject())).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa));
 
-        findings = sut.stream(Triple.createMatch(bAa.getSubject(), null, bAa.getObject())).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(bAa.getSubject(), null, bAa.getObject())).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(bAa));
 
-        findings = sut.stream(Triple.createMatch(cBa.getSubject(), null, cBa.getObject())).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(cBa.getSubject(), null, cBa.getObject())).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa));
 
-        findings = sut.stream(triple("d ?? d")).collect(Collectors.toList());
+        findings = sut.stream(triple("d ?? d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(triple("d ?? a")).collect(Collectors.toList());
+        findings = sut.stream(triple("d ?? a")).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(triple("a ?? d")).collect(Collectors.toList());
+        findings = sut.stream(triple("a ?? d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 
@@ -628,22 +626,22 @@ public abstract class AbstractTripleStoreTest {
         sut.add(cBb);
         sut.add(cBc);
 
-        var findings = sut.stream(Triple.createMatch(null, aAa.getPredicate(), aAa.getObject())).collect(Collectors.toList());
+        var findings = sut.stream(Triple.createMatch(null, aAa.getPredicate(), aAa.getObject())).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, bAa));
 
-        findings = sut.stream(Triple.createMatch(null, bAa.getPredicate(), bAa.getObject())).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(null, bAa.getPredicate(), bAa.getObject())).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(aAa, bAa));
 
-        findings = sut.stream(Triple.createMatch(null, cBa.getPredicate(), cBa.getObject())).collect(Collectors.toList());
+        findings = sut.stream(Triple.createMatch(null, cBa.getPredicate(), cBa.getObject())).toList();
         assertThat(findings, IsIterableContainingInAnyOrder.containsInAnyOrder(cBa));
 
-        findings = sut.stream(triple("?? C a")).collect(Collectors.toList());
+        findings = sut.stream(triple("?? C a")).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(triple("?? A d")).collect(Collectors.toList());
+        findings = sut.stream(triple("?? A d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
 
-        findings = sut.stream(triple("?? D d")).collect(Collectors.toList());
+        findings = sut.stream(triple("?? D d")).toList();
         assertThat(findings, IsEmptyCollection.empty());
     }
 

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRuleLoader.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRuleLoader.java
@@ -27,8 +27,6 @@ import org.apache.jena.shared.WrappedIOException;
 import org.junit.Test;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -72,6 +70,6 @@ public class TestRuleLoader  {
     public void load_from_file_with_custom_builtins() {
         BuiltinRegistry br = createBuiltinRegistry();
         List<Rule> rules = Rule.rulesFromURL("testing/reasoners/bugs/custom-builtins.rules", br);
-        assertEquals(List.of("ruleWithBuiltin"), rules.stream().map(Rule::getName).collect(Collectors.toList()));
+        assertEquals(List.of("ruleWithBuiltin"), rules.stream().map(Rule::getName).toList());
     }
 }

--- a/jena-db/jena-dboe-storage/src/main/java/org/apache/jena/dboe/storage/simple/StorageTuplesN.java
+++ b/jena-db/jena-dboe-storage/src/main/java/org/apache/jena/dboe/storage/simple/StorageTuplesN.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.atlas.lib.tuple.Tuple;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.Match;
@@ -50,7 +49,7 @@ public class StorageTuplesN {
     }
 
     public void removeAll(Tuple<Node> pattern) {
-        List<Tuple<Node>> acc = ListUtils.toList(find(pattern));
+        List<Tuple<Node>> acc = find(pattern).toList();
         acc.stream().forEach(this::delete);
     }
 

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/AccessPath.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/AccessPath.java
@@ -20,8 +20,6 @@ package org.apache.jena.dboe.trans.bplustree;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import org.apache.jena.atlas.lib.InternalErrorException;
 
 public class AccessPath {
@@ -64,7 +62,7 @@ public class AccessPath {
 
     @Override
     public String toString() {
-        return traversed.stream().map(x-> x.toString()).collect(Collectors.toList()).toString();
+        return traversed.stream().map(x-> x.toString()).toList().toString();
     }
 }
 

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ExprFactory.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/ExprFactory.java
@@ -19,8 +19,6 @@ package org.apache.jena.arq.querybuilder;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import org.apache.jena.arq.querybuilder.clauses.WhereClause;
 import org.apache.jena.graph.Node;
 import org.apache.jena.shared.PrefixMapping;
@@ -1599,7 +1597,7 @@ public class ExprFactory {
      */
     public final ExprList asList(Object... args) {
         // make sure the list is modifyable
-        List<Expr> lst = Arrays.asList(args).stream().map(arg -> asExpr(arg)).collect(Collectors.toList());
+        List<Expr> lst = Arrays.asList(args).stream().map(arg -> asExpr(arg)).toList();
         return new ExprList(lst);
     }
 

--- a/jena-extras/jena-serviceenhancer/src/test/java/org/apache/jena/sparql/service/enhancer/impl/TestServiceEnhancerBatcher.java
+++ b/jena-extras/jena-serviceenhancer/src/test/java/org/apache/jena/sparql/service/enhancer/impl/TestServiceEnhancerBatcher.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.jena.atlas.iterator.Iter;
@@ -100,8 +99,8 @@ public class TestServiceEnhancerBatcher {
 
         // For each obtained batch extract the list of values
         List<List<Integer>> actualBatchIds = Streams.stream(it)
-                .map(groupedBatch -> groupedBatch.getBatch().getItems().values().stream().map(Entry::getValue).collect(Collectors.toList()))
-                .collect(Collectors.toList());
+                .map(groupedBatch -> groupedBatch.getBatch().getItems().values().stream().map(Entry::getValue).toList())
+                .toList();
 
         Assert.assertEquals(expectedBatchIds, actualBatchIds);
     }

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/GraphFilterTDB1.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/GraphFilterTDB1.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.util.Symbol;
@@ -55,12 +54,10 @@ class GraphFilterTDB1 extends GraphFilter<NodeId> {
         List<NodeId> x =
             Txn.calculateRead(dsg, ()->{
                 NodeTable nt = TDBInternal.getDatasetGraphTDB(dsg).getQuadTable().getNodeTupleTable().getNodeTable();
-                return
-                    ListUtils.toList(
-                        namedGraphs.stream()
+                return namedGraphs.stream()
                         .map(n->nt.getNodeIdForNode(n))
                         .filter(Objects::nonNull)
-                        );
+                        .toList();
             });
         return new GraphFilterTDB1(x, matchDefaultGraph);
     }

--- a/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/GraphFilterTDB2.java
+++ b/jena-fuseki2/jena-fuseki-access/src/main/java/org/apache/jena/fuseki/access/GraphFilterTDB2.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.jena.atlas.lib.ListUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.util.Symbol;
@@ -55,12 +54,10 @@ class GraphFilterTDB2 extends GraphFilter<NodeId> {
         List<NodeId> x =
             Txn.calculateRead(dsg, ()->{
                 NodeTable nt = TDBInternal.getDatasetGraphTDB(dsg).getQuadTable().getNodeTupleTable().getNodeTable();
-                return
-                    ListUtils.toList(
-                        namedGraphs.stream()
+                return namedGraphs.stream()
                         .map(n->nt.getNodeIdForNode(n))
                         .filter(Objects::nonNull)
-                        );
+                        .toList();
             });
         return new GraphFilterTDB2(x, matchDefaultGraph);
     }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiAutoModules.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiAutoModules.java
@@ -23,8 +23,6 @@ import java.util.Objects;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.atlas.lib.Version;
 import org.apache.jena.atlas.logging.FmtLog;
@@ -207,12 +205,12 @@ public class FusekiAutoModules {
                     .map(mapper)
                     .filter(Objects::nonNull)
                     .sorted((x,y)-> Integer.compare(x.level(), y.level()))
-                    .collect(Collectors.toList());
+                    .toList();
             // Start, and convert to FusekiModules (generics issue)
             List<FusekiModule> fmods = autoMods.stream().map(afmod->{
                 afmod.start();
-                return afmod;
-            }).collect(Collectors.toList());
+                return (FusekiModule)afmod;
+            }).toList();
 
             fmods.forEach(m->{
                 String name = m.name();

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/mgt/ActionBackupList.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/mgt/ActionBackupList.java
@@ -27,8 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import org.apache.jena.atlas.json.JsonBuilder;
 import org.apache.jena.atlas.json.JsonValue;
 import org.apache.jena.fuseki.ctl.ActionCtl;
@@ -78,7 +76,7 @@ public class ActionBackupList extends ActionCtl {
             ServletOps.errorOccurred(ex);
         }
 
-        List<String> fileNames = paths.stream().map((p)->p.getFileName().toString()).sorted().collect(Collectors.toList());
+        List<String> fileNames = paths.stream().map((p)->p.getFileName().toString()).sorted().toList();
 
         JsonBuilder builder = new JsonBuilder();
         builder.startObject("top");

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/ModeSRS.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/configuration/ModeSRS.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import org.apache.jena.geosparql.implementation.GeometryWrapper;
 import org.apache.jena.geosparql.implementation.vocabulary.Geo;
 import org.apache.jena.geosparql.implementation.vocabulary.SRS_URI;
@@ -82,7 +81,7 @@ public class ModeSRS {
             }
         }
 
-        srsList = srsMap.entrySet().stream().sorted(Collections.reverseOrder(Map.Entry.comparingByValue())).collect(Collectors.toList());
+        srsList = srsMap.entrySet().stream().sorted(Collections.reverseOrder(Map.Entry.comparingByValue())).toList();
     }
 
     public List<Entry<String, Integer>> getSrsList() {

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/Imports.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/Imports.java
@@ -26,8 +26,6 @@ import static org.apache.jena.sparql.graph.NodeConst.nodeRDFType;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.jena.atlas.lib.Pair;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.jena.atlas.web.HttpException;
@@ -203,7 +201,7 @@ public class Imports {
      * indicating "any owl:imports".
      */
     public static List<Node> allImports(Node base, Graph graph) {
-        List<Node> imports = iter(G.listSP(graph, base, nodeOwlImports)).filter(Node::isURI).collect(Collectors.toList());
+        List<Node> imports = iter(G.listSP(graph, base, nodeOwlImports)).filter(Node::isURI).toList();
         return imports;
     }
 }

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/compact/writer/CompactWriter.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/compact/writer/CompactWriter.java
@@ -20,8 +20,6 @@ package org.apache.jena.shacl.compact.writer;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import org.apache.jena.atlas.io.IndentedLineBuffer;
 import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.atlas.lib.CollectionUtils;
@@ -139,10 +137,10 @@ public class CompactWriter {
     public static void output(IndentedWriter out, NodeFormatter nodeFmt, ShapeOutputVisitor visitor, Shape sh) {
         List<Target> targetImplicitClasses = sh.getTargets().stream()
             .filter(t->t.getTargetType()==TargetType.implicitClass)
-            .collect(Collectors.toList());
+            .toList();
         List<Target> targetClasses = sh.getTargets().stream()
             .filter(t->t.getTargetType()==TargetType.targetClass)
-            .collect(Collectors.toList());
+            .toList();
 
         if ( targetImplicitClasses.isEmpty() ) {
             out.print("shape ");

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/SparqlComponent.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/SparqlComponent.java
@@ -18,8 +18,6 @@
 
 package org.apache.jena.shacl.engine.constraint;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.List;
 import java.util.Objects;
 
@@ -58,11 +56,11 @@ public class SparqlComponent {
         this.requiredParameters = params.stream()
             .filter(param->!param.isOptional())
             .map(param->param.getParameterPath())
-            .collect(toList());
+            .toList();
         this.optionalParameters = params.stream()
             .filter(param->param.isOptional())
             .map(param->param.getParameterPath())
-            .collect(toList());
+            .toList();
         this.reportNode = reportNode;
         this.sparqlString = sparqlString;
         this.query = ShLib.parseQueryString(sparqlString);

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Constraints.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Constraints.java
@@ -21,8 +21,6 @@ package org.apache.jena.shacl.parser;
 import static org.apache.jena.shacl.lib.ShLib.displayStr;
 
 import java.util.*;
-import java.util.stream.Collectors;
-
 import org.apache.jena.atlas.lib.NotImplemented;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
@@ -244,7 +242,7 @@ public class Constraints {
     }
 
     private static List<Shape> shapes(Graph g, Map<Node, Shape> parsed, Set<Node> traversed, List<Node> elts) {
-        return elts.stream().map(x->ShapesParser.parseShapeStep(traversed, parsed, g, x)).collect(Collectors.toList());
+        return elts.stream().map(x->ShapesParser.parseShapeStep(traversed, parsed, g, x)).toList();
     }
 
     private static Constraint parseQualifiedValueShape(Graph g, Node s, Node p, Node o, Map<Node, Shape> parsed, Set<Node> traversed) {
@@ -304,6 +302,6 @@ public class Constraints {
             if ( ! Util.isSimpleString(n) )
                 throw new ShaclParseException("Not a string "+displayStr(n)+" in list "+elts);
             return n.getLiteralLexicalForm();
-        }).collect(Collectors.toList());
+        }).toList();
     }
 }

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Parameters.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Parameters.java
@@ -21,8 +21,6 @@ package org.apache.jena.shacl.parser;
 import static org.apache.jena.shacl.sys.C.TRUE;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
 import org.apache.commons.collections4.MultiMapUtils;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.jena.graph.Graph;
@@ -40,7 +38,7 @@ public class Parameters {
         List<Parameter> params =
             G.listSP(shapesGraph, sccNode, SHACL.parameter).stream()
                 .map(pn->parseParameter(shapesGraph, sccNode, pn))
-                .collect(Collectors.toList());
+                .toList();
         return params;
     }
 

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/validation/HandlerBasedValidationListener.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/validation/HandlerBasedValidationListener.java
@@ -193,7 +193,7 @@ public class HandlerBasedValidationListener implements ValidationListener {
         }
 
         private List<Consumer<ValidationEvent>> getHandlers(Map<Class<? extends ValidationEvent>, List<Consumer<ValidationEvent>>> handlers, List<Class<? extends ValidationEvent>> eventTypes) {
-            return eventTypes.stream().flatMap(t -> handlers.getOrDefault(t, List.of()).stream()).collect(Collectors.toList());
+            return eventTypes.stream().flatMap(t -> handlers.getOrDefault(t, List.of()).stream()).toList();
         }
     }
 

--- a/jena-shex/src/test/java/org/apache/jena/shex/runner/ShexTests.java
+++ b/jena-shex/src/test/java/org/apache/jena/shex/runner/ShexTests.java
@@ -19,8 +19,6 @@
 package org.apache.jena.shex.runner;
 
 import java.util.*;
-import java.util.stream.Collectors;
-
 import org.apache.jena.arq.junit.manifest.Manifest;
 import org.apache.jena.arq.junit.manifest.ManifestEntry;
 import org.apache.jena.arq.junit.manifest.Prefix;
@@ -308,7 +306,7 @@ public class ShexTests {
         if (traitsRsrc == null)
             return null;
         List<Statement> x = entry.getEntry().listProperties(ShexT.trait).toList();
-        return x.stream().map(t -> t.getObject().asResource()).collect(Collectors.toList());
+        return x.stream().map(t -> t.getObject().asResource()).toList();
     }
 
     private static boolean runTestExclusionsInclusions(ManifestEntry entry) {
@@ -328,7 +326,7 @@ public class ShexTests {
 
             List<Resource> traits = extractTraits(entry);
             if (traits != null) {
-                List<Resource> excludedBecause = traits.stream().filter(excl -> excludeTraits.contains(excl)).collect(Collectors.toList());
+                List<Resource> excludedBecause = traits.stream().filter(excl -> excludeTraits.contains(excl)).toList();
                 if (excludedBecause.size() > 0)
                     return false;
             }

--- a/jena-shex/src/test/java/org/apache/jena/shex/runner/ShexValidationTest.java
+++ b/jena-shex/src/test/java/org/apache/jena/shex/runner/ShexValidationTest.java
@@ -23,8 +23,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-
 import org.apache.jena.arq.junit.manifest.ManifestEntry;
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.lib.IRILib;
@@ -155,7 +153,7 @@ public class ShexValidationTest implements Runnable {
             }
             if (this.extensionResults != null) {
                 List<String> output = semActPlugin.getOut();
-                assertEquals(String.format("expected %s lines from SemAct, got %s", String.join("\n", extensionResults.stream().map(p -> p.getRight()).collect(Collectors.toList())), String.join("\n", output)), output.size(), extensionResults.size());
+                assertEquals(String.format("expected %s lines from SemAct, got %s", String.join("\n", extensionResults.stream().map(p -> p.getRight()).toList()), String.join("\n", output)), output.size(), extensionResults.size());
                 for(int i = 0; i < extensionResults.size(); i++) {
                     String expected = extensionResults.get(i).getRight();
                     String actual = output.get(i);


### PR DESCRIPTION
Clean-up.

Replaces `Stream.collect(Collectors.toList())` with `Stream.toList()` (which is immutable).





----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
