### PR TITLE
Support for JSON query type in QueryTransformOps.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/Query.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/Query.java
@@ -503,6 +503,17 @@ public class Query extends Prologue implements Cloneable, Printable
         return Collections.unmodifiableMap(jsonMapping);
     }
 
+    /**
+     * Overwrite all prior JSON mappings with new ones.
+     *
+     * @param newJsonMapping The new JSON mappings. Must not be null.
+     */
+    public void setJsonMapping(Map<String, Node> newJsonMapping) {
+        Objects.requireNonNull(newJsonMapping);
+        jsonMapping.clear();
+        jsonMapping.putAll(newJsonMapping);
+    }
+
     // ---- Aggregates
 
     // Record allocated aggregations.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
@@ -413,6 +413,7 @@ public class QueryTransformOps {
         @Override
         public void visitJsonResultForm(Query query) {
             newQuery.setQueryJsonType();
+            newQuery.setJsonMapping(query.getJsonMapping());
         }
 
         @Override

--- a/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
@@ -185,6 +185,12 @@ public class TestQuerySyntaxTransform
                            "x", "<urn:ex:z>");
     }
 
+    @Test public void transformTransformJsonReplace_30() {
+        testQuery("JSON { \"s\": ?s } { ?s ?p ?o }",
+                  "JSON { \"s\": 123 } { ?s ?p ?o }",
+                  "s", "123");
+    }
+
     //static final String PREFIX = "PREFIX : <http://example/>\n";
     static final String PREFIX = "";
 


### PR DESCRIPTION
Pull request Description: Minor fix for handling JSON in QueryTransformOps. One of our Linked Data viewers actually used this query type - and some of my rewrite plugins broke with it due to the missing transformation support.

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - (Key commit messages start with the issue number (GH-xxxx))

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
