### PR TITLE
GH-2960: Changed time unit in QueryExecDataset from microseconds to m…

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDatasetBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDatasetBuilder.java
@@ -164,7 +164,7 @@ public class QueryExecDatasetBuilder implements QueryExecMod, QueryExecBuilder {
 
     @Override
     public QueryExecDatasetBuilder timeout(long timeout) {
-        return timeout(timeout, TimeUnit.MICROSECONDS);
+        return timeout(timeout, TimeUnit.MILLISECONDS);
     }
 
     @Override


### PR DESCRIPTION
…illiseconds.

GitHub issue resolved #2960 

Pull request Description: Micros -> Millis

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
