### PR TITLE
GH-3044: HashJoin iterator construction no longer eagerly builds hash probe table.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterFilterExpr.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIterFilterExpr.java
@@ -21,6 +21,7 @@ package org.apache.jena.sparql.engine.iterator;
 import org.apache.jena.atlas.io.IndentedWriter;
 import org.apache.jena.atlas.lib.Lib;
 import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.query.QueryCancelledException;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
@@ -48,6 +49,9 @@ public class QueryIterFilterExpr extends QueryIterProcessBinding {
             if ( expr.isSatisfied(binding, super.getExecContext()) )
                 return binding;
             return null;
+        } catch (QueryCancelledException ex) {
+            ex.addSuppressed(new RuntimeException("Query cancelled exception."));
+            throw ex;
         } catch (ExprException ex) {
             // Some evaluation exception: should not happen.
             Log.warn(this, "Expression Exception in " + expr, ex);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/RowSetOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/RowSetOps.java
@@ -30,9 +30,9 @@ import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.core.Prologue;
 import org.apache.jena.sparql.resultset.ResultsWriter;
 
-/** 
+/**
  * RowSetOps - Convenience ways to call the various output formatters.
- * 
+ *
  * @see ResultSetMgr
  */
 
@@ -51,7 +51,7 @@ public class RowSetOps {
      * This operation consumes the RowSet.
      */
     public static long count(RowSet rowSet)
-    { return rowSet.rewindable().size(); }
+    { return rowSet.stream().count(); }
 
     /**
      * Output a result set in a text format.  The result set is consumed.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/RowSetStream.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/RowSetStream.java
@@ -21,6 +21,7 @@ package org.apache.jena.sparql.exec;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.sparql.core.Var;
@@ -71,5 +72,13 @@ public class RowSetStream implements RowSet {
     @Override
     public void close() {
         Iter.close(iterator);
+    }
+
+    @Override
+    public void forEachRemaining(Consumer<? super Binding> action) {
+        iterator.forEachRemaining(b -> {
+            ++rowNumber;
+            action.accept(b);
+        });
     }
 }

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/StageMatchTuple.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/StageMatchTuple.java
@@ -20,6 +20,7 @@ package org.apache.jena.tdb2.solver;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -28,6 +29,7 @@ import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.atlas.lib.tuple.Tuple;
 import org.apache.jena.atlas.lib.tuple.TupleFactory;
 import org.apache.jena.graph.Node;
+import org.apache.jena.query.QueryCancelledException;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.tdb2.store.NodeId;
@@ -66,6 +68,17 @@ class StageMatchTuple {
             List<Tuple<NodeId>> x = Iter.toList(iterMatches);
             System.out.println(x);
             iterMatches = x.iterator();
+        }
+
+        // Add cancel check.
+        AtomicBoolean cancelSignal = execCxt.getCancelSignal();
+        if (cancelSignal != null) {
+            iterMatches = Iter.map(iterMatches, x -> {
+                 if (cancelSignal.get()) {
+                     throw new QueryCancelledException();
+                 }
+                 return x;
+            });
         }
 
         // ** Allow a triple or quad filter here.


### PR DESCRIPTION
GitHub issue resolved #3044 
Pull request Description: Timeouts in QueryExecDataset were postponed until a so-far eager hash probe table construction completed because of locking. This PR proposes to initialize the hash probe table lazily such that the iterator construction becomes cheap and the lock is released quickly.

I added a test case that fails without the proposed fix.

----

 - [x] Tests are included.
 - (Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/))
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
