### PR TITLE
Cleanup some build warnings

### DIFF
--- a/jena-benchmarks/jena-benchmarks-shadedJena510/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena510/pom.xml
@@ -114,6 +114,7 @@
                                         <exclude>META-INF/DEPENDENCIES</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
                                         <exclude>**/module-info.class</exclude>
+                                        <exclude>META-INF/LICENSE-notice.md</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/jena-core/pom.xml
+++ b/jena-core/pom.xml
@@ -153,7 +153,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+          <argLine>-javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
           <includes>
             <include>org/apache/jena/test/TestPackage_core.java</include>
             <include>**/*_CS.java</include>

--- a/jena-extras/jena-querybuilder/pom.xml
+++ b/jena-extras/jena-querybuilder/pom.xml
@@ -93,7 +93,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/jena-fuseki2/jena-fuseki-core/pom.xml
+++ b/jena-fuseki2/jena-fuseki-core/pom.xml
@@ -172,7 +172,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
           <includes>
             <include>**/TS_*.java</include>
           </includes>

--- a/jena-fuseki2/jena-fuseki-fulljar/pom.xml
+++ b/jena-fuseki2/jena-fuseki-fulljar/pom.xml
@@ -116,8 +116,16 @@
                 <exclude>META-INF/DEPENDENCIES</exclude>
                 <exclude>META-INF/MANIFEST.MF</exclude>
                 <exclude>**/module-info.class</exclude>
+                <exclude>META-INF/versions/9/OSGI-INF/MANIFEST.MF</exclude>
               </excludes>
             </filter>
+            <filter>
+              <artifact>org.omnifaces:omnifaces</artifact>
+              <excludes>
+                <exclude>META-INF/beans.xml</exclude>
+                <exclude>META-INF/faces-config.xml</exclude>
+             </excludes>
+           </filter>
           </filters>
         </configuration>
         <executions>

--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -142,6 +142,7 @@
                   <exclude>META-INF/DEPENDENCIES</exclude>
                   <exclude>META-INF/MANIFEST.MF</exclude>
                   <exclude>**/module-info.class</exclude>
+                  <exclude>META-INF/versions/9/OSGI-INF/MANIFEST.MF</exclude>
                 </excludes>
               </filter>
             </filters>

--- a/jena-fuseki2/jena-fuseki-server/pom.xml
+++ b/jena-fuseki2/jena-fuseki-server/pom.xml
@@ -130,6 +130,7 @@
                 <exclude>META-INF/DEPENDENCIES</exclude>
                 <exclude>META-INF/MANIFEST.MF</exclude>
                 <exclude>**/module-info.class</exclude>
+                <exclude>META-INF/versions/9/OSGI-INF/MANIFEST.MF</exclude>
               </excludes>
             </filter>
           </filters>

--- a/jena-permissions/pom.xml
+++ b/jena-permissions/pom.xml
@@ -156,7 +156,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+          <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} -Xshare:off</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
GitHub issue resolved #

Pull request Description:

WIP

Looking at build and trying to fix warnings. This goes for both node and java, can split PR if it makes more sense, and squash to logical commits. Currently there are only 5 warnings left related to the geosparql tests. Will try to comment some thoughts inline. Much of the PR is just updating or ignoring warnings or paths.

Maybe some should be seen, or replaced by creating an issue?
----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).