### PR TITLE
GH-3015: Close files after TDB2 compaction

### DIFF
--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/DatasetGraphTDB.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/DatasetGraphTDB.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.tuple.Tuple;
 import org.apache.jena.dboe.base.file.Location;
-import org.apache.jena.dboe.storage.StoragePrefixes;
 import org.apache.jena.dboe.storage.system.DatasetGraphStorage;
 import org.apache.jena.dboe.trans.bplustree.BPlusTree;
 import org.apache.jena.dboe.transaction.txn.TransactionalSystem;
@@ -42,6 +41,7 @@ final
 public class DatasetGraphTDB extends DatasetGraphStorage
 {
     private final StorageTDB storageTDB;
+    private final StoragePrefixesTDB storagePrefixes;
     private final Location location;
     private final TransactionalSystem txnSystem;
     private final StoreParams storeParams;
@@ -49,8 +49,9 @@ public class DatasetGraphTDB extends DatasetGraphStorage
     private boolean isClosed = false;
 
     public DatasetGraphTDB(Location location, StoreParams params, ReorderTransformation reorderTransformation,
-                           StorageTDB storage, StoragePrefixes prefixes, TransactionalSystem txnSystem) {
+                           StorageTDB storage, StoragePrefixesTDB prefixes, TransactionalSystem txnSystem) {
         super(storage, prefixes, txnSystem);
+        this.storagePrefixes = prefixes;
         this.storageTDB = storage;
         this.location = location;
         this.storeParams = params;
@@ -96,13 +97,17 @@ public class DatasetGraphTDB extends DatasetGraphStorage
 
     @Override
     public void close() {
+        if ( isClosed )
+            return;
         isClosed = true;
         super.close();
+        storageTDB.close();
+        storagePrefixes.close();
     }
 
     public void shutdown() {
-        close();
         txnSystem.getTxnMgr().shutdown();
+        close();
     }
 
     @Override

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/StoragePrefixesTDB.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/StoragePrefixesTDB.java
@@ -37,9 +37,10 @@ import org.apache.jena.tdb2.store.nodetupletable.NodeTupleTable;
 
 public class StoragePrefixesTDB implements StoragePrefixes {
 
-    static final RecordFactory factory = new RecordFactory(3*NodeId.SIZE, 0);
+    /*package*/ static final RecordFactory factory = new RecordFactory(3*NodeId.SIZE, 0);
     private TransactionalSystem txnSystem;
     private NodeTupleTable prefixTable;
+    private boolean closed = false;
 
     public StoragePrefixesTDB(TransactionalSystem txnSystem, NodeTupleTable prefixTable) {
         this.txnSystem = txnSystem;
@@ -149,4 +150,14 @@ public class StoragePrefixesTDB implements StoragePrefixes {
             throw new TransactionException("Not in a transaction");
         txn.ensureWriteTxn();
     }
+
+    // This does not need to be synchronized.
+    // The caller is responsible for a quiet system (e.g. no transactions active)
+    /*package*/ void close() {
+        if ( closed )
+            return;
+        closed = true;
+        prefixTable.close();
+    }
+
 }

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/StorageTDB.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/StorageTDB.java
@@ -33,11 +33,9 @@ import org.apache.jena.sparql.core.Quad;
 
 /** {@link StorageRDF} for TDB2 */
 public class StorageTDB implements StorageRDF {
-    // SWITCHING. This could be the switch point, not the DatasetGraph. Probably makes little difference.
     private TripleTable                 tripleTable;
     private QuadTable                   quadTable;
     private TransactionalSystem         txnSystem;
-    // SWITCHING.
 
     // In notifyAdd and notifyDelete,  check whether the change is a real change or not.
     // e.g. Adding a quad already present is not a real change.
@@ -201,5 +199,15 @@ public class StorageTDB implements StorageRDF {
         if ( txn == null )
             throw new TransactionException("Not in a write transaction");
         txn.ensureWriteTxn();
+    }
+
+    // This does not need to be synchronized.
+    // The caller is responsible for a quiet system (e.g. no transactions active)
+    /*package*/ void close() {
+        if ( closed )
+            return;
+        closed = true;
+        tripleTable.close();
+        quadTable.close();
     }
 }

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/TDB2StorageBuilder.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/TDB2StorageBuilder.java
@@ -31,7 +31,6 @@ import org.apache.jena.dboe.base.record.RecordFactory;
 import org.apache.jena.dboe.index.Index;
 import org.apache.jena.dboe.index.RangeIndex;
 import org.apache.jena.dboe.storage.DatabaseRDF;
-import org.apache.jena.dboe.storage.StoragePrefixes;
 import org.apache.jena.dboe.sys.Names;
 import org.apache.jena.dboe.trans.bplustree.BPlusTree;
 import org.apache.jena.dboe.trans.bplustree.BPlusTreeFactory;
@@ -95,7 +94,7 @@ public class TDB2StorageBuilder {
 
         TDB2StorageBuilder builder = new TDB2StorageBuilder(txnSystem, location, params, new ComponentIdMgr(UUID.randomUUID()));
         StorageTDB storage = builder.buildStorage();
-        StoragePrefixes prefixes = builder.buildPrefixes();
+        StoragePrefixesTDB prefixes = builder.buildPrefixes();
 
         // Finalize.
         builder.components.forEach(txnCoord::add);
@@ -193,7 +192,7 @@ public class TDB2StorageBuilder {
         return dsg;
     }
 
-    private StoragePrefixes buildPrefixes() {
+    private StoragePrefixesTDB buildPrefixes() {
         NodeTable nodeTablePrefixes = buildNodeTable(params.getPrefixTableBaseName(), false);
         StoragePrefixesTDB prefixes = buildPrefixTable(nodeTablePrefixes);
         return prefixes;

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/StoreConnection.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/StoreConnection.java
@@ -134,10 +134,9 @@ public class StoreConnection
 
         // No transactions at this point
         // (or we don't care and are clearing up forcefully.)
+        // This closes open files.
 
         sConn.getDatasetGraphTDB().shutdown();
-        // Done by DatasetGraphTDB()
-        //txnCoord.shutdown();
 
         sConn.isValid = false;
         cache.remove(location);


### PR DESCRIPTION
GitHub issue resolved #3015

Close files after a database has been compacted.

This is done whether it is deleted or not.

This PR does not fix the JVM issue with MSWindows regarding release of memory-mapped files.

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
