### PR TITLE
GH-3148: Set HTTP header User-Agent when calling from SERVICE

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpEnv.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpEnv.java
@@ -23,6 +23,7 @@ import java.net.http.HttpClient.Redirect;
 import java.time.Duration;
 
 import org.apache.jena.http.sys.RegistryRequestModifier;
+import org.apache.jena.query.ARQ;
 import org.apache.jena.riot.RDFFormat;
 
 /**
@@ -59,6 +60,8 @@ public class HttpEnv {
     private static HttpClient buildDftHttpClient() {
         return httpClientBuilder().build();
     }
+
+    public static final String UserAgent = ARQ.VERSION.contains("devel") ? "ApacheJena" : "ApacheJena/"+ARQ.VERSION;
 
     public static HttpClient.Builder httpClientBuilder() {
         return HttpClient.newBuilder()

--- a/jena-arq/src/main/java/org/apache/jena/riot/web/HttpNames.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/web/HttpNames.java
@@ -42,6 +42,7 @@ public class HttpNames
     public static final String hServer              = "Server" ;
     public static final String hLocation            = "Location" ;
     public static final String hVary                = "Vary" ;
+    public static final String hUserAgent           = "User-Agent" ;
     public static final String charset              = "charset" ;
 
     // CORS:

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/Service.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/Service.java
@@ -33,6 +33,7 @@ import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.http.HttpEnv;
 import org.apache.jena.http.RegistryHttpClient;
 import org.apache.jena.query.*;
+import org.apache.jena.riot.web.HttpNames;
 import org.apache.jena.sparql.SystemARQ ;
 import org.apache.jena.sparql.algebra.Op ;
 import org.apache.jena.sparql.algebra.OpAsQuery ;
@@ -229,6 +230,7 @@ public class Service {
         QueryExecHTTP qExec = QueryExecHTTP.newBuilder()
                 .endpoint(serviceURL)
                 .timeout(timeoutMillis, TimeUnit.MILLISECONDS)
+                .httpHeader(HttpNames.hUserAgent, HttpEnv.UserAgent)
                 .query(query)
                 .params(serviceParams)
                 .context(context)


### PR DESCRIPTION
This does not complete issue #3148.

It is a pro-tem change solution that sets a user-agent for `SERVICE` (the original report #3139).

Application use of QueryExecution and GSP/DSP (Graph Store Protocol) though their builders can set the the User-Agent header so they are not blocked at the moment.

`SERVICE` does not expose this possibility.

A complete resolution of #3148 will be to have a way to change the default User-Agent without needing to change the setup via builders.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
