### PR TITLE
GH-2883: Fix for an NPE in OpAsQuery.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpAsQuery.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/OpAsQuery.java
@@ -81,6 +81,25 @@ public class OpAsQuery {
         return converter.convert() ;
     }
 
+    public static Element asElement(Op op) {
+        Query query = asQuery(op);
+        Element elt = isPrimitiveQuery(query)
+            ? query.getQueryPattern()
+            : new ElementSubQuery(query);
+        return elt;
+    }
+
+    /** Whether the query is a plain <code>SELECT * { pattern }</code>.  */
+    private static boolean isPrimitiveQuery(Query query) {
+        boolean isNonPrimitive =
+            !query.isQueryResultStar() || query.isDistinct() || query.isReduced() ||
+            query.hasLimit() || query.hasOffset() ||
+            query.hasAggregators() || query.hasGroupBy() || query.hasHaving() ||
+            query.hasOrderBy() ||
+            query.hasValues();
+        return !isNonPrimitive;
+    }
+
     static class /* struct */ QueryLevelDetails {
         // The stack of processing in a query is:
         // slice-distinct/reduce-project-order-filter[having]-extend*[AS and aggregate naming]-group-pattern

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/ExprTransformApplyElementTransform.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/ExprTransformApplyElementTransform.java
@@ -20,6 +20,7 @@ package org.apache.jena.sparql.syntax.syntaxtransform;
 
 import org.apache.jena.sparql.ARQInternalErrorException;
 import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpAsQuery;
 import org.apache.jena.sparql.expr.*;
 import org.apache.jena.sparql.syntax.Element;
 
@@ -43,7 +44,15 @@ public class ExprTransformApplyElementTransform extends ExprTransformCopy
     @Override
     public Expr transform(ExprFunctionOp funcOp, ExprList args, Op opArg)
     {
-        Element el2 = ElementTransformer.transform(funcOp.getElement(), transform);
+        // If the element is null then an attempt is made to obtain it from the algebra.
+        // A given element takes precedence over the algebra.
+        Element el1 = funcOp.getElement();
+        if (el1 == null) {
+            Op op = funcOp.getGraphPattern();
+            el1 = op == null ? null : OpAsQuery.asElement(op);
+        }
+        // ElementTransformer will warn should it happen that null is passed to it.
+        Element el2 = ElementTransformer.transform(el1, transform, this);
 
         if ( el2 == funcOp.getElement() )
             return super.transform(funcOp, args, opArg);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
@@ -69,7 +69,7 @@ public class QueryTransformOps {
         Query q2 = QueryTransformOps.shallowCopy(query);
         // Mutate the q2 structures which are already allocated and no other code can access yet.
 
-        mutateByQueryType(q2, transform, exprTransform);
+        mutateByQueryType(q2, exprTransform);
         mutateVarExprList(q2.getGroupBy(), exprTransform);
         mutateExprList(q2.getHavingExprs(), exprTransform);
         if (q2.getOrderBy() != null)
@@ -116,7 +116,7 @@ public class QueryTransformOps {
     }
 
     // Do the result form part of the cloned query.
-    private static void mutateByQueryType(Query q2, ElementTransform transform, ExprTransform exprTransform) {
+    private static void mutateByQueryType(Query q2, ExprTransform exprTransform) {
         switch(q2.queryType()) {
             case ASK : break;
             case CONSTRUCT :
@@ -125,7 +125,7 @@ public class QueryTransformOps {
                 Template template = q2.getConstructTemplate();
                 QuadAcc acc = new QuadAcc();
                 List<Quad> quads = template.getQuads();
-                template.getQuads().forEach(q->{
+                quads.forEach(q->{
                     Node g = transform(q.getGraph(), exprTransform);
                     Node s = transform(q.getSubject(), exprTransform);
                     Node p = transform(q.getPredicate(), exprTransform);
@@ -145,7 +145,8 @@ public class QueryTransformOps {
             case CONSTRUCT_JSON :
                 throw new UnsupportedOperationException("Transform of JSON template queries");
             case UNKNOWN :
-                throw new JenaException("Unknown qu ery type");
+            default :
+                throw new JenaException("Unknown query type");
         }
     }
 


### PR DESCRIPTION
GitHub issue resolved #2883 

Pull request Description: Changed a line to pass on an ExprTransform rather than null.

Notes for possible further improvements outside the scope of this PR:
* It may be the case that `ElementTransformer` needs to create an identity ExprTransform rather than passing null into the machinery.
* `QueryTransformOps.transformVarExprList` in my IDE warns that the `changed` flag is not used. Perhaps this needlessly creates clones of queries w.r.t. identity transforms.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
