### PR TITLE
Fuseki maintenance

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthEnv.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthEnv.java
@@ -79,6 +79,13 @@ public class AuthEnv {
     /**
      * Remove the registration for a URI endpoint.
      */
+    public void unregisterUsernamePassword(String uri) {
+        unregisterUsernamePassword(URI.create(uri));
+    }
+
+    /**
+     * Remove the registration for a URI endpoint.
+     */
     public void unregisterUsernamePassword(URI uri) {
         AuthDomain location = new AuthDomain(uri);
         passwordRegistry.remove(location);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
@@ -65,8 +65,8 @@ public class AssemblerUtils
         initialized = true ;
         registerDataset(tDataset,         new DatasetAssemblerGeneral());
         registerDataset(tDatasetOne,      new DatasetOneAssembler());
-        registerDataset(tDatasetZero,     new DatasetNullAssembler(tDatasetZero));
-        registerDataset(tDatasetSink,     new DatasetNullAssembler(tDatasetSink));
+        registerDataset(tDatasetZero,     new DatasetZeroAssembler());
+        registerDataset(tDatasetSink,     new DatasetSinkAssembler());
         registerDataset(tMemoryDataset,   new InMemDatasetAssembler());
         registerDataset(tDatasetTxnMem,   new InMemDatasetAssembler());
         registerDataset(tDatasetView,     new ViewDatasetAssembler());

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetAssemblerGeneral.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetAssemblerGeneral.java
@@ -19,7 +19,6 @@
 package org.apache.jena.sparql.core.assembler ;
 
 import java.util.List ;
-import java.util.Map;
 
 import org.apache.jena.assembler.Assembler ;
 import org.apache.jena.atlas.logging.Log ;
@@ -40,11 +39,6 @@ public class DatasetAssemblerGeneral extends NamedDatasetAssembler {
     }
 
     public DatasetAssemblerGeneral() {}
-
-    @Override
-    public Map<String, DatasetGraph> pool() {
-        return sharedDatasetPool;
-    }
 
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetOneAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetOneAssembler.java
@@ -19,7 +19,6 @@
 package org.apache.jena.sparql.core.assembler;
 
 import java.util.List;
-import java.util.Map;
 
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.assembler.exceptions.AssemblerException;
@@ -50,11 +49,6 @@ public class DatasetOneAssembler extends NamedDatasetAssembler  {
     }
 
     public DatasetOneAssembler() {}
-
-    @Override
-    public Map<String, DatasetGraph> pool() {
-        return sharedDatasetPool;
-    }
 
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetSinkAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetSinkAssembler.java
@@ -21,25 +21,25 @@ package org.apache.jena.sparql.core.assembler;
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphWrapper;
+import org.apache.jena.sparql.core.DatasetGraphSink;
+import org.apache.jena.sparql.core.DatasetGraphZero;
 
 /**
- * An assembler that layers on top of another dataset given by {@code ja:dataset}.
- * <p>
- * It enables adding extra context settings.
- * <p>
- * It can be used as a super class, where the subclass overrides {@link #createBaseDataset}.
+ * An assembler that creates datasets that do nothing, either a sink or an always empty one.
+
+ * @see DatasetGraphSink
+ * @see DatasetGraphZero
  */
-public class ViewDatasetAssembler extends NamedDatasetAssembler  {
 
-    public static Resource getType() { return DatasetAssemblerVocab.tDatasetView; }
+public class DatasetSinkAssembler extends NamedDatasetAssembler {
 
-    public ViewDatasetAssembler() {}
+    public static Resource getType() { return DatasetAssemblerVocab.tDatasetSink; }
+
+    public DatasetSinkAssembler() {}
 
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {
-        DatasetGraph sub = createBaseDataset(root, DatasetAssemblerVocab.pDataset);
-        DatasetGraph dsg = new DatasetGraphWrapper(sub);
+        DatasetGraph dsg = DatasetGraphSink.create();
         AssemblerUtils.mergeContext(root, dsg.getContext());
         return dsg;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetZeroAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/DatasetZeroAssembler.java
@@ -18,45 +18,27 @@
 
 package org.apache.jena.sparql.core.assembler;
 
-import java.util.Map;
-
 import org.apache.jena.assembler.Assembler;
-import org.apache.jena.atlas.lib.InternalErrorException;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphSink;
 import org.apache.jena.sparql.core.DatasetGraphZero;
 
 /**
- * An assembler that creates datasets that do nothing, either a sink or a always empty one.
-
- * @see DatasetGraphSink
+ * An assembler that creates datasets that do nothing, either a sink or an always empty one.
+ *
  * @see DatasetGraphZero
  */
 
-public class DatasetNullAssembler extends NamedDatasetAssembler {
+public class DatasetZeroAssembler extends NamedDatasetAssembler {
 
-    private final Resource tDataset;
+    public static Resource getType() { return DatasetAssemblerVocab.tDatasetZero; }
 
-    public DatasetNullAssembler(Resource tDataset) {
-        this.tDataset = tDataset;
-    }
+    public DatasetZeroAssembler() {}
 
     @Override
     public DatasetGraph createDataset(Assembler a, Resource root) {
-        DatasetGraph dsg;
-        if ( DatasetAssemblerVocab.tDatasetSink.equals(tDataset) )
-            dsg = DatasetGraphSink.create();
-        else if ( DatasetAssemblerVocab.tDatasetZero.equals(tDataset) )
-            dsg = DatasetGraphZero.create();
-        else
-            throw new InternalErrorException();
+        DatasetGraph dsg = DatasetGraphZero.create();
         AssemblerUtils.mergeContext(root, dsg.getContext());
         return dsg;
-    }
-
-    @Override
-    public Map<String, DatasetGraph> pool() {
-        return sharedDatasetPool;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/InMemDatasetAssembler.java
@@ -21,8 +21,6 @@ package org.apache.jena.sparql.core.assembler;
 import static org.apache.jena.sparql.core.assembler.AssemblerUtils.loadData;
 import static org.apache.jena.sparql.core.assembler.AssemblerUtils.mergeContext;
 
-import java.util.Map;
-
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Resource;
@@ -38,11 +36,6 @@ import org.apache.jena.vocabulary.RDF;
 public class InMemDatasetAssembler extends NamedDatasetAssembler {
 
     public InMemDatasetAssembler() {}
-
-    @Override
-    public Map<String, DatasetGraph> pool() {
-        return sharedDatasetPool;
-    }
 
     public static Resource getType() {
         return DatasetAssemblerVocab.tMemoryDataset ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/NamedDatasetAssembler.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/NamedDatasetAssembler.java
@@ -49,6 +49,11 @@ public abstract class NamedDatasetAssembler extends DatasetAssembler {
         return createDataset(a, root);
     }
 
-    /** Shared {@link DatasetGraph} objects */
-    public abstract Map<String, DatasetGraph> pool();
+    /**
+     * Shared {@link DatasetGraph} objects.
+     * Subclasses may override for a different policy, or return null for "don't pool".
+     * Pools only affect {@link #createNamedDataset} and then only when {@code ja:name}
+     * ({@code DatasetAssemblerVocab.pDatasetName}) is present.
+     */
+    public Map<String, DatasetGraph> pool() { return sharedDatasetPool; }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/ContextAccumulator.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/ContextAccumulator.java
@@ -43,7 +43,7 @@ public class ContextAccumulator {
     private Context      baseContext        = null;
 
     // Context when built
-    private Context      builtContext        = null;
+    private Context      builtContext       = null;
 
     public static ContextAccumulator newBuilder() {
         return new ContextAccumulator();
@@ -77,7 +77,7 @@ public class ContextAccumulator {
 
     /**
      * If no explicit base, this is the default. It will be copied to isolate it at the build point.
-     * Default implement is to return ARQ.getContext().
+     * Default implementation is to return ARQ.getContext().
      */
     protected Context baseContext() { return ARQ.getContext(); }
 
@@ -108,7 +108,7 @@ public class ContextAccumulator {
      */
     public Context context() {
         // Freeze and return.
-        return getOrBuiltContext();
+        return getOrBuildContext();
     }
 
     /**
@@ -129,7 +129,7 @@ public class ContextAccumulator {
     }
 
     // Build once.
-    private Context getOrBuiltContext() {
+    private Context getOrBuildContext() {
         if ( builtContext == null )
             builtContext = buildProcess();
         return builtContext;

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
@@ -318,4 +318,28 @@ public class IOX {
         }
         return null;
     }
+
+    /**
+     * Check whether a file name points to a readable, regular file.
+     * Generate an exception if not.
+     */
+    public static void checkReadableFile(String file, Function<String, RuntimeException> exceptionMaker) {
+        Path path = Path.of(file);
+        checkReadableFile(path, exceptionMaker);
+    }
+
+    /**
+     * Check whether a file path points to a readable, regular file.
+     * Generate an exception if not.
+     */
+    public static void checkReadableFile(Path path, Function<String, RuntimeException> exceptionMaker) {
+        if ( ! Files.exists(path) )
+            throw exceptionMaker.apply("File not found: "+path);
+        if ( Files.isDirectory(path) )
+            throw exceptionMaker.apply("Is a directory: "+path);
+        if ( !Files.isRegularFile(path) )
+            throw exceptionMaker.apply("Not a regular file: "+path);
+        if ( !Files.isReadable(path) )
+            throw exceptionMaker.apply("Not readable: "+path);
+    }
 }

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IOX.java
@@ -337,9 +337,31 @@ public class IOX {
             throw exceptionMaker.apply("File not found: "+path);
         if ( Files.isDirectory(path) )
             throw exceptionMaker.apply("Is a directory: "+path);
-        if ( !Files.isRegularFile(path) )
+        if ( ! Files.isRegularFile(path) )
             throw exceptionMaker.apply("Not a regular file: "+path);
-        if ( !Files.isReadable(path) )
+        if ( ! Files.isReadable(path) )
+            throw exceptionMaker.apply("Not readable: "+path);
+    }
+
+    /**
+     * Check whether a file path points to a readable directory.
+     * Generate an exception if not.
+     */
+    public static void checkReadableDirectory(String directory, Function<String, RuntimeException> exceptionMaker) {
+        Path path = Path.of(directory);
+        checkReadableDirectory(path, exceptionMaker);
+    }
+
+    /**
+     * Check whether a file path points to a readable directory.
+     * Generate an exception if not.
+     */
+    public static void checkReadableDirectory(Path path, Function<String, RuntimeException> exceptionMaker) {
+        if ( ! Files.exists(path) )
+            throw exceptionMaker.apply("File not found: "+path);
+        if ( ! Files.isDirectory(path) )
+            throw exceptionMaker.apply("Not a directory: "+path);
+        if ( ! Files.isReadable(path) )
             throw exceptionMaker.apply("Not readable: "+path);
     }
 }

--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtl.java
@@ -38,10 +38,11 @@ import org.slf4j.Logger;
  * This needs access to log4j2 binaries including log4j-core, which is encapsulated in LogCtlLog4j2.
  */
 public class LogCtl {
-    private static final boolean hasLog4j2 = hasClass("org.apache.logging.slf4j.Log4jLoggerFactory");
-    private static final boolean hasLog4j1 = hasClass("org.slf4j.impl.Log4jLoggerFactory");
-    private static final boolean hasJUL    = hasClass("org.slf4j.impl.JDK14LoggerFactory");
+    private static final boolean hasLog4j2   = hasClass("org.apache.logging.slf4j.Log4jLoggerFactory");
+    private static final boolean hasLog4j1   = hasClass("org.slf4j.impl.Log4jLoggerFactory");
     // JUL always present but needs slf4j adapter.
+    private static final boolean hasJUL      = hasClass("org.slf4j.impl.JDK14LoggerFactory");
+    private static final boolean hasLogback  = hasClass("ch.qos.logback.core.LogbackException");
     // Put per-logging system code in separate classes to avoid needing them on the classpath.
 
     private static boolean hasClass(String className) {
@@ -83,67 +84,34 @@ public class LogCtl {
         String s2 = getLevelLog4j2(logger);
         if ( s2 != null )
             return s2;
-        // Always present.
         String s3 = getLevelJUL(logger);
         if ( s3 != null )
             return s3;
         return null;
     }
 
-    static private String getLevelJUL(String logger) {
-        java.util.logging.Level level = java.util.logging.Logger.getLogger(logger).getLevel();
-        if ( level == null )
-            return null;
-        if ( level == java.util.logging.Level.SEVERE )
-            return "ERROR";
-        return level.getName();
-    }
-
     static private String getLevelLog4j2(String logger) {
         if ( !hasLog4j2 )
             return null;
-        org.apache.logging.log4j.Level level = org.apache.logging.log4j.LogManager.getLogger(logger).getLevel();
-        if ( level != null )
-            return level.toString();
-        return null;
+        return LogCtlLog4j2.getLoggerlevel(logger);
+    }
+
+    static private String getLevelJUL(String logger) {
+        if ( ! hasJUL )
+            return null;
+        return LogCtlJUL.getLevelJUL(logger);
     }
 
     private static void setLevelJUL(String logger, String levelName) {
-        java.util.logging.Level level = java.util.logging.Level.ALL;
-        if ( levelName == null )
-            level = null;
-        else if ( levelName.equalsIgnoreCase("info") )
-            level = java.util.logging.Level.INFO;
-        else if ( levelName.equalsIgnoreCase("debug") )
-            level = java.util.logging.Level.FINE;
-        else if ( levelName.equalsIgnoreCase("warn") || levelName.equalsIgnoreCase("warning") )
-            level = java.util.logging.Level.WARNING;
-        else if ( levelName.equalsIgnoreCase("error") || levelName.equalsIgnoreCase("severe") )
-            level = java.util.logging.Level.SEVERE;
-        else if ( levelName.equalsIgnoreCase("OFF") )
-            level = java.util.logging.Level.OFF;
-        java.util.logging.Logger.getLogger(logger).setLevel(level);
+        if ( ! hasJUL )
+            return ;
+        LogCtlJUL.setLevelJUL(logger, levelName);
     }
 
     private static void setLevelLog4j2(String logger, String levelName) {
         if ( !hasLog4j2 )
             return;
-        org.apache.logging.log4j.Level level = org.apache.logging.log4j.Level.ALL;
-        if ( levelName == null )
-            level = null;
-        else if ( levelName.equalsIgnoreCase("info") )
-            level = org.apache.logging.log4j.Level.INFO;
-        else if ( levelName.equalsIgnoreCase("debug") )
-            level = org.apache.logging.log4j.Level.DEBUG;
-        else if ( levelName.equalsIgnoreCase("warn") || levelName.equalsIgnoreCase("warning") )
-            level = org.apache.logging.log4j.Level.WARN;
-        else if ( levelName.equalsIgnoreCase("error") || levelName.equalsIgnoreCase("severe") )
-            level = org.apache.logging.log4j.Level.ERROR;
-        else if ( levelName.equalsIgnoreCase("fatal") )
-            level = org.apache.logging.log4j.Level.FATAL;
-        else if ( levelName.equalsIgnoreCase("OFF") )
-            level = org.apache.logging.log4j.Level.OFF;
-        LogCtlLog4j2.setLoggerlevel(logger, level);
+        LogCtlLog4j2.setLoggerlevel(logger, levelName);
     }
 
     /**

--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlJUL.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlJUL.java
@@ -54,6 +54,32 @@ public class LogCtlJUL {
 
     private LogCtlJUL() {}
 
+    /*package*/ static String getLevelJUL(String logger) {
+        java.util.logging.Level level = java.util.logging.Logger.getLogger(logger).getLevel();
+        if ( level == null )
+            return null;
+        if ( level == java.util.logging.Level.SEVERE )
+            return "ERROR";
+        return level.getName();
+    }
+
+    /*package*/ static void setLevelJUL(String logger, String levelName) {
+        java.util.logging.Level level = java.util.logging.Level.ALL;
+        if ( levelName == null )
+            level = null;
+        else if ( levelName.equalsIgnoreCase("info") )
+            level = java.util.logging.Level.INFO;
+        else if ( levelName.equalsIgnoreCase("debug") )
+            level = java.util.logging.Level.FINE;
+        else if ( levelName.equalsIgnoreCase("warn") || levelName.equalsIgnoreCase("warning") )
+            level = java.util.logging.Level.WARNING;
+        else if ( levelName.equalsIgnoreCase("error") || levelName.equalsIgnoreCase("severe") )
+            level = java.util.logging.Level.SEVERE;
+        else if ( levelName.equalsIgnoreCase("OFF") )
+            level = java.util.logging.Level.OFF;
+        java.util.logging.Logger.getLogger(logger).setLevel(level);
+    }
+
     /**
      * Reset java.util.logging - this overrides the previous configuration, if any.
      */

--- a/jena-base/src/main/java/org/apache/jena/atlas/net/Host.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/net/Host.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.atlas.net;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.UnknownHostException;
+import java.util.Enumeration;
+
+import org.apache.jena.atlas.RuntimeIOException;
+import org.apache.jena.atlas.io.IOX;
+
+public class Host {
+    /**
+     * Returns a host address, for what is most likely the machine's LAN IP address
+     * (not a loopback address, 127.0.0.x or ::1). If there is no other choice, it returns
+     * <code>a local host address</code>.
+     */
+    public static String getHostAddress() {
+        try {
+            InetAddress addr = getLocalHostLANAddress$();
+            if ( addr == null )
+                return null;
+            return addr.getHostAddress();
+        } catch ( UnknownHostException ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns an <code>InetAddress</code> object encapsulating what is most likely the machine's LAN IP address
+     * (not a loopback address, 127.0.0.x or ::1). If there is no other choice, it returns
+     * <code>InetAddress.getLocalHost</code>.
+     * Throw a {@link RuntimeIOException runtime IO exception} if no address choice found.
+     */
+    public static InetAddress getLocalHostLANAddress() {
+        try {
+            return getLocalHostLANAddress$();
+        } catch (IOException ioException) {
+            throw IOX.exception(ioException);
+        }
+    }
+
+    /**
+     * Returns an <code>InetAddress</code> object encapsulating what is most likely the machine's LAN IP address.
+     * <p/>
+     * This method is intended for use as a replacement of JDK method <code>InetAddress.getLocalHost</code>, because
+     * that method is ambiguous on Linux systems. Linux systems enumerate the loopback network interface the same
+     * way as regular LAN network interfaces, but the JDK <code>InetAddress.getLocalHost</code> method does not
+     * specify the algorithm used to select the address returned under such circumstances, and will often return the
+     * loopback address, which is not valid for network communication. Details
+     * <a href="http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4665037">here</a>.
+     * <p/>
+     * This method will scan all IP addresses on all network interfaces on the host machine to determine the IP address
+     * most likely to be the machine's LAN address. If the machine has multiple IP addresses, this method will prefer
+     * a site-local IP address (e.g. 192.168.x.x or 10.10.x.x, usually IPv4) if the machine has one (and will return the
+     * first site-local address if the machine has more than one), but if the machine does not hold a site-local
+     * address, this method will return simply the first non-loopback address found (IPv4 or IPv6).
+     * <p/>
+     * If this method cannot find a non-loopback address using this selection algorithm, it will fall back to
+     * calling and returning the result of JDK method <code>InetAddress.getLocalHost</code>.
+     * <p/>
+     *
+     * @throws UnknownHostException If the LAN address of the machine cannot be found.
+     */
+    private static InetAddress getLocalHostLANAddress$() throws UnknownHostException {
+        // This code comes from:
+        // https://issues.apache.org/jira/browse/JCS-40
+        try {
+            InetAddress candidateAddress = null;
+            // Iterate all NICs (network interface cards)...
+            for (Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces(); ifaces.hasMoreElements();) {
+                NetworkInterface iface = ifaces.nextElement();
+                // Iterate all IP addresses assigned to each card...
+                for (Enumeration<InetAddress> inetAddrs = iface.getInetAddresses(); inetAddrs.hasMoreElements();) {
+                    InetAddress inetAddr = inetAddrs.nextElement();
+                    if (!inetAddr.isLoopbackAddress()) {
+                        if (inetAddr.isSiteLocalAddress()) {
+                            // Found non-loopback site-local address. Return it immediately...
+                            return inetAddr;
+                        }
+                        if (candidateAddress == null) {
+                            // Found non-loopback address, but not necessarily site-local.
+                            // Store it as a candidate to be returned if site-local address is not subsequently found...
+                            candidateAddress = inetAddr;
+                            // Note that we don't repeatedly assign non-loopback non-site-local addresses as candidates,
+                            // only the first. For subsequent iterations, candidate will be non-null.
+                        }
+                    }
+                }
+            }
+            if (candidateAddress != null) {
+                // We did not find a site-local address, but we found some other non-loopback address.
+                // Server might have a non-site-local address assigned to its NIC (or it might be running
+                // IPv6 which deprecates the "site-local" concept).
+                // Return this non-loopback candidate address...
+                return candidateAddress;
+            }
+            // At this point, we did not find a non-loopback address.
+            // Fall back to returning whatever InetAddress.getLocalHost() returns...
+            InetAddress jdkSuppliedAddress = InetAddress.getLocalHost();
+            if (jdkSuppliedAddress == null) {
+                throw new UnknownHostException("The JDK InetAddress.getLocalHost() method unexpectedly returned null.");
+            }
+            return jdkSuppliedAddress;
+        }
+        catch (UnknownHostException e) { throw e; }
+        catch (Exception e) {
+            UnknownHostException unknownHostException = new UnknownHostException("Failed to determine LAN address: " + e);
+            unknownHostException.initCause(e);
+            throw unknownHostException;
+        }
+    }
+
+    // @formatter:off
+//    public static void main(String ... arg) throws UnknownHostException {
+//        try {
+//            for (Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces(); ifaces.hasMoreElements();) {
+//                NetworkInterface iface = ifaces.nextElement();
+//                // Iterate all IP addresses assigned to each card...
+//                for (Enumeration<InetAddress> inetAddrs = iface.getInetAddresses(); inetAddrs.hasMoreElements();) {
+//                    InetAddress inetAddr = inetAddrs.nextElement();
+//                    System.out.println("IP Address : '" +inetAddr.getHostAddress()+"'");
+//                }
+//            }
+//            System.out.println();
+//
+//            InetAddress inetAddr = getLocalHostLANAddress();
+//            //InetAddress localhost = InetAddress.getLocalHost();
+//            System.out.println("System IP Address : '" +inetAddr.getHostAddress()+"'");
+//        } catch (Exception ex) {
+//            ex.printStackTrace();
+//            System.exit(0);
+//        }
+//    }
+    // @formatter:on
+}

--- a/jena-base/src/test/java/org/apache/jena/atlas/net/TS_Net.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/net/TS_Net.java
@@ -16,28 +16,15 @@
  * limitations under the License.
  */
 
-package org.apache.jena.atlas;
+package org.apache.jena.atlas.net;
+
 
 import org.junit.runner.RunWith ;
 import org.junit.runners.Suite ;
 
-import org.apache.jena.atlas.io.TS_IO ;
-import org.apache.jena.atlas.iterator.TS_Iterator ;
-import org.apache.jena.atlas.lib.TS_Lib ;
-import org.apache.jena.atlas.lib.persistent.TS_Persistent;
-import org.apache.jena.atlas.lib.tuple.TS_Tuple ;
-import org.apache.jena.atlas.net.TS_Net;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses( {
-    // Library
-      TS_Lib.class
-    , TS_Tuple.class
-    , TS_Iterator.class
-    , TS_IO.class
-    , TS_Persistent.class
-    , TS_Net.class
+    TestHost.class
 })
-
-public class TC_Atlas
-{}
+public class TS_Net {}

--- a/jena-base/src/test/java/org/apache/jena/atlas/net/TestHost.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/net/TestHost.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.atlas.net;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.junit.Test;
+
+import org.apache.jena.atlas.RuntimeIOException;
+
+public class TestHost {
+    @Test public void host_localNonLoopback() {
+        // Assumes the machine has some kind of IP networking.
+        try {
+            InetAddress addr = Host.getLocalHostLANAddress();
+            assertNotNull(addr);
+            assertFalse(addr.isLoopbackAddress());
+        } catch ( RuntimeIOException ex) {
+            Throwable x = ex.getCause();
+            if ( x instanceof UnknownHostException )
+                return;
+            throw ex;
+        }
+    }
+
+    @Test public void host_localNonLoopbackAddress() {
+        // Assumes the machine has some kind of IP networking.
+        try {
+            // InetAddress.toString is "host/address"
+            String addr = Host.getHostAddress();
+            assertNotNull(addr);
+            assertFalse(addr.contains("/"));
+        } catch ( RuntimeIOException ex) {
+            Throwable x = ex.getCause();
+            if ( x instanceof UnknownHostException )
+                return;
+            throw ex;
+        }
+    }
+}

--- a/jena-fuseki2/apache-jena-fuseki/log4j2.properties
+++ b/jena-fuseki2/apache-jena-fuseki/log4j2.properties
@@ -1,6 +1,6 @@
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 status = error
-name = PropertiesConfig
+name = FusekiLogging
 filters = threshold
 
 filter.threshold.type = ThresholdFilter
@@ -11,7 +11,7 @@ appender.console.name = OUT
 appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
-#appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
+## appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
 
 rootLogger.level                  = INFO
 rootLogger.appenderRef.stdout.ref = OUT
@@ -49,7 +49,7 @@ logger.jetty.level = WARN
 logger.shiro.name = org.apache.shiro
 logger.shiro.level = WARN
 
-# Hide bug with Shiro 1.5.0+, 2.0.0
+# Hide issue with Shiro 1.5.0+, 2.0.0
 logger.shiro-realm.name = org.apache.shiro.realm.text.IniRealm
 logger.shiro-realm.level = ERROR
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -132,14 +132,16 @@ public class Fuseki {
     /** Instance of log for operations. */
     public static final Logger        adminLog          = LoggerFactory.getLogger(adminLogName);
 
-    /** Admin log file for operations. */
-    public static final String        builderLogName    = PATH + ".Builder";
-
-    /** Instance of log for operations. */
-    public static final Logger        builderLog        = LoggerFactory.getLogger(builderLogName);
-
-    /** Validation log file for operations. */
-    public static final String        validationLogName = PATH + ".Validate";
+    // Unused
+//    /** Admin log file for operations. */
+//    public static final String        builderLogName    = PATH + ".Builder";
+//
+//    /** Instance of log for operations. */
+//    public static final Logger        builderLog        = LoggerFactory.getLogger(builderLogName);
+//
+//    // Now validation uses action logger.
+//    /** Validation log file for operations. */
+//    public static final String        validationLogName = PATH + ".Validate";
 
     /** Instance of log for validation. */
     public static final Logger        validationLog     = LoggerFactory.getLogger(adminLogName);
@@ -150,10 +152,13 @@ public class Fuseki {
     /** Instance of log for general server messages. */
     public static final Logger        serverLog         = LoggerFactory.getLogger(serverLogName);
 
-    /** Logger used for the servletContent.log operations (if settable -- depends on environment) */
+    /**
+     * Logger used for the servletContent.log operations (if settable -- depends on environment).
+     * This is both the display name of the servlet context and the logger name.
+     */
     public static final String        servletRequestLogName     = PATH + ".Servlet";
 
-    /** Actual log file for config server messages. */
+    /** log for config server messages. */
     public static final String        configLogName     = PATH + ".Config";
 
     /** Instance of log for config server messages. */

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -26,15 +26,12 @@ import jakarta.servlet.ServletContext;
 
 import org.apache.jena.atlas.lib.DateTimeUtils;
 import org.apache.jena.atlas.lib.Version;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.riot.system.stream.LocatorFTP;
 import org.apache.jena.riot.system.stream.LocatorHTTP;
 import org.apache.jena.riot.system.stream.StreamManager;
 import org.apache.jena.sparql.util.Context;
-import org.apache.jena.sparql.util.MappingRegistry;
-import org.apache.jena.sys.JenaSystem;
-import org.apache.jena.tdb1.TDB1;
-import org.apache.jena.tdb1.transaction.TransactionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,6 +99,12 @@ public class Fuseki {
 
     public static boolean   outputJettyServerHeader     = developmentMode;
     public static boolean   outputFusekiServerHeader    = developmentMode;
+
+    /**
+     * Initialize is class.
+     * See also {@link FusekiCore} for Fuseki core initialization.
+     */
+    public static void initConsts() {}
 
     /** An identifier for the HTTP Fuseki server instance */
     static public final String  serverHttpName          = NAME + " (" + VERSION + ")";
@@ -205,8 +208,6 @@ public class Fuseki {
     // HTTP response header inserted to aid tracking.
     public static String FusekiRequestIdHeader = "Fuseki-Request-Id";
 
-    private static boolean            initialized       = false;
-
     // Server start time and uptime.
     private static final long startMillis = System.currentTimeMillis();
     // Hide server locale
@@ -229,26 +230,6 @@ public class Fuseki {
     /** XSD DateTime for when the server started */
     public static String serverStartedAt() {
         return startDateTime;
-    }
-
-    /**
-     * Initialize an instance of the Fuseki server stack.
-     * This is not done via Jena's initialization mechanism
-     * but done explicitly to give more control.
-     * Touching this class causes this to happen
-     * (see static block at the end of this class).
-     */
-    public synchronized static void init() {
-        if ( initialized )
-            return;
-        initialized = true;
-        JenaSystem.init();
-        MappingRegistry.addPrefixMapping("fuseki", FusekiSymbolIRI);
-
-        TDB1.setOptimizerWarningFlag(false);
-        // Don't use TDB1 batch commits.
-        // This can be slower, but it less memory hungry and more predictable.
-        TransactionManager.QueueBatchSize = 0;
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -116,6 +116,9 @@ public class Fuseki {
     /** Instance of log for operations */
     public static final Logger        actionLog         = LoggerFactory.getLogger(actionLogName);
 
+    /** Instance of log for operations : alternative variable name */
+    public static final Logger        fusekiLog         = LoggerFactory.getLogger(actionLogName);
+
     /** Logger name for standard webserver log file request log */
     public static final String        requestLogName    = PATH + ".Request";
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/Fuseki.java
@@ -40,37 +40,33 @@ import org.slf4j.LoggerFactory;
 
 public class Fuseki {
     // General fixed constants.
-    // See also FusekiServer for the naming on the filesystem
 
     /** Path as package name */
-    static public String    PATH                         = "org.apache.jena.fuseki";
+    static public final String PATH               = "org.apache.jena.fuseki";
 
     /** a unique IRI for the Fuseki namespace */
-    static public String    FusekiIRI                    = "http://jena.apache.org/Fuseki";
+    static public final String FusekiIRI          = "http://jena.apache.org/Fuseki";
 
     /**
      * a unique IRI including the symbol notation for which properties should be
      * appended
      */
-    static public String    FusekiSymbolIRI              = "http://jena.apache.org/fuseki#";
+    static public final String FusekiSymbolIRI    = "http://jena.apache.org/fuseki#";
 
     /** Default location of the pages for the Fuseki UI  */
-    static public String    PagesStatic                  = "pages";
+    static public final String PagesStatic        = "pages";
 
     /** Dummy base URi string for parsing SPARQL Query and Update requests */
-    static public final String BaseParserSPARQL          = "http://server/unset-base/";
+    static public final String BaseParserSPARQL   = "http://server/unset-base/";
 
     /** Dummy base URi string for parsing SPARQL Query and Update requests */
-    static public final String BaseUpload                = "http://server/unset-base/";
-
-    /** Add CORS header */
-    static public final boolean CORS_ENABLED = false;
+    static public final String BaseUpload         = "http://server/unset-base/";
 
     /** The name of the Fuseki server.*/
-    static public final String        NAME              = "Apache Jena Fuseki";
+    static public final String  NAME              = "Apache Jena Fuseki";
 
     /** Version of this Fuseki instance */
-    static public final String        VERSION           = Version.versionForClass(Fuseki.class).orElse("<development>");
+    static public final String  VERSION           = Version.versionForClass(Fuseki.class).orElse("<development>");
 
     /** Supporting Graph Store Protocol direct naming.
      * <p>
@@ -178,6 +174,7 @@ public class Fuseki {
     public static final String attrNameRegistry            = "org.apache.jena.fuseki:DataAccessPointRegistry";
     public static final String attrOperationRegistry       = "org.apache.jena.fuseki:OperationRegistry";
     public static final String attrAuthorizationService    = "org.apache.jena.fuseki:AuthorizationService";
+    public static final String attrFusekiServer            = "org.apache.jena.fuseki:Server";
 
     public static void setVerbose(ServletContext cxt, boolean verbose) {
         cxt.setAttribute(attrVerbose, Boolean.valueOf(verbose));

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/build/FusekiConfig.java
@@ -97,8 +97,6 @@ public class FusekiConfig {
                    Operation.GSP_RW,
                    Operation.Patch);
 
-    static { Fuseki.init(); }
-
     /** Convenience operation to populate a {@link DataService} with the conventional default services. */
     public static DataService.Builder populateStdServices(DataService.Builder dataServiceBuilder, boolean allowUpdate) {
         Set<Endpoint> endpoints = new HashSet<>();

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionContainerItem.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionContainerItem.java
@@ -43,7 +43,7 @@ public abstract class ActionContainerItem extends ActionCtl {
         else if ( method.equals(METHOD_DELETE) )
             performDelete(action);
         else
-            ServletOps.errorMethodNotAllowed(action.getMethod());
+            ServletOps.errorMethodNotAllowed(action.getRequestMethod());
     }
 
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionContainerItem.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionContainerItem.java
@@ -26,7 +26,6 @@ import org.apache.jena.atlas.json.JsonValue;
 import org.apache.jena.fuseki.servlets.ActionLib;
 import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.fuseki.servlets.ServletOps;
-import org.apache.jena.web.HttpSC;
 
 /** Base for actions that are container and also have actions on items */
 public abstract class ActionContainerItem extends ActionCtl {
@@ -44,9 +43,8 @@ public abstract class ActionContainerItem extends ActionCtl {
         else if ( method.equals(METHOD_DELETE) )
             performDelete(action);
         else
-            ServletOps.error(HttpSC.METHOD_NOT_ALLOWED_405);
+            ServletOps.errorMethodNotAllowed(action.getMethod());
     }
-
 
     @Override
     public void execOptions(HttpAction action) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionItem.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionItem.java
@@ -21,7 +21,6 @@ package org.apache.jena.fuseki.ctl;
 import org.apache.jena.atlas.json.JsonValue;
 import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.fuseki.servlets.ServletOps;
-import org.apache.jena.web.HttpSC;
 
 /** Action on items in a container, but not the container itself */
 public abstract class ActionItem extends ActionContainerItem
@@ -31,14 +30,14 @@ public abstract class ActionItem extends ActionContainerItem
     @Override
     final
     protected JsonValue execGetContainer(HttpAction action) {
-        ServletOps.error(HttpSC.METHOD_NOT_ALLOWED_405);
+        ServletOps.errorMethodNotAllowed(action.getMethod());
         return null;
     }
 
     @Override
     final
     protected JsonValue execPostContainer(HttpAction action) {
-        ServletOps.error(HttpSC.METHOD_NOT_ALLOWED_405);
+        ServletOps.errorMethodNotAllowed(action.getMethod());
         return null;
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionItem.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionItem.java
@@ -30,14 +30,14 @@ public abstract class ActionItem extends ActionContainerItem
     @Override
     final
     protected JsonValue execGetContainer(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod());
         return null;
     }
 
     @Override
     final
     protected JsonValue execPostContainer(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod());
         return null;
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionStats.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionStats.java
@@ -40,7 +40,6 @@ public class ActionStats extends ActionContainerItem
     @Override
     public void validate(HttpAction action) {}
 
-    // This does not consult the system database for dormant etc.
     protected JsonValue execCommonContainer(HttpAction action) {
         if ( action.verbose )
             action.log.info(format("[%d] GET stats all", action.id));

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionStatsText.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionStatsText.java
@@ -38,12 +38,12 @@ public class ActionStatsText extends ActionCtl
 
     @Override
     public void validate(HttpAction action) {
-        switch(action.getMethod() ) {
+        switch(action.getRequestMethod() ) {
             case HttpNames.METHOD_GET:
             case HttpNames.METHOD_POST:
                 return;
             default:
-                ServletOps.errorMethodNotAllowed(action.getMethod());
+                ServletOps.errorMethodNotAllowed(action.getRequestMethod());
         }
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionTasks.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionTasks.java
@@ -62,7 +62,7 @@ public class ActionTasks extends ActionCtl
         else if ( method.equals(METHOD_POST) )
             execPost(action, name);
         else
-            ServletOps.errorMethodNotAllowed(action.getMethod());
+            ServletOps.errorMethodNotAllowed(action.getRequestMethod());
     }
 
     private void execGet(HttpAction action, String name) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionTasks.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/ctl/ActionTasks.java
@@ -28,7 +28,6 @@ import org.apache.jena.fuseki.async.AsyncTask;
 import org.apache.jena.fuseki.servlets.ActionLib;
 import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.fuseki.servlets.ServletOps;
-import org.apache.jena.web.HttpSC;
 
 public class ActionTasks extends ActionCtl
 {
@@ -63,7 +62,7 @@ public class ActionTasks extends ActionCtl
         else if ( method.equals(METHOD_POST) )
             execPost(action, name);
         else
-            ServletOps.error(HttpSC.METHOD_NOT_ALLOWED_405);
+            ServletOps.errorMethodNotAllowed(action.getMethod());
     }
 
     private void execGet(HttpAction action, String name) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPointRegistry.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/DataAccessPointRegistry.java
@@ -27,6 +27,7 @@ import org.apache.jena.atlas.lib.Registry;
 import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiException;
+import org.apache.jena.fuseki.servlets.HttpAction;
 
 /**
  * Registry of (dataset name, {@link DataAccessPoint}).
@@ -59,7 +60,7 @@ public class DataAccessPointRegistry extends Registry<String, DataAccessPoint>
      */
     public List<DataAccessPoint> accessPoints() {
         List<DataAccessPoint> accessPoints = new ArrayList<>(size());
-        // Make a copy for safety.
+        // Copy for safety.
         forEach((_name, accessPoint) -> accessPoints.add(accessPoint));
         return accessPoints;
     }
@@ -90,7 +91,14 @@ public class DataAccessPointRegistry extends Registry<String, DataAccessPoint>
         });
     }
 
-    // The server DataAccessPointRegistry is held in the ServletContext for the server.
+    /** The server DataAccessPointRegistry is held in the ServletContext.
+     * <p>
+     * Reload may change this object for another one. Therefore, code should obtain the
+     * DataAccessPointRegistry once per operation.
+     * <p>
+     * Each request, has a stable {@link HttpAction#getDataAccessPointRegistry()}.
+     * <p>Getting the {@link DataAccessPointRegistry} is atomic.
+     */
     public static DataAccessPointRegistry get(ServletContext cxt) {
         DataAccessPointRegistry registry = (DataAccessPointRegistry)cxt.getAttribute(Fuseki.attrNameRegistry);
         if ( registry == null )
@@ -98,6 +106,10 @@ public class DataAccessPointRegistry extends Registry<String, DataAccessPoint>
         return registry;
     }
 
+    /**
+     * Set or change the {@link DataAccessPointRegistry}.
+     * This is atomic. (In Jetty, it is backed by a ConcurrentHashMap).
+     */
     public static void set(ServletContext cxt, DataAccessPointRegistry registry) {
         cxt.setAttribute(Fuseki.attrNameRegistry, registry);
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Dispatcher.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/Dispatcher.java
@@ -388,11 +388,11 @@ public class Dispatcher {
             } else if ( GSP_RW.equals(operation) ) {
                 // If asking for GSP_RW, but only GSP_R is available ...
                 // ... if OPTIONS, use GSP_R.
-                if ( action.getMethod().equals(HttpNames.METHOD_OPTIONS) && epSet.contains(GSP_R) )
+                if ( action.getRequestMethod().equals(HttpNames.METHOD_OPTIONS) && epSet.contains(GSP_R) )
                         return GSP_R;
                 // ... else 405
                 if ( epSet.contains(GSP_R) )
-                    ServletOps.errorMethodNotAllowed(action.getMethod());
+                    ServletOps.errorMethodNotAllowed(action.getRequestMethod());
             }
         }
         return operation;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionLib.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionLib.java
@@ -401,8 +401,6 @@ public class ActionLib {
     }
 
     private static void setCommonHeadersForOptions(HttpServletResponse httpResponse) {
-        if ( Fuseki.CORS_ENABLED )
-            httpResponse.setHeader(HttpNames.hAccessControlAllowHeaders, "X-Requested-With, Content-Type, Authorization");
         setCommonHeaders(httpResponse);
     }
 
@@ -411,8 +409,6 @@ public class ActionLib {
     }
 
     private static void setCommonHeaders(HttpServletResponse httpResponse) {
-        if ( Fuseki.CORS_ENABLED )
-            httpResponse.setHeader(HttpNames.hAccessControlAllowOrigin, "*");
         if ( Fuseki.outputFusekiServerHeader )
             httpResponse.setHeader(HttpNames.hServer, Fuseki.serverHttpName);
     }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionProcessor.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ActionProcessor.java
@@ -29,7 +29,7 @@ public interface ActionProcessor {
      * @param action   HTTP Action
      */
     public default void process(HttpAction action) {
-        switch ( action.getMethod() ) {
+        switch ( action.getRequestMethod() ) {
             case METHOD_GET ->       execGet(action);
             case METHOD_POST ->      execPost(action);
             case METHOD_PATCH ->     execPatch(action);
@@ -38,7 +38,7 @@ public interface ActionProcessor {
             case METHOD_HEAD ->      execHead(action);
             case METHOD_OPTIONS->    execOptions(action);
             case METHOD_TRACE ->     execTrace(action);
-            default -> execAny(action.getMethod(), action);
+            default -> execAny(action.getRequestMethod(), action);
         }
     }
 

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/BaseActionREST.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/BaseActionREST.java
@@ -46,6 +46,6 @@ public class BaseActionREST extends ActionREST {
     public void validate(HttpAction action) { }
 
     private void notSupported(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod()+" "+action.getDatasetName());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod()+" "+action.getDatasetName());
     }
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/FusekiFilter.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
  * for any service.
  */
 public class FusekiFilter implements Filter {
-    private static Logger log = Fuseki.serverLog;
+    private static Logger LOG = Fuseki.serverLog;
 
     @Override
     public void init(FilterConfig filterConfig) {}
@@ -50,7 +50,7 @@ public class FusekiFilter implements Filter {
             if ( handled )
                 return;
         } catch (Throwable ex) {
-            log.info("Filter: unexpected exception: "+ex.getMessage(),ex);
+            LOG.info("Filter: unexpected exception: "+ex.getMessage(),ex);
         }
 
         // Not found - continue.

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/HttpAction.java
@@ -316,6 +316,7 @@ public class HttpAction
             transactional.begin(txnType);
         activeDSG = dsg;
         if ( dataService != null )
+            // Paired with finishTxn in end()
             dataService.startTxn(txnType);
         startActionTxn();
     }
@@ -491,6 +492,7 @@ public class HttpAction
     // ----
 
     public void commit() {
+//dataService.finishTxn();
         if ( transactional != null )
             transactional.commit();
         endInternal();
@@ -616,6 +618,8 @@ public class HttpAction
 
     // ---- Request - response abstraction.
 
+    /** @deprecated Use {@link #getRequestMethod}. */
+    @Deprecated(since="5.1.0", forRemoval=true)
     public String getMethod()                           { return request.getMethod(); }
 
     public HttpServletRequest getRequest()              { return request; }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServletOps.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/ServletOps.java
@@ -248,11 +248,11 @@ public class ServletOps {
     }
 
     public static void error(int statusCode) {
-        throw new ActionErrorException(statusCode, null, null);
+        throw actionErrorException(statusCode, null, null);
     }
 
     public static void error(int statusCode, String string) {
-        throw new ActionErrorException(statusCode, string, null);
+        throw actionErrorException(statusCode, string, null);
     }
 
     public static void errorOccurred(String message) {
@@ -266,7 +266,12 @@ public class ServletOps {
     public static void errorOccurred(String message, Throwable ex) {
         if ( ex instanceof ActionErrorException actionErr )
             throw actionErr;
-        throw new ActionErrorException(HttpSC.INTERNAL_SERVER_ERROR_500, message, ex);
+        throw actionErrorException(HttpSC.INTERNAL_SERVER_ERROR_500, message, ex);
+        /* Does not return */
+    }
+
+    private static ActionErrorException actionErrorException(int statusCode, String message, Throwable ex) {
+        return new ActionErrorException(statusCode, message, ex);
     }
 
     public static String formatForLog(String string) {

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/UploadRDF.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/servlets/UploadRDF.java
@@ -54,7 +54,7 @@ public class UploadRDF extends ActionREST {
     @Override protected void doPatch(HttpAction action)     { unsupported(action); }
 
     private void unsupported(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod());
     }
 
     @Override

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiCore.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiCore.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.fuseki.system;
+
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.sparql.util.MappingRegistry;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.tdb1.TDB1;
+import org.apache.jena.tdb1.transaction.TransactionManager;
+
+/**
+ * Fuseki core initialization.
+ * <p>
+ * Initialize an instance of the Fuseki server core code.
+ * This is not done via Jena's initialization mechanism
+ * but done explicitly to give control.
+ * <p>
+ * It is done after Jena initializes.
+ * <p>
+ * {@code InitFusekiMain} is the code for Jena's initialization mechanism.
+ * It calls this class.
+ */
+public class FusekiCore {
+    // This is not triggered by a services file.
+
+    private static boolean initialized = false;
+
+    public synchronized static void init() {
+        if ( initialized )
+            return;
+
+        // Avoid re-entrancy.
+        initialized = true;
+
+        JenaSystem.init();
+        // Touch the Fuseki class to make sure statics get initialized.
+        Fuseki.initConsts();
+        MappingRegistry.addPrefixMapping("fuseki", Fuseki.FusekiSymbolIRI);
+
+        // TDB1
+        TDB1.setOptimizerWarningFlag(false);
+        // Don't use TDB1 batch commits.
+        // This can be slower, but it less memory hungry and more predictable.
+        TransactionManager.QueueBatchSize = 0;
+    }
+}

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
@@ -34,7 +34,7 @@ import org.apache.jena.fuseki.Fuseki;
 /**
  * FusekiLogging.
  * <p>
- * This applies to Fuseki run from the command line and embedded.
+ * This applies to Fuseki run from the command line, as a combined jar and as an embedded server.
  * <p>
  * This does not apply to Fuseki running in Tomcat where it uses the
  * servlet 3.0 mechanism described in
@@ -49,10 +49,9 @@ public class FusekiLogging
 
     // Set logging.
     // 1/ Use system property log4j2.configurationFile if defined.
-    // 2/ Use file:log4j2.properties if exists
+    // 2/ Use file:log4j2.properties if exists [Jena extension]
     // 3/ Use log4j2.properties on the classpath.
-    // 4/ Use org/apache/jena/fuseki/log4j2.properties on the classpath.
-    // 5/ Use built in string
+    // 4/ Use built in string
 
     /**
      * Places for the log4j properties file at (3).

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
@@ -81,7 +81,7 @@ public class FusekiLogging
             logLogging("Old system property used '%s'", logLoggingPropertyAlt);
             return x.equalsIgnoreCase("true");
         }
-        x = Lib.getenv("FUSEKI_LOGLOGGING", logLoggingProperty);
+        x = Lib.getenv(logLoggingProperty, envLogLoggingProperty);
         return x != null && x.equalsIgnoreCase("true");
     }
 
@@ -137,11 +137,16 @@ public class FusekiLogging
         }
 
         logLogging("Setup");
+
+        // NB Search for a file before looking on the classpath.
+        // This allows the file to override any built-in logging configuration.
+        // However, in tests, this means a development file "log4j2.properties"
+        // may get picked up.
+
         // Look for a log4j2.properties file in the current working directory
         // and a place (e.g. FUSEKI_BASE in the webapp/full server) for easy customization.
         String fn1 = "log4j2.properties";
         String fn2 = null;
-
         if ( extraDir != null )
             fn2 = extraDir.resolve("log4j2.properties").toString();
         if ( attempt(fn1) ) return;

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/FusekiLogging.java
@@ -279,15 +279,14 @@ public class FusekiLogging
                 logger.jetty.name  = org.eclipse.jetty
                 logger.jetty.level = WARN
 
-                logger.apache-http.name   = org.apache.http
-                logger.apache-http.level  = WARN
                 logger.shiro.name = org.apache.shiro
                 logger.shiro.level = WARN
 
-                # Hide bug in Shiro 1.5.0
+                # Hide issue with Shiro 1.5.0+, 2.0.0
                 logger.shiro-realm.name = org.apache.shiro.realm.text.IniRealm
                 logger.shiro-realm.level = ERROR
 
+                ## (NCSA) Common Log Format request log
                 # This goes out in NCSA format
                 appender.plain.type = Console
                 appender.plain.name = PLAIN

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiLib.java
@@ -59,9 +59,13 @@ public class FusekiLib {
     /**
      * Process a configuration mode to find the DataServices and reset the server
      * {@link DataAccessPointRegistry}. The only server-level setting processed is
-     * the {@code fuseki:services} list. Other settings are ignored.
+     * the {@code fuseki:services} list; other settings are ignored.
      */
     public static void reload(FusekiServer server, Model configuration) {
+        // See also FusekiServer.applyDatabaseSetup
+        //      prepareDataServices(dapRegistry, operationReg);
+        //      OperationRegistry.set(servletContext, operationReg);
+        //      DataAccessPointRegistry.set(servletContext, dapRegistry);
         DataAccessPointRegistry newRegistry = new DataAccessPointRegistry();
         OperationRegistry operationRegistry = server.getOperationRegistry();
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -520,6 +520,11 @@ public class FusekiServer {
         /** Set the location (filing system directory) to serve static files from. */
         public Builder staticFileBase(String directory) {
             requireNonNull(directory, "directory");
+            if ( directory.startsWith("jar:") ) {
+                // jetty resource
+                this.staticContentDir = directory;
+                return this;
+            }
             if ( ! FileOps.exists(directory) )
                 Fuseki.configLog.warn("File area not found: "+directory);
             // Resolve path.
@@ -836,7 +841,6 @@ public class FusekiServer {
             // Can further modify the services in the configuration file.
             x.forEach(dap->addDataAccessPoint(dap));
         }
-
 
         /** Add a {@link DataAccessPoint} as a builder. */
         private Builder addDataAccessPoint(DataAccessPoint dap) {

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -1705,7 +1705,7 @@ public class FusekiServer {
                 contextPath = "/" + contextPath;
             ServletContextHandler context = new ServletContextHandler();
             context.setDisplayName(Fuseki.servletRequestLogName);
-            // Also set on the server which handles request that don't dispatch.
+            // Also set on the server which handles requests that don't Fuseki-dispatch.
             context.setErrorHandler(errorHandler);
             context.setContextPath(contextPath);
             // SPARQL Update by HTML - not the best way but.

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -393,6 +393,7 @@ public class JettyServer {
             try {
                 Fuseki.setVerbose(cxt, verbose);
                 OperationRegistry.set(cxt, OperationRegistry.createEmpty());
+                // Empty DataAccessPointRegistry, no nulls!
                 DataAccessPointRegistry.set(cxt, new DataAccessPointRegistry());
             } catch (NoClassDefFoundError err) {
                 LOG.info("Fuseki classes not found");

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -41,6 +41,7 @@ import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.sys.FusekiAutoModules;
 import org.apache.jena.fuseki.main.sys.FusekiModules;
 import org.apache.jena.fuseki.main.sys.FusekiServerArgsCustomiser;
+import org.apache.jena.fuseki.main.sys.InitFusekiMain;
 import org.apache.jena.fuseki.server.DataAccessPoint;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.FusekiCoreInfo;
@@ -155,6 +156,7 @@ public class FusekiMain extends CmdARQ {
      */
     public static void run(String... argv) {
         JenaSystem.init();
+        InitFusekiMain.init();
         new FusekiMain(argv).mainRun();
     }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMain.java
@@ -240,9 +240,11 @@ public class FusekiMain extends CmdARQ {
     }
 
     private void argumentsSetup() {
-        getUsage().startCategory("Fuseki Main");
+        getUsage().startCategory("Fuseki");
 
-        // Control the order!
+        add(argConfig, "--config=FILE",
+            "Use a configuration file to determine the services");
+        // ---- Describe the dataset on the command line.
         add(argMem, "--mem",
             "Create an in-memory, non-persistent dataset for the server");
         add(argFile, "--file=FILE",
@@ -257,25 +259,33 @@ public class FusekiMain extends CmdARQ {
             "Create an in-memory, non-persistent dataset using TDB (testing only)");
         add(argRDFS, "--rdfs=FILE",
             "Apply RDFS on top of the dataset");
-        add(argConfig, "--config=FILE",
-            "Use a configuration file to determine the services");
+        add(argUpdate, "--update",
+                "Allow updates (via SPARQL Update and SPARQL HTTP Update)");
         addModule(modDataset);
 
+        // ---- Server setup
         add(argEmpty); // Hidden
         add(argPort, "--port",
             "Listen on this port number");
         add(argLocalhost, "--localhost",
             "Listen only on the localhost interface");
-        add(argTimeout, "--timeout=",
-            "Global timeout applied to queries (value in ms) -- format is X[,Y] ");
-        add(argUpdate, "--update",
-            "Allow updates (via SPARQL Update and SPARQL HTTP Update)");
         add(argGZip, "--gzip=on|off",
-            "Enable GZip compression (HTTP Accept-Encoding) if request header set");
+                "Enable GZip compression (HTTP Accept-Encoding) if request header set");
         add(argBase, "--base=DIR",
             "Directory for static content");
         add(argContextPath, "--contextPath=PATH",
             "Context path for the server");
+        add(argHttps, "--https=CONF",
+                "https certificate access details. JSON file { \"cert\":FILE , \"passwd\"; SECRET } ");
+        add(argHttpsPort, "--httpsPort=NUM",
+                "https port (default port is 3043)");
+        add(argPasswdFile, "--passwd=FILE",
+                "Password file");
+
+        add(argTimeout, "--timeout=",
+                "Global timeout applied to queries (value in ms) -- format is X[,Y] ");
+
+        // ---- Servlets
         add(argSparqler, "--sparqler=DIR",
             "Run with SPARQLer services Directory for static content");
         add(argValidators, "--validators",
@@ -285,13 +295,6 @@ public class FusekiMain extends CmdARQ {
 
         add(argAuth, "--auth=[basic|digest]",
             "Run the server using basic or digest authentication");
-        add(argHttps, "--https=CONF",
-            "https certificate access details. JSON file { \"cert\":FILE , \"passwd\"; SECRET } ");
-        add(argHttpsPort, "--httpsPort=NUM",
-            "https port (default port is 3043)");
-
-        add(argPasswdFile, "--passwd=FILE",
-            "Password file");
         add(argJettyConfig, "--jetty=FILE",
             "jetty.xml server configuration");
         add(argCORS, "--cors=FILE", "Configure CORS settings from file");

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerArgs.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/ServerArgs.java
@@ -65,10 +65,11 @@ public class ServerArgs {
     public boolean withCompact            = false;
 
     // Either a dataset setup from the command line (delayed creation of the dataset) ...
+    // The consumer should set the "dataset" field and the description field.
     public Consumer<ServerArgs> dsgMaker  = null;
-    public DatasetGraph dsg               = null;
+    public DatasetGraph dataset           = null;
     /** RDFS dataset - only when dataset is defined on the command line. */
-    public Graph rdfsGraph                = null;
+    public Graph rdfsSchemaGraph          = null;
 
     // ... or configuration file.
     public String serverConfigFile        = null;
@@ -76,6 +77,7 @@ public class ServerArgs {
 
     /** Allow no datasets without it being an error. This is not an argument. */
     public boolean allowEmpty             = false;
+    public SetupType setup                = SetupType.UNSET;
     /** Start without a dataset or configuration (this is {@code --empty}) */
     public boolean startEmpty             = false;
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/SetupType.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/SetupType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,29 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.jena.base.module;
+package org.apache.jena.fuseki.main.cmds;
 
-/** Lifecycle interface for modules and subsystems. */
-public interface SubsystemLifecycle {
-
-    /**
-     * start - a module should be ready to operate when this returns.
-     */
-    public void start();
-
-    /**
-     * stop - a module should have performed any shutdown operations by the time this
-     * returns. Caution: code must be prepared to operate without assuming this
-     * called. Abrupt termination of the JVM is always possible.
-     */
-    public void stop();
-
-    /**
-     * Provide a marker as to the level to order initialization, 10,20,30,...
-     * See {@link Subsystem} for details.
-     */
-    default public int level() {
-        return 9999;
-    }
+// Command line DSG
+public enum SetupType {
+    UNSET,
+    MEM, FILE, TDB, MEMTDB,  // Datasets on the command line
+    CONF,                    // Configuration file.
+    ASSEM,                   // Assembler for a datasets. Legacy.
+    NONE,                    // Explicitly no dataset or configuration file.
+    SPARQLer                 // SPARQler mode
 }
-

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiAutoModule.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiAutoModule.java
@@ -79,6 +79,15 @@ public interface FusekiAutoModule extends FusekiModule, FusekiLifecycle {
     @Override
     public default void stop() {}
 
+    /**
+     * Level for ordering calling all loaded {@code FusekiAutoModule}.
+     * Levels 0-999 are reserved and should not be used except by system FusekiAutoModule
+     */
+    @Override
+    public default int level() {
+        return 9999;
+    }
+
     // ---- Build cycle
 
     /** {@inheritDoc} */

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiAutoModules.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiAutoModules.java
@@ -218,9 +218,11 @@ public class FusekiAutoModules {
                 String name = m.name();
                 if ( name == null )
                     name = m.getClass().getSimpleName();
-                FmtLog.info(LOG, "Module: %s (%s)",
-                                 name,
-                                 Version.versionForClass(m.getClass()).orElse("unknown"));
+                String verStr = Version.versionForClass(m.getClass()).orElse(null);
+                if ( verStr == null )
+                    FmtLog.info(LOG, "Module: %s", name);
+                else
+                    FmtLog.info(LOG, "Module: %s (%s)", name, verStr);
             });
 
             return FusekiModules.create(fmods);

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiBuildCycle.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiBuildCycle.java
@@ -43,7 +43,7 @@ import org.apache.jena.rdf.model.Model;
  */
 public interface FusekiBuildCycle {
     /**
-     * Display name to identify this module.
+     * A display name to identify this module.
      */
     public String name();
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiLifecycle.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiLifecycle.java
@@ -24,7 +24,7 @@ import org.apache.jena.base.module.SubsystemLifecycle;
  * A {@link SubsystemLifecycle} for Fuseki.
  * This lifecycle is run after Jena system initialization.
  * Jena system initialization includes system initialization of Fuseki itself
- * in {@link InitFuseki}.
+ * in {@link InitFusekiMain}.
  * This lifecycle is for extensions to an initialized Fuseki server
  * and is used via {@link FusekiAutoModule}.
  */

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModule.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModule.java
@@ -60,8 +60,12 @@ public interface FusekiModule extends FusekiServerArgsCustomiser, FusekiBuildCyc
     // Gather all interface method together.
     // Inherited javadoc.
 
+    /**
+     * {@inheritDoc}
+     * <p>This defaults to the Java simple class name of module.
+     */
     @Override
-    public String name();
+    public default String name() { return null; }
 
     // ---- Build cycle
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModuleStep.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiModuleStep.java
@@ -77,7 +77,7 @@ public class FusekiModuleStep {
     }
 
     /**
-     * Sever reload.
+     * Server reload.
      * Return true if reload happened, else false.
      * @see FusekiBuildCycle#serverConfirmReload
      * @see FusekiBuildCycle#serverReload

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/InitFusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/InitFusekiMain.java
@@ -20,6 +20,7 @@ package org.apache.jena.fuseki.main.sys;
 
 import org.apache.jena.cmd.Cmds;
 import org.apache.jena.fuseki.main.cmds.FusekiMainCmd;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.sys.JenaSubsystemLifecycle;
 import org.apache.jena.sys.JenaSystem;
 
@@ -28,7 +29,7 @@ import org.apache.jena.sys.JenaSystem;
  * Level 101 - called during Jena system initialization
  * and after Jena itself has initialized.
  */
-public class InitFuseki implements JenaSubsystemLifecycle {
+public class InitFusekiMain implements JenaSubsystemLifecycle {
 
     private static volatile boolean initialized = false;
 
@@ -45,7 +46,8 @@ public class InitFuseki implements JenaSubsystemLifecycle {
         if ( initialized ) {
             return;
         }
-        synchronized (InitFuseki.class) {
+
+        synchronized (InitFusekiMain.class) {
             if ( initialized ) {
                 JenaSystem.logLifecycle("Fuseki.init - skip");
                 return;
@@ -53,7 +55,12 @@ public class InitFuseki implements JenaSubsystemLifecycle {
             initialized = true;
             JenaSystem.logLifecycle("Fuseki.init - start");
 
+            // Ensure core constants are initialized first.
+            FusekiCore.init();
             FusekiModules.init();
+
+            // Leave until known to be needed FusekiServer build with no specific FusekikModules given.
+            // FusekiModulesCtl.setup();
             try {
                 Cmds.injectCmd("fuseki", a->FusekiMainCmd.main(a));
             } catch (NoClassDefFoundError ex) {

--- a/jena-fuseki2/jena-fuseki-main/src/main/resources/META-INF/services/org.apache.jena.sys.JenaSubsystemLifecycle
+++ b/jena-fuseki2/jena-fuseki-main/src/main/resources/META-INF/services/org.apache.jena.sys.JenaSubsystemLifecycle
@@ -1,1 +1,1 @@
-org.apache.jena.fuseki.main.sys.InitFuseki
+org.apache.jena.fuseki.main.sys.InitFusekiMain

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/CustomTestService.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/CustomTestService.java
@@ -76,6 +76,6 @@ public class CustomTestService extends ActionREST {
     public void validate(HttpAction action) { }
 
     private void notSupported(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod()+" "+action.getDatasetName());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod()+" "+action.getDatasetName());
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TS_FusekiMain.java
@@ -18,10 +18,11 @@
 
 package org.apache.jena.fuseki.main;
 
-import org.apache.jena.fuseki.main.prefixes.*;
-import org.apache.jena.fuseki.main.sys.TestFusekiModules;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
+
+import org.apache.jena.fuseki.main.prefixes.PrefixesServiceTests;
+import org.apache.jena.fuseki.main.sys.TestFusekiModules;
 
 @Suite
 @SelectClasses({
@@ -55,9 +56,9 @@ import org.junit.platform.suite.api.Suite;
   , TestFusekiCustomScriptFunc.class
 
   , PrefixesServiceTests.class
-
   , TestMetrics.class
   , TestFusekiShaclValidation.class
+
 })
 public class TS_FusekiMain {}
 

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdArguments.java
@@ -281,8 +281,8 @@ public class TestFusekiMainCmdArguments {
     @Test
     public void test_error_configFile_directory() {
         // given
-        List<String> arguments = List.of("--config=testing/");
-        String expectedMessage = "Is a directory: testing/";
+        List<String> arguments = List.of("--config=testing");
+        String expectedMessage = "Is a directory: testing";
         // when, then
         testForCmdException(arguments, expectedMessage);
     }
@@ -323,7 +323,6 @@ public class TestFusekiMainCmdArguments {
         testForCmdException(arguments, expectedMessage);
     }
 
-
     @Test
     public void test_error_argConfigFile_UnrecognisedFileType() {
         // given
@@ -361,7 +360,6 @@ public class TestFusekiMainCmdArguments {
         // when, then
         testForCmdException(arguments, expectedMessage);
     }
-
 
     @Test
     public void test_error_incorrectContextPath() {
@@ -447,18 +445,10 @@ public class TestFusekiMainCmdArguments {
 
     private void testForCmdException(List<String> arguments, String expectedMessage) {
         // when
-        Throwable actual = null;
-        try {
-            buildServer(buildCmdLineArguments(arguments));
-        } catch (Exception e) {
-            actual = e;
-        }
+        CmdException actual = assertThrows(CmdException.class, ()->buildServer(buildCmdLineArguments(arguments)));
         // then
-        assertNotNull(actual);
-        assertTrue("Expecting correct exception", (actual instanceof CmdException));
         assertEquals("Expecting correct message", expectedMessage, actual.getMessage());
     }
-
 
     private static String[] buildCmdLineArguments(List<String> listArgs) {
         return listArgs.toArray(new String[0]);

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdCustomArguments.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiMainCmdCustomArguments.java
@@ -246,7 +246,7 @@ public class TestFusekiMainCmdCustomArguments {
             if ( argSeen ) {
                 serverArgs.serverConfigModel = fixedModel;
                 notedServerConfigModel = fixedModel;
-                serverArgs.dsg = null;
+                serverArgs.dataset = null;
             }
         }
 

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.util.function.Consumer;
 
+import jakarta.servlet.ServletContext;
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.atlas.logging.LogCtl;
@@ -60,9 +61,13 @@ public class TestFusekiServerBuild {
 
     @Test public void fuseki_build_1() {
         FusekiServer server = FusekiServer.create().port(3456).build();
-        // Not started. Port not assigned.
         assertTrue(server.getHttpPort() == 3456 );
         assertTrue(server.getHttpsPort() == -1 );
+
+        ServletContext cxt = server.getServletContext();
+        FusekiServer server2 = FusekiServer.get(cxt);
+        assertNotNull(server2);
+        assertEquals(server, server2);
     }
 
     @Test public void fuseki_build_2() {

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestPlainServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestPlainServer.java
@@ -109,7 +109,7 @@ public class TestPlainServer {
     }
 
     @Test public void plainFile3() {
-        String x = HttpOp.httpGetString(serverURL+"/file-top.txt");
+        String x = HttpOp.httpGetString(serverURL+"/exists.txt");
         assertNotNull(x);
         assertTrue(x.contains("CONTENT"));
     }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestFusekiSecurityAssembler.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/AbstractTestFusekiSecurityAssembler.java
@@ -36,6 +36,7 @@ import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.main.FusekiLib;
 import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.fuseki.main.sys.InitFusekiMain;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.QuerySolution;
@@ -46,7 +47,6 @@ import org.apache.jena.rdfconnection.RDFConnection;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.sse.SSE;
-import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.Txn;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -63,7 +63,7 @@ import org.junit.Test;
  */
 
 public abstract class AbstractTestFusekiSecurityAssembler {
-    static { JenaSystem.init(); }
+    static { InitFusekiMain.init(); }
     static final String DIR = "testing/Access/";
 
     private final String assemblerFile;

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/DemoService.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/DemoService.java
@@ -79,6 +79,6 @@ public class DemoService extends ActionREST {
     public void validate(HttpAction action) { }
 
     private void notSupported(HttpAction action) {
-        ServletOps.errorMethodNotAllowed(action.getMethod()+" "+action.getActionURI());
+        ServletOps.errorMethodNotAllowed(action.getRequestMethod()+" "+action.getActionURI());
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExFuseki_04_CustomOperation_Inline.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExFuseki_04_CustomOperation_Inline.java
@@ -25,6 +25,7 @@ import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.build.FusekiExt;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.sys.FusekiModule;
+import org.apache.jena.fuseki.main.sys.InitFusekiMain;
 import org.apache.jena.fuseki.server.Operation;
 import org.apache.jena.fuseki.servlets.ActionService;
 import org.apache.jena.fuseki.servlets.HttpAction;
@@ -32,7 +33,6 @@ import org.apache.jena.fuseki.system.FusekiLogging;
 import org.apache.jena.http.HttpOp;
 import org.apache.jena.riot.WebContent;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.web.HttpSC;
 
 /**
@@ -46,8 +46,8 @@ import org.apache.jena.web.HttpSC;
 public class ExFuseki_04_CustomOperation_Inline {
 
     static {
-        JenaSystem.init();
         FusekiLogging.setLogging();
+        InitFusekiMain.init();
     }
 
     public static void main(String...args) {

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExFuseki_04_CustomOperation_Module.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/examples/ExFuseki_04_CustomOperation_Module.java
@@ -27,6 +27,7 @@ import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.sys.FusekiModule;
 import org.apache.jena.fuseki.main.sys.FusekiModules;
+import org.apache.jena.fuseki.main.sys.InitFusekiMain;
 import org.apache.jena.fuseki.server.Operation;
 import org.apache.jena.fuseki.servlets.ActionService;
 import org.apache.jena.fuseki.servlets.HttpAction;
@@ -35,7 +36,6 @@ import org.apache.jena.http.HttpOp;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.WebContent;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.web.HttpSC;
 
 /**
@@ -48,8 +48,8 @@ import org.apache.jena.web.HttpSC;
 public class ExFuseki_04_CustomOperation_Module {
 
     static {
-        JenaSystem.init();
         FusekiLogging.setLogging();
+        InitFusekiMain.init();
     }
 
     // Example usage.

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/reload-config1.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/reload-config1.ttl
@@ -1,0 +1,16 @@
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+:service rdf:type fuseki:Service ;
+    fuseki:name "ds" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:patch ; ] ;
+    fuseki:dataset :dataset ;
+.
+
+:dataset rdf:type ja:MemoryDataset .

--- a/jena-fuseki2/jena-fuseki-main/testing/Config/reload-config2.ttl
+++ b/jena-fuseki2/jena-fuseki-main/testing/Config/reload-config2.ttl
@@ -1,0 +1,25 @@
+PREFIX :        <#>
+PREFIX fuseki:  <http://jena.apache.org/fuseki#>
+PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ja:      <http://jena.hpl.hp.com/2005/11/Assembler#>
+
+:service rdf:type fuseki:Service ;
+    fuseki:name "dataset2" ;
+    fuseki:endpoint [ fuseki:operation fuseki:query ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:update ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-rw ; ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:patch ; ] ;
+    fuseki:dataset :dataset ;
+.
+
+:dataset rdf:type ja:MemoryDataset ;
+     #ja:data "data.trig";
+.
+
+:service2 rdf:type fuseki:Service ;
+    fuseki:name "null" ;
+    ## No operations.
+    ## Always empty dataset.
+    fuseki:dataset [ rdf:type ja:RDFDatasetZero ] ;
+    .

--- a/jena-fuseki2/jena-fuseki-main/testing/Files/exists.txt
+++ b/jena-fuseki2/jena-fuseki-main/testing/Files/exists.txt
@@ -1,0 +1,2 @@
+This file is used by the plain server static resource tests.
+CONTENT

--- a/jena-fuseki2/jena-fuseki-main/testing/Files/file-top.txt
+++ b/jena-fuseki2/jena-fuseki-main/testing/Files/file-top.txt
@@ -1,2 +1,0 @@
-# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
-CONTENT

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiWebappCmd.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiWebappCmd.java
@@ -31,6 +31,7 @@ import org.apache.jena.cmd.TerminationException;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.mgt.Template;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.fuseki.system.FusekiLogging;
 import org.apache.jena.fuseki.webapp.FusekiEnv;
 import org.apache.jena.fuseki.webapp.FusekiServerListener;
@@ -96,7 +97,7 @@ public class FusekiWebappCmd {
         static public void innerMain(String... argv) {
             JenaSystem.init();
             // Do explicitly so it happens after subsystem initialization.
-            Fuseki.init();
+            FusekiCore.init();
             new FusekiCmdInner(argv).mainRun();
         }
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiWebappCmd.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/FusekiWebappCmd.java
@@ -58,7 +58,7 @@ public class FusekiWebappCmd {
     static {
         FusekiEnv.mode = FusekiEnv.INIT.STANDALONE;
         FusekiEnv.setEnvironment();
-        FusekiLogging.setLogging(FusekiEnv.FUSEKI_BASE);
+        FusekiLogging.setLogging(FusekiEnv.FUSEKI_BASE, false);
     }
 
     static public void main(String... argv) {

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
@@ -31,7 +31,9 @@ import org.apache.jena.fuseki.FusekiConfigException;
 import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.FusekiCoreInfo;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.fuseki.webapp.FusekiEnv;
+import org.apache.jena.sys.JenaSystem;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
@@ -59,7 +61,10 @@ public class JettyFusekiWebapp {
     // This class is becoming less important - it now sets up a Jetty server for in-process use
     // either for the command line in development
     // and in testing but not direct webapp deployments.
-    static { Fuseki.init(); }
+    static {
+        JenaSystem.init();
+        FusekiCore.init();
+    }
 
     public static JettyFusekiWebapp  instance    = null;
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/mgt/ActionDatasets.java
@@ -141,10 +141,6 @@ public class ActionDatasets extends ActionContainerItem {
                 else
                     assemblerFromBody(action, dest);
 
-                Model model = ModelFactory.createDefaultModel();
-                model.add(modelData);
-                AssemblerUtils.addRegistered(model);
-
                 // ----
                 // Keep a persistent copy immediately.  This is not used for
                 // anything other than being "for the record".
@@ -152,6 +148,12 @@ public class ActionDatasets extends ActionContainerItem {
                 try ( OutputStream outCopy = IO.openOutputFile(systemFileCopy) ) {
                     RDFDataMgr.write(outCopy, modelData, Lang.TURTLE);
                 }
+
+                Model model = ModelFactory.createDefaultModel();
+                model.add(modelData);
+                // Add the dataset and graph wiring.
+                AssemblerUtils.addRegistered(model);
+
                 // ----
                 // Process configuration.
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerEnvironmentInit.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerEnvironmentInit.java
@@ -45,7 +45,7 @@ public class FusekiServerEnvironmentInit implements ServletContextListener {
                 // https://logging.apache.org/log4j/2.x/manual/webapp.html
                 FusekiLogging.markInitialized(true);
             } else {
-                FusekiLogging.setLogging(FusekiEnv.FUSEKI_BASE);
+                FusekiLogging.setLogging(FusekiEnv.FUSEKI_BASE, false);
             }
         }
         JenaSystem.init();

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerEnvironmentInit.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiServerEnvironmentInit.java
@@ -22,6 +22,7 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
 import org.apache.jena.fuseki.system.FusekiLogging;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.sys.JenaSystem;
 
 /** Setup the environment and logging.
@@ -49,6 +50,8 @@ public class FusekiServerEnvironmentInit implements ServletContextListener {
             }
         }
         JenaSystem.init();
+        FusekiCore.init();
+
     }
 
     @Override

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/FusekiWebapp.java
@@ -46,6 +46,7 @@ import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.DataService;
 import org.apache.jena.fuseki.servlets.HttpAction;
 import org.apache.jena.fuseki.servlets.ServletOps;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.rdfs.RDFSFactory;
@@ -55,6 +56,7 @@ import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.riot.RDFParser;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
+import org.apache.jena.sys.JenaSystem;
 
 public class FusekiWebapp
 {
@@ -122,7 +124,8 @@ public class FusekiWebapp
             Path FUSEKI_HOME = FusekiEnv.FUSEKI_HOME;
             Path FUSEKI_BASE = FusekiEnv.FUSEKI_BASE;
 
-            Fuseki.init();
+            JenaSystem.init();
+            FusekiCore.init();
             Fuseki.configLog.info("FUSEKI_HOME="+ ((FUSEKI_HOME==null) ? "unset" : FUSEKI_HOME.toString()));
             Fuseki.configLog.info("FUSEKI_BASE="+FUSEKI_BASE.toString());
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/ShiroEnvironmentLoader.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/webapp/ShiroEnvironmentLoader.java
@@ -26,7 +26,9 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
 import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.irix.IRIs;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.shiro.lang.io.ResourceUtils;
 import org.apache.shiro.web.env.EnvironmentLoader;
 import org.apache.shiro.web.env.ResourceBasedWebEnvironment;
@@ -86,8 +88,9 @@ public class ShiroEnvironmentLoader extends EnvironmentLoader implements Servlet
 
     /** Look for a Shiro ini file, or return null */
     private static String huntForShiroIni(String[] locations) {
+        JenaSystem.init();
+        FusekiCore.init();
         FusekiEnv.setEnvironment();
-        Fuseki.init();
         for ( String loc : locations ) {
             // If file:, look for that file.
             // If a relative name without scheme, look in FUSEKI_BASE, FUSEKI_HOME, webapp.

--- a/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/log4j2.properties
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/webapp/log4j2.properties
@@ -1,14 +1,17 @@
 ## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
 
-## Plain output to stdout
 status = error
 name = FusekiLoggingWebapp
+filters = threshold
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = ALL
 
 appender.console.type = Console
 appender.console.name = OUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-10c{1} %-5p %m%n
+## appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
+appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
 
 rootLogger.level                  = INFO
 rootLogger.appenderRef.stdout.ref = OUT

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/ServerCtl.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/ServerCtl.java
@@ -30,6 +30,7 @@ import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.cmd.FusekiArgs;
 import org.apache.jena.fuseki.cmd.JettyFusekiWebapp;
 import org.apache.jena.fuseki.cmd.JettyServerConfig;
+import org.apache.jena.fuseki.system.FusekiCore;
 import org.apache.jena.fuseki.webapp.FusekiEnv;
 import org.apache.jena.fuseki.webapp.FusekiServerListener;
 import org.apache.jena.fuseki.webapp.FusekiWebapp;
@@ -37,6 +38,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.modify.request.Target;
 import org.apache.jena.sparql.modify.request.UpdateDrop;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.Txn;
 import org.apache.jena.update.Update;
 import org.apache.jena.update.UpdateExecutionFactory;
@@ -83,7 +85,10 @@ import org.apache.jena.update.UpdateProcessor;
  * </pre>
  */
 public class ServerCtl {
-    static { Fuseki.init(); }
+    static {
+        JenaSystem.init();
+        FusekiCore.init();
+    }
 
     /* Cut&Paste versions:
 

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TS_FusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TS_FusekiWebapp.java
@@ -26,15 +26,14 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-
 @RunWith(Suite.class)
 @Suite.SuiteClasses( {
       TestWebappSPARQLProtocol.class
     , TestWebappAuthQuery_JDK.class
     , TestWebappAuthUpdate_JDK.class
     , TestWebappFileUpload.class
-    , TestAdmin.class
-    , TestAdminAPI.class
+    , TestWebappAdmin.class
+    , TestWebappAdminAPI.class
     , TestWebappServerReadOnly.class
     , TestWebappMetrics.class
 })

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestWebappAdmin.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestWebappAdmin.java
@@ -56,7 +56,7 @@ import org.awaitility.Awaitility;
 import org.junit.*;
 
 /** Tests of the admin functionality */
-public class TestAdmin extends AbstractFusekiWebappTest {
+public class TestWebappAdmin extends AbstractFusekiWebappTest {
 
     // Name of the dataset in the assembler file.
     static String dsTest      = "test-ds1";

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestWebappAdminAPI.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestWebappAdminAPI.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 /** More tests of the admin functionality
  * See also TestAdmin.
  */
-public class TestAdminAPI extends AbstractFusekiWebappTest {
+public class TestWebappAdminAPI extends AbstractFusekiWebappTest {
 
     @Test public void add_delete_api_1() throws Exception {
         if ( org.apache.jena.tdb1.sys.SystemTDB.isWindows )

--- a/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestWebappFileUpload.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/test/java/org/apache/jena/fuseki/TestWebappFileUpload.java
@@ -40,6 +40,7 @@ import org.junit.Test;
  * Tests for multi-part file upload.
  */
 public class TestWebappFileUpload extends AbstractFusekiWebappTest {
+
     @Test
     public void upload_gsp_01() {
         FileSender x = new FileSender(ServerCtl.serviceGSP() + "?default");

--- a/jena-iri3986/src/main/java/org/apache/jena/rfc3986/URIScheme.java
+++ b/jena-iri3986/src/main/java/org/apache/jena/rfc3986/URIScheme.java
@@ -109,7 +109,7 @@ public enum URIScheme {
         };
     }
 
-    /** Scheme name */
+    /** Scheme name; no ':' */
     public String getSchemeName() {
         return schemeName;
     }


### PR DESCRIPTION
This PR is preparation for the first step #2775 -- replacing the `fuseki-server.jar` artifact with one based on FusekiMain, not Fuseki/Webapp, making no changes to functionality.

The PR is accumulated clear-up and reshuffling without making the changes so that the internal improvements are not sync'ed to the changes making a `fuseki-server.jar` and are available to Fuseki/Webapp.

The PR includes the reload code for #2462 but this PR does not expose the functionality. The reload ability will be part of the switch to a non-webapp Fuseki server jar with UI and admin controls.

----

 - [x] Tests are included but not for #2462 (coming later)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
