### PR TITLE
GH-2924: Lateral - fixed injection for tables and enhanced QueryExec API for easier testing.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/Algebra.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/Algebra.java
@@ -161,22 +161,27 @@ public class Algebra
 
         // If compatible, merge. Iterate over variables in right but not in left.
         BindingBuilder b = Binding.builder(bindingLeft);
-        for ( Iterator<Var> vIter = bindingRight.vars() ; vIter.hasNext() ; ) {
-            Var v = vIter.next();
-            Node n = bindingRight.get(v);
+        bindingRight.forEach((v, n) -> {
             if ( !bindingLeft.contains(v) )
                 b.add(v, n);
-        }
+        });
         return b.build();
     }
 
     public static boolean compatible(Binding bindingLeft, Binding bindingRight) {
         // Test to see if compatible: Iterate over variables in left
-        for ( Iterator<Var> vIter = bindingLeft.vars() ; vIter.hasNext() ; ) {
-            Var v = vIter.next();
-            Node nLeft = bindingLeft.get(v);
-            Node nRight = bindingRight.get(v);
+        return compatible(bindingLeft, bindingRight, bindingLeft.vars());
+    }
 
+    /** Test to see if bindings are compatible for all variables of the provided iterator. */
+    public static boolean compatible(Binding bindingLeft, Binding bindingRight, Iterator<Var> vars) {
+        while (vars.hasNext() ) {
+            Var v = vars.next();
+            Node nLeft = bindingLeft.get(v);
+            if ( nLeft == null )
+                continue;
+
+            Node nRight = bindingRight.get(v);
             if ( nRight != null && !nRight.equals(nLeft) )
                 return false;
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/table/TableBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/table/TableBuilder.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.algebra.table;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.jena.sparql.algebra.Table;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.join.ImmutableUniqueList;
+
+/**
+ * Builder for immutable instances of {@link Table}.
+ * This builder is not thread safe.
+ */
+public class TableBuilder {
+    private ImmutableUniqueList.Builder<Var> varsBuilder = ImmutableUniqueList.newUniqueListBuilder(Var.class);
+
+    private List<Binding> rows = new ArrayList<>();
+    private boolean copyRowsOnNextMutation = false;
+
+    // Vars ----
+
+    /** Returns an immutable snapshot of this builder's current variables. */
+    public List<Var> snapshotVars() {
+        return varsBuilder.build();
+    }
+
+    public int sizeVars() {
+        return varsBuilder.size();
+    }
+
+    public TableBuilder addVar(Var var) {
+        varsBuilder.add(var);
+        return this;
+    }
+
+    public TableBuilder addVars(Collection<Var> vars) {
+        varsBuilder.addAll(vars);
+        return this;
+    }
+
+    public TableBuilder addVars(Iterator<Var> vars) {
+        vars.forEachRemaining(varsBuilder::add);
+        return this;
+    }
+
+    /** Adds the variables of a binding but not the binding itself. */
+    public TableBuilder addVarsFromRow(Binding row) {
+        row.vars().forEachRemaining(varsBuilder::add);
+        return this;
+    }
+
+    // Rows -----
+
+    private void copyRowsIfNeeded() {
+        if (copyRowsOnNextMutation) {
+            rows = new ArrayList<>(rows);
+            copyRowsOnNextMutation = false;
+        }
+    }
+
+    /** Returns an immutable snapshot of this builder's current rows. */
+    public List<Binding> snapshotRows() {
+        return List.copyOf(rows);
+    }
+
+    public int sizeRows() {
+        return rows.size();
+    }
+
+    public TableBuilder addRow(Binding row) {
+        copyRowsIfNeeded();
+        rows.add(row);
+        return this;
+    }
+
+    public TableBuilder addRows(Collection<Binding> newRows) {
+        copyRowsIfNeeded();
+        rows.addAll(newRows);
+        return this;
+    }
+
+    public TableBuilder addRows(Iterator<Binding> newRows) {
+        copyRowsIfNeeded();
+        newRows.forEachRemaining(rows::add);
+        return this;
+    }
+
+    // Rows and Vars -----
+
+    /** This method assumes prior call to copyRowsIfNeeded(). */
+    private void addRowAndVarsInternal(Binding row) {
+        addVarsFromRow(row);
+        rows.add(row);
+    }
+
+    public TableBuilder addRowAndVars(Binding row) {
+        copyRowsIfNeeded();
+        addRowAndVarsInternal(row);
+        return this;
+    }
+
+    public TableBuilder addRowsAndVars(Collection<Binding> newRows) {
+        copyRowsIfNeeded();
+        newRows.forEach(this::addVarsFromRow);
+        rows.addAll(newRows);
+        return this;
+    }
+
+    public TableBuilder addRowsAndVars(Iterator<Binding> newRows) {
+        copyRowsIfNeeded();
+        newRows.forEachRemaining(this::addRowAndVarsInternal);
+        return this;
+    }
+
+    /** Add the rows and variables of another table. */
+    public TableBuilder addRowsAndVars(Table table) {
+        addVars(table.getVars());
+        addRows(table.rows());
+        return this;
+    }
+
+    /**
+     * Similar to {@link #addRowsAndVars(Iterator)} but
+     * also closes the given QueryIterator when done.
+     */
+    public TableBuilder consumeRowsAndVars(QueryIterator qIter) {
+        Objects.requireNonNull(qIter);
+        try {
+            addRowsAndVars(qIter);
+        } finally {
+            qIter.close();
+        }
+        return this;
+    }
+
+    // General -----
+
+    public TableBuilder resetVars() {
+        varsBuilder.clear();
+        return this;
+    }
+
+    public TableBuilder resetRows() {
+        if (copyRowsOnNextMutation) {
+            rows = new ArrayList<>();
+            copyRowsOnNextMutation = false;
+        } else {
+            rows.clear();
+        }
+        return this;
+    }
+
+    /** Reset variables and rows. */
+    public TableBuilder reset() {
+        resetVars();
+        resetRows();
+        return this;
+    }
+
+    public Table build() {
+        List<Var> finalVars = snapshotVars();
+        List<Binding> finalRows = Collections.unmodifiableList(rows);
+        copyRowsOnNextMutation = true;
+        return new TableData(finalVars, finalRows);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/table/TableData.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/table/TableData.java
@@ -18,23 +18,21 @@
 
 package org.apache.jena.sparql.algebra.table ;
 
+import java.util.Collections;
 import java.util.List ;
 
 import org.apache.jena.sparql.ARQException ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 
+/** Immutable table. */
 public class TableData extends TableN {
     public TableData(List<Var> variables, List<Binding> rows) {
-        super(variables, rows) ;
+        super(Collections.unmodifiableList(variables), Collections.unmodifiableList(rows)) ;
     }
 
     @Override
     public void addBinding(Binding binding) {
         throw new ARQException("Can't add bindings to an existing data table") ;
-    }
-
-    public List<Binding> getRows() {
-        return rows ;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/table/TableN.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/table/TableN.java
@@ -21,6 +21,7 @@ package org.apache.jena.sparql.algebra.table ;
 import java.util.ArrayList ;
 import java.util.Iterator ;
 import java.util.List ;
+import java.util.Objects ;
 
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.engine.ExecutionContext ;
@@ -49,15 +50,12 @@ public class TableN extends TableBase {
     }
 
     protected TableN(List<Var> variables, List<Binding> rows) {
-        this.vars = variables ;
-        this.rows = rows ;
+        this.vars = Objects.requireNonNull(variables) ;
+        this.rows = Objects.requireNonNull(rows) ;
     }
 
     private void materialize(QueryIterator qIter) {
-        while (qIter.hasNext()) {
-            Binding binding = qIter.nextBinding() ;
-            addBinding(binding) ;
-        }
+        qIter.forEachRemaining(this::addBinding);
         qIter.close() ;
     }
 
@@ -104,5 +102,9 @@ public class TableN extends TableBase {
     @Override
     public List<Var> getVars() {
         return vars ;
+    }
+
+    public List<Binding> getRows() {
+        return rows;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding.java
@@ -90,4 +90,11 @@ public interface Binding
 
     @Override
     public boolean equals(Object other);
+
+    /**
+     * Returns a binding which is guaranteed to be independent of
+     * any resources such as an ongoing query execution or a disk-based dataset.
+     * May return itself if it is already detached.
+     */
+    public Binding detach();
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding0.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding0.java
@@ -51,4 +51,9 @@ public class Binding0 extends BindingBase
 
     @Override
     protected Node get1(Var var) { return null; }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        return new Binding0(newParent);
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding1.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding1.java
@@ -70,4 +70,9 @@ public class Binding1 extends BindingBase {
             return value;
         return null;
     }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        return new Binding1(newParent, var, value);
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding2.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding2.java
@@ -77,4 +77,9 @@ public class Binding2 extends BindingBase
             return value2;
         return null;
     }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        return new Binding2(newParent, var1, value1, var2, value2);
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding3.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding3.java
@@ -132,4 +132,9 @@ public class Binding3 extends BindingBase {
 
         return null;
     }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        return new Binding3(newParent, var1, value1, var2, value2, var3, value3);
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding4.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/Binding4.java
@@ -154,4 +154,9 @@ public class Binding4 extends BindingBase {
 
         return null;
     }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        return new Binding4(newParent, var1, value1, var2, value2, var3, value3, var4, value4);
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingBase.java
@@ -202,4 +202,19 @@ abstract public class BindingBase implements Binding
         }
         return hash;
     }
+
+    @Override
+    public Binding detach() {
+        Binding newParent = (parent == null) ? null : parent.detach();
+        Binding result = (newParent == parent)
+                ? detachWithOriginalParent()
+                : detachWithNewParent(newParent);
+        return result;
+    }
+
+    protected Binding detachWithOriginalParent() {
+        return this;
+    }
+
+    protected abstract Binding detachWithNewParent(Binding newParent);
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingOverMap.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingOverMap.java
@@ -61,4 +61,9 @@ public class BindingOverMap extends BindingBase {
     protected boolean isEmpty1() {
         return map.isEmpty();
     }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        return new BindingOverMap(newParent, map);
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingProject.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingProject.java
@@ -35,4 +35,17 @@ public class BindingProject extends BindingProjectBase {
     protected boolean accept(Var var) {
         return projectionVars.contains(var) ;
     }
+
+    @Override
+    public Binding detach() {
+        Binding b = binding.detach();
+        return b == binding
+            ? this
+            : new BindingProject(projectionVars, b);
+    }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        throw new UnsupportedOperationException("Should never be called.");
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingProjectBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingProjectBase.java
@@ -25,13 +25,13 @@ import java.util.List ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.sparql.core.Var ;
 
-/** Common framework for projection; 
+/** Common framework for projection;
  * the projection policy is provided by
- * abstract method {@link #accept(Var)} 
+ * abstract method {@link #accept(Var)}
  */
 public abstract class BindingProjectBase extends BindingBase {
     private List<Var>     actualVars = null ;
-    private final Binding binding ;
+    protected final Binding binding ;
 
     public BindingProjectBase(Binding bind) {
         super(null) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingProjectNamed.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingProjectNamed.java
@@ -33,4 +33,17 @@ public class BindingProjectNamed extends BindingProjectBase {
     protected boolean accept(Var var) {
         return var.isNamedVar() ;
     }
+
+    @Override
+    public Binding detach() {
+        Binding b = binding.detach();
+        return b == binding
+            ? this
+            : new BindingProjectNamed(b);
+    }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        throw new UnsupportedOperationException("Should never be called.");
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingRoot.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/binding/BindingRoot.java
@@ -33,4 +33,9 @@ public class BindingRoot extends Binding0 {
     public void format1(StringBuilder sBuff) {
         sBuff.append("[Root]");
     }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        return this;
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/join/ImmutableUniqueList.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/join/ImmutableUniqueList.java
@@ -105,6 +105,10 @@ public class ImmutableUniqueList<T> extends AbstractList<T> {
             return this ;
         }
 
+        public int size() {
+            return items == null ? 0 : items.size();
+        }
+
         public boolean isEmpty() {
             return items == null || items.isEmpty();
         }
@@ -182,16 +186,5 @@ public class ImmutableUniqueList<T> extends AbstractList<T> {
             }
         }
         return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        return super.equals(obj);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestTableBuilder.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestTableBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.sparql.algebra;
+
+import org.apache.jena.sparql.algebra.table.TableBuilder;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.binding.BindingFactory;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sparql.util.NodeFactoryExtra;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTableBuilder {
+    @Test public void table_builder_01() {
+        Table expectedT1 = SSE.parseTable("(table (vars ?a ?b) (row (?a 1) (?b 2)))");
+        Table expectedT2 = SSE.parseTable("(table (vars ?a ?b ?c) (row (?a 1) (?b 2)) (row (?c 3)))");
+
+        TableBuilder builder = TableFactory.builder();
+        Table actualT1 = builder.addRowsAndVars(expectedT1.rows()).build();
+        Assert.assertEquals(expectedT1, actualT1);
+
+        // Mutating the builder must not affect the tables created from it.
+        Binding b = BindingFactory.binding(Var.alloc("c"), NodeFactoryExtra.intToNode(3));
+        builder.addRowAndVars(b);
+        Table actualT2 = builder.build();
+
+        Assert.assertEquals(expectedT1, actualT1);
+        Assert.assertEquals(expectedT2, actualT2);
+
+        builder.reset();
+
+        Assert.assertEquals(expectedT1, actualT1);
+        Assert.assertEquals(expectedT2, actualT2);
+        Assert.assertTrue(builder.snapshotVars().isEmpty());
+        Assert.assertTrue(builder.snapshotRows().isEmpty());
+    }
+}
+

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/solver/BindingTDB.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/solver/BindingTDB.java
@@ -26,9 +26,10 @@ import org.apache.jena.riot.out.NodeFmtLib ;
 import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.engine.binding.BindingBase ;
-import org.apache.jena.tdb1.TDB1Exception;
-import org.apache.jena.tdb1.store.NodeId;
-import org.apache.jena.tdb1.store.nodetable.NodeTable;
+import org.apache.jena.sparql.engine.binding.BindingFactory ;
+import org.apache.jena.tdb1.TDB1Exception ;
+import org.apache.jena.tdb1.store.NodeId ;
+import org.apache.jena.tdb1.store.nodetable.NodeTable ;
 
 /** Bind that delays turning a NodeId into a Node until explicitly needed by get() */
 
@@ -158,5 +159,15 @@ public class BindingTDB extends BindingBase
         Node node = get(var) ;
         String tmp = NodeFmtLib.displayStr(node) ;
         sbuff.append("( ?"+var.getVarName()+extra+" = "+tmp+" )") ;
+    }
+
+    @Override
+    public Binding detach() {
+        return BindingFactory.copy(this);
+    }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        throw new UnsupportedOperationException("Should never be called.");
     }
 }

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/BindingTDB.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/BindingTDB.java
@@ -26,6 +26,7 @@ import org.apache.jena.riot.out.NodeFmtLib;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.binding.BindingBase;
+import org.apache.jena.sparql.engine.binding.BindingFactory;
 import org.apache.jena.tdb2.TDBException;
 import org.apache.jena.tdb2.store.NodeId;
 import org.apache.jena.tdb2.store.nodetable.NodeTable;
@@ -158,5 +159,15 @@ public class BindingTDB extends BindingBase
         Node node = get(var);
         String tmp = NodeFmtLib.displayStr(node);
         sbuff.append("( ?"+var.getVarName()+extra+" = "+tmp+" )");
+    }
+
+    @Override
+    public Binding detach() {
+        return BindingFactory.copy(this);
+    }
+
+    @Override
+    protected Binding detachWithNewParent(Binding newParent) {
+        throw new UnsupportedOperationException("Should never be called.");
     }
 }


### PR DESCRIPTION
GitHub issue resolved #2924

Pull request Description:

* Added a new test case with nested laterals.
* Fixed nested laterals by merging compatible bindings in `QueryIterLateral`
* While writing the tests, I added a few shorthands to the QueryExecBuilder API: Its now possible to write `QueryExec.dataset(...).query("SELECT ...").table()` to generally safely obtain a detached materialized in-memory table without having to worry about resource leaks or try-with-resources blocks. In the revised tests, the tables are used directly when asserting the equality of expected and actual results. In an attempt to allow for cleanly detaching BindingTDB instances, I added `Binding.detach()` with appropriate implementations. `Binding.detach` avoids copying of bindings that are already in-memory, and is thus more subtle than `BindingFactory.copy`.
* Added a `TableBuilder` class to build immutable tables.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
