### PR TITLE
GH-2932: Fix for NodeFmtLib.strNT and added variants for Triple and Quad.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/out/NodeFmtLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/out/NodeFmtLib.java
@@ -76,6 +76,32 @@ public class NodeFmtLib
         return strNodesTTL(q.getGraph(), q.getSubject(), q.getPredicate(), q.getObject());
     }
 
+    /** Format a triple as N-Triples. */
+    public static String strNT(Triple triple) {
+        return strNQ(triple.getSubject(), triple.getPredicate(), triple.getObject(), null);
+    }
+
+    /** Format a quad as N-Quads. */
+    public static String strNQ(Quad quad) {
+        return strNQ(quad.getSubject(), quad.getPredicate(), quad.getObject(), quad.getGraph());
+    }
+
+    /** Format the components of a quad as N-Quads. The graph component may be null. */
+    public static String strNQ(Node s, Node p, Node o, Node g) {
+        StringBuilder result = new StringBuilder();
+        result.append(strNT(s));
+        result.append(" ");
+        result.append(strNT(p));
+        result.append(" ");
+        result.append(strNT(o));
+        if (g != null && !Quad.isDefaultGraph(g)) {
+            result.append(" ");
+            result.append(strNT(g));
+        }
+        result.append(" .");
+        return result.toString();
+    }
+
     /** With Turtle abbreviation for literals, no prefixes of base URI */
     public static String strTTL(Node node) {
         return strNode(node, ttlFormatter);
@@ -83,7 +109,7 @@ public class NodeFmtLib
 
     /** Format in N-triples style. */
     public static String strNT(Node node) {
-        return strNode(node, ttlFormatter);
+        return strNode(node, ntFormatter);
     }
 
     /** Format in N-triples style. */


### PR DESCRIPTION
GitHub issue resolved #2932

Pull request Description:
* Fixes NodeFmtLib.strNT
* Also adds `strNT` and `strNQ` variants for formatting as N-Quads (and N-Triples). It seems that so far there were no reliable util methods to create a single valid NQ string - unless one goes through riot. None of the formatting methods in `NodeFmtLib` and `FmtUtils` seem to produce NQ.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
