### PR TITLE
Fixed ExprUtils.eval raising exception because of null dataset.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/ExprUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/ExprUtils.java
@@ -203,7 +203,7 @@ public class ExprUtils
     public static NodeValue eval(Expr expr, Binding binding) {
         Context context = ARQ.getContext().copy();
         context.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime());
-        FunctionEnv env = ExecutionContext.create(null, context);
+        FunctionEnv env = ExecutionContext.create(context);
         NodeValue r = expr.eval(binding, env);
         return r;
     }

--- a/jena-cmds/src/main/java/arq/qexpr.java
+++ b/jena-cmds/src/main/java/arq/qexpr.java
@@ -180,7 +180,7 @@ public class qexpr {
                     } else {
                         // Default action
                         ARQ.getContext().set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime());
-                        FunctionEnv env = ExecutionContext.create(null, ARQ.getContext().copy());
+                        FunctionEnv env = ExecutionContext.create(ARQ.getContext().copy());
                         NodeValue r = expr.eval(null, env);
                         // System.out.println(r.asQuotedString()) ;
                         Node n = r.asNode();


### PR DESCRIPTION
This PR changes a couple of `ExecutionContext.create(null, context)` instances to `ExecutionContext.create(context)` because the former now raises an exception because of a null dataset.

I noticed this issue because in my code I used `ExprUtils.eval(expr, binding)` which suddenly stopped working.
