### PR TITLE
GH-2902: Use jena-fuseki-server for fuseki-server.jar

### DIFF
--- a/jena-fuseki2/apache-jena-fuseki/assembly-dist.xml
+++ b/jena-fuseki2/apache-jena-fuseki/assembly-dist.xml
@@ -17,8 +17,7 @@
 -->
 
 <!-- 
-  The distribution.
-  Assumes jar made and onejar has been assembled.
+  The distribution for Apache Jena Fuseki.
 -->
 
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
@@ -39,20 +38,10 @@
     <dependencySet>
       <useProjectArtifact>false</useProjectArtifact>
       <includes>
-        <include>org.apache.jena:jena-fuseki-fulljar:jar</include>
+        <include>org.apache.jena:jena-fuseki-server:jar</include>
       </includes>
       <outputFileNameMapping>fuseki-server.jar</outputFileNameMapping>
-
     </dependencySet>
-    <!-- WAR file
-    <dependencySet>
-      <useProjectArtifact>false</useProjectArtifact>
-      <includes>
-        <include>org.apache.jena:jena-fuseki-war:war</include>
-      </includes>
-      <outputFileNameMapping>fuseki.war</outputFileNameMapping>
-    </dependencySet>
-    -->
   </dependencySets>
 
   <files>
@@ -91,20 +80,15 @@
     </fileSet>
 
     <fileSet>
-       <!-- Executables -->
-       <outputDirectory></outputDirectory>
-       <fileMode>0755</fileMode>
-       <includes>
-         <include>fuseki-server</include>
-         <include>fuseki-backup</include>
-         <include>bin/*</include>
-       </includes>
-     </fileSet>
-
-    <fileSet>
-      <directory>../jena-fuseki-webapp/target/webapp/</directory>
-      <outputDirectory>webapp</outputDirectory>
+      <!-- Executables -->
+      <outputDirectory></outputDirectory>
+      <fileMode>0755</fileMode>
+      <includes>
+        <include>fuseki-server</include>
+        <include>fuseki-backup</include>
+        <include>bin/*</include>
+      </includes>
     </fileSet>
-
+    
   </fileSets>
 </assembly>

--- a/jena-fuseki2/apache-jena-fuseki/fuseki
+++ b/jena-fuseki2/apache-jena-fuseki/fuseki
@@ -296,17 +296,19 @@ then
 fi
 
 # Run command
+## Plain server, no UI, no admin work area.
+## MAIN=org.apache.jena.fuseki.main.cmds.FusekiMainCmd
+MAIN=org.apache.jena.fuseki.main.cmds.FusekiServerCmd
 
 if [ -z "$FUSEKI_CLASSES" ]
 then
-  RUN_ARGS=(${JAVA_OPTIONS[@]} -jar "$FUSEKI_START" "${FUSEKI_ADDITIONAL_ARGS[@]}" $FUSEKI_ARGS)
+  RUN_ARGS=(${JAVA_OPTIONS[@]} -cp "$FUSEKI_START" "$MAIN" "${FUSEKI_ADDITIONAL_ARGS[@]}" $FUSEKI_ARGS)
 else
-  RUN_ARGS=(${JAVA_OPTIONS[@]} -cp "$FUSEKI_START:$FUSEKI_CLASSES" org.apache.jena.fuseki.cmd.FusekiCmd "${FUSEKI_ADDITIONAL_ARGS[@]}" $FUSEKI_ARGS)
+  RUN_ARGS=(${JAVA_OPTIONS[@]} -cp "$FUSEKI_START:$FUSEKI_CLASSES" "$MAIN" "${FUSEKI_ADDITIONAL_ARGS[@]}" $FUSEKI_ARGS)
 fi
 RUN_CMD=("$JAVA" "${RUN_ARGS[@]}")
 
 # Export the variables to be seen by the java server process.
-export FUSEKI_HOME
 export FUSEKI_BASE
 
 #####################################################

--- a/jena-fuseki2/apache-jena-fuseki/fuseki-server
+++ b/jena-fuseki2/apache-jena-fuseki/fuseki-server
@@ -114,14 +114,16 @@ then
     LOGGING="-Dlog4j.configurationFile=$DFT_LOG_CONF"
 fi
 
+## Plain server, no UI, no admin work area.
+## MAIN=org.apache.jena.fuseki.main.cmds.FusekiMainCmd
+MAIN=org.apache.jena.fuseki.main.cmds.FusekiServerCmd
+
 if [ -n "$LOGGING" ]
 then
-    exec "$JAVA" $JVM_ARGS "$LOGGING" -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
+    exec "$JAVA" $JVM_ARGS "$LOGGING" -cp "$CP" "$MAIN" "$@"
 else
-    exec "$JAVA" $JVM_ARGS -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
+    exec "$JAVA" $JVM_ARGS -cp "$CP" "$MAIN" "$@"
 fi
-
-exec "$JAVA" $JVM_ARGS $LOGGING -cp "$CP" org.apache.jena.fuseki.cmd.FusekiCmd "$@"
 
 ## Adding custom code to the Fuseki server:
 ##

--- a/jena-fuseki2/apache-jena-fuseki/fuseki-server.bat
+++ b/jena-fuseki2/apache-jena-fuseki/fuseki-server.bat
@@ -16,13 +16,10 @@
 
 @echo off
 @REM modify this to name the server jar
-java -Xmx1200M -jar fuseki-server.jar %*
+java -Xmx1500M -cp fuseki-server.jar org.apache.jena.fuseki.main.cmds.FusekiServerCmd %*
 
 @REM Adding custom code to the Fuseki server:
 @REM  
-@REM It is also possible to launch Fuseki using 
-@REM   java ..jvmarsg... -cp $JAR org.apache.jena.fuseki.cmd.FusekiCmd %*
-@REM 
 @REM In this way, you can add custom java to the classpath:
 @REM 
-@REM  java ... -cp fuseki-server.jar;MyCustomCode.jar org.apache.jena.fuseki.cmd.FusekiCmd %*
+@REM  java ... -cp fuseki-server.jar;MyCustomCode.jar org.apache.jena.fuseki.main.cmds.FusekiServerCmd %*

--- a/jena-fuseki2/apache-jena-fuseki/pom.xml
+++ b/jena-fuseki2/apache-jena-fuseki/pom.xml
@@ -36,17 +36,10 @@
 
     <dependency>
       <groupId>org.apache.jena</groupId>
-      <artifactId>jena-fuseki-fulljar</artifactId>
+      <artifactId>jena-fuseki-server</artifactId>
       <version>${project.version}</version>
     </dependency>
     
-    <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-fuseki-war</artifactId>
-      <version>${project.version}</version>
-      <type>war</type>
-    </dependency>
-
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
This is the PR to switch `apache-jena-fuseki` to having `jena-fuseki-server` as `fuseki-servar.jar`

This PR of a single commit is the switchover in the apache-jena-fuseki download from the internally webapp-based Fuseki to "Fuseki server" - fuseki/main + all Fuseki modules to provide the Shiro security, admin and UI.


----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
