### PR TITLE
GH-2868: [ontapi] change register\unregister ModelChangedListener functionality

### DIFF
--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/OntGraphModelImpl.java
@@ -68,6 +68,7 @@ import org.apache.jena.ontapi.utils.StdModels;
 import org.apache.jena.rdf.model.InfModel;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelChangedListener;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFList;
 import org.apache.jena.rdf.model.RDFNode;
@@ -353,6 +354,25 @@ public class OntGraphModelImpl extends ModelCom implements OntModel, OntEnhGraph
     @Override
     public Model getBaseModel() {
         return new ModelCom(getBaseGraph());
+    }
+
+    @Override
+    public OntGraphModelImpl register(ModelChangedListener listener) {
+        getUnionGraph().getEventManager().register(adapt(listener));
+        return this;
+    }
+
+    @Override
+    public OntGraphModelImpl unregister(ModelChangedListener listener) {
+        getUnionGraph().getEventManager().unregister(adapt(listener));
+        return this;
+    }
+
+    @Override
+    public OntGraphModelImpl notifyEvent(Object event) {
+        var ug = getUnionGraph();
+        ug.getEventManager().notifyEvent(ug, event);
+        return this;
     }
 
     @Override

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/UnionGraphImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/UnionGraphImpl.java
@@ -18,17 +18,18 @@
 
 package org.apache.jena.ontapi.impl;
 
-import org.apache.jena.ontapi.UnionGraph;
-import org.apache.jena.ontapi.utils.Graphs;
-import org.apache.jena.ontapi.utils.Iterators;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.GraphEventManager;
 import org.apache.jena.graph.GraphEvents;
 import org.apache.jena.graph.GraphListener;
+import org.apache.jena.graph.GraphUtil;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.graph.compose.CompositionBase;
 import org.apache.jena.graph.impl.SimpleEventManager;
+import org.apache.jena.ontapi.UnionGraph;
+import org.apache.jena.ontapi.utils.Graphs;
+import org.apache.jena.ontapi.utils.Iterators;
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.util.iterator.ExtendedIterator;
 
@@ -223,7 +224,7 @@ public class UnionGraphImpl extends CompositionBase implements UnionGraph {
         Triple t = Triple.createMatch(s, p, o);
         UnionGraph.EventManager em = getEventManager();
         em.onDeleteTriple(this, t);
-        super.remove(s, p, o);
+        GraphUtil.remove(this, s, p, o);
         em.notifyEvent(this, GraphEvents.remove(s, p, o));
     }
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntSimpleClassImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntSimpleClassImpl.java
@@ -22,6 +22,7 @@ import org.apache.jena.enhanced.EnhGraph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.ontapi.OntJenaException;
 import org.apache.jena.ontapi.OntModelControls;
+import org.apache.jena.ontapi.common.OntPersonalities;
 import org.apache.jena.ontapi.impl.OntGraphModelImpl;
 import org.apache.jena.ontapi.model.OntClass;
 import org.apache.jena.ontapi.model.OntDataProperty;
@@ -34,6 +35,7 @@ import org.apache.jena.ontapi.model.OntRelationalProperty;
 import org.apache.jena.ontapi.model.OntStatement;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.OWL2;
+import org.apache.jena.vocabulary.RDFS;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,10 +44,9 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * {@code owl:Class} Implementation.
- * Instance of this class as a class with unknown nature is only available in a spec with corresponding permissions
- * ({@link OntModelControls}).
- * Specialized classes have their own implementations ({@link NamedImpl} or {@link OntClassImpl}).
+ * Simple Ontology Class implementation.
+ * Represents RDFS OntClass or OWL OntClass with unknown nature.
+ * Specialized OWL classes have their own implementations ({@link NamedImpl} or {@link OntClassImpl}).
  */
 @SuppressWarnings("WeakerAccess")
 public class OntSimpleClassImpl extends OntObjectImpl implements OntClass {
@@ -56,7 +57,7 @@ public class OntSimpleClassImpl extends OntObjectImpl implements OntClass {
 
     @Override
     public Optional<OntStatement> findRootStatement() {
-        return getOptionalRootStatement(this, OWL2.Class);
+        return getOptionalRootStatement(this, OntPersonalities.isRDFS(getModel().getOntPersonality()) ? RDFS.Class : OWL2.Class);
     }
 
     @Override

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/MutableModel.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/MutableModel.java
@@ -21,6 +21,7 @@ package org.apache.jena.ontapi.model;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelChangedListener;
 import org.apache.jena.rdf.model.ModelCon;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
@@ -109,4 +110,36 @@ interface MutableModel<R extends Model> extends Model {
 
     @Override
     R add(Resource s, Property p, String lex, String lang);
+
+    /**
+     * Registers a listener for model-changed events on this model.
+     * The methods on the listener will be called when API add/remove calls on the model succeed
+     * [in whole or in part].
+     * The same listener may be registered many times;
+     * if so, its methods will be called as many times as it's registered for each event.
+     *
+     * @param listener {@link ModelChangedListener}, not null
+     * @return this model, for cascading
+     */
+    R register(ModelChangedListener listener);
+
+    /**
+     * Unregisters a listener from model-changed events on this model.
+     * The listener is detached from the model.
+     * The model is returned to permit cascading.
+     * If the listener is not attached to the model, then nothing happens.
+     *
+     * @param listener {@link ModelChangedListener}, not null
+     */
+    R unregister(ModelChangedListener listener);
+
+    /**
+     * Notifies any listeners that the {@code event} has occurred.
+     *
+     * @param event the event, which has occurred, e.g. {@code GraphEvents#startRead}
+     * @return this model, for cascading
+     * @see ModelChangedListener
+     * @see org.apache.jena.graph.GraphEvents
+     */
+    R notifyEvent(Object event);
 }


### PR DESCRIPTION
GitHub issue resolved #2868

Pull request Description:

- use only UnionGraph (not InfGraph) to hold graph-listeners
- minor fix in OntSimpleClassImpl


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
