### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 
     <ver.caffeine>3.2.0</ver.caffeine>
     <!-- Most of Jena uses other libraries for equivalent functionality. -->
-    <ver.guava>33.4.6-jre</ver.guava>
+    <ver.guava>33.4.7-jre</ver.guava>
 
     <ver.gson>2.12.1</ver.gson>
     <ver.lucene>9.12.1</ver.lucene>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <ver.gson>2.12.1</ver.gson>
     <ver.lucene>9.12.1</ver.lucene>
 
-    <ver.commons-io>2.18.0</ver.commons-io>
+    <ver.commons-io>2.19.0</ver.commons-io>
     <ver.commons-cli>1.7.0</ver.commons-cli>
     <ver.commons-lang3>3.17.0</ver.commons-lang3>
     <ver.commons-rdf>0.5.0</ver.commons-rdf>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <!-- Most of Jena uses other libraries for equivalent functionality. -->
     <ver.guava>33.4.7-jre</ver.guava>
 
-    <ver.gson>2.12.1</ver.gson>
+    <ver.gson>2.13.0</ver.gson>
     <ver.lucene>9.12.1</ver.lucene>
 
     <ver.commons-io>2.19.0</ver.commons-io>

--- a/pom.xml
+++ b/pom.xml
@@ -722,13 +722,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.python</groupId>
-        <artifactId>jython-standalone</artifactId>
-        <version>${ver.jython}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
         <groupId>org.openjdk.jmh</groupId>
         <artifactId>jmh-core</artifactId>
         <version>${ver.org.openjdk.jmh}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
          These two go together
          See jena-fuseki-webapp and https://shiro.apache.org/jakarta-ee.html
     -->
-    <ver.shiro>2.0.2</ver.shiro>
+    <ver.shiro>2.0.3</ver.shiro>
     <ver.omnifaces>4.6.1</ver.omnifaces>
 
     <ver.protobuf>4.30.2</ver.protobuf>


### PR DESCRIPTION
Bump ver.commons-io from 2.18.0 to 2.19.0
Bump ver.shiro from 2.0.2 to 2.0.3
Bump ver.gson from 2.12.1 to 2.13.0
Bump ver.guava from 33.4.6-jre to 33.4.7-jre

Remove unused dependency management of jython

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
