### PR TITLE
Adjust output of 'rdftests' to allow for manifests

### DIFF
--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/TextTestRunner.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/TextTestRunner.java
@@ -22,10 +22,10 @@ import java.util.function.Function;
 
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
-import org.junit.runner.Runner;
 
 import org.apache.jena.arq.junit.manifest.Manifest;
 import org.apache.jena.arq.junit.manifest.ManifestEntry;
+import org.apache.jena.arq.junit.runners.RunnerOneManifest;
 import org.apache.jena.arq.junit.runners.SetupManifests;
 import org.apache.jena.atlas.junit.TextListenerLong;
 import org.apache.jena.sparql.expr.E_Function;
@@ -40,7 +40,8 @@ public class TextTestRunner {
 
     public static void runOne(EarlReport report, String manifestFile, Function<ManifestEntry, Runnable> testMaker) {
         Manifest manifest = Manifest.parse(manifestFile);
-        Runner top = SetupManifests.build(report, manifest, testMaker, null);
+        RunnerOneManifest top = SetupManifests.build(report, manifest, testMaker, null);
+        int countManifests = top.getManifestCount();
 
         NodeValue.VerboseWarnings = false ;
         E_Function.WarnOnUnknownFunction = false ;
@@ -50,11 +51,14 @@ public class TextTestRunner {
 
         // Count includes the manifest itself.
         JUnitCore junitCore = new JUnitCore();
-        junitCore.addListener(new TextListenerLong(System.out));
+        junitCore.addListener(new TextListenerLong(System.out, countManifests));
         //junit.addListener(new TextListenerDots(System.out));
+
         Result result = junitCore.run(top);
-        System.out.println("Run: "+result.getRunCount());
-        System.out.println("Failures: "+result.getFailureCount());
+
+        System.out.println("Tests run: "+(result.getRunCount()-countManifests));
+        System.out.println("Failures:  "+result.getFailureCount());
+        System.out.println("Manifests: "+top.getManifestCount());
     }
 }
 

--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/runners/RunnerOneManifest.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/runners/RunnerOneManifest.java
@@ -31,6 +31,7 @@ public class RunnerOneManifest extends Runner {
     private Description description;
     private List<Runner> tests = new ArrayList<>();
     private Manifest manifest;
+    private int manifestCount = -1;
 
     public RunnerOneManifest(Manifest manifest, Description description) {
         this.manifest = manifest;
@@ -53,5 +54,13 @@ public class RunnerOneManifest extends Runner {
     public void add(Runner runner) {
         description.addChild(runner.getDescription());
         tests.add(runner);
+    }
+
+    public int getManifestCount() {
+        return this.manifestCount;
+    }
+
+    public void setManifestCount(int manifestCount) {
+        this.manifestCount = manifestCount;
     }
 }

--- a/jena-base/src/test/java/org/apache/jena/atlas/junit/TextListenerLong.java
+++ b/jena-base/src/test/java/org/apache/jena/atlas/junit/TextListenerLong.java
@@ -22,16 +22,19 @@ import java.io.PrintStream ;
 
 import org.junit.internal.TextListener ;
 import org.junit.runner.Description ;
+import org.junit.runner.Result;
 import org.junit.runner.notification.Failure ;
 
 /** JUnit4 test listener that prints one line per test */
 public class TextListenerLong extends TextListener
 {
     private PrintStream out ;
+    private int manifestCount;
 
-    public TextListenerLong(PrintStream writer) {
+    public TextListenerLong(PrintStream writer, int manifestCount) {
         super(writer) ;
         this.out = writer ;
+        this.manifestCount = manifestCount;
     }
 
     @Override
@@ -60,4 +63,31 @@ public class TextListenerLong extends TextListener
         //out.print(each.getTrimmedTrace());
     }
 
+    // TextListener does not expose getWriter()
+    private PrintStream getWriter() {
+        return this.out;
+    }
+
+    @Override
+    protected void printFooter(Result result) {
+        //super.printFooter(result);
+
+        int testCount = result.getRunCount();
+        // Adjust for manifests.
+        if ( manifestCount > 0 )
+            testCount = testCount - manifestCount;
+
+        // Copied from super, modified to count tests, not manifests.
+        if (result.wasSuccessful()) {
+            getWriter().println();
+            getWriter().print("OK");
+            getWriter().println(" (" + testCount + " test" + (testCount == 1 ? "" : "s") + ")");
+
+        } else {
+            getWriter().println();
+            getWriter().println("FAILURES!!!");
+            getWriter().println("Tests run: " + testCount + ",  Failures: " + result.getFailureCount());
+        }
+        getWriter().println();
+    }
 }

--- a/jena-cmds/src/test/java/arq/rdftests.java
+++ b/jena-cmds/src/test/java/arq/rdftests.java
@@ -192,6 +192,7 @@ public class rdftests extends CmdGeneral
     static void oneManifest(String testManifest) {
         TextTestRunner.runOne(testManifest, testMaker());
     }
+
     static void oneManifestEarl(EarlReport report, String testManifest) {
         TextTestRunner.runOne(report, testManifest, testMaker());
     }


### PR DESCRIPTION
Make the summary consistent:

```
... last test T-381 ...

Time: 0.133

OK (381 tests)

Tests run: 381
Failures:  0
Manifests: 4
```
not
```
... last test T-381 ...

Time: 0.133

OK (385 tests)

Run: 385
Failures: 0
```
The old form counted manifests as tests.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
