### PR TITLE
Fix DBpedia examples in the jena-examples module

### DIFF
--- a/jena-examples/src/main/java/arq/examples/ExampleDBpedia1.java
+++ b/jena-examples/src/main/java/arq/examples/ExampleDBpedia1.java
@@ -26,7 +26,7 @@ public class ExampleDBpedia1
     static public void main(String... argv) {
         String queryString = 
             "SELECT * WHERE { " +
-            "    SERVICE <http://dbpedia-live.openlinksw.com/sparql?timeout=2000> { " +
+            "    SERVICE <http://dbpedia.org/sparql?timeout=2000> { " +
             "        SELECT DISTINCT ?company where {?company a <http://dbpedia.org/ontology/Company>} LIMIT 20" +
             "    }" +
             "}" ;

--- a/jena-examples/src/main/java/arq/examples/ExampleDBpedia3.java
+++ b/jena-examples/src/main/java/arq/examples/ExampleDBpedia3.java
@@ -29,7 +29,7 @@ import org.apache.jena.rdf.model.ModelFactory ;
 public class ExampleDBpedia3
 {
     static public void main(String... argv) {
-        String serviceURI  = "http://dbpedia-live.openlinksw.com/sparql" ;
+        String serviceURI  = "http://dbpedia.org/sparql" ;
         String queryString =
             "SELECT * WHERE { " +
             "    SERVICE <" + serviceURI + "> { " +
@@ -39,7 +39,7 @@ public class ExampleDBpedia3
 
         Query query = QueryFactory.create(queryString) ;
 
-        // Local execution which uses SERBVICE for remote access.
+        // Local execution which uses SERVICE for remote access.
         QueryExecutionDatasetBuilder.create().context(null);
 
         try(QueryExecution qexec = QueryExecutionFactory.create(query, ModelFactory.createDefaultModel())) {


### PR DESCRIPTION
Pull request Description:

When I tried to run examples in the jena-examples module, arq.examples.ExampleDBpedia1 and ExampleDBpedia3 failed as follows:

```
$ bin/jena arq.examples.ExampleDBpedia1
2025-06-14T11:52:53.149716377Z main ERROR Reconfiguration failed: No configuration found for '30946e09' at 'null' in 'null'
Exception in thread "main" HttpException: -1 Unexpected error making the query: GET http://dbpedia-live.openlinksw.com/sparql?timeout=2000&query=SELECT+DISTINCT++?company%0AWHERE%0A++%7B+?co
mpany++a++%3Chttp://dbpedia.org/ontology/Company%3E+%7D%0ALIMIT+++20%0A

...

Caused by: java.net.ConnectException: HTTP connect timed out
        at java.net.http/jdk.internal.net.http.MultiExchange.toTimeoutException(MultiExchange.java:581)
        ... 10 more
```

Using dbpedia.org instead of dbpedia-live.openlinksw.com just like ExampleDBpedia2 seems to work.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
