### PR TITLE
QueryTransformOps applied to JSON template queries

### DIFF
--- a/jena-arq/Grammar/arq.jj
+++ b/jena-arq/Grammar/arq.jj
@@ -201,10 +201,10 @@ void JsonObjectMember() : { Node o ; String s ; Token t; }
       throwParseException("Prefix name expression not legal at this point : "+t.image, t.beginLine, t.beginColumn) ;
   }
   (
-    o = Var() { getQuery().addResultVar((Var)o) ; getQuery().addJsonMapping(s, o) ; }
-  | o = RDFLiteral() { getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s, o) ; }
-  | o = NumericLiteral() { getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s, o) ; }
-  | o = BooleanLiteral() { getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s, o) ; }
+    o = Var() { getQuery().addJsonMapping(s, o) ; }
+  | o = RDFLiteral() { getQuery().addJsonMapping(s, o) ; }
+  | o = NumericLiteral() { getQuery().addJsonMapping(s, o) ; }
+  | o = BooleanLiteral() { getQuery().addJsonMapping(s, o) ; }
   )
 }
 void DatasetClause() : {}

--- a/jena-arq/Grammar/main.jj
+++ b/jena-arq/Grammar/main.jj
@@ -361,13 +361,12 @@ void JsonObjectMember() : { Node o ; String s ; Token t; }
       throwParseException("Prefix name expression not legal at this point : "+t.image, t.beginLine, t.beginColumn) ;
   }
   (
-    o = Var() { getQuery().addResultVar((Var)o) ; getQuery().addJsonMapping(s, o) ; }
-  | o = RDFLiteral() { getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s, o) ; }
-  | o = NumericLiteral() { getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s, o) ; }
-  | o = BooleanLiteral() { getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s, o) ; }
+    o = Var()            { getQuery().addJsonMapping(s, o) ; }
+  | o = RDFLiteral()     { getQuery().addJsonMapping(s, o) ; }
+  | o = NumericLiteral() { getQuery().addJsonMapping(s, o) ; }
+  | o = BooleanLiteral() { getQuery().addJsonMapping(s, o) ; }
   )
 }
-
 #endif
 
 // ----

--- a/jena-arq/src/main/java/org/apache/jena/query/Query.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/Query.java
@@ -503,6 +503,17 @@ public class Query extends Prologue implements Cloneable, Printable
         return Collections.unmodifiableMap(jsonMapping);
     }
 
+    /**
+     * Overwrite all prior JSON mappings with new ones.
+     *
+     * @param newJsonMapping The new JSON mappings. Must not be null.
+     */
+    public void setJsonMapping(Map<String, Node> newJsonMapping) {
+        Objects.requireNonNull(newJsonMapping);
+        jsonMapping.clear();
+        jsonMapping.putAll(newJsonMapping);
+    }
+
     // ---- Aggregates
 
     // Record allocated aggregations.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/QueryCompare.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/QueryCompare.java
@@ -96,6 +96,7 @@ public class QueryCompare implements QueryVisitor
     @Override
     public void visitJsonResultForm(Query query) {
         check("Not both JSON queries", query2.isJsonType());
+        check("Json mapping", query.getJsonMapping(), query2.getJsonMapping());
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTransform.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTransform.java
@@ -18,7 +18,9 @@
 
 package org.apache.jena.sparql.expr;
 
+import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.algebra.Op ;
+import org.apache.jena.sparql.core.Var;
 
 public interface ExprTransform
 {
@@ -29,8 +31,17 @@ public interface ExprTransform
     public Expr transform(ExprFunctionN func, ExprList args) ;
     public Expr transform(ExprFunctionOp funcOp, ExprList args, Op opArg) ;
     public Expr transform(NodeValue nv) ;
-    //default public Expr transform(ExprNone exprNone) { return exprNone ; }
+
+    public default Expr transform(Node node) {
+        if ( Var.isVar(node) ) {
+            ExprVar exprVar = new ExprVar(node);
+            return transform(exprVar);
+        }
+        NodeValue nv = NodeValue.makeNode(node);
+        return transform(nv);
+    }
+
     public Expr transform(ExprNone exprNone) ;
-    public Expr transform(ExprVar nv) ;
+    public Expr transform(ExprVar exprVar) ;
     public Expr transform(ExprAggregator eAgg) ;
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransformExpr.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransformExpr.java
@@ -50,13 +50,13 @@ public class NodeTransformExpr extends ExprTransformCopy {
     }
 
     /** Transform node then create a {@link ExprVar} or {@link NodeValue}. */
-    private Expr transform(Node input) {
+    @Override
+    public Expr transform(Node input) {
         Node n = transform.apply(input);
         if ( n == null )
             throw new InternalErrorException("NodeTransform creates a null");
         if ( ! Var.isVar(n) )
             return NodeValue.makeNode(n);
-        String name = Var.alloc(n).getVarName();
-        return new ExprVar(n.getName());
+        return new ExprVar(n);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/ARQParser.java
@@ -778,7 +778,7 @@ if ( ! t.image.equals(":") )
     case VAR1:
     case VAR2:{
       o = Var();
-getQuery().addResultVar((Var)o) ; getQuery().addJsonMapping(s, o) ;
+getQuery().addJsonMapping(s, o) ;
       break;
       }
     case STRING_LITERAL1:
@@ -786,7 +786,7 @@ getQuery().addResultVar((Var)o) ; getQuery().addJsonMapping(s, o) ;
     case STRING_LITERAL_LONG1:
     case STRING_LITERAL_LONG2:{
       o = RDFLiteral();
-getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s, o) ;
+getQuery().addJsonMapping(s, o) ;
       break;
       }
     case INTEGER:
@@ -799,13 +799,13 @@ getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s,
     case DECIMAL_NEGATIVE:
     case DOUBLE_NEGATIVE:{
       o = NumericLiteral();
-getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s, o) ;
+getQuery().addJsonMapping(s, o) ;
       break;
       }
     case TRUE:
     case FALSE:{
       o = BooleanLiteral();
-getQuery().addResultVar(s, NodeValue.makeNode(o)) ; getQuery().addJsonMapping(s, o) ;
+getQuery().addJsonMapping(s, o) ;
       break;
       }
     default:

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/JavaCharStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/JavaCharStream.java
@@ -13,7 +13,7 @@ public
 class JavaCharStream
 {
   /** Whether parser is static. */
-
+  
 @SuppressWarnings("all")
 public static final boolean staticFlag = false;
 
@@ -65,7 +65,7 @@ public static final boolean staticFlag = false;
   }
 
 /* Position in buffer. */
-
+  
 @SuppressWarnings("all")
 public int bufpos = -1;
   int bufsize;
@@ -90,10 +90,10 @@ public int bufpos = -1;
   protected int tabSize = 1;
   protected boolean trackLineColumn = true;
 
-
+  
 @SuppressWarnings("all")
 public void setTabSize(int i) { tabSize = i; }
-
+  
 @SuppressWarnings("all")
 public int getTabSize() { return tabSize; }
 
@@ -185,7 +185,7 @@ public int getTabSize() { return tabSize; }
   }
 
 /* @return starting character for token. */
-
+  
 @SuppressWarnings("all")
 public char BeginToken() throws java.io.IOException
   {
@@ -267,7 +267,7 @@ public char BeginToken() throws java.io.IOException
   }
 
 /* Read a character. */
-
+  
 @SuppressWarnings("all")
 public char readChar() throws java.io.IOException
   {
@@ -367,7 +367,7 @@ public char readChar() throws java.io.IOException
    * @see #getEndColumn
    */
   @Deprecated
-
+  
 @SuppressWarnings("all")
 public int getColumn() {
     return bufcolumn[bufpos];
@@ -379,7 +379,7 @@ public int getColumn() {
    * @return the line number.
    */
   @Deprecated
-
+  
 @SuppressWarnings("all")
 public int getLine() {
     return bufline[bufpos];
@@ -388,7 +388,7 @@ public int getLine() {
 /** Get end column.
  * @return the end column or -1
  */
-
+  
 @SuppressWarnings("all")
 public int getEndColumn() {
     return bufcolumn[bufpos];
@@ -397,7 +397,7 @@ public int getEndColumn() {
 /** Get end line.
  * @return the end line number or -1
  */
-
+  
 @SuppressWarnings("all")
 public int getEndLine() {
     return bufline[bufpos];
@@ -405,21 +405,21 @@ public int getEndLine() {
 
 /** Get the beginning column.
  * @return column of token start */
-
+  
 @SuppressWarnings("all")
 public int getBeginColumn() {
     return bufcolumn[tokenBegin];
   }
 
 /** @return line number of token start */
-
+  
 @SuppressWarnings("all")
 public int getBeginLine() {
     return bufline[tokenBegin];
   }
 
 /** Retreat. */
-
+  
 @SuppressWarnings("all")
 public void backup(int amount) {
 
@@ -434,7 +434,7 @@ public void backup(int amount) {
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -455,7 +455,7 @@ public JavaCharStream(java.io.Reader dstream,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -465,15 +465,16 @@ public JavaCharStream(java.io.Reader dstream,
 
 /** Constructor.
  * @param dstream the underlying data source.
+ * @param startline line number of the first character of the stream, mostly for error messages.
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.Reader dstream)
   {
     this(dstream, 1, 1, 4096);
   }
 /* Reinitialise. */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                  int startline, int startcolumn, int buffersize)
@@ -496,7 +497,7 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream,
                                         int startline, int startcolumn)
@@ -505,14 +506,14 @@ public void ReInit(java.io.Reader dstream,
   }
 
 /* Reinitialise. */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.Reader dstream)
   {
     ReInit(dstream, 1, 1, 4096);
   }
 /** Constructor. */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -526,7 +527,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -539,9 +540,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
                         int startcolumn) throws java.io.UnsupportedEncodingException
@@ -554,7 +555,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding, int startlin
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, int startline,
                         int startcolumn)
@@ -565,9 +566,9 @@ public JavaCharStream(java.io.InputStream dstream, int startline,
 /** Constructor.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -577,7 +578,7 @@ public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.
   /** Constructor.
    * @param dstream the underlying data source.
    */
-
+  
 @SuppressWarnings("all")
 public JavaCharStream(java.io.InputStream dstream)
   {
@@ -591,7 +592,7 @@ public JavaCharStream(java.io.InputStream dstream)
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
   int startcolumn, int buffersize) throws java.io.UnsupportedEncodingException
@@ -605,7 +606,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startcolumn column number of the first character of the stream.
  * @param buffersize size of the buffer
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
   int startcolumn, int buffersize)
@@ -617,9 +618,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding, int startline,
                      int startcolumn) throws java.io.UnsupportedEncodingException
@@ -631,7 +632,7 @@ public void ReInit(java.io.InputStream dstream, String encoding, int startline,
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, int startline,
                      int startcolumn)
@@ -641,9 +642,9 @@ public void ReInit(java.io.InputStream dstream, int startline,
 /** Reinitialise.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws UnsupportedEncodingException encoding is invalid or unsupported.
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -653,7 +654,7 @@ public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.
 /** Reinitialise.
  * @param dstream the underlying data source.
  */
-
+  
 @SuppressWarnings("all")
 public void ReInit(java.io.InputStream dstream)
   {
@@ -662,7 +663,7 @@ public void ReInit(java.io.InputStream dstream)
 
   /** Get the token timage.
    * @return token image as String */
-
+  
 @SuppressWarnings("all")
 public String GetImage()
   {
@@ -676,7 +677,7 @@ public String GetImage()
   /** Get the suffix as an array of characters.
    * @param len the length of the array to return.
    * @return suffix */
-
+  
 @SuppressWarnings("all")
 public char[] GetSuffix(int len)
   {
@@ -695,7 +696,7 @@ public char[] GetSuffix(int len)
   }
 
   /** Set buffers back to null when finished. */
-
+  
 @SuppressWarnings("all")
 public void Done()
   {
@@ -711,7 +712,7 @@ public void Done()
    * @param newLine the new line number.
    * @param newCol the new column number.
    */
-
+  
 @SuppressWarnings("all")
 public void adjustBeginLineColumn(int newLine, int newCol)
   {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
@@ -413,6 +413,7 @@ public class QueryTransformOps {
         @Override
         public void visitJsonResultForm(Query query) {
             newQuery.setQueryJsonType();
+            newQuery.setJsonMapping(query.getJsonMapping());
         }
 
         @Override

--- a/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
@@ -185,17 +185,38 @@ public class TestQuerySyntaxTransform
                            "x", "<urn:ex:z>");
     }
 
-    @Test public void transformTransformJsonReplace_30() {
-        testQuery("JSON { \"s\": ?s } { ?s ?p ?o }",
-                  "JSON { \"s\": 123 } { ?s ?p ?o }",
-                  "s", "123");
+    @Test public void transformTransformJsonReplace_01() {
+        testQuery("JSON { 'key': ?x } {  }",
+                  "JSON { 'key': 123 } { }",
+                  "x", "123");
+    }
+
+    @Test public void transformTransformJsonReplace_02() {
+        testQuery("PREFIX : <http://example/> JSON { \"o\": ?o } { ?s :p ?o }",
+                  "PREFIX : <http://example/> JSON { \"o\": 123 } { ?s :p 123}",
+                  "o", "123");
+    }
+
+    @Test public void transformTransformJsonReplace_03() {
+        String queryString = """
+                JSON { "s" : ?s ,
+                       "x" : ?x ,
+                       "unused": ?unused ,
+                       "fixed" : 'fixed' } WHERE {}
+              """;
+        String expectedString = """
+                JSON { "s" : ?s ,
+                       "x" : "abc" ,
+                       "unused": ?unused ,
+                       "fixed" : 'fixed' } WHERE {}
+                """;
+        testQuery(queryString, expectedString, "x", "'abc'");
     }
 
     //static final String PREFIX = "PREFIX : <http://example/>\n";
     static final String PREFIX = "";
 
-    private void testQuery(String input, String output, String varStr, String valStr)
-    {
+    private void testQuery(String input, String output, String varStr, String valStr) {
         Query q1 = QueryFactory.create(PREFIX+input);
         Query qExpected = QueryFactory.create(PREFIX+output);
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
@@ -185,6 +185,12 @@ public class TestQuerySyntaxTransform
                            "x", "<urn:ex:z>");
     }
 
+    @Test public void transformTransformJsonReplace_30() {
+        testQuery("JSON { \"s\": ?s } { ?s ?p ?o }",
+                  "JSON { \"s\": 123 } { ?s ?p ?o }",
+                  "s", "123");
+    }
+
     //static final String PREFIX = "PREFIX : <http://example/>\n";
     static final String PREFIX = "";
 


### PR DESCRIPTION
Pull request Description:
This included and completes PR #3033. There were two general bugs in JSON-WHERE handling that #3033 uncovers.

1. QueryCompare ignored the JSON template
2. The parser added spurious entries as if it was a SELECT query.

Thank you to @Aklakan for #3033.

----

 - [x] Tests are included.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
