### PR TITLE
Don't group npm ecosystem updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,8 @@ updates:
       interval: "weekly"
       day: "wednesday"
     versioning-strategy: increase-if-necessary
-    groups:
-      npm-patch-group:
-        update-types:
-        - "minor"
+##     groups:
+##       npm-patch-group:
+##         update-types:
+##         - "minor"
     open-pull-requests-limit: 10


### PR DESCRIPTION

PR #3059, and #3037 before that, consistently fails the UI test matrix in the Firefox upload test.

The PR has 6 minor updates and a cascade of version updates which makes it difficult to find out which update is causing the problem.

This PR switch off grouping for npm updates so there will be individual PRs. We can find which are not causing problems, and get them through, and also see where the problem is.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
