### PR TITLE
Make Node and ExprTransform affect OpPropFunc arguments

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/walker/OpVisitorByTypeAndExpr.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/walker/OpVisitorByTypeAndExpr.java
@@ -94,6 +94,9 @@ public interface OpVisitorByTypeAndExpr extends OpVisitor
 
     @Override
     public default void visit(OpPropFunc opPropFunc) {
+        visitExpr(opPropFunc.getObjectArgs().asExprList());
+        visitExpr(opPropFunc.getSubjectArgs().asExprList());
+        // visitExpr(new ExprList(ExprLib.nodeToExpr(opPropFunc.getProperty())));
         visit1(opPropFunc);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprLib.java
@@ -224,6 +224,20 @@ public class ExprLib
         return NodeValue.makeNode(n);
     }
 
+    /**
+     * Go from an expression to a node.
+     * If the argument cannot be converted to a node then an {@link IllegalArgumentException} is raised.
+     */
+    public static Node exprToNode(Expr e) {
+        if (e.isConstant()) {
+            return e.getConstant().asNode();
+        } else if (e.isVariable()) {
+            return e.getExprVar().asVar();
+        } else {
+            throw new IllegalArgumentException("Cannot convert Expression to Node: " + e);
+        }
+    }
+
     public static Expr rewriteTriple(Triple t) {
         Expr e1 = nodeToExpr(t.getSubject());
         Expr e2 = nodeToExpr(t.getPredicate());

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestNodeTransform.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/TestNodeTransform.java
@@ -20,6 +20,7 @@ package org.apache.jena.sparql.algebra;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.sparql.core.Var;
@@ -109,4 +110,28 @@ public class TestNodeTransform {
                 ? Var.alloc(n.getName() + "ZZZ")
                 : n;
     };
+
+    @Test
+    public void transformPropFunc() {
+        Op inOp = SSE.parseOp("""
+            (propfunc <urn:p>
+              <urn:x> ("y" ?z)
+              (table unit))
+            """);
+
+        // Property function name is not affected by node transform.
+        Op expectedOp = SSE.parseOp("""
+            (propfunc <urn:p>
+              <URN:X> ("Y" ?Z)
+              (table unit))
+            """);
+
+        Op actualOp = NodeTransformLib.transform(x ->
+            x.isURI() ? NodeFactory.createURI(x.getURI().toUpperCase()) :
+            x.isVariable() ? Var.alloc(x.getName().toUpperCase()) :
+            x.isLiteral() ? NodeFactory.createLiteralString(x.getLiteralLexicalForm().toUpperCase()) :
+            x, inOp);
+
+        assertEquals(expectedOp, actualOp);
+    }
 }


### PR DESCRIPTION
As the title says. (If desired I can create an issue). The issue occurred to me when I was trying to post process variable names in Ops after the optimizer had already run. OpPropFunc arguments were not affected then.
One detail question is whether the NodeTransform should affect the property function URI.
My argument against it are:
* It's probably desired to prevent a node transform from mapping a  property function name to a blank node or literal.
* Renaming property function names in the BGPs could be done before the optimizer runs.
* In the worst case, it would still be possible to subclass TransformCopy just for that case.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - (Key commit messages start with the issue number (GH-xxxx))

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
