### PR TITLE
Format string error in LangTags

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/graph/langtag/LangTags.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/langtag/LangTags.java
@@ -113,7 +113,7 @@ public class LangTags {
                 sb.setLength(0);
                 continue;
             }
-            error("Bad character: (0x%02X) '%c' index %d", (int)ch, str(ch), idx);
+            error("Bad character: (0x%02X) '%c' index %d", (int)ch, ch, idx);
         }
         String strLast = sb.toString();
         if ( strLast.isEmpty() ) {


### PR DESCRIPTION
`%c` requires a `char`, but a `String` was supplied.

For more details, see here:
<https://docs.oracle.com/javase/8/docs/api/java/util/Formatter.html#syntax>

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).