### PR TITLE
Remove Firefox from test matrix due to Cypress upgrade

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -59,7 +59,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [ firefox, chrome, electron ]
+        ##browser: [ firefox, chrome, electron ]
+        ## Firefox removed for now - it now consistently fails after a cypress upgrade
+        browser: [ chrome, electron ]
         os: [ ubuntu-latest ]
 
     env:


### PR DESCRIPTION
The Firefox upload test now fails nearly every time after a Cypress upgrade. It was failing intermittently.

While there are several Cypress reports are about Firefox+Cypress, none are exactly what we're seeing here which is that the other tests are working with Firefox, it is just `upload.cy.js` that fails.

Changing the timeout does not have any effect, except a longer wait. It is as if whatever Cypress is waiting for, happens and completes (server exit?) before Cypress starts to polling.

Manual testing shows the UI to be functioning in Firefox.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
