### PR TITLE
GH-2928: Workflow for checking dependency updates

### DIFF
--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -1,0 +1,44 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+name: Maven Build on PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+    branches:
+      - 'main'
+      
+permissions:
+  contents: read
+
+jobs:
+      
+  build-pr:
+    ## Dependabot only
+    if: github.actor == 'dependabot[bot]'
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk_distribution: ['temurin']
+        os: [ubuntu-latest]
+        java_version: ['21']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{ matrix.jdk_distribution }}
+          java-version: ${{ matrix.java_version }}
+
+      - name: Build with Maven (Java${{ matrix.java_version }} ${{ matrix.jdk_distribution }})
+        ## No javadoc - that needs visual check
+        run: mvn -B --file pom.xml -Dmaven.javadoc.skip=true install


### PR DESCRIPTION
Run a build when dependabot submitts a PR

This is doing checking of dependencies so the matrix is minimal - one job, running with Java21 (the POM will target Java17) on Linux.

The trigger is "open pull request".

----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
