### PR TITLE
GH-3016: Streamlined methods for starting over custom service execs  + tests

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/OpExecutor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/OpExecutor.java
@@ -308,7 +308,7 @@ public class OpExecutor {
     }
 
     protected QueryIterator execute(OpService opService, QueryIterator input) {
-        return ServiceExec.exec(input, opService, execCxt);
+        return ServiceExec.exec(opService, input, execCxt);
     }
 
     // Quad form, "GRAPH ?g {}" Flip back to OpGraph.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExec.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/service/ServiceExec.java
@@ -21,23 +21,63 @@ package org.apache.jena.sparql.service;
 import org.apache.jena.sparql.algebra.op.OpService;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.service.bulk.ServiceExecutorBulk;
 import org.apache.jena.sparql.service.bulk.ServiceExecutorBulkOverRegistry;
+import org.apache.jena.sparql.service.single.ServiceExecutor;
+import org.apache.jena.sparql.service.single.ServiceExecutorOverRegistry;
 import org.apache.jena.sparql.util.Context;
 
 /**
  * Entry into the service executor from SPARQL queries.
  */
 public class ServiceExec {
+
+    /**
+     * Use {@link #exec(OpService, QueryIterator, ExecutionContext)} whose parameter order matches that of
+     * {@link ServiceExecutorBulk#createExecution(OpService, QueryIterator, ExecutionContext)}.
+     */
+    @Deprecated(forRemoval = true, since = "5.4.0")
+    public static QueryIterator exec(QueryIterator input, OpService opService, ExecutionContext execCxt) {
+        return exec(input, opService, execCxt);
+    }
+
     /**
      * Execute an OpService w.r.t. the execCxt's service executor registry.
      * This is the route from OpExecutor.
+     *
+     * This method can also be used to pass a modified request through the whole
+     * service executor chain, as exemplified below:
+     * <pre>{@code
+     * ServiceExecutorRegistry.get().addBulkLink((opService, input, execCxt, chain) -> {
+     *     if (canHandle(opService)) {
+     *         OpService modifiedOp = modifyOp(opService);
+     *         // Forward the request to the beginning of the chain.
+     *         return ServiceExec.exec(modifiedOp, input, execCxt);
+     *     } else {
+     *         // Forward the request to the remaining handlers in the chain.
+     *         return chain.createExecution(opService, input, execCxt);
+     *     }
+     * });
+     * }</pre>
      */
-    public static QueryIterator exec(QueryIterator input, OpService opService, ExecutionContext execCxt) {
+    public static QueryIterator exec(OpService opService, QueryIterator input, ExecutionContext execCxt) {
         Context cxt = execCxt.getContext();
         ServiceExecutorRegistry registry = ServiceExecutorRegistry.chooseRegistry(cxt);
         ServiceExecutorBulk serviceExecutor = new ServiceExecutorBulkOverRegistry(registry);
         QueryIterator qIter = serviceExecutor.createExecution(opService, input, execCxt);
+        return qIter;
+    }
+
+    /**
+     * Execute an OpService w.r.t. the execCxt's service executor registry -
+     * concretely its single chain which operates on a per-binding basis.
+     */
+    public static QueryIterator exec(OpService opExecute, OpService original, Binding binding, ExecutionContext execCxt) {
+        Context cxt = execCxt.getContext();
+        ServiceExecutorRegistry registry = ServiceExecutorRegistry.chooseRegistry(cxt);
+        ServiceExecutor serviceExecutor = new ServiceExecutorOverRegistry(registry);
+        QueryIterator qIter = serviceExecutor.createExecution(opExecute, original, binding, execCxt);
         return qIter;
     }
 }


### PR DESCRIPTION
GitHub issue resolved #3016

* Aligned parameter order of `Service.exec`
* Added tests to ensure that starting a service chain over works as expected. The use case is where a plugin modifies a request and wants to have it re-processed by all registered plugins in the execution context.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
