### PR TITLE
GH-2799, GH-3040: QueryTransformOps: Record replacements; support variable renaming.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/Rename.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/Rename.java
@@ -139,7 +139,6 @@ public class Rename {
 
     }
 
-
     // ---- Transforms that do the renaming and unrenaming.
 
     static class RenameNode implements NodeTransform {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprVar.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprVar.java
@@ -18,118 +18,112 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.atlas.io.IndentedWriter ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.query.Query ;
-import org.apache.jena.sparql.ARQInternalErrorException ;
-import org.apache.jena.sparql.core.Var ;
-import org.apache.jena.sparql.engine.binding.Binding ;
-import org.apache.jena.sparql.function.FunctionEnv ;
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.graph.Node;
+import org.apache.jena.query.Query;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.function.FunctionEnv;
 import org.apache.jena.sparql.graph.NodeTransform;
 
 /** An expression that is a variable in an expression. */
- 
+
 public class ExprVar extends ExprNode
 {
     // AKA ExprFunction0
-    protected Var varNode = null ;
-    
-    public ExprVar(String name) { varNode = Var.alloc(name) ; }
-    public ExprVar(Node n)
-    { 
-        if ( ! n.isVariable() )
-            throw new ARQInternalErrorException("Attempt to create a NodeVar from a non variable Node: "+n) ;
-        varNode = Var.alloc(n) ;
-    }
-    
-    public ExprVar(Var v)
-    { 
-        varNode = v ;
-    }
-    
-    @Override
-    public NodeValue eval(Binding binding, FunctionEnv env)
-    {
-        return eval(varNode, binding, env) ;
+    protected Var varNode = null;
+
+    public ExprVar(String name) { varNode = Var.alloc(name); }
+
+    public ExprVar(Node n) {
+        if ( !n.isVariable() )
+            throw new ARQInternalErrorException("Attempt to create a NodeVar from a non-variable Node: " + n);
+        varNode = Var.alloc(n);
     }
 
-    static NodeValue eval(Var v, Binding binding, FunctionEnv env)
-    {
+    public ExprVar(Var v) {
+        varNode = v;
+    }
+
+    @Override
+    public NodeValue eval(Binding binding, FunctionEnv env) {
+        return eval(varNode, binding, env);
+    }
+
+    static NodeValue eval(Var v, Binding binding, FunctionEnv env) {
         if ( binding == null )
-            throw new VariableNotBoundException("Not bound: (no binding): "+v) ;
-        Node nv = binding.get(v) ;
+            throw new VariableNotBoundException("Not bound: (no binding): " + v);
+        Node nv = binding.get(v);
         if ( nv == null )
-            throw new VariableNotBoundException("Not bound: variable "+v) ;
+            throw new VariableNotBoundException("Not bound: variable " + v);
         // Wrap as a NodeValue.
-        return NodeValue.makeNode(nv) ;
+        return NodeValue.makeNode(nv);
     }
-    
+
     @Override
-    public Expr copySubstitute(Binding binding)
-    {
-        Var v = varNode ;  
+    public Expr copySubstitute(Binding binding) {
+        Var v = varNode;
         if ( binding == null || !binding.contains(v) )
-            return new ExprVar(v) ;
+            return new ExprVar(v);
         Node v2 = binding.get(v);
-        return v2.isVariable() ? new ExprVar(v2) : eval(binding, null) ;
+        return v2.isVariable() ? new ExprVar(v2) : eval(binding, null);
     }
-    
+
     @Override
-    public Expr applyNodeTransform(NodeTransform transform)
-    {
-        Node node = transform.apply(varNode) ;
-        if ( Var.isVar(node))
-            return new ExprVar(Var.alloc(node)) ;
-        return NodeValue.makeNode(node) ;
+    public Expr applyNodeTransform(NodeTransform transform) {
+        Node node = transform.apply(varNode);
+        if ( Var.isVar(node) )
+            return new ExprVar(Var.alloc(node));
+        return NodeValue.makeNode(node);
     }
-    
-    public Expr copy(Var v)  { return new ExprVar(v) ; }
-    
-    
+
+    public Expr copy(Var v)  { return new ExprVar(v); }
+
     @Override
-    public void visit(ExprVisitor visitor) { visitor.visit(this) ; }
-    
-    public Expr apply(ExprTransform transform)  { 
+    public void visit(ExprVisitor visitor) { visitor.visit(this); }
+
+    public Expr apply(ExprTransform transform)  {
         if ( transform == null )
-            throw new NullPointerException() ;
-        return transform.transform(this) ; }
-    
+            throw new NullPointerException();
+        return transform.transform(this); }
+
     public void format(Query query, IndentedWriter out)
     {
-        out.print('?') ;
-        out.print(varNode.getName()) ;
+        out.print('?');
+        out.print(varNode.getName());
     }
-    
+
     @Override
-    public int hashCode() { return varNode.hashCode() ; }
-    
+    public int hashCode() { return varNode.hashCode(); }
+
     @Override
     public boolean equals(Expr other, boolean bySyntax) {
-        if ( other == null ) return false ;
-        if ( this == other ) return true ;
+        if ( other == null ) return false;
+        if ( this == other ) return true;
         if ( ! ( other instanceof ExprVar ) )
-            return false ;
-        ExprVar nvar = (ExprVar)other ;
-        return getVarName().equals(nvar.getVarName()) ;
+            return false;
+        ExprVar nvar = (ExprVar)other;
+        return getVarName().equals(nvar.getVarName());
     }
-    
+
     @Override
-    public boolean isVariable() { return true ; }
+    public boolean isVariable() { return true; }
     /** @return Returns the name. */
     @Override
-    public String getVarName()  { return varNode.getName() ; }
+    public String getVarName()  { return varNode.getName(); }
     @Override
-    public ExprVar getExprVar() { return this ; }
+    public ExprVar getExprVar() { return this; }
     @Override
-    public Var asVar()          { return varNode ; }
-    public Node getAsNode()     { return varNode ; }
-    
-    
-    public String toPrefixString()  { return varNode.toString() ; }
+    public Var asVar()          { return varNode; }
+    public Node getAsNode()     { return varNode; }
+
+
+    public String toPrefixString()  { return varNode.toString(); }
     // As an expression (aggregators override this).
-    public String asSparqlExpr()    { return  varNode.toString() ; }
+    public String asSparqlExpr()    { return  varNode.toString(); }
 
     // ??? Just use format?
     @Override
-    public String toString()        { return varNode.toString() ; }
+    public String toString()        { return varNode.toString(); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -246,37 +246,33 @@ public abstract class NodeValue extends ExprNode
     // ----------------------------------------------------------------
     // ---- Construct NodeValue from graph nodes
 
-    public static NodeValue makeNode(Node n)
-    {
-        return nodeToNodeValue(n);
+    public static NodeValue makeNode(Node node) {
+        return nodeToNodeValue(node);
     }
 
-    public static NodeValue makeNode(String lexicalForm, RDFDatatype dtype)
-    {
+    public static NodeValue makeNode(String lexicalForm, RDFDatatype dtype) {
         Node n = NodeFactory.createLiteralDT(lexicalForm, dtype);
         return NodeValue.makeNode(n);
     }
 
     // Convenience - knows that lang tags aren't allowed with datatypes.
-    public static NodeValue makeNode(String lexicalForm, String langTag, Node datatype)
-    {
-        String uri = (datatype==null) ? null : datatype.getURI();
-        return makeNode(lexicalForm, langTag,  uri);
+    public static NodeValue makeNode(String lexicalForm, String langTag, Node datatype) {
+        String uri = (datatype == null) ? null : datatype.getURI();
+        return makeNode(lexicalForm, langTag, uri);
     }
 
-    public static NodeValue makeNode(String lexicalForm, String langTag, String datatype)
-    {
+    public static NodeValue makeNode(String lexicalForm, String langTag, String datatype) {
         if ( datatype != null && datatype.equals("") )
             datatype = null;
 
         if ( langTag != null && datatype != null )
             // raise??
-            Log.warn(NodeValue.class, "Both lang tag and datatype defined (lexcial form '"+lexicalForm+"')");
+            Log.warn(NodeValue.class, "Both lang tag and datatype defined (lexcial form '" + lexicalForm + "')");
 
         Node n = null;
         if ( langTag != null )
             n = NodeFactory.createLiteralLang(lexicalForm, langTag);
-        else if ( datatype != null) {
+        else if ( datatype != null ) {
             RDFDatatype dType = TypeMapper.getInstance().getSafeTypeByName(datatype);
             n = NodeFactory.createLiteralDT(lexicalForm, dType);
         } else
@@ -353,16 +349,16 @@ public abstract class NodeValue extends ExprNode
    // ----------------------------------------------------------------
    // ---- Expr interface
 
-    @Override
-    public NodeValue eval(Binding binding, FunctionEnv env)
-    { return this; }
+   @Override
+   public NodeValue eval(Binding binding, FunctionEnv env) {
+       return this;
+   }
 
-    // NodeValues are immutable so no need to duplicate.
-    @Override
-    public Expr copySubstitute(Binding binding)
-    {
-        return this;
-    }
+   // NodeValues are immutable so no need to duplicate.
+   @Override
+   public Expr copySubstitute(Binding binding) {
+       return this;
+   }
 
     @Override
     public Expr applyNodeTransform(NodeTransform transform)
@@ -524,16 +520,14 @@ public abstract class NodeValue extends ExprNode
     public boolean isTime()         { return false; }
     public boolean isDuration()     { return false; }
 
-    public boolean isYearMonthDuration()
-    {
+    public boolean isYearMonthDuration() {
         if ( ! isDuration() ) return false;
         Duration dur = getDuration();
         return ( dur.isSet(YEARS) || dur.isSet(MONTHS) ) &&
                ! dur.isSet(DAYS) && ! dur.isSet(HOURS) && ! dur.isSet(MINUTES) && ! dur.isSet(SECONDS);
     }
 
-    public boolean isDayTimeDuration()
-    {
+    public boolean isDayTimeDuration() {
         if ( ! isDuration() ) return false;
         Duration dur = getDuration();
         return !dur.isSet(YEARS) && ! dur.isSet(MONTHS) &&

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransform.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransform.java
@@ -22,8 +22,6 @@ import java.util.function.Function;
 
 import org.apache.jena.graph.Node ;
 
-/** Convert nodes to nodes - Vars may need to be translated into Vars. */
+/** Convert nodes to nodes */
 @FunctionalInterface
-public interface NodeTransform extends Function<Node, Node>
-{
-}
+public interface NodeTransform extends Function<Node, Node> {}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransformExpr.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransformExpr.java
@@ -24,7 +24,8 @@ import org.apache.jena.sparql.algebra.walker.ApplyTransformVisitor;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.expr.*;
 
-/** An {@link ExprTransform} that applies a {@link NodeTransform}
+/**
+ * An {@link ExprTransform} that applies a {@link NodeTransform}
  * to {@link NodeValue} and {@link ExprVar} inside expressions.
  * <p>
  * This does not transform triple patterns in {@link ExprFunctionOp}
@@ -34,9 +35,8 @@ import org.apache.jena.sparql.expr.*;
  */
 public class NodeTransformExpr extends ExprTransformCopy {
     private final NodeTransform transform ;
-    public NodeTransformExpr(NodeTransform transform)
-    {
-        this.transform = transform ;
+    public NodeTransformExpr(NodeTransform transform) {
+        this.transform = transform;
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransformOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransformOp.java
@@ -35,8 +35,8 @@ import org.apache.jena.sparql.core.Var ;
 import org.apache.jena.sparql.core.VarExprList ;
 import org.apache.jena.sparql.path.Path ;
 
-/** A {@link Transform} that applies a {@link NodeTransform}
- * to graph patterns.
+/**
+ *  A {@link Transform} that applies a {@link NodeTransform} to graph patterns.
  * <p>
  * This does not transform expressions. That is done by {@link NodeTransformExpr}.
  *
@@ -44,7 +44,7 @@ import org.apache.jena.sparql.path.Path ;
  */
 class NodeTransformOp extends TransformCopy {
 
-    // This finds everywhere that nodes can lurk in an algebra expression:
+    // This finds everywhere that nodes can occur in an algebra expression:
     //   BGPs, paths, triples, quads, service
     //   GRAPH, GRAPH{} (DatasetNames)
     //   OrderBy, GroupBy

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QuerySyntaxSubstituteScope.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QuerySyntaxSubstituteScope.java
@@ -61,7 +61,7 @@ public class QuerySyntaxSubstituteScope {
 
     private static void checkAssignment(String context, Collection<Var> vars, Var assignedVar) {
         if ( vars.contains(assignedVar) )
-            reject("BIND", assignedVar);
+            reject(context, assignedVar);
     }
 
     private static void reject(String elementName, Var badVar) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/syntax/TS_Syntax.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/syntax/TS_Syntax.java
@@ -25,12 +25,6 @@ import org.apache.jena.sparql.syntax.syntaxtransform.*;
 
 @Suite
 @SelectClasses({
-
-//import org.junit.runner.RunWith;
-//import org.junit.runners.Suite;
-//import org.junit.runners.Suite.SuiteClasses;
-//@RunWith(Suite.class)
-//@SuiteClasses({
     TestQueryParser.class
     , TestSerialization.class
     , TestQueryShallowCopy.class

--- a/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxSubstitute.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxSubstitute.java
@@ -21,6 +21,7 @@ package org.apache.jena.sparql.syntax.syntaxtransform;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -34,8 +35,17 @@ import org.apache.jena.sparql.core.Var;
 public class TestQuerySyntaxSubstitute {
 
     private static Map<Var, Node> substitutions1 = Map.of(Var.alloc("x"), NodeFactory.createURI("http://example/xxx"));
-    private static Map<Var, Node> substitutions2 = Map.of(Var.alloc("x"), NodeFactory.createURI("http://example/xxx"),
-                                                          Var.alloc("y"), NodeFactory.createURI("http://example/yyy"));
+    private static Map<Var, Node> substitutions2 = orderedMapOf(Var.alloc("x"), NodeFactory.createURI("http://example/xxx"),
+                                                                Var.alloc("y"), NodeFactory.createURI("http://example/yyy"));
+    private static Map<Var, Var> varRenames = Map.of(Var.alloc("x"), Var.alloc("x1"),
+                                                     Var.alloc("y"), Var.alloc("y1"));
+
+    private static <K, V> Map<K, V> orderedMapOf(K k1, V v1, K k2, V v2) {
+        Map<K, V> map = new LinkedHashMap<>();
+        map.put(k1,v1);
+        map.put(k2, v2);
+        return map;
+    }
 
     @Test public void syntaxSubstitute_01() {
         testSubstitute("SELECT * { ?x :p ?z }", substitutions1,
@@ -74,46 +84,91 @@ public class TestQuerySyntaxSubstitute {
     }
 
     // GH-2799: Sub-queries not yet ready.
-//    // Sub-query visible variable.
-//    @Test public void syntaxSubstitute_12() {
-//        testSubstitute("SELECT * { ?s ?p ?o { SELECT ?x { ?x :p ?y } } }", substitutions1,
-//                      "SELECT (:yyy AS ?y) ?p (:xxx AS ?x) { ?s ?p ?o { SELECT * { :xxx :p ?y } }}"
-//                      );
-//    }
-//
-//    // Sub-query hidden variable.
-//    @Test public void syntaxSubstitute_13() {
-//        testSubstitute("SELECT * { ?s ?p ?o { SELECT ?y { ?x :p ?y } } }", substitutions1,
-//                      "SELECT ?s ?p ?o (:xxx AS ?x) { ?s ?p ?o { SELECT * { :xxx :p ?y } }}"
-//                      );
-//    }
-//
-//    // Multi-level variable.
-//    @Test public void syntaxSubstitute_14() {
-//        testSubstitute("SELECT * { ?x ?p ?o { SELECT * { ?x :p ?y } } }", substitutions2,
-//                      "" //"SELECT (:yyy AS ?y) ?p (:xxx AS ?x) { ?s ?p ?o { SELECT * { :xxx :p ?y } }}"
-//                      );
-//    }
+    // Sub-query with a visible variable and a hidden variable
+    @Test public void syntaxSubstitute_12() {
+        testSubstitute("SELECT * { ?s ?p ?o { SELECT ?x { ?x :p ?y } } }", substitutions2,
+                       "SELECT ?s ?p ?o ?x (:yyy AS ?y) { ?s ?p ?o { SELECT (:xxx AS ?x) { :xxx :p :yyy } }}"
+                );
+    }
 
-    @Test public void syntaxSubstitute_50() {
+    @Test public void syntaxSubstitute_13() {
+        testSubstitute("SELECT * { ?s ?p ?o { SELECT * { ?s ?p ?o . ?x :p ?y } } }", substitutions2,
+                       "SELECT ?s ?p ?o (:xxx AS ?x) (:yyy AS ?y) { ?s ?p ?o { SELECT * { ?s ?p ?o . :xxx :p :yyy } }}"
+                );
+    }
+
+    // Multi-level variable.
+    @Test public void syntaxSubstitute_14() {
+        testSubstitute("SELECT * { ?x ?p ?o { SELECT * { ?x :p ?z } } }", substitutions2,
+                       "SELECT ?p ?o ?z (:xxx AS ?x) (:yyy AS ?y) { :xxx ?p ?o { SELECT * { :xxx :p ?z } }}"
+                      );
+    }
+
+    // ==== Variable-variable renaming.
+    // This is always possible so no scoping checks are done.
+
+    @Test public void syntaxSubstituteVarToVar_01() {
+        testSubstituteVars("SELECT ?x { ?x :p ?z }", varRenames, "SELECT ?x1 { ?x1 :p ?z }");
+    }
+
+    @Test public void syntaxSubstituteVarToVar_02() {
+        testSubstituteVars("SELECT ?x { ?x :p ?y }", varRenames, "SELECT ?x1 { ?x1 :p ?y1 }");
+    }
+
+    @Test public void syntaxSubstituteVarToVar_03() {
+        testSubstituteVars("SELECT ?z ?y { ?a ?b ?z { SELECT ?y { :s :p ?y } GROUP BY ?y} }", varRenames,
+                           "SELECT ?z ?y1 { ?a ?b ?z { SELECT ?y1 { :s :p ?y1 } GROUP BY ?y1} }" );
+    }
+
+    // Var to var where var to constant is not allowed.
+    @Test public void syntaxSubstituteVarToVar_10() {
+        testSubstituteVars("SELECT ?x { ?x ?c ?d FILTER( ?x != ?b ) }", varRenames,
+                           "SELECT ?x1 { ?x1 ?c ?d FILTER( ?x1 != ?b ) }");
+    }
+
+    @Test public void syntaxSubstituteVarToVar_11() {
+        // Still hitting the scope check.
+        testSubstituteVars("SELECT * { BIND (:q AS ?x) BIND (?x + 99 AS ?A) }", varRenames,
+                           "SELECT * { BIND (:q AS ?x1) BIND (?x1 + 99 AS ?A) }");
+    }
+
+    @Test public void syntaxSubstituteVarToVar_12() {
+        // Still hitting the scope check.
+        testSubstituteVars("SELECT * { VALUES ?x { :q } }", varRenames,
+                           "SELECT * { VALUES ?x1 { :q } }");
+    }
+
+    // ==== Scope failures.
+
+    @Test public void syntaxSubstituteScopeEx_01() {
         assertThrows(QueryScopeException.class, ()->
             testSubstitute("SELECT (456 AS ?x) { ?y :p ?z }",  substitutions1,
                           ""
                           ));
     }
 
-    @Test public void syntaxSubstitute_51() {
+    @Test public void syntaxSubstituteScopeEx_02() {
         assertThrows(QueryScopeException.class, ()->
             testSubstitute("SELECT * { ?y :p ?z BIND(789 AS ?x)}", substitutions1,
                           ""
                           ));
     }
 
-    private void testSubstitute(String qs, Map<Var, Node> substitutions, String outcome) {
+    private void testSubstitute(String qs, Map<Var, ? extends Node> substitutions, String outcome) {
         String prologue = "PREFIX : <http://example/> ";
         String queryString = prologue+qs;
         Query query = QueryFactory.create(queryString);
-        Query query2 = QueryTransformOps.syntaxSubstitute(query, substitutions);
+        Query query2 = QueryTransformOps.syntaxSubstitute(query, substitutions);    // syntaxSubstitute, including modifying the SELECT clause
+        String queryOutcomeString = prologue+outcome;
+        Query queryOutcome = QueryFactory.create(queryOutcomeString);
+        assertEquals(queryOutcome,  query2);
+    }
+
+    private void testSubstituteVars(String qs, Map<Var, ? extends Node> substitutions, String outcome) {
+        String prologue = "PREFIX : <http://example/> ";
+        String queryString = prologue+qs;
+        Query query = QueryFactory.create(queryString);
+        Query query2 = QueryTransformOps.replaceVars(query, substitutions);     // replaceVars
         Query queryOutcome = QueryFactory.create(prologue+outcome);
         assertEquals(queryOutcome,  query2);
     }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxSubstitute.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxSubstitute.java
@@ -37,79 +37,79 @@ public class TestQuerySyntaxSubstitute {
     private static Map<Var, Node> substitutions2 = Map.of(Var.alloc("x"), NodeFactory.createURI("http://example/xxx"),
                                                           Var.alloc("y"), NodeFactory.createURI("http://example/yyy"));
 
-    @Test public void syntaxSubstitue_01() {
-        testSubstitue("SELECT * { ?x :p ?z }", substitutions1,
+    @Test public void syntaxSubstitute_01() {
+        testSubstitute("SELECT * { ?x :p ?z }", substitutions1,
                       "SELECT ?z (:xxx AS ?x) { :xxx :p ?z }"
                       );
     }
 
-    @Test public void syntaxSubstitue_02() {
-        testSubstitue("SELECT ?x { ?x :p ?z }", substitutions1,
+    @Test public void syntaxSubstitute_02() {
+        testSubstitute("SELECT ?x { ?x :p ?z }", substitutions1,
                       "SELECT (:xxx AS ?x) { :xxx :p ?z }"
                       );
     }
 
-    @Test public void syntaxSubstitue_03() {
-        testSubstitue("SELECT ?z { :a :p ?z }", substitutions1,
+    @Test public void syntaxSubstitute_03() {
+        testSubstitute("SELECT ?z { :a :p ?z }", substitutions1,
                       "SELECT ?z (:xxx AS ?x) { :a :p ?z }"
                       );
     }
 
-    @Test public void syntaxSubstitue_04() {
-        testSubstitue("SELECT ?x ?z { ?x :p ?z }", substitutions1,
+    @Test public void syntaxSubstitute_04() {
+        testSubstitute("SELECT ?x ?z { ?x :p ?z }", substitutions1,
                       "SELECT (:xxx AS ?x) ?z { :xxx :p ?z }"
                       );
     }
 
-    @Test public void syntaxSubstitue_10() {
-        testSubstitue("SELECT ?y ?x { ?x :p ?y }", substitutions2,
+    @Test public void syntaxSubstitute_10() {
+        testSubstitute("SELECT ?y ?x { ?x :p ?y }", substitutions2,
                       "SELECT (:yyy AS ?y) (:xxx AS ?x) { :xxx :p :yyy }"
                       );
     }
 
-    @Test public void syntaxSubstitue_11() {
-        testSubstitue("SELECT ?y ?p ?x { ?x ?p ?y }", substitutions2,
+    @Test public void syntaxSubstitute_11() {
+        testSubstitute("SELECT ?y ?p ?x { ?x ?p ?y }", substitutions2,
                       "SELECT (:yyy AS ?y) ?p (:xxx AS ?x) { :xxx ?p :yyy }"
                       );
     }
 
     // GH-2799: Sub-queries not yet ready.
 //    // Sub-query visible variable.
-//    @Test public void syntaxSubstitue_12() {
-//        testSubstitue("SELECT * { ?s ?p ?o { SELECT ?x { ?x :p ?y } } }", substitutions1,
+//    @Test public void syntaxSubstitute_12() {
+//        testSubstitute("SELECT * { ?s ?p ?o { SELECT ?x { ?x :p ?y } } }", substitutions1,
 //                      "SELECT (:yyy AS ?y) ?p (:xxx AS ?x) { ?s ?p ?o { SELECT * { :xxx :p ?y } }}"
 //                      );
 //    }
 //
 //    // Sub-query hidden variable.
-//    @Test public void syntaxSubstitue_13() {
-//        testSubstitue("SELECT * { ?s ?p ?o { SELECT ?y { ?x :p ?y } } }", substitutions1,
+//    @Test public void syntaxSubstitute_13() {
+//        testSubstitute("SELECT * { ?s ?p ?o { SELECT ?y { ?x :p ?y } } }", substitutions1,
 //                      "SELECT ?s ?p ?o (:xxx AS ?x) { ?s ?p ?o { SELECT * { :xxx :p ?y } }}"
 //                      );
 //    }
 //
 //    // Multi-level variable.
-//    @Test public void syntaxSubstitue_14() {
-//        testSubstitue("SELECT * { ?x ?p ?o { SELECT * { ?x :p ?y } } }", substitutions2,
+//    @Test public void syntaxSubstitute_14() {
+//        testSubstitute("SELECT * { ?x ?p ?o { SELECT * { ?x :p ?y } } }", substitutions2,
 //                      "" //"SELECT (:yyy AS ?y) ?p (:xxx AS ?x) { ?s ?p ?o { SELECT * { :xxx :p ?y } }}"
 //                      );
 //    }
 
-    @Test public void syntaxSubstitue_50() {
+    @Test public void syntaxSubstitute_50() {
         assertThrows(QueryScopeException.class, ()->
-            testSubstitue("SELECT (456 AS ?x) { ?y :p ?z }",  substitutions1,
+            testSubstitute("SELECT (456 AS ?x) { ?y :p ?z }",  substitutions1,
                           ""
                           ));
     }
 
-    @Test public void syntaxSubstitue_51() {
+    @Test public void syntaxSubstitute_51() {
         assertThrows(QueryScopeException.class, ()->
-            testSubstitue("SELECT * { ?y :p ?z BIND(789 AS ?x)}", substitutions1,
+            testSubstitute("SELECT * { ?y :p ?z BIND(789 AS ?x)}", substitutions1,
                           ""
                           ));
     }
 
-    private void testSubstitue(String qs, Map<Var, Node> substitutions, String outcome) {
+    private void testSubstitute(String qs, Map<Var, Node> substitutions, String outcome) {
         String prologue = "PREFIX : <http://example/> ";
         String queryString = prologue+qs;
         Query query = QueryFactory.create(queryString);


### PR DESCRIPTION
GitHub issue resolved #2799 (record replacements in projection)
GitHub issue resolved #3040 (renaming variables)

Pull request Description: See issues.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
