### PR TITLE
Fix: Set the server static variable (pt 2)

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestCrossOriginFilter.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestCrossOriginFilter.java
@@ -58,9 +58,6 @@ public class TestCrossOriginFilter {
 
     /** System property that allows "Host" to be set. */
     private static String jdkAllowRestrictedHeaders = "jdk.httpclient.allowRestrictedHeaders";
-
-//    private static FusekiServer server = null;
-//    private static String URL = null;
     private static Optional<String> systemValue = null;
 
     @BeforeAll

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiDatasetSharing.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiDatasetSharing.java
@@ -66,7 +66,6 @@ public class TestFusekiDatasetSharing {
         Graph g = RDFParser.source(DIR+"ds-sharing.ttl").lang(Lang.TTL).toGraph();
 
         server = FusekiServer.create().port(0).parseConfig(g).start();
-        //FusekiMainInfo.logServer(Fuseki.serverLog, server, true);
 
         // fuseki:name "ds-named"
         // fuseki:name "ds-rdfs-base-named"

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiStdReadOnlySetup.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiStdReadOnlySetup.java
@@ -60,7 +60,7 @@ public class TestFusekiStdReadOnlySetup {
 
         DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
 
-        FusekiServer server = FusekiServer.create()
+        server = FusekiServer.create()
             .add("/ds", dsg, false)
             .port(0)
             .build();

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiStdSetup.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiStdSetup.java
@@ -59,7 +59,7 @@ public class TestFusekiStdSetup {
 
         DatasetGraph dsg = DatasetGraphFactory.createTxnMem();
 
-        FusekiServer server = FusekiServer.create()
+        server = FusekiServer.create()
             .add("/ds", dsg)
             .port(0)
             .build();

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestPlainServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestPlainServer.java
@@ -45,7 +45,7 @@ public class TestPlainServer {
 
     @BeforeAll
     public static void beforeClass() {
-        FusekiServer server = FusekiServer.create()
+        server = FusekiServer.create()
             .port(0)
             .add("/ds", DatasetGraphFactory.createTxnMem())
             // Named like a dataset service


### PR DESCRIPTION
May be related to #3008 

There are some more places in tests for jena-fuseki-main and jena-integration-tests 
with the same flaw that #3006 fixes for `TestFusekiShaclValidation`.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
