### PR TITLE
Cleaning code -- Query and ExecutionContext

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/QueryVisitor.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QueryVisitor.java
@@ -24,25 +24,25 @@ import org.apache.jena.sparql.core.Prologue ;
 
 public interface QueryVisitor
 {
-    public void startVisit(Query query) ;
-    public void visitPrologue(Prologue prologue) ;
+    public default void startVisit(Query query) {}
+    public default void visitPrologue(Prologue prologue) {}
 
-    public void visitResultForm(Query query) ;
-    public void visitSelectResultForm(Query query) ;
-    public void visitConstructResultForm(Query query) ;
-    public void visitDescribeResultForm(Query query) ;
-    public void visitAskResultForm(Query query) ;
-    public void visitJsonResultForm(Query query);
+    public default void visitResultForm(Query query) {}
+    public default void visitSelectResultForm(Query query) {}
+    public default void visitConstructResultForm(Query query) {}
+    public default void visitDescribeResultForm(Query query) {}
+    public default void visitAskResultForm(Query query) {}
+    public default void visitJsonResultForm(Query query) {}
 
-    public void visitDatasetDecl(Query query) ;
-    public void visitQueryPattern(Query query) ;
-    
-    public void visitGroupBy(Query query) ;
-    public void visitHaving(Query query) ;
-    public void visitOrderBy(Query query) ;
-    public void visitLimit(Query query) ;
-    public void visitOffset(Query query) ;
-    public void visitValues(Query query) ;
-    
-    public void finishVisit(Query query) ;
+    public default void visitDatasetDecl(Query query) {}
+    public default void visitQueryPattern(Query query) {}
+
+    public default void visitGroupBy(Query query) {}
+    public default void visitHaving(Query query) {}
+    public default void visitOrderBy(Query query) {}
+    public default void visitLimit(Query query) {}
+    public default void visitOffset(Query query) {}
+    public default void visitValues(Query query) {}
+
+    public default void finishVisit(Query query) {}
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/VarExprList.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/VarExprList.java
@@ -124,6 +124,8 @@ public class VarExprList {
     }
 
     public void add(Var var) {
+        if ( var == null )
+            throw new ARQInternalErrorException("Attempt to add a null variable");
         // Checking here controls whether duplicate variables are allowed.
         // Duplicates with expressions are not allowed (add(Var, Expr))
         // See ARQ.allowDuplicateSelectColumns
@@ -140,8 +142,6 @@ public class VarExprList {
             return;
         }
 
-        if ( var == null )
-            throw new ARQInternalErrorException("Attempt to add a named expression with a null variable");
         if ( exprs.containsKey(var) )
             throw new ARQInternalErrorException("Attempt to assign an expression again");
         add(var);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterRoot.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterRoot.java
@@ -25,18 +25,17 @@ import org.apache.jena.sparql.engine.binding.Binding ;
 import org.apache.jena.sparql.engine.binding.BindingRoot ;
 import org.apache.jena.sparql.serializer.SerializationContext ;
 
-/** The root binding is one-row, usually no columns making it the join identity.
- *  It has columns only for an initial binding.
+/** The root binding is one-row and has no columns making it the join identity.
  *  It is useful to be able to spot it before having to activate a {@link QueryIterator}.
- *  Executing with a pre-set binding does not use QueryIterRoot.
+ *  Executing with a pre-set binding does not use {@code QueryIterRoot}.
  */
-public class QueryIterRoot extends QueryIterYieldN 
+public class QueryIterRoot extends QueryIterYieldN
     // Not "extends QueryIterSingleton" so we don't get its factory statics.
 {
-    /** Create a root */ 
+    /** Create a root */
     public static QueryIterator create(ExecutionContext execCxt)
     { return create(BindingRoot.create(), execCxt) ; }
-    
+
     /** Create a root with an initial binding */
     public static QueryIterator create(Binding binding, ExecutionContext execCxt)
     { return new QueryIterRoot(binding, execCxt) ; }
@@ -52,7 +51,7 @@ public class QueryIterRoot extends QueryIterYieldN
         else
             out.print("QueryIterRoot: "+binding);
     }
-    
+
     @Override
     public boolean isJoinIdentity() { return binding.isEmpty(); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/OpExecutor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/OpExecutor.java
@@ -145,7 +145,7 @@ public class OpExecutor {
         // default graph and union graph.
 
         if ( Quad.isDefaultGraph(gn) ) {
-            ExecutionContext cxt2 = new ExecutionContext(execCxt, execCxt.getDataset().getDefaultGraph());
+            ExecutionContext cxt2 = ExecutionContext.copyChangeActiveGraph(execCxt, execCxt.getDataset().getDefaultGraph());
             return execute(subOp, input, cxt2);
         }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/QueryEngineMain.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/QueryEngineMain.java
@@ -33,24 +33,24 @@ import org.apache.jena.sparql.util.Context ;
 
 public class QueryEngineMain extends QueryEngineBase
 {
-    static public QueryEngineFactory getFactory() { return factory ; } 
+    static public QueryEngineFactory getFactory() { return factory ; }
     static public void register()       { QueryEngineRegistry.addFactory(factory) ; }
     static public void unregister()     { QueryEngineRegistry.removeFactory(factory) ; }
 
     public QueryEngineMain(Op op, DatasetGraph dataset, Binding input, Context context)
     { super(op, dataset, input, context) ; }
-    
+
     public QueryEngineMain(Query query, DatasetGraph dataset, Binding input, Context context)
-    { 
+    {
         super(query, dataset, input, context) ;
     }
-    
+
     @Override
     public QueryIterator eval(Op op, DatasetGraph dsg, Binding input, Context context)
     {
-        ExecutionContext execCxt = new ExecutionContext(context, dsg.getDefaultGraph(), dsg, QC.getFactory(context)) ;
-        QueryIterator qIter1 = 
-            ( input.isEmpty() ) ? QueryIterRoot.create(execCxt) 
+        ExecutionContext execCxt = ExecutionContext.create(dsg, context);
+        QueryIterator qIter1 =
+            ( input.isEmpty() ) ? QueryIterRoot.create(execCxt)
                                 : QueryIterRoot.create(input, execCxt);
         QueryIterator qIter = QC.execute(op, qIter1, execCxt) ;
         // Wrap with something to check for closed iterators.
@@ -60,27 +60,27 @@ public class QueryEngineMain extends QueryEngineBase
             qIter = QueryIteratorTiming.time(qIter) ;
         return qIter ;
     }
-    
+
     @Override
     protected Op modifyOp(Op op)
-    { 
+    {
         if ( context.isFalse(ARQ.optimization) )
             return minimalModifyOp(op) ;
         return Algebra.optimize(op, super.context) ;
     }
-    
+
     protected Op minimalModifyOp(Op op) {
         return Optimize.minimalOptimizationFactory.create(context).rewrite(op);
     }
-    
+
     // -------- Factory
-    
+
     private static QueryEngineFactory factory = new QueryEngineMainFactory() ;
-    
+
     protected static class QueryEngineMainFactory implements QueryEngineFactory
     {
         @Override
-        public boolean accept(Query query, DatasetGraph dataset, Context context) 
+        public boolean accept(Query query, DatasetGraph dataset, Context context)
         { return true ; }
 
         @Override
@@ -89,9 +89,9 @@ public class QueryEngineMain extends QueryEngineBase
             QueryEngineMain engine = new QueryEngineMain(query, dataset, input, context) ;
             return engine.getPlan() ;
         }
-        
+
         @Override
-        public boolean accept(Op op, DatasetGraph dataset, Context context) 
+        public boolean accept(Op op, DatasetGraph dataset, Context context)
         { return true ; }
 
         @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/iterator/QueryIterGraph.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/iterator/QueryIterGraph.java
@@ -182,7 +182,7 @@ public class QueryIterGraph extends QueryIterRepeatApply
                 return null ;
                 //throw new ARQInternalErrorException(".containsGraph was true but .getGraph is null") ;
 
-            ExecutionContext cxt2 = new ExecutionContext(outerCxt, g) ;
+            ExecutionContext cxt2 = ExecutionContext.copyChangeActiveGraph(outerCxt, g) ;
             QueryIterator subInput = QueryIterSingleton.create(binding, cxt2) ;
             return QC.execute(opExec, subInput, cxt2) ;
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/ref/QueryEngineRef.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/ref/QueryEngineRef.java
@@ -30,7 +30,6 @@ import org.apache.jena.sparql.engine.*;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.binding.BindingFactory;
 import org.apache.jena.sparql.engine.iterator.QueryIteratorCheck;
-import org.apache.jena.sparql.engine.main.QC;
 import org.apache.jena.sparql.util.Context;
 
 /** "Reference" query engine - this simply executes the algebra expression as-is
@@ -65,8 +64,7 @@ public class QueryEngineRef extends QueryEngineBase
     public QueryIterator eval(Op op, DatasetGraph dsg, Binding binding, Context context) {
         if ( binding.vars().hasNext() )
             op = Substitute.substitute(op, binding);
-
-        ExecutionContext execCxt = new ExecutionContext(context, dsg.getDefaultGraph(), dsg, QC.getFactory(context));
+        ExecutionContext execCxt = ExecutionContext.create(dsg, context);
         Evaluator eval = EvaluatorFactory.create(execCxt);
         Table table = RefEval.eval(eval, op);
         QueryIterator qIter = table.iterator(execCxt);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/ref/RefEval.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/ref/RefEval.java
@@ -98,7 +98,7 @@ public class RefEval {
             Graph graph = execCxt.getDataset().getGraph(opGraph.getNode());
             if ( graph == null ) // But contains was true?!!
                 throw new InternalErrorException("Graph was present, now it's not");
-            ExecutionContext execCxt2 = new ExecutionContext(execCxt, graph);
+            ExecutionContext execCxt2 = ExecutionContext.copyChangeActiveGraph(execCxt, graph);
             Evaluator e2 = EvaluatorFactory.create(execCxt2);
             return eval(e2, opGraph.getSubOp());
         }
@@ -109,7 +109,7 @@ public class RefEval {
         for ( Iterator<Node> iter = execCxt.getDataset().listGraphNodes() ; iter.hasNext() ; ) {
             Node gn = iter.next();
             Graph graph = execCxt.getDataset().getGraph(gn);
-            ExecutionContext execCxt2 = new ExecutionContext(execCxt, graph);
+            ExecutionContext execCxt2 = ExecutionContext.copyChangeActiveGraph(execCxt, graph);
             Evaluator e2 = EvaluatorFactory.create(execCxt2);
 
             Table tableVarURI = TableFactory.create(gVar, gn);
@@ -150,13 +150,13 @@ public class RefEval {
                 g = ds.getGraph(opQuad.getGraphNode());
             if ( g == null )
                 return new TableEmpty();
-            ExecutionContext cxt2 = new ExecutionContext(cxt, g);
+            ExecutionContext cxt2 = ExecutionContext.copyChangeActiveGraph(cxt, g);
             QueryIterator qIter = executeBGP(pattern, QueryIterRoot.create(cxt2), cxt2);
             return TableFactory.create(qIter);
         } else {
             // Variable.
             Var gVar = Var.alloc(opQuad.getGraphNode());
-            // Or just just devolve to OpGraph and get OpUnion chain of OpJoin
+            // Or just devolve to OpGraph and get OpUnion chain of OpJoin
             QueryIterConcat concat = new QueryIterConcat(cxt);
             for ( Iterator<Node> graphNodes = cxt.getDataset().listGraphNodes() ; graphNodes.hasNext() ; ) {
                 Node gn = graphNodes.next();
@@ -165,7 +165,7 @@ public class RefEval {
 
                 Graph g = cxt.getDataset().getGraph(gn);
                 Binding b = BindingFactory.binding(BindingRoot.create(), gVar, gn);
-                ExecutionContext cxt2 = new ExecutionContext(cxt, g);
+                ExecutionContext cxt2 = ExecutionContext.copyChangeActiveGraph(cxt, g);
 
                 // Eval the pattern, eval the variable, join.
                 // Pattern may be non-linear in the variable - do a pure execution.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprFunctionOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprFunctionOp.java
@@ -62,11 +62,7 @@ public abstract class ExprFunctionOp extends ExprFunction
 
     @Override
     public final NodeValue eval(Binding binding, FunctionEnv env) {
-        ExecutionContext execCxt = new ExecutionContext(env.getContext(),
-                                                        env.getActiveGraph(),
-                                                        env.getDataset(),
-                                                        QC.getFactory(env.getContext())
-                                                        );
+        ExecutionContext execCxt = ExecutionContext.fromFunctionEnv(env);
         QueryIterator qIter1 = QueryIterSingleton.create(binding, execCxt);
         QueryIterator qIter = QC.execute(op, qIter1, execCxt);
         // Wrap with something to check for closed iterators.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/eval/PathEngine.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/eval/PathEngine.java
@@ -205,13 +205,14 @@ abstract public class PathEngine
         return graph.find(s, p, o) ;
     }
 
+    /* As general as possible property function inclusion */
     private Iterator<Triple> graphFindWorker(Graph graph, Node s, PropertyFunctionFactory f, Node p, Node o, Context context) {
         // Expensive?
         PropertyFunction pf = f.create(p.getURI()) ;
         PropFuncArg sv = arg(s, "S") ;
         PropFuncArg ov = arg(o, "O") ;
-        QueryIterator r = QueryIterRoot.create(new ExecutionContext(context, graph, null, null)) ;
-        QueryIterator qIter = pf.exec(r, sv, p, ov, new ExecutionContext(ARQ.getContext(), graph, null, null)) ;
+        QueryIterator r = QueryIterRoot.create(ExecutionContext.createForGraph(graph, context));
+        QueryIterator qIter = pf.exec(r, sv, p, ov, ExecutionContext.createForGraph(graph, ARQ.getContext()));
         if ( ! qIter.hasNext() )
             return Iter.nullIterator() ;
         List<Triple> array = new ArrayList<>() ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/ExprUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/ExprUtils.java
@@ -203,7 +203,7 @@ public class ExprUtils
     public static NodeValue eval(Expr expr, Binding binding) {
         Context context = ARQ.getContext().copy();
         context.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime());
-        FunctionEnv env = new ExecutionContext(context, null, null, null);
+        FunctionEnv env = ExecutionContext.create(null, context);
         NodeValue r = expr.eval(binding, env);
         return r;
     }

--- a/jena-arq/src/test/java/org/apache/jena/riot/out/TestNodeFmtLib.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/out/TestNodeFmtLib.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestCancelDistinct.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestCancelDistinct.java
@@ -17,25 +17,27 @@
  */
 package org.apache.jena.sparql.engine.iterator;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.junit.Test;
+
 import org.apache.jena.atlas.data.DistinctDataBag;
 import org.apache.jena.atlas.io.IndentedWriter;
-import org.apache.jena.graph.Graph;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.binding.BindingFactory;
-import org.apache.jena.sparql.engine.main.OpExecutorFactory;
 import org.apache.jena.sparql.serializer.SerializationContext;
 import org.apache.jena.sparql.util.Context;
-import org.junit.Test;
 
 public class TestCancelDistinct {
 
@@ -98,12 +100,8 @@ public class TestCancelDistinct {
     }
 
     final Context params = new Context();
-
-    final Graph activeGraph = null;
     final DatasetGraph dataset = null;
-    final OpExecutorFactory factory = null;
-
-    final ExecutionContext c = new ExecutionContext(params, activeGraph, dataset, factory);
+    final ExecutionContext cxt = ExecutionContext.create(dataset, params);
 
     /**
        test that of a QueryIterDistinct with an active databag is
@@ -113,7 +111,7 @@ public class TestCancelDistinct {
         params.set(ARQ.spillToDiskThreshold, 0);
 
         QueryIteratorBase base = new MockQueryIterator(BindingFactory.empty());
-        QueryIterDistinct d = new QueryIterDistinct(base, null, c);
+        QueryIterDistinct d = new QueryIterDistinct(base, null, cxt);
 
         assertNull(d.db);
 
@@ -132,7 +130,7 @@ public class TestCancelDistinct {
         params.set(ARQ.spillToDiskThreshold, 0);
 
         QueryIteratorBase base = new MockQueryIterator(BindingFactory.empty());
-        QueryIterDistinct d = new QueryIterDistinct(base, null, c);
+        QueryIterDistinct d = new QueryIterDistinct(base, null, cxt);
 
         // when there is no databag, close leaves it null
         assertNull(d.db);
@@ -144,7 +142,7 @@ public class TestCancelDistinct {
         params.set(ARQ.spillToDiskThreshold, 0);
 
         QueryIteratorBase base = new MockQueryIterator(BindingFactory.empty());
-        QueryIterDistinct d = new QueryIterDistinct(base, null, c);
+        QueryIterDistinct d = new QueryIterDistinct(base, null, cxt);
 
         assertNull(d.db);
         Binding ignored = d.next();

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestDistinctDataBagLimited.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestDistinctDataBagLimited.java
@@ -33,7 +33,7 @@ public class TestDistinctDataBagLimited extends AbstractTestDistinctReduced {
         QueryIterator qIter = QueryIterPlainWrapper.create(data.iterator()) ;
         Context cxt = new Context() ;
         cxt.set(ARQ.spillToDiskThreshold, 2L);
-        return new QueryIterDistinct(qIter, null, new ExecutionContext(cxt, null, null, null)) ;
+        return new QueryIterDistinct(qIter, null, ExecutionContext.create(null, cxt));
     }
 
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestDistinctMem.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestDistinctMem.java
@@ -23,14 +23,13 @@ import java.util.List ;
 import org.apache.jena.sparql.engine.ExecutionContext ;
 import org.apache.jena.sparql.engine.QueryIterator ;
 import org.apache.jena.sparql.engine.binding.Binding ;
-import org.apache.jena.sparql.util.Context ;
 
 public class TestDistinctMem extends AbstractTestDistinctReduced {
 
     @Override
     protected QueryIterator createQueryIter(List<Binding> data) {
         QueryIterator qIter = QueryIterPlainWrapper.create(data.iterator()) ;
-        return new QueryIterDistinctMem(qIter, new ExecutionContext(new Context(), null, null, null)) ;
+        return new QueryIterDistinctMem(qIter, ExecutionContext.createForGraph(null)) ;
     }
 
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestQueryIterSort.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/iterator/TestQueryIterSort.java
@@ -23,122 +23,116 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.ArrayList ;
-import java.util.Iterator ;
-import java.util.List ;
-import java.util.Random ;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
 
-import org.apache.jena.atlas.data.DataBagExaminer ;
-import org.apache.jena.atlas.io.IndentedWriter ;
-import org.apache.jena.datatypes.xsd.XSDDatatype ;
-import org.apache.jena.graph.Graph ;
-import org.apache.jena.graph.NodeFactory ;
-import org.apache.jena.query.ARQ ;
-import org.apache.jena.query.Query ;
-import org.apache.jena.query.QueryCancelledException ;
-import org.apache.jena.query.SortCondition ;
-import org.apache.jena.shared.PrefixMapping ;
-import org.apache.jena.sparql.ARQNotImplemented ;
-import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.sparql.core.Var ;
-import org.apache.jena.sparql.engine.ExecutionContext ;
-import org.apache.jena.sparql.engine.QueryIterator ;
-import org.apache.jena.sparql.engine.binding.Binding ;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.jena.atlas.data.DataBagExaminer;
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.query.ARQ;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryCancelledException;
+import org.apache.jena.query.SortCondition;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.sparql.ARQNotImplemented;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.engine.binding.BindingBuilder;
-import org.apache.jena.sparql.engine.binding.BindingComparator ;
-import org.apache.jena.sparql.engine.main.OpExecutorFactory ;
-import org.apache.jena.sparql.expr.ExprVar ;
-import org.apache.jena.sparql.serializer.SerializationContext ;
-import org.apache.jena.sparql.util.Context ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.apache.jena.sparql.engine.binding.BindingComparator;
+import org.apache.jena.sparql.expr.ExprVar;
+import org.apache.jena.sparql.serializer.SerializationContext;
+import org.apache.jena.sparql.util.Context;
 
 public class TestQueryIterSort {
 
-    private static final String LETTERS = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM" ;
-    private Random random ;
-    private List<Binding> unsorted ;
-    private BindingComparator comparator ;
-    private CallbackIterator iterator ;
+    private static final String LETTERS = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM";
+    private Random random;
+    private List<Binding> unsorted;
+    private BindingComparator comparator;
+    private CallbackIterator iterator;
 
     @Before
-    public void setup()
-    {
+    public void setup() {
         random = new Random();
         Var[] vars = new Var[]{
+            // @formatter:off
             Var.alloc("1"), Var.alloc("2"), Var.alloc("3"),
             Var.alloc("4"), Var.alloc("5"), Var.alloc("6"),
-            Var.alloc("7"), Var.alloc("8"), Var.alloc("9"), Var.alloc("0")
+            Var.alloc("7"), Var.alloc("8"), Var.alloc("9"),
+            Var.alloc("0")
+            // @formatter:on
         };
         unsorted = new ArrayList<>();
-        for(int i = 0; i < 500; i++){
+        for ( int i = 0 ; i < 500 ; i++ ) {
             unsorted.add(randomBinding(vars));
         }
 
         List<SortCondition> conditions = new ArrayList<>();
         conditions.add(new SortCondition(new ExprVar("8"), Query.ORDER_ASCENDING));
         comparator = new BindingComparator(conditions);
-
         iterator = new CallbackIterator(unsorted.iterator(), 25, null);
-        iterator.setCallback(new Callback() {
-            @Override
-            public void call() { throw new QueryCancelledException() ; }
+        iterator.setCallback(() -> {
+            throw new QueryCancelledException();
         });
     }
 
+    private static ExecutionContext createExecutionContext(Context context) {
+        return ExecutionContext.create(null, context);
+    }
+
     @Test
-    public void testNoSpill()
-    {
-        iterator.setCallback(()->{});
-        //new Callback() { @Override
-        //public void call() { /* do nothing */ } });
+    public void testNoSpill() {
+        iterator.setCallback(() -> {});
+        // new Callback() { @Override
+        // public void call() { /* do nothing */ } });
         assertEquals(0, iterator.getReturnedElementCount());
-        Context context = new Context() ;
-        ExecutionContext executionContext = new ExecutionContext(context, (Graph)null, (DatasetGraph)null, (OpExecutorFactory)null) ;
-        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext) ;
-        try
-        {
-            assertEquals(0, iterator.getReturnedElementCount()) ;
-            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
-            qIter.hasNext() ;
-            assertEquals(500, iterator.getReturnedElementCount()) ;
-            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
-        }
-        finally
-        {
-            qIter.close() ;
+        Context context = new Context();
+        ExecutionContext executionContext = createExecutionContext(context);
+        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext);
+        try {
+            assertEquals(0, iterator.getReturnedElementCount());
+            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
+            qIter.hasNext();
+            assertEquals(500, iterator.getReturnedElementCount());
+            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
+        } finally {
+            qIter.close();
         }
     }
 
     @Test
-    public void testCleanAfterClose()
-    {
-        iterator.setCallback(()->{});   // Do nothing.
+    public void testCleanAfterClose() {
+        iterator.setCallback(() -> {});   // Do nothing.
         assertEquals(0, iterator.getReturnedElementCount());
-        Context context = new Context() ;
-        context.set(ARQ.spillToDiskThreshold, 10L) ;
-        ExecutionContext executionContext = new ExecutionContext(context, (Graph)null, (DatasetGraph)null, (OpExecutorFactory)null) ;
-        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext) ;
-        try
-        {
-            assertEquals(0, iterator.getReturnedElementCount()) ;
-            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
-            qIter.hasNext() ;
-            assertEquals(500, iterator.getReturnedElementCount()) ;
-            assertEquals(49, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
-        }
-        finally
-        {
-            qIter.close() ;
+        Context context = new Context();
+        context.set(ARQ.spillToDiskThreshold, 10L);
+        ExecutionContext executionContext = createExecutionContext(context);
+        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext);
+        try {
+            assertEquals(0, iterator.getReturnedElementCount());
+            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
+            qIter.hasNext();
+            assertEquals(500, iterator.getReturnedElementCount());
+            assertEquals(49, DataBagExaminer.countTemporaryFiles(qIter.db));
+        } finally {
+            qIter.close();
         }
 
-        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
+        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
     }
 
     @Test
     public void testCloseClosesSourceIterator() {
-        Context context = new Context() ;
-        ExecutionContext ec = new ExecutionContext(context, (Graph) null, (DatasetGraph) null, (OpExecutorFactory) null);
+        Context context = new Context();
+        ExecutionContext ec = createExecutionContext(context);
         QueryIterSort qis = new QueryIterSort(iterator, comparator, ec);
         qis.close();
         assertTrue("source iterator should have been closed", iterator.isClosed());
@@ -147,20 +141,22 @@ public class TestQueryIterSort {
     @Test
     public void testExhaustionClosesSourceIterator() {
         iterator.setCallback(() -> {});
-        Context context = new Context() ;
-        ExecutionContext ec = new ExecutionContext(context, (Graph) null, (DatasetGraph) null, (OpExecutorFactory) null);
+        Context context = new Context();
+        ExecutionContext ec = createExecutionContext(context);
         QueryIterSort qis = new QueryIterSort(iterator, comparator, ec);
-        while (qis.hasNext()) qis.next();
+        while (qis.hasNext())
+            qis.next();
         assertTrue("source iterator should have been closed", iterator.isClosed());
     }
 
     @Test
     public void testCancelClosesSourceIterator() {
-        Context context = new Context() ;
-        ExecutionContext ec = new ExecutionContext(context, (Graph) null, (DatasetGraph) null, (OpExecutorFactory) null);
+        Context context = new Context();
+        ExecutionContext ec = createExecutionContext(context);
         QueryIterSort qis = new QueryIterSort(iterator, comparator, ec);
         try {
-            while (qis.hasNext()) qis.next();
+            while (qis.hasNext())
+                qis.next();
             fail("query should have been cancelled by trigger");
         } catch (QueryCancelledException q) {
             assertTrue("source iterator should have been closed", iterator.isClosed());
@@ -168,122 +164,111 @@ public class TestQueryIterSort {
     }
 
     @Test
-    public void testCleanAfterExhaustion()
-    {
+    public void testCleanAfterExhaustion() {
         iterator.setCallback(() -> {});
         assertEquals(0, iterator.getReturnedElementCount());
-        Context context = new Context() ;
-        context.set(ARQ.spillToDiskThreshold, 10L) ;
-        ExecutionContext executionContext = new ExecutionContext(context, (Graph)null, (DatasetGraph)null, (OpExecutorFactory)null) ;
-        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext) ;
+        Context context = new Context();
+        context.set(ARQ.spillToDiskThreshold, 10L);
+        ExecutionContext executionContext = createExecutionContext(context);
+        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext);
 
-        // Usually qIter should be in a try/finally block, but we are testing the case that the user forgot to do that.
-        // As a failsafe, QueryIteratorBase should close it when the iterator is exhausted.
-        assertEquals(0, iterator.getReturnedElementCount()) ;
-        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
-        qIter.hasNext() ;
-        assertEquals(500, iterator.getReturnedElementCount()) ;
-        assertEquals(49, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
+        // Usually qIter should be in a try/finally block, but we are testing the
+        // case that the user forgot to do that.
+        // As a failsafe, QueryIteratorBase should close it when the iterator is
+        // exhausted.
+        assertEquals(0, iterator.getReturnedElementCount());
+        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
+        qIter.hasNext();
+        assertEquals(500, iterator.getReturnedElementCount());
+        assertEquals(49, DataBagExaminer.countTemporaryFiles(qIter.db));
         while (qIter.hasNext())
             qIter.next();
-        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
-        qIter.close() ;
+        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
+        qIter.close();
     }
 
-    @Test(expected=QueryCancelledException.class)
-    public void testCancelInterruptsInitialisation()
-    {
+    @Test(expected = QueryCancelledException.class)
+    public void testCancelInterruptsInitialisation() {
 
         assertEquals(0, iterator.getReturnedElementCount());
-        Context context = new Context() ;
-        context.set(ARQ.spillToDiskThreshold, 10L) ;
-        ExecutionContext executionContext = new ExecutionContext(context, (Graph)null, (DatasetGraph)null, (OpExecutorFactory)null) ;
-        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext) ;
-        try
-        {
-            assertEquals(0, iterator.getReturnedElementCount()) ;
-            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
-            qIter.cancel() ;
-            qIter.hasNext() ;  // throws a QueryCancelledException
-        }
-        finally
-        {
-            assertTrue(iterator.isCanceled()) ;
-            assertEquals(0, iterator.getReturnedElementCount()) ;
+        Context context = new Context();
+        context.set(ARQ.spillToDiskThreshold, 10L);
+        ExecutionContext executionContext = createExecutionContext(context);
+        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext);
+        try {
+            assertEquals(0, iterator.getReturnedElementCount());
             assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
-            qIter.close() ;
+            qIter.cancel();
+            qIter.hasNext();  // throws a QueryCancelledException
+        } finally {
+            assertTrue(iterator.isCanceled());
+            assertEquals(0, iterator.getReturnedElementCount());
+            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
+            qIter.close();
         }
 
-        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
+        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
     }
 
-    @Test(expected=QueryCancelledException.class)
-    public void testCancelInterruptsExternalSortAfterStartingIteration()
-    {
+    @Test(expected = QueryCancelledException.class)
+    public void testCancelInterruptsExternalSortAfterStartingIteration() {
         assertEquals(0, iterator.getReturnedElementCount());
-        Context context = new Context() ;
-        context.set(ARQ.spillToDiskThreshold, 10L) ;
-        ExecutionContext executionContext = new ExecutionContext(context, (Graph)null, (DatasetGraph)null, (OpExecutorFactory)null) ;
-        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext) ;
-        try
-        {
-            assertEquals(0, iterator.getReturnedElementCount()) ;
-            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
-            qIter.hasNext() ;  // throws a QueryCancelledException
-        }
-        catch ( QueryCancelledException e )
-        {
+        Context context = new Context();
+        context.set(ARQ.spillToDiskThreshold, 10L);
+        ExecutionContext executionContext = createExecutionContext(context);
+        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext);
+        try {
+            assertEquals(0, iterator.getReturnedElementCount());
+            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
+            qIter.hasNext();  // throws a QueryCancelledException
+        } catch (QueryCancelledException e) {
             // expected
-            assertEquals(26, iterator.getReturnedElementCount()) ;
-            // This is zero because QueryIteratorBase will call close() before throwing the QueryCancelledException.
-            // It does this as a failsafe in case the user doesn't close the QueryIterator themselves.
-            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
-            throw e ;
-        }
-        finally
-        {
-            qIter.close() ;
+            assertEquals(26, iterator.getReturnedElementCount());
+            // This is zero because QueryIteratorBase will call close() before
+            // throwing the QueryCancelledException.
+            // It does this as a failsafe in case the user doesn't close the
+            // QueryIterator themselves.
+            assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
+            throw e;
+        } finally {
+            qIter.close();
         }
 
-        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
+        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
     }
 
-    @Test(expected=QueryCancelledException.class)
-    public void testCancelInterruptsExternalSortAtStartOfIteration()
-    {
+    @Test(expected = QueryCancelledException.class)
+    public void testCancelInterruptsExternalSortAtStartOfIteration() {
         iterator = new CallbackIterator(unsorted.iterator(), 25, null);
-        iterator.setCallback(()->{});
+        iterator.setCallback(() -> {});
         assertEquals(0, iterator.getReturnedElementCount());
-        Context context = new Context() ;
-        context.set(ARQ.spillToDiskThreshold, 10L) ;
-        ExecutionContext executionContext = new ExecutionContext(context, (Graph)null, (DatasetGraph)null, (OpExecutorFactory)null) ;
-        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext) ;
-        try
-        {
-            assertTrue(qIter.hasNext()) ;
+        Context context = new Context();
+        context.set(ARQ.spillToDiskThreshold, 10L);
+        ExecutionContext executionContext = createExecutionContext(context);
+        QueryIterSort qIter = new QueryIterSort(iterator, comparator, executionContext);
+        try {
+            assertTrue(qIter.hasNext());
             assertEquals(49, DataBagExaminer.countTemporaryFiles(qIter.db));
-            assertNotNull(qIter.next()) ;
-            assertTrue(qIter.hasNext()) ;
-            qIter.cancel() ;
-            qIter.hasNext() ;  // throws a QueryCancelledException
-        }
-        finally
-        {
-            //assertTrue(iterator.isCanceled()) ;
-            assertEquals(500, iterator.getReturnedElementCount()) ;
+            assertNotNull(qIter.next());
+            assertTrue(qIter.hasNext());
+            qIter.cancel();
+            qIter.hasNext();  // throws a QueryCancelledException
+        } finally {
+            // assertTrue(iterator.isCanceled()) ;
+            assertEquals(500, iterator.getReturnedElementCount());
             assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
-            qIter.close() ;
+            qIter.close();
         }
 
-        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db)) ;
+        assertEquals(0, DataBagExaminer.countTemporaryFiles(qIter.db));
     }
 
     @Test
     public void testTopNCloseClosesSource() {
         long numItems = 3;
         boolean distinct = false;
-        Context context = new Context() ;
-        ExecutionContext ec = new ExecutionContext(context, (Graph) null, (DatasetGraph) null, (OpExecutorFactory) null);
+        Context context = new Context();
+        ExecutionContext ec = createExecutionContext(context);
         QueryIterTopN tn = new QueryIterTopN(iterator, comparator, numItems, distinct, ec);
         tn.close();
         assertTrue(iterator.isClosed());
@@ -294,16 +279,15 @@ public class TestQueryIterSort {
         iterator.setCallback(() -> {});
         long numItems = 3;
         boolean distinct = false;
-        Context context = new Context() ;
-        ExecutionContext ec = new ExecutionContext(context, (Graph) null, (DatasetGraph) null, (OpExecutorFactory) null);
+        Context context = new Context();
+        ExecutionContext ec = createExecutionContext(context);
         QueryIterTopN tn = new QueryIterTopN(iterator, comparator, numItems, distinct, ec);
-        while (tn.hasNext()) tn.next();
+        while (tn.hasNext())
+            tn.next();
         assertTrue(iterator.isClosed());
     }
 
-
-    private Binding randomBinding(Var[] vars)
-    {
+    private Binding randomBinding(Var[] vars) {
         BindingBuilder builder = Binding.builder();
         builder.add(vars[0], NodeFactory.createBlankNode());
         builder.add(vars[1], NodeFactory.createURI(randomURI()));
@@ -318,107 +302,106 @@ public class TestQueryIterSort {
         return builder.build();
     }
 
-    private String randomURI()
-    {
+    private String randomURI() {
         return String.format("http://%s.example.com/%s", randomString(10), randomString(10));
     }
 
-    private String randomString(int length)
-    {
+    private String randomString(int length) {
         StringBuilder builder = new StringBuilder();
-        for(int i = 0; i < length; i++){
+        for ( int i = 0 ; i < length ; i++ ) {
             builder.append(LETTERS.charAt(random.nextInt(LETTERS.length())));
         }
         return builder.toString();
     }
 
+    private static class CallbackIterator implements QueryIterator {
+        int elementsReturned = 0;
+        Callback callback;
+        int trigger;
+        Iterator<Binding> delegate;
+        boolean canceled = false;
+        boolean closed = false;
 
-    private static class CallbackIterator implements QueryIterator
-    {
-        int elementsReturned = 0 ;
-        Callback callback ;
-        int trigger ;
-        Iterator<Binding> delegate ;
-        boolean canceled = false ;
-        boolean closed = false ;
-
-        public CallbackIterator(Iterator<Binding> delegate, int trigger, Callback callback)
-        {
-            this.delegate = delegate ;
-            this.callback = callback ;
-            this.trigger = trigger ;
+        public CallbackIterator(Iterator<Binding> delegate, int trigger, Callback callback) {
+            this.delegate = delegate;
+            this.callback = callback;
+            this.trigger = trigger;
         }
 
-        public void setCallback(Callback callback)
-        {
-            this.callback = callback ;
+        public void setCallback(Callback callback) {
+            this.callback = callback;
         }
 
         @Override
-        public boolean hasNext()
-        {
-        // self-closing
-        boolean has = delegate.hasNext() ;
-        if (has == false) closed = true;
-        return has ;
+        public boolean hasNext() {
+            // self-closing
+            boolean has = delegate.hasNext();
+            if ( has == false )
+                closed = true;
+            return has;
         }
 
         @Override
-        public Binding next()
-        {
-            if (elementsReturned++ >= trigger)
-            {
-                callback.call() ;
+        public Binding next() {
+            if ( elementsReturned++ >= trigger ) {
+                callback.call();
             }
-            return delegate.next() ;
+            return delegate.next();
         }
 
         @Override
-        public void remove()
-        {
-            delegate.remove() ;
+        public void remove() {
+            delegate.remove();
         }
 
-        public int getReturnedElementCount()
-        {
-            return elementsReturned ;
+        public int getReturnedElementCount() {
+            return elementsReturned;
         }
 
         public boolean isClosed() {
-            return closed ;
+            return closed;
         }
 
         public boolean isCanceled() {
-            return canceled ;
+            return canceled;
         }
 
         @Override
-        public Binding nextBinding()
-        {
-            if (elementsReturned++ >= trigger) callback.call() ;
-            return delegate.next() ;
+        public Binding nextBinding() {
+            if ( elementsReturned++ >= trigger )
+                callback.call();
+            return delegate.next();
         }
 
         @Override
-        public void cancel() { canceled = true ; }
+        public void cancel() {
+            canceled = true;
+        }
 
         @Override
-        public void close() { closed = true ; }
+        public void close() {
+            closed = true;
+        }
 
         @Override
-        public void output(IndentedWriter out, SerializationContext sCxt) { throw new ARQNotImplemented() ; }
+        public void output(IndentedWriter out, SerializationContext sCxt) {
+            throw new ARQNotImplemented();
+        }
 
         @Override
-        public String toString(PrefixMapping pmap) { throw new ARQNotImplemented() ; }
+        public String toString(PrefixMapping pmap) {
+            throw new ARQNotImplemented();
+        }
 
         @Override
-        public void output(IndentedWriter out) { throw new ARQNotImplemented() ; }
+        public void output(IndentedWriter out) {
+            throw new ARQNotImplemented();
+        }
 
     }
 
-    public interface Callback
-    {
-        public void call() ;
+    public interface Callback {
+        public void call();
     }
 
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/join/TestTableJoin.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/join/TestTableJoin.java
@@ -23,7 +23,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.HashSet ;
 import java.util.Set ;
 
-import org.apache.jena.query.ARQ ;
+import org.junit.Test ;
+
 import org.apache.jena.query.ResultSet ;
 import org.apache.jena.query.ResultSetFactory ;
 import org.apache.jena.sparql.algebra.Table ;
@@ -36,16 +37,15 @@ import org.apache.jena.sparql.engine.ref.TableJoin;
 import org.apache.jena.sparql.expr.ExprList ;
 import org.apache.jena.sparql.resultset.ResultSetCompare ;
 import org.apache.jena.sparql.sse.SSE ;
-import org.junit.Test ;
 
-/** Tests on tables and the simple nest loop join (TableJoin) used by the reference query engine */ 
+/** Tests on tables and the simple nest loop join (TableJoin) used by the reference query engine */
 public class TestTableJoin
 {
-    Table unit = new TableUnit() ; 
+    Table unit = new TableUnit() ;
     Table zero = new TableEmpty() ;
     Table zeroData = SSE.parseTable("(table)") ;
     Table unitData = SSE.parseTable("(table (row))") ;
-    
+
     Table data1 = SSE.parseTable("(table (row (?a 1) (?b 2)))") ;
     Table data2 = SSE.parseTable("(table (row (?a 1) (?c 3)) (row (?a 9) (?c 5))  )") ;
     Table data3 = SSE.parseTable("(table (row (?a 1) (?c 3)) (row (?a 1) (?c 4)) (row (?a 9) (?c 5))  )") ;
@@ -53,9 +53,9 @@ public class TestTableJoin
     Table data1J2 = SSE.parseTable("(table (row (?a 1) (?b 2) (?c 3)) )") ;
     Table data1LJ2 = SSE.parseTable("(table (row (?a 1) (?b 2) (?c 3)) )") ;
     Table data2LJ1 = SSE.parseTable("(table (row (?a 1) (?b 2) (?c 3)) (row (?a 9) (?c 5)) )") ;
-    
+
     Table data1J3 = SSE.parseTable("(table (row (?a 1) (?b 2) (?c 3)) (row (?a 1) (?b 2) (?c 4)) )") ;
-    
+
     @Test public void table_01() { test(unit, zero, true, null, zero) ; }
     @Test public void table_02() { test(zero, unit, true, null, zero) ; }
     @Test public void table_03() { test(unit, zero, false, null, unit) ; }
@@ -70,7 +70,7 @@ public class TestTableJoin
     @Test public void table_11() { test(zero, data1, true, null, zero) ; }
     @Test public void table_12() { test(data1, zero, false, null, data1) ; }
     @Test public void table_13() { test(zero, data1, false, null, zero) ; }
-    
+
     @Test public void table_14() { test(data1, zeroData, true, null, zeroData) ; }
     @Test public void table_15() { test(zeroData, data1, true, null, zeroData) ; }
     @Test public void table_16() { test(data1, zeroData, false, null, data1) ; }
@@ -78,28 +78,28 @@ public class TestTableJoin
 
     @Test public void table_18() { test(data2, unitData, true, null, data2) ; }
     @Test public void table_19() { test(unitData, data2, true, null, data2) ; }
-    
+
     @Test public void table_20() { test(data1, data2, true, null, data1J2) ; }
     @Test public void table_21() { test(data2, data1, true, null, data1J2) ; }
     @Test public void table_22() { test(data1, data2, false, null, data1LJ2) ; }
     @Test public void table_23() { test(data2, data1, false, null, data2LJ1) ; }
-    
+
     @Test public void table_24() { test(data1, data3, true, null, data1J3) ; }
     @Test public void table_25() { test(data3, data1, true, null, data1J3) ; }
 
     private void test(Table left, Table right, boolean normalJoin, ExprList exprs, Table expected) {
-        ExecutionContext execCxt = new ExecutionContext(ARQ.getContext(), null, null, null) ;
+        ExecutionContext execCxt = ExecutionContext.createForGraph(null) ;
         QueryIterator leftIter = left.iterator(execCxt) ;
-        QueryIterator qIter = normalJoin 
+        QueryIterator qIter = normalJoin
             ? TableJoin.join(leftIter, right, exprs, execCxt)
             : TableJoin.leftJoin(leftIter, right, exprs, execCxt) ;
-        
+
             // Order issues
-            
+
         Set<String> vars1 = new HashSet<>() ;
         vars1.addAll(left.getVarNames()) ;
         vars1.addAll(right.getVarNames()) ;
-        
+
         TableN results = new TableN(qIter) ;
         boolean b = TableCompare.equalsByTerm(expected, results) ;
         if ( !b ) {
@@ -110,7 +110,7 @@ public class TestTableJoin
         }
         assertTrue(b) ;
     }
-    
+
     static class TableCompare {
         public static boolean equalsByTerm(Table table1, Table table2) {
             ResultSet rs1 = ResultSetFactory.create(table1.iterator(null), table1.getVarNames()) ;
@@ -118,5 +118,5 @@ public class TestTableJoin
             return ResultSetCompare.equalsByTerm(rs1, rs2) ;
         }
     }
-        
+
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestCastXSD.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestCastXSD.java
@@ -18,18 +18,20 @@
 
 package org.apache.jena.sparql.expr;
 
+import org.junit.AfterClass ;
+import org.junit.Assert ;
+import org.junit.BeforeClass ;
+import org.junit.Test ;
+
 import org.apache.jena.graph.Node ;
 import org.apache.jena.query.ARQ ;
 import org.apache.jena.sparql.ARQConstants ;
 import org.apache.jena.sparql.engine.ExecutionContext ;
 import org.apache.jena.sparql.function.FunctionEnv ;
 import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.ExprUtils ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
-import org.junit.AfterClass ;
-import org.junit.Assert ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
 
 public class TestCastXSD {
 
@@ -148,8 +150,8 @@ public class TestCastXSD {
 
     private NodeValue cast(String input$) {
         Expr input = ExprUtils.parse(input$) ;
-        ARQ.getContext().set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime()) ;
-        FunctionEnv env = new ExecutionContext(ARQ.getContext(), null, null, null) ;
+        Context cxt = ARQ.getContext().copy().set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime()) ;
+        FunctionEnv env = ExecutionContext.create(null, cxt);
         return input.eval(null, env) ;
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPath.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPath.java
@@ -28,6 +28,9 @@ import java.util.Arrays ;
 import java.util.Iterator ;
 import java.util.List ;
 
+import org.junit.Assert ;
+import org.junit.Test ;
+
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
@@ -50,8 +53,6 @@ import org.apache.jena.sparql.sse.Item ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.apache.jena.sparql.sse.builders.BuilderPath ;
 import org.apache.jena.sparql.sse.writers.WriterPath ;
-import org.junit.Assert ;
-import org.junit.Test ;
 
 public class TestPath
 {
@@ -255,80 +256,79 @@ public class TestPath
     @Test public void path_34()   { test(graph3, n1,   ":p+",       n2,n3,n4) ; }
 
 
-    private static List<Binding> eval(Graph graph, String start$, String pathStr, String finish$)
-    {
-        return eval(graph, SSE.parseNode(start$, pmap), pathStr, SSE.parseNode(finish$, pmap)) ;
+    private static List<Binding> eval(Graph graph, String start$, String pathStr, String finish$) {
+        return eval(graph, SSE.parseNode(start$, pmap), pathStr, SSE.parseNode(finish$, pmap));
     }
 
-    private static List<Binding> eval(Graph graph, Node start, String pathStr, Node finish)
-    {
-        Path path = SSE.parsePath(pathStr, pmap) ;
-        QueryIterator qIter = PathLib.execTriplePath(BindingFactory.root(), start, path, finish, new ExecutionContext(ARQ.getContext(), graph, null, null)) ;
-        return Iter.toList(qIter) ;
+    private static List<Binding> eval(Graph graph, Node start, String pathStr, Node finish) {
+        Path path = SSE.parsePath(pathStr, pmap);
+        QueryIterator qIter = PathLib.execTriplePath(BindingFactory.root(), start, path, finish,
+                                                     ExecutionContext.createForGraph(graph));
+        return Iter.toList(qIter);
     }
 
-    @Test public void path_35()
-    {
-        List<Binding> x = eval(graph6, "?x", "(path+ :p)", "?y" ) ;
-        assertEquals(4, x.size()) ;
+    @Test
+    public void path_35() {
+        List<Binding> x = eval(graph6, "?x", "(path+ :p)", "?y");
+        assertEquals(4, x.size());
     }
 
-    @Test public void path_36()
-    {
+    @Test
+    public void path_36() {
         // Same end points.
-        List<Binding> x = eval(graph6, "?x", "(path+ :p)", "?x" ) ;
-        assertEquals(2, x.size()) ;
+        List<Binding> x = eval(graph6, "?x", "(path+ :p)", "?x");
+        assertEquals(2, x.size());
     }
 
-    @Test public void path_37()
-    {
-        List<Binding> x = eval(graph6, "?x", "(path* :p)", "?x" ) ;
-        assertEquals(2, x.size()) ;
-        Node node1 = x.get(0).get(Var.alloc("x")) ;
-        Node node2 = x.get(1).get(Var.alloc("x")) ;
-        assertFalse(node1.equals(node2)) ;
-        assertTrue(node1.equals(n1) || node1.equals(n2)) ;
-        assertTrue(node2.equals(n1) || node2.equals(n2)) ;
+    @Test
+    public void path_37() {
+        List<Binding> x = eval(graph6, "?x", "(path* :p)", "?x");
+        assertEquals(2, x.size());
+        Node node1 = x.get(0).get(Var.alloc("x"));
+        Node node2 = x.get(1).get(Var.alloc("x"));
+        assertFalse(node1.equals(node2));
+        assertTrue(node1.equals(n1) || node1.equals(n2));
+        assertTrue(node2.equals(n1) || node2.equals(n2));
     }
 
-    @Test public void path_38()
-    {
+    @Test
+    public void path_38() {
         // Same end points.
-        List<Binding> x = eval(graph6, "?x", "(pathN+ :p)", "?x" ) ;
+        List<Binding> x = eval(graph6, "?x", "(pathN+ :p)", "?x");
 
-        assertEquals(2, x.size()) ;
-        Node node1 = x.get(0).get(Var.alloc("x")) ;
-        Node node2 = x.get(1).get(Var.alloc("x")) ;
-        assertFalse(node1.equals(node2)) ;
-        assertTrue(node1.equals(n1) || node1.equals(n2)) ;
-        assertTrue(node2.equals(n1) || node2.equals(n2)) ;
+        assertEquals(2, x.size());
+        Node node1 = x.get(0).get(Var.alloc("x"));
+        Node node2 = x.get(1).get(Var.alloc("x"));
+        assertFalse(node1.equals(node2));
+        assertTrue(node1.equals(n1) || node1.equals(n2));
+        assertTrue(node2.equals(n1) || node2.equals(n2));
     }
 
-    @Test public void path_39()
-    {
-        List<Binding> x = eval(graph6, "?x", "(pathN* :p)", "?x" ) ;
-        assertEquals(2, x.size()) ;
+    @Test
+    public void path_39() {
+        List<Binding> x = eval(graph6, "?x", "(pathN* :p)", "?x");
+        assertEquals(2, x.size());
     }
 
-    @Test public void path_50()
-    {
-        List<Binding> x = eval(graph1, "?x", "(notoneof :DoesNotExist)", "<n4>" ) ;
-        assertEquals(1, x.size()) ;
+    @Test
+    public void path_50() {
+        List<Binding> x = eval(graph1, "?x", "(notoneof :DoesNotExist)", "<n4>");
+        assertEquals(1, x.size());
     }
 
-    @Test public void path_51()
-    {
-        List<Binding> x = eval(graph1, "?x", "(notoneof :DoesNotExist)", "?z" ) ;
-        assertEquals(3, x.size()) ;
+    @Test
+    public void path_51() {
+        List<Binding> x = eval(graph1, "?x", "(notoneof :DoesNotExist)", "?z");
+        assertEquals(3, x.size());
     }
 
-    @Test public void path_52()
-    {
-        List<Binding> x = eval(graph1, "<n1>", "(notoneof :DoesNotExist)", "?z" ) ;
-        assertEquals(1, x.size()) ;
+    @Test
+    public void path_52() {
+        List<Binding> x = eval(graph1, "<n1>", "(notoneof :DoesNotExist)", "?z");
+        assertEquals(1, x.size());
     }
 
-    // TODO Shortest path is not implemented yet.  These also need to be verified that they are correct.
+    // Shortest path is not implemented.  These also need to be verified that they are correct.
 //    @Ignore @Test public void path_40()   { test(graph1, n1,   "shortest(:p*)",       n1) ; }
 //    @Ignore @Test public void path_41()   { test(graph1, n1,   "shortest(:p+)",       n2) ; }
 //    @Ignore @Test public void path_42()   { test(graph2, n1,   "shortest(:p*/:q)",    n4) ; }
@@ -338,27 +338,26 @@ public class TestPath
 //    @Ignore @Test public void path_46()   { test(graph5, n1,   "shortest(:p*/:q)",    n4, n5) ; }
 
     // ----
-    private static void testOrdered(Graph graph, Node start, String string, Node... expectedNodes) {
-        test(graph, start, string, expectedNodes, true, true) ;
+    private static void testOrdered(Graph graph, Node start, String string, Node...expectedNodes) {
+        test(graph, start, string, expectedNodes, true, true);
     }
 
-    private static void test(Graph graph, Node start, String string, Node... expectedNodes) {
-        test(graph, start, string, expectedNodes, true, false) ;
+    private static void test(Graph graph, Node start, String string, Node...expectedNodes) {
+        test(graph, start, string, expectedNodes, true, false);
     }
 
-    private static void testReverseOrdered(Graph graph, Node start, String string, Node... expectedNodes) {
-        test(graph, start, string, expectedNodes, false, true) ;
+    private static void testReverseOrdered(Graph graph, Node start, String string, Node...expectedNodes) {
+        test(graph, start, string, expectedNodes, false, true);
     }
 
-    private static void test(Graph graph, Node start, String string, Node[] expectedNodes,
-                             boolean directionForward, boolean ordered) {
-        Path p = PathParser.parse(string, pmap) ;
-        Iterator<Node> resultsIter =
-            directionForward ? PathEval.eval(graph, start, p, ARQ.getContext()) : PathEval.evalReverse(graph, start, p, ARQ.getContext()) ;
-        List<Node> results = Iter.toList(resultsIter) ;
-        List<Node> expected = Arrays.asList(expectedNodes) ;
-        Assert.assertTrue("expected:"+expected+", got:"+results, equalsUnordered(expected, results)) ;
+    private static void test(Graph graph, Node start, String string, Node[] expectedNodes, boolean directionForward, boolean ordered) {
+        Path p = PathParser.parse(string, pmap);
+        Iterator<Node> resultsIter = directionForward
+            ? PathEval.eval(graph, start, p, ARQ.getContext()) : PathEval.evalReverse(graph, start, p, ARQ.getContext());
+        List<Node> results = Iter.toList(resultsIter);
+        List<Node> expected = Arrays.asList(expectedNodes);
+        Assert.assertTrue("expected:" + expected + ", got:" + results, equalsUnordered(expected, results));
         if ( ordered )
-            Assert.assertEquals("expected(ordered)", expected, results) ;
+            Assert.assertEquals("expected(ordered)", expected, results);
     }
 }

--- a/jena-cmds/src/main/java/arq/qexpr.java
+++ b/jena-cmds/src/main/java/arq/qexpr.java
@@ -180,7 +180,7 @@ public class qexpr {
                     } else {
                         // Default action
                         ARQ.getContext().set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime());
-                        FunctionEnv env = new ExecutionContext(ARQ.getContext(), null, null, null);
+                        FunctionEnv env = ExecutionContext.create(null, ARQ.getContext().copy());
                         NodeValue r = expr.eval(null, env);
                         // System.out.println(r.asQuotedString()) ;
                         Node n = r.asNode();


### PR DESCRIPTION
Pull request Description:
* Reformat the `Query` class - no other changes
* Reduce the surface of `ExecutionContext`
  Use functions, not client code calls to constructors, so they have meaning full names.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
