### PR TITLE
Update QueryIteratorWrapper to performClose and performRequestCancel

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIteratorWrapper.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/iterator/QueryIteratorWrapper.java
@@ -44,17 +44,13 @@ public class QueryIteratorWrapper extends QueryIteratorBase {
 
     @Override
     protected void closeIterator() {
-        if ( iterator != null ) {
-            iterator.close();
-            iterator = null;
-        }
+        performClose(iterator);
+        iterator = null;
     }
 
     @Override
     protected void requestCancel() {
-        if ( iterator != null ) {
-            iterator.cancel();
-        }
+        performRequestCancel(iterator);
     }
 
     @Override
@@ -70,5 +66,4 @@ public class QueryIteratorWrapper extends QueryIteratorBase {
         out.decIndent();
         // out.println(Utils.className(this)+"/"+Utils.className(iterator)) ;
     }
-
 }


### PR DESCRIPTION
Pull request Description: Fix a rare race condition that can cause a test failure during build. `QueryIteratorWrapper` is updated to reuse `QueryIteratorBase.performClose and performRequestCancel`. These methods ensure that the reference to the delegate iterator remains unchanged during the "if not null" check and the subsequent cancel / close action.

Should be unrelated to #3063.

Below is the build error I got for the first time since contributing the `TestQueryExecutionCancel` test case.

```
[ERROR] Tests run: 21, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.723 s <<< FAILURE! -- in org.apache.jena.sparql.api.TestQueryExecutionCancel
[ERROR] org.apache.jena.sparql.api.TestQueryExecutionCancel.test_cancel_concurrent_1 -- Time elapsed: 0.091 s <<< ERROR!
java.lang.NullPointerException
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
	at java.base/java.util.concurrent.ForkJoinTask.getThrowableException(ForkJoinTask.java:564)
	at java.base/java.util.concurrent.ForkJoinTask.reportException(ForkJoinTask.java:591)
	at java.base/java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:689)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:159)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateParallel(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:765)
	at org.apache.jena.sparql.api.TestQueryExecutionCancel.runConcurrentAbort(TestQueryExecutionCancel.java:385)
	at org.apache.jena.sparql.api.TestQueryExecutionCancel.test_cancel_concurrent(TestQueryExecutionCancel.java:365)
	at org.apache.jena.sparql.api.TestQueryExecutionCancel.test_cancel_concurrent_1(TestQueryExecutionCancel.java:342)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.jena.sparql.engine.QueryIterator.cancel()" because "this.iterator" is null
	at org.apache.jena.sparql.engine.iterator.QueryIteratorWrapper.requestCancel(QueryIteratorWrapper.java:56)
	at org.apache.jena.sparql.engine.iterator.QueryIteratorBase.cancel(QueryIteratorBase.java:212)
	at org.apache.jena.sparql.engine.iterator.QueryIteratorWrapper.requestCancel(QueryIteratorWrapper.java:56)
	at org.apache.jena.sparql.engine.iterator.QueryIteratorBase.cancel(QueryIteratorBase.java:212)
	at org.apache.jena.sparql.exec.QueryExecDataset.abort(QueryExecDataset.java:162)
	at org.apache.jena.sparql.exec.QueryExecutionAdapter.abort(QueryExecutionAdapter.java:228)
	at org.apache.jena.sparql.exec.QueryExecutionCompat.abort(QueryExecutionCompat.java:173)
	at org.apache.jena.sparql.api.TestQueryExecutionCancel.lambda$runConcurrentAbort$9(TestQueryExecutionCancel.java:404)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:720)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.ForEachOps$ForEachTask.compute(ForEachOps.java:290)
	at java.base/java.util.concurrent.CountedCompleter.exec(CountedCompleter.java:754)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
