### PR TITLE
GH-2949: Bump base Docker image to `eclipse-temurin:21-alpine`

### DIFF
--- a/jena-fuseki2/jena-fuseki-docker/Dockerfile
+++ b/jena-fuseki2/jena-fuseki-docker/Dockerfile
@@ -19,7 +19,7 @@
 
 ARG JAVA_VERSION=21
 
-ARG ALPINE_VERSION=3.17.1
+ARG ALPINE_VERSION=3.21.2
 ARG JENA_VERSION=""
 
 # Internal, passed between stages.

--- a/jena-fuseki2/jena-fuseki-docker/Dockerfile
+++ b/jena-fuseki2/jena-fuseki-docker/Dockerfile
@@ -17,7 +17,7 @@
 
 ## This Dockefile builds a reduced footprint container.
 
-ARG JAVA_VERSION=17
+ARG JAVA_VERSION=21
 
 ARG ALPINE_VERSION=3.17.1
 ARG JENA_VERSION=""


### PR DESCRIPTION
GitHub issue resolved #2949 

Pull request Description:

 `eclipse-temurin:21-alpine` base image is multi-platform while `eclipse-temurin:17-alpine` was not

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
