### PR TITLE
GH-3050: Fixed open iterator in test case for custom service executors.

### DIFF
--- a/jena-integration-tests/src/test/java/org/apache/jena/test/service/TestCustomServiceExecutor.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/test/service/TestCustomServiceExecutor.java
@@ -39,6 +39,7 @@ import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.ExecutionContext;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.iterator.QueryIter;
 import org.apache.jena.sparql.exec.QueryExec;
 import org.apache.jena.sparql.resultset.ResultSetCompare;
 import org.apache.jena.sparql.service.ServiceExec;
@@ -146,7 +147,7 @@ public class TestCustomServiceExecutor {
                 return ServiceExec.exec(new OpService(b, opService.getSubOp(), false), input, execCxt);
             } else if (node.equals(c)) {
                 // 4. Match 'c' and return the test table
-                return table.iterator(execCxt);
+                return QueryIter.flatMap(input, x -> table.iterator(execCxt), execCxt);
             } else {
                 throw new RuntimeException("Unexpectedly got: " + node);
             }


### PR DESCRIPTION
GitHub issue resolved #3050 

Pull request Description: Fixes an open iterator warning due to the input iterator not being connected to the returned iterator.

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
