### PR TITLE
Update jena-iri3986 to all JUnit5

### DIFF
--- a/jena-iri3986/pom.xml
+++ b/jena-iri3986/pom.xml
@@ -38,22 +38,9 @@
 
   <dependencies>
 
-    <!-- For testing -->
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestBuild.java
+++ b/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestBuild.java
@@ -20,7 +20,7 @@ package org.apache.jena.rfc3986;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Building IRIs from components. */
 public class TestBuild {

--- a/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestParseDID.java
+++ b/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestParseDID.java
@@ -20,7 +20,7 @@ package org.apache.jena.rfc3986;
 
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.rfc3986.ParseDID.DIDParseException;
 

--- a/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestParseDNS.java
+++ b/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestParseDNS.java
@@ -20,7 +20,8 @@ package org.apache.jena.rfc3986;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 /** Test the class ParseDNS */
 public class TestParseDNS {

--- a/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestParseIPv4Address.java
+++ b/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestParseIPv4Address.java
@@ -20,7 +20,7 @@ package org.apache.jena.rfc3986;
 
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestParseIPv4Address {
     @Test public void addr_ipv4_01()    { good4("15.16.17.18"); }

--- a/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestParseOID.java
+++ b/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestParseOID.java
@@ -18,12 +18,12 @@
 
 package org.apache.jena.rfc3986;
 
-import org.junit.Test;
-
-import org.apache.jena.rfc3986.ParseOID.OIDParseException;
-
 import static org.apache.jena.rfc3986.LibTestURI.test3986;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.rfc3986.ParseOID.OIDParseException;
 
 /** Test the class ParseOID */
 public class TestParseOID {

--- a/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestURISchemes.java
+++ b/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestURISchemes.java
@@ -22,7 +22,7 @@ import static org.apache.jena.rfc3986.LibTestURI.badSyntax;
 import static org.apache.jena.rfc3986.LibTestURI.good;
 import static org.apache.jena.rfc3986.LibTestURI.schemeViolation;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Test IRIs for scheme-specific validation rules. */
 public class TestURISchemes {


### PR DESCRIPTION
Pull request Description:

This PR cleans up module `jena-iri3986` to use JUnit5 exclusively.
It was a mixture of JUnit4 and JUnit5.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
