### PR TITLE
GH-3014: Support both possible TDB dataset type names

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
@@ -142,14 +142,14 @@ public class AssemblerUtils
     }
 
     public static Object build(Model assemblerModel, Resource type) {
-        Resource root = null ;
+        Resource root = null;
         try {
-            root = GraphUtils.findRootByType(assemblerModel, type) ;
+            root = GraphUtils.findRootByType(assemblerModel, type);
             if ( root == null )
-                throw new ARQException("No such type: <"+type+">");
-
-        } catch (TypeNotUniqueException ex)
-        { throw new ARQException("Multiple types for: "+tDataset) ; }
+                throw new ARQException("No such type: <" + type + ">");
+        } catch (TypeNotUniqueException ex) {
+            throw new ARQException("Multiple types for: " + tDataset);
+        }
         return Assembler.general.open(root) ;
     }
     /** Look for and build context declarations.

--- a/jena-cmds/src/main/java/tdb/cmdline/ModTDBDataset.java
+++ b/jena-cmds/src/main/java/tdb/cmdline/ModTDBDataset.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import arq.cmdline.ModDataset;
+import org.apache.jena.assembler.Assembler;
 import org.apache.jena.atlas.logging.Log;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdArgModule;
@@ -29,10 +30,13 @@ import org.apache.jena.cmd.CmdException;
 import org.apache.jena.cmd.CmdGeneral;
 import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.shared.JenaException;
+import org.apache.jena.sparql.ARQException;
 import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sparql.core.assembler.DatasetAssemblerVocab;
+import org.apache.jena.sparql.util.graph.GraphUtils;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.tdb1.assembler.VocabTDB1;
 import org.apache.jena.tdb1.base.file.Location;
@@ -41,11 +45,11 @@ import org.apache.jena.tdb1.transaction.DatasetGraphTransaction;
 public class ModTDBDataset extends ModDataset {
     // Mixes assembler, location and "tdb"
     // Can make a single model or a dataset
-    
+
     private ArgDecl argMem                  = new ArgDecl(ArgDecl.HasValue, "mem", "data") ;
     private ModTDBAssembler modAssembler    = new ModTDBAssembler() ;
     private String inMemFile                = null ;
-    
+
     public ModTDBDataset() {}
 
     @Override
@@ -73,7 +77,7 @@ public class ModTDBDataset extends ModDataset {
             Dataset thing = null;
             // Two variants: plain dataset with a TDB graph or a TDB dataset.
             try {
-                thing = (Dataset)AssemblerUtils.build(modAssembler.getAssemblerFile(), VocabTDB1.tDatasetTDB);
+                thing = buildDataset(modAssembler);
                 if ( thing != null && !(thing.asDatasetGraph() instanceof DatasetGraphTransaction) )
                     Log.warn(this, "Unexpected: Not a TDB dataset for type DatasetTDB");
 
@@ -95,6 +99,19 @@ public class ModTDBDataset extends ModDataset {
         // No assembler - use location to find a database.
         Dataset ds = TDB1Factory.createDataset(modAssembler.getLocation());
         return ds;
+    }
+
+    /** Build a dataset - several possible names (legacy) */
+    private static Dataset buildDataset(ModTDBAssembler modAssembler) {
+        Model spec = AssemblerUtils.readAssemblerFile(modAssembler.getAssemblerFile());
+        // throws ARQException("Multiple types for: " + tDataset);
+        Resource root = GraphUtils.findRootByType(spec, VocabTDB1.tDatasetTDB);
+        if ( root == null )
+            // Not found - try again.
+            root = GraphUtils.findRootByType(spec, VocabTDB1.tDatasetTDB1);
+        if ( root == null )
+            throw new ARQException("Not found: No such type: <" + VocabTDB1.tDatasetTDB + ">");
+        return (Dataset)Assembler.general.open(root) ;
     }
 
     public Location getLocation() {

--- a/jena-fuseki2/examples/config-inference-2.ttl
+++ b/jena-fuseki2/examples/config-inference-2.ttl
@@ -45,7 +45,7 @@ PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
     tdb2:dataset :tdbDataset .
 
 ## Base data in TDB.
-:tdbDataset rdf:type tdb2:DatasetTDB2 ;
+:tdbDataset rdf:type tdb2:DatasetTDB ;
     tdb2:location "DB" ;
     # If the unionDefaultGraph is used, then the "update" service should be removed.
     # tdb:unionDefaultGraph true ;

--- a/jena-fuseki2/examples/config-tdb2.ttl
+++ b/jena-fuseki2/examples/config-tdb2.ttl
@@ -46,7 +46,7 @@ PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
     fuseki:dataset :dataset_tdb2 ;
     .
 
-:dataset_tdb2 rdf:type  tdb2:DatasetTDB2 ;
+:dataset_tdb2 rdf:type  tdb2:DatasetTDB ;
     tdb2:location "DB2" ;
     ## Optional - with union default for query and update WHERE matching.
     ## tdb2:unionDefaultGraph true ;

--- a/jena-fuseki2/examples/config-text-tdb2.ttl
+++ b/jena-fuseki2/examples/config-text-tdb2.ttl
@@ -57,7 +57,7 @@ PREFIX text:    <http://jena.apache.org/text#>
     text:index     :indexLucene ;
     .
 
-:base_dataset rdf:type      tdb2:DatasetTDB2 ;
+:base_dataset rdf:type      tdb2:DatasetTDB ;
     tdb2:location "DB2"
     .
 

--- a/jena-fuseki2/examples/tdb2-select-graphs.ttl
+++ b/jena-fuseki2/examples/tdb2-select-graphs.ttl
@@ -74,6 +74,6 @@ PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
 
 ## The database
 
-:dataset_tdb2  rdf:type tdb2:DatasetTDB2 ;
+:dataset_tdb2  rdf:type tdb2:DatasetTDB ;
     tdb2:location "DB2" ;
     .

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/assembler/VocabTDB2.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/assembler/VocabTDB2.java
@@ -35,16 +35,20 @@ public class VocabTDB2
 
     // Types
 
+    // Preferred
     public static final Resource tDatasetTDB        = Vocab.type(NS, "DatasetTDB");
+    // Another accept name.
     public static final Resource tDatasetTDB2       = Vocab.type(NS, "DatasetTDB2");
+
     /** @deprecated Use {@link #tDatasetTDB} */
     @Deprecated(forRemoval = true)
     public static final Resource tDatasetTDB_alt    = Vocab.type(NS, "DatasetTDB");
 
     public static final Resource tGraphTDB          = Vocab.type(NS, "GraphTDB");
     public static final Resource tGraphTDB2         = Vocab.type(NS, "GraphTDB2");
+
     /** @deprecated Use {@link #tGraphTDB} */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static final Resource tGraphTDB_alt      = Vocab.type(NS, "GraphTDB");
 
 //    public static final Resource tTupleIndex        = Vocab.type(NS, "TupleIndex");


### PR DESCRIPTION
GitHub issue resolved #3014

Pull request Description:
`:DatasetTDB` and `:DatasetTDB2` have been used in the past. 
Ensure ModAssembler (TDB2) accepts both from the command line `--desc`.

Same for TDB1.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
