### PR TITLE
Universal TripleCollector

### DIFF
--- a/jena-arq/Grammar/arq.jj
+++ b/jena-arq/Grammar/arq.jj
@@ -962,11 +962,11 @@ void PropertyListNotEmpty(Node s, TripleCollector acc) :
     { Node p = null ; }
 {
     p = Verb()
-    ObjectList(s, p, null, acc)
+    ObjectList(s, p, acc)
   ( <SEMICOLON>
     (
        p = Verb()
-      ObjectList(s, p, null, acc)
+      ObjectList(s, p, acc)
     )?
   )*
 }
@@ -975,17 +975,17 @@ Node Verb() : { Node p ;}
   ( p = VarOrIri() | <KW_A> { p = nRDFtype ; } )
   { return p ; }
 }
-void ObjectList(Node s, Node p, Path path, TripleCollector acc): { Node o ; }
+void ObjectList(Node s, Node p, TripleCollector acc): { Node o ; }
 {
-  Object(s, p, path, acc)
-  ( <COMMA> Object(s, p, path, acc) )*
+  Object(s, p, acc)
+  ( <COMMA> Object(s, p, acc) )*
 }
-void Object(Node s, Node p, Path path, TripleCollector acc): { Node o ; }
+void Object(Node s, Node p, TripleCollector acc): { Node o ; }
 {
   { ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ; }
   o = GraphNode(tempAcc)
-  { insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ; }
-  Annotation(acc, s, p, path, o)
+  { insert(tempAcc, mark, s, p, o) ; insert(acc, tempAcc) ; }
+  Annotation(acc, s, p, o)
 }
 void TriplesSameSubjectPath(TripleCollector acc) : { Node s ; }
 {
@@ -1171,7 +1171,7 @@ P_Path0 PathOneInPropertySet() : { String str ; Node n ; }
     )
   )
 }
-Node TriplesNode(TripleCollectorMark acc) : { Node n ; }
+Node TriplesNode(TripleCollector acc) : { Node n ; }
 {
    n = Collection(acc) { return n ; }
  |
@@ -1185,7 +1185,7 @@ Node BlankNodePropertyList(TripleCollector acc) : { Token t ; }
   <RBRACKET>
     { return n ; }
 }
-Node TriplesNodePath(TripleCollectorMark acc) : { Node n ; }
+Node TriplesNodePath(TripleCollector acc) : { Node n ; }
 {
    n = CollectionPath(acc) { return n ; }
  |
@@ -1199,7 +1199,7 @@ Node BlankNodePropertyListPath(TripleCollector acc) : { Token t ; }
   <RBRACKET>
     { return n ; }
 }
-Node Collection(TripleCollectorMark acc) :
+Node Collection(TripleCollector acc) :
     { Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ; }
 {
   t = <LPAREN>
@@ -1223,7 +1223,7 @@ Node Collection(TripleCollectorMark acc) :
        insert(acc, lastCell, nRDFrest, nRDFnil) ;
      return listHead ; }
 }
-Node CollectionPath(TripleCollectorMark acc) :
+Node CollectionPath(TripleCollector acc) :
     { Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ; }
 {
   t = <LPAREN>
@@ -1270,16 +1270,16 @@ void AnnotationBlockPath(TripleCollector acc, Node reifId) : { }
       PropertyListPathNotEmpty(reifId, acc)
    <R_ANN>
 }
-void Annotation(TripleCollector acc, Node s, Node p, Path path, Node o) : { Node reifId = null ; }
+void Annotation(TripleCollector acc, Node s, Node p, Node o) : { Node reifId = null ; }
 {
   (
-    { p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn); }
+    { p = preConditionReifier(s, p,null, o, token.beginLine, token.beginColumn); }
     reifId = Reifier()
     { reifId = insertTripleReifier(acc, reifId, s, p, o, token.beginLine, token.beginColumn) ; }
     { setReifierId(reifId); }
   |
     {
-      p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn);
+      p = preConditionReifier(s, p, null, o, token.beginLine, token.beginColumn);
       reifId = getOrAllocReifierId(acc, s, p, o, token.beginLine, token.beginColumn);
     }
     { clearReifierId(); }
@@ -1292,7 +1292,7 @@ void AnnotationBlock(TripleCollector acc, Node reifId) : { }
       PropertyListNotEmpty(reifId, acc)
    <R_ANN>
 }
-Node GraphNode(TripleCollectorMark acc) : { Node n ; }
+Node GraphNode(TripleCollector acc) : { Node n ; }
 {
    n = VarOrTerm() { return n ; }
  |
@@ -1300,7 +1300,7 @@ Node GraphNode(TripleCollectorMark acc) : { Node n ; }
  |
    n = ReifiedTriple(acc) { return n ; }
 }
-Node GraphNodePath(TripleCollectorMark acc) : { Node n ; }
+Node GraphNodePath(TripleCollector acc) : { Node n ; }
 {
   n = VarOrTerm() { return n ; }
 |

--- a/jena-arq/Grammar/main.jj
+++ b/jena-arq/Grammar/main.jj
@@ -1341,11 +1341,11 @@ void PropertyListNotEmpty(Node s, TripleCollector acc) :
     { Node p = null ; }
 {
     p = Verb()
-    ObjectList(s, p, null, acc)
+    ObjectList(s, p, acc)
   ( <SEMICOLON> 
     ( /* TriG template: LOOKAHEAD(2) */
        p = Verb()
-      ObjectList(s, p, null, acc)
+      ObjectList(s, p, acc)
     )? 
   )*
 }
@@ -1358,18 +1358,18 @@ Node Verb() : { Node p ;}
   { return p ; }
 }
 
-void ObjectList(Node s,  Node p, Path path, TripleCollector acc): { Node o ; } 
+void ObjectList(Node s, Node p, TripleCollector acc): { Node o ; } 
 {
-  Object(s, p, path, acc)
-  ( <COMMA> Object(s, p, path, acc) )*
+  Object(s, p, acc)
+  ( <COMMA> Object(s, p, acc) )*
 }
 
-void Object(Node s, Node p, Path path, TripleCollector acc): { Node o ; }
+void Object(Node s, Node p, TripleCollector acc): { Node o ; }
 {
   { ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ; }
   o = GraphNode(tempAcc) 
-  { insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ; }
-  Annotation(acc, s, p, path, o)
+  { insert(tempAcc, mark, s, p, o) ; insert(acc, tempAcc) ; }
+  Annotation(acc, s, p, o)
 }
 
 // -------- BGPs with paths.
@@ -1610,7 +1610,7 @@ P_Path0 PathOneInPropertySet() : { String str ; Node n ; }
 // Anything that can stand in a node slot and which is
 // a number of triples
 
-Node TriplesNode(TripleCollectorMark acc) : { Node n ; }
+Node TriplesNode(TripleCollector acc) : { Node n ; }
 {
    n = Collection(acc) { return n ; }
  |
@@ -1626,7 +1626,7 @@ Node BlankNodePropertyList(TripleCollector acc) : { Token t ; }
     { return n ; }
 }
 
-Node TriplesNodePath(TripleCollectorMark acc) : { Node n ; }
+Node TriplesNodePath(TripleCollector acc) : { Node n ; }
 {
    n = CollectionPath(acc) { return n ; }
  |
@@ -1644,7 +1644,7 @@ Node BlankNodePropertyListPath(TripleCollector acc) : { Token t ; }
 
 // ------- RDF collections
 
-Node Collection(TripleCollectorMark acc) : 
+Node Collection(TripleCollector acc) : 
     { Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ; }
 {
   t = <LPAREN>
@@ -1670,7 +1670,7 @@ Node Collection(TripleCollectorMark acc) :
      return listHead ; }
 }
 
-Node CollectionPath(TripleCollectorMark acc) : 
+Node CollectionPath(TripleCollector acc) : 
     { Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ; }
 {
   t = <LPAREN>
@@ -1725,17 +1725,17 @@ void AnnotationBlockPath(TripleCollector acc, Node reifId) : { }
 
 // ---- RDF-star Annotation Syntax
 // No paths. Construct templates.
-void Annotation(TripleCollector acc, Node s, Node p, Path path, Node o) : { Node reifId = null ; }
+void Annotation(TripleCollector acc, Node s, Node p, Node o) : { Node reifId = null ; }
 {
   (
-    { p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn); }
+    { p = preConditionReifier(s, p,null, o, token.beginLine, token.beginColumn); }
     reifId = Reifier()
     // @@ Rewrite java?
     { reifId = insertTripleReifier(acc, reifId, s, p, o, token.beginLine, token.beginColumn) ; }    
     { setReifierId(reifId); }
   |
     {
-      p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn);
+      p = preConditionReifier(s, p, null, o, token.beginLine, token.beginColumn);
       reifId = getOrAllocReifierId(acc, s, p, o, token.beginLine, token.beginColumn);
     }
     { clearReifierId(); }
@@ -1755,7 +1755,7 @@ void AnnotationBlock(TripleCollector acc, Node reifId) : { }
 
 // Object position RDF term, element of a list
 // No paths in TriplesNode
-Node GraphNode(TripleCollectorMark acc) : { Node n ; }
+Node GraphNode(TripleCollector acc) : { Node n ; }
 {
    n = VarOrTerm() { return n ; }
  |
@@ -1765,7 +1765,7 @@ Node GraphNode(TripleCollectorMark acc) : { Node n ; }
 }
 
 // Object position RDF term. NEW-SYNTAX Rename?
-Node GraphNodePath(TripleCollectorMark acc) : { Node n ; }
+Node GraphNodePath(TripleCollector acc) : { Node n ; }
 {
   n = VarOrTerm() { return n ; }
 |

--- a/jena-arq/Grammar/sparql_12.jj
+++ b/jena-arq/Grammar/sparql_12.jj
@@ -799,11 +799,11 @@ void PropertyListNotEmpty(Node s, TripleCollector acc) :
     { Node p = null ; }
 {
     p = Verb()
-    ObjectList(s, p, null, acc)
+    ObjectList(s, p, acc)
   ( <SEMICOLON>
     (
        p = Verb()
-      ObjectList(s, p, null, acc)
+      ObjectList(s, p, acc)
     )?
   )*
 }
@@ -812,17 +812,17 @@ Node Verb() : { Node p ;}
   ( p = VarOrIri() | <KW_A> { p = nRDFtype ; } )
   { return p ; }
 }
-void ObjectList(Node s, Node p, Path path, TripleCollector acc): { Node o ; }
+void ObjectList(Node s, Node p, TripleCollector acc): { Node o ; }
 {
-  Object(s, p, path, acc)
-  ( <COMMA> Object(s, p, path, acc) )*
+  Object(s, p, acc)
+  ( <COMMA> Object(s, p, acc) )*
 }
-void Object(Node s, Node p, Path path, TripleCollector acc): { Node o ; }
+void Object(Node s, Node p, TripleCollector acc): { Node o ; }
 {
   { ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ; }
   o = GraphNode(tempAcc)
-  { insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ; }
-  Annotation(acc, s, p, path, o)
+  { insert(tempAcc, mark, s, p, o) ; insert(acc, tempAcc) ; }
+  Annotation(acc, s, p, o)
 }
 void TriplesSameSubjectPath(TripleCollector acc) : { Node s ; }
 {
@@ -956,7 +956,7 @@ P_Path0 PathOneInPropertySet() : { String str ; Node n ; }
     )
   )
 }
-Node TriplesNode(TripleCollectorMark acc) : { Node n ; }
+Node TriplesNode(TripleCollector acc) : { Node n ; }
 {
    n = Collection(acc) { return n ; }
  |
@@ -970,7 +970,7 @@ Node BlankNodePropertyList(TripleCollector acc) : { Token t ; }
   <RBRACKET>
     { return n ; }
 }
-Node TriplesNodePath(TripleCollectorMark acc) : { Node n ; }
+Node TriplesNodePath(TripleCollector acc) : { Node n ; }
 {
    n = CollectionPath(acc) { return n ; }
  |
@@ -984,7 +984,7 @@ Node BlankNodePropertyListPath(TripleCollector acc) : { Token t ; }
   <RBRACKET>
     { return n ; }
 }
-Node Collection(TripleCollectorMark acc) :
+Node Collection(TripleCollector acc) :
     { Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ; }
 {
   t = <LPAREN>
@@ -1008,7 +1008,7 @@ Node Collection(TripleCollectorMark acc) :
        insert(acc, lastCell, nRDFrest, nRDFnil) ;
      return listHead ; }
 }
-Node CollectionPath(TripleCollectorMark acc) :
+Node CollectionPath(TripleCollector acc) :
     { Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ; }
 {
   t = <LPAREN>
@@ -1055,16 +1055,16 @@ void AnnotationBlockPath(TripleCollector acc, Node reifId) : { }
       PropertyListPathNotEmpty(reifId, acc)
    <R_ANN>
 }
-void Annotation(TripleCollector acc, Node s, Node p, Path path, Node o) : { Node reifId = null ; }
+void Annotation(TripleCollector acc, Node s, Node p, Node o) : { Node reifId = null ; }
 {
   (
-    { p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn); }
+    { p = preConditionReifier(s, p,null, o, token.beginLine, token.beginColumn); }
     reifId = Reifier()
     { reifId = insertTripleReifier(acc, reifId, s, p, o, token.beginLine, token.beginColumn) ; }
     { setReifierId(reifId); }
   |
     {
-      p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn);
+      p = preConditionReifier(s, p, null, o, token.beginLine, token.beginColumn);
       reifId = getOrAllocReifierId(acc, s, p, o, token.beginLine, token.beginColumn);
     }
     { clearReifierId(); }
@@ -1077,7 +1077,7 @@ void AnnotationBlock(TripleCollector acc, Node reifId) : { }
       PropertyListNotEmpty(reifId, acc)
    <R_ANN>
 }
-Node GraphNode(TripleCollectorMark acc) : { Node n ; }
+Node GraphNode(TripleCollector acc) : { Node n ; }
 {
    n = VarOrTerm() { return n ; }
  |
@@ -1085,7 +1085,7 @@ Node GraphNode(TripleCollectorMark acc) : { Node n ; }
  |
    n = ReifiedTriple(acc) { return n ; }
 }
-Node GraphNodePath(TripleCollectorMark acc) : { Node n ; }
+Node GraphNodePath(TripleCollector acc) : { Node n ; }
 {
   n = VarOrTerm() { return n ; }
 |

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/QueryParserBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/QueryParserBase.java
@@ -538,7 +538,7 @@ public class QueryParserBase {
         acc.addTriple(Triple.create(s, p, o));
     }
 
-    protected void insert(TripleCollectorMark acc, int index, Node s, Node p, Node o) {
+    protected void insert(TripleCollector acc, int index, Node s, Node p, Node o) {
         acc.addTriple(index, Triple.create(s, p, o));
     }
 
@@ -549,7 +549,7 @@ public class QueryParserBase {
             acc.addTriple(Triple.create(s, p, o));
     }
 
-    protected void insert(TripleCollectorMark acc, int index, Node s, Node p, Path path, Node o) {
+    protected void insert(TripleCollector acc, int index, Node s, Node p, Path path, Node o) {
         if ( p == null )
             acc.addTriplePath(index, new TriplePath(s, path, o));
         else

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/javacc/ARQParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/javacc/ARQParser.java
@@ -3735,7 +3735,7 @@ insert(acc, tempAcc) ;
 
   final public void PropertyListNotEmpty(Node s, TripleCollector acc) throws ParseException {Node p = null ;
     p = Verb();
-    ObjectList(s, p, null, acc);
+    ObjectList(s, p, acc);
     label_28:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -3756,7 +3756,7 @@ insert(acc, tempAcc) ;
       case VAR2:
       case KW_A:{
         p = Verb();
-        ObjectList(s, p, null, acc);
+        ObjectList(s, p, acc);
         break;
         }
       default:
@@ -3790,8 +3790,8 @@ p = nRDFtype ;
     throw new Error("Missing return statement in function");
 }
 
-  final public void ObjectList(Node s, Node p, Path path, TripleCollector acc) throws ParseException {Node o ;
-    Object(s, p, path, acc);
+  final public void ObjectList(Node s, Node p, TripleCollector acc) throws ParseException {Node o ;
+    Object(s, p, acc);
     label_29:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -3804,15 +3804,15 @@ p = nRDFtype ;
         break label_29;
       }
       jj_consume_token(COMMA);
-      Object(s, p, path, acc);
+      Object(s, p, acc);
     }
 }
 
-  final public void Object(Node s, Node p, Path path, TripleCollector acc) throws ParseException {Node o ;
+  final public void Object(Node s, Node p, TripleCollector acc) throws ParseException {Node o ;
 ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ;
     o = GraphNode(tempAcc);
-insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ;
-    Annotation(acc, s, p, path, o);
+insert(tempAcc, mark, s, p, o) ; insert(acc, tempAcc) ;
+    Annotation(acc, s, p, o);
 }
 
   final public void TriplesSameSubjectPath(TripleCollector acc) throws ParseException {Node s ;
@@ -4382,7 +4382,7 @@ n = createNode(str) ; {if ("" != null) return new P_ReverseLink(n) ;}
     throw new Error("Missing return statement in function");
 }
 
-  final public Node TriplesNode(TripleCollectorMark acc) throws ParseException {Node n ;
+  final public Node TriplesNode(TripleCollector acc) throws ParseException {Node n ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case LPAREN:{
       n = Collection(acc);
@@ -4411,7 +4411,7 @@ Node n = createBNode( t.beginLine, t.beginColumn) ;
     throw new Error("Missing return statement in function");
 }
 
-  final public Node TriplesNodePath(TripleCollectorMark acc) throws ParseException {Node n ;
+  final public Node TriplesNodePath(TripleCollector acc) throws ParseException {Node n ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case LPAREN:{
       n = CollectionPath(acc);
@@ -4440,7 +4440,7 @@ Node n = createBNode( t.beginLine, t.beginColumn) ;
     throw new Error("Missing return statement in function");
 }
 
-  final public Node Collection(TripleCollectorMark acc) throws ParseException {Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ;
+  final public Node Collection(TripleCollector acc) throws ParseException {Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ;
     t = jj_consume_token(LPAREN);
 int beginLine = t.beginLine; int beginColumn = t.beginColumn; t = null;
     label_35:
@@ -4497,7 +4497,7 @@ if ( lastCell != null )
     throw new Error("Missing return statement in function");
 }
 
-  final public Node CollectionPath(TripleCollectorMark acc) throws ParseException {Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ;
+  final public Node CollectionPath(TripleCollector acc) throws ParseException {Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ;
     t = jj_consume_token(LPAREN);
 int beginLine = t.beginLine; int beginColumn = t.beginColumn; t = null;
     label_36:
@@ -4597,7 +4597,7 @@ clearReifierId();
     jj_consume_token(R_ANN);
 }
 
-  final public void Annotation(TripleCollector acc, Node s, Node p, Path path, Node o) throws ParseException {Node reifId = null ;
+  final public void Annotation(TripleCollector acc, Node s, Node p, Node o) throws ParseException {Node reifId = null ;
     label_38:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -4612,14 +4612,14 @@ clearReifierId();
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case TILDE:{
-p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn);
+p = preConditionReifier(s, p,null, o, token.beginLine, token.beginColumn);
         reifId = Reifier();
 reifId = insertTripleReifier(acc, reifId, s, p, o, token.beginLine, token.beginColumn) ;
 setReifierId(reifId);
         break;
         }
       case L_ANN:{
-p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn);
+p = preConditionReifier(s, p, null, o, token.beginLine, token.beginColumn);
       reifId = getOrAllocReifierId(acc, s, p, o, token.beginLine, token.beginColumn);
 clearReifierId();
         AnnotationBlock(acc, reifId);
@@ -4639,7 +4639,7 @@ clearReifierId();
     jj_consume_token(R_ANN);
 }
 
-  final public Node GraphNode(TripleCollectorMark acc) throws ParseException {Node n ;
+  final public Node GraphNode(TripleCollector acc) throws ParseException {Node n ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IRIref:
     case PNAME_NS:
@@ -4688,7 +4688,7 @@ clearReifierId();
     throw new Error("Missing return statement in function");
 }
 
-  final public Node GraphNodePath(TripleCollectorMark acc) throws ParseException {Node n ;
+  final public Node GraphNodePath(TripleCollector acc) throws ParseException {Node n ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IRIref:
     case PNAME_NS:

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/javacc/SPARQLParser12.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/javacc/SPARQLParser12.java
@@ -2770,7 +2770,7 @@ insert(acc, tempAcc) ;
 
   final public void PropertyListNotEmpty(Node s, TripleCollector acc) throws ParseException {Node p = null ;
     p = Verb();
-    ObjectList(s, p, null, acc);
+    ObjectList(s, p, acc);
     label_22:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -2791,7 +2791,7 @@ insert(acc, tempAcc) ;
       case VAR2:
       case KW_A:{
         p = Verb();
-        ObjectList(s, p, null, acc);
+        ObjectList(s, p, acc);
         break;
         }
       default:
@@ -2825,8 +2825,8 @@ p = nRDFtype ;
     throw new Error("Missing return statement in function");
 }
 
-  final public void ObjectList(Node s, Node p, Path path, TripleCollector acc) throws ParseException {Node o ;
-    Object(s, p, path, acc);
+  final public void ObjectList(Node s, Node p, TripleCollector acc) throws ParseException {Node o ;
+    Object(s, p, acc);
     label_23:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -2839,15 +2839,15 @@ p = nRDFtype ;
         break label_23;
       }
       jj_consume_token(COMMA);
-      Object(s, p, path, acc);
+      Object(s, p, acc);
     }
 }
 
-  final public void Object(Node s, Node p, Path path, TripleCollector acc) throws ParseException {Node o ;
+  final public void Object(Node s, Node p, TripleCollector acc) throws ParseException {Node o ;
 ElementPathBlock tempAcc = new ElementPathBlock() ; int mark = tempAcc.mark() ;
     o = GraphNode(tempAcc);
-insert(tempAcc, mark, s, p, path, o) ; insert(acc, tempAcc) ;
-    Annotation(acc, s, p, path, o);
+insert(tempAcc, mark, s, p, o) ; insert(acc, tempAcc) ;
+    Annotation(acc, s, p, o);
 }
 
   final public void TriplesSameSubjectPath(TripleCollector acc) throws ParseException {Node s ;
@@ -3282,7 +3282,7 @@ n = createNode(str) ; {if ("" != null) return new P_ReverseLink(n) ;}
     throw new Error("Missing return statement in function");
 }
 
-  final public Node TriplesNode(TripleCollectorMark acc) throws ParseException {Node n ;
+  final public Node TriplesNode(TripleCollector acc) throws ParseException {Node n ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case LPAREN:{
       n = Collection(acc);
@@ -3311,7 +3311,7 @@ Node n = createBNode( t.beginLine, t.beginColumn) ;
     throw new Error("Missing return statement in function");
 }
 
-  final public Node TriplesNodePath(TripleCollectorMark acc) throws ParseException {Node n ;
+  final public Node TriplesNodePath(TripleCollector acc) throws ParseException {Node n ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case LPAREN:{
       n = CollectionPath(acc);
@@ -3340,7 +3340,7 @@ Node n = createBNode( t.beginLine, t.beginColumn) ;
     throw new Error("Missing return statement in function");
 }
 
-  final public Node Collection(TripleCollectorMark acc) throws ParseException {Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ;
+  final public Node Collection(TripleCollector acc) throws ParseException {Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ;
     t = jj_consume_token(LPAREN);
 int beginLine = t.beginLine; int beginColumn = t.beginColumn; t = null;
     label_29:
@@ -3397,7 +3397,7 @@ if ( lastCell != null )
     throw new Error("Missing return statement in function");
 }
 
-  final public Node CollectionPath(TripleCollectorMark acc) throws ParseException {Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ;
+  final public Node CollectionPath(TripleCollector acc) throws ParseException {Node listHead = nRDFnil ; Node lastCell = null ; int mark ; Node n ; Token t ;
     t = jj_consume_token(LPAREN);
 int beginLine = t.beginLine; int beginColumn = t.beginColumn; t = null;
     label_30:
@@ -3497,7 +3497,7 @@ clearReifierId();
     jj_consume_token(R_ANN);
 }
 
-  final public void Annotation(TripleCollector acc, Node s, Node p, Path path, Node o) throws ParseException {Node reifId = null ;
+  final public void Annotation(TripleCollector acc, Node s, Node p, Node o) throws ParseException {Node reifId = null ;
     label_32:
     while (true) {
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
@@ -3512,14 +3512,14 @@ clearReifierId();
       }
       switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
       case TILDE:{
-p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn);
+p = preConditionReifier(s, p,null, o, token.beginLine, token.beginColumn);
         reifId = Reifier();
 reifId = insertTripleReifier(acc, reifId, s, p, o, token.beginLine, token.beginColumn) ;
 setReifierId(reifId);
         break;
         }
       case L_ANN:{
-p = preConditionReifier(s, p, path, o, token.beginLine, token.beginColumn);
+p = preConditionReifier(s, p, null, o, token.beginLine, token.beginColumn);
       reifId = getOrAllocReifierId(acc, s, p, o, token.beginLine, token.beginColumn);
 clearReifierId();
         AnnotationBlock(acc, reifId);
@@ -3539,7 +3539,7 @@ clearReifierId();
     jj_consume_token(R_ANN);
 }
 
-  final public Node GraphNode(TripleCollectorMark acc) throws ParseException {Node n ;
+  final public Node GraphNode(TripleCollector acc) throws ParseException {Node n ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IRIref:
     case PNAME_NS:
@@ -3588,7 +3588,7 @@ clearReifierId();
     throw new Error("Missing return statement in function");
 }
 
-  final public Node GraphNodePath(TripleCollectorMark acc) throws ParseException {Node n ;
+  final public Node GraphNodePath(TripleCollector acc) throws ParseException {Node n ;
     switch ((jj_ntk==-1)?jj_ntk_f():jj_ntk) {
     case IRIref:
     case PNAME_NS:

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/request/QuadDataAcc.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/request/QuadDataAcc.java
@@ -18,65 +18,60 @@
 
 package org.apache.jena.sparql.modify.request;
 
-import java.util.ArrayList ;
-import java.util.Collections ;
-import java.util.List ;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
-import org.apache.jena.atlas.lib.SinkToCollection ;
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.sparql.core.Quad ;
-import org.apache.jena.sparql.core.TriplePath ;
-import org.apache.jena.sparql.syntax.TripleCollectorMark ;
+import org.apache.jena.atlas.lib.SinkToCollection;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.core.TriplePath;
+import org.apache.jena.sparql.syntax.TripleCollectorMark;
 
 /** Accumulate quads (excluding allowing variables) during parsing. */
-public class QuadDataAcc extends QuadDataAccSink implements TripleCollectorMark
-{
-    private final List<Quad> quads ;
-    private final List<Quad> quadsView ;
+public class QuadDataAcc extends QuadDataAccSink implements TripleCollectorMark {
+    private final List<Quad> quads;
+    private final List<Quad> quadsView;
 
-    public QuadDataAcc()
-    {
+    public QuadDataAcc() {
         this(new ArrayList<Quad>());
     }
 
-    public QuadDataAcc(List<Quad> quads)
-    {
+    public QuadDataAcc(List<Quad> quads) {
         super(new SinkToCollection<>(quads));
         this.quads = quads;
-        this.quadsView = Collections.unmodifiableList(quads) ;
+        this.quadsView = Collections.unmodifiableList(quads);
     }
 
-    public List<Quad> getQuads()
-    {
-        return quadsView ;
-    }
-
-    @Override
-    public int hashCode() { return quads.hashCode() ; }
-
-    @Override
-    public boolean equals(Object other)
-    {
-        if ( ! ( other instanceof QuadDataAcc acc ) ) return false ;
-        return quads.equals(acc.quads) ;
+    public List<Quad> getQuads() {
+        return quadsView;
     }
 
     @Override
-    public int mark()
-    {
-        return quads.size() ;
+    public int hashCode() {
+        return quads.hashCode();
     }
 
     @Override
-    public void addTriple(int index, Triple triple)
-    {
-        check(triple) ;
-        quads.add(index, new Quad(graphNode, triple)) ;
+    public boolean equals(Object other) {
+        if ( !(other instanceof QuadDataAcc acc) )
+            return false;
+        return quads.equals(acc.quads);
     }
 
     @Override
-    public void addTriplePath(int index, TriplePath tPath)
-    {
-        throw new UnsupportedOperationException("Can't add paths to quads") ;
+    public int mark() {
+        return quads.size();
+    }
+
+    @Override
+    public void addTriple(int index, Triple triple) {
+        check(triple);
+        quads.add(index, new Quad(graphNode, triple));
+    }
+
+    @Override
+    public void addTriplePath(int index, TriplePath tPath) {
+        throw new UnsupportedOperationException("Can't add paths to quads");
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementPathBlock.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementPathBlock.java
@@ -27,7 +27,7 @@ import org.apache.jena.sparql.core.TriplePath;
 import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** A SPARQL BasicGraphPattern (SPARQL 1.1) */
-public class ElementPathBlock extends Element implements TripleCollectorMark {
+public class ElementPathBlock extends Element implements TripleCollector, TripleCollectorMark {
     private PathBlock pattern = new PathBlock();
 
     public ElementPathBlock() {}

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementTriplesBlock.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/ElementTriplesBlock.java
@@ -27,7 +27,7 @@ import org.apache.jena.sparql.core.TriplePath;
 import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /** The syntax element for a SPARQL BasicGraphPattern (SPARQL 1.0)*/
-public class ElementTriplesBlock extends Element implements TripleCollectorMark
+public class ElementTriplesBlock extends Element implements TripleCollector, TripleCollectorMark
 {
     private final BasicPattern pattern;
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollector.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollector.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.sparql.syntax;
 
+import org.apache.jena.atlas.lib.InternalErrorException;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.core.TriplePath;
 
@@ -27,4 +28,17 @@ public interface TripleCollector
     public void addTriple(Triple t);
 
     public void addTriplePath(TriplePath tPath);
+
+    // The mark is used by some TripleCollector so
+    // that triple order if nicer for RDF lists.
+
+    // The contract with the mark is that there should be no disturbing
+    // triples 0..(mark-1) before using a mark. That is, use marks in
+    // LIFO (stack) order.
+
+    public default int mark() { throw new InternalErrorException("Mark no tsupported"); }
+
+    public default void addTriple(int index, Triple t) { addTriple(t); }
+
+    public default void addTriplePath(int index, TriplePath tPath) { addTriplePath(tPath); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollectorBGP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollectorBGP.java
@@ -25,7 +25,7 @@ import org.apache.jena.sparql.core.TriplePath;
 
 /** A triples-only TripleCollector. */
 
-public class TripleCollectorBGP implements TripleCollectorMark
+public class TripleCollectorBGP implements TripleCollector, TripleCollectorMark
 {
     BasicPattern bgp = new BasicPattern();
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollectorMark.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollectorMark.java
@@ -18,17 +18,7 @@
 
 package org.apache.jena.sparql.syntax;
 
-import org.apache.jena.graph.Triple;
-import org.apache.jena.sparql.core.TriplePath;
-
-
+// LEGACY
+// Retained to avoid needing to rebuild old parsers (SPARQL 1.0, SPARQL 1.1).
 public interface TripleCollectorMark extends TripleCollector
-{
-    // The contract with the mark is that there should be no disturbing
-    // triples 0..(mark-1) before using a mark. That is, use marks in
-    // LIFO (stack) order.
-    public int mark();
-    public void addTriple(int index, Triple t);
-
-    public void addTriplePath(int index, TriplePath tPath);
-}
+{}


### PR DESCRIPTION
This is an internal change to SPARQL parsing to make reusing grammar fragments more convenient.

The mark is used for ordering triples when RDF lists are involved.

All implementations of `TripleCollector` provide the mark (interface `TripleCollectorMark`) so merge this facility in to  `TripleCollector`.

Leave a stub `TripleCollectorMark` behind so there is no need to rebuild the SPARQL 1.0 or SHARQL 1.1 parsers.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
