### PR TITLE
cypress-run to depend on a maven build

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'apache/jena'
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false
@@ -42,7 +42,7 @@ jobs:
           java-version: ${{ matrix.java_version }}
 
       - name: Build with Maven
-        run: mvn -B --file pom.xml --projects jena-fuseki2/jena-fuseki-ui --also-make-dependents test install
+        run: mvn -B --file pom.xml clean install -Pdev -Dmaven.javadoc.skip=true
 
       - name: Lint
         working-directory: jena-fuseki2/jena-fuseki-ui
@@ -54,6 +54,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    needs: unit-test-and-build
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR does two things:

* `cyrpress-run` is made to run after the build job. It appears that the jobs run in parallel at the moment - I see the Cypress runs finish before the build step has. The Cypress job is quick.

* Change the build step to do a "dev" build. Currently, it does not build from the start of the Jena build. If there has been a change in earlier dependency, then the Fuseki steps fail.

If this become smooth, we should consider combining into a PR workflow.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
