### PR TITLE
Debug ci failures

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -183,7 +183,10 @@ public class HttpLib {
         else if ( inRange(httpStatusCode, 200, 299) ) {
             // Success. Continue processing.
         }
-        else if ( inRange(httpStatusCode, 300, 399) ) {
+        // update end of range to 599 to cover exception for larger range
+        // to debug if replacing exception(response, httpStatusCode) removes
+        // CI failure
+        else if ( inRange(httpStatusCode, 300, 599) ) {
             // We had follow redirects on (default client) so it's http->https,
             // or the application passed on a HttpClient with redirects off.
             // Either way, we should not continue processing.
@@ -270,7 +273,8 @@ public class HttpLib {
      * This consumes the response body.
      */
     static HttpException exception(HttpResponse<InputStream> response, int httpStatusCode) {
-        URI uri = response.request().uri();
+        // URI not used
+       // URI uri = response.request().uri();
         InputStream in = response.body();
         if ( in == null )
             return new HttpException(httpStatusCode, HttpSC.getMessage(httpStatusCode));
@@ -281,6 +285,7 @@ public class HttpLib {
                 if ( msg.isBlank())
                     msg = null;
             } catch (RuntimeIOException e) {
+                LOG.warn("HttpException exception(hr<is> r, int hsc) msg:{} stack trace: {}", e.getMessage(), e.getStackTrace().toString());
                 msg = null;
             }
             return new HttpException(httpStatusCode, HttpSC.getMessage(httpStatusCode), msg);

--- a/jena-fuseki2/jena-fuseki-main/pom.xml
+++ b/jena-fuseki2/jena-fuseki-main/pom.xml
@@ -215,6 +215,7 @@
           <includes>
             <include>**/TS_*.java</include>
           </includes>
+            <argLine>-Dfuseki.loglogging=true -Djdk.httpclient.HttpClient.log=errors,requests,headers,frames[:control:data:window:all..],content,ssl,trace,channel</argLine>
         </configuration>
       </plugin>
 

--- a/jena-fuseki2/jena-fuseki-main/src/test/resources/log4j2-test.properties
+++ b/jena-fuseki2/jena-fuseki-main/src/test/resources/log4j2-test.properties
@@ -13,7 +13,7 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-10c{1} :: %m%n
 #appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-10c{1} :: %m%n
 
-rootLogger.level                  = INFO
+rootLogger.level                  = DEBUG
 rootLogger.appenderRef.stdout.ref = OUT
 
 logger.jena.name  = org.apache.jena
@@ -23,7 +23,7 @@ logger.arq-exec.name  = org.apache.jena.arq.exec
 logger.arq-exec.level = INFO
 
 logger.fuseki.name  = org.apache.jena.fuseki
-logger.fuseki.level = WARN
+logger.fuseki.level = INFO
 
 ## Some tests correctly log warnings. TS_PrefixesService
 logger.fuseki-fuseki.name  = org.apache.jena.fuseki.Fuseki
@@ -33,7 +33,7 @@ logger.fuseki-autoload.name  = org.apache.jena.fuseki.main.sys.FusekiAutoModules
 logger.fuseki-autoload.level = ERROR
 
 logger.http.name  = org.apache.jena.http
-logger.http.level = INFO
+logger.http.level = DEBUG
 
 logger.riot.name  = org.apache.jena.riot
 logger.riot.level = INFO
@@ -42,7 +42,7 @@ logger.riot.name  = org.apache.shiro
 logger.riot.level = WARN
 
 logger.jetty.name  = org.eclipse.jetty
-logger.jetty.level = WARN
+logger.jetty.level = INFO
 
 # This goes out in NCSA format
 appender.plain.type = Console


### PR DESCRIPTION
GitHub issue resolved #

Pull request Description:

* Add temporarily more logging to httpClient to check what errors are cause CI failures in #3008
* I think one error suggests that one problem could be places where QueryExecution isn't closed. I have now naively added it to try-with for all occasions of conn.Query() which wasn't a try-with, like the javadocs suggest. The error shows up in the verbose log, but continues the run, so could be unrelated.

Expanded logs when running are not readable from the GUI (becomes laggy) because of size, but can be downloaded from "Download log archive".

<img width="1535" alt="Skjermbilde 2025-03-10 kl  21 38 43" src="https://github.com/user-attachments/assets/db5c16f1-0586-4b62-9a99-8d5089b47820" />

Alot of errors show up and then the CI job continues, like:
```
2025-03-10T19:22:41.9792413Z Mar 10, 2025 7:22:41 PM jdk.internal.net.http.Http1AsyncReceiver onReadError
2025-03-10T19:22:41.9794722Z INFO: ERROR: HTTP/1 read subscriber recorded error: http://localhost:45971/ds-dataset?query=PREFIX+afn:+%3Chttp://jena.apache.org/ARQ/function%23%3E%0APREFIX+fuseki:+%3Chttp://jena.apache.org/fuseki%23%3E%0APREFIX+rdf:+%3Chttp://www.w3.org/1999/02/22-rdf-syntax-ns%23%3E%0APREFIX+rdfs:+%3Chttp://www.w3.org/2000/01/rdf-schema%23%3E%0A%0ASELECT+?V+%7B+BIND%28afn:context%28%27CONTEXT:DATASET%27%29+AS+?V%29+%7D GET - java.io.IOException: subscription cancelled
2025-03-10T19:22:41.9795050Z Mar 10, 2025 7:22:41 PM jdk.internal.net.http.Http1AsyncReceiver onReadError
```

There are still errors and failing CI jobs.

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
