### PR TITLE
Deprecations for removal in Jena6

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/writer/TurtleWriter.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/writer/TurtleWriter.java
@@ -39,7 +39,7 @@ public class TurtleWriter extends TurtleWriterBase {
         private void write(Graph graph) {
             writeBase(baseURI);
             writePrefixes(prefixMap);
-            if ( !prefixMap.isEmpty() && !graph.isEmpty() )
+            if ( ( baseURI != null || !prefixMap.isEmpty() ) && !graph.isEmpty() )
                 out.println();
             writeGraphTTL(graph);
         }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/SystemARQ.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/SystemARQ.java
@@ -58,8 +58,10 @@ public class SystemARQ
     public static boolean EnableRomanNumerals   = true ;
 
     /**
-     * Use a plain graph (sameValueAs is term equality)
+     * Use a plain graph (sameAs is term equality)
+     * @deprecated From jena5, all graph are term equality except where support the Model API.
      */
+    @Deprecated(forRemoval = true)
     public static boolean UsePlainGraph         = false ;
 
     /**

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphFactory.java
@@ -23,7 +23,6 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.impl.GraphPlain;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.sparql.SystemARQ;
 import org.apache.jena.sys.JenaSystem;
 
 /** Ways to make graphs and models */
@@ -48,7 +47,9 @@ public class GraphFactory {
      * with the system default is same value (Jena4).
      * <p>
      * This affects {@link #createDefaultGraph}.
+     * @deprecated Do not use.
      */
+    @Deprecated
     public static void setDftGraphSameTerm(boolean value) {
         defaultSameTerm = value;
     }
@@ -78,13 +79,11 @@ public class GraphFactory {
 
     /**
      * Create a graph - ARQ-wide default type.
-     *
-     * In Jena5, this is "same-term"
+     * <p>
+     * From Jena5, this is "same-term"
      */
     public static Graph createDefaultGraph() {
-        // Normal usage is SystemARQ.UsePlainGraph = false and use
-        // createJenaDefaultGraph
-        return SystemARQ.UsePlainGraph ? createPlainGraph() : createJenaDefaultGraph();
+        return createJenaDefaultGraph();
     }
 
     /** Create a graph - the Jena default graph for ARQ and RIOT */
@@ -92,7 +91,12 @@ public class GraphFactory {
         return GraphMemFactory.createDefaultGraph();
     }
 
-    /** Graph that uses same-term for find() and contains(). */
+    /**
+     * Graph that uses same-term for find() and contains().
+     *
+     * @deprecated From Jena5, graphs are all "same term" except for {@link org.apache.jena.mem.GraphMem}.
+     */
+    @Deprecated
     public static Graph createPlainGraph() {
         return GraphPlain.plain();
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphReadOnly.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/GraphReadOnly.java
@@ -66,4 +66,9 @@ public class GraphReadOnly extends WrappedGraph
     public PrefixMapping getPrefixMapping() {
         return new PrefixMappingReadOnly(getWrapped().getPrefixMapping());
     }
+
+    @Override
+    public String toString() {
+        return super.base.toString();
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/SyntaxVarScope.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/SyntaxVarScope.java
@@ -89,7 +89,7 @@ public class SyntaxVarScope {
     }
 
     /**
-     * @deprecated use {@link checkElement}
+     * @deprecated use {@link #checkElement}
      */
     @Deprecated(forRemoval = true)
     public static void check(Element queryPattern) { checkElement(queryPattern); }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/ModelUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/ModelUtils.java
@@ -73,6 +73,10 @@ public class ModelUtils
         return convertGraphNodeToRDFNode(node, null);
     }
 
+    /**
+     * @deprecated Use {@link Model#asStatement(Triple)}.
+     */
+   @Deprecated(forRemoval = true)
     public static Statement tripleToStatement(Model model, Triple t) {
         if ( model == null )
             throw new ARQInternalErrorException("Attempt to create statement with null model");
@@ -81,7 +85,7 @@ public class ModelUtils
         Node pNode = t.getPredicate();
         Node oNode = t.getObject();
 
-        if (!isValidAsStatement(sNode, pNode, oNode)) return null;
+        if (!NodeUtils.isValidAsRDF(sNode, pNode, oNode)) return null;
 
         return model.asStatement(t);
     }
@@ -99,11 +103,15 @@ public class ModelUtils
      *
      * @deprecated Use {@link NodeUtils#isValidAsRDF(Node, Node, Node)}.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static boolean isValidAsStatement(Node s, Node p, Node o) {
         return NodeUtils.isValidAsRDF(s, p, o);
     }
 
+    /**
+    * @deprecated Use {@link NodeUtils#isValidAsRDF(Node, Node, Node)}.
+    */
+   @Deprecated(forRemoval = true)
     public static StmtIterator triplesToStatements(final Iterator<Triple> it, final Model refModel) {
         return new StmtIteratorImpl(Iter.map(it, refModel::asStatement)) {
             // Make sure to close the incoming iterator
@@ -118,15 +126,19 @@ public class ModelUtils
         };
     }
 
+    /** @deprecated To be removed. */
+    @Deprecated(forRemoval = true)
     public static ModelCollector intersectCollector() {
         return new ModelCollector.IntersectionModelCollector();
     }
 
+    /** @deprecated To be removed. */
+    @Deprecated(forRemoval = true)
     public static ModelCollector unionCollector() {
         return new ModelCollector.UnionModelCollector();
     }
-
-    public static Iterator<Triple> statementsToTriples(final Iterator<Statement> it) {
-        return Iter.onClose(Iter.map(it, Statement::asTriple), ()->Iter.close(it));
-    }
+//
+//    public static Iterator<Triple> statementsToTriples(final Iterator<Statement> it) {
+//        return Iter.onClose(Iter.map(it, Statement::asTriple), ()->Iter.close(it));
+//    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/system/G.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/G.java
@@ -18,6 +18,13 @@
 
 package org.apache.jena.system;
 
+import static org.apache.jena.graph.Node.ANY;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.Copyable;
 import org.apache.jena.datatypes.RDFDatatype;
@@ -30,15 +37,7 @@ import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.graph.NodeConst;
 import org.apache.jena.sparql.util.graph.GNode;
 import org.apache.jena.sparql.util.graph.GraphList;
-import org.apache.jena.util.IteratorCollection;
 import org.apache.jena.util.iterator.ExtendedIterator;
-
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-
-import static org.apache.jena.graph.Node.ANY;
 
 /**
  * A library of functions for working with {@link Graph graphs}. Internally, all
@@ -975,8 +974,7 @@ public class G {
     }
 
     private static void addIteratorWorker( Graph graph, Iterator<Triple> it ) {
-        List<Triple> s = IteratorCollection.iteratorToList( it );
-        addIteratorWorkerDirect(graph, s.iterator());
+        addIteratorWorkerDirect(graph, it);
     }
 
     private static void addIteratorWorkerDirect( Graph graph, Iterator<Triple> it ) {

--- a/jena-arq/src/main/java/org/apache/jena/system/buffering/BufferingGraph.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/buffering/BufferingGraph.java
@@ -31,7 +31,6 @@ import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.graph.impl.GraphPlain;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.sparql.core.Transactional;
@@ -66,10 +65,7 @@ public class BufferingGraph extends GraphWrapper implements BufferingCtl {
     public BufferingGraph(Graph graph) {
         super(graph);
         prefixMapping = new BufferingPrefixMapping(graph.getPrefixMapping());
-        if ( graph.getCapabilities().handlesLiteralTyping())
-            addedGraph = GraphMemFactory.createDefaultGraph();
-        else
-            addedGraph = GraphPlain.plain();
+        addedGraph = GraphMemFactory.createDefaultGraph();
     }
 
     public Graph base() { return get(); }

--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/sparql/tests/QueryEvalTest.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/sparql/tests/QueryEvalTest.java
@@ -41,7 +41,6 @@ import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.shared.JenaException;
-import org.apache.jena.sparql.SystemARQ;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.ResultSetStream;
@@ -175,30 +174,23 @@ public class QueryEvalTest implements Runnable {
     }
 
     private Dataset createDataset(List<String> defaultGraphURIs, List<String> namedGraphURIs) {
-        // Allow "qt:data" to be quads in defaultGraphURIs.
-        SystemARQ.UsePlainGraph = true;
-        try {
-            Dataset ds = createEmptyDataset();
-            Txn.executeWrite(ds, ()->{
-                if ( defaultGraphURIs != null ) {
-                    for ( String sourceURI : defaultGraphURIs ) {
-                        SparqlTestLib.parser(sourceURI).parse(ds);
-                    }
+    // Allow "qt:data" to be quads in defaultGraphURIs.
+        Dataset ds = createEmptyDataset();
+        Txn.executeWrite(ds, ()->{
+            if ( defaultGraphURIs != null ) {
+                for ( String sourceURI : defaultGraphURIs ) {
+                    SparqlTestLib.parser(sourceURI).parse(ds);
                 }
-                if ( namedGraphURIs != null ) {
-                    for ( String sourceURI : namedGraphURIs ) {
-                        String absSourceURI = IRIs.resolve(sourceURI);
-                        Model m = ds.getNamedModel(absSourceURI);
-                        SparqlTestLib.parser(sourceURI).parse(m);
-                    }
+            }
+            if ( namedGraphURIs != null ) {
+                for ( String sourceURI : namedGraphURIs ) {
+                    String absSourceURI = IRIs.resolve(sourceURI);
+                    Model m = ds.getNamedModel(absSourceURI);
+                    SparqlTestLib.parser(sourceURI).parse(m);
                 }
-            });
-            return ds;
-        }
-        finally {
-            SystemARQ.UsePlainGraph = false;
-        }
-
+            }
+        });
+        return ds;
     }
 
     private void runTestSelect(Query query, QueryExecution qe) {

--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/sparql/tests/QueryTestItem.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/sparql/tests/QueryTestItem.java
@@ -142,7 +142,7 @@ public class QueryTestItem
 
         if ( ResultsFormat.isRDFGraphSyntax(format) ) {
             // Load plain.
-            Graph g = GraphFactory.createPlainGraph();
+            Graph g = GraphFactory.createDefaultGraph();
             SparqlTestLib.parser(resultFile).parse(g);
             Model m = ModelFactory.createModelForGraph(g);
             return new SPARQLResult(m) ;

--- a/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/TestRDFParser.java
@@ -287,7 +287,7 @@ public class TestRDFParser {
     private static Node p = SSE.parseNode(":p");
 
     private void testNormalization(String input, String output, RDFParserBuilder builder) {
-        Graph graph = GraphFactory.createPlainGraph();
+        Graph graph = GraphFactory.createDefaultGraph();
         String x = PREFIX + ":s :p " + input;
         builder.source(new StringReader(x)).parse(graph);
         assertEquals(1, graph.size());

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestAPI.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestAPI.java
@@ -52,7 +52,6 @@ import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.sparql.util.IsoMatcher;
-import org.apache.jena.sparql.util.ModelUtils;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Test;
@@ -394,11 +393,11 @@ public class TestAPI
 
         QueryExecution qExec = QueryExecutionFactory.create(q, d);
 
-        Iterator<Triple> ts = qExec.execConstructTriples();
+        Iterator<Triple> iterTriples = qExec.execConstructTriples();
         Model result = ModelFactory.createDefaultModel();
-        while (ts.hasNext()) {
-            Triple t = ts.next();
-            Statement stmt = ModelUtils.tripleToStatement(result, t);
+        while (iterTriples.hasNext()) {
+            Triple triple = iterTriples.next();
+            Statement stmt = result.asStatement(triple);
             if ( stmt != null )
                 result.add(stmt);
         }
@@ -413,13 +412,13 @@ public class TestAPI
 
         QueryExecution qExec = QueryExecutionFactory.create(q, d);
 
-        Iterator<Quad> ts = qExec.execConstructQuads();
+        Iterator<Quad> iterQuads = qExec.execConstructQuads();
         DatasetGraph result = DatasetGraphFactory.create();
         long count = 0;
-        while (ts.hasNext()) {
+        while (iterQuads.hasNext()) {
             count++;
-            Quad qd = ts.next();
-            result.add(qd);
+            Quad quad = iterQuads.next();
+            result.add(quad);
         }
 
         DatasetGraph expected = DatasetGraphFactory.create();
@@ -437,12 +436,12 @@ public class TestAPI
 
         QueryExecution qExec = QueryExecutionFactory.create(q, d);
 
-        Iterator<Quad> ts = qExec.execConstructQuads();
+        Iterator<Quad> iterQuads = qExec.execConstructQuads();
         DatasetGraph result = DatasetGraphFactory.create();
         long count = 0;
-        while (ts.hasNext()) {
+        while (iterQuads.hasNext()) {
             count++;
-            result.add( ts.next() );
+            result.add( iterQuads.next() );
         }
         DatasetGraph expected = DatasetGraphFactory.create();
         expected.add(Quad.defaultGraphNodeGenerated, s.asNode(), p.asNode(), o.asNode());
@@ -456,11 +455,11 @@ public class TestAPI
         String queryString = "CONSTRUCT { ?s ?p ?o GRAPH ?g1 { ?s1 ?p1 ?o1 } } WHERE { ?s ?p ?o. GRAPH ?g1 { ?s1 ?p1 ?o1 } }";
         Query q = QueryFactory.create(queryString, Syntax.syntaxARQ);
         QueryExecution qExec = QueryExecutionFactory.create(q, d);
-        Iterator<Triple> ts = qExec.execConstructTriples();
+        Iterator<Triple> iterTriples = qExec.execConstructTriples();
         Model result = ModelFactory.createDefaultModel();
-        while (ts.hasNext()) {
-            Triple t = ts.next();
-            Statement stmt = ModelUtils.tripleToStatement(result, t);
+        while (iterTriples.hasNext()) {
+            Triple triple = iterTriples.next();
+            Statement stmt = result.asStatement(triple);
             if ( stmt != null )
                 result.add(stmt);
         }
@@ -488,13 +487,13 @@ public class TestAPI
 
         QueryExecution qExec = QueryExecutionFactory.create(q, d);
 
-        Iterator<Quad> ts = qExec.execConstructQuads();
+        Iterator<Quad> iterQuads = qExec.execConstructQuads();
         long count = 0;
         Quad expected = Quad.create( g1.asNode(), s.asNode(), p.asNode(), o.asNode());
-        while (ts.hasNext()) {
+        while (iterQuads.hasNext()) {
             count++;
-            Quad qd = ts.next();
-            assertEquals(expected, qd);
+            Quad quad = iterQuads.next();
+            assertEquals(expected, quad);
         }
         assertEquals(3, count); // 3 duplicated quads
     }
@@ -521,13 +520,13 @@ public class TestAPI
 
         QueryExecution qExec = QueryExecutionFactory.create(q, d);
 
-        Iterator<Quad> ts = qExec.execConstructQuads();
+        Iterator<Quad> iterQuads = qExec.execConstructQuads();
         long count = 0;
         Quad expected = Quad.create( g1.asNode(), s.asNode(), p.asNode(), o.asNode());
-        while (ts.hasNext()) {
+        while (iterQuads.hasNext()) {
             count++;
-            Quad qd = ts.next();
-            assertEquals(expected, qd);
+            Quad quad = iterQuads.next();
+            assertEquals(expected, quad);
         }
         assertEquals(6, count); // 6 duplicated quads
     }
@@ -539,12 +538,12 @@ public class TestAPI
 
         QueryExecution qExec = QueryExecutionFactory.create(q, d);
 
-        Iterator<Quad> quads = qExec.execConstructQuads();
+        Iterator<Quad> iterQuads = qExec.execConstructQuads();
         DatasetGraph result = DatasetGraphFactory.create();
         long count = 0;
-        while (quads.hasNext()) {
+        while (iterQuads.hasNext()) {
             count++;
-            Quad qd = quads.next();
+            Quad qd = iterQuads.next();
             result.add(qd);
         }
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraph.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/AbstractTestUpdateGraph.java
@@ -360,7 +360,7 @@ public abstract class AbstractTestUpdateGraph extends AbstractTestUpdateBase
         DatasetGraph gStore = getEmptyDatasetGraph();
         script(gStore, "data-2.ru");
 
-        Graph g = GraphFactory.createPlainGraph();
+        Graph g = GraphFactory.createDefaultGraph();
         Node b = org.apache.jena.graph.NodeFactory.createBlankNode();
 
         g.add(Triple.create(s, p, b));

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
@@ -354,7 +354,7 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     /** Set the marker included at end of line - set to null for "none".  Usually used for debugging. */
     public void setEndOfLineMarker(String marker)  {  endOfLineMarker = marker; }
 
-    /** Flat mode - print without NL, for a more compact representation*/
+    /** Flat mode - print without NL, for a more compact representation */
     public boolean inFlatMode()                     { return flatMode; }
     /** Flat mode - print without NL, for a more compact representation*/
     public void setFlatMode(boolean flatMode)       { this.flatMode = flatMode; }

--- a/jena-base/src/main/java/org/apache/jena/atlas/iterator/Iter.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/iterator/Iter.java
@@ -221,24 +221,28 @@ public class Iter<T> implements IteratorCloseable<T> {
     }
 
     // ---- collect
-    /** See {@link Stream#collect(Supplier, BiConsumer, BiConsumer)}, except without the {@code BiConsumer<R, R> combiner} */
-    public static <T,R> R collect(Iterator<T> iter, Supplier<R> supplier, BiConsumer<R, ? super T> accumulator) {
-        R result = supplier.get();
-        iter.forEachRemaining(elt -> accumulator.accept(result, elt));
-        return result;
-    }
-
     /** See {@link Stream#collect(Collector)} */
     public static <T, R, A> R collect(Iterator<T> iter, Collector<? super T, A, R> collector) {
         A a = collect(iter, collector.supplier(), collector.accumulator());
         return collector.finisher().apply(a);
     }
 
+    /** See {@link Stream#collect(Supplier, BiConsumer, BiConsumer)}, except without the {@code BiConsumer<R, R> combiner} */
+    public static <T,R> R collect(Iterator<T> iter, Supplier<R> supplier, BiConsumer<R, ? super T> accumulator) {
+        R result = supplier.get();
+        apply(iter, elt -> accumulator.accept(result, elt));
+        return result;
+    }
+
     /** Act on elements of an iterator.
      * @see #map(Iterator, Function)
      */
-    public static <T> void apply(Iterator<? extends T> stream, Consumer<T> action) {
-        stream.forEachRemaining(action);
+    public static <T> void apply(Iterator<? extends T> iter, Consumer<T> action) {
+        try {
+            iter.forEachRemaining(action);
+        } finally {
+            Iter.close(iter);
+        }
     }
 
     // ---- Filter

--- a/jena-core/src/main/java/org/apache/jena/graph/GraphMemFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/GraphMemFactory.java
@@ -111,6 +111,7 @@ public class GraphMemFactory
      * used in Jena2, Jena3 and Jena4 for in-memory graphs.
      * Jena5 changed to "same term" semantics.
      * This method will continue to provide a "same value" graph.
+     * This is used for the Model API.
      */
     public static Graph createDefaultGraphSameValue() {
         @SuppressWarnings("deprecation")

--- a/jena-core/src/main/java/org/apache/jena/graph/GraphUtil.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/GraphUtil.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.impl.GraphWithPerform;
-import org.apache.jena.util.IteratorCollection;
 import org.apache.jena.util.iterator.ExtendedIterator;
 import org.apache.jena.util.iterator.WrappedIterator;
 
@@ -123,28 +122,28 @@ public class GraphUtil
     public static void add(Graph graph, Iterator<Triple> it) {
         if ( OldStyle && graph instanceof GraphWithPerform ) {
             // Materialize for the notify.
-            List<Triple> s = IteratorCollection.iteratorToList(it) ;
+            List<Triple> s = Iter.toList(it) ;
             addIteratorWorkerDirect(graph, s.iterator());
             graph.getEventManager().notifyAddIterator(graph, s) ;
         }
         else
             addIteratorWorker(graph, it);
     }
-    
+
     /** Add triples into the destination (arg 1) from the source (arg 2)*/
     public static void addInto(Graph dstGraph, Graph srcGraph ) {
         if ( dstGraph == srcGraph && ! dstGraph.getEventManager().listening() )
             return ;
         dstGraph.getPrefixMapping().setNsPrefixes(srcGraph.getPrefixMapping()) ;
-        addIteratorWorker(dstGraph, findAll( srcGraph ));  
+        addIteratorWorker(dstGraph, findAll( srcGraph ));
         dstGraph.getEventManager().notifyAddGraph( dstGraph, srcGraph );
     }
-    
-    private static void addIteratorWorker( Graph graph, Iterator<Triple> it ) { 
-        List<Triple> s = IteratorCollection.iteratorToList( it );
+
+    private static void addIteratorWorker( Graph graph, Iterator<Triple> it ) {
+        List<Triple> s = Iter.toList(it);
         addIteratorWorkerDirect(graph, s.iterator());
     }
-    
+
     private static void addIteratorWorkerDirect( Graph graph, Iterator<Triple> it ) {
         if ( OldStyle && graph instanceof GraphWithPerform ) {
             GraphWithPerform g = (GraphWithPerform)graph;
@@ -179,7 +178,7 @@ public class GraphUtil
     public static void delete(Graph graph, Iterator<Triple> it) {
         if ( OldStyle && graph instanceof GraphWithPerform ) {
             // Materialize for the notify.
-            List<Triple> s = IteratorCollection.iteratorToList(it) ;
+            List<Triple> s = Iter.toList(it); ;
             deleteIteratorWorkerDirect(graph, s.iterator());
             graph.getEventManager().notifyDeleteIterator(graph, s) ;
         } else
@@ -264,7 +263,7 @@ public class GraphUtil
      * modification" safe - it internally takes a copy of the iterator.
      */
     private static void deleteIteratorWorker(Graph graph, Iterator<Triple> it) {
-        List<Triple> s = IteratorCollection.iteratorToList(it) ;
+        List<Triple> s = Iter.toList(it) ;
         deleteIteratorWorkerDirect(graph, s.iterator());
     }
 

--- a/jena-core/src/main/java/org/apache/jena/graph/compose/CompositionBase.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/compose/CompositionBase.java
@@ -21,16 +21,13 @@
 package org.apache.jena.graph.compose;
 
 
-// Imports
-///////////////
 import java.util.*;
 import java.util.function.Predicate;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.* ;
 import org.apache.jena.graph.impl.* ;
-import org.apache.jena.util.IteratorCollection ;
 import org.apache.jena.util.iterator.* ;
-
 
 /**
  * <p>
@@ -44,39 +41,39 @@ public abstract class CompositionBase extends GraphBase
     /**
      * <p>
      * Answer a {@link Predicate} that will reject any element that is a member of iterator i.
-     * As a side-effect, i will be closed. 
+     * As a side-effect, i will be closed.
      * </p>
-     * 
+     *
      * @param i A closable iterator
      * @return A Predicate that will accept any object not a member of i.
      */
     public static <T> Predicate<T> reject( final ClosableIterator<? extends T> i )
         {
-        final Set< ? extends T> suppress = IteratorCollection.iteratorToSet( i );
+        final Set< ? extends T> suppress = Iter.toSet( i );
         return o -> !suppress.contains( o );
         }
-        
+
     /**
      * <p>
      * Answer an iterator over the elements of iterator a that are not members of iterator b.
      * As a side-effect, iterator b will be closed.
      * </p>
-     * 
+     *
      * @param a An iterator that will be filtered by rejecting the elements of b
-     * @param b A closable iterator 
+     * @param b A closable iterator
      * @return The iteration of elements in a but not in b.
      */
     public static <T> ClosableIterator<T> butNot( final ClosableIterator<T> a, final ClosableIterator<? extends T> b )
         {
         return new FilterIterator<>( reject( b ), a );
         }
-        
+
     /**
      * <p>
      * Answer an iterator that will record every element delived by <code>next()</code> in
-     * the set <code>seen</code>. 
+     * the set <code>seen</code>.
      * </p>
-     * 
+     *
      * @param i A closable iterator
      * @param seen A set that will record each element of i in turn
      * @return An iterator that records the elements of i.
@@ -88,29 +85,29 @@ public abstract class CompositionBase extends GraphBase
             @Override
             public void remove()
                 { i.remove(); }
-            
+
             @Override
             public boolean hasNext()
-                { return i.hasNext(); }    
-            
+                { return i.hasNext(); }
+
             @Override
             public T next()
-                { T x = i.next(); 
-                try { seen.add( x ); } catch (OutOfMemoryError e) { throw e; } return x; }  
-                
+                { T x = i.next();
+                try { seen.add( x ); } catch (OutOfMemoryError e) { throw e; } return x; }
+
             @Override
             public void close()
                 { i.close(); }
             };
         }
-        
+
     //static final Object absent = new Object();
-    
+
     /**
      * <p>
-     * Answer an iterator over the elements of iterator i that are not in the set <code>seen</code>. 
+     * Answer an iterator over the elements of iterator i that are not in the set <code>seen</code>.
      * </p>
-     * 
+     *
      * @param i An extended iterator
      * @param seen A set of objects
      * @return An iterator over the elements of i that are not in the set <code>seen</code>.
@@ -119,7 +116,7 @@ public abstract class CompositionBase extends GraphBase
         {
         return i.filterDrop( seen::contains );
         }
-        
+
     /**
          Answer an iterator over the elements of <code>i</code> that are not in
          the graph <code>seen</code>.
@@ -128,34 +125,34 @@ public abstract class CompositionBase extends GraphBase
         {
         return i.filterDrop( seen::contains );
         }
-  
+
     /**
      * <p>
-     * Answer a {@link Predicate} that will accept any object that is an element of 
-     * iterator i.  As a side-effect, i will be evaluated and closed. 
+     * Answer a {@link Predicate} that will accept any object that is an element of
+     * iterator i.  As a side-effect, i will be evaluated and closed.
      * </p>
-     * 
-     * @param i A closable iterator 
+     *
+     * @param i A closable iterator
      * @return A Predicate that will accept any object in iterator i.
      */
     public static <T> Predicate<T> ifIn( final ClosableIterator<T> i )
         {
-        final Set<T> allow = IteratorCollection.iteratorToSet( i );
+        final Set<T> allow = Iter.toSet( i );
         return allow::contains;
         }
-        
+
     /**
      * <p>
-     * Answer a {@link Predicate} that will accept any triple that is an edge of 
-     * graph g. 
+     * Answer a {@link Predicate} that will accept any triple that is an edge of
+     * graph g.
      * </p>
-     * 
-     * @param g A graph 
+     *
+     * @param g A graph
      * @return A Predicate that will accept any triple that is an edge in g.
      */
     public static Predicate<Triple> ifIn( final Graph g )
         {
         return g::contains;
         }
-        
+
 }

--- a/jena-core/src/main/java/org/apache/jena/graph/compose/Delta.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/compose/Delta.java
@@ -37,6 +37,7 @@ public class Delta extends CompositionBase implements Graph {
     private Graph additions;
     private Graph deletions;
 
+    @SuppressWarnings("deprecation")
     public Delta(Graph base) {
         super();
         this.base = GraphPlain.plain(base);

--- a/jena-core/src/main/java/org/apache/jena/graph/impl/GraphPlain.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/impl/GraphPlain.java
@@ -35,24 +35,31 @@ import org.apache.jena.util.iterator.ExtendedIterator ;
  */
 public class GraphPlain extends WrappedGraph
 {
-    /** Return a graph that only has term-equality
+    /**
+     * Return a graph that only has term-equality
      * and storage in the {@code base} graph.
      * Update affects the base graph.
+     * @deprecated From Jena5, graphs are all "same term".
      */
+    @Deprecated
     public static Graph plain(Graph base) {
         if ( ! base.getCapabilities().handlesLiteralTyping() )
             return base;
         return new GraphPlain(base);
     }
 
-    /** Return a graph that only has term-equality. */
+    /**
+     * Return a graph that only has term-equality.
+     * @deprecated From Jena5, graphs are all "same term".
+     */
+    @Deprecated
     public static Graph plain() {
         return plain(GraphMemFactory.createDefaultGraph());
     }
 
     private final Capabilities capabilities;
 
-    protected GraphPlain(Graph other) {
+    private GraphPlain(Graph other) {
         super(other);
         capabilities = new WrappedCapabilities(base.getCapabilities()) {
             @Override public boolean handlesLiteralTyping() { return false; }
@@ -121,7 +128,7 @@ public class GraphPlain extends WrappedGraph
     }
 
     /**
-     * Match a ground triple (even ANY and variablesare considered ground terms in the
+     * Match a ground triple (even ANY and variables are considered ground terms in the
      * data triple) with S/P/O which can be wildcards (ANY or null).
      */
     private static boolean sameTermMatch(Node matchSubj, Node matchPred, Node matchObj, Triple dataTriple) {

--- a/jena-core/src/main/java/org/apache/jena/graph/impl/SimpleEventManager.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/impl/SimpleEventManager.java
@@ -18,12 +18,16 @@
 
 package org.apache.jena.graph.impl;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.apache.jena.graph.*;
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.GraphEventManager;
+import org.apache.jena.graph.GraphListener;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.mem.TrackingTripleIterator;
-import org.apache.jena.util.IteratorCollection;
 import org.apache.jena.util.iterator.ExtendedIterator;
 
 /**
@@ -104,7 +108,7 @@ public class SimpleEventManager implements GraphEventManager
 
     @Override
     public void notifyAddIterator(Graph g, Iterator<Triple> it) {
-        notifyAddIterator(g, IteratorCollection.iteratorToList(it));
+        notifyAddIterator(g, Iter.toList(it));
     }
 
     @Override
@@ -139,7 +143,7 @@ public class SimpleEventManager implements GraphEventManager
 
     @Override
     public void notifyDeleteIterator(Graph g, Iterator<Triple> it) {
-        notifyDeleteIterator(g, IteratorCollection.iteratorToList(it));
+        notifyDeleteIterator(g, Iter.toList(it));
     }
 
     @Override

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
@@ -54,41 +54,6 @@ public class ModelFactory extends ModelFactoryBase
         {}
 
     /**
-        Answer a Model constructed from the single resource in
-        <code>singleRoot</code> of type <code>ja:Model</code>.
-        See the Assembler howto (doc/assembler/assembler-howto.html)
-        for documentation of Assembler descriptions. See also
-        <code>findAssemblerRoots</code> to find the set of possible
-        roots in a description, and <code>assemblerModelFrom(Resource)</code>
-        for assembling a model from its single description.
-    */
-    public static Model assembleModelFrom(Model singleRoot) {
-        return assembleModelFrom(AssemblerHelp.singleModelRoot(singleRoot));
-    }
-
-    /**
-        Answer a Set of resources present in <code>m</code> that are
-        explicitly or implicitly of type ja:Object, ie, suitable as roots for
-        <code>assemblerModelFrom</code>. Note that the resource
-        objects returned need <i>not</i> have <code>m</code> as
-        their <code>getModel()</code> - they may be members of an
-        extended constructed model.
-    */
-    public static Set<Resource> findAssemblerRoots(Model m) {
-        return AssemblerHelp.findAssemblerRoots(m);
-    }
-
-    /**
-        Answer a Model as described the Assembler specification rooted
-        at the Resource <code>root</code> in its Model. <code>Resource</code>
-        must be of rdf:type <code>ja:Object</code>, where <code>ja</code>
-        is the prefix of Jena Assembler objects.
-    */
-    public static Model assembleModelFrom(Resource root) {
-        return Assembler.general().openModel(root);
-    }
-
-    /**
      * Answer a fresh Model for use with the Model API.
      * <p>
      * This model is "same value" for Model API compatibility.
@@ -222,6 +187,41 @@ public class ModelFactory extends ModelFactoryBase
      */
     public static OntModel createOntologyModel() {
         return createOntologyModel( ProfileRegistry.OWL_LANG );
+    }
+
+    /**
+        Answer a Model constructed from the single resource in
+        <code>singleRoot</code> of type <code>ja:Model</code>.
+        See the Assembler howto (doc/assembler/assembler-howto.html)
+        for documentation of Assembler descriptions. See also
+        <code>findAssemblerRoots</code> to find the set of possible
+        roots in a description, and <code>assemblerModelFrom(Resource)</code>
+        for assembling a model from its single description.
+    */
+    public static Model assembleModelFrom(Model singleRoot) {
+        return assembleModelFrom(AssemblerHelp.singleModelRoot(singleRoot));
+    }
+
+    /**
+        Answer a Set of resources present in <code>m</code> that are
+        explicitly or implicitly of type ja:Object, i.e., suitable as roots for
+        <code>assemblerModelFrom</code>. Note that the resource
+        objects returned need <i>not</i> have <code>m</code> as
+        their <code>getModel()</code> - they may be members of an
+        extended constructed model.
+    */
+    public static Set<Resource> findAssemblerRoots(Model m) {
+        return AssemblerHelp.findAssemblerRoots(m);
+    }
+
+    /**
+        Answer a Model as described the Assembler specification rooted
+        at the Resource <code>root</code> in its Model. <code>Resource</code>
+        must be of rdf:type <code>ja:Object</code>, where <code>ja</code>
+        is the prefix of Jena Assembler objects.
+    */
+    public static Model assembleModelFrom(Resource root) {
+        return Assembler.general().openModel(root);
     }
 
     /**

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmloutput/impl/SplitRDFXML.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmloutput/impl/SplitRDFXML.java
@@ -31,7 +31,7 @@ import org.apache.jena.util.SplitIRI;
  */
 class SplitRDFXML {
 
-    @SuppressWarnings("removal")
+    @SuppressWarnings("deprecation")
     static int splitXML10(String uri) {
         return SplitIRI.splitXML10(uri);
     }

--- a/jena-core/src/main/java/org/apache/jena/util/IteratorCollection.java
+++ b/jena-core/src/main/java/org/apache/jena/util/IteratorCollection.java
@@ -23,11 +23,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.util.iterator.NiceIterator ;
 
 
 /**
+ * @deprecated Use {@link Iter#toList(Iterator)} and {@link Iter#toSet(Iterator)}
  */
+@Deprecated(forRemoval = true)
 public class IteratorCollection
     {
     /**
@@ -35,7 +38,7 @@ public class IteratorCollection
     */
     private IteratorCollection()
         {}
-    
+
     /**
         Answer the elements of the given iterator as a set. The iterator is consumed
         by the operation. Even if an exception is thrown, the iterator will be closed.

--- a/jena-core/src/main/java/org/apache/jena/util/ModelCollector.java
+++ b/jena-core/src/main/java/org/apache/jena/util/ModelCollector.java
@@ -26,13 +26,17 @@ import org.apache.jena.atlas.lib.IdentityFinishCollector.UnorderedIdentityFinish
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 
+/**
+ * @deprecated To be removed.
+ */
+@Deprecated(forRemoval = true)
 public abstract class ModelCollector implements UnorderedIdentityFinishCollector<Model, Model> {
 
     @Override
     public Supplier<Model> supplier() {
         return ModelFactory::createDefaultModel;
     }
-    
+
     public ConcurrentModelCollector concurrent() {
         return new ConcurrentModelCollector(this);
     }

--- a/jena-core/src/main/java/org/apache/jena/util/MonitorGraph.java
+++ b/jena-core/src/main/java/org/apache/jena/util/MonitorGraph.java
@@ -25,15 +25,18 @@ import org.apache.jena.graph.impl.* ;
 
 /**
  * Graph wrapper which provides normal access to an underlying graph but
- * also maintains a snapshot of the triples it was last known to contain. 
+ * also maintains a snapshot of the triples it was last known to contain.
  * A snapshot action
  * causes the set of changes between this and the previous snapshot to
- * be calculated and the cache updated. The snapshot process will also 
+ * be calculated and the cache updated. The snapshot process will also
  * fire change notification.
+ *
+ * @deprecated Do not use - to be removed.
  */
+@Deprecated(forRemoval = true)
 
 public class MonitorGraph extends WrappedGraph {
-    
+
     /** The last known snapshot, a set of triples */
     protected Set<Triple> snapshot = new HashSet<>();
 
@@ -41,7 +44,7 @@ public class MonitorGraph extends WrappedGraph {
     public MonitorGraph(Graph g) {
         super(g);
     }
-    
+
     /**
      * Compute the differences between the current monitored graph and the last
      * snapshot. The changes will also be forwarded to any listeners.
@@ -53,11 +56,11 @@ public class MonitorGraph extends WrappedGraph {
         boolean listening = getEventManager().listening();
         boolean wantAdditions = listening || additions != null;
         boolean wantDeletions = listening || deletions != null;
-        
+
         List<Triple> additionsTemp = (additions != null) ? additions : new ArrayList<>();
         List<Triple> deletionsTemp = (deletions != null) ? deletions : new ArrayList<>();
         Set<Triple>  deletionsTempSet = (wantDeletions) ? new HashSet<>() : null;
-        
+
         if (wantAdditions || wantDeletions) {
             if (wantDeletions) {
                 deletionsTempSet.addAll(snapshot);
@@ -77,12 +80,12 @@ public class MonitorGraph extends WrappedGraph {
             // for the method signature for compatibility with listeners
             deletionsTemp.addAll(deletionsTempSet);
         }
-        
+
         if (listening) {
             getEventManager().notifyAddList(this, additionsTemp);
             getEventManager().notifyDeleteList(this, deletionsTemp);
         }
-        
+
         // Update shapshot
         // In somecases applying the already computed changes may be cheaper, could optmize
         // this based on relative sizes if it becomes an issue.
@@ -92,5 +95,5 @@ public class MonitorGraph extends WrappedGraph {
         }
 
     }
-    
+
 }

--- a/jena-core/src/main/java/org/apache/jena/util/MonitorModel.java
+++ b/jena-core/src/main/java/org/apache/jena/util/MonitorModel.java
@@ -31,8 +31,10 @@ import org.apache.jena.rdf.model.impl.ModelCom ;
  * causes the set of changes between this and the previous snapshot to
  * be calculated and the cache updated. The snapshot process will also
  * fire change notification.
+ *
+ * @deprecated Do not use - to be removed.
  */
-
+@Deprecated(forRemoval = true)
 public class MonitorModel extends ModelCom {
 
     /**

--- a/jena-core/src/main/java/org/apache/jena/util/SplitIRI.java
+++ b/jena-core/src/main/java/org/apache/jena/util/SplitIRI.java
@@ -67,7 +67,8 @@ public class SplitIRI
         return string.substring(0, i);
     }
 
-    /** Calculate a localname - do not escape PN_LOCAL_ESC.
+    /**
+     * Calculate a localname - do not escape PN_LOCAL_ESC.
      * This is not guaranteed to be legal Turtle.
      * Use with {@link #namespace}
      * Return an empty string if there is no split point.
@@ -177,7 +178,8 @@ public class SplitIRI
 */
     // @formatter:on
 
-    /** Find the URI split point, return the index into the string that is the
+    /**
+     * Find the URI split point, return the index into the string that is the
      *  first character of a legal Turtle local name.
      * <p>
      * This is a pragmatic choice, not just finding the maximal point.
@@ -236,7 +238,7 @@ public class SplitIRI
 
         int splitPoint = -1;
         // Work backwards, checking for
-        // ((PN_CHARS | '.' | ':' | PLX)*
+        // (PN_CHARS | '.' | ':' | PLX)*
         for ( int i = uri.length()-1; i > limit; i-- ) {
             char ch = uri.charAt(i);
             if ( /*RiotChars.*/isPNChars_U_N(ch) || /*RiotChars.*/isPN_LOCAL_ESC(ch) || ch == ':' || ch == '-' || ch == '.' )
@@ -282,7 +284,7 @@ public class SplitIRI
      * splitXML with local stricter XML 1.0 rules (only single Java characters)
      * @deprecated Retained as a record of previous split handling.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public static int splitXML10(String string) { return splitNamespaceXML10(string); }
 
     /**

--- a/jena-core/src/test/java/org/apache/jena/graph/GraphContractTest.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/GraphContractTest.java
@@ -30,6 +30,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.junit.After;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.impl.LiteralLabelFactory;
 import org.apache.jena.mem.TrackingTripleIterator;
 import org.apache.jena.rdf.model.Model;
@@ -42,7 +45,6 @@ import org.apache.jena.testing_framework.AbstractGraphProducer;
 import org.apache.jena.testing_framework.NodeCreateUtils;
 import org.apache.jena.util.iterator.ClosableIterator;
 import org.apache.jena.util.iterator.ExtendedIterator;
-import org.junit.After;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xenei.junit.contract.Contract;
@@ -822,7 +824,7 @@ public class GraphContractTest<T extends Graph>
 							"Should have found 4 elements, does %s really implement literal typing",
 							g.getClass()),
 					4,
-					iteratorToSet(
+					Iter.toSet(
 							g.find(Node.ANY, P, NodeCreateUtils.create("42")))
 									.size());
 			txnRollback(g);
@@ -960,7 +962,7 @@ public class GraphContractTest<T extends Graph>
 					String.format(
 							"Should have found 4 elements, does %s really implement literal typing",
 							g.getClass()),
-					4, iteratorToSet(g.find(Triple.create(Node.ANY, P,
+					4, Iter.toSet(g.find(Triple.create(Node.ANY, P,
 							NodeCreateUtils.create("42")))).size());
 			txnRollback(g);
 		}

--- a/jena-core/src/test/java/org/apache/jena/graph/RecordingGraphListener.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/RecordingGraphListener.java
@@ -21,8 +21,8 @@ package org.apache.jena.graph;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.testing_framework.AbstractRecordingListener;
-import org.apache.jena.testing_framework.GraphHelper;
 
 /**
  * This testing listener records the event names and data, and provides a method
@@ -48,7 +48,7 @@ public class RecordingGraphListener extends AbstractRecordingListener implements
 
 	@Override
 	public void notifyAddIterator(Graph g, Iterator<Triple> it) {
-		record("addIterator", g, GraphHelper.iteratorToList(it));
+		record("addIterator", g, Iter.toList(it));
 	}
 
 	@Override
@@ -73,7 +73,7 @@ public class RecordingGraphListener extends AbstractRecordingListener implements
 
 	@Override
 	public void notifyDeleteIterator(Graph g, Iterator<Triple> it) {
-		record("deleteIterator", g, GraphHelper.iteratorToList(it));
+		record("deleteIterator", g, Iter.toList(it));
 	}
 
 	@Override

--- a/jena-core/src/test/java/org/apache/jena/graph/impl/TripleStoreContractTest.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/impl/TripleStoreContractTest.java
@@ -18,14 +18,18 @@
 
 package org.apache.jena.graph.impl;
 
+import static org.apache.jena.testing_framework.GraphHelper.nodeSet;
+import static org.apache.jena.testing_framework.GraphHelper.triple;
+import static org.apache.jena.testing_framework.GraphHelper.tripleSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
 import org.junit.After;
 import org.junit.Before;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.xenei.junit.contract.Contract;
 import org.xenei.junit.contract.ContractTest;
-
-import static org.junit.Assert.*;
-
-import static org.apache.jena.testing_framework.GraphHelper.*;
 import org.xenei.junit.contract.IProducer;
 
 /**
@@ -36,7 +40,7 @@ import org.xenei.junit.contract.IProducer;
 public class TripleStoreContractTest<T extends TripleStore> {
 
 	protected TripleStore store;
-	
+
 	private IProducer<T> producer;
 
 	public TripleStoreContractTest() {
@@ -71,23 +75,23 @@ public class TripleStoreContractTest<T extends TripleStore> {
 		assertEquals(false, store.isEmpty());
 		assertEquals(1, store.size());
 		assertEquals(true, store.contains(triple("x P y")));
-		assertEquals(nodeSet("x"), iteratorToSet(store.listSubjects()));
-		assertEquals(nodeSet("y"), iteratorToSet(store.listObjects()));
+		assertEquals(nodeSet("x"), Iter.toSet(store.listSubjects()));
+		assertEquals(nodeSet("y"), Iter.toSet(store.listObjects()));
 		assertEquals(tripleSet("x P y"),
-				iteratorToSet(store.find(triple("?? ?? ??"))));
+				Iter.toSet(store.find(triple("?? ?? ??"))));
 	}
 
 	@ContractTest
 	public void testListSubjects() {
 		someStatements(store);
-		assertEquals(nodeSet("a x _z r q"), iteratorToSet(store.listSubjects()));
+		assertEquals(nodeSet("a x _z r q"), Iter.toSet(store.listSubjects()));
 	}
 
 	@ContractTest
 	public void testListObjects() {
 		someStatements(store);
 		assertEquals(nodeSet("b y i _j _t 17"),
-				iteratorToSet(store.listObjects()));
+				Iter.toSet(store.listObjects()));
 	}
 
 	@ContractTest
@@ -111,17 +115,17 @@ public class TripleStoreContractTest<T extends TripleStore> {
 	public void testFind() {
 		someStatements(store);
 		assertEquals(tripleSet(""),
-				iteratorToSet(store.find(triple("no such thing"))));
+				Iter.toSet(store.find(triple("no such thing"))));
 		assertEquals(tripleSet("a P b; a P i"),
-				iteratorToSet(store.find(triple("a P ??"))));
+				Iter.toSet(store.find(triple("a P ??"))));
 		assertEquals(tripleSet("a P b; x P y; a P i"),
-				iteratorToSet(store.find(triple("?? P ??"))));
+				Iter.toSet(store.find(triple("?? P ??"))));
 		assertEquals(tripleSet("x P y; x R y"),
-				iteratorToSet(store.find(triple("x ?? y"))));
+				Iter.toSet(store.find(triple("x ?? y"))));
 		assertEquals(tripleSet("_z Q _j"),
-				iteratorToSet(store.find(triple("?? ?? _j"))));
+				Iter.toSet(store.find(triple("?? ?? _j"))));
 		assertEquals(tripleSet("q R 17"),
-				iteratorToSet(store.find(triple("?? ?? 17"))));
+				Iter.toSet(store.find(triple("?? ?? 17"))));
 	}
 
 	@ContractTest
@@ -131,10 +135,10 @@ public class TripleStoreContractTest<T extends TripleStore> {
 		store.add(triple("king before queen"));
 		store.delete(triple("ace before king"));
 		assertEquals(tripleSet("king before queen; nothing before ace"),
-				iteratorToSet(store.find(triple("?? ?? ??"))));
+				Iter.toSet(store.find(triple("?? ?? ??"))));
 		store.delete(triple("king before queen"));
 		assertEquals(tripleSet("nothing before ace"),
-				iteratorToSet(store.find(triple("?? ?? ??"))));
+				Iter.toSet(store.find(triple("?? ?? ??"))));
 	}
 
 	protected void someStatements(TripleStore ts) {

--- a/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestGraphMaker.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestGraphMaker.java
@@ -20,6 +20,7 @@ package org.apache.jena.graph.test;
 
 import java.util.Set;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.Triple ;
@@ -43,15 +44,15 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
     {
     public AbstractTestGraphMaker( String name )
         { super( name ); }
-            
+
     public abstract GraphMaker getGraphMaker();
-    
+
     private GraphMaker gf;
-    
+
     @Override
     public void setUp()
         { gf = getGraphMaker(); }
-        
+
     @Override
     public void tearDown()
         { gf.close(); }
@@ -67,22 +68,22 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         assertSame( g1, gf.getGraph() );
         g1.close();
         }
-        
+
     public void testCreateGraph()
         {
-        assertDiffer( "each created graph must differ", gf.createGraph(), gf.createGraph() );    
+        assertDiffer( "each created graph must differ", gf.createGraph(), gf.createGraph() );
         }
-    
+
     public void testAnyName()
         {
         gf.createGraph( "plain" ).close();
         gf.createGraph( "with.dot" ).close();
         gf.createGraph( "http://electric-hedgehog.net/topic#marker" ).close();
         }
-        
+
     /**
-        Test that we can't create a graph with the same name twice. 
-    */    
+        Test that we can't create a graph with the same name twice.
+    */
     public void testCannotCreateTwice()
         {
         String name = jName( "bonsai" );
@@ -95,10 +96,10 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         catch (AlreadyExistsException e)
             {}
         }
-        
+
     private String jName( String name )
         { return "jena-test-AbstractTestGraphMaker-" + name; }
-        
+
     public void testCanCreateTwice()
         {
         String name = jName( "bridge" );
@@ -108,17 +109,17 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         Graph g3 = gf.createGraph( name );
         assertTrue( "graphs should be the same", sameGraph( g1, g3 ) );
         }
-    
+
     /**
         Test that we cannot open a graph that does not exist.
-    */    
+    */
     public void testCannotOpenUncreated()
         {
         String name = jName( "noSuchGraph" );
         try { gf.openGraph( name, true );  fail( name + " should not exist" ); }
-        catch (DoesNotExistException e) { }  
+        catch (DoesNotExistException e) { }
         }
-        
+
     /**
         Test that we *can* open a graph that hasn't been created
     */
@@ -129,20 +130,20 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         g1.close();
         gf.openGraph( name, true );
         }
-    
+
     /**
         Utility - test that a graph with the given name exists.
-     */    
+     */
     private void testExists( String name )
         { assertTrue( name + " should exist", gf.hasGraph( name ) ); }
-     
-        
+
+
     /**
         Utility - test that no graph with the given name exists.
      */
     private void testDoesNotExist( String name )
         {  assertFalse( name + " should exist", gf.hasGraph( name ) ); }
-            
+
     /**
         Test that we can find a graph once its been created. We need to know
         if two graphs are "the same" here: we have a temporary
@@ -159,7 +160,7 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         assertTrue( "should find alpha", sameGraph( g1, g2 ) );
         assertTrue( "should find beta", sameGraph( h1, h2 ) );
         }
-        
+
     /**
         Weak test for "same graph": adding this to one is visible in t'other.
         Stopgap for use in testCanFindCreatedGraph.
@@ -172,7 +173,7 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         g2.add( Triple.create( O, P, S ) );
         return g2.contains( S, P, O ) && g1.contains( O, P, S );
         }
-        
+
     /**
         Test that we can remove a graph from the factory without disturbing
         another graph's binding.
@@ -188,7 +189,7 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         testExists( beta );
         testDoesNotExist( alpha );
         }
-        
+
     public void testHasnt()
         {
         assertFalse( "no such graph", gf.hasGraph( "john" ) );
@@ -199,18 +200,18 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         assertTrue( "john now exists", gf.hasGraph( "john" ) );
         assertFalse( "no such graph", gf.hasGraph( "paul" ) );
         assertFalse( "no such graph", gf.hasGraph( "george" ) );
-    /* */    
+    /* */
         gf.createGraph( "paul", true );
         assertTrue( "john still exists", gf.hasGraph( "john" ) );
         assertTrue( "paul now exists", gf.hasGraph( "paul" ) );
         assertFalse( "no such graph", gf.hasGraph( "george" ) );
-    /* */    
+    /* */
         gf.removeGraph( "john" );
         assertFalse( "john has been removed", gf.hasGraph( "john" ) );
         assertTrue( "paul still exists", gf.hasGraph( "paul" ) );
         assertFalse( "no such graph", gf.hasGraph( "george" ) );
         }
-        
+
     public void testCarefulClose()
         {
         Graph x = gf.createGraph( "x" );
@@ -220,34 +221,34 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         y.add( triple( "p RR q" ) );
         y.close();
         }
-        
+
     /**
         Test that a maker with no graphs lists no names.
     */
     public void testListNoGraphs()
-        { 
+        {
         Set<String> s = gf.listGraphs().toSet();
         if (s.size() > 0)
             fail( "found names from 'empty' graph maker: " + s );
         }
-    
+
     /**
         Test that a maker with three graphs inserted lists those three grapsh; we don't
         mind what order they appear in. We also use funny names to ensure that the spelling
-        that goes in is the one that comes out [should really be in a separate test]. 
-    */    
+        that goes in is the one that comes out [should really be in a separate test].
+    */
     public void testListThreeGraphs()
         { String x = "x", y = "y/sub", z = "z:boo";
         Graph X = gf.createGraph( x );
         Graph Y = gf.createGraph( y );
         Graph Z = gf.createGraph( z );
         Set<String> wanted = setOfStrings( x + " " + y + " " + z );
-        assertEquals( wanted, iteratorToSet( gf.listGraphs() ) ); 
+        assertEquals( wanted, Iter.toSet( gf.listGraphs() ) );
         X.close(); Y.close(); Z.close(); }
-        
+
     /**
         Test that a maker with some things put in and then some removed gets the right
-        things listed. 
+        things listed.
     */
     public void testListAfterDelete()
         { String x = "x_y", y = "y//zub", z = "a:b/c";
@@ -255,9 +256,9 @@ public abstract class AbstractTestGraphMaker extends GraphTestBase
         Graph Y = gf.createGraph( y );
         Graph Z = gf.createGraph( z );
         gf.removeGraph( x );
-        Set<String> s = iteratorToSet( gf.listGraphs() );
+        Set<String> s = Iter.toSet( gf.listGraphs() );
         assertEquals( setOfStrings( y + " " + z ), s );
         X.close(); Y.close(); Z.close();
         }
-        
+
     }

--- a/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestReifier.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestReifier.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.graph.test;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.* ;
 import org.apache.jena.rdf.model.impl.ReifierStd ;
 import org.apache.jena.shared.AlreadyReifiedException ;
@@ -25,7 +26,7 @@ import org.apache.jena.shared.CannotReifyException ;
 import org.apache.jena.vocabulary.RDF ;
 
 /**
-    Abstract base class for reification tests. 
+    Abstract base class for reification tests.
  */
 public abstract class AbstractTestReifier extends GraphTestBase
 {
@@ -65,12 +66,12 @@ public abstract class AbstractTestReifier extends GraphTestBase
         g.add( NodeCreateUtils.createTriple( "x rdf:subject s" ) );
         assertEquals( 1, g.size() );
         g.add( NodeCreateUtils.createTriple( "x rdf:predicate p" ) );
-        assertEquals( 2, g.size() );  
+        assertEquals( 2, g.size() );
         g.add( NodeCreateUtils.createTriple( "x rdf:object o" ) );
-        assertEquals( 3, g.size() );            
+        assertEquals( 3, g.size() );
         g.add( NodeCreateUtils.createTriple( "x rdf:type rdf:Statement" ) );
         assertEquals( 4, g.size() );
-        assertTrue( ReifierStd.hasTriple(g, triple( "s p o" ) ) );                      
+        assertTrue( ReifierStd.hasTriple(g, triple( "s p o" ) ) );
     }
 
     /**
@@ -95,19 +96,19 @@ public abstract class AbstractTestReifier extends GraphTestBase
         Graph g = getGraph();
         graphAdd( g, "x rdf:subject A; x rdf:predicate P; x rdf:object O; x rdf:type rdf:Statement" );
         assertEquals( triple( "A P O" ), ReifierStd.getTriple(g, node( "x" ) ) );
-        graphAdd( g, "x rdf:subject BOOM" ); 
+        graphAdd( g, "x rdf:subject BOOM" );
         assertEquals( null, ReifierStd.getTriple( g, node( "x" ) ) );
     }
 
     public void testReificationSubjectClash()
     {
         testReificationClash( "x rdf:subject SS" );
-    }    
+    }
 
     public void testReificationPredicateClash()
     {
         testReificationClash( "x rdf:predicate PP" );
-    }    
+    }
 
     public void testReificationObjectClash()
     {
@@ -131,7 +132,7 @@ public abstract class AbstractTestReifier extends GraphTestBase
      */
     public void testManifestQuads()
     {
-        Graph g = getGraph();   
+        Graph g = getGraph();
         ReifierStd.reifyAs(g, node( "A" ), triple( "S P O" ) ) ;
         String reified = "A rdf:type rdf:Statement; A rdf:subject S; A rdf:predicate P; A rdf:object O";
         assertIsomorphic( graphWith( reified ), g );
@@ -141,7 +142,7 @@ public abstract class AbstractTestReifier extends GraphTestBase
     {
         Graph g = getGraph();
         ReifierStd.reifyAs( g, node( "A" ), triple( "S P O" ) );
-        assertTrue( ReifierStd.findEither( g , ALL, false ).hasNext() );    
+        assertTrue( ReifierStd.findEither( g , ALL, false ).hasNext() );
     }
 
     public void testRetrieveTriplesByNode()
@@ -167,7 +168,7 @@ public abstract class AbstractTestReifier extends GraphTestBase
         ReifierStd.reifyAs( G, N, T );
         assertTrue( "R must have T", ReifierStd.hasTriple( G, T ) );
         assertFalse( "R must not have T2", ReifierStd.hasTriple( G, T2 ) );
-    }   
+    }
 
     public void testReifyAs()
     {
@@ -183,7 +184,7 @@ public abstract class AbstractTestReifier extends GraphTestBase
         ReifierStd.reifyAs( G, node("x"), triple( "cows eat grass" ) );
         ReifierStd.reifyAs( G, node("y"), triple( "pigs can fly" ) );
         ReifierStd.reifyAs( G, node("z"), triple( "dogs may bark" ) );
-        assertEquals( "", nodeSet( "z y x" ), iteratorToSet( ReifierStd.allNodes(G) ) );
+        assertEquals( "", nodeSet( "z y x" ), Iter.toSet( ReifierStd.allNodes(G) ) );
     }
 
     public void testRemoveByNode()
@@ -210,7 +211,7 @@ public abstract class AbstractTestReifier extends GraphTestBase
         ReifierStd.reifyAs( G, X, triple( "x R y" ) );
         ReifierStd.reifyAs( G, X, triple( "x R y" ) );
         try { ReifierStd.reifyAs( G, X, triple( "x R z" ) ); fail( "did not detect already reified node" ); }
-        catch (AlreadyReifiedException e) { }      
+        catch (AlreadyReifiedException e) { }
     }
 
     public void testKevinCaseA()
@@ -218,7 +219,7 @@ public abstract class AbstractTestReifier extends GraphTestBase
         Graph G = getGraph();
         Node X = node( "x" ), a = node( "a" ), b = node( "b" ), c = node( "c" );
         G.add( Triple.create( X, RDF.Nodes.type, RDF.Nodes.Statement ) );
-        ReifierStd.reifyAs( G, X, Triple.create( a, b, c ) ); 
+        ReifierStd.reifyAs( G, X, Triple.create( a, b, c ) );
     }
 
     public void testKevinCaseB()
@@ -279,7 +280,7 @@ public abstract class AbstractTestReifier extends GraphTestBase
     { testReifierFind( "x rdf:predicate P; x rdf:subject S; x rdf:object O; x rdf:type rdf:Statement" ); }
 
     public void testReifierFindFilter()
-    { 
+    {
         Graph g = getGraph();
         graphAdd( g, "s rdf:subject S" );
         assertEquals( tripleSet( "" ), ReifierStd.findExposed( g, triple( "s otherPredicate S" ) ).toSet() );

--- a/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestTripleStore.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/AbstractTestTripleStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.graph.test;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.impl.TripleStore ;
 
 /**
@@ -27,46 +28,46 @@ public abstract class AbstractTestTripleStore extends GraphTestBase
     {
     public AbstractTestTripleStore( String name )
         { super( name ); }
-    
+
     /**
-         Subclasses must over-ride to return a new empty TripleStore. 
+         Subclasses must over-ride to return a new empty TripleStore.
     */
     public abstract TripleStore getTripleStore();
-    
+
     protected TripleStore store;
-    
+
     @Override
     public void setUp()
         {
         store = getTripleStore();
         }
-    
+
     public void testEmpty()
         { testEmpty( store ); }
-    
+
     public void testAddOne()
         {
         store.add( triple( "x P y" ) );
         assertEquals( false, store.isEmpty() );
         assertEquals( 1, store.size() );
         assertEquals( true, store.contains( triple( "x P y" ) ) );
-        assertEquals( nodeSet( "x" ), iteratorToSet( store.listSubjects() ) );
-        assertEquals( nodeSet( "y" ), iteratorToSet( store.listObjects() ) );
-        assertEquals( tripleSet( "x P y" ), iteratorToSet( store.find( triple( "?? ?? ??" ) ) ) );
+        assertEquals( nodeSet( "x" ), Iter.toSet( store.listSubjects() ) );
+        assertEquals( nodeSet( "y" ), Iter.toSet( store.listObjects() ) );
+        assertEquals( tripleSet( "x P y" ), Iter.toSet( store.find( triple( "?? ?? ??" ) ) ) );
         }
 
     public void testListSubjects()
         {
         someStatements( store );
-        assertEquals( nodeSet( "a x _z r q" ), iteratorToSet( store.listSubjects() ) );
+        assertEquals( nodeSet( "a x _z r q" ), Iter.toSet( store.listSubjects() ) );
         }
-    
+
     public void testListObjects()
         {
         someStatements( store );
-        assertEquals( nodeSet( "b y i _j _t 17" ), iteratorToSet( store.listObjects() ) );
+        assertEquals( nodeSet( "b y i _j _t 17" ), Iter.toSet( store.listObjects() ) );
         }
-    
+
     public void testContains()
         {
         someStatements( store );
@@ -83,29 +84,29 @@ public abstract class AbstractTestTripleStore extends GraphTestBase
         assertEquals( false, store.contains( triple( "b Z r" ) ) );
         assertEquals( false, store.contains( triple( "_a P x" ) ) );
         }
-    
+
     public void testFind()
         {
         someStatements( store );
-        assertEquals( tripleSet( "" ), iteratorToSet( store.find( triple( "no such thing" ) ) ) );
-        assertEquals( tripleSet( "a P b; a P i" ), iteratorToSet( store.find( triple( "a P ??" ) ) ) );
-        assertEquals( tripleSet( "a P b; x P y; a P i" ), iteratorToSet( store.find( triple( "?? P ??" ) ) ) );
-        assertEquals( tripleSet( "x P y; x R y" ), iteratorToSet( store.find( triple( "x ?? y" ) ) ) );
-        assertEquals( tripleSet( "_z Q _j" ), iteratorToSet( store.find( triple( "?? ?? _j" ) ) ) );
-        assertEquals( tripleSet( "q R 17" ), iteratorToSet( store.find( triple( "?? ?? 17" ) ) ) );
+        assertEquals( tripleSet( "" ), Iter.toSet( store.find( triple( "no such thing" ) ) ) );
+        assertEquals( tripleSet( "a P b; a P i" ), Iter.toSet( store.find( triple( "a P ??" ) ) ) );
+        assertEquals( tripleSet( "a P b; x P y; a P i" ), Iter.toSet( store.find( triple( "?? P ??" ) ) ) );
+        assertEquals( tripleSet( "x P y; x R y" ), Iter.toSet( store.find( triple( "x ?? y" ) ) ) );
+        assertEquals( tripleSet( "_z Q _j" ), Iter.toSet( store.find( triple( "?? ?? _j" ) ) ) );
+        assertEquals( tripleSet( "q R 17" ), Iter.toSet( store.find( triple( "?? ?? 17" ) ) ) );
         }
-    
+
     public void testRemove()
         {
         store.add( triple( "nothing before ace" ) );
         store.add( triple( "ace before king" ) );
         store.add( triple( "king before queen" ) );
         store.delete( triple( "ace before king" ) );
-        assertEquals( tripleSet( "king before queen; nothing before ace" ), iteratorToSet( store.find( triple( "?? ?? ??" ) ) ) );
+        assertEquals( tripleSet( "king before queen; nothing before ace" ), Iter.toSet( store.find( triple( "?? ?? ??" ) ) ) );
         store.delete( triple( "king before queen" ) );
-        assertEquals( tripleSet( "nothing before ace" ), iteratorToSet( store.find( triple( "?? ?? ??" ) ) ) );
+        assertEquals( tripleSet( "nothing before ace" ), Iter.toSet( store.find( triple( "?? ?? ??" ) ) ) );
         }
-    
+
     public void someStatements( TripleStore ts )
         {
         ts.add( triple( "a P b" ) );
@@ -116,7 +117,7 @@ public abstract class AbstractTestTripleStore extends GraphTestBase
         ts.add( triple( "r S _t" ) );
         ts.add( triple( "q R 17" ) );
         }
-    
+
     public void testEmpty( TripleStore ts )
         {
         assertEquals( true, ts.isEmpty() );

--- a/jena-core/src/test/java/org/apache/jena/graph/test/GraphTestBase.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/GraphTestBase.java
@@ -26,14 +26,7 @@ import java.io.FileNotFoundException;
 import java.lang.reflect.Constructor ;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
+import java.util.*;
 
 import org.apache.jena.graph.* ;
 import org.apache.jena.ontology.impl.TestListSyntaxCategories ;
@@ -41,7 +34,6 @@ import org.apache.jena.shared.JenaException ;
 import org.apache.jena.shared.PrefixMapping ;
 import org.apache.jena.test.JenaTestBase ;
 import org.apache.jena.util.CollectionFactory ;
-import org.apache.jena.util.IteratorCollection ;
 import org.apache.jena.util.iterator.ExtendedIterator ;
 
 public class GraphTestBase extends JenaTestBase
@@ -69,21 +61,17 @@ public class GraphTestBase extends JenaTestBase
     public static Node node( String x )
         { return NodeCreateUtils.create( x ); }
 
-    /**
-        Answer a set containing the elements from the iterator <code>it</code>;
-        a shorthand for <code>IteratorCollection.iteratorToSet(it)</code>,
-        which see.
-    */
-    public static <T> Set<T> iteratorToSet( Iterator<? extends T> it )
-        { return IteratorCollection.iteratorToSet( it ); }
-
-    /**
-        Answer a list containing the elements from the iterator <code>it</code>,
-        in order; a shorthand for <code>IteratorCollection.iteratorToList(it)</code>,
-        which see.
-    */
-    public static <T> List<T> iteratorToList( Iterator<? extends T> it )
-        { return IteratorCollection.iteratorToList( it ); }
+//    /**
+//        Answer a set containing the elements from the iterator <code>it</code>.
+//    */
+//    public static <T> Set<T> Iter.toSet( Iterator<? extends T> it )
+//        { return Iter.toSet( it ); }
+//
+//    /**
+//        Answer a list containing the elements from the iterator <code>it</code>.
+//    */
+//    public static <T> List<T> Iter.toList( Iterator<? extends T> it )
+//        { return Iter.toList( it ); }
 
     /**
         Answer a set of the nodes described (as per <code>node()</code>) by

--- a/jena-core/src/test/java/org/apache/jena/graph/test/RecordingListener.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/RecordingListener.java
@@ -23,99 +23,101 @@ import java.util.Arrays ;
 import java.util.Iterator ;
 import java.util.List ;
 
+import org.junit.Assert ;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Graph ;
 import org.apache.jena.graph.GraphListener ;
 import org.apache.jena.graph.Triple ;
-import org.junit.Assert ;
 
 /**
     This testing listener records the event names and data, and provides
-    a method for comparing the actual with the expected history. 
-*/    
+    a method for comparing the actual with the expected history.
+*/
 public class RecordingListener implements GraphListener
     {
     public List<Object> history = new ArrayList<>();
-    
+
     @Override
     public void notifyAddTriple( Graph g, Triple t )
         { record( "add", g, t ); }
-        
+
     @Override
     public void notifyAddArray( Graph g, Triple [] triples )
         { record( "add[]", g, triples ); }
-        
+
     @Override
     public void notifyAddList( Graph g, List<Triple> triples )
         { record( "addList", g, triples ); }
-        
+
     @Override
     public void notifyAddIterator( Graph g, Iterator<Triple> it )
-        { record( "addIterator", g, GraphTestBase.iteratorToList( it ) ); }
-        
+        { record( "addIterator", g, Iter.toList( it ) ); }
+
     @Override
     public void notifyAddGraph( Graph g, Graph added )
         { record( "addGraph", g, added ); }
-        
+
     @Override
     public void notifyDeleteTriple( Graph g, Triple t )
         { record( "delete", g, t ); }
-        
+
     @Override
     public void notifyDeleteArray( Graph g, Triple [] triples )
         { record( "delete[]", g, triples ); }
-        
+
     @Override
     public void notifyDeleteList( Graph g, List<Triple> triples )
         { record( "deleteList", g, triples ); }
-        
+
     @Override
     public void notifyDeleteIterator( Graph g, Iterator<Triple> it )
-        { record( "deleteIterator", g, GraphTestBase.iteratorToList( it ) ); }
-        
+        { record( "deleteIterator", g, Iter.toList( it ) ); }
+
     @Override
     public void notifyDeleteGraph( Graph g, Graph removed )
         { record( "deleteGraph", g, removed ); }
-    
+
     @Override
     public void notifyEvent( Graph source, Object event )
         { record( "someEvent", source, event ); }
-        
+
     protected void record( String tag, Object x, Object y )
         { history.add( tag ); history.add( x ); history.add( y ); }
-    
+
     protected void record( String tag, Object info )
         { history.add( tag ); history.add( info ); }
-        
+
     public void clear()
         { history.clear(); }
 
     public boolean has( List<Object> things )
-        { return Arrays.deepEquals(history.toArray(), things.toArray() ); } 
-    
+        { return Arrays.deepEquals(history.toArray(), things.toArray() ); }
+
     public boolean hasStart( List<Object> L )
         { return L.size() <= history.size() && L.equals( history.subList( 0, L.size() ) ); }
-    
+
     public boolean hasEnd( List<Object> L )
         { return L.size() <= history.size() && L.equals( history.subList( history.size() - L.size(), history.size() ) ); }
-    
+
     public boolean has( Object [] things )
-        { return Arrays.deepEquals(history.toArray(), things ); } 
-        
+        { return Arrays.deepEquals(history.toArray(), things ); }
+
     public void assertHas( List<Object> things )
-        { if (has( things ) == false) Assert.fail( "expected " + things + " but got " + history ); }  
-    
+        { if (has( things ) == false) Assert.fail( "expected " + things + " but got " + history ); }
+
     public void assertHas( Object [] things )
         { assertHas( Arrays.asList( things ) ); }
-    
+
     public void assertHasStart( Object [] start )
-        { 
+        {
         List<Object> L = Arrays.asList( start );
         if (hasStart( L ) == false) Assert.fail( "expected " + L + " at the beginning of " + history );
         }
-    
+
     public void assertHasEnd( Object [] end )
         {
         List<Object> L = Arrays.asList( end );
-        if (hasEnd( L ) == false) Assert.fail( "expected " + L + " at the end of " + history );        
+        if (hasEnd( L ) == false) Assert.fail( "expected " + L + " at the end of " + history );
         }
     }

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestFindLiterals.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestFindLiterals.java
@@ -21,6 +21,7 @@ package org.apache.jena.graph.test;
 import java.util.Set;
 
 import junit.framework.TestSuite;
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -161,6 +162,6 @@ public class TestFindLiterals extends GraphTestBase {
         g.add( Triple.create( SS, P, as ) );
         g.add( Triple.create( SI, P, ai ) );
         g.add( Triple.create( SL, P, al ) );
-        assertEquals( 4, iteratorToSet( g.find( Node.ANY, P, NodeCreateUtils.create( "42" ) ) ).size() );
+        assertEquals( 4, Iter.toSet( g.find( Node.ANY, P, NodeCreateUtils.create( "42" ) ) ).size() );
         }
     }

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestGraphPlain.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestGraphPlain.java
@@ -35,14 +35,15 @@ import org.apache.jena.util.iterator.ExtendedIterator ;
 import org.junit.BeforeClass ;
 import org.junit.Test ;
 
+@SuppressWarnings("deprecation")
 public class TestGraphPlain {
 
     private static Graph graph;
 
-    @SuppressWarnings("deprecation")
     @BeforeClass public static void setUp() {
+        // GraphMem is the old in-memeory graph which has value-based indexing.
+        // It is not the default graph implementation.
         graph = new org.apache.jena.mem.GraphMem();
-
         if ( ! graph.getCapabilities().handlesLiteralTyping() )
             throw new IllegalArgumentException("Test graph does not do the value thing");
         graphAdd(graph, "s p o ; s p 1 ; s p 01");

--- a/jena-core/src/test/java/org/apache/jena/graph/test/TestNodeToTriplesMapMem.java
+++ b/jena-core/src/test/java/org/apache/jena/graph/test/TestNodeToTriplesMapMem.java
@@ -18,11 +18,17 @@
 
 package org.apache.jena.graph.test;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 import junit.framework.TestSuite;
-import org.apache.jena.graph.* ;
-import org.apache.jena.graph.Triple.* ;
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Node_URI;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.graph.Triple.Field;
 import org.apache.jena.mem.NodeToTriplesMapMem ;
 
 /**
@@ -34,88 +40,88 @@ public class TestNodeToTriplesMapMem extends GraphTestBase
     {
     public TestNodeToTriplesMapMem(String name )
         { super( name ); }
-    
+
     public static TestSuite suite()
         { return new TestSuite( TestNodeToTriplesMapMem.class ); }
-    
+
     protected NodeToTriplesMapMem ntS = new NodeToTriplesMapMem( Field.fieldSubject, Field.fieldPredicate, Field.fieldObject );
-    	
+
     protected NodeToTriplesMapMem ntP = new NodeToTriplesMapMem( Field.fieldPredicate, Field.fieldObject, Field.fieldSubject );
-    	
+
     protected NodeToTriplesMapMem ntO = new NodeToTriplesMapMem( Field.fieldObject, Field.fieldPredicate, Field.fieldSubject );
 
     protected static final Node x = node( "x" );
-    
+
     protected static final Node y = node( "y" );
-    
+
     public void testZeroSize()
         {
         testZeroSize( "fresh NTM", ntS );
         }
-    
+
     protected void testZeroSize( String title, NodeToTriplesMapMem nt )
         {
         assertEquals( title + " should have size 0", 0, nt.size() );
         assertEquals( title + " should be isEmpty()", true, nt.isEmpty() );
         assertEquals( title + " should have empty domain", false, nt.domain().hasNext() );
         }
-    
+
     public void testAddOne()
         {
         ntS.add( triple( "x P y" ) );
         testJustOne( x, ntS );
         }
-    
+
     public void testAddOneTwice()
         {
         addTriples( ntS, "x P y; x P y" );
         testJustOne( x, ntS );
         }
-    
+
     protected void testJustOne( Node x, NodeToTriplesMapMem nt )
         {
         assertEquals( 1, nt.size() );
         assertEquals( false, nt.isEmpty() );
-        assertEquals( just( x ), iteratorToSet( nt.domain() ) );
+        assertEquals( just( x ), Iter.toSet( nt.domain() ) );
         }
-    
+
     public void testAddTwoUnshared()
         {
         addTriples( ntS, "x P a; y Q b" );
         assertEquals( 2, ntS.size() );
         assertEquals( false, ntS.isEmpty() );
-        assertEquals( both( x, y ), iteratorToSet( ntS.domain() ) );
+        assertEquals( both( x, y ), Iter.toSet( ntS.domain() ) );
         }
-    
+
     public void testAddTwoShared()
         {
         addTriples( ntS, "x P a; x Q b" );
         assertEquals( 2, ntS.size() );
         assertEquals( false, ntS.isEmpty() );
-        assertEquals( just( x ), iteratorToSet( ntS.domain() ) );
+        assertEquals( just( x ), Iter.toSet( ntS.domain() ) );
         }
-    
+
     public void testClear()
         {
         addTriples( ntS, "x P a; x Q b; y R z" );
         ntS.clear();
         testZeroSize( "cleared NTM", ntS );
         }
-    
+
     public void testAllIterator()
         {
         String triples = "x P b; y P d; y P f";
         addTriples( ntS, triples );
-        assertEquals( tripleSet( triples ), iteratorToSet( ntS.iterateAll() ) );
+        assertEquals( tripleSet( triples ), Iter.toSet( ntS.iterateAll() ) );
         }
-    
+
     public void testOneIterator()
         {
         addTriples( ntS, "x P b; y P d; y P f" );
         assertEquals( tripleSet( "x P b" ), ntS.iterator( x, null ).toSet() );
         assertEquals( tripleSet( "y P d; y P f" ), ntS.iterator( y, null ).toSet() );
         }
-    
+
     public void testRemove()
         {
         addTriples( ntS, "x P b; y P d; y R f" );
@@ -123,7 +129,7 @@ public class TestNodeToTriplesMapMem extends GraphTestBase
         assertEquals( 2, ntS.size() );
         assertEquals( tripleSet( "x P b; y R f" ), ntS.iterateAll().toSet() );
         }
-    
+
     public void testRemoveByIterator()
         {
         addTriples( ntS, "x nice a; a nasty b; x nice c" );
@@ -199,21 +205,21 @@ public class TestNodeToTriplesMapMem extends GraphTestBase
         ntS.remove( triple( "x P a" ) );
         assertEquals( tripleSet( "y Q b; z R c" ), ntS.iterateAll().toSet() );
         }
-    
+
     public void testUnspecificRemoveP()
         {
         addTriples( ntP, "x P a; y Q b; z R c" );
         ntP.remove( triple( "y Q b" ) );
         assertEquals( tripleSet( "x P a; z R c" ), ntP.iterateAll().toSet() );
         }
-    
+
     public void testUnspecificRemoveO()
         {
         addTriples( ntO, "x P a; y Q b; z R c" );
         ntO.remove( triple( "z R c" ) );
         assertEquals( tripleSet( "x P a; y Q b" ), ntO.iterateAll().toSet() );
         }
-    
+
     public void testAddBooleanResult()
         {
         assertEquals( true, ntS.add( triple( "x P y" ) ) );
@@ -225,7 +231,7 @@ public class TestNodeToTriplesMapMem extends GraphTestBase
         assertEquals( true, ntS.add( triple( "y R s" ) ) );
         assertEquals( false, ntS.add( triple( "y R s" ) ) );
         }
-    
+
     public void testRemoveBooleanResult()
         {
         assertEquals( false, ntS.remove( triple( "x P y" ) ) );
@@ -234,7 +240,7 @@ public class TestNodeToTriplesMapMem extends GraphTestBase
         assertEquals( true, ntS.remove( triple( "x P y" ) ) );
         assertEquals( false, ntS.remove( triple( "x P y" ) ) );
         }
-    
+
     public void testContains()
         {
         addTriples( ntS, "x P y; a P b" );
@@ -246,9 +252,9 @@ public class TestNodeToTriplesMapMem extends GraphTestBase
         assertFalse( ntS.contains( triple( "e T f" ) ) );
         assertFalse( ntS.contains( triple( "_x F 17" ) ) );
         }
-    
+
     // TODO more here
-    
+
     protected void addTriples( NodeToTriplesMapMem nt, String facts )
         {
         Triple [] t = tripleArray( facts );
@@ -257,7 +263,7 @@ public class TestNodeToTriplesMapMem extends GraphTestBase
                 nt.add( aT );
             }
         }
-    
+
     protected static <T> Set<T> just( T x )
         {
         Set<T> result = new HashSet<>();
@@ -271,5 +277,5 @@ public class TestNodeToTriplesMapMem extends GraphTestBase
         result.add( y );
         return result;
         }
-    
+
     }

--- a/jena-core/src/test/java/org/apache/jena/mem/GraphMem_CS.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/GraphMem_CS.java
@@ -27,14 +27,12 @@ import static org.junit.Assert.fail;
 
 import java.util.Iterator;
 
-import org.apache.jena.graph.Graph;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.Node_URI;
-import org.apache.jena.graph.Triple;
+import org.junit.runner.RunWith;
+
+import org.apache.jena.graph.*;
 import org.apache.jena.shared.JenaException;
 import org.apache.jena.testing_framework.AbstractGraphProducer;
 import org.apache.jena.util.iterator.ExtendedIterator;
-import org.junit.runner.RunWith;
 import org.xenei.junit.contract.Contract.Inject;
 import org.xenei.junit.contract.ContractImpl;
 import org.xenei.junit.contract.ContractSuite;
@@ -46,11 +44,11 @@ import org.xenei.junit.contract.IProducer;
 @SuppressWarnings("deprecation")
 public class GraphMem_CS {
 
-	protected IProducer<GraphMem> graphProducer = new AbstractGraphProducer<GraphMem>() {
+	protected IProducer<Graph> graphProducer = new AbstractGraphProducer<Graph>() {
 
 		@Override
-		protected GraphMem createNewGraph() {
-			return new GraphMem();
+		protected Graph createNewGraph() {
+			return GraphMemFactory.createDefaultGraph();
 		}
 
 		@Override
@@ -66,7 +64,7 @@ public class GraphMem_CS {
 	};
 
 	@Inject
-	public IProducer<GraphMem> getGraphProducer() {
+	public IProducer<Graph> getGraphProducer() {
 		return graphProducer;
 	}
 

--- a/jena-core/src/test/java/org/apache/jena/mem/TripleBunchContractTest.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/TripleBunchContractTest.java
@@ -17,24 +17,25 @@
  */
 package org.apache.jena.mem;
 
-import static org.junit.Assert.*;
-import static org.apache.jena.testing_framework.GraphHelper.*;
+import static org.apache.jena.testing_framework.GraphHelper.triple;
+import static org.apache.jena.testing_framework.GraphHelper.tripleSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
-import org.xenei.junit.contract.Contract;
-import org.xenei.junit.contract.ContractTest;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Triple;
-import org.xenei.junit.contract.IProducer;
 import org.apache.jena.testing_framework.NodeCreateUtils;
 import org.apache.jena.util.iterator.ExtendedIterator;
+import org.xenei.junit.contract.Contract;
+import org.xenei.junit.contract.ContractTest;
+import org.xenei.junit.contract.IProducer;
 
 /**
  * Test triple bunch implementations - NOT YET FINISHED
@@ -83,7 +84,7 @@ public class TripleBunchContractTest {
 		testingBunch.add(tripleSPO);
 		assertEquals(1, testingBunch.size());
 		assertTrue(testingBunch.contains(tripleSPO));
-		assertEquals(listOf(tripleSPO), iteratorToList(testingBunch.iterator()));
+		assertEquals(listOf(tripleSPO), Iter.toList(testingBunch.iterator()));
 	}
 
 	@ContractTest
@@ -94,7 +95,7 @@ public class TripleBunchContractTest {
 		assertTrue(testingBunch.contains(tripleSPO));
 		assertTrue(testingBunch.contains(tripleXQY));
 		assertEquals(setOf(tripleSPO, tripleXQY),
-				iteratorToSet(testingBunch.iterator()));
+				Iter.toSet(testingBunch.iterator()));
 	}
 
 	@ContractTest
@@ -114,7 +115,7 @@ public class TripleBunchContractTest {
 		assertEquals(1, testingBunch.size());
 		assertFalse(testingBunch.contains(tripleSPO));
 		assertTrue(testingBunch.contains(tripleXQY));
-		assertEquals(listOf(tripleXQY), iteratorToList(testingBunch.iterator()));
+		assertEquals(listOf(tripleXQY), Iter.toList(testingBunch.iterator()));
 	}
 
 	@ContractTest

--- a/jena-core/src/test/java/org/apache/jena/mem/test/TestTripleBunch.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/test/TestTripleBunch.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Triple ;
 import org.apache.jena.graph.test.GraphTestBase ;
 import org.apache.jena.mem.* ;
@@ -40,9 +41,9 @@ public abstract class TestTripleBunch extends GraphTestBase
         { super( name ); }
 
     protected static final TripleBunch emptyBunch = new ArrayBunch();
-    
+
     protected abstract TripleBunch getBunch();
-    
+
     public void testEmptyBunch()
         {
         TripleBunch b = getBunch();
@@ -58,9 +59,9 @@ public abstract class TestTripleBunch extends GraphTestBase
         b.add( tripleSPO );
         assertEquals( 1, b.size() );
         assertTrue( b.contains( tripleSPO ) );
-        assertEquals( listOf( tripleSPO ), iteratorToList( b.iterator() ) );
+        assertEquals( listOf( tripleSPO ), Iter.toList( b.iterator() ) );
         }
-    
+
     public void testAddElements()
         {
         TripleBunch b = getBunch();
@@ -69,9 +70,9 @@ public abstract class TestTripleBunch extends GraphTestBase
         assertEquals( 2, b.size() );
         assertTrue( b.contains( tripleSPO ) );
         assertTrue( b.contains( tripleXQY ) );
-        assertEquals( setOf( tripleSPO, tripleXQY ), iteratorToSet( b.iterator() ) );
+        assertEquals( setOf( tripleSPO, tripleXQY ), Iter.toSet( b.iterator() ) );
         }
-    
+
     public void testRemoveOnlyElement()
         {
         TripleBunch b = getBunch();
@@ -81,7 +82,7 @@ public abstract class TestTripleBunch extends GraphTestBase
         assertFalse( b.contains( tripleSPO ) );
         assertFalse( b.iterator().hasNext() );
         }
-    
+
     public void testRemoveFirstOfTwo()
         {
         TripleBunch b = getBunch();
@@ -91,7 +92,7 @@ public abstract class TestTripleBunch extends GraphTestBase
         assertEquals( 1, b.size() );
         assertFalse( b.contains( tripleSPO ) );
         assertTrue( b.contains( tripleXQY ) );
-        assertEquals( listOf( tripleXQY ), iteratorToList( b.iterator() ) );
+        assertEquals( listOf( tripleXQY ), Iter.toList( b.iterator() ) );
         }
 
     public void testTableGrows()
@@ -102,7 +103,7 @@ public abstract class TestTripleBunch extends GraphTestBase
         b.add( triple( "a I b" ) );
         b.add( triple( "c J d" ) );
         }
-    
+
     public void testIterator()
         {
         TripleBunch b = getBunch();
@@ -111,7 +112,7 @@ public abstract class TestTripleBunch extends GraphTestBase
         b.add( triple( "e R f" ) );
         assertEquals( tripleSet( "a P b; c Q d; e R f" ), b.iterator().toSet() );
         }
-    
+
     public void testIteratorRemoveOneItem()
         {
         TripleBunch b = getBunch();
@@ -122,7 +123,7 @@ public abstract class TestTripleBunch extends GraphTestBase
         while (it.hasNext()) if (it.next().equals( triple( "c Q d") )) it.remove();
         assertEquals( tripleSet( "a P b; e R f" ), b.iterator().toSet() );
         }
-    
+
     public void testIteratorRemoveAlltems()
         {
         TripleBunch b = getBunch();
@@ -133,21 +134,21 @@ public abstract class TestTripleBunch extends GraphTestBase
         while (it.hasNext()) it.removeNext();
         assertEquals( tripleSet( "" ), b.iterator().toSet() );
         }
-        
+
     protected List<Triple> listOf( Triple x )
         {
         List<Triple> result = new ArrayList<>();
         result.add( x );
         return result;
         }
-    
+
     protected Set<Triple> setOf( Triple x, Triple y )
         {
         Set<Triple> result = setOf( x );
         result.add( y );
         return result;
         }
-    
+
     protected Set<Triple> setOf( Triple x )
         {
         Set<Triple> result = new HashSet<>();

--- a/jena-core/src/test/java/org/apache/jena/ontology/makers/GraphMakerContractTest.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/makers/GraphMakerContractTest.java
@@ -19,12 +19,13 @@
 package org.apache.jena.ontology.makers;
 
 import static org.junit.Assert.*;
+
 import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
-import org.xenei.junit.contract.Contract;
-import org.xenei.junit.contract.ContractTest;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
@@ -32,8 +33,10 @@ import org.apache.jena.ontology.models.GraphMaker;
 import org.apache.jena.shared.AlreadyExistsException;
 import org.apache.jena.shared.DoesNotExistException;
 import org.apache.jena.testing_framework.GraphHelper;
-import org.xenei.junit.contract.IProducer;
 import org.apache.jena.testing_framework.TestUtils;
+import org.xenei.junit.contract.Contract;
+import org.xenei.junit.contract.ContractTest;
+import org.xenei.junit.contract.IProducer;
 
 /**
  * GraphMaker contract test.
@@ -170,7 +173,7 @@ public class GraphMakerContractTest {
 	 * Test that we can find a graph once its been created. We need to know if
 	 * two graphs are "the same" here: we have a temporary work-around but it is
 	 * not sound.
-	 * 
+	 *
 	 */
 	@ContractTest
 	public void testCanFindCreatedGraph() {
@@ -267,7 +270,7 @@ public class GraphMakerContractTest {
 		Graph Y = graphMaker.createGraph(y);
 		Graph Z = graphMaker.createGraph(z);
 		Set<String> wanted = TestUtils.setOfStrings(x + " " + y + " " + z);
-		assertEquals(wanted, GraphHelper.iteratorToSet(graphMaker.listGraphs()));
+		assertEquals(wanted, Iter.toSet(graphMaker.listGraphs()));
 		X.close();
 		Y.close();
 		Z.close();
@@ -284,7 +287,7 @@ public class GraphMakerContractTest {
 		Graph Y = graphMaker.createGraph(y);
 		Graph Z = graphMaker.createGraph(z);
 		graphMaker.removeGraph(x);
-		Set<String> s = GraphHelper.iteratorToSet(graphMaker.listGraphs());
+		Set<String> s = Iter.toSet(graphMaker.listGraphs());
 		assertEquals(TestUtils.setOfStrings(y + " " + z), s);
 		X.close();
 		Y.close();

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/RecordingModelListener.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/RecordingModelListener.java
@@ -22,101 +22,102 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.jena.graph.test.GraphTestBase ;
+import org.junit.Assert;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelChangedListener ;
 import org.apache.jena.rdf.model.Statement ;
 import org.apache.jena.rdf.model.StmtIterator ;
-import org.junit.Assert;
 
 
 public class RecordingModelListener implements ModelChangedListener
     {
     List<Object> history = new ArrayList<>();
-    
+
     @Override
     public void addedStatement( Statement s )
         { record( "add", s ); }
-        
+
     @Override
     public void addedStatements( Statement [] statements )
         { record( "add[]", Arrays.asList( statements ) ); }
-        
+
     @Override
     public void addedStatements( List<Statement> statements )
         { record( "addList", statements ); }
-        
+
     @Override
     public void addedStatements( StmtIterator statements )
-        { record( "addIterator", GraphTestBase.iteratorToList( statements ) ); }
-        
+        { record( "addIterator", Iter.toList( statements ) ); }
+
     @Override
     public void addedStatements( Model m )
         { record( "addModel", m ); }
-        
+
     @Override
     public void removedStatements( Statement [] statements )
         { record( "remove[]", Arrays.asList( statements ) ); }
-    
+
    @Override
 public void removedStatement( Statement s )
         { record( "remove", s ); }
-        
+
     @Override
     public void removedStatements( List<Statement> statements )
         { record( "removeList", statements ); }
-        
+
     @Override
     public void removedStatements( StmtIterator statements )
-        { record( "removeIterator", GraphTestBase.iteratorToList( statements ) ); }
-        
+        { record( "removeIterator", Iter.toList( statements ) ); }
+
     @Override
     public void removedStatements( Model m )
         { record( "removeModel", m ); }
-    
+
     @Override
     public void notifyEvent( Model m, Object event )
         { record( "someEvent", m, event ); }
-    
+
     protected void record( String tag, Object x, Object y )
         { history.add( tag ); history.add( x ); history.add( y ); }
-        
+
     protected void record( String tag, Object info )
         { history.add( tag ); history.add( info ); }
-        
-    public boolean has( Object [] things ) 
+
+    public boolean has( Object [] things )
         { return history.equals( Arrays.asList( things ) ); }
-        
+
     public void assertHas( Object [] things )
         {
         if (has( things ) == false)
             Assert.fail( "expected " + Arrays.asList( things ) + " but got " + history );
-        }    
-    
+        }
+
     public boolean has( List<?> things )
-            { return history.equals( things ); } 
-        
+            { return history.equals( things ); }
+
     public boolean hasStart( List<Object> L )
         { return L.size() <= history.size() && L.equals( history.subList( 0, L.size() ) ); }
-    
+
     public boolean hasEnd( List<Object> L )
         { return L.size() <= history.size() && L.equals( history.subList( history.size() - L.size(), history.size() ) ); }
-    
+
     public void assertHas( List<?> things )
-        { if (has( things ) == false) Assert.fail( "expected " + things + " but got " + history ); }  
-    
+        { if (has( things ) == false) Assert.fail( "expected " + things + " but got " + history ); }
+
     public void assertHasStart( Object [] start )
-        { 
+        {
         List<Object> L = Arrays.asList( start );
         if (hasStart( L ) == false) Assert.fail( "expected " + L + " at the beginning of " + history );
         }
-    
+
     public void assertHasEnd( Object [] end )
         {
         List<Object> L = Arrays.asList( end );
-        if (hasEnd( L ) == false) Assert.fail( "expected " + L + " at the end of " + history );        
+        if (hasEnd( L ) == false) Assert.fail( "expected " + L + " at the end of " + history );
         }
-    
+
     public void clear()
     { history.clear(); }
 

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestModelEvents.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestModelEvents.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,14 +18,11 @@
 
 package org.apache.jena.rdf.model.test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import org.apache.jena.graph.test.GraphTestBase ;
+import org.junit.Assert;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.rdf.listeners.ChangedListener ;
 import org.apache.jena.rdf.listeners.NullListener ;
 import org.apache.jena.rdf.listeners.ObjectListener ;
@@ -38,7 +35,6 @@ import org.apache.jena.rdf.model.impl.StmtIteratorImpl ;
 import org.apache.jena.rdf.model.test.helpers.ModelHelper ;
 import org.apache.jena.rdf.model.test.helpers.RecordingModelListener ;
 import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
-import org.junit.Assert;
 
 /**
  * Tests for model events and listeners.
@@ -65,7 +61,7 @@ public class TestModelEvents extends AbstractModelTestBase
 			}
 			if (x instanceof Iterator<?>)
 			{
-				return GraphTestBase.iteratorToList((Iterator<?>) x);
+				return Iter.toList((Iterator<?>) x);
 			}
 			return x;
 		}

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestObjects.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestObjects.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,12 +22,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.jena.graph.test.GraphTestBase ;
+import org.junit.Assert;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.rdf.model.test.helpers.ModelHelper ;
 import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
 import org.apache.jena.vocabulary.RDF ;
-import org.junit.Assert;
 
 public class TestObjects extends AbstractModelTestBase
 {
@@ -145,13 +146,13 @@ public class TestObjects extends AbstractModelTestBase
 		final Set<Literal> wanted = literalsUpto(TestObjects.numberSubjects
 				* TestObjects.numberPredicates);
 		Assert.assertEquals(wanted,
-				GraphTestBase.iteratorToSet(model.listObjects()));
+				Iter.toSet(model.listObjects()));
 	}
 
 	public void testListObjectsOfPropertyByProperty()
 	{
 		fill(model);
-		final List<RDFNode> L = GraphTestBase.iteratorToList(model
+		final List<RDFNode> L = Iter.toList(model
 				.listObjectsOfProperty(ModelHelper
 						.property(TestObjects.predicatePrefix + "0/p")));
 		Assert.assertEquals(TestObjects.numberSubjects, L.size());
@@ -167,7 +168,7 @@ public class TestObjects extends AbstractModelTestBase
 		{
 			model.addLiteral(s, RDF.value, i);
 		}
-		final List<RDFNode> L = GraphTestBase.iteratorToList(model
+		final List<RDFNode> L = Iter.toList(model
 				.listObjectsOfProperty(s, RDF.value));
 		Assert.assertEquals(size, L.size());
 		final Set<Literal> wanted = literalsUpto(size);
@@ -188,7 +189,7 @@ public class TestObjects extends AbstractModelTestBase
 		final List<Resource> L = model.listSubjects().toList();
 		Assert.assertEquals(TestObjects.numberSubjects, L.size());
 		final Set<Resource> wanted = subjectSet(TestObjects.numberSubjects);
-		Assert.assertEquals(wanted, GraphTestBase.iteratorToSet(L.iterator()));
+		Assert.assertEquals(wanted, Iter.toSet(L.iterator()));
 	}
 
 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestResourceMethods.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestResourceMethods.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,9 @@
 
 package org.apache.jena.rdf.model.test;
 
-import org.apache.jena.graph.test.GraphTestBase ;
+import org.junit.Assert;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.rdf.model.Literal ;
 import org.apache.jena.rdf.model.RDFNode ;
 import org.apache.jena.rdf.model.Resource ;
@@ -27,7 +29,6 @@ import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
 import org.apache.jena.shared.PropertyNotFoundException ;
 import org.apache.jena.test.JenaTestBase ;
 import org.apache.jena.vocabulary.RDF ;
-import org.junit.Assert;
 
 public class TestResourceMethods extends AbstractModelTestBase
 {
@@ -96,13 +97,9 @@ public class TestResourceMethods extends AbstractModelTestBase
 
 	public void testCountsCorrect()
 	{
-		Assert.assertEquals(13,
-				GraphTestBase.iteratorToList(model.listStatements()).size());
-		Assert.assertEquals(13,
-				GraphTestBase.iteratorToList(r.listProperties(RDF.value))
-						.size());
-		Assert.assertEquals(0,
-				GraphTestBase.iteratorToList(r.listProperties(RDF.type)).size());
+		Assert.assertEquals(13, Iter.toList(model.listStatements()).size());
+		Assert.assertEquals(13, Iter.toList(r.listProperties(RDF.value)).size());
+		Assert.assertEquals(0,  Iter.toList(r.listProperties(RDF.type)).size());
 	}
 
 	public void testDouble()

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestResources.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestResources.java
@@ -21,14 +21,15 @@ package org.apache.jena.rdf.model.test;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.jena.graph.test.GraphTestBase ;
+import org.junit.Assert;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
 import org.apache.jena.shared.InvalidPropertyURIException ;
 import org.apache.jena.shared.PropertyNotFoundException ;
 import org.apache.jena.test.JenaTestBase ;
 import org.apache.jena.vocabulary.RDF ;
-import org.junit.Assert;
 
 public class TestResources extends AbstractModelTestBase
 {
@@ -260,24 +261,21 @@ public class TestResources extends AbstractModelTestBase
             JenaTestBase.pass();
         }
 		//
-		Assert.assertEquals(13,
-				GraphTestBase.iteratorToSet(r.listProperties(RDF.value)).size());
-		Assert.assertEquals(setOf(r), GraphTestBase.iteratorToSet(r
-				.listProperties(RDF.value).mapWith(Statement::getSubject)));
+		Assert.assertEquals(13, Iter.toSet(r.listProperties(RDF.value)).size());
+		Assert.assertEquals(setOf(r), Iter.toSet(r.listProperties(RDF.value).mapWith(Statement::getSubject)));
 		//
-		Assert.assertEquals(0, GraphTestBase.iteratorToSet(r.listProperties(p))
+		Assert.assertEquals(0, Iter.toSet(r.listProperties(p))
 				.size());
 		Assert.assertEquals(
 				new HashSet<Resource>(),
-				GraphTestBase.iteratorToSet(r.listProperties(p).mapWith(
+				Iter.toSet(r.listProperties(p).mapWith(
 						Statement::getSubject)));
 		//
 		Assert.assertEquals(13 + numProps,
-				GraphTestBase.iteratorToSet(r.listProperties()).size());
+		                    Iter.toSet(r.listProperties()).size());
 		Assert.assertEquals(
 				setOf(r),
-				GraphTestBase.iteratorToSet(r.listProperties().mapWith(
-						Statement::getSubject)));
+				Iter.toSet(r.listProperties().mapWith(Statement::getSubject)));
 		//
 		r.removeProperties();
 		Assert.assertEquals(0, r.listProperties().toList().size());

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/helpers/RecordingModelListener.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/helpers/RecordingModelListener.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,12 +23,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.jena.graph.test.GraphTestBase ;
+import org.junit.Assert;
+
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelChangedListener ;
 import org.apache.jena.rdf.model.Statement ;
 import org.apache.jena.rdf.model.StmtIterator ;
-import org.junit.Assert;
 /**
  * Class to listen to model changes and record them for testing.
  */
@@ -63,7 +64,7 @@ public class RecordingModelListener implements ModelChangedListener
 	@Override
 	public void addedStatements( final StmtIterator statements )
 	{
-		record("addIterator", GraphTestBase.iteratorToList(statements));
+		record("addIterator", Iter.toList(statements));
 	}
 
 	public void assertHas( final List<?> things )
@@ -221,7 +222,7 @@ public class RecordingModelListener implements ModelChangedListener
 	@Override
 	public void removedStatements( final StmtIterator statements )
 	{
-		record("removeIterator", GraphTestBase.iteratorToList(statements));
+		record("removeIterator", Iter.toList(statements));
 	}
 
 }

--- a/jena-core/src/test/java/org/apache/jena/shared/RandomOrderGraph.java
+++ b/jena-core/src/test/java/org/apache/jena/shared/RandomOrderGraph.java
@@ -18,10 +18,14 @@
 
 package org.apache.jena.shared;
 
-import org.apache.jena.graph.* ;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.GraphMemFactory;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.graph.impl.WrappedGraph ;
-import org.apache.jena.rdf.model.* ;
-import org.apache.jena.util.iterator.* ;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.util.iterator.ExtendedIterator;
 
 /**
  * Wraps a graph and randomizes the order of find results.

--- a/jena-core/src/test/java/org/apache/jena/shared/RandomOrderIterator.java
+++ b/jena-core/src/test/java/org/apache/jena/shared/RandomOrderIterator.java
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.jena.util.iterator;
+package org.apache.jena.shared;
 
 import java.util.*;
+
+import org.apache.jena.util.iterator.WrappedIterator;
 /**
  * RandomOrderIterator - Reorders the elements returned by an Iterator.
  */

--- a/jena-core/src/test/java/org/apache/jena/testing_framework/GraphHelper.java
+++ b/jena-core/src/test/java/org/apache/jena/testing_framework/GraphHelper.java
@@ -21,28 +21,17 @@ package org.apache.jena.testing_framework;
 /**
  * Foo set of static test helpers.  Generally included as a static.
  */
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
+import java.util.*;
 
-import org.apache.jena.graph.GraphMemFactory;
-import org.apache.jena.graph.Graph;
-import org.apache.jena.graph.GraphUtil;
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.Triple;
+import org.apache.jena.graph.*;
 import org.apache.jena.shared.JenaException;
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.util.CollectionFactory;
-import org.apache.jena.util.IteratorCollection;
 import org.apache.jena.util.iterator.ExtendedIterator;
 
 public class GraphHelper extends TestUtils {
@@ -55,23 +44,19 @@ public class GraphHelper extends TestUtils {
 		return NodeCreateUtils.create(x);
 	}
 
-	/**
-	 * Answer a set containing the elements from the iterator <code>it</code>; a
-	 * shorthand for <code>IteratorCollection.iteratorToSet(it)</code>, which
-	 * see.
-	 */
-	public static <T> Set<T> iteratorToSet(Iterator<? extends T> it) {
-		return IteratorCollection.iteratorToSet(it);
-	}
-
-	/**
-	 * Answer a list containing the elements from the iterator <code>it</code>,
-	 * in order; a shorthand for
-	 * <code>IteratorCollection.iteratorToList(it)</code>, which see.
-	 */
-	public static <T> List<T> iteratorToList(Iterator<? extends T> it) {
-		return IteratorCollection.iteratorToList(it);
-	}
+//	/**
+//	 * Answer a set containing the elements from the iterator <code>it</code>.
+//	 */
+//	public static <T> Set<T> Iter.toSet(Iterator<? extends T> it) {
+//		return Iter.toSet(it);
+//	}
+//
+//	/**
+//	 * Answer a list containing the elements from the iterator <code>it</code>.
+//	 */
+//	public static <T> List<T> Iter.toList(Iterator<? extends T> it) {
+//		return Iter.toList(it);
+//	}
 
 	/**
 	 * Answer a set of the nodes described (as per <code>node()</code>) by the

--- a/jena-core/src/test/java/org/apache/jena/util/TestIteratorCollection.java
+++ b/jena-core/src/test/java/org/apache/jena/util/TestIteratorCollection.java
@@ -31,6 +31,7 @@ import org.apache.jena.util.iterator.NullIterator ;
 import org.apache.jena.util.iterator.SingletonIterator ;
 import org.apache.jena.util.iterator.WrappedIterator ;
 
+@SuppressWarnings("removal")
 public class TestIteratorCollection extends GraphTestBase
     {
     public TestIteratorCollection( String name )
@@ -38,24 +39,24 @@ public class TestIteratorCollection extends GraphTestBase
 
     public static TestSuite suite()
         { return new TestSuite( TestIteratorCollection.class ); }
-    
+
     public void testEmptyToEmptySet()
         {
         assertEquals( CollectionFactory.createHashedSet(), IteratorCollection.iteratorToSet( NullIterator.instance() ) );
         }
-    
+
     public void testSingletonToSingleSet()
         {
-        assertEquals( oneSet( "single" ), iteratorToSet( new SingletonIterator<>( "single" ) ) );
+        assertEquals( oneSet( "single" ), IteratorCollection.iteratorToSet( new SingletonIterator<>( "single" ) ) );
         }
-    
+
     public void testLotsToSet()
         {
         Object [] elements = new Object[] {"now", "is", "the", "time"};
         Iterator<Object> it = Arrays.asList( elements ).iterator();
         assertEquals( setLots( elements ), IteratorCollection.iteratorToSet( it ) );
         }
-    
+
     public void testCloseForSet()
         {
         testCloseForSet( new Object[] {} );
@@ -64,13 +65,13 @@ public class TestIteratorCollection extends GraphTestBase
         testCloseForSet( new Object[] {"another", "one", "plus", Boolean.FALSE} );
         testCloseForSet( new Object[] {"the", "king", "is", "in", "his", "counting", "house"} );
         }
-    
+
     protected void testCloseForSet( Object[] objects )
         {
         final boolean [] closed = {false};
-        Iterator<Object> iterator = new WrappedIterator<Object>( Arrays.asList( objects ).iterator() ) 
+        Iterator<Object> iterator = new WrappedIterator<Object>( Arrays.asList( objects ).iterator() )
             { @Override public void close() { super.close(); closed[0] = true; } };
-        iteratorToSet( iterator );
+        IteratorCollection.iteratorToSet( iterator );
         assertTrue( closed[0] );
         }
 
@@ -78,18 +79,18 @@ public class TestIteratorCollection extends GraphTestBase
         {
         assertEquals( new ArrayList<>(), IteratorCollection.iteratorToList( NullIterator.instance() ) );
         }
-    
+
     public void testSingletonToSingletonList()
         {
         assertEquals( oneList( "just one" ), IteratorCollection.iteratorToList( new SingletonIterator<>( "just one" ) ) );
         }
-    
+
     public void testLotsToList()
         {
         List<Object> list = Arrays.asList( new Object[] {"to", "be", "or", "not", "to", "be"}  );
         assertEquals( list, IteratorCollection.iteratorToList( list.iterator() ) );
         }
-        
+
     public void testCloseForList()
         {
         testCloseForList( new Object[] {} );
@@ -98,13 +99,13 @@ public class TestIteratorCollection extends GraphTestBase
         testCloseForList( new Object[] {"another", "one", "plus", Boolean.FALSE} );
         testCloseForList( new Object[] {"the", "king", "is", "in", "his", "counting", "house"} );
         }
-    
+
     protected void testCloseForList( Object[] objects )
         {
         final boolean [] closed = {false};
-        Iterator<Object> iterator = new WrappedIterator<Object>( Arrays.asList( objects ).iterator() ) 
+        Iterator<Object> iterator = new WrappedIterator<Object>( Arrays.asList( objects ).iterator() )
             { @Override public void close() { super.close(); closed[0] = true; } };
-        iteratorToList( iterator );
+        IteratorCollection.iteratorToList( iterator );
         assertTrue( closed[0] );
         }
 
@@ -114,7 +115,7 @@ public class TestIteratorCollection extends GraphTestBase
         result.add( x );
         return result;
         }
-    
+
     protected Set<Object> setLots( Object [] elements )
         {
         Set<Object> result = new HashSet<>();
@@ -124,7 +125,7 @@ public class TestIteratorCollection extends GraphTestBase
             }
         return result;
         }
-    
+
     protected List<Object> oneList( Object x )
         {
         List<Object> result = new ArrayList<>();

--- a/jena-core/src/test/java/org/apache/jena/util/TestModelCollector.java
+++ b/jena-core/src/test/java/org/apache/jena/util/TestModelCollector.java
@@ -52,6 +52,7 @@ import org.apache.jena.util.ModelCollector.IntersectionModelCollector;
 import org.apache.jena.util.ModelCollector.UnionModelCollector;
 import org.junit.Test;
 
+@SuppressWarnings("removal")
 public class TestModelCollector {
 
     public static junit.framework.Test suite() {

--- a/jena-core/src/test/java/org/apache/jena/util/TestMonitors.java
+++ b/jena-core/src/test/java/org/apache/jena/util/TestMonitors.java
@@ -31,25 +31,25 @@ import org.apache.jena.reasoner.test.TestUtil ;
 /**
  * Tests for MonitorGraph implementation.
  */
-
+@SuppressWarnings("removal")
 public class TestMonitors extends TestCase {
 
     /**
      * Boilerplate for junit
-     */ 
+     */
     public TestMonitors( String name ) {
-        super( name ); 
+        super( name );
     }
-    
+
     /**
      * Boilerplate for junit.
      * This is its own test suite
      */
     public static TestSuite suite() {
-        return new TestSuite( TestMonitors.class ); 
-    }  
+        return new TestSuite( TestMonitors.class );
+    }
 
-    // constants used in the tests 
+    // constants used in the tests
     String NS = "http://jena.hpl.hp.com/test#";
     Node a = NodeCreateUtils.create(NS + "a");
     Node p = NodeCreateUtils.create(NS + "p");
@@ -59,32 +59,32 @@ public class TestMonitors extends TestCase {
     Triple t4 = Triple.create(a, p, NodeCreateUtils.create(NS + "v4"));
     Triple t5 = Triple.create(a, p, NodeCreateUtils.create(NS + "v5"));
     Triple t6 = Triple.create(a, p, NodeCreateUtils.create(NS + "v6"));
-    
+
     /**
      * Basic graph level test, no monitoring
      */
     public void testBasics() {
         Graph base = GraphMemFactory.createGraphMem();
         MonitorGraph monitor = new MonitorGraph(base);
-        
+
         // base data
         base.add(t1);
         base.add(t2);
         base.add(t3);
-        
+
         // Test changes from empty
         List<Triple> additions = new ArrayList<>();
         List<Triple> deletions = new ArrayList<>();
         monitor.snapshot(additions, deletions);
         TestUtil.assertIteratorValues(this, additions.iterator(), new Object[] {t1, t2, t3});
         TestUtil.assertIteratorValues(this, deletions.iterator(), new Object[] {});
-        
+
         // Make some new changes
         base.add(t4);
         base.add(t5);
         base.delete(t1);
         base.delete(t2);
-        
+
         additions.clear();
         deletions.clear();
         monitor.snapshot(additions, deletions);
@@ -92,7 +92,7 @@ public class TestMonitors extends TestCase {
         TestUtil.assertIteratorValues(this, deletions.iterator(), new Object[] {t1, t2});
         TestUtil.assertIteratorValues(this, monitor.find(Node.ANY, Node.ANY, Node.ANY), new Object[] {t3, t4, t5});
     }
-    
+
     /**
      * Monitoring test.
      */
@@ -105,36 +105,36 @@ public class TestMonitors extends TestCase {
         base.add(t1);
         base.add(t2);
         base.add(t3);
-        
+
         listener.has(new Object[]{});
-        
+
         // Test changes from empty
         List<Triple> additions = new ArrayList<>();
         List<Triple> deletions = new ArrayList<>();
         monitor.snapshot(additions, deletions);
         TestUtil.assertIteratorValues(this, additions.iterator(), new Object[] {t1, t2, t3});
         TestUtil.assertIteratorValues(this, deletions.iterator(), new Object[] {});
-        
+
         listener.assertHas(new Object[] {"addList", monitor, additions, "deleteList", monitor, deletions});
         listener.clear();
-        
+
         // Make some new changes
         base.add(t4);
         base.add(t5);
         base.delete(t1);
         base.delete(t2);
-        
+
         additions.clear();
         deletions.clear();
         monitor.snapshot(additions, deletions);
         TestUtil.assertIteratorValues(this, additions.iterator(), new Object[] {t4, t5});
         TestUtil.assertIteratorValues(this, deletions.iterator(), new Object[] {t1, t2});
         TestUtil.assertIteratorValues(this, monitor.find(Node.ANY, Node.ANY, Node.ANY), new Object[] {t3, t4, t5});
-        
+
         listener.assertHas(new Object[] {"addList", monitor, additions, "deleteList", monitor, deletions});
         listener.clear();
     }
-    
+
     /**
      * Test model level access
      */
@@ -148,16 +148,16 @@ public class TestMonitors extends TestCase {
         Statement s3 = base.createStatement(ar, pr, "3");
         Statement s4 = base.createStatement(ar, pr, "4");
         Statement s5 = base.createStatement(ar, pr, "5");
-        
+
         MonitorModel monitor = new MonitorModel(base);
         RecordingModelListener listener = new RecordingModelListener();
         monitor.register(listener);
-        
+
         // base data
         base.add(s1);
         base.add(s2);
         base.add(s3);
-        
+
         // Test changes from empty
         List<Statement> additions = new ArrayList<>();
         List<Statement> deletions = new ArrayList<>();
@@ -166,22 +166,22 @@ public class TestMonitors extends TestCase {
         TestUtil.assertIteratorValues(this, deletions.iterator(), new Object[] {});
         listener.assertHas(new Object[] {"addList", additions, "removeList", deletions});
         listener.clear();
-        
+
         // Make some new changes
         base.add(s4);
         base.add(s5);
         base.remove(s1);
         base.remove(s2);
-        
+
         additions.clear();
         deletions.clear();
         monitor.snapshot(additions, deletions);
         TestUtil.assertIteratorValues(this, additions.iterator(), new Object[] {s4, s5});
         TestUtil.assertIteratorValues(this, deletions.iterator(), new Object[] {s1, s2});
         TestUtil.assertIteratorValues(this, monitor.listStatements(), new Object[] {s3, s4, s5});
-        
+
         listener.assertHas(new Object[] {"addList", additions, "removeList", deletions});
         listener.clear();
     }
-   
+
 }

--- a/jena-core/src/test/java/org/apache/jena/util/iterator/test/TestAndThen.java
+++ b/jena-core/src/test/java/org/apache/jena/util/iterator/test/TestAndThen.java
@@ -21,6 +21,7 @@ package org.apache.jena.util.iterator.test;
 import java.util.List ;
 
 import junit.framework.TestSuite ;
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.rdf.model.test.ModelTestBase ;
 import org.apache.jena.util.iterator.ExtendedIterator ;
 import org.apache.jena.util.iterator.NiceIterator ;
@@ -30,19 +31,19 @@ public class TestAndThen extends ModelTestBase
     {
     public TestAndThen( String name )
         { super( name ); }
-    
+
     public static TestSuite suite()
         { return new TestSuite( TestAndThen.class ); }
 
     public void testAndThen()
-        { 
+        {
         ExtendedIterator<String> L = iteratorOfStrings( "a b c" );
         ExtendedIterator<String> R = iteratorOfStrings( "d e f" );
         assertInstanceOf( NiceIterator.class, L );
         assertInstanceOf( NiceIterator.class, R );
-        assertEquals( listOfStrings( "a b c d e f" ), iteratorToList( L.andThen( R ) ) );
+        assertEquals( listOfStrings( "a b c d e f" ), Iter.toList( L.andThen( R ) ) );
         }
-    
+
     public void testAndThenExtension()
         {
         ExtendedIterator<String> L = iteratorOfStrings( "a b c" );
@@ -52,9 +53,9 @@ public class TestAndThen extends ModelTestBase
         ExtendedIterator<String> LRX = LR.andThen( X );
         assertSame( LR, LRX );
         List<String> aToI = listOfStrings( "a b c d e f g h i" );
-        assertEquals( aToI, iteratorToList( LRX ) );
+        assertEquals( aToI, Iter.toList( LRX ) );
         }
-    
+
     public void testClosingConcatenationClosesRemainingIterators()
         {
         LoggingClosableIterator<String> L = new LoggingClosableIterator<>( iteratorOfStrings( "only" ) );
@@ -66,77 +67,77 @@ public class TestAndThen extends ModelTestBase
         assertTrue( "middle iterator should have been closed", M.isClosed() );
         assertTrue( "final iterator should have been closed", R.isClosed() );
         }
-    
+
     public void testRemove1()
     {
         List<String> L = listOfStrings("a b c");
         List<String> R = listOfStrings("d e f");
-        
+
         ExtendedIterator<String> Lit = WrappedIterator.create(L.iterator());
         ExtendedIterator<String> Rit = WrappedIterator.create(R.iterator());
-        
+
         ExtendedIterator<String> LR = Lit.andThen( Rit ) ;
-        
+
         while (LR.hasNext())
         {
             String s = LR.next();
-            
+
             if ("c".equals(s))
             {
                 LR.hasNext();  // test for JENA-60
                 LR.remove();
             }
         }
-        
+
         assertEquals("ab", concatAsString(L));
         assertEquals("def", concatAsString(R));
     }
-    
+
     public void testRemove2()
     {
         List<String> L = listOfStrings("a b c");
         List<String> R = listOfStrings("d e f");
-        
+
         ExtendedIterator<String> Lit = WrappedIterator.create(L.iterator());
         ExtendedIterator<String> Rit = WrappedIterator.create(R.iterator());
-        
+
         ExtendedIterator<String> LR = Lit.andThen( Rit ) ;
-        
+
         while (LR.hasNext())
         {
             String s = LR.next();
-            
+
             if ("d".equals(s))
             {
                 LR.hasNext();  // test for JENA-60
                 LR.remove();
             }
         }
-        
+
         assertEquals("abc", concatAsString(L));
         assertEquals("ef", concatAsString(R));
     }
-    
+
     public void testRemove3()
     {
         List<String> L = listOfStrings("a b c");
         List<String> R = listOfStrings("d e f");
-        
+
         ExtendedIterator<String> Lit = WrappedIterator.create(L.iterator());
         ExtendedIterator<String> Rit = WrappedIterator.create(R.iterator());
-        
+
         ExtendedIterator<String> LR = Lit.andThen( Rit ) ;
-        
+
         while (LR.hasNext())
         {
             LR.next();
         }
         LR.remove();
-        
+
         assertEquals("abc", concatAsString(L));
         assertEquals("de", concatAsString(R));
     }
-    
+
     private String concatAsString(List<String> strings)
     {
         String toReturn = "";
@@ -146,5 +147,5 @@ public class TestAndThen extends ModelTestBase
         }
         return toReturn;
     }
-    
+
     }

--- a/jena-core/src/test/java/org/apache/jena/util/iterator/test/TestFilters.java
+++ b/jena-core/src/test/java/org/apache/jena/util/iterator/test/TestFilters.java
@@ -18,31 +18,31 @@
 
 package org.apache.jena.util.iterator.test;
 
-import java.util.*;
+import java.util.Iterator;
 import java.util.function.Predicate;
 
 import junit.framework.TestSuite;
-
+import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.rdf.model.test.ModelTestBase ;
-import org.apache.jena.util.iterator.* ;
+import org.apache.jena.util.iterator.FilterIterator;
 
 public class TestFilters extends ModelTestBase
     {
     public TestFilters( String name )
         { super( name ); }
-    
+
     public static TestSuite suite()
         { return new TestSuite( TestFilters.class ); }
 
-    protected Predicate<String> containsA = o -> contains( o, 'a' );    
-    
+    protected Predicate<String> containsA = o -> contains( o, 'a' );
+
     public void testFilterIterator()
         {
         Iterator<String> i = iteratorOfStrings( "there's an a in some animals" );
         Iterator<String> it = new FilterIterator<>( containsA, i );
-        assertEquals( listOfStrings( "an a animals" ), iteratorToList( it ) );
+        assertEquals( listOfStrings( "an a animals" ), Iter.toList( it ) );
         }
-    
+
     protected boolean contains( Object o, char ch )
         { return o.toString().indexOf( ch ) > -1; }
     }

--- a/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/Converters.java
+++ b/jena-extras/jena-querybuilder/src/main/java/org/apache/jena/arq/querybuilder/Converters.java
@@ -18,12 +18,7 @@
 package org.apache.jena.arq.querybuilder;
 
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -38,7 +33,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.riot.RiotException;
-import org.apache.jena.riot.system.PrefixMapFactory;
+import org.apache.jena.riot.system.Prefixes;
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.sparql.ARQInternalErrorException;
 import org.apache.jena.sparql.core.TriplePath;
@@ -186,7 +181,7 @@ public class Converters {
 
         if (o instanceof String) {
             try {
-                return checkVar(NodeFactoryExtra.parseNode((String) o, PrefixMapFactory.create(pMapping)));
+                return checkVar(NodeFactoryExtra.parseNode((String) o, Prefixes.adapt(pMapping)));
             } catch (final RiotException e) {
                 // expected in some cases -- do nothing
             }


### PR DESCRIPTION
Add `@Deprecated(forRemoval=true)` to some things that look like they can be removed at Jena6, because they are not used in Jena or duplicate functionality and there are replacements. Mainly from `jena-core`; some associated changes to switch away from deprecated operations.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
