### PR TITLE
GH-3240: TDB2 database delete

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -77,7 +77,7 @@ Issues: https://s.apache.org/jena-5.3.0-issues
 Announcement:
 https://lists.apache.org/thread/4gk0kpf75hyk58db343hx13nzq8pvldg
 
-ena 5.3.0 has changes in the structure of the Fuseki server; a new IRI provider; and clean-up and simplification of Jena's use of Apache Xerces code in RDF Datatypes.
+Jena 5.3.0 has changes in the structure of the Fuseki server; a new IRI provider; and clean-up and simplification of Jena's use of Apache Xerces code in RDF Datatypes.
 
 ==== Contributions
 

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/StoreConnection.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/StoreConnection.java
@@ -148,6 +148,15 @@ public class StoreConnection
             sConn.lock.unlock();
             ProcessFileLock.release(sConn.lock);
         }
+        // https://bugs.openjdk.org/browse/JDK-4724038
+        //   Release of memory mapped files.
+        //
+        // This can help with memory mapped buffers but this is not a guarantee.
+        // TDB2 does not hand out the MappedByBuffer the reference and
+        // closing nulls the references. The GC usually causes the clearup.
+        //
+        // This does not fix the MS-Windows specific issue.
+        Runtime.getRuntime().gc();
     }
 
     /** Create or fetch a {@link ProcessFileLock} for a Location */


### PR DESCRIPTION
GitHub issue resolved #3240

Trigger a GC after deleting a database.
This is reported to improve (not completely fix) the situation relating to memory mapped files -- https://bugs.openjdk.org/browse/JDK-4724038

----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
