### PR TITLE
GH-3258: Support for bzip2 encoding in upload via GSP and SPARQL LOAD.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -43,6 +43,7 @@ import java.util.function.Function;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.jena.atlas.RuntimeIOException;
 import org.apache.jena.atlas.io.IO;
 import org.apache.jena.atlas.lib.IRILib;
@@ -150,6 +151,8 @@ public class HttpLib {
                     return responseInput;
                 case "gzip" :
                     return new GZIPInputStream(responseInput, 2*1024);
+                case "bzip2" :
+                    return new BZip2CompressorInputStream(responseInput, true);
                 case "inflate" :
                     return new InflaterInputStream(responseInput);
                 case "br" : // RFC7932

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/DataUploader.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/DataUploader.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
 
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.fileupload2.core.FileItemInput;
 import org.apache.commons.fileupload2.core.FileItemInputIterator;
 import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
@@ -174,6 +175,8 @@ public class DataUploader {
             lang = RDFLanguages.pathnameToLang(submittedFileName);
             if (submittedFileName.endsWith(".gz"))
                 input = new GZIPInputStream(input);
+            else if (submittedFileName.endsWith(".bz2"))
+                input = new BZip2CompressorInputStream(input, true);
         }
         if ( lang == null )
             // Desperate.


### PR DESCRIPTION
GitHub issue resolved #3258 

Pull request Description: Proposal to add bzip2 as a recognized encoding to `HttpLib` and `DataUploader`.

Note: The Web server from which one attempts to upload a file needs to be configured to serve content type and encoding separately:

```
curl -I http://myserver/file.nt.bz2

Content-Type: application/n-triples
Content-Encoding: bzip2
```

For example, by default, the Apache Web server would serve .bz2 files as `Content-Type: application/x-bzip2`. This way a client wouldn't know what actual content is being encoded.

----

 - (No extra tests are so far included because the change turned out to be trivial)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
