### PR TITLE
Reformat query syntax elements

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/Element1.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/Element1.java
@@ -18,17 +18,14 @@
 
 package org.apache.jena.sparql.syntax;
 
-
 /** Element1 - elements that have a single subElement. */
-
-public abstract class Element1 extends Element
-{
+public abstract class Element1 extends Element {
     // Not used very widely.
     // For historical reasons ElementOptional does not use this.
     // It could do - it just doesn't.
-    private Element element ;
+    private Element element;
 
-    protected Element1(Element element) { this.element = element ; }
+    protected Element1(Element element) { this.element = element; }
 
-    public Element getElement() { return element ; }
+    public Element getElement() { return element; }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementAssign.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementAssign.java
@@ -18,53 +18,46 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.sparql.core.Var ;
-import org.apache.jena.sparql.expr.Expr ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
-public class ElementAssign extends Element
-{
-    private Var var ;
-    private Expr expr ;
+public class ElementAssign extends Element {
+    private Var var;
+    private Expr expr;
 
-    public ElementAssign(Var v, Expr expr)
-    {
-        this.var = v ; 
-        this.expr = expr ;
+    public ElementAssign(Var v, Expr expr) {
+        this.var = v;
+        this.expr = expr;
     }
 
-    public Var getVar()
-    {
-        return var ;
+    public Var getVar() {
+        return var;
     }
 
-    public Expr getExpr()
-    {
-        return expr ;
+    public Expr getExpr() {
+        return expr;
     }
 
     @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( ! ( el2 instanceof ElementAssign ) )
-            return false ;
-        ElementAssign f2 = (ElementAssign)el2 ;
-        if ( ! this.getVar().equals(f2.getVar() ))
-            return false ;
-        if ( ! this.getExpr().equals(f2.getExpr()) )
-            return false ;
-        return true ;
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( !(el2 instanceof ElementAssign) )
+            return false;
+        ElementAssign f2 = (ElementAssign)el2;
+        if ( !this.getVar().equals(f2.getVar()) )
+            return false;
+        if ( !this.getExpr().equals(f2.getExpr()) )
+            return false;
+        return true;
     }
 
     @Override
-    public int hashCode()
-    {
-        return var.hashCode()^expr.hashCode();
+    public int hashCode() {
+        return var.hashCode() ^ expr.hashCode();
     }
 
     @Override
-    public void visit(ElementVisitor v)
-    {
-        v.visit(this) ;
+    public void visit(ElementVisitor v) {
+        v.visit(this);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementBind.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementBind.java
@@ -18,53 +18,46 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.sparql.core.Var ;
-import org.apache.jena.sparql.expr.Expr ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
-public class ElementBind extends Element
-{
-    private Var var ;
-    private Expr expr ;
+public class ElementBind extends Element {
+    private Var var;
+    private Expr expr;
 
-    public ElementBind(Var v, Expr expr)
-    {
-        this.var = v ; 
-        this.expr = expr ;
+    public ElementBind(Var v, Expr expr) {
+        this.var = v;
+        this.expr = expr;
     }
 
-    public Var getVar()
-    {
-        return var ;
+    public Var getVar() {
+        return var;
     }
 
-    public Expr getExpr()
-    {
-        return expr ;
+    public Expr getExpr() {
+        return expr;
     }
 
     @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( ! ( el2 instanceof ElementBind ) )
-            return false ;
-        ElementBind f2 = (ElementBind)el2 ;
-        if ( ! this.getVar().equals(f2.getVar() ))
-            return false ;
-        if ( ! this.getExpr().equals(f2.getExpr()) )
-            return false ;
-        return true ;
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( !(el2 instanceof ElementBind) )
+            return false;
+        ElementBind f2 = (ElementBind)el2;
+        if ( !this.getVar().equals(f2.getVar()) )
+            return false;
+        if ( !this.getExpr().equals(f2.getExpr()) )
+            return false;
+        return true;
     }
 
     @Override
-    public int hashCode()
-    {
-        return var.hashCode()^expr.hashCode();
+    public int hashCode() {
+        return var.hashCode() ^ expr.hashCode();
     }
 
     @Override
-    public void visit(ElementVisitor v)
-    {
-        v.visit(this) ;
+    public void visit(ElementVisitor v) {
+        v.visit(this);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementData.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementData.java
@@ -18,83 +18,71 @@
 
 package org.apache.jena.sparql.syntax;
 
-import java.util.ArrayList ;
-import java.util.Iterator ;
-import java.util.List ;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
-import org.apache.jena.sparql.ARQException ;
-import org.apache.jena.sparql.algebra.Table ;
-import org.apache.jena.sparql.algebra.table.TableData ;
-import org.apache.jena.sparql.core.Var ;
-import org.apache.jena.sparql.engine.binding.Binding ;
+import org.apache.jena.sparql.ARQException;
+import org.apache.jena.sparql.algebra.Table;
+import org.apache.jena.sparql.algebra.table.TableData;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.resultset.ResultsCompare;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
-public class ElementData extends Element
-{
-    private List<Var> vars ;
-    private List<Binding> rows ;
+public class ElementData extends Element {
+    private List<Var> vars;
+    private List<Binding> rows;
 
-    public ElementData()
-    {
-        this(new ArrayList<>(), new ArrayList<>()) ;
+    public ElementData() {
+        this(new ArrayList<>(), new ArrayList<>());
     }
 
-    public ElementData(List<Var> vars, List<Binding> rows)
-    {
-        this.vars = vars ;
-        this.rows = rows ;
+    public ElementData(List<Var> vars, List<Binding> rows) {
+        this.vars = vars;
+        this.rows = rows;
     }
 
-    public Table getTable()
-    {
-        return new TableData(vars, rows) ;
+    public Table getTable() {
+        return new TableData(vars, rows);
     }
 
-    public List<Var> getVars()      { return vars ; }
-    public List<Binding> getRows()  { return rows ; }
+    public List<Var> getVars()      { return vars; }
+    public List<Binding> getRows()  { return rows; }
 
-    public void add(Var var)
-    {
-        if ( ! vars.contains(var) )
-            vars.add(var) ;
+    public void add(Var var) {
+        if ( !vars.contains(var) )
+            vars.add(var);
     }
 
-    public void add(Binding binding)
-    {
-        Iterator<Var> iter = binding.vars() ;
-        while(iter.hasNext())
-        {
-            Var v = iter.next() ;
-            if ( ! vars.contains(v) )
-                throw new ARQException("Variable "+v+" not already declared for ElementData") ;
+    public void add(Binding binding) {
+        Iterator<Var> iter = binding.vars();
+        while (iter.hasNext()) {
+            Var v = iter.next();
+            if ( !vars.contains(v) )
+                throw new ARQException("Variable " + v + " not already declared for ElementData");
         }
-        rows.add(binding) ;
+        rows.add(binding);
     }
 
     @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( ! ( el2 instanceof ElementData ) )
-            return false ;
-        ElementData f2 = (ElementData)el2 ;
-        if ( ! vars.equals(f2.vars) )
-            return false ;
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( !(el2 instanceof ElementData) )
+            return false;
+        ElementData f2 = (ElementData)el2;
+        if ( !vars.equals(f2.vars) )
+            return false;
 
-        if ( ! ResultsCompare.equalsByTerm(rows, f2.rows) )
-            return false ;
-        return true ;
+        if ( !ResultsCompare.equalsByTerm(rows, f2.rows) )
+            return false;
+        return true;
     }
 
     @Override
-    public int hashCode()
-    {
-        return vars.hashCode()^rows.hashCode() ;
+    public int hashCode() {
+        return vars.hashCode() ^ rows.hashCode();
     }
 
     @Override
-    public void visit(ElementVisitor v)
-    {
-        v.visit(this) ;
-    }
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementDataset.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementDataset.java
@@ -18,57 +18,57 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
-/** ElementDataset - an association of an RDF Dataset 
- * (graph level version) with a query pattern.
- * Unused in parser. */
+/**
+ * ElementDataset - an association of an RDF Dataset (graph level version) with a
+ * query pattern. Unused in parser.
+ */
 
-public class ElementDataset extends Element1
-{
+public class ElementDataset extends Element1 {
     // Can keep either form - but not both.
     // Helps because models have prefixes.
-    private DatasetGraph dataset = null ;
-    
-    public ElementDataset(DatasetGraph data, Element patternElement)
-    {
-        super(patternElement) ;
-        this.dataset = data ;
+    private DatasetGraph dataset = null;
+
+    public ElementDataset(DatasetGraph data, Element patternElement) {
+        super(patternElement);
+        this.dataset = data;
     }
-    
-    public DatasetGraph getDataset() { return dataset ; }
-    
+
+    public DatasetGraph getDataset() {
+        return dataset;
+    }
+
     @Override
-    public int hashCode()
-    { 
-        int x = getElement().hashCode() ;
+    public int hashCode() {
+        int x = getElement().hashCode();
         if ( getDataset() != null )
-            x ^= getDataset().hashCode() ;
-        return x ;
+            x ^= getDataset().hashCode();
+        return x;
     }
-    
+
     @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( el2 == null ) return false ;
-        if ( ! ( el2 instanceof ElementDataset ) )
-            return false ;
-        ElementDataset blk = (ElementDataset)el2 ;
-        
-        if ( ! getElement().equalTo(blk.getElement(), isoMap) )
-            return false ;
-        
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( el2 == null )
+            return false;
+        if ( !(el2 instanceof ElementDataset) )
+            return false;
+        ElementDataset blk = (ElementDataset)el2;
+
+        if ( !getElement().equalTo(blk.getElement(), isoMap) )
+            return false;
+
         // Dataset both null
         if ( getDataset() == null && blk.getDataset() == null )
-            return true ;
-        
+            return true;
+
         if ( getDataset() != blk.getDataset() )
-            return false ;
-        
-        return true ;
+            return false;
+
+        return true;
     }
-    
+
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementExists.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementExists.java
@@ -18,10 +18,9 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** The syntax element for "Exists" in a pattern. */
-
 public class ElementExists extends Element1 {
     public ElementExists(Element el) {
         super(el);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementFilter.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementFilter.java
@@ -18,35 +18,34 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.sparql.expr.Expr ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** A constraint (Filter) in a query expression. */
-
 public class ElementFilter extends Element
 {
-    Expr expr = null ;
+    Expr expr = null;
 
-    public ElementFilter(Expr expr) { this.expr = expr ; }
-    
-    public Expr getExpr() { return expr ; }
-    
-    @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public ElementFilter(Expr expr) { this.expr = expr; }
+
+    public Expr getExpr() { return expr; }
 
     @Override
-    public int hashCode() { return expr.hashCode() ; }
-    
+    public void visit(ElementVisitor v) { v.visit(this); }
+
+    @Override
+    public int hashCode() { return expr.hashCode(); }
+
     @Override
     public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
     {
-        if ( el2 == null ) return false ;
+        if ( el2 == null ) return false;
 
         if ( ! ( el2 instanceof ElementFilter ) )
-            return false ;
-        ElementFilter f2 = (ElementFilter)el2 ;
+            return false;
+        ElementFilter f2 = (ElementFilter)el2;
         if ( ! this.getExpr().equalsBySyntax(f2.getExpr()) )
-            return false ;
-        return true ;
+            return false;
+        return true;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementGroup.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementGroup.java
@@ -18,104 +18,97 @@
 
 package org.apache.jena.sparql.syntax;
 
-import java.util.ArrayList ;
-import java.util.List ;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** A number of graph query elements.
  *  Evaluation is a conjunction(AND) of the elements of the groups */
 
-public class ElementGroup extends Element
-{
-    List<Element> elements = new ArrayList<>() ;
+public class ElementGroup extends Element {
+    List<Element> elements = new ArrayList<>();
 
-    public ElementGroup()
-    {  }
+    public ElementGroup() {}
 
-    public void addElement(Element el)
-    { 
-        elements.add(el) ;
+    public void addElement(Element el) {
+        elements.add(el);
     }
 
     // In SPARQL, triple patterns are in basic graph patterns.
     // This is a helper method.
-    
-    public void addTriplePattern(Triple t)
-    { 
-        ensureBGP().addTriple(t) ;
+
+    public void addTriplePattern(Triple t) {
+        ensureBGP().addTriple(t);
     }
 
-    public void addElementFilter(ElementFilter el)
-    { 
-        addElement(el) ;
+    public void addElementFilter(ElementFilter el) {
+        addElement(el);
     }
-    
+
     // Ensure the current top element is a basic graph pattern.
-    
-    private ElementTriplesBlock ensureBGP()
-    {
-        if ( elements.size() == 0 )
-            return pushBGP() ;
 
-        Element top = top() ;
-        ElementTriplesBlock bgp = null ;
+    private ElementTriplesBlock ensureBGP() {
+        if ( elements.size() == 0 )
+            return pushBGP();
+
+        Element top = top();
+        ElementTriplesBlock bgp = null;
         if ( top instanceof ElementTriplesBlock )
-            return (ElementTriplesBlock)top ;
-        return pushBGP() ;
+            return (ElementTriplesBlock)top;
+        return pushBGP();
     }
-    
-    private ElementTriplesBlock pushBGP()
-    {
-        ElementTriplesBlock bgp = new ElementTriplesBlock() ;
-        elements.add(bgp) ;
-        return bgp ;
+
+    private ElementTriplesBlock pushBGP() {
+        ElementTriplesBlock bgp = new ElementTriplesBlock();
+        elements.add(bgp);
+        return bgp;
     }
-    
-    private void setTop(Element el) { elements.set(elements.size()-1, el) ; }
-    private Element top() { return elements.get(elements.size()-1) ; }
-    
-    public int mark() { return elements.size() ; }
-    
+
+    private void setTop(Element el) { elements.set(elements.size()-1, el); }
+    private Element top() { return elements.get(elements.size()-1); }
+
+    public int mark() { return elements.size(); }
+
     public List<Element> getElements()  { return elements; }
-    public boolean isEmpty()            { return elements.size() == 0 ; }
-    public int size()                   { return elements.size() ; }
-    public Element get(int idx)         { return elements.get(idx) ; }
-    public Element getLast() { 
+    public boolean isEmpty()            { return elements.size() == 0; }
+    public int size()                   { return elements.size(); }
+    public Element get(int idx)         { return elements.get(idx); }
+    public Element getLast() {
         if ( elements.isEmpty() )
-            return null ;
-        return elements.get(elements.size()-1) ;
+            return null;
+        return elements.get(elements.size()-1);
     }
 
     @Override
     public int hashCode()
-    { 
-        int calcHashCode = Element.HashGroup ; // So the empty group isn't zero.
-        calcHashCode ^=  getElements().hashCode() ; 
-        return calcHashCode ;
+    {
+        int calcHashCode = Element.HashGroup; // So the empty group isn't zero.
+        calcHashCode ^=  getElements().hashCode();
+        return calcHashCode;
     }
 
     @Override
     public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
     {
-        if ( el2 == null ) return false ;
+        if ( el2 == null ) return false;
 
         if ( ! ( el2 instanceof ElementGroup) )
-            return false ;
-        ElementGroup eg2 = (ElementGroup)el2 ;
+            return false;
+        ElementGroup eg2 = (ElementGroup)el2;
         if ( this.getElements().size() != eg2.getElements().size() )
-            return false ;
-        for ( int i = 0 ; i < this.getElements().size() ; i++ )
+            return false;
+        for ( int i = 0; i < this.getElements().size(); i++ )
         {
-            Element e1 = getElements().get(i) ;
-            Element e2 = eg2.getElements().get(i) ;
+            Element e1 = getElements().get(i);
+            Element e2 = eg2.getElements().get(i);
             if ( ! e1.equalTo(e2, isoMap) )
-                return false ;
+                return false;
         }
-        return true ;
+        return true;
     }
-    
+
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementLateral.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementLateral.java
@@ -24,36 +24,38 @@ import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** LATERAL */
-public class ElementLateral extends Element
-{
-    private final Element right ;
+public class ElementLateral extends Element {
+    private final Element right;
 
     public ElementLateral(Element right) {
         this(right, null, false);
     }
 
     private ElementLateral(Element right, List<Var> vars, boolean seenStar) {
-        this.right = right ;
+        this.right = right;
     }
 
-    public Element getLateralElement()  { return right ; }
+    public Element getLateralElement() {
+        return right;
+    }
 
     @Override
     public int hashCode() {
-        int hash = Element.HashLateral ;
-        hash = hash ^ getLateralElement().hashCode() ;
-        return hash ;
+        int hash = Element.HashLateral;
+        hash = hash ^ getLateralElement().hashCode();
+        return hash;
     }
 
     @Override
     public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
-        if ( el2 == null ) return false ;
-        if ( ! ( el2 instanceof ElementLateral ) )
-            return false ;
-        ElementLateral other = (ElementLateral)el2 ;
+        if ( el2 == null )
+            return false;
+        if ( !(el2 instanceof ElementLateral) )
+            return false;
+        ElementLateral other = (ElementLateral)el2;
         return getLateralElement().equalTo(other.getLateralElement(), isoMap);
     }
 
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementMinus.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementMinus.java
@@ -18,41 +18,38 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
-/** An optional element in a query. */
+public class ElementMinus extends Element {
+    private Element minusPart;
 
-public class ElementMinus extends Element
-{
-    Element minusPart ;
-
-    public ElementMinus(Element minusPart)
-    {
-        this.minusPart = minusPart ;
+    public ElementMinus(Element minusPart) {
+        this.minusPart = minusPart;
     }
 
-    public Element getMinusElement() { return minusPart ; }
-
-    @Override
-    public int hashCode()
-    {
-        int hash = Element.HashOptional ;
-        hash = hash ^ getMinusElement().hashCode() ;
-        return hash ;
+    public Element getMinusElement() {
+        return minusPart;
     }
 
     @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( el2 == null ) return false ;
-
-        if ( ! ( el2 instanceof ElementMinus ) ) 
-            return false ;
-        
-        ElementMinus opt2 = (ElementMinus)el2 ;
-        return getMinusElement().equalTo(opt2.getMinusElement(), isoMap) ;
+    public int hashCode() {
+        int hash = Element.HashOptional;
+        hash = hash ^ getMinusElement().hashCode();
+        return hash;
     }
-    
+
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( el2 == null )
+            return false;
+
+        if ( !(el2 instanceof ElementMinus) )
+            return false;
+
+        ElementMinus opt2 = (ElementMinus)el2;
+        return getMinusElement().equalTo(opt2.getMinusElement(), isoMap);
+    }
+
+    @Override
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementNamedGraph.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementNamedGraph.java
@@ -18,56 +18,55 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.graph.Node ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** Evaluate a query element based on source information in a named collection. */
 
-public class ElementNamedGraph extends Element
-{
-    private Node sourceNode ;
-    private Element element ;
+public class ElementNamedGraph extends Element {
+    private Node sourceNode;
+    private Element element;
 
     // GRAPH * (not in SPARQL)
-    public ElementNamedGraph(Element el)
-    {
-        this(null, el) ;
+    public ElementNamedGraph(Element el) {
+        this(null, el);
     }
 
     // GRAPH <uri> or GRAPH ?var
-    public ElementNamedGraph(Node n, Element el)
-    {
-        sourceNode = n ;
-        element = el ;
+    public ElementNamedGraph(Node n, Element el) {
+        sourceNode = n;
+        element = el;
     }
-    
-    public Node getGraphNameNode() { return sourceNode ; }
-    
+
+    public Node getGraphNameNode() {
+        return sourceNode;
+    }
+
     /** @return Returns the element. */
-    public Element getElement()
-    {
-        return element ;
-    }
-    
-    @Override
-    public int hashCode() { return element.hashCode() ^ sourceNode.hashCode() ; }
-
-    @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( el2 == null ) return false ;
-
-        if ( ! ( el2 instanceof ElementNamedGraph ) ) 
-            return false ;
-        ElementNamedGraph g2 = (ElementNamedGraph)el2 ;
-        if ( ! this.getGraphNameNode().equals(g2.getGraphNameNode()) )
-            return false ;
-        if ( ! this.getElement().equalTo(g2.getElement(), isoMap) )
-            return false ;
-        return true ;
+    public Element getElement() {
+        return element;
     }
 
-    
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public int hashCode() {
+        return element.hashCode() ^ sourceNode.hashCode();
+    }
+
+    @Override
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( el2 == null )
+            return false;
+
+        if ( !(el2 instanceof ElementNamedGraph) )
+            return false;
+        ElementNamedGraph g2 = (ElementNamedGraph)el2;
+        if ( !this.getGraphNameNode().equals(g2.getGraphNameNode()) )
+            return false;
+        if ( !this.getElement().equalTo(g2.getElement(), isoMap) )
+            return false;
+        return true;
+    }
+
+    @Override
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementNotExists.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementNotExists.java
@@ -18,12 +18,11 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** The syntax element for "Not Exists" in a pattern. */
 
-public class ElementNotExists extends Element1
-{
+public class ElementNotExists extends Element1 {
     public ElementNotExists(Element el) {
         super(el);
     }
@@ -47,7 +46,5 @@ public class ElementNotExists extends Element1
     }
 
     @Override
-    public void visit(ElementVisitor v) {
-        v.visit(this);
-    }
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementOptional.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementOptional.java
@@ -18,41 +18,40 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** An optional element in a query. */
 
-public class ElementOptional extends Element
-{
-    Element optionalPart ;
+public class ElementOptional extends Element {
+    Element optionalPart;
 
-    public ElementOptional(Element optionalPart)
-    {
-        this.optionalPart = optionalPart ;
+    public ElementOptional(Element optionalPart) {
+        this.optionalPart = optionalPart;
     }
 
-    public Element getOptionalElement() { return optionalPart ; }
-
-    @Override
-    public int hashCode()
-    {
-        int hash = Element.HashOptional ;
-        hash = hash ^ getOptionalElement().hashCode() ;
-        return hash ;
+    public Element getOptionalElement() {
+        return optionalPart;
     }
 
     @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( el2 == null ) return false ;
-
-        if ( ! ( el2 instanceof ElementOptional ) ) 
-            return false ;
-        
-        ElementOptional opt2 = (ElementOptional)el2 ;
-        return getOptionalElement().equalTo(opt2.getOptionalElement(), isoMap) ;
+    public int hashCode() {
+        int hash = Element.HashOptional;
+        hash = hash ^ getOptionalElement().hashCode();
+        return hash;
     }
-    
+
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( el2 == null )
+            return false;
+
+        if ( !(el2 instanceof ElementOptional) )
+            return false;
+
+        ElementOptional opt2 = (ElementOptional)el2;
+        return getOptionalElement().equalTo(opt2.getOptionalElement(), isoMap);
+    }
+
+    @Override
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementPathBlock.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementPathBlock.java
@@ -18,78 +18,71 @@
 
 package org.apache.jena.sparql.syntax;
 
-import java.util.Iterator ;
+import java.util.Iterator;
 
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.sparql.core.BasicPattern ;
-import org.apache.jena.sparql.core.PathBlock ;
-import org.apache.jena.sparql.core.TriplePath ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.BasicPattern;
+import org.apache.jena.sparql.core.PathBlock;
+import org.apache.jena.sparql.core.TriplePath;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** A SPARQL BasicGraphPattern (SPARQL 1.1) */
+public class ElementPathBlock extends Element implements TripleCollectorMark {
+    private PathBlock pattern = new PathBlock();
 
-public class ElementPathBlock extends Element implements TripleCollectorMark
-{
-    private PathBlock pattern = new PathBlock() ;
+    public ElementPathBlock() {}
 
-    public ElementPathBlock()
-    {  }
-
-    public ElementPathBlock(PathBlock pattern)
-    {
+    public ElementPathBlock(PathBlock pattern) {
         this.pattern = pattern;
     }
 
-    public ElementPathBlock(BasicPattern bgp)
-    {
+    public ElementPathBlock(BasicPattern bgp) {
         for ( Triple t : bgp.getList() )
-            addTriple(t) ;
+            addTriple(t);
     }
 
-    public boolean isEmpty() { return pattern.isEmpty() ; }
+    public boolean isEmpty() { return pattern.isEmpty(); }
 
     public void addTriple(TriplePath tp)
-    { pattern.add(tp) ; }
+    { pattern.add(tp); }
 
     @Override
-    public int mark() { return pattern.size() ; }
+    public int mark() { return pattern.size(); }
 
     @Override
     public void addTriple(Triple t)
-    { addTriplePath(new TriplePath(t)) ; }
+    { addTriplePath(new TriplePath(t)); }
 
     @Override
     public void addTriple(int index, Triple t)
-    { addTriplePath(index, new TriplePath(t)) ; }
+    { addTriplePath(index, new TriplePath(t)); }
 
     @Override
     public void addTriplePath(TriplePath tPath)
-    { pattern.add(tPath) ; }
+    { pattern.add(tPath); }
 
     @Override
     public void addTriplePath(int index, TriplePath tPath)
-    { pattern.add(index, tPath) ; }
+    { pattern.add(index, tPath); }
 
-    public PathBlock getPattern() { return pattern ; }
+    public PathBlock getPattern() { return pattern; }
     public Iterator<TriplePath> patternElts() { return pattern.iterator(); }
 
     @Override
-    public int hashCode()
-    {
-        int calcHashCode = Element.HashBasicGraphPattern ;
-        calcHashCode ^= pattern.hashCode() ;
-        return calcHashCode ;
+    public int hashCode() {
+        int calcHashCode = Element.HashBasicGraphPattern;
+        calcHashCode ^= pattern.hashCode();
+        return calcHashCode;
     }
 
     @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( ! ( el2 instanceof ElementPathBlock) )
-            return false ;
-        ElementPathBlock eg2 = (ElementPathBlock)el2 ;
-        return this.pattern.equiv(eg2.pattern, isoMap) ;
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( !(el2 instanceof ElementPathBlock) )
+            return false;
+        ElementPathBlock eg2 = (ElementPathBlock)el2;
+        return this.pattern.equiv(eg2.pattern, isoMap);
     }
 
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementService.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementService.java
@@ -18,62 +18,56 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.atlas.logging.Log ;
-import org.apache.jena.graph.Node ;
-import org.apache.jena.graph.NodeFactory ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.atlas.logging.Log;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** A SERVICE pattern - access a remote SPARQL service. */
+public class ElementService extends Element {
+    private final Node serviceNode;
+    private final Element element;
+    private final boolean silent;
 
-public class ElementService extends Element
-{
-    private final Node serviceNode ;
-    private final Element element ;
-    private final boolean silent ;
+    public ElementService(String serviceURI, Element el) {
+        this(NodeFactory.createURI(serviceURI), el, false);
+    }
 
-    public ElementService(String serviceURI, Element el)
-    { 
-        this(NodeFactory.createURI(serviceURI), el, false) ;
+    public ElementService(String serviceURI, Element el, boolean silent) {
+        this(NodeFactory.createURI(serviceURI), el, silent);
     }
-    
-    public ElementService(String serviceURI, Element el, boolean silent)
-    { 
-        this(NodeFactory.createURI(serviceURI), el, silent) ;
-    }
-    
+
     // Variable?
-    public ElementService(Node n, Element el, boolean silent)
-    {
-        if ( ! n.isURI() && ! n.isVariable() )
-            Log.error(this, "Must be a URI (or variable which will be bound) for a service endpoint") ;
-        this.serviceNode = n ;
-        this.element = el ;
-        this.silent = silent ;
+    public ElementService(Node n, Element el, boolean silent) {
+        if ( !n.isURI() && !n.isVariable() )
+            Log.error(this, "Must be a URI (or variable which will be bound) for a service endpoint");
+        this.serviceNode = n;
+        this.element = el;
+        this.silent = silent;
     }
-    
-    public Element getElement() { return element ; } 
-    public Node getServiceNode() { return serviceNode ; }
-    public boolean getSilent() { return silent ; } 
-    
+
+    public Element getElement() { return element; }
+    public Node getServiceNode() { return serviceNode; }
+    public boolean getSilent() { return silent; }
+
     @Override
     public int hashCode()
     { return serviceNode.hashCode() ^ element.hashCode(); }
 
     @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( ! ( el2 instanceof ElementService ) )
-            return false ;
-        ElementService service = (ElementService)el2 ;
-        if ( ! serviceNode.equals(service.serviceNode) )
-            return false ;
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( !(el2 instanceof ElementService) )
+            return false;
+        ElementService service = (ElementService)el2;
+        if ( !serviceNode.equals(service.serviceNode) )
+            return false;
         if ( service.getSilent() != getSilent() )
-            return false ;
-        if ( ! this.getElement().equalTo(service.getElement(), isoMap) )
-            return false ;
-        return true ;
+            return false;
+        if ( !this.getElement().equalTo(service.getElement(), isoMap) )
+            return false;
+        return true;
     }
-    
+
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementSubQuery.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementSubQuery.java
@@ -18,36 +18,35 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.query.Query ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.query.Query;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 public class ElementSubQuery extends Element
 {
-    Query query ;
-    
-    public ElementSubQuery(Query query)
-    {
-        this.query = query ;
+    private Query query;
+
+    public ElementSubQuery(Query query) {
+        this.query = query;
     }
-    
-    public Query getQuery() { return query ; } 
-    
-    @Override
-    public boolean equalTo(Element other, NodeIsomorphismMap isoMap)
-    {
-        if ( ! ( other instanceof ElementSubQuery) )
-            return false ;
-        ElementSubQuery el = (ElementSubQuery)other ;
-        return query.equals(el.query) ;
+
+    public Query getQuery() {
+        return query;
     }
 
     @Override
-    public int hashCode()
-    {
-        return query.hashCode() ;
+    public boolean equalTo(Element other, NodeIsomorphismMap isoMap) {
+        if ( !(other instanceof ElementSubQuery) )
+            return false;
+        ElementSubQuery el = (ElementSubQuery)other;
+        return query.equals(el.query);
+    }
+
+    @Override
+    public int hashCode() {
+        return query.hashCode();
     }
 
     @Override
     public void visit(ElementVisitor v)
-    { v.visit(this) ; }
+    { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementTriplesBlock.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementTriplesBlock.java
@@ -18,73 +18,68 @@
 
 package org.apache.jena.sparql.syntax;
 
-import java.util.Iterator ;
+import java.util.Iterator;
 
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.sparql.ARQException ;
-import org.apache.jena.sparql.core.BasicPattern ;
-import org.apache.jena.sparql.core.TriplePath ;
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.ARQException;
+import org.apache.jena.sparql.core.BasicPattern;
+import org.apache.jena.sparql.core.TriplePath;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** The syntax element for a SPARQL BasicGraphPattern (SPARQL 1.0)*/
-
 public class ElementTriplesBlock extends Element implements TripleCollectorMark
 {
-    private final BasicPattern pattern ; 
+    private final BasicPattern pattern;
 
-    public ElementTriplesBlock()
-    { 
-        pattern = new BasicPattern() ; 
-    }
-    
-    public ElementTriplesBlock(BasicPattern bgp)
-    { 
-        pattern = bgp ;
+    public ElementTriplesBlock() {
+        pattern = new BasicPattern();
     }
 
-    public boolean isEmpty() { return pattern.isEmpty() ; }
-    
+    public ElementTriplesBlock(BasicPattern bgp) {
+        pattern = bgp;
+    }
+
+    public boolean isEmpty() { return pattern.isEmpty(); }
+
     @Override
     public void addTriple(Triple t)
-    { pattern.add(t) ; }
-    
+    { pattern.add(t); }
+
     @Override
-    public int mark() { return pattern.size() ; }
-    
+    public int mark() { return pattern.size(); }
+
     @Override
     public void addTriple(int index, Triple t)
-    { pattern.add(index, t) ; }
-    
+    { pattern.add(index, t); }
+
     @Override
     public void addTriplePath(TriplePath path)
-    { throw new ARQException("Triples-only collector") ; }
+    { throw new ARQException("Triples-only collector"); }
 
     @Override
     public void addTriplePath(int index, TriplePath path)
-    { throw new ARQException("Triples-only collector") ; }
-    
-    public BasicPattern getPattern() { return pattern ; }
+    { throw new ARQException("Triples-only collector"); }
+
+    public BasicPattern getPattern() { return pattern; }
     public Iterator<Triple> patternElts() { return pattern.iterator(); }
-    
+
     @Override
-    public int hashCode()
-    { 
-        int calcHashCode = Element.HashBasicGraphPattern ;
-        calcHashCode ^=  pattern.hashCode() ; 
-        return calcHashCode ;
+    public int hashCode() {
+        int calcHashCode = Element.HashBasicGraphPattern;
+        calcHashCode ^= pattern.hashCode();
+        return calcHashCode;
     }
 
     @Override
-    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( ! ( el2 instanceof ElementTriplesBlock) )
-            return false ;
-        ElementTriplesBlock eg2 = (ElementTriplesBlock)el2 ;
-        return this.pattern.equiv(eg2.pattern, isoMap) ; 
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( !(el2 instanceof ElementTriplesBlock) )
+            return false;
+        ElementTriplesBlock eg2 = (ElementTriplesBlock)el2;
+        return this.pattern.equiv(eg2.pattern, isoMap);
     }
 
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public void visit(ElementVisitor v) { v.visit(this); }
 
- 
+
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementUnion.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementUnion.java
@@ -18,57 +18,50 @@
 
 package org.apache.jena.sparql.syntax;
 
-import java.util.ArrayList ;
-import java.util.List ;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.apache.jena.sparql.util.NodeIsomorphismMap ;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
-public class ElementUnion extends Element
-{
-    List<Element> elements = new ArrayList<>() ;
+public class ElementUnion extends Element {
+    List<Element> elements = new ArrayList<>();
 
-    public ElementUnion()
-    { }
+    public ElementUnion() {}
 
-    public ElementUnion(Element el)
-    { 
-        //Used by the SPARQL 1.1 style UNION
-        this() ;
-        addElement(el) ;
+    public ElementUnion(Element el) {
+        this();
+        addElement(el);
     }
 
-    
-    public void addElement(Element el) { elements.add(el) ; }
-    public List<Element> getElements() { return elements ; }
-   
+    public void addElement(Element el) { elements.add(el); }
+    public List<Element> getElements() { return elements; }
+
     @Override
-    public int hashCode()
-    { 
-        int calcHashCode = Element.HashUnion ; 
-        calcHashCode ^=  getElements().hashCode() ;
-        return calcHashCode ;
+    public int hashCode() {
+        int calcHashCode = Element.HashUnion;
+        calcHashCode ^= getElements().hashCode();
+        return calcHashCode;
     }
 
     @Override
-   public boolean equalTo(Element el2, NodeIsomorphismMap isoMap)
-    {
-        if ( el2 == null ) return false ;
+    public boolean equalTo(Element el2, NodeIsomorphismMap isoMap) {
+        if ( el2 == null )
+            return false;
 
-        if ( ! ( el2 instanceof ElementUnion) )
-            return false ;
-        ElementUnion eu2 = (ElementUnion)el2 ;
+        if ( !(el2 instanceof ElementUnion) )
+            return false;
+        ElementUnion eu2 = (ElementUnion)el2;
         if ( this.getElements().size() != eu2.getElements().size() )
-            return false ;
-        for ( int i = 0 ; i < this.getElements().size() ; i++ )
-        {
-            Element e1 = getElements().get(i) ;
-            Element e2 = eu2.getElements().get(i) ;
-            if ( ! e1.equalTo(e2, isoMap) )
-                return false ;
+            return false;
+        for ( int i = 0; i < this.getElements().size(); i++ ) {
+            Element e1 = getElements().get(i);
+            Element e2 = eu2.getElements().get(i);
+            if ( !e1.equalTo(e2, isoMap) )
+                return false;
         }
-        return true ;
+        return true;
     }
- 
+
     @Override
-    public void visit(ElementVisitor v) { v.visit(this) ; }
+    public void visit(ElementVisitor v) { v.visit(this); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementVisitorBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementVisitorBase.java
@@ -24,63 +24,24 @@ package org.apache.jena.sparql.syntax;
 
 public class ElementVisitorBase implements ElementVisitor
 {
-    @Override
-    public void visit(ElementTriplesBlock el)   { }
-
-    @Override
-    public void visit(ElementFilter el)         { }
-
-    @Override
-    public void visit(ElementAssign el)         { }
-
-    @Override
-    public void visit(ElementBind el)           { }
-
-    @Override
-    public void visit(ElementUnfold el)         { }
-
-    @Override
-    public void visit(ElementData el)           { }
-
-    @Override
-    public void visit(ElementUnion el)          { }
-
-    @Override
-    public void visit(ElementDataset el)        { }
-
-    @Override
-    public void visit(ElementOptional el)       { }
-
-    @Override
-    public void visit(ElementLateral el)        { }
-
-    @Override
-    public void visit(ElementSemiJoin el)       { }
-
-    @Override
-    public void visit(ElementAntiJoin el)       { }
-
-    @Override
-    public void visit(ElementGroup el)          { }
-
-    @Override
-    public void visit(ElementNamedGraph el)     { }
-
-    @Override
-    public void visit(ElementExists el)         { }
-
-    @Override
-    public void visit(ElementNotExists el)      { }
-
-    @Override
-    public void visit(ElementMinus el)          { }
-
-    @Override
-    public void visit(ElementService el)        { }
-
-    @Override
-    public void visit(ElementSubQuery el)       { }
-
-    @Override
-    public void visit(ElementPathBlock el)      { }
+    @Override public void visit(ElementTriplesBlock el)   { }
+    @Override public void visit(ElementFilter el)         { }
+    @Override public void visit(ElementAssign el)         { }
+    @Override public void visit(ElementBind el)           { }
+    @Override public void visit(ElementUnfold el)         { }
+    @Override public void visit(ElementData el)           { }
+    @Override public void visit(ElementUnion el)          { }
+    @Override public void visit(ElementDataset el)        { }
+    @Override public void visit(ElementOptional el)       { }
+    @Override public void visit(ElementLateral el)        { }
+    @Override public void visit(ElementSemiJoin el)       { }
+    @Override public void visit(ElementAntiJoin el)       { }
+    @Override public void visit(ElementGroup el)          { }
+    @Override public void visit(ElementNamedGraph el)     { }
+    @Override public void visit(ElementExists el)         { }
+    @Override public void visit(ElementNotExists el)      { }
+    @Override public void visit(ElementMinus el)          { }
+    @Override public void visit(ElementService el)        { }
+    @Override public void visit(ElementSubQuery el)       { }
+    @Override public void visit(ElementPathBlock el)      { }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementWalker.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementWalker.java
@@ -93,9 +93,9 @@ public class ElementWalker {
         @Override
         public void visit(ElementUnfold el)
         {
-            before(el) ;
-            proc.visit(el) ;
-            after(el) ;
+            before(el);
+            proc.visit(el);
+            after(el);
         }
 
         @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/Template.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/Template.java
@@ -33,142 +33,136 @@ import org.apache.jena.sparql.util.Iso;
 import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** Quads/Triples template. */
-
-public class Template
-{
-    static final int HashTemplateGroup     = 0xB1 ;
-    private final QuadAcc qp ;
+public class Template {
+    static final int HashTemplateGroup = 0xB1;
+    private final QuadAcc qp;
     private final BasicPattern bgp;
 
-    public Template(QuadAcc qp)
-    {
-        this.qp = qp ;
+    public Template(QuadAcc qp) {
+        this.qp = qp;
         this.bgp = null;
     }
 
-    public Template(BasicPattern bgp)
-    {
-    	this.bgp = bgp;
-    	this.qp = null;
+    public Template(BasicPattern bgp) {
+        this.bgp = bgp;
+        this.qp = null;
     }
 
-    public boolean containsRealQuad(){
-    	for(Quad quad : this.getQuads()){
-    		if ( ! Quad.defaultGraphNodeGenerated.equals( quad.getGraph())){
-    			return true;
-    		}
-    	}
-    	return false;
+    public boolean containsRealQuad() {
+        for ( Quad quad : this.getQuads() ) {
+            if ( !Quad.defaultGraphNodeGenerated.equals(quad.getGraph()) ) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    public BasicPattern getBGP()
-    {
-    	if (this.bgp != null){
-    		return this.bgp;
-    	}
-    	BasicPattern bgp = new BasicPattern();
-    	for(Quad q: qp.getQuads()){
-    		if (Quad.defaultGraphNodeGenerated.equals(q.getGraph()))
-    			bgp.add(q.asTriple());
-    	}
-    	return bgp;
+    public BasicPattern getBGP() {
+        if ( this.bgp != null ) {
+            return this.bgp;
+        }
+        BasicPattern bgp = new BasicPattern();
+        for ( Quad q : qp.getQuads() ) {
+            if ( Quad.defaultGraphNodeGenerated.equals(q.getGraph()) )
+                bgp.add(q.asTriple());
+        }
+        return bgp;
     }
-    public List<Triple> getTriples()
-    {
-    	if(this.bgp != null){
-    		return this.bgp.getList();
-    	}
-    	List<Triple> triples = new ArrayList<>();
-    	for(Quad q: qp.getQuads()) {
-    		if (Quad.defaultGraphNodeGenerated.equals(q.getGraph()))
-    			triples.add(q.asTriple());
-    	}
-    	return triples;
+
+    public List<Triple> getTriples() {
+        if ( this.bgp != null ) {
+            return this.bgp.getList();
+        }
+        List<Triple> triples = new ArrayList<>();
+        for ( Quad q : qp.getQuads() ) {
+            if ( Quad.defaultGraphNodeGenerated.equals(q.getGraph()) )
+                triples.add(q.asTriple());
+        }
+        return triples;
     }
 
     public List<Quad> getQuads() {
-    	if( this.bgp != null){
-    		List<Quad> quads = new ArrayList<>();
-    		for(Triple triple: this.bgp.getList()) {
-    			quads.add( new Quad( Quad.defaultGraphNodeGenerated, triple ) );
-    		}
-    		return quads;
-    	}
-    	return qp.getQuads() ;
+        if ( this.bgp != null ) {
+            List<Quad> quads = new ArrayList<>();
+            for ( Triple triple : this.bgp.getList() ) {
+                quads.add(new Quad(Quad.defaultGraphNodeGenerated, triple));
+            }
+            return quads;
+        }
+        return qp.getQuads();
     }
 
-    public Map<Node, BasicPattern> getGraphPattern(){
+    public Map<Node, BasicPattern> getGraphPattern() {
         List<Quad> quads = getQuads();
         HashMap<Node, BasicPattern> graphs = new HashMap<>();
-        for (Quad q: quads){
+        for ( Quad q : quads ) {
             BasicPattern bgp = graphs.get(q.getGraph());
-            if (bgp == null){
+            if ( bgp == null ) {
                 bgp = new BasicPattern();
                 graphs.put(q.getGraph(), bgp);
             }
-            bgp.add( q.asTriple() );
+            bgp.add(q.asTriple());
         }
         return graphs;
     }
 
     // -------------------------
 
-    private int calcHashCode = -1 ;
+    private int calcHashCode = -1;
     @Override
-    public int hashCode()
-    {
+    public int hashCode() {
         // BNode invariant hashCode.
-        int calcHashCode = Template.HashTemplateGroup ;
+        int calcHashCode = Template.HashTemplateGroup;
         for ( Quad q : getQuads() )
-            calcHashCode ^=  hash(q) ^ calcHashCode<<1 ;
-        return calcHashCode ;
+            calcHashCode ^= hash(q) ^ calcHashCode << 1;
+        return calcHashCode;
     }
 
-    private static int hash(Quad quad)
-    {
-        int hash = 0 ;
-        hash = hashNode(quad.getSubject())   ^ hash<<1 ;
-        hash = hashNode(quad.getPredicate()) ^ hash<<1 ;
-        hash = hashNode(quad.getObject())    ^ hash<<1 ;
-        hash = hashGraph(quad.getGraph())    ^ hash<<1 ;
-        return hash ;
+    private static int hash(Quad quad) {
+        int hash = 0;
+        hash = hashNode(quad.getSubject()) ^ hash << 1;
+        hash = hashNode(quad.getPredicate()) ^ hash << 1;
+        hash = hashNode(quad.getObject()) ^ hash << 1;
+        hash = hashGraph(quad.getGraph()) ^ hash << 1;
+        return hash;
     }
 
-    private static int hashGraph(Node node){
-    	if ( node == null ) return Quad.defaultGraphNodeGenerated.hashCode() ;
-        if ( node.isBlank() ) return 59 ;
-        return node.hashCode() ;
+    private static int hashGraph(Node node) {
+        if ( node == null )
+            return Quad.defaultGraphNodeGenerated.hashCode();
+        if ( node.isBlank() )
+            return 59;
+        return node.hashCode();
     }
 
-    private static int hashNode(Node node)
-    {
-    	if ( node == null ) return 37 ;
-        if ( node.isBlank() ) return 59 ;
-        return node.hashCode() ;
+    private static int hashNode(Node node) {
+        if ( node == null )
+            return 37;
+        if ( node.isBlank() )
+            return 59;
+        return node.hashCode();
     }
 
-    public boolean equalIso(Object temp2, NodeIsomorphismMap labelMap)
-    {
+    public boolean equalIso(Object temp2, NodeIsomorphismMap labelMap) {
         if ( !(temp2 instanceof Template tg2) )
             return false;
-        List<Quad> list1 = this.getQuads() ;
-        List<Quad> list2 = tg2.getQuads() ;
-        if ( list1.size() != list2.size() ) return false ;
+        List<Quad> list1 = this.getQuads();
+        List<Quad> list2 = tg2.getQuads();
+        if ( list1.size() != list2.size() )
+            return false;
 
-        for ( int i = 0 ; i < list1.size() ; i++ )
-        {
-            Quad q1 = list1.get(i) ;
-            Quad q2 = list2.get(i) ;
-            boolean iso = Iso.quadIso(q1, q2, labelMap) ;
-            if(!iso){
-            	return false;
+        for ( int i = 0; i < list1.size(); i++ ) {
+            Quad q1 = list1.get(i);
+            Quad q2 = list2.get(i);
+            boolean iso = Iso.quadIso(q1, q2, labelMap);
+            if ( !iso ) {
+                return false;
             }
         }
-        return true ;
+        return true;
     }
 
-    public void format(FormatterTemplate fmtTemplate)
-    {
-        fmtTemplate.format(this) ;
+    public void format(FormatterTemplate fmtTemplate) {
+        fmtTemplate.format(this);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollector.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollector.java
@@ -18,13 +18,13 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.sparql.core.TriplePath ;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.TriplePath;
 
 
 public interface TripleCollector
 {
-    public void addTriple(Triple t) ;
-    
-    public void addTriplePath(TriplePath tPath) ;
+    public void addTriple(Triple t);
+
+    public void addTriplePath(TriplePath tPath);
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollectorBGP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollectorBGP.java
@@ -18,35 +18,35 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.sparql.ARQException ;
-import org.apache.jena.sparql.core.BasicPattern ;
-import org.apache.jena.sparql.core.TriplePath ;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.ARQException;
+import org.apache.jena.sparql.core.BasicPattern;
+import org.apache.jena.sparql.core.TriplePath;
 
 /** A triples-only TripleCollector. */
 
 public class TripleCollectorBGP implements TripleCollectorMark
 {
-    BasicPattern bgp = new BasicPattern() ;
-    
+    BasicPattern bgp = new BasicPattern();
+
     public TripleCollectorBGP() {}
-    
-    public BasicPattern getBGP() { return bgp ; }
-    
+
+    public BasicPattern getBGP() { return bgp; }
+
     @Override
-    public void addTriple(Triple t) { bgp.add(t) ; }
-    
+    public void addTriple(Triple t) { bgp.add(t); }
+
     @Override
-    public int mark() { return bgp.size() ; }
-    
+    public int mark() { return bgp.size(); }
+
     @Override
-    public void addTriple(int index, Triple t) { bgp.add(index, t) ; }
-    
+    public void addTriple(int index, Triple t) { bgp.add(index, t); }
+
     @Override
     public void addTriplePath(TriplePath path)
-    { throw new ARQException("Triples-only collector") ; }
+    { throw new ARQException("Triples-only collector"); }
 
     @Override
     public void addTriplePath(int index, TriplePath path)
-    { throw new ARQException("Triples-only collector") ; }
+    { throw new ARQException("Triples-only collector"); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollectorMark.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollectorMark.java
@@ -18,8 +18,8 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.sparql.core.TriplePath ;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.TriplePath;
 
 
 public interface TripleCollectorMark extends TripleCollector
@@ -27,8 +27,8 @@ public interface TripleCollectorMark extends TripleCollector
     // The contract with the mark is that there should be no disturbing
     // triples 0..(mark-1) before using a mark. That is, use marks in
     // LIFO (stack) order.
-    public int mark() ;
-    public void addTriple(int index, Triple t) ;
-    
-    public void addTriplePath(int index, TriplePath tPath) ;
+    public int mark();
+    public void addTriple(int index, Triple t);
+
+    public void addTriplePath(int index, TriplePath tPath);
 }


### PR DESCRIPTION
Reformatting the `Element*` classes for `Query` - layout, no space before `;`, remove trailing white space.

No functional changes.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
