### PR TITLE
Changes to the Model API for RDF 1.2 triple terms and triple reifiers

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/QuerySolution.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/QuerySolution.java
@@ -22,43 +22,61 @@ import java.util.Iterator ;
 import org.apache.jena.rdf.model.Literal ;
 import org.apache.jena.rdf.model.RDFNode ;
 import org.apache.jena.rdf.model.Resource ;
-
+import org.apache.jena.rdf.model.StatementTerm;
 
 /**
- * A single answer from a SELECT query. */
+ * A single answer from a SELECT query.
+ */
 
 public interface QuerySolution
 {
-    /** Return the value of the named variable in this binding.
-     *  A return of null indicates that the variable is not present in this solution.
-     *  @param varName
-     *  @return RDFNode
+    /**
+     * Return the value of the named variable in this binding. A return of null
+     * indicates that the variable is not present in this solution.
+     *
+     * @param varName
+     * @return RDFNode
      */
     public RDFNode get(String varName);
 
-    /** Return the value of the named variable in this binding, casting to a Resource.
-     *  A return of null indicates that the variable is not present in this solution.
-     *  An exception indicates it was present but not a resource.
-     *  @param varName
-     *  @return Resource
+    /**
+     * Return the value of the named variable in this binding, casting to a
+     * {@link Resource}. A return of null indicates that the variable is not present
+     * in this solution. An exception indicates it was present but not a resource.
+     *
+     * @param varName
+     * @return Resource
      */
     public Resource getResource(String varName);
 
-    /** Return the value of the named variable in this binding, casting to a Literal.
-     *  A return of null indicates that the variable is not present in this solution.
-     *  An exception indicates it was present but not a literal.
-     *  @param varName
-     *  @return Resource
+    /**
+     * Return the value of the named variable in this binding, casting to a
+     * {@link Literal}. A return of null indicates that the variable is not present
+     * in this solution. An exception indicates it was present but not a literal.
+     *
+     * @param varName
+     * @return Resource
      */
     public Literal getLiteral(String varName);
 
-    
+    /**
+     * Return the value of the named variable in this binding, casting to a
+     * {@link StatementTerm}. A return of null indicates that the variable is not
+     * present in this solution. An exception indicates it was present but not a
+     * triple term.
+     *
+     * @param varName
+     * @return Resource
+     */
+    public StatementTerm getStatementTerm(String varName);
+
     /** Return true if the named variable is in this binding */
     public boolean contains(String varName);
 
-    /** Iterate over the variable names (strings) in this QuerySolution.
+    /**
+     * Iterate over the variable names (strings) in this QuerySolution.
+     *
      * @return Iterator of strings
-     */ 
-    public Iterator<String> varNames() ;
-    
+     */
+    public Iterator<String> varNames();
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/QuerySolutionBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/QuerySolutionBase.java
@@ -24,27 +24,31 @@ import org.apache.jena.query.QuerySolution ;
 import org.apache.jena.rdf.model.Literal ;
 import org.apache.jena.rdf.model.RDFNode ;
 import org.apache.jena.rdf.model.Resource ;
+import org.apache.jena.rdf.model.StatementTerm;
 
-/** Implementation of QuerySolution that contains the canonicalization and casting code. */ 
+/** Implementation of QuerySolution that contains the canonicalization and casting code. */
 
 public abstract class QuerySolutionBase implements QuerySolution
 {
     @Override
     public RDFNode get(String varName)          { return _get(Var.canonical(varName)) ; }
-    
-    protected abstract RDFNode _get(String varName) ; 
+
+    protected abstract RDFNode _get(String varName) ;
 
     @Override
-    public Resource getResource(String varName) { return (Resource)get(varName) ; } 
+    public Resource getResource(String varName) { return (Resource)get(varName) ; }
 
     @Override
     public Literal getLiteral(String varName)   { return (Literal)get(varName) ; }
 
     @Override
-    public boolean contains(String varName)     { return _contains(Var.canonical(varName)) ; }  
+    public StatementTerm getStatementTerm(String varName)   { return (StatementTerm)get(varName) ; }
+
+    @Override
+    public boolean contains(String varName)     { return _contains(Var.canonical(varName)) ; }
 
     protected abstract boolean _contains(String varName) ;
-    
+
     @Override
     public abstract Iterator<String> varNames() ;
 }

--- a/jena-core/src/main/java/org/apache/jena/enhanced/EnhNode.java
+++ b/jena-core/src/main/java/org/apache/jena/enhanced/EnhNode.java
@@ -30,13 +30,13 @@ import org.apache.jena.rdf.model.* ;
 */
 public class EnhNode extends Polymorphic<RDFNode> implements FrontsNode
 {
-    
+
     /** The graph node that this enhanced node is wrapping */
     final protected Node node;
-    
+
     /** The enhanced graph containing this node */
     final protected EnhGraph enhGraph;
-    
+
     public EnhNode( Node n, EnhGraph g ) {
         super();
         node=n;
@@ -44,8 +44,8 @@ public class EnhNode extends Polymorphic<RDFNode> implements FrontsNode
    }
 
     // External interface
-    
-    /** 
+
+    /**
      * Answer the graph node that this enhanced node wraps
      * @return A plain node
      */
@@ -53,40 +53,40 @@ public class EnhNode extends Polymorphic<RDFNode> implements FrontsNode
     public Node asNode() {
         return node;
     }
-    
+
     /**
      * Answer the graph containing this node
-     * @return An enhanced graph 
+     * @return An enhanced graph
      */
     public EnhGraph getGraph() {
         return enhGraph;
     }
-    
+
     /**
         An enhanced node is Anon[ymous] iff its underlying node is Blank.
     */
     public final boolean isAnon() {
         return node.isBlank();
     }
-    
+
     /**
         An enhanced node is Literal iff its underlying node is too.
     */
     public final boolean isLiteral() {
         return node.isLiteral();
     }
- 
+
     /**
         An enhanced node is a URI resource iff its underlying node is too.
     */
     public final boolean isURIResource() {
         return node.isURI();
     }
-    
+
     /**
         An enhanced node is a statement resource iff its underlying node is a triple term (RDF-star).
      */
-    public final boolean isStmtResource() {
+    public final boolean isStatementTerm() {
         return node.isTripleTerm();
     }
 
@@ -96,29 +96,29 @@ public class EnhNode extends Polymorphic<RDFNode> implements FrontsNode
     public final boolean isResource() {
         return node.isURI() || node.isBlank() || node.isTripleTerm();
     }
-    
+
     /**
      * Answer a facet of this node, where that facet is denoted by the
      * given type.
-     * 
+     *
      * @param t A type denoting the desired facet of the underlying node
      * @return An enhanced nodet that corresponds to t; this may be <i>this</i>
      *         Java object, or a different object.
-     */ 
+     */
     public <X extends RDFNode> X viewAs( Class<X> t ) {
-        return asInternal( t ); 
+        return asInternal( t );
     }
-    
+
     /** allow subclasses to implement RDFNode &amp; its subinterface */
     public <T extends RDFNode> T as( Class<T> t )
         { return asInternal( t ); }
-      
+
     /**
         API-level method for polymorphic testing
     */
     public <X extends RDFNode> boolean canAs( Class<X> t )
         { return canSupport( t ); }
-        
+
     /**
      * The hash code of an enhanced node is defined to be the same as the underlying node.
      * @return The hashcode as an int
@@ -126,46 +126,46 @@ public class EnhNode extends Polymorphic<RDFNode> implements FrontsNode
     @Override final public int hashCode() {
      	return node.hashCode();
     }
-       
+
     /**
-     * An enhanced node is equal to another enhanced node n iff the underlying 
+     * An enhanced node is equal to another enhanced node n iff the underlying
      * nodes are equal. We generalise to allow the other object to be any class
      * implementing asNode, because we allow other implemementations of
      * Resource than EnhNodes, at least in principle.
      * This is deemed to be a complete and correct interpretation of enhanced node
      * equality, which is why this method has been marked final.
-     * 
+     *
      * @param o An object to test for equality with this node
      * @return True if o is equal to this node.
      */
     @Override final public boolean equals( Object o )
         { return o instanceof FrontsNode && node.equals(((FrontsNode) o).asNode()); }
-    
+
     @Override public boolean isValid()
         { return true; }
-        
-    /** 
-        Answer an new enhanced node object that presents <i>this</i> in a way 
+
+    /**
+        Answer an new enhanced node object that presents <i>this</i> in a way
         which satisfies type <code>t</code>. The new object is linked into this
         object's sibling ring. If the node cannot be converted, throw an
         UnsupportedPolymorphismException.
     */
-    @Override protected <X extends RDFNode> X convertTo( Class<X> t ) 
+    @Override protected <X extends RDFNode> X convertTo( Class<X> t )
         {
         EnhGraph eg = getGraph();
         if (eg == null) throw new UnsupportedPolymorphismException( this, false, t );
         Implementation imp = getPersonality().getImplementation( t );
         if (imp == null) throw new UnsupportedPolymorphismException( this, true, t );
-        EnhNode result = imp.wrap( asNode(), eg );          
+        EnhNode result = imp.wrap( asNode(), eg );
         this.addView( result );
         return t.cast( result );
         }
-    
+
     /**
         answer true iff this enhanced node can support the class <code>t</code>,
         ie it is already a value <code>t</code> or it can be reimplemented
         as a <code>t</code> via the graph's personality's implementation.
-        If this node has no graph, answer false.       
+        If this node has no graph, answer false.
     */
     @Override protected <X extends RDFNode> boolean canSupport( Class<X> t )
         {
@@ -176,13 +176,13 @@ public class EnhNode extends Polymorphic<RDFNode> implements FrontsNode
         }
 
     /**
-     * Answer the personality object bound to this enhanced node, which we obtain from 
+     * Answer the personality object bound to this enhanced node, which we obtain from
      * the associated enhanced graph.
-     * 
+     *
      * @return The personality object
      */
     @Override protected Personality<RDFNode> getPersonality() {
         return getGraph().getPersonality();
     }
-    
+
 }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/Model.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/Model.java
@@ -229,7 +229,7 @@ public interface Model
      * @param statement
      * @return a new resource linked to this model.
      */
-    public RDFNode createStatementTerm( Statement statement );
+    public StatementTerm createStatementTerm( Statement statement );
 
     /**
      * Create an anonymous resource that reifies a statement (RDF 1.2)
@@ -237,9 +237,9 @@ public interface Model
      * @param statement
      * @return the reifier resource.
      */
-    public default Resource createReifiedStmt( Statement statement ) {
+    public default Resource createReifier( Statement statement ) {
         Resource reifier = this.createResource();
-        return createReifiedStmt(reifier, statement);
+        return createReifier(reifier, statement);
     }
 
     /**
@@ -250,8 +250,8 @@ public interface Model
      * @param statement
      * @return the reifier
      */
-    public default Resource createReifiedStmt( Resource reifier, Statement statement ) {
-        RDFNode n = createStatementTerm(statement);
+    public default Resource createReifier( Resource reifier, Statement statement ) {
+        StatementTerm n = createStatementTerm(statement);
         this.add(reifier, RDF.reifies, n);
         return reifier;
     }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/Model.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/Model.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier ;
 
 import org.apache.jena.datatypes.* ;
 import org.apache.jena.shared.* ;
+import org.apache.jena.vocabulary.RDF;
 
 /**
     An RDF Model.
@@ -210,11 +211,50 @@ public interface Model
 	public Resource createResource( String uri ) ;
 
 	/**
-	 * Create a resource that represents a statement. This is in support of RDF-star.
-	 * @param statement
-	 * @return a new resource linked to this model.
-	 */
-	public Resource createResource( Statement statement ) ;
+	 * Create a resource that represents a statement.
+	 * This is in support of RDF 1.2 triple terms.
+     * @deprecated Use {@link #createStatementTerm}
+     */
+    @Deprecated(forRemoval = true)
+	public default RDFNode createResource( Statement statement ) {
+        return createStatementTerm(statement);
+    }
+
+    /**
+     * Create an RDFNode for a statement.
+     * This is in support of RDF 1.2 triple terms.
+     * Triple terms can only appear in the object position.
+     * Use with predicate {@code rdf:reifies}
+     *
+     * @param statement
+     * @return a new resource linked to this model.
+     */
+    public RDFNode createStatementTerm( Statement statement );
+
+    /**
+     * Create an anonymous resource that reifies a statement (RDF 1.2)
+     *
+     * @param statement
+     * @return the reifier resource.
+     */
+    public default Resource createReifiedStmt( Statement statement ) {
+        Resource reifier = this.createResource();
+        return createReifiedStmt(reifier, statement);
+    }
+
+    /**
+     * Create a reification statement in the model.
+     * {@code reifier rdf:reifies statement}
+     *
+     * @param reifier
+     * @param statement
+     * @return the reifier
+     */
+    public default Resource createReifiedStmt( Resource reifier, Statement statement ) {
+        RDFNode n = createStatementTerm(statement);
+        this.add(reifier, RDF.reifies, n);
+        return reifier;
+    }
 
 	/**
         Create a property with a given URI composed from a namespace part and a

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/RDFNode.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/RDFNode.java
@@ -18,113 +18,115 @@
 
 package org.apache.jena.rdf.model;
 
-import org.apache.jena.graph.FrontsNode ;
+import org.apache.jena.graph.FrontsNode;
 
-/** 
-    Interface covering RDF resources and literals. Allows probing whether a
-    node is a literal/[blank, URI]resource, moving nodes from model to model,
-    and viewing them as different Java types using the .as() polymorphism.
-*/
-public interface RDFNode extends FrontsNode
-    {
-    /** 
-        Answer a String representation of the node.  The form of the string 
-        depends on the type of the node and is intended for human consumption,
-        not machine analysis.
-    */
+/**
+ * Interface covering RDF resources and literals. Allows probing whether a node is a
+ * literal/[blank, URI]resource, moving nodes from model to model, and viewing them
+ * as different Java types using the .as() polymorphism.
+ */
+public interface RDFNode extends FrontsNode {
+    /**
+     * Answer a String representation of the node. The form of the string depends on
+     * the type of the node and is intended for human consumption, not machine
+     * analysis.
+     */
     @Override
     public String toString();
-    
-    /** 
-        Answer true iff this RDFNode is an anonymous resource. Useful for
-        one-off tests: see also visitWith() for making literal/anon/URI choices.
-    */
-    public boolean isAnon();
-    
-    /** 
-        Answer true iff this RDFNode is a literal resource. Useful for
-        one-off tests: see also visitWith() for making literal/anon/URI choices.
-    */
-    public boolean isLiteral();
-    
-    /** 
-        Answer true iff this RDFNode is an named resource. Useful for
-        one-off tests: see also visitWith() for making literal/anon/URI choices.
-    */
-    public boolean isURIResource();
-    
+
     /**
-        Answer true iff this RDFNode is a URI resource or an anonymous
-        resource or a statement term (ie is not a literal). Useful for one-off tests: see also 
-        visitWith() for making literal/anon/URI choices.
-    */
-    public boolean isResource();
-    
-    /**
-        Answer true iff this RDFNode is a resource representing an RDF-star triple term. 
+     * Answer true iff this RDFNode is an anonymous resource. Useful for one-off
+     * tests: see also visitWith() for making literal/anon/URI choices.
      */
-    
-    public boolean isStmtResource();
-    
-    /**
-        RDFNodes can be converted to different implementation types. Convert
-        this RDFNode to a type supporting the <code>view</code>interface. The 
-        resulting RDFNode should be an instance of <code>view</code> and should 
-        have any internal invariants as specified.
-    <p>
-        If the RDFNode has no Model attached, it can only be .as()ed to
-        a type it (this particular RDFNOde) already has.
-    <p>
-        If the RDFNode cannot be converted, an UnsupportedPolymorphism
-        exception is thrown..
-    */
-    public <T extends RDFNode> T as( Class<T> view );
-    
-    /**
-        Answer true iff this RDFNode can be viewed as an instance of
-        <code>view</code>: that is, if it has already been viewed in this
-        way, or if it has an attached model in which it has properties that
-        permit it to be viewed in this way. If <code>canAs</code> returns
-        <code>true</code>, <code>as</code> on the same view should
-        deliver an instance of that class. 
-    */
-    public <T extends RDFNode> boolean canAs( Class<T> view );
+    public boolean isAnon();
 
-    /** 
-        Return the model associated with this resource. If the Resource
-        was not created by a Model, the result may be null.
+    /**
+     * Answer true iff this RDFNode is a literal resource. Useful for one-off tests:
+     * see also visitWith() for making literal/anon/URI choices.
+     */
+    public boolean isLiteral();
 
-        @return The model associated with this resource.
-    */
+    /**
+     * Answer true iff this RDFNode is an named resource. Useful for one-off tests:
+     * see also visitWith() for making literal/anon/URI choices.
+     */
+    public boolean isURIResource();
+
+    /**
+     * Answer true iff this RDFNode is a URI resource or an anonymous resource or a
+     * statement term (ie is not a literal). Useful for one-off tests: see also
+     * visitWith() for making literal/anon/URI choices.
+     */
+    public boolean isResource();
+
+    /**
+     * Answer true iff this RDFNode is a resource representing an RDF-star triple
+     * term.
+     */
+    public boolean isStatementTerm();
+
+    /**
+     * RDFNodes can be converted to different implementation types. Convert this
+     * RDFNode to a type supporting the <code>view</code>interface. The resulting
+     * RDFNode should be an instance of <code>view</code> and should have any
+     * internal invariants as specified.
+     * <p>
+     * If the RDFNode has no Model attached, it can only be .as()ed to a type it
+     * (this particular RDFNOde) already has.
+     * <p>
+     * If the RDFNode cannot be converted, an UnsupportedPolymorphism exception is
+     * thrown..
+     */
+    public <T extends RDFNode> T as(Class<T> view);
+
+    /**
+     * Answer true iff this RDFNode can be viewed as an instance of
+     * <code>view</code>: that is, if it has already been viewed in this way, or if
+     * it has an attached model in which it has properties that permit it to be
+     * viewed in this way. If <code>canAs</code> returns <code>true</code>,
+     * <code>as</code> on the same view should deliver an instance of that class.
+     */
+    public <T extends RDFNode> boolean canAs(Class<T> view);
+
+    /**
+     * Return the model associated with this resource. If the Resource was not
+     * created by a Model, the result may be null.
+     *
+     * @return The model associated with this resource.
+     */
     public Model getModel();
-    
-    /**
-        Answer a .equals() version of this node, except that it's in the model 
-        <code>m</code>.
-        
-        @param m a model to move the node to
-        @return this, if it's already in m (or no model), a copy in m otherwise
-    */
-    public RDFNode inModel( Model m );
-    
-    /**
-        Apply the appropriate method of the visitor to this node's content and
-        return the result.
-        
-        @param rv an RDFVisitor with a method for URI/blank/literal nodes
-        @return the result returned by the selected method
-    */
-    public Object visitWith( RDFVisitor rv );
 
     /**
-       If this node is a Resource, answer that resource; otherwise throw an
-       exception. 
-    */
-    public Resource asResource();
-    
+     * Answer a .equals() version of this node, except that it's in the model
+     * <code>m</code>.
+     *
+     * @param m a model to move the node to
+     * @return this, if it's already in m (or no model), a copy in m otherwise
+     */
+    public RDFNode inModel(Model m);
+
     /**
-        If this node is a Literal, answer that literal; otherwise throw an
-        exception. 
+     * Apply the appropriate method of the visitor to this node's content and return
+     * the result.
+     *
+     * @param rv an RDFVisitor with a method for URI/blank/literal nodes
+     * @return the result returned by the selected method
+     */
+    public Object visitWith(RDFVisitor rv);
+
+    /**
+     * If this node is a Resource, answer that resource; otherwise throw an
+     * exception.
+     */
+    public Resource asResource();
+
+    /**
+     * If this node is a Literal, answer that literal; otherwise throw an exception.
      */
     public Literal asLiteral();
-    }
+
+    /**
+     * If this node is a StatementTerm, answer that statement term; otherwise throw an exception.
+     */
+    public StatementTerm asStatementTerm();
+}

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/RDFVisitor.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/RDFVisitor.java
@@ -19,40 +19,41 @@
 package org.apache.jena.rdf.model;
 
 /**
-    The interface for visiting (ie type-dispatching) an RDF Node.
-*/
-public interface RDFVisitor
-    {
+ * The interface for visiting (ie type-dispatching) an RDF Node.
+ */
+public interface RDFVisitor {
     /**
-        Method to call when visiting a blank node r with identifier id.
-        @param r the blank RDF node being visited
-        @param id the identifier of that node
-        @return value to be returned from the visit
-    */
-    Object visitBlank( Resource r, AnonId id );
-    
+     * Method to call when visiting a blank node r with identifier id.
+     *
+     * @param r the blank RDF node being visited
+     * @param id the identifier of that node
+     * @return value to be returned from the visit
+     */
+    Object visitBlank(Resource r, AnonId id);
+
     /**
-        Method to call when visiting a URI node r with the given uri.
-        @param r the URI node being visited
-        @param uri the URI string of that node
-        @return value to be returned from the visit
-    */
-    Object visitURI( Resource r, String uri );
-    
-    
+     * Method to call when visiting a URI node r with the given uri.
+     *
+     * @param r the URI node being visited
+     * @param uri the URI string of that node
+     * @return value to be returned from the visit
+     */
+    Object visitURI(Resource r, String uri);
+
     /**
-     * Method to call when visiting a resource with a statement.
-     *   @param r the resource node being visited
-     *   @param statement the statement of that node
-     *   @return value to be returned from the visit
-     */ 
-        
-    default Object visitStmt( Resource r, Statement statement) { return null; }
-    
+     * Method to call when visiting a literal RDF node l.
+     *
+     * @param l the RDF Literal node
+     * @return a value to be returned from the visit
+     */
+    Object visitLiteral(Literal l);
+
     /**
-        Method to call when visiting a literal RDF node l.
-        @param l the RDF Literal node
-        @return a value to be returned from the visit
-    */
-    Object visitLiteral( Literal l );
-    }
+     * Method to call when visiting a statement term.
+     *
+     * @param statementTerm the statement term being visited
+     * @param statement the statement of that node
+     * @return value to be returned from the visit
+     */
+    default Object visitStmt(StatementTerm StatementTerm, Statement statement) { return statement; }
+}

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/Resource.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/Resource.java
@@ -81,13 +81,6 @@ public interface Resource extends RDFNode {
      */
     public String getURI();
 
-    /**
-     * Return the statement of this resource, or null if it is not an RDF-star triple term.
-     * This is not a resource for a reified statement.
-     * @return The statement of this resource,or null if it is not an RDF-star triple term.
-     */
-    public Statement getStmtTerm();
-
     /** Returns the namespace associated with this resource if it is a URI, else return null.
      * <p>
      * The namespace is suitable for use with localname in RDF/XML.

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/ResourceFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/ResourceFactory.java
@@ -25,10 +25,7 @@ import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.datatypes.xsd.XSDDateTime ;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory ;
-import org.apache.jena.rdf.model.impl.LiteralImpl;
-import org.apache.jena.rdf.model.impl.PropertyImpl;
-import org.apache.jena.rdf.model.impl.ResourceImpl;
-import org.apache.jena.rdf.model.impl.StatementImpl;
+import org.apache.jena.rdf.model.impl.*;
 
 /** A Factory class for creating resources.
  *
@@ -92,15 +89,6 @@ public class ResourceFactory {
      */
     public static Resource createResource(String uriref) {
         return instance.createResource(uriref);
-    }
-
-    /**
-     * Create a new resource representing an RDF-star triple term.
-     * @param statement
-     * @return a new resource
-     */
-    public static Resource createStmtResource(Statement statement) {
-        return instance.createStmtResource(statement);
     }
 
     /**
@@ -203,6 +191,18 @@ public class ResourceFactory {
         return instance.createStatement(subject, predicate, object);
     }
 
+    /**
+     * Create a new statement term.
+     * <p>
+     * Uses the current factory object to create a new statement.</p>
+     *
+     * @param statement
+     * @return a new statement term for the statement
+     */
+    public static StatementTerm createStatementTerm(Statement statement) {
+        return instance.createStatementTerm(statement);
+    }
+
     /** The interface to resource factory objects.
      */
     public interface Interface {
@@ -219,13 +219,6 @@ public class ResourceFactory {
          * @return a new resource
          */
         public Resource createResource(String uriref);
-
-        /** Create a new resource representing an RDF-star triple term.
-         *
-         * @param statement
-         * @return a new resource
-         */
-        public Resource createStmtResource(Statement statement);
 
         /**
          * Answer a string (xsd:string) literal.
@@ -287,10 +280,14 @@ public class ResourceFactory {
          * @param object object of the new statement
          * @return a new statement
          */
-        public Statement createStatement(
-            Resource subject,
-            Property predicate,
-            RDFNode object);
+        public Statement createStatement(Resource subject, Property predicate, RDFNode object);
+
+        /** Create a new statement term representing an RDF 1.2 triple term.
+        *
+        * @param statement
+        * @return a new statement term
+        */
+       public StatementTerm createStatementTerm(Statement statement);
     }
 
     static class Impl implements Interface {
@@ -306,11 +303,6 @@ public class ResourceFactory {
         @Override
         public Resource createResource(String uriref) {
             return new ResourceImpl(uriref);
-        }
-
-        @Override
-        public Resource createStmtResource(Statement statement) {
-            return new ResourceImpl(statement, null);
         }
 
         @Override
@@ -357,6 +349,11 @@ public class ResourceFactory {
             Property predicate,
             RDFNode object) {
             return new StatementImpl(subject, predicate, object);
+        }
+
+        @Override
+        public StatementTerm createStatementTerm(Statement statement) {
+            return new StatementTermImpl(statement);
         }
     }
 }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/Statement.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/Statement.java
@@ -69,7 +69,7 @@ public interface Statement extends FrontsTriple
      */
     public Property getPredicate();
 
-    /** An accessor funtion to return the object of the statement.
+    /** An accessor function to return the object of the statement.
      * @return Return the object of the statement.
      */
     public RDFNode getObject();

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/StatementTerm.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/StatementTerm.java
@@ -16,25 +16,15 @@
  * limitations under the License.
  */
 
-package org.apache.jena.enhanced.test;
-
-import org.apache.jena.rdf.model.RDFNode ;
+package org.apache.jena.rdf.model;
 
 /**
- * An interface for viewing object nodes in the graph.
+ * The Jena Model abstraction of a RDF 1.2 triple term.
  */
-public interface TestObject extends RDFNode, TestNode {
+public interface StatementTerm extends RDFNode {
 
     /**
-     * Checks whether this node is right now the object of some
-     * triple in the graph.
-     * @return true if this interface is currently working.
+     * Return the {@link Statement} that this {@link StatementTerm} represents.
      */
-    boolean isObject();
-
-    /** The subject of a triple of which I am object.
-     *
-     * @return the subject of a triple.
-     */
-    TestSubject aSubject();
+    public Statement getStatement();
 }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/StmtTermRequiredException.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/StmtTermRequiredException.java
@@ -16,25 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.jena.enhanced.test;
+package org.apache.jena.rdf.model;
 
-import org.apache.jena.rdf.model.RDFNode ;
+import org.apache.jena.graph.* ;
+import org.apache.jena.shared.* ;
 
 /**
- * An interface for viewing object nodes in the graph.
- */
-public interface TestObject extends RDFNode, TestNode {
+    Exception to throw when an RDFNode required to be a StatementTerm isn't, or when a Node
+    supposed to be a triple term isn't.
+*/
+public class StmtTermRequiredException extends JenaException
+    {
+    public StmtTermRequiredException( RDFNode n )
+        { this( n.asNode() ); }
 
-    /**
-     * Checks whether this node is right now the object of some
-     * triple in the graph.
-     * @return true if this interface is currently working.
-     */
-    boolean isObject();
-
-    /** The subject of a triple of which I am object.
-     *
-     * @return the subject of a triple.
-     */
-    TestSubject aSubject();
-}
+    public StmtTermRequiredException( Node n )
+        { super( n.toString( PrefixMapping.Extended) ); }
+    }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/LiteralImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/LiteralImpl.java
@@ -79,6 +79,10 @@ public class LiteralImpl extends EnhNode implements Literal {
     public Resource asResource()
         { throw new ResourceRequiredException( asNode() ); }
 
+    @Override
+    public StatementTerm asStatementTerm()
+        { throw new StmtTermRequiredException( asNode() ); }
+
     /**
         Answer the model this literal was created in, if any, otherwise null.
     */

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ModelCom.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ModelCom.java
@@ -524,8 +524,8 @@ public class ModelCom extends EnhGraph implements Model, PrefixMapping, Lock
     { return getResource( uri ).addProperty( RDF.type, type ); }
 
     @Override
-    public RDFNode createStatementTerm( Statement statement )
-    { return new ResourceImpl( statement, this ); }
+    public StatementTerm createStatementTerm( Statement statement )
+    { return new StatementTermImpl( statement, this ); }
 
     /** create a type literal from a boolean value.
      *

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ModelCom.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ModelCom.java
@@ -524,7 +524,7 @@ public class ModelCom extends EnhGraph implements Model, PrefixMapping, Lock
     { return getResource( uri ).addProperty( RDF.type, type ); }
 
     @Override
-    public Resource createResource( Statement statement )
+    public RDFNode createStatementTerm( Statement statement )
     { return new ResourceImpl( statement, this ); }
 
     /** create a type literal from a boolean value.

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ResourceImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ResourceImpl.java
@@ -138,8 +138,6 @@ public class ResourceImpl extends EnhNode implements Resource {
             return this;
         if ( isAnon() )
             return m.createResource( getId() );
-        if ( isStmtResource() )
-            return m.createResource( getStmtTerm() );
         if ( asNode().isConcrete() == false )
             return (Resource) m.getRDFNode( asNode() );
         // if isURIResource()

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ResourceImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/ResourceImpl.java
@@ -24,7 +24,6 @@ import org.apache.jena.enhanced.EnhNode ;
 import org.apache.jena.enhanced.Implementation ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
-import org.apache.jena.graph.Triple;
 import org.apache.jena.rdf.model.* ;
 import org.apache.jena.shared.PropertyNotFoundException;
 
@@ -46,16 +45,16 @@ public class ResourceImpl extends EnhNode implements Resource {
     final static public Implementation rdfNodeFactory = new Implementation() {
         @Override
         public boolean canWrap( Node n, EnhGraph eg )
-            { return true; }
+        { return true; }
         @Override
         public EnhNode wrap(Node n,EnhGraph eg) {
-		if ( n.isURI() || n.isBlank() )
-		  return new ResourceImpl(n,eg);
-		if ( n.isLiteral() )
-		  return new LiteralImpl(n,eg);
-		return null;
-	}
-};
+            if ( n.isURI() || n.isBlank() )
+                return new ResourceImpl(n,eg);
+            if ( n.isLiteral() )
+                return new LiteralImpl(n,eg);
+            return null;
+        }
+    };
 
     /**
         the main constructor: make a new Resource in the given model,
@@ -76,7 +75,6 @@ public class ResourceImpl extends EnhNode implements Resource {
     public ResourceImpl( ModelCom m ) {
         this( fresh( null ), m );
     }
-
 
     public ResourceImpl( Node n, EnhGraph m ) {
         super( n, m );
@@ -110,16 +108,10 @@ public class ResourceImpl extends EnhNode implements Resource {
         this( NodeFactory.createURI( nameSpace + localName ), m );
     }
 
-    public ResourceImpl(Statement statement, ModelCom m) {
-        this( NodeFactory.createTripleTerm(statement.asTriple()), m);
-    }
-
     @Override
     public Object visitWith(RDFVisitor rv) {
         if ( isAnon() )
             return rv.visitBlank(this, getId());
-        if ( isStmtResource() )
-            return rv.visitStmt(this, getStmtTerm());
         // if isURIResource()
         return rv.visitURI(this, getURI());
     }
@@ -131,6 +123,11 @@ public class ResourceImpl extends EnhNode implements Resource {
     @Override
     public Literal asLiteral()
         { throw new LiteralRequiredException( asNode() ); }
+
+    @Override
+    public StatementTerm asStatementTerm() {
+        { throw new StmtTermRequiredException( asNode() ); }
+    }
 
     @Override
     public Resource inModel( Model m ) {
@@ -155,15 +152,6 @@ public class ResourceImpl extends EnhNode implements Resource {
     @Override
     public String  getURI() {
         return this.isURIResource() ? node.getURI() : null;
-    }
-
-    @Override
-    public Statement getStmtTerm() {
-        if ( ! isStmtResource() )
-            return null;
-        Triple t = node.getTriple();
-        Statement stmt = StatementImpl.toStatement(t, getModelCom());
-        return stmt;
     }
 
     @Override

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/StatementBase.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/StatementBase.java
@@ -23,7 +23,7 @@ import org.apache.jena.rdf.model.* ;
 import org.apache.jena.shared.JenaException ;
 
 /**
- 	Abstract base class for StaementImpl - pulls up the stuff that doesn't depend
+ 	Abstract base class for StatementImpl - pulls up the stuff that doesn't depend
  	on how statements are represented (as S/P/O or as Triples).
 */
 public abstract class StatementBase

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/StatementImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/StatementImpl.java
@@ -21,6 +21,7 @@ package org.apache.jena.rdf.model.impl;
 import org.apache.jena.enhanced.* ;
 import org.apache.jena.graph.* ;
 import org.apache.jena.rdf.model.* ;
+import org.apache.jena.shared.JenaException;
 
 /** An implementation of Statement.
  */
@@ -177,9 +178,17 @@ public class StatementImpl extends StatementBase implements Statement {
     }
 
     /**
-     * create an RDF node which might be a literal, or not.
+     * Create an RDF node from a {@link Node} for a {@link Model}.
      */
     public static RDFNode createObject(Node n, EnhGraph g) {
-        return n.isLiteral() ? (RDFNode)new LiteralImpl(n, g) : new ResourceImpl(n, g);
+        if ( n.isBlank() || n.isURI() )
+            return new ResourceImpl(n, g);
+        if ( n.isLiteral() )
+            return new LiteralImpl(n, g);
+        if ( n.isTripleTerm() )
+            return new StatementTermImpl(n, g);
+        if (Node.ANY.equals(n) )
+            return new ResourceImpl(n, g);
+        throw new JenaException("Node type not compatible with Model: "+n);
     }
 }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/StatementTermImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/StatementTermImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.rdf.model.impl;
+
+import java.util.Objects;
+
+import org.apache.jena.enhanced.EnhGraph ;
+import org.apache.jena.enhanced.EnhNode ;
+import org.apache.jena.enhanced.Implementation ;
+import org.apache.jena.graph.Node ;
+import org.apache.jena.graph.NodeFactory ;
+import org.apache.jena.rdf.model.* ;
+
+/**
+ * An implementation of statement terms (RDf 1.2 triple terms).
+ */
+
+public class StatementTermImpl extends EnhNode implements StatementTerm {
+
+    final static public Implementation factory = new Implementation() {
+        @Override
+        public boolean canWrap( Node n, EnhGraph eg )
+            { return !n.isLiteral(); }
+        @Override
+        public EnhNode wrap(Node n,EnhGraph eg) {
+            if (n.isLiteral()) throw new ResourceRequiredException( n );
+            return new StatementTermImpl(n,eg);
+        }
+    };
+    final static public Implementation rdfNodeFactory = new Implementation() {
+        @Override
+        public boolean canWrap( Node n, EnhGraph eg )
+        { return true; }
+        @Override
+        public EnhNode wrap(Node n,EnhGraph eg) {
+            if ( n.isURI() || n.isBlank() )
+                return new StatementTermImpl(n,eg);
+            if ( n.isLiteral() )
+                return new LiteralImpl(n,eg);
+            return null;
+        }
+    };
+
+    private final Statement statement;
+
+    public StatementTermImpl(Statement stmt) {
+        this( stmt, (ModelCom)(stmt.getModel()));
+    }
+
+    public StatementTermImpl(Statement statement, ModelCom m) {
+        super( NodeFactory.createTripleTerm(statement.asTriple()), m);
+        this.statement = Objects.requireNonNull(statement);
+    }
+
+    public StatementTermImpl( Node n, EnhGraph m ) {
+        super( n, m );
+        if ( ! n.isTripleTerm() )
+            throw new StmtTermRequiredException(n);
+        this.statement = StatementImpl.toStatement(n.getTriple(), (ModelCom)m);
+    }
+
+    @Override
+    public Resource asResource()
+    { throw new ResourceRequiredException( asNode() ); }
+
+    @Override
+    public Literal asLiteral()
+    { throw new LiteralRequiredException( asNode() ); }
+
+    @Override
+    public StatementTerm asStatementTerm() {
+        return this;
+    }
+
+    @Override
+    public Statement getStatement() {
+        return statement;
+    }
+
+    @Override
+    public Model getModel() {
+        return (Model)enhGraph;
+    }
+
+    @Override
+    public Object visitWith(RDFVisitor rv) {
+        return rv.visitStmt(this, this.getStatement());
+    }
+
+    @Override
+    public StatementTerm inModel( Model m ) {
+        if ( getModel() == m )
+            return this;
+        return new StatementTermImpl(statement, (ModelCom)m);
+    }
+}

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmloutput/impl/RDFXML_Basic.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmloutput/impl/RDFXML_Basic.java
@@ -145,7 +145,7 @@ public class RDFXML_Basic extends BaseXMLWriter
 		if (r.isAnon()) {
 			writer.print(rdfAt("nodeID") + "=" + attributeQuoted(anonId(r)));
 		} else {
-		    if ( r.isStmtResource() )
+		    if ( r.isStatementTerm() )
 		        throw new JenaException("Triple terms not supported in RDF/XML");
 
 			writer.print(

--- a/jena-core/src/main/java/org/apache/jena/rdfxml/xmloutput/impl/Unparser.java
+++ b/jena-core/src/main/java/org/apache/jena/rdfxml/xmloutput/impl/Unparser.java
@@ -397,7 +397,7 @@ class Unparser {
         if (!(val instanceof Resource))
             return false;
         Resource r = (Resource) val;
-        if ( r.isStmtResource() )
+        if ( r.isStatementTerm() )
             throw new JenaException("Triple terms not supported in RDF/XML");
 
         if (!(allPropsAreAttr(r) || doing.contains(r)))
@@ -1282,7 +1282,7 @@ class Unparser {
 
     private boolean hasProperties(Resource r) {
         ExtendedIterator<Statement> ss = listProperties(r);
-        if (avoidExplicitReification && (!r.isAnon()) && !r.isStmtResource() && isLocalReference(r) && res2statement.containsKey(r)) {
+        if (avoidExplicitReification && (!r.isAnon()) && !r.isStatementTerm() && isLocalReference(r) && res2statement.containsKey(r)) {
             ss = new MapFilterIterator<>(new MapFilter<Statement, Statement>() {
                 @Override
                 public Statement accept(Statement o) {

--- a/jena-core/src/test/java/org/apache/jena/enhanced/test/TestAllImpl.java
+++ b/jena-core/src/test/java/org/apache/jena/enhanced/test/TestAllImpl.java
@@ -32,12 +32,12 @@ public class TestAllImpl extends TestCommonImpl implements TestSubject, TestProp
         return new TestAllImpl(n,eg);
     }
 };
-    
+
     /** Creates a new instance of TestAllImpl */
     private TestAllImpl(Node n,EnhGraph eg) {
         super( n, eg );
     }
-    
+
     @Override public <X extends RDFNode> boolean supports( Class<X> t )
         {
         // return convertTo( t ) != null;
@@ -48,42 +48,46 @@ public class TestAllImpl extends TestCommonImpl implements TestSubject, TestProp
             : false
             ;
         }
-        
+
     @Override
     public boolean isObject() {
         return findObject() != null;
     }
-    
+
     @Override
     public boolean isProperty() {
         return findPredicate() != null;
     }
-    
+
     @Override
     public boolean isSubject() {
         return findSubject() != null;
-    } 
-    
+    }
+
     @Override
     public TestObject anObject() {
         if (!isProperty())
-            
             throw new IllegalStateException("Node is not the property of a triple.");
         return enhGraph.getNodeAs(findPredicate().getObject(),TestObject.class);
     }
-    
+
     @Override
     public TestProperty aProperty() {
         if (!isSubject())
             throw new IllegalStateException("Node is not the subject of a triple.");
         return enhGraph.getNodeAs(findSubject().getPredicate(),TestProperty.class);
     }
-    
+
     @Override
     public TestSubject aSubject() {
         if (!isObject())
             throw new IllegalStateException("Node is not the object of a triple.");
         return enhGraph.getNodeAs(findObject().getSubject(),TestSubject.class);
     }
-    
+
+    @Override
+    public StatementTerm asStatementTerm() {
+        throw new IllegalStateException("StatementTerm");
+    }
+
 }

--- a/jena-core/src/test/java/org/apache/jena/enhanced/test/TestCommonImpl.java
+++ b/jena-core/src/test/java/org/apache/jena/enhanced/test/TestCommonImpl.java
@@ -29,65 +29,68 @@ class TestCommonImpl extends EnhNode implements TestNode {
     TestCommonImpl(Node n, EnhGraph m ) {
         super(n,m);
     }
-    
+
     /**
        We can't return TestModel now, because it clashes with the getModel()
        in RDFNode, which we have to inherit because of the personality tests.
        Fortunately the EnhGraph test set doesn't /need/ getModel, so we give
        it return type Model and throw an exception if it's ever called.
     */
-    public Model getModel() 
-        { throw new JenaException( "getModel() should not be called in the EnhGraph/Node tests" ); }
-    
+    public Model getModel()
+    { throw new JenaException( "getModel() should not be called in the EnhGraph/Node tests" ); }
+
     public Resource asResource()
-        { throw new JenaException( "asResource() should not be called in the EnhGraph/Node tests" ); }
-    
+    { throw new JenaException( "asResource() should not be called in the EnhGraph/Node tests" ); }
+
     public Literal asLiteral()
-        { throw new JenaException( "asLiteral() should not be called in the EnhGraph/Node tests" ); }
+    { throw new JenaException( "asLiteral() should not be called in the EnhGraph/Node tests" ); }
+
+    public StatementTerm asStatementTerm()
+    { throw new JenaException( "asStatementTerm() should not be called in the EnhGraph/Node tests" ); }
 
     Triple findSubject()
         { return findNode( node, null, null ); }
-        
+
     Triple findPredicate()
         { return findNode( null, node, null ); }
-        
+
     Triple findObject()
         { return findNode( null, null, node ); }
-        
-    Triple findNode( Node s, Node p, Node o )
-        {
-        ClosableIterator<Triple> it = enhGraph.asGraph().find( s, p, o );
-        try { return it.hasNext() ? it.next() : null; }
-        finally { it.close(); }
-        }
-        
-    // Convenience routines, that wrap the generic
-    // routines from EnhNode.
-    @Override
-    public TestSubject asSubject() {
-        return asInternal(TestSubject.class);
-    }
-    
-    @Override
-    public TestObject asObject() {
-        return asInternal(TestObject.class);
-    }
-    
-    @Override
-    public TestProperty asProperty() {
-        return asInternal(TestProperty.class);
-    }
 
-    public RDFNode inModel( Model m )
-        {
-        
-        return null;
+        Triple findNode(Node s, Node p, Node o) {
+            ClosableIterator<Triple> it = enhGraph.asGraph().find(s, p, o);
+            try {
+                return it.hasNext() ? it.next() : null;
+            } finally {
+                it.close();
+            }
         }
 
-    public Object visitWith( RDFVisitor rv )
-        {
-        
-        return null;
+        // Convenience routines, that wrap the generic
+        // routines from EnhNode.
+        @Override
+        public TestSubject asSubject() {
+            return asInternal(TestSubject.class);
         }
-    
+
+        @Override
+        public TestProperty asProperty() {
+            return asInternal(TestProperty.class);
+        }
+
+        @Override
+        public TestObject asObject() {
+            return asInternal(TestObject.class);
+        }
+
+        public RDFNode inModel(Model m) {
+
+            return null;
+        }
+
+        public Object visitWith(RDFVisitor rv) {
+
+            return null;
+        }
+
 }

--- a/jena-core/src/test/java/org/apache/jena/enhanced/test/TestNode.java
+++ b/jena-core/src/test/java/org/apache/jena/enhanced/test/TestNode.java
@@ -19,12 +19,12 @@
 package org.apache.jena.enhanced.test;
 
 public interface TestNode {
-	// Convenience routines for converting between different 
+	// Convenience routines for converting between different
 	// views using the subinterfaces,
 	// These are implemented in the base implementation class
 	// TestCommonImpl.
     TestSubject asSubject();
     TestObject asObject();
     TestProperty asProperty();
-    
+
 }

--- a/jena-core/src/test/java/org/apache/jena/enhanced/test/TestPackage_enh.java
+++ b/jena-core/src/test/java/org/apache/jena/enhanced/test/TestPackage_enh.java
@@ -339,141 +339,135 @@ public class TestPackage_enh extends GraphTestBase  {
     	}
     }
 
-    static class Example extends EnhNode implements RDFNode
-        {
-        public Example( Node n, EnhGraph g )
-            { super( n, g ); }
+    static class Example extends EnhNode implements RDFNode {
+        public Example(Node n, EnhGraph g) {
+            super(n, g);
+        }
 
-        static final Implementation factory = new Implementation()
-            {
-            @Override public EnhNode wrap( Node n, EnhGraph g )
-                { return new EnhNode( n, g ); }
+        static final Implementation factory = new Implementation() {
+            @Override
+            public EnhNode wrap(Node n, EnhGraph g) {
+                return new EnhNode(n, g);
+            }
 
-            @Override public boolean canWrap( Node n, EnhGraph g )
-                { return n.isURI(); }
-            };
+            @Override
+            public boolean canWrap(Node n, EnhGraph g) {
+                return n.isURI();
+            }
+        };
 
         @Override
         public RDFNode inModel( Model m )
-            { return null; }
+        { return null; }
 
         @Override
         public Model getModel()
-            { throw new JenaException( "getModel() should not be called in the EnhGraph/Node tests" ); }
+        { throw new JenaException( "getModel() should not be called in the EnhGraph/Node tests" ); }
 
         @Override
         public Resource asResource()
-            { throw new JenaException( "asResource() should not be called in the EnhGraph/Node tests" ); }
+        { throw new JenaException( "asResource() should not be called in the EnhGraph/Node tests" ); }
 
         @Override
         public Literal asLiteral()
-            { throw new JenaException( "asLiteral() should not be called in the EnhGraph/Node tests" ); }
+        { throw new JenaException( "asLiteral() should not be called in the EnhGraph/Node tests" ); }
+
+        @Override
+        public StatementTerm asStatementTerm()
+        { throw new JenaException( "asStatementTerm() should not be called in the EnhGraph/Node tests" ); }
 
         @Override
         public Object visitWith( RDFVisitor rv )
             { return null; }
         }
 
-    public void testSimple()
-        {
-        Graph g = GraphMemFactory.createGraphMem();
-        Personality<RDFNode> ours = BuiltinPersonalities.model.copy().add( Example.class, Example.factory );
-        EnhGraph eg = new EnhGraph( g, ours );
-        Node n = NodeFactory.createURI( "spoo:bar" );
-        EnhNode eNode = new EnhNode( NodeFactory.createURI( "spoo:bar" ), eg );
-        EnhNode eBlank = new EnhNode( NodeFactory.createBlankNode(), eg );
-        assertTrue( "URI node can be an Example", eNode.supports( Example.class ) );
-        assertFalse( "Blank node cannot be an Example", eBlank.supports( Example.class ) );
+        public void testSimple() {
+            Graph g = GraphMemFactory.createGraphMem();
+            Personality<RDFNode> ours = BuiltinPersonalities.model.copy().add(Example.class, Example.factory);
+            EnhGraph eg = new EnhGraph(g, ours);
+            Node n = NodeFactory.createURI("spoo:bar");
+            EnhNode eNode = new EnhNode(NodeFactory.createURI("spoo:bar"), eg);
+            EnhNode eBlank = new EnhNode(NodeFactory.createBlankNode(), eg);
+            assertTrue("URI node can be an Example", eNode.supports(Example.class));
+            assertFalse("Blank node cannot be an Example", eBlank.supports(Example.class));
         }
 
-    static class AnotherExample
-        {
-        static final Implementation factory = new Implementation()
-            {
-            @Override
-            public EnhNode wrap( Node n, EnhGraph g ) { return new EnhNode( n, g ); }
+        static class AnotherExample {
+            static final Implementation factory = new Implementation() {
+                @Override
+                public EnhNode wrap(Node n, EnhGraph g) {
+                    return new EnhNode(n, g);
+                }
 
-            @Override
-            public boolean canWrap( Node n, EnhGraph g ) { return n.isURI(); }
+                @Override
+                public boolean canWrap(Node n, EnhGraph g) {
+                    return n.isURI();
+                }
             };
         }
 
-    public void testAlreadyLinkedViewException()
-        {
-         Graph g = GraphMemFactory.createGraphMem();
-         Personality<RDFNode> ours = BuiltinPersonalities.model.copy().add( Example.class, Example.factory );
-         EnhGraph eg = new EnhGraph( g, ours );
-         Node n = NodeCreateUtils.create( "spoo:bar" );
-         EnhNode eNode = new Example( n, eg );
-         EnhNode multiplexed = new Example( n, eg );
-         multiplexed.as( Property.class );
-         eNode.viewAs( Example.class );
-         try
-            {
-            eNode.addView( multiplexed );
-            fail( "should raise an AlreadyLinkedViewException " );
-            }
-        catch (AlreadyLinkedViewException e)
-            {}
+        public void testAlreadyLinkedViewException() {
+            Graph g = GraphMemFactory.createGraphMem();
+            Personality<RDFNode> ours = BuiltinPersonalities.model.copy().add(Example.class, Example.factory);
+            EnhGraph eg = new EnhGraph(g, ours);
+            Node n = NodeCreateUtils.create("spoo:bar");
+            EnhNode eNode = new Example(n, eg);
+            EnhNode multiplexed = new Example(n, eg);
+            multiplexed.as(Property.class);
+            eNode.viewAs(Example.class);
+            try {
+                eNode.addView(multiplexed);
+                fail("should raise an AlreadyLinkedViewException ");
+            } catch (AlreadyLinkedViewException e) {}
         }
 
-    /**
-        Test that an attempt to polymorph an enhanced node into a class that isn't
-        supported by the enhanced graph generates an UnsupportedPolymorphism
-        exception.
-    */
-    public void testNullPointerTrap()
-        {
-        EnhGraph eg = new EnhGraph( GraphMemFactory.createGraphMem(), new Personality<RDFNode>() );
-        Node n = NodeCreateUtils.create( "eh:something" );
-        EnhNode en = new EnhNode( n, eg );
-        try
-            {
-            en.as( Property.class );
-            fail( "oops" );
-            }
-        catch (UnsupportedPolymorphismException e)
-            {
-            assertEquals( en, e.getBadNode() );
-            assertTrue( "exception should have cuplprit graph", eg == ((EnhNode)e.getBadNode()).getGraph() );
-            assertSame( "exception should have culprit class", Property.class, e.getBadClass() );
+        /**
+         * Test that an attempt to polymorph an enhanced node into a class that isn't
+         * supported by the enhanced graph generates an UnsupportedPolymorphism
+         * exception.
+         */
+        public void testNullPointerTrap() {
+            EnhGraph eg = new EnhGraph(GraphMemFactory.createGraphMem(), new Personality<RDFNode>());
+            Node n = NodeCreateUtils.create("eh:something");
+            EnhNode en = new EnhNode(n, eg);
+            try {
+                en.as(Property.class);
+                fail("oops");
+            } catch (UnsupportedPolymorphismException e) {
+                assertEquals(en, e.getBadNode());
+                assertTrue("exception should have cuplprit graph", eg == ((EnhNode)e.getBadNode()).getGraph());
+                assertSame("exception should have culprit class", Property.class, e.getBadClass());
             }
         }
 
-    public void testNullPointerTrapInCanSupport()
-        {
-        EnhGraph eg = new EnhGraph( GraphMemFactory.createGraphMem(), new Personality<RDFNode>() );
-        Node n = NodeCreateUtils.create( "eh:something" );
-        EnhNode en = new EnhNode( n, eg );
-        assertFalse( en.canAs( Property.class ) );
+        public void testNullPointerTrapInCanSupport() {
+            EnhGraph eg = new EnhGraph(GraphMemFactory.createGraphMem(), new Personality<RDFNode>());
+            Node n = NodeCreateUtils.create("eh:something");
+            EnhNode en = new EnhNode(n, eg);
+            assertFalse(en.canAs(Property.class));
         }
 
-    public void testAsToOwnClassWithNoModel()
-        {
-        Resource r = ResourceFactory.createResource();
-        assertEquals( null, r.getModel() );
-        assertTrue( r.canAs( Resource.class ) );
-        assertSame( r, r.as( Resource.class ) );
+        public void testAsToOwnClassWithNoModel() {
+            Resource r = ResourceFactory.createResource();
+            assertEquals(null, r.getModel());
+            assertTrue(r.canAs(Resource.class));
+            assertSame(r, r.as(Resource.class));
         }
 
-    public void testCanAsReturnsFalseIfNoModel()
-        {
-        Resource r = ResourceFactory.createResource();
-        assertEquals( false, r.canAs( Example.class ) );
+        public void testCanAsReturnsFalseIfNoModel() {
+            Resource r = ResourceFactory.createResource();
+            assertEquals(false, r.canAs(Example.class));
         }
 
-    public void testAsThrowsPolymorphismExceptionIfNoModel()
-        {
-        Resource r = ResourceFactory.createResource();
-        try
-            { r.as( Example.class );
-            fail( "should throw UnsupportedPolymorphismException" ); }
-        catch (UnsupportedPolymorphismException e)
-            {
-        	assertTrue( e.getBadNode() instanceof EnhNode );
-            assertEquals( null, ((EnhNode)e.getBadNode()).getGraph() );
-            assertEquals( Example.class, e.getBadClass() );
+        public void testAsThrowsPolymorphismExceptionIfNoModel() {
+            Resource r = ResourceFactory.createResource();
+            try {
+                r.as(Example.class);
+                fail("should throw UnsupportedPolymorphismException");
+            } catch (UnsupportedPolymorphismException e) {
+                assertTrue(e.getBadNode() instanceof EnhNode);
+                assertEquals(null, ((EnhNode)e.getBadNode()).getGraph());
+                assertEquals(Example.class, e.getBadClass());
             }
         }
-
 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/AbstractTestModel.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/AbstractTestModel.java
@@ -33,9 +33,9 @@ import org.apache.jena.rdf.model.impl.ModelCom ;
 import org.apache.jena.shared.PropertyNotFoundException;
 
 public abstract class AbstractTestModel extends ModelTestBase
-    {
+{
     public AbstractTestModel( String name )
-        { super(name); }
+    { super(name); }
 
     public abstract Model getModel();
 
@@ -43,11 +43,11 @@ public abstract class AbstractTestModel extends ModelTestBase
 
     @Override
     public void setUp()
-        { model = getModel(); }
+    { model = getModel(); }
 
     @Override
     public void tearDown()
-        { model.close(); }
+    { model.close(); }
 
     public void testTransactions() {
         if ( model.supportsTransactions() )
@@ -55,28 +55,28 @@ public abstract class AbstractTestModel extends ModelTestBase
     }
 
     public void testCreateResourceFromNode()
-        {
+    {
         RDFNode S = model.getRDFNode( NodeCreateUtils.create( "spoo:S" ) );
         assertInstanceOf( Resource.class, S );
         assertEquals( "spoo:S", ((Resource) S).getURI() );
-        }
+    }
 
     public void testCreateLiteralFromNode()
-        {
+    {
         RDFNode S = model.getRDFNode( NodeCreateUtils.create( "42" ) );
         assertInstanceOf( Literal.class, S );
         assertEquals( "42", ((Literal) S).getLexicalForm() );
-        }
+    }
 
-   public void testCreateBlankFromNode()
-        {
+    public void testCreateBlankFromNode()
+    {
         RDFNode S = model.getRDFNode( NodeCreateUtils.create( "_Blank" ) );
         assertInstanceOf( Resource.class, S );
         assertEquals( new AnonId( "_Blank" ), ((Resource) S).getId() );
-        }
+    }
 
     public void testIsEmpty()
-        {
+    {
         Statement S1 = statement( model, "model rdf:type nonEmpty" );
         Statement S2 = statement( model, "pinky rdf:type Pig" );
         assertTrue( model.isEmpty() );
@@ -88,10 +88,10 @@ public abstract class AbstractTestModel extends ModelTestBase
         assertFalse( model.isEmpty() );
         model.remove( S2 );
         assertTrue( model.isEmpty() );
-        }
+    }
 
     public void testContainsResource()
-        {
+    {
         modelAdd( model, "x R y; _a P _b" );
         assertTrue( model.containsResource( resource( model, "x" ) ) );
         assertTrue( model.containsResource( resource( model, "R" ) ) );
@@ -101,28 +101,30 @@ public abstract class AbstractTestModel extends ModelTestBase
         assertTrue( model.containsResource( resource( model, "_b" ) ) );
         assertFalse( model.containsResource( resource( model, "i" ) ) );
         assertFalse( model.containsResource( resource( model, "_j" ) ) );
-        }
+    }
+
+
 
     /**
         Test the new version of getProperty(), which delivers null for not-found
         properties.
-    */
+     */
     public void testGetProperty()
-        {
+    {
         modelAdd( model, "x P a; x P b; x R c" );
         Resource x = resource( model, "x" );
         assertEquals( resource( model, "c" ), x.getProperty( property( model, "R" ) ).getObject() );
         RDFNode ob = x.getProperty( property( model, "P" ) ).getObject();
         assertTrue( ob.equals( resource( model, "a" ) ) || ob.equals( resource( model, "b" ) ) );
         assertNull( x.getProperty( property( model, "noSuchPropertyHere" ) ) );
-        }
+    }
 
     /**
      * Tests {@link Resource#getProperty(Property, String)} and
      * {@link Resource#getRequiredProperty(Property, String)}.
      */
     public void testGetPropertyWithLanguage()
-        {
+    {
         model.add(ModelTestBase.resource(model, "x"), ModelTestBase.property(model, "P"), "a", "pt");
         model.add(ModelTestBase.resource(model, "x"), ModelTestBase.property(model, "P"), "b", "en");
         model.add(ModelTestBase.resource(model, "x"), ModelTestBase.property(model, "P"), "c", "es");
@@ -130,83 +132,83 @@ public abstract class AbstractTestModel extends ModelTestBase
         model.add(ModelTestBase.resource(model, "x"), ModelTestBase.property(model, "R"), "e", "de");
 
         {//Tests {@link Resource#getProperty(Property, String)}
-        final Resource x = resource( model, "x" );
-        assertEquals("a", x.getProperty( property( model, "P" ), "pt").getString() );
-        assertEquals("b", x.getProperty( property( model, "P" ), "en").getString() );
-        assertNull(x.getProperty( property( model, "P" ), "ja") );
-        final Literal l = x.getProperty( property(model, "R") ).getLiteral();
-        assertTrue( "d".equals( l.getString() ) || "e".equals( l.getString() ) );
+            final Resource x = resource( model, "x" );
+            assertEquals("a", x.getProperty( property( model, "P" ), "pt").getString() );
+            assertEquals("b", x.getProperty( property( model, "P" ), "en").getString() );
+            assertNull(x.getProperty( property( model, "P" ), "ja") );
+            final Literal l = x.getProperty( property(model, "R") ).getLiteral();
+            assertTrue( "d".equals( l.getString() ) || "e".equals( l.getString() ) );
         }
 
         {//Tests {@link Resource#getRequiredProperty(Property, String)}
-        final Resource x = resource( model, "x" );
-        assertEquals("a", x.getRequiredProperty( property( model, "P" ), "pt").getString() );
-        assertEquals("b", x.getRequiredProperty( property( model, "P" ), "en").getString() );
-        try {
-            x.getRequiredProperty( property( model, "P" ), "ja");
-            fail("Must thrown PropertyNotFoundException.");
-        } catch (PropertyNotFoundException e) {}
-        final Literal l = x.getRequiredProperty( property(model, "R") ).getLiteral();
-        assertTrue( "d".equals( l.getString() ) || "e".equals( l.getString() ) );
-        assertTrue("de".equals( l.getLanguage() ) || "fr".equals( l.getLanguage() ) );
+            final Resource x = resource( model, "x" );
+            assertEquals("a", x.getRequiredProperty( property( model, "P" ), "pt").getString() );
+            assertEquals("b", x.getRequiredProperty( property( model, "P" ), "en").getString() );
+            try {
+                x.getRequiredProperty( property( model, "P" ), "ja");
+                fail("Must thrown PropertyNotFoundException.");
+            } catch (PropertyNotFoundException e) {}
+            final Literal l = x.getRequiredProperty( property(model, "R") ).getLiteral();
+            assertTrue( "d".equals( l.getString() ) || "e".equals( l.getString() ) );
+            assertTrue("de".equals( l.getLanguage() ) || "fr".equals( l.getLanguage() ) );
         }
-        }
+    }
 
     public void testToStatement()
-        {
+    {
         Triple t = triple( "a P b" );
         Statement s = model.asStatement( t );
         assertEquals( node( "a" ), s.getSubject().asNode() );
         assertEquals( node( "P" ), s.getPredicate().asNode() );
         assertEquals( node( "b" ), s.getObject().asNode() );
-        }
+    }
 
     public void testAsRDF()
-        {
+    {
         testPresentAsRDFNode( node( "a" ), Resource.class );
         testPresentAsRDFNode( node( "17" ), Literal.class );
         testPresentAsRDFNode( node( "_b" ), Resource.class );
-        }
+    }
 
     private void testPresentAsRDFNode( Node n, Class<? extends RDFNode> nodeClass )
-        {
+    {
         RDFNode r = model.asRDFNode( n );
         assertSame( n, r.asNode() );
         assertInstanceOf( nodeClass, r );
-        }
+    }
 
     public void testURINodeAsResource()
-        {
+    {
         Node n = node( "a" );
         Resource r = model.wrapAsResource( n );
         assertSame( n, r.asNode() );
-        }
+    }
 
     public void testLiteralNodeAsResourceFails()
-        {
+    {
         try
-            {
+        {
             model.wrapAsResource( node( "17" ) );
             fail( "should fail to convert literal to Resource" );
-            }
-        catch (UnsupportedOperationException e)
-            { pass(); }
         }
+        catch (UnsupportedOperationException e)
+        { pass(); }
+    }
 
     public void testRemoveAll()
-        {
+    {
         testRemoveAll( "" );
         testRemoveAll( "a RR b" );
         testRemoveAll( "x P y; a Q b; c R 17; _d S 'e'" );
         testRemoveAll( "subject Predicate 'object'; http://nowhere/x scheme:cunning not:plan" );
-        }
+    }
 
     protected void testRemoveAll( String statements )
-        {
+    {
         modelAdd( model, statements );
         assertSame( model, model.removeAll() );
         assertEquals( "model should have size 0 following removeAll(): ", 0, model.size() );
-        }
+    }
 
     /**
  		Test cases for RemoveSPO(); each entry is a triple (add, remove, result).
@@ -215,57 +217,57 @@ public abstract class AbstractTestModel extends ModelTestBase
 	 	<li>remove - the pattern to use in the removal
 	 	<li>result - the triples that should remain in the graph
 	 	</ul>
-	*/
-	protected String[][] cases =
-		{
-	            { "x R y", "x R y", "" },
-	            { "x R y; a P b", "x R y", "a P b" },
-	            { "x R y; a P b", "?? R y", "a P b" },
-	            { "x R y; a P b", "x R ??", "a P b" },
-	            { "x R y; a P b", "x ?? y", "a P b" },
-	            { "x R y; a P b", "?? ?? ??", "" },
-	            { "x R y; a P b; c P d", "?? P ??", "x R y" },
-	            { "x R y; a P b; x S y", "x ?? ??", "a P b" },
-		};
+     */
+    protected String[][] cases =
+        {
+            { "x R y", "x R y", "" },
+            { "x R y; a P b", "x R y", "a P b" },
+            { "x R y; a P b", "?? R y", "a P b" },
+            { "x R y; a P b", "x R ??", "a P b" },
+            { "x R y; a P b", "x ?? y", "a P b" },
+            { "x R y; a P b", "?? ?? ??", "" },
+            { "x R y; a P b; c P d", "?? P ??", "x R y" },
+            { "x R y; a P b; x S y", "x ?? ??", "a P b" },
+        };
 
     /**
  	Test that remove(s, p, o) works, in the presence of inferencing graphs that
  	mean emptyness isn't available. This is why we go round the houses and
  	test that expected ~= initialContent + addedStuff - removed - initialContent.
- 	*/
-	public void testRemoveSPO()
-	    {
-	    ModelCom mc = (ModelCom) ModelFactory.createDefaultModel();
-            for ( String[] aCase : cases )
+     */
+    public void testRemoveSPO()
+    {
+        ModelCom mc = (ModelCom) ModelFactory.createDefaultModel();
+        for ( String[] aCase : cases )
+        {
+            for ( int j = 0; j < 3; j += 1 )
             {
-                for ( int j = 0; j < 3; j += 1 )
-                {
-                    Model content = getModel();
-                    Model baseContent = copy( content );
-                    modelAdd( content, aCase[0] );
-                    Triple remove = triple( aCase[1] );
-                    Node s = remove.getSubject(), p = remove.getPredicate(), o = remove.getObject();
-                    Resource S = (Resource) ( s.equals( Node.ANY ) ? null : mc.getRDFNode( s ) );
-                    Property P = ( ( p.equals( Node.ANY ) ? null : mc.getRDFNode( p ).as( Property.class ) ) );
-                    RDFNode O = o.equals( Node.ANY ) ? null : mc.getRDFNode( o );
-                    Model expected = modelWithStatements( aCase[2] );
-                    content.removeAll( S, P, O );
-                    Model finalContent = copy( content ).remove( baseContent );
-                    assertIsoModels( aCase[1], expected, finalContent );
-                }
+                Model content = getModel();
+                Model baseContent = copy( content );
+                modelAdd( content, aCase[0] );
+                Triple remove = triple( aCase[1] );
+                Node s = remove.getSubject(), p = remove.getPredicate(), o = remove.getObject();
+                Resource S = (Resource) ( s.equals( Node.ANY ) ? null : mc.getRDFNode( s ) );
+                Property P = ( ( p.equals( Node.ANY ) ? null : mc.getRDFNode( p ).as( Property.class ) ) );
+                RDFNode O = o.equals( Node.ANY ) ? null : mc.getRDFNode( o );
+                Model expected = modelWithStatements( aCase[2] );
+                content.removeAll( S, P, O );
+                Model finalContent = copy( content ).remove( baseContent );
+                assertIsoModels( aCase[1], expected, finalContent );
             }
-	    }
+        }
+    }
 
     public void testIsClosedDelegatedToGraph()
-        {
+    {
         Model m = getModel();
         assertFalse( m.isClosed() );
         m.close();
         assertTrue( m.isClosed() );
-        }
-
-	protected Model copy( Model m )
-	    {
-	    return ModelFactory.createDefaultModel().add( m );
-	    }
     }
+
+    protected Model copy( Model m )
+    {
+        return ModelFactory.createDefaultModel().add( m );
+    }
+}

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/AbstractTestPackage.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/AbstractTestPackage.java
@@ -27,7 +27,7 @@ import java.util.List;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
-import org.apache.jena.shared.Lock ;
+import org.apache.jena.shared.Lock;
 
 /**
  * Collected test suite for the .model package.
@@ -69,33 +69,19 @@ public abstract class AbstractTestPackage extends TestSuite
 		addTest(TestContains.class, modelFactory);
 		addTest(TestLiteralImpl.class, modelFactory);
 		addTest(TestResourceImpl.class, modelFactory);
+		addTest(TestStatementTerms.class, modelFactory);
+
 		addTest(TestHiddenStatements.class, modelFactory);
 		addTest(TestNamespace.class, modelFactory);
 		addTest(TestModelBulkUpdate.class, modelFactory);
-		addTest(TestConcurrencyNesting.class, modelFactory,
-				TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL1,
-				Lock.READ, Lock.READ, false);
-		addTest(TestConcurrencyNesting.class, modelFactory,
-				TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL1,
-				Lock.WRITE, Lock.WRITE, false);
-		addTest(TestConcurrencyNesting.class, modelFactory,
-				TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL1,
-				Lock.READ, Lock.WRITE, true);
-		addTest(TestConcurrencyNesting.class, modelFactory,
-				TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL1,
-				Lock.WRITE, Lock.READ, false);
-		addTest(TestConcurrencyNesting.class, modelFactory,
-				TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL2,
-				Lock.READ, Lock.READ, false);
-		addTest(TestConcurrencyNesting.class, modelFactory,
-				TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL2,
-				Lock.WRITE, Lock.WRITE, false);
-		addTest(TestConcurrencyNesting.class, modelFactory,
-				TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL2,
-				Lock.READ, Lock.WRITE, false);
-		addTest(TestConcurrencyNesting.class, modelFactory,
-				TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL2,
-				Lock.WRITE, Lock.READ, false);
+		addTest(TestConcurrencyNesting.class, modelFactory, TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL1, Lock.READ, Lock.READ, false);
+		addTest(TestConcurrencyNesting.class, modelFactory, TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL1, Lock.WRITE, Lock.WRITE, false);
+      addTest(TestConcurrencyNesting.class, modelFactory, TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL1, Lock.READ, Lock.WRITE, true);
+      addTest(TestConcurrencyNesting.class, modelFactory, TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL1, Lock.WRITE, Lock.READ, false);
+      addTest(TestConcurrencyNesting.class, modelFactory, TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL2, Lock.READ, Lock.READ, false);
+      addTest(TestConcurrencyNesting.class, modelFactory, TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL2, Lock.WRITE, Lock.WRITE, false);
+      addTest(TestConcurrencyNesting.class, modelFactory, TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL2, Lock.READ, Lock.WRITE, false);
+      addTest(TestConcurrencyNesting.class, modelFactory, TestConcurrencyNesting.MODEL1, TestConcurrencyNesting.MODEL2, Lock.WRITE, Lock.READ, false);
 
 		addTest(TestConcurrencyParallel.class, modelFactory);
 		addTest(TestContainers.class, modelFactory);

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestAddModel.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestAddModel.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,81 +18,70 @@
 
 package org.apache.jena.rdf.model.test;
 
-import org.apache.jena.rdf.model.Model ;
-import org.apache.jena.rdf.model.StmtIterator ;
-import org.apache.jena.rdf.model.test.helpers.ModelHelper ;
-import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
-import org.apache.jena.vocabulary.RDF ;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.rdf.model.test.helpers.ModelHelper;
+import org.apache.jena.rdf.model.test.helpers.TestingModelFactory;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.Assert;
 
-public class TestAddModel extends AbstractModelTestBase
-{
-	private Model model2;
+public class TestAddModel extends AbstractModelTestBase {
+    private Model model2;
 
-	public TestAddModel( final TestingModelFactory modelFactory,
-			final String name )
-	{
-		super(modelFactory, name);
-	}
+    public TestAddModel(final TestingModelFactory modelFactory, final String name) {
+        super(modelFactory, name);
+    }
 
-	protected void assertContainsAll( final Model model, final Model model2 )
-	{
-		for (final StmtIterator s = model2.listStatements(); s.hasNext();)
-		{
-			Assert.assertTrue(model.contains(s.nextStatement()));
-		}
-	}
+    protected void assertContainsAll(final Model model, final Model model2) {
+        for ( final StmtIterator s = model2.listStatements() ; s.hasNext() ; ) {
+            Assert.assertTrue(model.contains(s.nextStatement()));
+        }
+    }
 
-	protected void assertSameStatements( final Model model, final Model model2 )
-	{
-		assertContainsAll(model, model2);
-		assertContainsAll(model2, model);
-	}
+    protected void assertSameStatements(final Model model, final Model model2) {
+        assertContainsAll(model, model2);
+        assertContainsAll(model2, model);
+    }
 
-	@Override
-	public void setUp()
-	{
-		super.setUp();
-		model2 = createModel();
-	}
+    @Override
+    public void setUp() {
+        super.setUp();
+        model2 = createModel();
+    }
 
-	@Override
-	public void tearDown()
-	{
-		super.tearDown();
-		model2.close();
-	}
+    @Override
+    public void tearDown() {
+        super.tearDown();
+        model2.close();
+    }
 
-	public void testAddByIterator()
-	{
+    public void testAddByIterator() {
 
-		ModelHelper.modelAdd(model, "a P b; c P d; x Q 1; y Q 2");
-		model2.add(model.listStatements());
-		Assert.assertEquals(model.size(), model2.size());
-		assertSameStatements(model, model2);
-		model.add(model.createResource(), RDF.value, model.createResource());
-		model.add(model.createResource(), RDF.value, model.createResource());
-		model.add(model.createResource(), RDF.value, model.createResource());
-		final StmtIterator s = model.listStatements();
-		model2.remove(s.nextStatement()).remove(s);
-		Assert.assertEquals(0, model2.size());
-	}
+        ModelHelper.modelAdd(model, "a P b; c P d; x Q 1; y Q 2");
+        model2.add(model.listStatements());
+        Assert.assertEquals(model.size(), model2.size());
+        assertSameStatements(model, model2);
+        model.add(model.createResource(), RDF.value, model.createResource());
+        model.add(model.createResource(), RDF.value, model.createResource());
+        model.add(model.createResource(), RDF.value, model.createResource());
+        final StmtIterator s = model.listStatements();
+        model2.remove(s.nextStatement()).remove(s);
+        Assert.assertEquals(0, model2.size());
+    }
 
-	public void testAddByModel()
-	{
+    public void testAddByModel() {
 
-		ModelHelper.modelAdd(model, "a P b; c P d; x Q 1; y Q 2");
-		model2.add(model);
-		Assert.assertEquals(model.size(), model2.size());
-		assertSameStatements(model, model2);
-	}
+        ModelHelper.modelAdd(model, "a P b; c P d; x Q 1; y Q 2");
+        model2.add(model);
+        Assert.assertEquals(model.size(), model2.size());
+        assertSameStatements(model, model2);
+    }
 
-	public void testRemoveByModel()
-	{
+    public void testRemoveByModel() {
 
-		ModelHelper.modelAdd(model, "a P b; c P d; x Q 1; y Q 2");
-		model2.add(model).remove(model);
-		Assert.assertEquals(0, model2.size());
-		Assert.assertFalse(model2.listStatements().hasNext());
-	}
+        ModelHelper.modelAdd(model, "a P b; c P d; x Q 1; y Q 2");
+        model2.add(model).remove(model);
+        Assert.assertEquals(0, model2.size());
+        Assert.assertFalse(model2.listStatements().hasNext());
+    }
 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestPackage_model.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestPackage_model.java
@@ -6,62 +6,54 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.jena.rdf.model.test;
 
 import junit.framework.TestSuite;
-import org.apache.jena.graph.Graph ;
-import org.apache.jena.rdf.model.Model ;
-import org.apache.jena.rdf.model.ModelFactory ;
-import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
-import org.apache.jena.shared.PrefixMapping ;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.test.helpers.TestingModelFactory;
+import org.apache.jena.shared.PrefixMapping;
 
 /**
- * Implementation of the basic Model TestPackage. Uses the standard
- * ModelFactory to create models for testing.
- * 
+ * Implementation of the basic Model TestPackage. Uses the standard ModelFactory to
+ * create models for testing.
  */
 
-public class TestPackage_model extends AbstractTestPackage
-{
+public class TestPackage_model extends AbstractTestPackage {
 
-	public static class PlainModelFactory implements TestingModelFactory
-	{
-		@Override
-		public Model createModel()
-		{
-			return ModelFactory.createDefaultModel();
-		}
+    public static class PlainModelFactory implements TestingModelFactory {
+        @Override
+        public Model createModel() {
+            return ModelFactory.createDefaultModel();
+        }
 
-		@Override
-		public Model createModel( final Graph base )
-		{
-			return ModelFactory.createModelForGraph(base);
-		}
+        @Override
+        public Model createModel(final Graph base) {
+            return ModelFactory.createModelForGraph(base);
+        }
 
-		@Override
-		public PrefixMapping getPrefixMapping()
-		{
-			return ModelFactory.createDefaultModel().getGraph()
-					.getPrefixMapping();
-		}
-	}
+        @Override
+        public PrefixMapping getPrefixMapping() {
+            return ModelFactory.createDefaultModel().getGraph().getPrefixMapping();
+        }
+    }
 
-	static public TestSuite suite()
-	{
-		return new TestPackage_model();
-	}
+    static public TestSuite suite() {
+        return new TestPackage_model();
+    }
 
-	public TestPackage_model()
-	{
-		super("Model", new PlainModelFactory());
-	}
+    public TestPackage_model() {
+        super("Model", new PlainModelFactory());
+    }
 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestRDFNodes.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestRDFNodes.java
@@ -21,187 +21,163 @@ package org.apache.jena.rdf.model.test;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.jena.rdf.model.* ;
-import org.apache.jena.rdf.model.test.helpers.ModelHelper ;
-import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
-import org.apache.jena.test.JenaTestBase ;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.test.helpers.ModelHelper;
+import org.apache.jena.rdf.model.test.helpers.TestingModelFactory;
+import org.apache.jena.test.JenaTestBase;
 import org.junit.Assert;
 
 /**
  * This class tests various properties of RDFNodes.
  */
-public class TestRDFNodes extends AbstractModelTestBase
-{
+public class TestRDFNodes extends AbstractModelTestBase {
 
-	public TestRDFNodes( final TestingModelFactory modelFactory,
-			final String name )
-	{
-		super(modelFactory, name);
-	}
+    public TestRDFNodes(final TestingModelFactory modelFactory, final String name) {
+        super(modelFactory, name);
+    }
 
-	public void testInModel()
-	{
-		final Model m1 = ModelHelper.modelWithStatements(this, "");
-		final Model m2 = ModelHelper.modelWithStatements(this, "");
-		final Resource r1 = ModelHelper.resource(m1, "r1");
-		final Resource r2 = ModelHelper.resource(m1, "_r2");
-		/* */
-		Assert.assertEquals(r1.getModel(), m1);
-		Assert.assertEquals(r2.getModel(), m1);
-		Assert.assertFalse(r1.isAnon());
-		Assert.assertTrue(r2.isAnon());
-		/* */
-		Assert.assertEquals(r1.inModel(m2).getModel(), m2);
-		Assert.assertEquals(r2.inModel(m2).getModel(), m2);
-		/* */
-		Assert.assertEquals(r1, r1.inModel(m2));
-		Assert.assertEquals(r2, r2.inModel(m2));
-	}
+    public void testInModel() {
+        final Model m1 = ModelHelper.modelWithStatements(this, "");
+        final Model m2 = ModelHelper.modelWithStatements(this, "");
+        final Resource r1 = ModelHelper.resource(m1, "r1");
+        final Resource r2 = ModelHelper.resource(m1, "_r2");
+        /* */
+        Assert.assertEquals(r1.getModel(), m1);
+        Assert.assertEquals(r2.getModel(), m1);
+        Assert.assertFalse(r1.isAnon());
+        Assert.assertTrue(r2.isAnon());
+        /* */
+        Assert.assertEquals(r1.inModel(m2).getModel(), m2);
+        Assert.assertEquals(r2.inModel(m2).getModel(), m2);
+        /* */
+        Assert.assertEquals(r1, r1.inModel(m2));
+        Assert.assertEquals(r2, r2.inModel(m2));
+    }
 
-	public void testIsAnon()
-	{
-		final Model m = ModelHelper.modelWithStatements(this, "");
-		Assert.assertEquals(false, m.createResource("eh:/foo").isAnon());
-		Assert.assertEquals(true, m.createResource().isAnon());
-		Assert.assertEquals(false, m.createTypedLiteral(17).isAnon());
-		Assert.assertEquals(false, m.createTypedLiteral("hello").isAnon());
-	}
+    public void testIsAnon() {
+        final Model m = ModelHelper.modelWithStatements(this, "");
+        Assert.assertEquals(false, m.createResource("eh:/foo").isAnon());
+        Assert.assertEquals(true, m.createResource().isAnon());
+        Assert.assertEquals(false, m.createTypedLiteral(17).isAnon());
+        Assert.assertEquals(false, m.createTypedLiteral("hello").isAnon());
+    }
 
-	public void testIsLiteral()
-	{
-		final Model m = ModelHelper.modelWithStatements(this, "");
-		Assert.assertEquals(false, m.createResource("eh:/foo").isLiteral());
-		Assert.assertEquals(false, m.createResource().isLiteral());
-		Assert.assertEquals(true, m.createTypedLiteral(17).isLiteral());
-		Assert.assertEquals(true, m.createTypedLiteral("hello").isLiteral());
-	}
+    public void testIsLiteral() {
+        final Model m = ModelHelper.modelWithStatements(this, "");
+        Assert.assertEquals(false, m.createResource("eh:/foo").isLiteral());
+        Assert.assertEquals(false, m.createResource().isLiteral());
+        Assert.assertEquals(true, m.createTypedLiteral(17).isLiteral());
+        Assert.assertEquals(true, m.createTypedLiteral("hello").isLiteral());
+    }
 
-	public void testIsResource()
-	{
-		final Model m = ModelHelper.modelWithStatements(this, "");
-		Assert.assertEquals(true, m.createResource("eh:/foo").isResource());
-		Assert.assertEquals(true, m.createResource().isResource());
-		Assert.assertEquals(false, m.createTypedLiteral(17).isResource());
-		Assert.assertEquals(false, m.createTypedLiteral("hello").isResource());
-	}
+    public void testIsResource() {
+        final Model m = ModelHelper.modelWithStatements(this, "");
+        Assert.assertEquals(true, m.createResource("eh:/foo").isResource());
+        Assert.assertEquals(true, m.createResource().isResource());
+        Assert.assertEquals(false, m.createTypedLiteral(17).isResource());
+        Assert.assertEquals(false, m.createTypedLiteral("hello").isResource());
+    }
 
-	public void testIsURIResource()
-	{
-		final Model m = ModelHelper.modelWithStatements(this, "");
-		Assert.assertEquals(true, m.createResource("eh:/foo").isURIResource());
-		Assert.assertEquals(false, m.createResource().isURIResource());
-		Assert.assertEquals(false, m.createTypedLiteral(17).isURIResource());
-		Assert.assertEquals(false, m.createTypedLiteral("hello")
-				.isURIResource());
-	}
+    public void testIsURIResource() {
+        final Model m = ModelHelper.modelWithStatements(this, "");
+        Assert.assertEquals(true, m.createResource("eh:/foo").isURIResource());
+        Assert.assertEquals(false, m.createResource().isURIResource());
+        Assert.assertEquals(false, m.createTypedLiteral(17).isURIResource());
+        Assert.assertEquals(false, m.createTypedLiteral("hello").isURIResource());
+    }
 
-	public void testLiteralAsResourceThrows()
-	{
-		final Model m = ModelHelper.modelWithStatements(this, "");
-		final Resource r = m.createResource("eh:/spoo");
-		try
-		{
-			r.asLiteral();
-			Assert.fail("should not be able to do Resource.asLiteral()");
-		}
-		catch (final LiteralRequiredException e)
-		{
-		}
-	}
+    public void testLiteralAsResourceThrows() {
+        final Model m = ModelHelper.modelWithStatements(this, "");
+        final Resource r = m.createResource("eh:/spoo");
+        try {
+            r.asLiteral();
+            Assert.fail("should not be able to do Resource.asLiteral()");
+        } catch (final LiteralRequiredException e) {}
+    }
 
-	public void testRDFNodeAsLiteral()
-	{
-		final Model m = ModelHelper.modelWithStatements(this, "");
-		final Literal l = m.createLiteral("hello, world");
-		Assert.assertSame(l, l.asLiteral());
-	}
+    public void testRDFNodeAsLiteral() {
+        final Model m = ModelHelper.modelWithStatements(this, "");
+        final Literal l = m.createLiteral("hello, world");
+        Assert.assertSame(l, l.asLiteral());
+    }
 
-	public void testRDFNodeAsResource()
-	{
-		final Model m = ModelHelper.modelWithStatements(this, "");
-		final Resource r = m.createResource("eh:/spoo");
-		Assert.assertSame(r, r.asResource());
-	}
+    public void testRDFNodeAsResource() {
+        final Model m = ModelHelper.modelWithStatements(this, "");
+        final Resource r = m.createResource("eh:/spoo");
+        Assert.assertSame(r, r.asResource());
+    }
 
-	public void testRDFVisitor()
-	{
-		final List<String> history = new ArrayList<>();
-		final Model m = ModelFactory.createDefaultModel();
-		final RDFNode S = m.createResource();
-		final RDFNode P = m.createProperty("eh:PP");
-		final RDFNode O = m.createLiteral("LL");
-		/* */
-		final RDFVisitor rv = new RDFVisitor() {
-			@Override
-			public Object visitBlank( final Resource R, final AnonId id )
-			{
-				history.add("blank");
-				Assert.assertTrue("must visit correct node", R == S);
-				Assert.assertEquals("must have correct field", R.getId(), id);
-				return "blank result";
-			}
+    public void testRDFVisitor() {
+        final List<String> history = new ArrayList<>();
+        final Model m = ModelFactory.createDefaultModel();
+        final RDFNode S = m.createResource();
+        final RDFNode P = m.createProperty("eh:PP");
+        final RDFNode O = m.createLiteral("LL");
+        final Statement stmt = m.createStatement((Resource)S, (Property)P, O);
+        final RDFNode ST = m.createStatementTerm(stmt);
 
-			@Override
-			public Object visitLiteral( final Literal L )
-			{
-				history.add("literal");
-				Assert.assertTrue("must visit correct node", L == O);
-				return "literal result";
-			}
-
-			@Override
-			public Object visitURI( final Resource R, final String uri )
-			{
-				history.add("uri");
-				Assert.assertTrue("must visit correct node", R == P);
-				Assert.assertEquals("must have correct field", R.getURI(), uri);
-				return "uri result";
-			}
+        /* */
+        final RDFVisitor rv = new RDFVisitor() {
+            @Override
+            public Object visitBlank(final Resource R, final AnonId id) {
+                history.add("blank");
+                Assert.assertTrue("must visit correct node", R == S);
+                Assert.assertEquals("must have correct field", R.getId(), id);
+                return "blank result";
+            }
 
             @Override
-            public Object visitStmt(Resource r, Statement statement) {
+            public Object visitLiteral(final Literal L) {
+                history.add("literal");
+                Assert.assertTrue("must visit correct node", L == O);
+                return "literal result";
+            }
+
+            @Override
+            public Object visitURI(final Resource R, final String uri) {
+                history.add("uri");
+                Assert.assertTrue("must visit correct node", R == P);
+                Assert.assertEquals("must have correct field", R.getURI(), uri);
+                return "uri result";
+            }
+
+            @Override
+            public Object visitStmt(StatementTerm statementTerm, Statement statement) {
                 history.add("statementTerm");
                 return "statement term result";
             }
-		};
-		/* */
-		Assert.assertEquals("blank result", S.visitWith(rv));
-		Assert.assertEquals("uri result", P.visitWith(rv));
-		Assert.assertEquals("literal result", O.visitWith(rv));
-		Assert.assertEquals(JenaTestBase.listOfStrings("blank uri literal"),
-				history);
-	}
+        };
+        /* */
+        Assert.assertEquals("blank result", S.visitWith(rv));
+        Assert.assertEquals("uri result", P.visitWith(rv));
+        Assert.assertEquals("literal result", O.visitWith(rv));
+        Assert.assertEquals("statement term result", ST.visitWith(rv));
 
-	public void testRemoveAllBoring()
-	{
-		final Model m1 = ModelHelper.modelWithStatements(this, "x P a; y Q b");
-		final Model m2 = ModelHelper.modelWithStatements(this, "x P a; y Q b");
-		ModelHelper.resource(m2, "x").removeAll(ModelHelper.property(m2, "Z"));
-		ModelHelper.assertIsoModels("m2 should be unchanged", m1, m2);
-	}
+        Assert.assertEquals(JenaTestBase.listOfStrings("blank uri literal statementTerm"), history);
+    }
 
-	public void testRemoveAllRemoves()
-	{
-		final String ps = "x P a; x P b", rest = "x Q c; y P a; y Q b";
-		final Model m = ModelHelper.modelWithStatements(this, ps + "; " + rest);
-		final Resource r = ModelHelper.resource(m, "x");
-		final Resource r2 = r.removeAll(ModelHelper.property(m, "P"));
-		Assert.assertSame("removeAll should deliver its receiver", r, r2);
-		ModelHelper.assertIsoModels("x's P-values should go",
-				ModelHelper.modelWithStatements(this, rest), m);
-	}
+    public void testRemoveAllBoring() {
+        final Model m1 = ModelHelper.modelWithStatements(this, "x P a; y Q b");
+        final Model m2 = ModelHelper.modelWithStatements(this, "x P a; y Q b");
+        ModelHelper.resource(m2, "x").removeAll(ModelHelper.property(m2, "Z"));
+        ModelHelper.assertIsoModels("m2 should be unchanged", m1, m2);
+    }
 
-	public void testResourceAsLiteralThrows()
-	{
-		final Model m = ModelHelper.modelWithStatements(this, "");
-		final Literal l = m.createLiteral("hello, world");
-		try
-		{
-			l.asResource();
-			Assert.fail("should not be able to do Literal.asResource()");
-		}
-		catch (final ResourceRequiredException e)
-		{
-		}
-	}
+    public void testRemoveAllRemoves() {
+        final String ps = "x P a; x P b", rest = "x Q c; y P a; y Q b";
+        final Model m = ModelHelper.modelWithStatements(this, ps + "; " + rest);
+        final Resource r = ModelHelper.resource(m, "x");
+        final Resource r2 = r.removeAll(ModelHelper.property(m, "P"));
+        Assert.assertSame("removeAll should deliver its receiver", r, r2);
+        ModelHelper.assertIsoModels("x's P-values should go", ModelHelper.modelWithStatements(this, rest), m);
+    }
+
+    public void testResourceAsLiteralThrows() {
+        final Model m = ModelHelper.modelWithStatements(this, "");
+        final Literal l = m.createLiteral("hello, world");
+        try {
+            l.asResource();
+            Assert.fail("should not be able to do Literal.asResource()");
+        } catch (final ResourceRequiredException e) {}
+    }
 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestResourceFactory.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestResourceFactory.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,206 +32,173 @@ import junit.framework.TestSuite;
 public class TestResourceFactory extends TestCase
 {
 
-	class TestFactory implements ResourceFactory.Interface
-	{
+    class TestFactory implements ResourceFactory.Interface {
 
-		Resource resource;
+        Resource resource;
 
-		TestFactory( final Resource r )
-		{
-			resource = r;
-		}
+        TestFactory(final Resource r) {
+            resource = r;
+        }
 
-		@Override
-		public Literal createLangLiteral( final String string, final String lang )
-		{
-			return null;
-		}
-
-		@Override
-		public Literal createStringLiteral( final String string )
-		{
-			return null;
-		}
-
-		@Override
-		public Property createProperty( final String uriref )
-		{
-			return null;
-		}
-
-		@Override
-		public Property createProperty( final String namespace,
-				final String localName )
-		{
-			return null;
-		}
-
-		@Override
-		public Resource createResource()
-		{
-			return resource;
-		}
-
-		@Override
-		public Resource createResource( final String uriref )
-		{
-			return null;
-		}
-
-		@Override
-        public Resource createStmtResource(Statement statement) {
+        @Override
+        public Literal createLangLiteral(final String string, final String lang) {
             return null;
         }
 
         @Override
-		public Statement createStatement( final Resource subject,
-				final Property predicate, final RDFNode object )
-		{
-			return null;
-		}
+        public Literal createStringLiteral(final String string) {
+            return null;
+        }
 
-		@Override
-		public Literal createTypedLiteral( final Object value )
-		{
-			return null;
-		}
+        @Override
+        public Property createProperty(final String uriref) {
+            return null;
+        }
 
-		@Override
-		public Literal createTypedLiteral( final String string,
-				final RDFDatatype datatype )
-		{
-			return null;
-		}
-	}
+        @Override
+        public Property createProperty(final String namespace, final String localName) {
+            return null;
+        }
 
-	static final String uri1 = "http://example.org/example#a1";
+        @Override
+        public Resource createResource() {
+            return resource;
+        }
 
-	static final String uri2 = "http://example.org/example#a2";
+        @Override
+        public Resource createResource(final String uriref) {
+            return null;
+        }
 
-	public static TestSuite suite()
-	{
-		return new TestSuite(TestResourceFactory.class);
-	}
+        @Override
+        public StatementTerm createStatementTerm(final Statement statement) {
+            return null;
+        }
 
-	public TestResourceFactory( final String name )
-	{
-		super(name);
-	}
+        @Override
+        public Statement createStatement(final Resource subject, final Property predicate, final RDFNode object) {
+            return null;
+        }
 
-	public void testCreateLiteral()
-	{
-		final Literal l = ResourceFactory.createPlainLiteral("lex");
-		Assert.assertTrue(l.getLexicalForm().equals("lex"));
-		Assert.assertTrue(l.getLanguage().equals(""));
-		Assert.assertNull(l.getDatatype());
-		Assert.assertNull(l.getDatatypeURI());
-	}
+        @Override
+        public Literal createTypedLiteral(final Object value) {
+            return null;
+        }
 
-	public void testCreateProperty()
-	{
-		final Property p1 = ResourceFactory
-				.createProperty(TestResourceFactory.uri1);
-		Assert.assertTrue(p1.getURI().equals(TestResourceFactory.uri1));
-		final Property p2 = ResourceFactory.createProperty(
-				TestResourceFactory.uri1, "2");
-		Assert.assertTrue(p2.getURI().equals(TestResourceFactory.uri1 + "2"));
-	}
+        @Override
+        public Literal createTypedLiteral(final String string, final RDFDatatype datatype) {
+            return null;
+        }
+    }
 
-	public void testCreateResource()
-	{
-		Resource r1 = ResourceFactory.createResource();
-		Assert.assertTrue(r1.isAnon());
-		final Resource r2 = ResourceFactory.createResource();
-		Assert.assertTrue(r2.isAnon());
-		Assert.assertTrue(!r1.equals(r2));
+    static final String uri1 = "http://example.org/example#a1";
 
-		r1 = ResourceFactory.createResource(TestResourceFactory.uri1);
-		Assert.assertTrue(r1.getURI().equals(TestResourceFactory.uri1));
-	}
+    static final String uri2 = "http://example.org/example#a2";
 
-	public void testCreateStmtTerm() {
-	    Resource s = ResourceFactory.createResource();
-	    Property p = ResourceFactory.createProperty(TestResourceFactory.uri2);
-	    Resource o = ResourceFactory.createResource();
-	    Statement stmt = ResourceFactory.createStatement(s, p, o);
+    public static TestSuite suite() {
+        return new TestSuite(TestResourceFactory.class);
+    }
 
-	    Resource r = ResourceFactory.createStmtResource(stmt);
-	    Assert.assertTrue(r.isResource());
-	    Assert.assertFalse(r.isURIResource());
-	    Assert.assertFalse(r.isAnon());
-	    Assert.assertTrue(r.isStmtResource());
-	}
+    public TestResourceFactory(final String name) {
+        super(name);
+    }
 
-	public void testCreateStatement()
-	{
-		final Resource s = ResourceFactory.createResource();
-		final Property p = ResourceFactory
-				.createProperty(TestResourceFactory.uri2);
-		final Resource o = ResourceFactory.createResource();
-		final Statement stmt = ResourceFactory.createStatement(s, p, o);
-		Assert.assertTrue(stmt.getSubject().equals(s));
-		Assert.assertTrue(stmt.getPredicate().equals(p));
-		Assert.assertTrue(stmt.getObject().equals(o));
-	}
+    public void testCreateLiteral() {
+        final Literal l = ResourceFactory.createPlainLiteral("lex");
+        Assert.assertTrue(l.getLexicalForm().equals("lex"));
+        Assert.assertTrue(l.getLanguage().equals(""));
+        Assert.assertNull(l.getDatatype());
+        Assert.assertNull(l.getDatatypeURI());
+    }
 
-	public void testCreateTypedLiteral()
-	{
-		final Literal l = ResourceFactory.createTypedLiteral("22",
-				XSDDatatype.XSDinteger);
-		Assert.assertTrue(l.getLexicalForm().equals("22"));
-		Assert.assertTrue(l.getLanguage().equals(""));
-		Assert.assertTrue(l.getDatatype() == XSDDatatype.XSDinteger);
-		Assert.assertTrue(l.getDatatypeURI().equals(XSDDatatype.XSDinteger.getURI()));
-	}
+    public void testCreateProperty() {
+        final Property p1 = ResourceFactory.createProperty(TestResourceFactory.uri1);
+        Assert.assertTrue(p1.getURI().equals(TestResourceFactory.uri1));
+        final Property p2 = ResourceFactory.createProperty(TestResourceFactory.uri1, "2");
+        Assert.assertTrue(p2.getURI().equals(TestResourceFactory.uri1 + "2"));
+    }
 
-	public void testCreateTypedLiteralObject()
-	{
-		final Literal l = ResourceFactory.createTypedLiteral( 22 );
-		Assert.assertEquals("22", l.getLexicalForm());
-		Assert.assertEquals("", l.getLanguage());
-		Assert.assertEquals(XSDDatatype.XSDint, l.getDatatype());
-	}
+    public void testCreateResource() {
+        Resource r1 = ResourceFactory.createResource();
+        Assert.assertTrue(r1.isAnon());
+        final Resource r2 = ResourceFactory.createResource();
+        Assert.assertTrue(r2.isAnon());
+        Assert.assertTrue(!r1.equals(r2));
 
-	public void testCreateTypedLiteralOverload()
-	{
-		final Calendar testCal = new GregorianCalendar(
-				TimeZone.getTimeZone("GMT"));
-		testCal.set(1999, 4, 30, 15, 9, 32);
-		testCal.set(Calendar.MILLISECOND, 0); // ms field can be undefined on
-		// Linux
-		final Literal lc = ResourceFactory.createTypedLiteral(testCal);
-		Assert.assertEquals("calendar overloading test", ResourceFactory
-				.createTypedLiteral("1999-05-30T15:09:32Z",
-						XSDDatatype.XSDdateTime), lc);
+        r1 = ResourceFactory.createResource(TestResourceFactory.uri1);
+        Assert.assertTrue(r1.getURI().equals(TestResourceFactory.uri1));
+    }
 
-	}
+    public void testCreateStatement() {
+        final Resource s = ResourceFactory.createResource();
+        final Property p = ResourceFactory.createProperty(TestResourceFactory.uri2);
+        final Resource o = ResourceFactory.createResource();
+        final Statement stmt = ResourceFactory.createStatement(s, p, o);
+        Assert.assertTrue(stmt.getSubject().equals(s));
+        Assert.assertTrue(stmt.getPredicate().equals(p));
+        Assert.assertTrue(stmt.getObject().equals(o));
+    }
 
-	public void testGetInstance()
-	{
-		ResourceFactory.getInstance();
-		final Resource r1 = ResourceFactory.createResource();
-		Assert.assertTrue(r1.isAnon());
-		final Resource r2 = ResourceFactory.createResource();
-		Assert.assertTrue(r2.isAnon());
-		Assert.assertTrue(!r1.equals(r2));
-	}
+    public void testCreateTypedLiteral() {
+        final Literal l = ResourceFactory.createTypedLiteral("22", XSDDatatype.XSDinteger);
+        Assert.assertTrue(l.getLexicalForm().equals("22"));
+        Assert.assertTrue(l.getLanguage().equals(""));
+        Assert.assertTrue(l.getDatatype() == XSDDatatype.XSDinteger);
+        Assert.assertTrue(l.getDatatypeURI().equals(XSDDatatype.XSDinteger.getURI()));
+    }
 
-	public void testSetInstance()
-	{
-		final Resource r = ResourceFactory.createResource();
-		final ResourceFactory.Interface oldFactory = ResourceFactory
-				.getInstance();
-		final ResourceFactory.Interface factory = new TestFactory(r);
-		try
-		{
-			ResourceFactory.setInstance(factory);
-			Assert.assertTrue(factory.equals(ResourceFactory.getInstance()));
-			Assert.assertTrue(ResourceFactory.createResource() == r);
-		}
-		finally
-		{
-			ResourceFactory.setInstance(oldFactory);
-		}
-	}
+    public void testCreateTypedLiteralObject() {
+        final Literal l = ResourceFactory.createTypedLiteral(22);
+        Assert.assertEquals("22", l.getLexicalForm());
+        Assert.assertEquals("", l.getLanguage());
+        Assert.assertEquals(XSDDatatype.XSDint, l.getDatatype());
+    }
+
+    public void testCreateTypedLiteralOverload() {
+        final Calendar testCal = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
+        testCal.set(1999, 4, 30, 15, 9, 32);
+        testCal.set(Calendar.MILLISECOND, 0); // ms field can be undefined on
+        // Linux
+        final Literal lc = ResourceFactory.createTypedLiteral(testCal);
+        Assert.assertEquals("calendar overloading test",
+                            ResourceFactory.createTypedLiteral("1999-05-30T15:09:32Z", XSDDatatype.XSDdateTime), lc);
+
+    }
+
+    public void testCreateStatementTerm() {
+        final Resource s = ResourceFactory.createResource();
+        final Property p = ResourceFactory.createProperty(TestResourceFactory.uri2);
+        final Resource o = ResourceFactory.createResource();
+        final Statement stmt0 = ResourceFactory.createStatement(s, p, o);
+
+        final StatementTerm stmtTerm = ResourceFactory.createStatementTerm(stmt0);
+        Assert.assertEquals(stmt0, stmtTerm.getStatement());
+
+        final Statement stmt = stmtTerm.getStatement();
+        Assert.assertTrue(stmt.getSubject().equals(s));
+        Assert.assertTrue(stmt.getPredicate().equals(p));
+        Assert.assertTrue(stmt.getObject().equals(o));
+    }
+
+    public void testGetInstance() {
+        ResourceFactory.getInstance();
+        final Resource r1 = ResourceFactory.createResource();
+        Assert.assertTrue(r1.isAnon());
+        final Resource r2 = ResourceFactory.createResource();
+        Assert.assertTrue(r2.isAnon());
+        Assert.assertTrue(!r1.equals(r2));
+    }
+
+    public void testSetInstance() {
+        final Resource r = ResourceFactory.createResource();
+        final ResourceFactory.Interface oldFactory = ResourceFactory.getInstance();
+        final ResourceFactory.Interface factory = new TestFactory(r);
+        try {
+            ResourceFactory.setInstance(factory);
+            Assert.assertTrue(factory.equals(ResourceFactory.getInstance()));
+            Assert.assertTrue(ResourceFactory.createResource() == r);
+        } finally {
+            ResourceFactory.setInstance(oldFactory);
+        }
+    }
 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestStatementCreation.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestStatementCreation.java
@@ -18,147 +18,125 @@
 
 package org.apache.jena.rdf.model.test;
 
-import org.apache.jena.datatypes.xsd.XSDDatatype ;
-import org.apache.jena.rdf.model.* ;
-import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.test.helpers.TestingModelFactory;
 import org.junit.Assert;
 
-public class TestStatementCreation extends AbstractModelTestBase
-{
+public class TestStatementCreation extends AbstractModelTestBase {
 
-	static final String subjURI = "http://aldabaran.hpl.hp.com/foo";
-	static final String predURI = "http://aldabaran.hpl.hp.com/bar";
+    static final String subjURI = "http://aldabaran.hpl.hp.com/foo";
+    static final String predURI = "http://aldabaran.hpl.hp.com/bar";
 
-	protected Resource r;
-	protected Property p;
+    protected Resource r;
+    protected Property p;
 
-	public TestStatementCreation( final TestingModelFactory modelFactory,
-			final String name )
-	{
-		super(modelFactory, name);
-	}
+    public TestStatementCreation(final TestingModelFactory modelFactory, final String name) {
+        super(modelFactory, name);
+    }
 
-	@Override
-	public void setUp()
-	{
-		super.setUp();
-		r = model.createResource(TestStatementCreation.subjURI);
-		p = model.createProperty(TestStatementCreation.predURI);
-	}
+    @Override
+    public void setUp() {
+        super.setUp();
+        r = model.createResource(TestStatementCreation.subjURI);
+        p = model.createProperty(TestStatementCreation.predURI);
+    }
 
-	@Override
-	public void tearDown()
-	{
-		r = null;
-		p = null;
-		super.tearDown();
-	}
+    @Override
+    public void tearDown() {
+        r = null;
+        p = null;
+        super.tearDown();
+    }
 
-	public void testCreateStatementByteMax()
-	{
-		final Statement s = model.createLiteralStatement(r, p, Byte.MAX_VALUE);
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals(Byte.MAX_VALUE, s.getByte());
-	}
+    public void testCreateStatementByteMax() {
+        final Statement s = model.createLiteralStatement(r, p, Byte.MAX_VALUE);
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals(Byte.MAX_VALUE, s.getByte());
+    }
 
-	public void testCreateStatementChar()
-	{
-		final Statement s = model.createLiteralStatement(r, p, '$');
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals('$', s.getChar());
-	}
+    public void testCreateStatementChar() {
+        final Statement s = model.createLiteralStatement(r, p, '$');
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals('$', s.getChar());
+    }
 
-	public void testCreateStatementDouble()
-	{
-		final Statement s = model.createStatement(r, p,
-				model.createTypedLiteral(12345.67890d));
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals(12345.67890d, s.getDouble(), 0.0000005);
-	}
+    public void testCreateStatementDouble() {
+        final Statement s = model.createStatement(r, p, model.createTypedLiteral(12345.67890d));
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals(12345.67890d, s.getDouble(), 0.0000005);
+    }
 
-	public void testCreateStatementFactory()
-	{
-		final LitTestObj tv = new LitTestObj(Long.MIN_VALUE);
-		final Statement s = model.createLiteralStatement(r, p, tv);
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		// assertEquals( tv, s.getObject( new LitTestObjF() ) );
-	}
+    public void testCreateStatementFactory() {
+        final LitTestObj tv = new LitTestObj(Long.MIN_VALUE);
+        final Statement s = model.createLiteralStatement(r, p, tv);
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        // assertEquals( tv, s.getObject( new LitTestObjF() ) );
+    }
 
-	public void testCreateStatementFloat()
-	{
-		final Statement s = model.createStatement(r, p,
-				model.createTypedLiteral(123.456f));
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals(123.456f, s.getFloat(), 0.0005);
-	}
+    public void testCreateStatementFloat() {
+        final Statement s = model.createStatement(r, p, model.createTypedLiteral(123.456f));
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals(123.456f, s.getFloat(), 0.0005);
+    }
 
-	public void testCreateStatementIntMax()
-	{
-		final Statement s = model.createLiteralStatement(r, p,
-				Integer.MAX_VALUE);
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals(Integer.MAX_VALUE, s.getInt());
-	}
+    public void testCreateStatementIntMax() {
+        final Statement s = model.createLiteralStatement(r, p, Integer.MAX_VALUE);
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals(Integer.MAX_VALUE, s.getInt());
+    }
 
-	public void testCreateStatementLongMax()
-	{
-		final Statement s = model.createLiteralStatement(r, p, Long.MAX_VALUE);
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals(Long.MAX_VALUE, s.getLong());
-	}
+    public void testCreateStatementLongMax() {
+        final Statement s = model.createLiteralStatement(r, p, Long.MAX_VALUE);
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals(Long.MAX_VALUE, s.getLong());
+    }
 
-	public void testCreateStatementResource()
-	{
-		final Resource tv = model.createResource();
-		final Statement s = model.createStatement(r, p, tv);
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals(tv, s.getResource());
-	}
+    public void testCreateStatementResource() {
+        final Resource tv = model.createResource();
+        final Statement s = model.createStatement(r, p, tv);
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals(tv, s.getResource());
+    }
 
-	public void testCreateStatementShortMax()
-	{
-		final Statement s = model.createLiteralStatement(r, p, Short.MAX_VALUE);
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals(Short.MAX_VALUE, s.getShort());
-	}
+    public void testCreateStatementShortMax() {
+        final Statement s = model.createLiteralStatement(r, p, Short.MAX_VALUE);
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals(Short.MAX_VALUE, s.getShort());
+    }
 
-	public void testCreateStatementString()
-	{
-		final String string = "this is a plain string", lang = "en";
-		final Statement s = model.createStatement(r, p, string);
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals(string, s.getString());
-		Assert.assertEquals(lang, model.createStatement(r, p, string, lang)
-				.getLanguage());
-	}
+    public void testCreateStatementString() {
+        final String string = "this is a plain string", lang = "en";
+        final Statement s = model.createStatement(r, p, string);
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals(string, s.getString());
+        Assert.assertEquals(lang, model.createStatement(r, p, string, lang).getLanguage());
+    }
 
-	public void testCreateStatementTrue()
-	{
-		final Statement s = model.createLiteralStatement(r, p, true);
-		Assert.assertEquals(r, s.getSubject());
-		Assert.assertEquals(p, s.getPredicate());
-		Assert.assertEquals(true, s.getBoolean());
-	}
+    public void testCreateStatementTrue() {
+        final Statement s = model.createLiteralStatement(r, p, true);
+        Assert.assertEquals(r, s.getSubject());
+        Assert.assertEquals(p, s.getPredicate());
+        Assert.assertEquals(true, s.getBoolean());
+    }
 
-	public void testCreateStatementTypeLiteral()
-	{
-		final Model model = ModelFactory.createDefaultModel();
-		final Resource R = model.createResource("http://example/r");
-		final Property P = model.createProperty("http://example/p");
-		model.add(R, P, "2", XSDDatatype.XSDinteger);
-		final Literal L = ResourceFactory.createTypedLiteral("2",
-				XSDDatatype.XSDinteger);
-		Assert.assertTrue(model.contains(R, P, L));
-		Assert.assertFalse(model.contains(R, P, "2"));
-	}
+    public void testCreateStatementTypeLiteral() {
+        final Model model = ModelFactory.createDefaultModel();
+        final Resource R = model.createResource("http://example/r");
+        final Property P = model.createProperty("http://example/p");
+        model.add(R, P, "2", XSDDatatype.XSDinteger);
+        final Literal L = ResourceFactory.createTypedLiteral("2", XSDDatatype.XSDinteger);
+        Assert.assertTrue(model.contains(R, P, L));
+        Assert.assertFalse(model.contains(R, P, "2"));
+    }
 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestStatementMethods.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestStatementMethods.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,396 +18,281 @@
 
 package org.apache.jena.rdf.model.test;
 
-import org.apache.jena.rdf.model.* ;
-import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
-import org.apache.jena.test.JenaTestBase ;
-import org.apache.jena.vocabulary.RDF ;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.test.helpers.TestingModelFactory;
+import org.apache.jena.test.JenaTestBase;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.Assert;
 
-public class TestStatementMethods extends AbstractModelTestBase
-{
+public class TestStatementMethods extends AbstractModelTestBase {
 
-	protected Resource r;
+    protected Resource r;
 
-	public TestStatementMethods( final TestingModelFactory modelFactory,
-			final String name )
-	{
-		super(modelFactory, name);
-	}
+    public TestStatementMethods(final TestingModelFactory modelFactory, final String name) {
+        super(modelFactory, name);
+    }
 
-	protected void checkChangedStatementSP( final Statement changed )
-	{
-		Assert.assertEquals(r, changed.getSubject());
-		Assert.assertEquals(RDF.value, changed.getPredicate());
-	}
+    protected void checkChangedStatementSP(final Statement changed) {
+        Assert.assertEquals(r, changed.getSubject());
+        Assert.assertEquals(RDF.value, changed.getPredicate());
+    }
 
-	protected void checkCorrectStatements( final Statement sTrue,
-			final Statement changed )
-	{
-		Assert.assertFalse(model.contains(sTrue));
-		Assert.assertFalse(model.containsLiteral(r, RDF.value, true));
-		Assert.assertTrue(model.contains(changed));
-	}
+    protected void checkCorrectStatements(final Statement sTrue, final Statement changed) {
+        Assert.assertFalse(model.contains(sTrue));
+        Assert.assertFalse(model.containsLiteral(r, RDF.value, true));
+        Assert.assertTrue(model.contains(changed));
+    }
 
-	protected Statement loadInitialStatement()
-	{
-		final Statement sTrue = model
-				.createLiteralStatement(r, RDF.value, true);
-		model.add(sTrue);
-		return sTrue;
-	}
+    protected Statement loadInitialStatement() {
+        final Statement sTrue = model.createLiteralStatement(r, RDF.value, true);
+        model.add(sTrue);
+        return sTrue;
+    }
 
-	@Override
-	public void setUp()
-	{
-		super.setUp();
-		r = model.createResource();
-	}
+    @Override
+    public void setUp() {
+        super.setUp();
+        r = model.createResource();
+    }
 
-	public void testAlt()
-	{
-		final Alt tvAlt = model.createAlt();
-		Assert.assertEquals(tvAlt, model.createStatement(r, RDF.value, tvAlt)
-				.getAlt());
-	}
+    public void testAlt() {
+        final Alt tvAlt = model.createAlt();
+        Assert.assertEquals(tvAlt, model.createStatement(r, RDF.value, tvAlt).getAlt());
+    }
 
-	public void testBag()
-	{
-		final Bag tvBag = model.createBag();
-		Assert.assertEquals(tvBag, model.createStatement(r, RDF.value, tvBag)
-				.getBag());
-	}
+    public void testBag() {
+        final Bag tvBag = model.createBag();
+        Assert.assertEquals(tvBag, model.createStatement(r, RDF.value, tvBag).getBag());
+    }
 
-	public void testBoolean()
-	{
-		final Statement s = model.createLiteralStatement(r, RDF.value, true);
-		Assert.assertEquals(model.createTypedLiteral(true), s.getObject());
-		Assert.assertEquals(true, s.getBoolean());
-	}
+    public void testBoolean() {
+        final Statement s = model.createLiteralStatement(r, RDF.value, true);
+        Assert.assertEquals(model.createTypedLiteral(true), s.getObject());
+        Assert.assertEquals(true, s.getBoolean());
+    }
 
-	public void testByte()
-	{
-		final Statement s = model.createLiteralStatement(r, RDF.value,
-				AbstractModelTestBase.tvByte);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvByte),
-				s.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvByte, s.getLong());
-	}
+    public void testByte() {
+        final Statement s = model.createLiteralStatement(r, RDF.value, AbstractModelTestBase.tvByte);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvByte), s.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvByte, s.getLong());
+    }
 
-	public void testChangeObjectBoolean()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement sFalse = sTrue.changeLiteralObject(false);
-		checkChangedStatementSP(sFalse);
-		Assert.assertEquals(model.createTypedLiteral(false), sFalse.getObject());
-		Assert.assertEquals(false, sFalse.getBoolean());
-		checkCorrectStatements(sTrue, sFalse);
-		Assert.assertTrue(model.containsLiteral(r, RDF.value, false));
-	}
+    public void testChangeObjectBoolean() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement sFalse = sTrue.changeLiteralObject(false);
+        checkChangedStatementSP(sFalse);
+        Assert.assertEquals(model.createTypedLiteral(false), sFalse.getObject());
+        Assert.assertEquals(false, sFalse.getBoolean());
+        checkCorrectStatements(sTrue, sFalse);
+        Assert.assertTrue(model.containsLiteral(r, RDF.value, false));
+    }
 
-	public void testChangeObjectByte()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue
-				.changeLiteralObject(AbstractModelTestBase.tvByte);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvByte),
-				changed.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvByte, changed.getByte());
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.containsLiteral(r, RDF.value,
-				AbstractModelTestBase.tvByte));
-	}
+    public void testChangeObjectByte() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeLiteralObject(AbstractModelTestBase.tvByte);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvByte), changed.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvByte, changed.getByte());
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.containsLiteral(r, RDF.value, AbstractModelTestBase.tvByte));
+    }
 
-	public void testChangeObjectChar()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue
-				.changeLiteralObject(AbstractModelTestBase.tvChar);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(AbstractModelTestBase.tvChar, changed.getChar());
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvChar),
-				changed.getObject());
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.containsLiteral(r, RDF.value,
-				AbstractModelTestBase.tvChar));
-	}
+    public void testChangeObjectChar() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeLiteralObject(AbstractModelTestBase.tvChar);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(AbstractModelTestBase.tvChar, changed.getChar());
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvChar), changed.getObject());
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.containsLiteral(r, RDF.value, AbstractModelTestBase.tvChar));
+    }
 
-	public void testChangeObjectDouble()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue
-				.changeLiteralObject(AbstractModelTestBase.tvDouble);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvDouble),
-				changed.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvDouble,
-				changed.getDouble(), AbstractModelTestBase.dDelta);
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.containsLiteral(r, RDF.value,
-				AbstractModelTestBase.tvDouble));
-	}
+    public void testChangeObjectDouble() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeLiteralObject(AbstractModelTestBase.tvDouble);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvDouble), changed.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvDouble, changed.getDouble(), AbstractModelTestBase.dDelta);
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.containsLiteral(r, RDF.value, AbstractModelTestBase.tvDouble));
+    }
 
-	public void testChangeObjectFloat()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue
-				.changeLiteralObject(AbstractModelTestBase.tvFloat);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvFloat),
-				changed.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvFloat, changed.getFloat(),
-				AbstractModelTestBase.fDelta);
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.containsLiteral(r, RDF.value,
-				AbstractModelTestBase.tvFloat));
-	}
+    public void testChangeObjectFloat() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeLiteralObject(AbstractModelTestBase.tvFloat);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvFloat), changed.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvFloat, changed.getFloat(), AbstractModelTestBase.fDelta);
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.containsLiteral(r, RDF.value, AbstractModelTestBase.tvFloat));
+    }
 
-	public void testChangeObjectInt()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue
-				.changeLiteralObject(AbstractModelTestBase.tvInt);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvInt),
-				changed.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvInt, changed.getInt());
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.containsLiteral(r, RDF.value,
-				AbstractModelTestBase.tvInt));
-	}
+    public void testChangeObjectInt() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeLiteralObject(AbstractModelTestBase.tvInt);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvInt), changed.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvInt, changed.getInt());
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.containsLiteral(r, RDF.value, AbstractModelTestBase.tvInt));
+    }
 
-	public void testChangeObjectLiteral()
-	{
-		final Statement sTrue = loadInitialStatement();
-		model.remove(sTrue);
-		Assert.assertFalse(model.contains(sTrue));
-		Assert.assertFalse(model.containsLiteral(r, RDF.value, true));
-	}
+    public void testChangeObjectLiteral() {
+        final Statement sTrue = loadInitialStatement();
+        model.remove(sTrue);
+        Assert.assertFalse(model.contains(sTrue));
+        Assert.assertFalse(model.containsLiteral(r, RDF.value, true));
+    }
 
-	// public void testResObj()
-	// {
-	// Resource tvResObj = model.createResource( new ResTestObjF() );
-	// assertEquals( tvResObj, model.createStatement( r, RDF.value, tvResObj
-	// ).getResource() );
-	// }
+    // public void testResObj()
+    // {
+    // Resource tvResObj = model.createResource( new ResTestObjF() );
+    // assertEquals( tvResObj, model.createStatement( r, RDF.value, tvResObj
+    // ).getResource() );
+    // }
 
-	// public void testLitObj()
-	// {
-	// assertEquals( tvLitObj, model.createLiteralStatement( r, RDF.value,
-	// tvLitObj ).getObject( new LitTestObjF() ) );
-	// }
+    // public void testLitObj()
+    // {
+    // assertEquals( tvLitObj, model.createLiteralStatement( r, RDF.value,
+    // tvLitObj ).getObject( new LitTestObjF() ) );
+    // }
 
-	public void testChangeObjectLong()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue
-				.changeLiteralObject(AbstractModelTestBase.tvLong);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvLong),
-				changed.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvLong, changed.getLong());
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.containsLiteral(r, RDF.value,
-				AbstractModelTestBase.tvLong));
-	}
+    public void testChangeObjectLong() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeLiteralObject(AbstractModelTestBase.tvLong);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvLong), changed.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvLong, changed.getLong());
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.containsLiteral(r, RDF.value, AbstractModelTestBase.tvLong));
+    }
 
-	public void testChangeObjectShort()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue
-				.changeLiteralObject(AbstractModelTestBase.tvShort);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvShort),
-				changed.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvShort, changed.getShort());
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.containsLiteral(r, RDF.value,
-				AbstractModelTestBase.tvShort));
-	}
+    public void testChangeObjectShort() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeLiteralObject(AbstractModelTestBase.tvShort);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvShort), changed.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvShort, changed.getShort());
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.containsLiteral(r, RDF.value, AbstractModelTestBase.tvShort));
+    }
 
-	public void testChangeObjectString()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue
-				.changeObject(AbstractModelTestBase.tvString);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(AbstractModelTestBase.tvString, changed.getString());
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.contains(r, RDF.value,
-				AbstractModelTestBase.tvString));
-	}
+    public void testChangeObjectString() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeObject(AbstractModelTestBase.tvString);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(AbstractModelTestBase.tvString, changed.getString());
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.contains(r, RDF.value, AbstractModelTestBase.tvString));
+    }
 
-	public void testChangeObjectStringWithLanguage()
-	{
-		final String lang = "en";
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue.changeObject(
-				AbstractModelTestBase.tvString, lang);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(AbstractModelTestBase.tvString, changed.getString());
-		Assert.assertEquals(lang, changed.getLanguage());
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.contains(r, RDF.value,
-				AbstractModelTestBase.tvString, lang));
-	}
+    public void testChangeObjectStringWithLanguage() {
+        final String lang = "en";
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeObject(AbstractModelTestBase.tvString, lang);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(AbstractModelTestBase.tvString, changed.getString());
+        Assert.assertEquals(lang, changed.getLanguage());
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.contains(r, RDF.value, AbstractModelTestBase.tvString, lang));
+    }
 
-	public void testChangeObjectYByte()
-	{
-		final Statement sTrue = loadInitialStatement();
-		final Statement changed = sTrue
-				.changeLiteralObject(AbstractModelTestBase.tvByte);
-		checkChangedStatementSP(changed);
-		Assert.assertEquals(AbstractModelTestBase.tvByte, changed.getByte());
-		checkCorrectStatements(sTrue, changed);
-		Assert.assertTrue(model.containsLiteral(r, RDF.value,
-				AbstractModelTestBase.tvByte));
-	}
+    public void testChangeObjectYByte() {
+        final Statement sTrue = loadInitialStatement();
+        final Statement changed = sTrue.changeLiteralObject(AbstractModelTestBase.tvByte);
+        checkChangedStatementSP(changed);
+        Assert.assertEquals(AbstractModelTestBase.tvByte, changed.getByte());
+        checkCorrectStatements(sTrue, changed);
+        Assert.assertTrue(model.containsLiteral(r, RDF.value, AbstractModelTestBase.tvByte));
+    }
 
-	public void testChar()
-	{
-		final Statement s = model.createLiteralStatement(r, RDF.value,
-				AbstractModelTestBase.tvChar);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvChar),
-				s.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvChar, s.getChar());
-	}
+    public void testChar() {
+        final Statement s = model.createLiteralStatement(r, RDF.value, AbstractModelTestBase.tvChar);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvChar), s.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvChar, s.getChar());
+    }
 
-	public void testDouble()
-	{
-		final Statement s = model.createLiteralStatement(r, RDF.value,
-				AbstractModelTestBase.tvDouble);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvDouble),
-				s.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvDouble, s.getDouble(),
-				AbstractModelTestBase.dDelta);
-	}
+    public void testDouble() {
+        final Statement s = model.createLiteralStatement(r, RDF.value, AbstractModelTestBase.tvDouble);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvDouble), s.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvDouble, s.getDouble(), AbstractModelTestBase.dDelta);
+    }
 
-	public void testFloat()
-	{
-		final Statement s = model.createLiteralStatement(r, RDF.value,
-				AbstractModelTestBase.tvFloat);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvFloat),
-				s.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvFloat, s.getFloat(),
-				AbstractModelTestBase.fDelta);
-	}
+    public void testFloat() {
+        final Statement s = model.createLiteralStatement(r, RDF.value, AbstractModelTestBase.tvFloat);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvFloat), s.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvFloat, s.getFloat(), AbstractModelTestBase.fDelta);
+    }
 
-	public void testGetLiteralFailure()
-	{
-		try
-		{
-			model.createStatement(r, RDF.value, r).getLiteral();
-			Assert.fail("should trap non-literal object");
-		}
-		catch (final LiteralRequiredException e)
-		{
-			JenaTestBase.pass();
-		}
-	}
+    public void testGetLiteralFailure() {
+        try {
+            model.createStatement(r, RDF.value, r).getLiteral();
+            Assert.fail("should trap non-literal object");
+        } catch (final LiteralRequiredException e) {
+            JenaTestBase.pass();
+        }
+    }
 
-	public void testGetResource()
-	{
-		Assert.assertEquals(r, model.createStatement(r, RDF.value, r)
-				.getResource());
-	}
+    public void testGetResource() {
+        Assert.assertEquals(r, model.createStatement(r, RDF.value, r).getResource());
+    }
 
-	public void testGetResourceFailure()
-	{
-		try
-		{
-			model.createLiteralStatement(r, RDF.value, false).getResource();
-			Assert.fail("should trap non-resource object");
-		}
-		catch (final ResourceRequiredException e)
-		{
-			JenaTestBase.pass();
-		}
-	}
+    public void testGetResourceFailure() {
+        try {
+            model.createLiteralStatement(r, RDF.value, false).getResource();
+            Assert.fail("should trap non-resource object");
+        } catch (final ResourceRequiredException e) {
+            JenaTestBase.pass();
+        }
+    }
 
-	public void testGetTrueBoolean()
-	{
-		Assert.assertEquals(true,
-				model.createLiteralStatement(r, RDF.value, true).getLiteral()
-						.getBoolean());
-	}
+    public void testGetTrueBoolean() {
+        Assert.assertEquals(true, model.createLiteralStatement(r, RDF.value, true).getLiteral().getBoolean());
+    }
 
-	public void testInt()
-	{
-		final Statement s = model.createLiteralStatement(r, RDF.value,
-				AbstractModelTestBase.tvInt);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvInt),
-				s.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvInt, s.getInt());
-	}
+    public void testInt() {
+        final Statement s = model.createLiteralStatement(r, RDF.value, AbstractModelTestBase.tvInt);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvInt), s.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvInt, s.getInt());
+    }
 
-	// public void testChangeObjectResObject()
-	// {
-	// Resource tvResObj = model.createResource( new ResTestObjF() );
-	// Statement sTrue = loadInitialStatement();
-	// Statement changed = sTrue.changeObject( tvResObj );
-	// checkChangedStatementSP( changed );
-	// assertEquals( tvResObj, changed.getResource() );
-	// checkCorrectStatements( sTrue, changed );
-	// assertTrue( model.contains( r, RDF.value, tvResObj ) );
-	// }
+    // public void testChangeObjectResObject()
+    // {
+    // Resource tvResObj = model.createResource( new ResTestObjF() );
+    // Statement sTrue = loadInitialStatement();
+    // Statement changed = sTrue.changeObject( tvResObj );
+    // checkChangedStatementSP( changed );
+    // assertEquals( tvResObj, changed.getResource() );
+    // checkCorrectStatements( sTrue, changed );
+    // assertTrue( model.contains( r, RDF.value, tvResObj ) );
+    // }
 
-	public void testLong()
-	{
-		final Statement s = model.createLiteralStatement(r, RDF.value,
-				AbstractModelTestBase.tvLong);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvLong),
-				s.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvLong, s.getLong());
-	}
+    public void testLong() {
+        final Statement s = model.createLiteralStatement(r, RDF.value, AbstractModelTestBase.tvLong);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvLong), s.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvLong, s.getLong());
+    }
 
-	public void testSeq()
-	{
-		final Seq tvSeq = model.createSeq();
-		Assert.assertEquals(tvSeq, model.createStatement(r, RDF.value, tvSeq)
-				.getSeq());
-	}
+    public void testSeq() {
+        final Seq tvSeq = model.createSeq();
+        Assert.assertEquals(tvSeq, model.createStatement(r, RDF.value, tvSeq).getSeq());
+    }
 
-	public void testShort()
-	{
-		final Statement s = model.createLiteralStatement(r, RDF.value,
-				AbstractModelTestBase.tvShort);
-		Assert.assertEquals(
-				model.createTypedLiteral(AbstractModelTestBase.tvShort),
-				s.getObject());
-		Assert.assertEquals(AbstractModelTestBase.tvShort, s.getShort());
-	}
+    public void testShort() {
+        final Statement s = model.createLiteralStatement(r, RDF.value, AbstractModelTestBase.tvShort);
+        Assert.assertEquals(model.createTypedLiteral(AbstractModelTestBase.tvShort), s.getObject());
+        Assert.assertEquals(AbstractModelTestBase.tvShort, s.getShort());
+    }
 
-	public void testString()
-	{
-		Assert.assertEquals(AbstractModelTestBase.tvString, model
-				.createStatement(r, RDF.value, AbstractModelTestBase.tvString)
-				.getString());
-	}
+    public void testString() {
+        Assert.assertEquals(AbstractModelTestBase.tvString,
+                            model.createStatement(r, RDF.value, AbstractModelTestBase.tvString).getString());
+    }
 
-	public void testStringWithLanguage()
-	{
-		final String lang = "fr";
-		Assert.assertEquals(
-				AbstractModelTestBase.tvString,
-				model.createStatement(r, RDF.value,
-						AbstractModelTestBase.tvString, lang).getString());
-		Assert.assertEquals(
-				lang,
-				model.createStatement(r, RDF.value,
-						AbstractModelTestBase.tvString, lang).getLanguage());
-	}
+    public void testStringWithLanguage() {
+        final String lang = "fr";
+        Assert.assertEquals(AbstractModelTestBase.tvString,
+                            model.createStatement(r, RDF.value, AbstractModelTestBase.tvString, lang).getString());
+        Assert.assertEquals(lang, model.createStatement(r, RDF.value, AbstractModelTestBase.tvString, lang).getLanguage());
+    }
 }

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestStatementTerms.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestStatementTerms.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.rdf.model.test;
+
+import org.junit.Assert;
+
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.test.helpers.ModelHelper;
+import org.apache.jena.rdf.model.test.helpers.TestingModelFactory;
+import org.apache.jena.vocabulary.RDF;
+
+public class TestStatementTerms extends AbstractModelTestBase {
+    public TestStatementTerms(TestingModelFactory modelFactory, String name) {
+        super(modelFactory, name);
+    }
+
+    public void testStatementTerms() {
+        String fakeURI = "fake:URI";
+        Resource S = model.createResource();
+        Property P = ModelHelper.property(model, "PP");
+        RDFNode O = model.createTypedLiteral("42", fakeURI);
+
+        Statement stmt = model.createStatement(S, P, O);
+        Assert.assertTrue(model.isEmpty());
+
+        StatementTerm stmtTerm = model.createStatementTerm(stmt);
+        Assert.assertTrue(model.isEmpty());
+
+        Assert.assertEquals(S, stmtTerm.getStatement().getSubject());
+        Assert.assertEquals(P, stmtTerm.getStatement().getPredicate());
+        Assert.assertEquals(O, stmtTerm.getStatement().getObject());
+    }
+
+    private static StatementTerm create(Model model) {
+        String fakeURI = "fake:URI";
+        Resource S = model.createResource();
+        Property P = ModelHelper.property(model, "PP");
+        RDFNode O = model.createTypedLiteral("42", fakeURI);
+
+        Statement stmt = model.createStatement(S, P, O);
+        StatementTerm stmtTerm = model.createStatementTerm(stmt);
+        return stmtTerm;
+    }
+
+
+    public void testStatementReifierAnon() {
+        String fakeURI = "fake:URI";
+        Resource S = model.createResource();
+        Property P = ModelHelper.property(model, "PP");
+        RDFNode O = model.createTypedLiteral("42", fakeURI);
+        Statement stmt = model.createStatement(S, P, O);
+
+        Resource r = model.createReifier(stmt);
+        Assert.assertFalse(model.isEmpty());
+        Assert.assertEquals(1, model.size());
+
+        Statement s = model.listStatements().next();
+
+        RDFNode x = s.getObject();
+        Assert.assertTrue(s.getSubject().isAnon());
+        Assert.assertTrue(s.getPredicate().equals(RDF.reifies));
+        Assert.assertTrue(s.getObject().isStatementTerm());
+
+        StatementTerm st = s.getObject().asStatementTerm();
+        Assert.assertTrue(st != null);
+        Assert.assertEquals(st.getStatement(), stmt);
+    }
+
+    public void testStatementReifierResource() {
+        String fakeURI = "fake:URI";
+        String reifURI = "reifier:URI";
+
+        Resource reifier = model.createResource(reifURI);
+
+        Resource S = model.createResource();
+        Property P = ModelHelper.property(model, "PP");
+        RDFNode O = model.createTypedLiteral("42", fakeURI);
+        Statement stmt = model.createStatement(S, P, O);
+
+        Resource r = model.createReifier(reifier, stmt);
+        Assert.assertEquals(reifURI, r.getURI());
+
+        Assert.assertFalse(model.isEmpty());
+        Assert.assertEquals(1, model.size());
+
+        StatementTerm st = r.getProperty(RDF.reifies).getObject().asStatementTerm();
+        Assert.assertTrue(st != null);
+        Assert.assertEquals(st.getStatement(), stmt);
+    }
+}

--- a/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestStatements.java
+++ b/jena-core/src/test/java/org/apache/jena/rdf/model/test/TestStatements.java
@@ -18,120 +18,106 @@
 
 package org.apache.jena.rdf.model.test;
 
-import org.apache.jena.graph.FrontsTriple ;
-import org.apache.jena.rdf.model.* ;
-import org.apache.jena.rdf.model.test.helpers.ModelHelper ;
-import org.apache.jena.rdf.model.test.helpers.TestingModelFactory ;
-import org.apache.jena.test.JenaTestBase ;
-import org.apache.jena.vocabulary.RDF ;
+import org.apache.jena.graph.FrontsTriple;
+import org.apache.jena.rdf.model.*;
+import org.apache.jena.rdf.model.test.helpers.ModelHelper;
+import org.apache.jena.rdf.model.test.helpers.TestingModelFactory;
+import org.apache.jena.test.JenaTestBase;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.Assert;
 
-public class TestStatements extends AbstractModelTestBase
-{
-	public TestStatements( final TestingModelFactory modelFactory,
-			final String name )
-	{
-		super(modelFactory, name);
-	}
+public class TestStatements extends AbstractModelTestBase {
+    public TestStatements(final TestingModelFactory modelFactory, final String name) {
+        super(modelFactory, name);
+    }
 
-	public void testOtherStuff()
-	{
-		final Model A = createModel();
-		final Model B = createModel();
-		final Resource S = A.createResource("jena:S");
-		final Resource R = A.createResource("jena:R");
-		final Property P = A.createProperty("jena:P");
-		final RDFNode O = A.createResource("jena:O");
-		A.add(S, P, O);
-		B.add(S, P, O);
-		Assert.assertTrue("X1", A.isIsomorphicWith(B));
-		/* */
-		A.add(R, RDF.subject, S);
-		B.add(R, RDF.predicate, P);
-		Assert.assertFalse("X2", A.isIsomorphicWith(B));
-		/* */
-		A.add(R, RDF.predicate, P);
-		B.add(R, RDF.subject, S);
-		Assert.assertTrue("X3", A.isIsomorphicWith(B));
-		/* */
-		A.add(R, RDF.object, O);
-		B.add(R, RDF.type, RDF.Statement);
-		Assert.assertFalse("X4", A.isIsomorphicWith(B));
-		/* */
-		A.add(R, RDF.type, RDF.Statement);
-		B.add(R, RDF.object, O);
-		Assert.assertTrue("X5", A.isIsomorphicWith(B));
-	}
+    public void testOtherStuff() {
+        final Model A = createModel();
+        final Model B = createModel();
+        final Resource S = A.createResource("jena:S");
+        final Resource R = A.createResource("jena:R");
+        final Property P = A.createProperty("jena:P");
+        final RDFNode O = A.createResource("jena:O");
+        A.add(S, P, O);
+        B.add(S, P, O);
+        Assert.assertTrue("X1", A.isIsomorphicWith(B));
+        /* */
+        A.add(R, RDF.subject, S);
+        B.add(R, RDF.predicate, P);
+        Assert.assertFalse("X2", A.isIsomorphicWith(B));
+        /* */
+        A.add(R, RDF.predicate, P);
+        B.add(R, RDF.subject, S);
+        Assert.assertTrue("X3", A.isIsomorphicWith(B));
+        /* */
+        A.add(R, RDF.object, O);
+        B.add(R, RDF.type, RDF.Statement);
+        Assert.assertFalse("X4", A.isIsomorphicWith(B));
+        /* */
+        A.add(R, RDF.type, RDF.Statement);
+        B.add(R, RDF.object, O);
+        Assert.assertTrue("X5", A.isIsomorphicWith(B));
+    }
 
-	public void testPortingBlankNodes()
-	{
-		final Model B = createModel();
-		final Resource anon = model.createResource();
-		final Resource bAnon = anon.inModel(B);
-		Assert.assertTrue("moved resource should still be blank",
-				bAnon.isAnon());
-		Assert.assertEquals("move resource should equal original", anon, bAnon);
-	}
+    public void testPortingBlankNodes() {
+        final Model B = createModel();
+        final Resource anon = model.createResource();
+        final Resource bAnon = anon.inModel(B);
+        Assert.assertTrue("moved resource should still be blank", bAnon.isAnon());
+        Assert.assertEquals("move resource should equal original", anon, bAnon);
+    }
 
-	public void testSet()
-	{
-		final Model A = createModel();
-		createModel();
-		final Resource S = A.createResource("jena:S");
-		A.createResource("jena:R");
-		final Property P = A.createProperty("jena:P");
-		final RDFNode O = A.createResource("jena:O");
-		final Statement spo = A.createStatement(S, P, O);
-		A.add(spo);
-		final Statement sps = A.createStatement(S, P, S);
-		Assert.assertEquals(sps, spo.changeObject(S));
-		Assert.assertFalse(A.contains(spo));
-		Assert.assertTrue(A.contains(sps));
-	}
+    public void testSet() {
+        final Model A = createModel();
+        createModel();
+        final Resource S = A.createResource("jena:S");
+        A.createResource("jena:R");
+        final Property P = A.createProperty("jena:P");
+        final RDFNode O = A.createResource("jena:O");
+        final Statement spo = A.createStatement(S, P, O);
+        A.add(spo);
+        final Statement sps = A.createStatement(S, P, S);
+        Assert.assertEquals(sps, spo.changeObject(S));
+        Assert.assertFalse(A.contains(spo));
+        Assert.assertTrue(A.contains(sps));
+    }
 
-	/**
-	 * Feeble test that toString'ing a Statement[Impl] will display the
-	 * data-type
-	 * of its object if it has one.
-	 */
-	public void testStatementPrintsType()
-	{
-		final String fakeURI = "fake:URI";
-		final Resource S = model.createResource();
-		final Property P = ModelHelper.property(model, "PP");
-		final RDFNode O = model.createTypedLiteral("42", fakeURI);
-		final Statement st = model.createStatement(S, P, O);
-		Assert.assertTrue(st.toString().indexOf(fakeURI) > 0);
-	}
+    /**
+     * Feeble test that toString'ing a Statement[Impl] will display the data-type of
+     * its object if it has one.
+     */
+    public void testStatementPrintsType() {
+        final String fakeURI = "fake:URI";
+        final Resource S = model.createResource();
+        final Property P = ModelHelper.property(model, "PP");
+        final RDFNode O = model.createTypedLiteral("42", fakeURI);
+        final Statement st = model.createStatement(S, P, O);
+        Assert.assertTrue(st.toString().indexOf(fakeURI) > 0);
+    }
 
-	public void testStatmentMap1Selectors()
-	{
-		final Statement stmt = ModelHelper.statement("sub pred obj");
-		Assert.assertEquals(ModelHelper.resource("sub"), stmt.getSubject());
-		Assert.assertEquals(ModelHelper.resource("pred"), stmt.getPredicate()) ;
-		Assert.assertEquals(ModelHelper.resource("obj"), stmt.getObject()) ;
-	}
+    public void testStatmentMap1Selectors() {
+        final Statement stmt = ModelHelper.statement("sub pred obj");
+        Assert.assertEquals(ModelHelper.resource("sub"), stmt.getSubject());
+        Assert.assertEquals(ModelHelper.resource("pred"), stmt.getPredicate());
+        Assert.assertEquals(ModelHelper.resource("obj"), stmt.getObject());
+    }
 
-	/**
-	 * A resource created in one
-	 * model and incorporated into a statement asserted constructed by a
-	 * different model should test equal to the resource extracted from that
-	 * statement, even if it's a bnode.
-	 */
-	public void testStuff()
-	{
-		final Model red = createModel();
-		final Model blue = createModel();
-		final Resource r = red.createResource();
-		final Property p = red.createProperty("");
-		final Statement s = blue.createStatement(r, p, r);
-		Assert.assertEquals("subject preserved", r, s.getSubject());
-		Assert.assertEquals("object preserved", r, s.getObject());
-	}
+    /**
+     * A resource created in one model and incorporated into a statement asserted
+     * constructed by a different model should test equal to the resource extracted
+     * from that statement, even if it's a bnode.
+     */
+    public void testStuff() {
+        final Model red = createModel();
+        final Model blue = createModel();
+        final Resource r = red.createResource();
+        final Property p = red.createProperty("");
+        final Statement s = blue.createStatement(r, p, r);
+        Assert.assertEquals("subject preserved", r, s.getSubject());
+        Assert.assertEquals("object preserved", r, s.getObject());
+    }
 
-	public void testTripleWrapper()
-	{
-		JenaTestBase.assertInstanceOf(FrontsTriple.class,
-				ModelHelper.statement(model, "s p o"));
-	}
+    public void testTripleWrapper() {
+        JenaTestBase.assertInstanceOf(FrontsTriple.class, ModelHelper.statement(model, "s p o"));
+    }
 }

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/Factory.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/Factory.java
@@ -34,7 +34,7 @@ public class Factory {
 
     /**
      * Create an instance of the SecuredGraph
-     * 
+     *
      * @param securityEvaluator The security evaluator to use
      * @param graphIRI          The IRI for the graph.
      * @param graph             The graph that we are wrapping.
@@ -48,7 +48,7 @@ public class Factory {
 
     /**
      * Get an instance of SecuredModel
-     * 
+     *
      * @param securityEvaluator The security evaluator to use
      * @param modelIRI          The securedModel IRI (graph IRI) to evaluate
      *                          against.

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/SecuredStatementTerm.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/SecuredStatementTerm.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.permissions.model;
+
+import org.apache.jena.rdf.model.*;
+
+/**
+ * The interface for secured StatementTerm instances.
+ *
+ * Use a secured Model to create instances.
+ */
+public interface SecuredStatementTerm extends StatementTerm, SecuredRDFNode {
+}

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredLiteralImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredLiteralImpl.java
@@ -25,10 +25,8 @@ import org.apache.jena.permissions.impl.SecuredItemInvoker;
 import org.apache.jena.permissions.model.SecuredLiteral;
 import org.apache.jena.permissions.model.SecuredModel;
 import org.apache.jena.permissions.model.SecuredResource;
-import org.apache.jena.rdf.model.Literal;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.RDFVisitor;
-import org.apache.jena.rdf.model.ResourceRequiredException;
+import org.apache.jena.permissions.model.SecuredStatementTerm;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.shared.AuthenticationRequiredException;
 import org.apache.jena.shared.ReadDeniedException;
 
@@ -98,6 +96,14 @@ public class SecuredLiteralImpl extends SecuredRDFNodeImpl implements SecuredLit
             throw new ResourceRequiredException(asNode());
         }
         throw new ResourceRequiredException(NodeFactory.createLiteralString("Can not read"));
+    }
+
+    @Override
+    public SecuredStatementTerm asStatementTerm() {
+        if (canRead()) {
+            throw new StmtTermRequiredException(asNode());
+        }
+        throw new StmtTermRequiredException(NodeFactory.createLiteralString("Can not read"));
     }
 
     /**

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
@@ -1345,8 +1345,17 @@ public class SecuredModelImpl extends SecuredItemImpl implements SecuredModel {
     }
 
     @Override
-    public Resource createResource(Statement statement) {
-        return SecuredResourceImpl.getInstance(holder.getSecuredItem(), holder.getBaseItem().createResource(statement));
+    public RDFNode createStatementTerm(Statement statement) {
+        return SecuredResourceImpl.getInstance(holder.getSecuredItem(), holder.getBaseItem().createStatementTerm(statement));
+    }
+
+    @Override
+    public Resource createReifier( Resource reifier, Statement statement ) {
+        RDFNode n = createStatementTerm(statement);
+        Statement stmt = this.createStatement(reifier, RDF.reifies, n);
+        Statement stmtx =  SecuredStatementImpl.getInstance(this, stmt);
+        this.add(stmtx);
+        return reifier;
     }
 
     private void checkReadOrUpdate(Resource s, Property p, RDFNode o) {

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredModelImpl.java
@@ -1345,8 +1345,8 @@ public class SecuredModelImpl extends SecuredItemImpl implements SecuredModel {
     }
 
     @Override
-    public RDFNode createStatementTerm(Statement statement) {
-        return SecuredResourceImpl.getInstance(holder.getSecuredItem(), holder.getBaseItem().createStatementTerm(statement));
+    public StatementTerm createStatementTerm(Statement statement) {
+        return SecuredStatementTermImpl.getInstance(holder.getSecuredItem(), holder.getBaseItem().createStatementTerm(statement));
     }
 
     @Override

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredRDFNodeImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredRDFNodeImpl.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,10 +28,7 @@ import org.apache.jena.permissions.impl.SecuredItemImpl;
 import org.apache.jena.permissions.model.SecuredModel;
 import org.apache.jena.permissions.model.SecuredRDFNode;
 import org.apache.jena.permissions.model.SecuredUnsupportedPolymorphismException;
-import org.apache.jena.rdf.model.Literal;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.shared.AuthenticationRequiredException;
 import org.apache.jena.shared.ReadDeniedException;
 
@@ -40,7 +37,7 @@ import org.apache.jena.shared.ReadDeniedException;
  */
 public abstract class SecuredRDFNodeImpl extends SecuredItemImpl implements SecuredRDFNode {
     /**
-     * 
+     *
      * @param securedModel the Secured Model to use.
      * @param rdfNode      the node to secure.
      * @return the secured RDFNode
@@ -48,6 +45,9 @@ public abstract class SecuredRDFNodeImpl extends SecuredItemImpl implements Secu
     public static SecuredRDFNode getInstance(final SecuredModel securedModel, final RDFNode rdfNode) {
         if (rdfNode instanceof Literal) {
             return SecuredLiteralImpl.getInstance(securedModel, (Literal) rdfNode);
+        }
+        if (rdfNode instanceof StatementTerm ) {
+            return SecuredStatementTermImpl.getInstance(securedModel, (StatementTerm)rdfNode);
         }
         return SecuredResourceImpl.getInstance(securedModel, (Resource) rdfNode);
     }
@@ -60,7 +60,7 @@ public abstract class SecuredRDFNodeImpl extends SecuredItemImpl implements Secu
 
     /**
      * Constructor
-     * 
+     *
      * @param securedModel the Secured Model to use.
      * @param holder       the item holder that will contain this SecuredRDFNode.
      */
@@ -198,8 +198,8 @@ public abstract class SecuredRDFNodeImpl extends SecuredItemImpl implements Secu
     }
 
     @Override
-    public boolean isStmtResource() {
-        return holder.getBaseItem().isStmtResource();
+    public boolean isStatementTerm() {
+        return holder.getBaseItem().isStatementTerm();
     }
 
     /**
@@ -208,7 +208,7 @@ public abstract class SecuredRDFNodeImpl extends SecuredItemImpl implements Secu
      * asNode, because we allow other implementations of Resource, at least in
      * principle. This is deemed to be a complete and correct interpretation of
      * RDFNode equality, which is why this method has been marked final.
-     * 
+     *
      * @param o An object to test for equality with this node
      * @return True if o is equal to this node.
      * @throws ReadDeniedException
@@ -222,7 +222,7 @@ public abstract class SecuredRDFNodeImpl extends SecuredItemImpl implements Secu
 
     /**
      * The hash code of an RDFnode is defined to be the same as the underlying node.
-     * 
+     *
      * @return The hashcode as an int
      */
     @Override

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredResourceImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredResourceImpl.java
@@ -298,6 +298,12 @@ public class SecuredResourceImpl extends SecuredRDFNodeImpl implements SecuredRe
     }
 
     @Override
+    public StatementTerm asStatementTerm() {
+        checkRead();
+        throw new StmtTermRequiredException(asNode());
+    }
+
+    @Override
     public SecuredResource begin() {
         holder.getBaseItem().begin();
         return holder.getSecuredItem();
@@ -503,27 +509,6 @@ public class SecuredResourceImpl extends SecuredRDFNodeImpl implements SecuredRe
     public String getURI() throws ReadDeniedException, AuthenticationRequiredException {
         checkRead();
         return holder.getBaseItem().getURI();
-    }
-
-    /**
-     * @sec.graph Read
-     *
-     *            if {@link SecurityEvaluator#isHardReadError()} is true and the
-     *            user does not have read access then @{code null} is returned.
-     *
-     * @throws ReadDeniedException
-     * @throws AuthenticationRequiredException if user is not authenticated and is
-     *                                         required to be.
-     */
-    @Override
-    public Statement getStmtTerm() {
-        if (checkSoftRead()) {
-            Statement stmt = holder.getBaseItem().getStmtTerm();
-            if (stmt != null && canRead(stmt)) {
-                return SecuredStatementImpl.getInstance(getModel(), stmt);
-            }
-        }
-        return null;
     }
 
     /**

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredStatementImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredStatementImpl.java
@@ -457,7 +457,6 @@ public class SecuredStatementImpl extends SecuredItemImpl implements SecuredStat
         checkRead(holder.getBaseItem().asTriple());
         final RDFNode rdfNode = holder.getBaseItem().getObject();
         return SecuredRDFNodeImpl.getInstance(getModel(), rdfNode);
-
     }
 
     /**

--- a/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredStatementTermImpl.java
+++ b/jena-permissions/src/main/java/org/apache/jena/permissions/model/impl/SecuredStatementTermImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jena.permissions.model.impl;
+
+import org.apache.jena.permissions.impl.ItemHolder;
+import org.apache.jena.permissions.impl.SecuredItemInvoker;
+import org.apache.jena.permissions.model.*;
+import org.apache.jena.rdf.model.*;
+
+/**
+ * Implementation of SecuredStatement to be used by a SecuredItemInvoker proxy.
+ */
+public class SecuredStatementTermImpl extends SecuredRDFNodeImpl implements SecuredStatementTerm {
+    /**
+     * get a SecuredStatement
+     *
+     * @param securedModel The secured model that provides the security context
+     * @param stmt         The statement to secure.
+     * @return the SecuredStatement
+     */
+    public static SecuredStatementTerm getInstance(final SecuredModel securedModel, final StatementTerm stmtTerm) {
+        if (securedModel == null) {
+            throw new IllegalArgumentException("Secured securedModel may not be null");
+        }
+        if (stmtTerm == null) {
+            throw new IllegalArgumentException("StatemenTerm may not be null");
+        }
+
+        final ItemHolder<StatementTerm, SecuredStatementTerm> holder = new ItemHolder<>(stmtTerm);
+
+        final SecuredStatementTermImpl checker = new SecuredStatementTermImpl(securedModel, holder);
+        // if we are going to create a duplicate proxy, just return this
+        // one.
+        if (stmtTerm instanceof SecuredStatementTerm) {
+            if (checker.isEquivalent((SecuredStatement) stmtTerm)) {
+                return (SecuredStatementTerm) stmtTerm;
+            }
+        }
+        return holder.setSecuredItem(new SecuredItemInvoker(holder.getBaseItem().getClass(), checker));
+    }
+
+    // the item holder that contains this SecuredStatement.
+    private final ItemHolder<StatementTerm, SecuredStatementTerm> holder;
+
+    private final SecuredModel securedModel;
+
+    /**
+     * Constructor.
+     *
+     * @param securityEvaluator The security evaluator to use.
+     * @param graphIRI          the graph IRI to verify against.
+     * @param holder            The item holder that will contain this
+     *                          SecuredStatement.
+     */
+    private SecuredStatementTermImpl(final SecuredModel securedModel,
+            final ItemHolder<StatementTerm, SecuredStatementTerm> holder) {
+        super(securedModel, holder);
+        this.holder = holder;
+        this.securedModel = securedModel;
+    }
+
+    @Override
+    public SecuredLiteral asLiteral() {
+        checkRead();
+        throw new LiteralRequiredException(asNode());
+    }
+
+    @Override
+    public SecuredResource asResource() {
+        checkRead();
+        throw new ResourceRequiredException(asNode());
+    }
+
+    @Override
+    public SecuredStatementTerm asStatementTerm() {
+        checkRead();
+        return this;
+    }
+
+    @Override
+    public Statement getStatement() {
+        checkRead();
+        return SecuredStatementImpl.getInstance(securedModel, holder.getBaseItem().getStatement());
+    }
+
+    @Override
+    public Object visitWith(RDFVisitor rv) {
+        return rv.visitStmt(this, this.getStatement());
+    }
+}


### PR DESCRIPTION

* Create a new kind of RDFNode -- StatementTerm -- as the Model API representation of "triple terms".
* Add statement reifier support (RDF 1.2 style)



----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
