### PR TITLE
GH-3221 Fix `SchemaDO._abstract` URI

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/vocabulary/SchemaDO.java
+++ b/jena-core/src/main/java/org/apache/jena/vocabulary/SchemaDO.java
@@ -2244,7 +2244,7 @@ public class SchemaDO {
     public static final Property lastReviewed = m.createProperty(NS+"lastReviewed");
     public static final Property broadcaster = m.createProperty(NS+"broadcaster");
     public static final Property inCodeSet = m.createProperty(NS+"inCodeSet");
-    public static final Property _abstract = m.createProperty(NS+"_abstract");
+    public static final Property _abstract = m.createProperty(NS+"abstract");
     public static final Property parent = m.createProperty(NS+"parent");
     public static final Property guidelineDate = m.createProperty(NS+"guidelineDate");
     public static final Property eligibleRegion = m.createProperty(NS+"eligibleRegion");


### PR DESCRIPTION
The property URI should not have a leading underscore

GitHub issue resolved #3221 

Pull request Description:



----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
