### PR TITLE
GH-2881: Mitigate cases of open iterators when cancelling queries.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterPeek.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterPeek.java
@@ -25,23 +25,23 @@ import org.apache.jena.sparql.engine.binding.Binding ;
 
 public class QueryIterPeek extends QueryIter1
 {
-    private Binding binding = null ; 
+    private Binding binding = null ;
     private boolean closed = false ;
-    
+
     public static QueryIterPeek create(QueryIterator iterator, ExecutionContext cxt)
     {
         if ( iterator instanceof QueryIterPeek)
             return (QueryIterPeek)iterator ;
         return new QueryIterPeek(iterator, cxt) ;
     }
-    
+
     private QueryIterPeek(QueryIterator iterator, ExecutionContext cxt)
     {
         super(iterator, cxt) ;
     }
 
     /** Returns the next binding without moving on.  Returns "null" for no such element. */
-    public Binding peek() 
+    public Binding peek()
     {
         if ( closed ) return null ;
         if ( ! hasNextBinding() )
@@ -73,7 +73,7 @@ public class QueryIterPeek extends QueryIter1
     @Override
     protected void closeSubIterator()
     { closed = true ; }
-    
+
     @Override
     protected void requestSubCancel()
     { }


### PR DESCRIPTION
GitHub issue resolved #2881 

Pull request Description:
- Added a test case that should emit warnings without the fixes (the tests do not fail otherwise)
- Adds exception handling to OpUnion and StageGeneratorGeneric, mainly to cope with concurrent QueryCancelledException.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
