### PR TITLE
Fix: Set the server static variable

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiShaclValidation.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiShaclValidation.java
@@ -39,7 +39,7 @@ public class TestFusekiShaclValidation {
 
     @BeforeAll
     public static void beforeClass() {
-        FusekiServer server = FusekiServer.create()
+        server = FusekiServer.create()
             .port(0)
             .parseConfigFile(DIR+"config-validation.ttl")
             .build();
@@ -49,8 +49,10 @@ public class TestFusekiShaclValidation {
 
     @AfterAll
     public static void afterClass() {
-        if ( server != null )
+        if ( server != null ) {
             server.stop();
+            server = null;
+        }
     }
 
     @Test


### PR DESCRIPTION
While looking for the cause of the intermittent test failures on GH builds, I came across a bug.

It does not seem explain the intermittent failures, but if has an effect, that would be useful information. 

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
