### PR TITLE
GH-2908: Adjust for T24:00:00 in xsd:dateTime

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeFunctions.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/NodeFunctions.java
@@ -503,10 +503,14 @@ public class NodeFunctions {
         return NodeValue.makeLangString(lex, lang) ;
     }
 
+
+    /** Canonocal duration of 0 -- "P0S" */
+    private static Duration zeroDuration = NodeValue.xmlDatatypeFactory.newDuration(true, null, null, null, null, null, BigDecimal.ZERO) ;
+
     /** A duration, tided */
     public static Duration duration(int seconds) {
         if ( seconds == 0 )
-            return XSDFuncOp.zeroDuration;
+            return zeroDuration;
         Duration dur = NodeValue.xmlDatatypeFactory.newDuration(1000L*seconds);
         // Neaten the duration. Not all the fields are zero.
         dur = NodeValue.xmlDatatypeFactory.newDuration(dur.getSign()>=0,

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -1142,6 +1142,13 @@ public class XSDFuncOp
                 dt.setHour(0);
             return dt;
         }
+        if ( nv.isDateTime() ) {
+            if ( dt.getHour() == 24 ) {
+                dt.setHour(0);
+                dt.add(duration1day);
+            }
+            return dt;
+        }
         return dt;
     }
 
@@ -1169,6 +1176,14 @@ public class XSDFuncOp
             if ( dt.getHour() == 24 )
                 // Normalize "24:00:00"
                 dt.setHour(0);
+            return dt;
+        }
+        if ( nv.isDateTime() ) {
+            if ( dt.getHour() == 24 ) {
+                dt.setHour(0);
+                dt.add(duration1day);
+            }
+            return dt;
         }
         return dt;
     }
@@ -1611,7 +1626,9 @@ public class XSDFuncOp
         return NodeValue.makeInteger((BigInteger)x) ;
     }
 
-    public static Duration zeroDuration = NodeValue.xmlDatatypeFactory.newDuration(true, null, null, null, null, null, BigDecimal.ZERO) ;
+    private static Duration duration1day = NodeValue.xmlDatatypeFactory.newDuration(true,
+                                                                                    BigInteger.ZERO, BigInteger.ZERO, BigInteger.ONE,
+                                                                                    BigInteger.ZERO, BigInteger.ZERO, BigDecimal.ZERO) ;
 
     public static int compareDuration(NodeValue nv1, NodeValue nv2) {
         return compareDuration(nv1.getDuration(), nv2.getDuration()) ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions.java
@@ -205,6 +205,17 @@ public class TestExpressions
     @Test(expected=ExprEvalException.class)
     public void boolean_74()       { testBoolean("isNumeric(?x)", true) ; }
 
+    // 24:00:00
+    // Equal
+    static String dateTime1999_24 = "'1999-12-31T24:00:00Z'^^<"+XSDDatatype.XSDdateTime.getURI()+">" ;
+    static String dateTime2000_00 = "'2000-01-01T00:00:00Z'^^<"+XSDDatatype.XSDdateTime.getURI()+">" ;
+
+    static String time_24 = "'24:00:00'^^<"+XSDDatatype.XSDtime.getURI()+">" ;
+    static String time_00 = "'00:00:00'^^<"+XSDDatatype.XSDtime.getURI()+">" ;
+
+    @Test public void dateTime24_01() { testBoolean(dateTime1999_24+" = "+dateTime2000_00 , true) ; }
+    @Test public void time24_01()     { testBoolean(time_24+" = "+time_00 , true) ; }
+
     static String duration1 =  "'P1Y1M1DT1H1M1S"+"'^^<"+XSDDatatype.XSDduration.getURI()+">";
     static String duration2 =  "'P2Y1M1DT1H1M1S"+"'^^<"+XSDDatatype.XSDduration.getURI()+">";
     static String duration3 =  "'P1Y1M1DT1H1M1S"+"'^^<"+XSDDatatype.XSDduration.getURI()+">";
@@ -418,6 +429,7 @@ public class TestExpressions
     static String dateTime3 = "'2005-01-01T12:03:34Z'^^<"+XSDDatatype.XSDdateTime.getURI()+">" ;
     // Later
     static String dateTime4 = "'2005-02-25T13:00:00Z'^^<"+XSDDatatype.XSDdateTime.getURI()+">" ;
+
     static String time1 = "'12:03:34Z'^^<" + XSDDatatype.XSDtime.getURI() + ">";
     static String time2 = "'12:03:34Z'^^<" + XSDDatatype.XSDtime.getURI() + ">";
     static String time3 = "'13:00:00Z'^^<" + XSDDatatype.XSDtime.getURI() + ">";


### PR DESCRIPTION
GitHub issue resolved #2908

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
