### PR TITLE
Group npm ecosystem updates by patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,8 +37,8 @@ updates:
       interval: "weekly"
       day: "wednesday"
     versioning-strategy: increase-if-necessary
-##     groups:
-##       npm-patch-group:
-##         update-types:
-##         - "minor"
+    groups:
+      npm-patch-group:
+        update-types:
+        - "patch"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This puts back grouping of npm dependency update. For now, set to "patch"; it was "minor" before #3062 and investigation of which update was causing problems.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
