### PR TITLE
GH-3144: Refinement of calling SPARQL functions by using their URI.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/BasicPattern.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/BasicPattern.java
@@ -48,7 +48,7 @@ public class BasicPattern implements Iterable<Triple> {
         triples.addAll(other.triples) ;
     }
 
-    private BasicPattern(List<Triple> triples) {
+    public BasicPattern(List<Triple> triples) {
         this.triples = triples ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_AdjustToTimezone.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_AdjustToTimezone.java
@@ -25,6 +25,10 @@ import org.apache.jena.sparql.sse.Tags;
 /** Do any of FN_Adjust(date/time)ToTimezone */
 public class E_AdjustToTimezone extends ExprFunctionN {
 
+    public E_AdjustToTimezone(Expr expr1){
+        this(expr1, null);
+    }
+
     public E_AdjustToTimezone(Expr expr1, Expr expr2){
         super(Tags.tagAdjust, expr1, expr2);
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_BNode.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_BNode.java
@@ -36,17 +36,17 @@ public class E_BNode implements Unstable
     private static final Symbol keyMap = Symbol.create("arq:internal:bNodeMappings");
 
     public static Expr create() {
-        return new E_BNode0();
+        return new BNode0();
     }
 
     public static Expr create(Expr expr) {
-        return new E_BNode1(expr);
+        return new BNode1(expr);
     }
 
     // --- The zero argument case.
-    private static class E_BNode0 extends ExprFunction0  implements Unstable {
+    public static class BNode0 extends ExprFunction0  implements Unstable {
 
-        protected E_BNode0() {
+        protected BNode0() {
             super(symbol);
         }
 
@@ -57,13 +57,13 @@ public class E_BNode implements Unstable
 
         @Override
         public Expr copy() {
-            return new E_BNode0();
+            return new BNode0();
         }
     }
 
     // --- The one argument case.
-    private static class E_BNode1 extends ExprFunction1  implements Unstable {
-        protected E_BNode1(Expr expr) {
+    public static class BNode1 extends ExprFunction1  implements Unstable {
+        protected BNode1(Expr expr) {
             super(expr, symbol);
         }
 
@@ -102,8 +102,7 @@ public class E_BNode implements Unstable
 
         @Override
         public Expr copy(Expr expr) {
-            return new E_BNode1(expr);
+            return new BNode1(expr);
         }
     }
-
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Bound.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Bound.java
@@ -18,51 +18,50 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.sparql.engine.binding.Binding ;
-import org.apache.jena.sparql.function.FunctionEnv ;
-import org.apache.jena.sparql.sse.Tags ;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.function.FunctionEnv;
+import org.apache.jena.sparql.sse.Tags;
 
 public class E_Bound extends ExprFunction1
 {
-    private static final String symbol = Tags.tagBound ;
-    boolean isBound = false ;
+    private static final String symbol = Tags.tagBound;
+    boolean isBound = false;
 
-    public E_Bound(Expr expr)
-    {
-        super(expr, symbol) ;
+    public E_Bound(Expr expr) {
+        super(expr, symbol);
     }
-    
+
     @Override
-    public NodeValue evalSpecial(Binding binding, FunctionEnv env) { 
+    public NodeValue evalSpecial(Binding binding, FunctionEnv env) {
         // See also ExprLib.evalOrNull.
-        // This code predates that; it handles exceptions 
+        // This code predates that; it handles exceptions
         // slightly differently (VariableNotBoundException not
         // a general ExprEvalException).
-        
+
         if ( expr.isConstant() )
             // The case of the variable having been substituted for a constant.
-            // Note: this has often been optimized away by constant folding 
+            // Note: this has often been optimized away by constant folding
             // (ExprTransformConstantFold) which called eval(NodeValue x) -> TRUE.
-            return NodeValue.TRUE ;
-        
+            return NodeValue.TRUE;
+
         if ( expr.isVariable() )
-            // The case of the expr being a single variable. 
-            return NodeValue.booleanReturn(binding.contains(expr.asVar())) ; 
-        
+            // The case of the expr being a single variable.
+            return NodeValue.booleanReturn(binding.contains(expr.asVar()));
+
         // General expression. This case can't be written in SPARQL
         // but we keep the code general in case some optimization rewrite
         // or algebra expression uses the generalized feature.
 		try {
-			expr.eval(binding, env) ;
-            return NodeValue.TRUE ;
+			expr.eval(binding, env);
+            return NodeValue.TRUE;
 		} catch (VariableNotBoundException ex) {
-			return NodeValue.FALSE ;
+			return NodeValue.FALSE;
 		}
     }
 
     @Override
-    public NodeValue eval(NodeValue x) { return NodeValue.TRUE ; }
-    
+    public NodeValue eval(NodeValue x) { return NodeValue.TRUE; }
+
     @Override
-    public Expr copy(Expr expr) { return new E_Bound(expr) ; } 
+    public Expr copy(Expr expr) { return new E_Bound(expr); }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Coalesce.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Coalesce.java
@@ -18,44 +18,40 @@
 
 package org.apache.jena.sparql.expr;
 
-import java.util.List ;
+import java.util.List;
 
-import org.apache.jena.sparql.ARQInternalErrorException ;
-import org.apache.jena.sparql.engine.binding.Binding ;
-import org.apache.jena.sparql.function.FunctionEnv ;
-import org.apache.jena.sparql.sse.Tags ;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.function.FunctionEnv;
+import org.apache.jena.sparql.sse.Tags;
 
 /** SPARQL coalesce special form. */
 
-public class E_Coalesce extends ExprFunctionN
-{
-    private static final String name = Tags.tagCoalesce ;
-    
-    public E_Coalesce(ExprList args)
-    {
-        super(name, args) ;
+public class E_Coalesce extends ExprFunctionN {
+    private static final String name = Tags.tagCoalesce;
+
+    public E_Coalesce(ExprList args) {
+        super(name, args);
     }
 
     @Override
-    public NodeValue evalSpecial(Binding binding, FunctionEnv env)
-    {
-        for ( Expr expr : super.getArgs() )
-        {
-            try { 
-                NodeValue nv = expr.eval(binding, env) ;
-                return nv ;
+    public NodeValue evalSpecial(Binding binding, FunctionEnv env) {
+        for ( Expr expr : super.getArgs() ) {
+            try {
+                NodeValue nv = expr.eval(binding, env);
+                return nv;
             } catch (ExprEvalException ex) {}
         }
-        throw new ExprEvalException("COALESCE: no value") ;
-    }
-    
-    @Override
-    public Expr copy(ExprList newArgs)
-    {
-        return new E_Coalesce(newArgs) ;
+        throw new ExprEvalException("COALESCE: no value");
     }
 
     @Override
-    public NodeValue eval(List<NodeValue> args)
-    { throw new ARQInternalErrorException() ; }
+    public Expr copy(ExprList newArgs) {
+        return new E_Coalesce(newArgs);
+    }
+
+    @Override
+    public NodeValue eval(List<NodeValue> args) {
+        throw new ARQInternalErrorException();
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI.java
@@ -34,8 +34,8 @@ import org.apache.jena.sparql.sse.Tags;
  * The function URI(expr) is the same, but under a different name as a
  * subclass.
  * <p>
- * As an ARQ extension , there is also {@code IRI(base, relative)} form which is E_IRI2.
- * The relative URI (string or IRI) is resolved against the result of the "base" expression.
+ * See also E_IRI2, an ARQ extension. That allows a base and a relative IRI.
+ * The relative URI (string or IRI) is resolved against the result of the value of the base expression.
  * which in turn is resolved as per the one-argument form.
  */
 public class E_IRI extends ExprFunction1 {
@@ -62,7 +62,7 @@ public class E_IRI extends ExprFunction1 {
         this.relExpr = relExpr;
     }
 
-    // Evaluation of a "one argument with access to the env.
+    // Evaluation of a "one argument" with access to the env.
     @Override
     protected NodeValue evalSpecial(Binding binding, FunctionEnv env) {
         // IRI(relative)
@@ -72,15 +72,18 @@ public class E_IRI extends ExprFunction1 {
         return resolve(nvRel, baseIRI, env);
     }
 
+    @Override
+    public NodeValue eval(NodeValue v, FunctionEnv env) {
+        // Shouldn't be called. Legacy only.
+        return resolve(v, parserBase, env);
+    }
+
     /*package*/ static NodeValue resolve(NodeValue relative, String baseIRI, FunctionEnv env) {
         if ( baseIRI == null ) {
             if ( env.getContext() != null ) {
                 Query query = (Query)env.getContext().get(ARQConstants.sysCurrentQuery);
                 if ( query != null )
                     baseIRI = query.getBaseURI();
-                // If still null, NodeFunctions.iri will use the system base.
-//                if ( baseIRI == null )
-//                    baseIRI = IRIs.getBaseStr();
             }
         }
         if ( NodeFunctions.isIRI(relative.asNode()) ) {
@@ -88,12 +91,6 @@ public class E_IRI extends ExprFunction1 {
         }
 
         return NodeFunctions.iri(relative, baseIRI);
-    }
-
-    @Override
-    public NodeValue eval(NodeValue v, FunctionEnv env) {
-        // Shouldn't be called. Legacy only. Does not support baseExpr!=null
-        return resolve(v, parserBase, env);
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI2.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_IRI2.java
@@ -43,14 +43,19 @@ public class E_IRI2 extends ExprFunction2 {
     private static final String sseFunctionName = Tags.tagIri2;
 
     // The base in force when the function was created.
-    // Kept separate from baseExpr so we can see whether it was the one argument or two argument form.
     protected final String parserBase;
 
     // ARQ extension: "IRI(base, relative)"
     protected final Expr baseExpr;
     protected final Expr relExpr;
 
+    public E_IRI2(Expr baseExpr, Expr relExpr) {
+        this(baseExpr, null, relExpr);
+    }
+
     public E_IRI2(Expr baseExpr, String parserBaseURI, Expr relExpr) {
+        // BaseStr is the base in force at the time this expression was created.
+        // This may be null.
         this(baseExpr, parserBaseURI, relExpr, sparqlPrintName, sseFunctionName);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_LogicalAnd.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_LogicalAnd.java
@@ -42,7 +42,7 @@ public class E_LogicalAnd extends ExprFunction2
         try {
             NodeValue x = getArg1().eval(binding, env) ;
     
-            if ( ! XSDFuncOp.booleanEffectiveValue(x) )
+            if ( ! XSDFuncOp.effectiveBooleanValue(x) )
                 return NodeValue.FALSE ; 
         } catch (ExprEvalException eee)
         {
@@ -55,7 +55,7 @@ public class E_LogicalAnd extends ExprFunction2
         try {
             NodeValue y = getArg2().eval(binding, env) ;
     
-            if ( ! XSDFuncOp.booleanEffectiveValue(y) )
+            if ( ! XSDFuncOp.effectiveBooleanValue(y) )
                 return NodeValue.FALSE ;
             
             // RHS is true but was there an error earlier?

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_LogicalOr.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_LogicalOr.java
@@ -57,7 +57,7 @@ public class E_LogicalOr extends ExprFunction2
         try {
             NodeValue x = getArg1().eval(binding, env) ;
     
-            if ( XSDFuncOp.booleanEffectiveValue(x) )
+            if ( XSDFuncOp.effectiveBooleanValue(x) )
     			return NodeValue.TRUE ; 
         } catch (ExprEvalException eee)
         {
@@ -70,7 +70,7 @@ public class E_LogicalOr extends ExprFunction2
         try {
             NodeValue y = getArg2().eval(binding, env) ;
     
-    		if ( XSDFuncOp.booleanEffectiveValue(y) )
+    		if ( XSDFuncOp.effectiveBooleanValue(y) )
     			return NodeValue.TRUE ;
             
             // RHS is false but was there an error earlier?

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_OneOf.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_OneOf.java
@@ -28,32 +28,29 @@ import org.apache.jena.sparql.sse.Tags ;
 public class E_OneOf extends E_OneOfBase
 {
 
-    private static final String functionName = Tags.tagIn ;
-    
-    public E_OneOf(Expr expr, ExprList args)
-    {
-        super(functionName, expr, args) ;
+    private static final String functionName = Tags.tagIn;
+
+    public E_OneOf(Expr expr, ExprList args) {
+        super(functionName, expr, args);
     }
-    
-    protected E_OneOf(ExprList args)
-    {
-        super(functionName, args) ;
+
+    protected E_OneOf(ExprList args) {
+        super(functionName, args);
     }
 
     @Override
-    public NodeValue evalSpecial(Binding binding, FunctionEnv env)
-    {
-        boolean b = super.evalOneOf(binding, env) ;
-        return NodeValue.booleanReturn(b) ;
+    public NodeValue evalSpecial(Binding binding, FunctionEnv env) {
+        boolean b = super.evalOneOf(binding, env);
+        return NodeValue.booleanReturn(b);
     }
-    
+
     @Override
-    public NodeValue eval(List<NodeValue> args)
-    { throw new ARQInternalErrorException() ; }
-    
+    public NodeValue eval(List<NodeValue> args) {
+        throw new ARQInternalErrorException();
+    }
+
     @Override
-    public Expr copy(ExprList newArgs)
-    {
-        return new E_OneOf(newArgs) ;
+    public Expr copy(ExprList newArgs) {
+        return new E_OneOf(newArgs);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_OneOfBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_OneOfBase.java
@@ -18,75 +18,69 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.sparql.engine.binding.Binding ;
-import org.apache.jena.sparql.function.FunctionEnv ;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.function.FunctionEnv;
 
-public abstract class E_OneOfBase extends ExprFunctionN
-{   
-    /* This operation stores it's arguments as a single list.
-     * The first element of the array is the expression being tested,
-     * the rest are the items to be used to test against.
-     * There are cached copies of the LHS (car) and RHS (cdr).
-     */
-    
+public abstract class E_OneOfBase extends ExprFunctionN {
+    /* This operation stores it's arguments as a single list. The first element of
+     * the array is the expression being tested, the rest are the items to be used to
+     * test against. There are cached copies of the LHS (car) and RHS (cdr). */
+
     // Cached values.
-    protected final Expr expr ;
-    protected final ExprList possibleValues ;
-    
-    protected E_OneOfBase(String name, Expr expr, ExprList args)
-    {
-        super(name, fixup(expr, args)) ;
-        this.expr = expr ;
-        this.possibleValues = args ;
+    protected final Expr expr;
+    protected final ExprList possibleValues;
+
+    protected E_OneOfBase(String name, Expr expr, ExprList args) {
+        super(name, fixup(expr, args));
+        this.expr = expr;
+        this.possibleValues = args;
     }
-    
+
     // All ArgList, first arg is the expression.
-    protected E_OneOfBase(String name, ExprList args)
-    {
-        super(name, args) ;
-        this.expr = args.get(0) ;
-        this.possibleValues = args.tail(1) ;
-    }
-    
-    private static ExprList fixup(Expr expr2, ExprList args)
-    {
-        ExprList allArgs = new ExprList(expr2) ;
-        allArgs.addAll(args) ;
-        return allArgs ;
+    protected E_OneOfBase(String name, ExprList args) {
+        super(name, args);
+        this.expr = args.get(0);
+        this.possibleValues = args.tail(1);
     }
 
-    public Expr getLHS()        { return expr ; }
-    public ExprList getRHS()    { return possibleValues; }
+    private static ExprList fixup(Expr expr2, ExprList args) {
+        ExprList allArgs = new ExprList(expr2);
+        allArgs.addAll(args);
+        return allArgs;
+    }
 
-    
-//    public Expr getLHS() { return expr ; }
-//    public ExprList getRHS() { return possibleValues ; }
+    public Expr getLHS() {
+        return expr;
+    }
 
-    protected boolean evalOneOf(Binding binding, FunctionEnv env)
-    {
+    public ExprList getRHS() {
+        return possibleValues;
+    }
+
+// public Expr getLHS() { return expr ; }
+// public ExprList getRHS() { return possibleValues ; }
+
+    protected boolean evalOneOf(Binding binding, FunctionEnv env) {
         // Special form.
         // Like ( expr = expr1 ) || ( expr = expr2 ) || ...
 
-        NodeValue nv = expr.eval(binding, env) ;
-        ExprEvalException error = null ;
-        for ( Expr inExpr : possibleValues )
-        {
+        NodeValue nv = expr.eval(binding, env);
+        ExprEvalException error = null;
+        for ( Expr inExpr : possibleValues ) {
             try {
-                NodeValue maybe = inExpr.eval(binding, env) ;
+                NodeValue maybe = inExpr.eval(binding, env);
                 if ( NodeValue.sameValueAs(nv, maybe) )
-                    return true ;
-            } catch (ExprEvalException ex)
-            {
-                error = ex ;
+                    return true;
+            } catch (ExprEvalException ex) {
+                error = ex;
             }
         }
         if ( error != null )
-            throw error ;
-        return false ;
+            throw error;
+        return false;
     }
-    
-    protected boolean evalNotOneOf(Binding binding, FunctionEnv env)
-    {
-        return ! evalOneOf(binding, env) ;
+
+    protected boolean evalNotOneOf(Binding binding, FunctionEnv env) {
+        return !evalOneOf(binding, env);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Regex.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Regex.java
@@ -33,6 +33,10 @@ public class E_Regex extends ExprFunctionN
     private static final String name = Tags.tagRegex;
     private RegexEngine regexEngine = null;
 
+    public E_Regex(Expr expr, Expr pattern) {
+        this(expr, pattern, null);
+    }
+
     public E_Regex(Expr expr, Expr pattern, Expr flags) {
         super(name, expr, pattern, flags);
         init(pattern, flags);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_StrReplace.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_StrReplace.java
@@ -25,19 +25,25 @@ import org.apache.jena.sparql.expr.nodevalue.XSDFuncOp ;
 import org.apache.jena.sparql.sse.Tags ;
 
 public class E_StrReplace extends ExprFunctionN {
-    private static final String symbol  = Tags.tagReplace ;
-    private Pattern             pattern = null ;
+    private static final String symbol  = Tags.tagReplace;
+    private final Pattern pattern;
+
+    public E_StrReplace(Expr expr1, Expr expr2, Expr expr3) {
+        this(expr1, expr2, expr3, null);
+    }
 
     public E_StrReplace(Expr expr1, Expr expr2, Expr expr3, Expr expr4) {
-        super(symbol, expr1, expr2, expr3, expr4) ;
+        super(symbol, expr1, expr2, expr3, expr4);
 
+        Pattern pattern0 = null;
         if ( isString(expr2) && (expr4 == null || isString(expr4)) ) {
             String flags = null;
             if ( expr4 != null && expr4.isConstant() && expr4.getConstant().isString() )
                 flags = expr4.getConstant().getString();
             String patternStr = expr2.getConstant().getString();
-            pattern = RegexEngine.makePattern("REPLACE", patternStr, flags);
+            pattern0 = RegexEngine.makePattern("REPLACE", patternStr, flags);
         }
+        pattern = pattern0;
     }
 
     private static boolean isString(Expr expr) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_URI.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_URI.java
@@ -33,18 +33,18 @@ public class E_URI extends E_IRI {
         this(null, relExpr);
     }
 
-    public E_URI(String baseStr, Expr relExpr) {
-        super(baseStr, relExpr, sparqlPrintName, sseFunctionName);
+    public E_URI(String parserBaseURI, Expr relExpr) {
+        super(parserBaseURI, relExpr, sparqlPrintName, sseFunctionName);
     }
-
-    @Override
-    public String getFunctionPrintName(SerializationContext cxt)
-    { return sparqlPrintName ; }
 
     @Override
     public Expr copy(Expr expr) {
         return new E_URI(parserBase, expr);
     }
+
+    @Override
+    public String getFunctionPrintName(SerializationContext cxt)
+    { return sparqlPrintName ; }
 
     @Override
     public int hashCode() {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_URI2.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_URI2.java
@@ -29,22 +29,24 @@ public class E_URI2 extends E_IRI2 {
     private static final String sparqlPrintName = "URI";
     private static final String sseFunctionName = Tags.tagUri2;
 
-    public E_URI2(String baseURI, Expr relExpr) {
-        this(null, baseURI, relExpr);
+    public E_URI2(Expr baseExpr, Expr relExpr) {
+        this(baseExpr, null, relExpr);
     }
 
     public E_URI2(Expr baseExpr, String baseStr, Expr relExpr) {
+        // BaseStr is the base in force at the time this expression was created.
+        // This may be null.
         super(baseExpr, baseStr, relExpr, sparqlPrintName, sseFunctionName);
     }
-
-    @Override
-    public String getFunctionPrintName(SerializationContext cxt)
-    { return sparqlPrintName ; }
 
     @Override
     public Expr copy(Expr expr1, Expr expr2) {
         return new E_URI2(expr1, parserBase, expr2);
     }
+
+    @Override
+    public String getFunctionPrintName(SerializationContext cxt)
+    { return sparqlPrintName ; }
 
     @Override
     public int hashCode() {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Version.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Version.java
@@ -18,28 +18,25 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.query.ARQ ;
+import org.apache.jena.sparql.expr.nodevalue.ARQFuncOp;
 import org.apache.jena.sparql.function.FunctionEnv ;
 import org.apache.jena.sparql.sse.Tags ;
 
 public class E_Version extends ExprFunction0
 {
     static private String fName = Tags.tagVersion ;
-    
-    public E_Version()
-    {
-        super(fName) ;
+
+    public E_Version() {
+        super(fName);
     }
 
     @Override
-    public Expr copy()
-    {
-        return new E_Version() ;
+    public Expr copy() {
+        return new E_Version();
     }
 
     @Override
-    public NodeValue eval(FunctionEnv env)
-    {
-        return NodeValue.makeString(ARQ.NAME+" "+ARQ.VERSION) ;
+    public NodeValue eval(FunctionEnv env) {
+        return ARQFuncOp.version();
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/Expr.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/Expr.java
@@ -38,7 +38,7 @@ public interface Expr
     public static final int CMP_UNEQUAL  = -9 ;
     public static final int CMP_INDETERMINATE  = DatatypeConstants.INDETERMINATE ;
 
-    /** Test whether a Constraint is satisfied, given a set of bindings
+    /** Test whether a constraint is satisfied, given a set of bindings.
      *  Includes error propagation and Effective Boolean Value rules.
      *
      * @param binding   The bindings

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprFunction.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprFunction.java
@@ -96,15 +96,15 @@ public abstract class ExprFunction extends ExprNode
     }
 
     /**
-     * Name used for output in SPARQL format needing functional form (no specific keyword).
+     * Name used for output in SPARQL format needing functional syntax: name(arg1, arg2, ...)
      * e.g. regexp(), custom functions, ...
      */
     public String getFunctionPrintName(SerializationContext cxt)
     { return funcSymbol.getSymbol(); }
 
     /**
-     * Name used in a functional form (i.e. SPARQL algebra).
-     * getOpName() is used in preference as a short, symbol name.
+     * Name used in the SPARQL algebra.
+     * See also {@link #getOpName} for an operator form.
      */
     public String getFunctionName(SerializationContext cxt)
     { return funcSymbol.getSymbol(); }
@@ -116,7 +116,7 @@ public abstract class ExprFunction extends ExprNode
     /** URI for this function, whether custom or specification defined URI (these are keywords in the language) */
     public String getFunctionIRI() { return null; }
 
-    /** Get the symbol name (+, ! etc) for this function -- maybe null for none */
+    /** Get the operator symbol name (+, ! etc) for this function -- maybe null for none */
     public String getOpName()
     { return opSign; }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprList.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprList.java
@@ -30,21 +30,29 @@ import org.apache.jena.sparql.util.Context ;
 public class ExprList implements Iterable<Expr>
 {
     private final List<Expr> expressions ;
-    /** Create a copy which does not share the list of expressions with the original */ 
+    /** Create a copy which does not share the list of expressions with the original */
     public static ExprList copy(ExprList other) { return new ExprList(other) ; }
-    
+
     /** Create an ExprList that contains the expressions */
     public static ExprList create(Collection<Expr> exprs) {
         ExprList exprList = new ExprList() ;
         exprs.forEach(exprList::add) ;
-        return exprList ; 
-    } 
-    
+        return exprList ;
+    }
+
+    /** Create an ExprList from a number of Expr or an array. */
+    public static ExprList create(Expr...exprs) {
+        ExprList exprList = new ExprList() ;
+        for (Expr expr : exprs)
+            exprList.add(expr);
+        return exprList ;
+    }
+
     /** Empty, immutable ExprList */
     public static final ExprList emptyList = new ExprList(Collections.emptyList()) ;
-    
+
     public ExprList() { expressions = new ArrayList<>() ; }
-    
+
     private ExprList(ExprList other) {
         this() ;
         expressions.addAll(other.expressions) ;
@@ -64,13 +72,13 @@ public class ExprList implements Iterable<Expr>
         }
         return true ;
     }
-    
+
     public Expr get(int idx)                            { return expressions.get(idx) ; }
     public int size()                                   { return expressions.size() ; }
     public boolean isEmpty()                            { return expressions.isEmpty() ; }
     public ExprList subList(int fromIdx, int toIdx)     { return new ExprList(expressions.subList(fromIdx, toIdx)) ; }
     public ExprList tail(int fromIdx)                   { return subList(fromIdx, expressions.size()) ; }
-    
+
     public Set<Var> getVarsMentioned() {
         return ExprVars.getVarsMentioned(this);
     }
@@ -82,7 +90,7 @@ public class ExprList implements Iterable<Expr>
         ExprList x = new ExprList() ;
         for ( Expr e : expressions)
             x.add(e.applyNodeTransform(transform));
-        return x ; 
+        return x ;
     }
 
     public ExprList copySubstitute(Binding binding) {
@@ -101,34 +109,34 @@ public class ExprList implements Iterable<Expr>
     public List<Expr> getListRaw()          { return expressions ; }
     @Override
     public Iterator<Expr> iterator()        { return expressions.iterator() ; }
-    
+
     public void prepareExprs(Context context) {
         ExprBuild build = new ExprBuild(context) ;
         // Give each expression the chance to set up (bind functions)
         for (Expr expr : expressions)
             Walker.walk(expr, build) ;
     }
-    
+
     @Override
     public String toString()
     { return expressions.toString() ; }
-    
+
     @Override
     public int hashCode() { return expressions.hashCode() ; }
 
     public boolean equals(ExprList other, boolean bySyntax) {
         if ( this == other ) return true ;
         if (expressions.size() != other.expressions.size()) return false;
-        
+
         for ( int i = 0 ; i < expressions.size() ; i++ ) {
             Expr e1 = expressions.get(i) ;
             Expr e2 = other.expressions.get(i) ;
-            if ( ! e1.equals(e2, bySyntax) ) 
+            if ( ! e1.equals(e2, bySyntax) )
                 return false ;
         }
         return true ;
     }
-    
+
     @Override
     public boolean equals(Object other) {
         if ( this == other ) return true ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprNode.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprNode.java
@@ -40,7 +40,7 @@ public abstract class ExprNode implements Expr
     public boolean isSatisfied(Binding binding, FunctionEnv funcEnv) {
         try {
             NodeValue v = eval(binding, funcEnv);
-            boolean b = XSDFuncOp.booleanEffectiveValue(v);
+            boolean b = XSDFuncOp.effectiveBooleanValue(v);
             return b;
         }
         catch (ExprEvalException ex) {
@@ -48,7 +48,11 @@ public abstract class ExprNode implements Expr
         }
     }
 
+    /** @deprecated Unnecessary - to be removed */
+    @Deprecated(forRemoval = true)
     public boolean isExpr()     { return true; }
+    /** @deprecated Unnecessary - to be removed */
+    @Deprecated(forRemoval = true)
     public final Expr getExpr() { return this; }
 
     // --- interface Constraint

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/ARQFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/ARQFuncOp.java
@@ -16,20 +16,30 @@
  * limitations under the License.
  */
 
-package org.apache.jena.sparql.function.library.leviathan;
+package org.apache.jena.sparql.expr.nodevalue;
 
-import org.apache.jena.sparql.expr.E_MD5 ;
-import org.apache.jena.sparql.expr.ExprDigest ;
-import org.apache.jena.sparql.expr.NodeValue ;
-import org.apache.jena.sparql.function.FunctionBase1 ;
+import java.util.Optional;
 
-public class md5hash extends FunctionBase1 {
+import org.apache.jena.atlas.lib.Version;
+import org.apache.jena.query.ARQ;
+import org.apache.jena.sparql.expr.NodeValue;
 
-    private ExprDigest digest = new E_MD5(NodeValue.makeBoolean(true));
+/** Functions specific to ARQ */
+public class ARQFuncOp {
 
-    @Override
-    public NodeValue exec(NodeValue v) {
-        return digest.eval(v);
+    /** The return version information as a human-readable string.*/
+    public static NodeValue version() {
+        String verStr = versionString();
+        return NodeValue.makeString(verStr);
     }
 
+    private static String versionString() {
+        if ( true )
+            return ARQ.NAME+" "+ARQ.VERSION;
+        Optional<String> version = Version.versionForClass(ARQ.class);
+        if ( version.isPresent() )
+            return String.format("Apache Jena version %s", version.get());
+
+        return "Apache Jena";
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/nodevalue/XSDFuncOp.java
@@ -295,19 +295,33 @@ public class XSDFuncOp
 
     /** {@literal F&O} fn:not */
     public static NodeValue not(NodeValue nv) {
-        boolean b = XSDFuncOp.booleanEffectiveValue(nv);
+        boolean b = XSDFuncOp.effectiveBooleanValue(nv);
         return NodeValue.booleanReturn(!b);
     }
 
-    /** {@literal F&O} fn:boolean */
+    /** @deprecated Renamed as {@link effectiveBooleanValueAsNodeValue}. */
+    @Deprecated(forRemoval = true)
     public static NodeValue booleanEffectiveValueAsNodeValue(NodeValue nv) {
-        if ( nv.isBoolean() ) // "Optimization" (saves on object churn)
-            return nv;
-        return NodeValue.booleanReturn(booleanEffectiveValue(nv));
+        return effectiveBooleanValueAsNodeValue(nv);
     }
 
     /** {@literal F&O} fn:boolean */
+    public static NodeValue effectiveBooleanValueAsNodeValue(NodeValue nv) {
+        if ( nv.isBoolean() ) // "Optimization" (saves on object churn)
+            return nv;
+        return NodeValue.booleanReturn(effectiveBooleanValue(nv));
+    }
+
+    /** @deprecated Renamed as {@link effectiveBooleanValue}. */
+    @Deprecated(forRemoval = true)
     public static boolean booleanEffectiveValue(NodeValue nv) {
+        return effectiveBooleanValue(nv);
+    }
+
+    /** {@literal F&O} fn:boolean */
+    public static boolean effectiveBooleanValue(NodeValue nv) {
+        Objects.requireNonNull(nv, "NodeValue is null in call to effectiveBooleanValue");
+
         // Apply the "boolean effective value" rules
         // boolean: value of the boolean (strictly, if derived from xsd:boolean)
         // plain literal: lexical form length(string) > 0

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/urifunctions/SPARQLDispatch.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/urifunctions/SPARQLDispatch.java
@@ -123,6 +123,18 @@ public class SPARQLDispatch {
     }
 
     // Switch on arity
+    static void register(Map<String, Call> map, String uri, Function3 function3, Function4 function4) {
+        Call call = args->{
+            if ( args.length == 3 )
+                return function3.exec(args[0], args[1], args[2]);
+            if ( args.length == 4 )
+                return function4.exec(args[0], args[1], args[2], args[3]);
+            throw exception("%s: Expected three or four arguments. Got %d", uri, args.length);
+        };
+        registerCall(map, uri, call);
+    }
+
+    // Arity N
     static void register(Map<String, Call> map, String uri, FunctionN function) {
         Call call = args->{
             return function.exec(args);
@@ -150,6 +162,10 @@ public class SPARQLDispatch {
 
     static Map<String, Call> buildDispatchMap() {
         Map<String, Call> map = new HashMap<>();
+
+        // Move out/rename to "FunctionDispatch"
+        // Add ARQ specials.
+
         register(map, "plus", SPARQLFuncOp::sparql_plus );
         register(map, "add", SPARQLFuncOp::sparql_plus );           // Alt name.
         register(map, "subtract", SPARQLFuncOp::sparql_subtract );
@@ -161,7 +177,7 @@ public class SPARQLDispatch {
         register(map, "not-equals", SPARQLFuncOp::sparql_not_equals );
         register(map, "greaterThan", SPARQLFuncOp::sparql_greaterThan );
         register(map, "greaterThanOrEqual", SPARQLFuncOp::sparql_greaterThanOrEqual );
-        register(map, "lessThan", SPARQLFuncOp::sparql_lessThat );
+        register(map, "lessThan", SPARQLFuncOp::sparql_lessThan );
         register(map, "lessThanOrEqual", SPARQLFuncOp::sparql_lessThanOrEqual );
 
         register(map, "and", SPARQLFuncOp::sparql_function_and );
@@ -184,9 +200,13 @@ public class SPARQLDispatch {
         register(map, "floor", SPARQLFuncOp::sparql_floor);
         register(map, "haslang", SPARQLFuncOp::sparql_haslang);
         register(map, "haslangdir", SPARQLFuncOp::sparql_haslangdir);
+
         // Arity 1/2
-        register(map, "iri", x->SPARQLFuncOp.sparql_iri(x), (x,b)->SPARQLFuncOp.sparql_iri(x,b));
-        register(map, "uri", SPARQLFuncOp::sparql_uri);
+        //register(map, "iri", x->SPARQLFuncOp.sparql_iri(x), (x,b)->SPARQLFuncOp.arq_iri(x,b));
+        register(map, "iri", SPARQLFuncOp::sparql_iri, SPARQLFuncOp::arq_iri);
+        //register(map, "uri", x->SPARQLFuncOp.sparql_uri(x), (x,b)->SPARQLFuncOp.arq_uri(x,b));
+        register(map, "uri", SPARQLFuncOp::sparql_uri, SPARQLFuncOp::arq_uri);
+
         register(map, "isBlank", SPARQLFuncOp::sparql_isBlank);
         register(map, "isLiteral", SPARQLFuncOp::sparql_isLiteral);
         register(map, "isNumeric", SPARQLFuncOp::sparql_isNumeric);
@@ -199,8 +219,12 @@ public class SPARQLDispatch {
         register(map, "ucase", SPARQLFuncOp::sparql_ucase);
         register(map, "now", SPARQLFuncOp::sparql_now);
         register(map, "rand", SPARQLFuncOp::sparql_rand);
-        register(map, "regex", SPARQLFuncOp::sparql_regex);
-        register(map, "replace", SPARQLFuncOp::sparql_replace);
+        // Arity 2/3
+        register(map, "regex", SPARQLFuncOp::sparql_regex, SPARQLFuncOp::sparql_regex);
+
+        // Arity 3/4
+        register(map, "replace", SPARQLFuncOp::sparql_replace, SPARQLFuncOp::sparql_replace);
+
         register(map, "round", SPARQLFuncOp::sparql_round);
         register(map, "sameTerm", SPARQLFuncOp::sparql_sameTerm);
         register(map, "sameValue", SPARQLFuncOp::sparql_sameValue);
@@ -223,6 +247,7 @@ public class SPARQLDispatch {
 
         register(map, "md5", SPARQLFuncOp::sparql_md5);
         register(map, "sha1", SPARQLFuncOp::sparql_sha1);
+        register(map, "sha224", SPARQLFuncOp::sparql_sha224);
         register(map, "sha256", SPARQLFuncOp::sparql_sha256);
         register(map, "sha384", SPARQLFuncOp::sparql_sha384);
         register(map, "sha512", SPARQLFuncOp::sparql_sha512);
@@ -237,7 +262,7 @@ public class SPARQLDispatch {
         register(map, "strlen", SPARQLFuncOp::sparql_strlen);
         register(map, "strstarts", SPARQLFuncOp::sparql_strstarts);
         // Arity 2/3
-        register(map, "substr", (s,x)->SPARQLFuncOp.sparql_substr(s,x), (s,x,y)->SPARQLFuncOp.sparql_substr(s,x,y));
+        register(map, "substr", SPARQLFuncOp::sparql_substr, SPARQLFuncOp::sparql_substr);
         register(map, "struuid", SPARQLFuncOp::sparql_struuid);
 
         return Map.copyOf(map);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/urifunctions/SPARQLFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/urifunctions/SPARQLFuncOp.java
@@ -143,7 +143,7 @@ public class SPARQLFuncOp {
         return NodeValue.booleanReturn(r == Expr.CMP_GREATER);
     }
 
-    public static NodeValue sparql_lessThat(NodeValue nv1, NodeValue nv2) {
+    public static NodeValue sparql_lessThan(NodeValue nv1, NodeValue nv2) {
         int r = NodeValue.compare(nv1, nv2);
         return NodeValue.booleanReturn(r == Expr.CMP_LESS);
     }
@@ -158,22 +158,22 @@ public class SPARQLFuncOp {
         return NodeValue.booleanReturn(r == Expr.CMP_LESS || r == Expr.CMP_EQUAL);
     }
 
-    // and,or,not as functions (arguments have been evaluated)
+    // and, or, not as functions (arguments have been evaluated)
 
     public static NodeValue sparql_function_and(NodeValue nv1, NodeValue nv2) {
-        boolean arg1 = XSDFuncOp.booleanEffectiveValue(nv1);
-        boolean arg2 = XSDFuncOp.booleanEffectiveValue(nv2);
+        boolean arg1 = XSDFuncOp.effectiveBooleanValue(nv1);
+        boolean arg2 = XSDFuncOp.effectiveBooleanValue(nv2);
         return NodeValue.booleanReturn(arg1 && arg2);
     }
 
     public static NodeValue sparql_function_or(NodeValue nv1, NodeValue nv2) {
-        boolean arg1 = XSDFuncOp.booleanEffectiveValue(nv1);
-        boolean arg2 = XSDFuncOp.booleanEffectiveValue(nv2);
+        boolean arg1 = XSDFuncOp.effectiveBooleanValue(nv1);
+        boolean arg2 = XSDFuncOp.effectiveBooleanValue(nv2);
         return NodeValue.booleanReturn(arg1 || arg2);
     }
 
   public static NodeValue sparql_function_not(NodeValue nv) {
-      boolean arg = XSDFuncOp.booleanEffectiveValue(nv);
+      boolean arg = XSDFuncOp.effectiveBooleanValue(nv);
       return NodeValue.booleanReturn(!arg);
   }
 
@@ -226,10 +226,11 @@ public class SPARQLFuncOp {
     // Term functions : NodeFunctions
 
     public static NodeValue sparql_iri(NodeValue nv) { return NodeFunctions.iri(nv, null); }
-    // Extension
-    public static NodeValue sparql_iri(NodeValue nv, NodeValue nvBase) { return NodeFunctions.iri(nv, nvBase.getString()); }
-
     public static NodeValue sparql_uri(NodeValue nv) { return sparql_iri(nv); }
+
+    // Extension
+    public static NodeValue arq_iri(NodeValue nv, NodeValue nvBase) { return NodeFunctions.iri(nv, nvBase.getString()); }
+    public static NodeValue arq_uri(NodeValue nv, NodeValue nvBase) { return NodeFunctions.iri(nv, nvBase.getString()); }
 
     // Only BNODE(), not BNODE(str)
     public static NodeValue sparql_bnode() { return null; }
@@ -256,10 +257,7 @@ public class SPARQLFuncOp {
     public static NodeValue sparql_contains(NodeValue nv1, NodeValue nv2) { return XSDFuncOp.strContains(nv1, nv2); }
     public static NodeValue sparql_strbefore(NodeValue nv1, NodeValue nv2) { return XSDFuncOp.strBefore(nv1, nv2); }
     public static NodeValue sparql_strafter(NodeValue nv1, NodeValue nv2) { return XSDFuncOp.strAfter(nv1, nv2); }
-
-    public static NodeValue sparql_concat(NodeValue...args) {
-        return XSDFuncOp.strConcat(List.of(args));
-    }
+    public static NodeValue sparql_concat(NodeValue...args) { return XSDFuncOp.strConcat(List.of(args)); }
 
     public static NodeValue sparql_langMatches(NodeValue nv1, NodeValue nv2) { return NodeFunctions.langMatches(nv1, nv2); }
 
@@ -270,10 +268,11 @@ public class SPARQLFuncOp {
         return regexEngineCache.get(cacheKey, (key)->E_Regex.makeRegexEngine(key.pattern, key.flags));
     }
 
+    public static NodeValue sparql_regex(NodeValue string, NodeValue pattern) { return sparql_regex(string, pattern, null); }
     public static NodeValue sparql_regex(NodeValue string, NodeValue pattern, NodeValue flags) {
         // Cache - this means regexes are compiled once.
         String patternStr = pattern.getString();
-        String flagsStr = flags.getString();
+        String flagsStr = (flags == null) ? null : flags.getString();
         RegexEngine regexEngine = getRegexEngine(patternStr, flagsStr);
         String str = string.getString();
         boolean b = regexEngine.match(str);
@@ -282,6 +281,9 @@ public class SPARQLFuncOp {
 
     public static NodeValue sparql_replace(NodeValue nvStr, NodeValue nvPattern, NodeValue nvReplacement)
     { return XSDFuncOp.strReplace(nvStr, nvPattern, nvReplacement); }
+
+    public static NodeValue sparql_replace(NodeValue nvStr, NodeValue nvPattern, NodeValue nvReplacement, NodeValue envFlags)
+    { return XSDFuncOp.strReplace(nvStr, nvPattern, nvReplacement, envFlags); }
 
     public static NodeValue sparql_encode(NodeValue nv) { return XSDFuncOp.strEncodeForURI(nv); }
     public static NodeValue sparql_abs(NodeValue nv)    { return XSDFuncOp.abs(nv); }
@@ -316,6 +318,7 @@ public class SPARQLFuncOp {
 
     public static NodeValue sparql_md5(NodeValue nv)    { return NodeValueDigest.calculateDigest(nv, "MD-5"); }
     public static NodeValue sparql_sha1(NodeValue nv)   { return NodeValueDigest.calculateDigest(nv, "SHA-1"); }
+    public static NodeValue sparql_sha224(NodeValue nv) { return NodeValueDigest.calculateDigest(nv, "SHA-224"); }
     public static NodeValue sparql_sha256(NodeValue nv) { return NodeValueDigest.calculateDigest(nv, "SHA-256"); }
     public static NodeValue sparql_sha384(NodeValue nv) { return NodeValueDigest.calculateDigest(nv, "SHA-384"); }
     public static NodeValue sparql_sha512(NodeValue nv) { return NodeValueDigest.calculateDigest(nv, "SHA-512"); }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/FunctionBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/FunctionBase.java
@@ -66,5 +66,5 @@ public abstract class FunctionBase implements Function {
     /** Function call to a list of evaluated argument values */
     public abstract NodeValue exec(List<NodeValue> args) ;
 
-    public abstract void checkBuild(String uri, ExprList args) ;
+    public abstract void checkBuild(String uri, ExprList args);
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_BEV.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/FN_BEV.java
@@ -29,6 +29,6 @@ public class FN_BEV extends FunctionBase1
     @Override
     public NodeValue exec(NodeValue x)
     {
-        return XSDFuncOp.booleanEffectiveValueAsNodeValue(x) ;
+        return XSDFuncOp.effectiveBooleanValueAsNodeValue(x) ;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/leviathan/sha256hash.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/leviathan/sha256hash.java
@@ -25,8 +25,8 @@ import org.apache.jena.sparql.function.FunctionBase1 ;
 
 public class sha256hash extends FunctionBase1 {
 
-    private ExprDigest digest = new E_SHA256(NodeValue.makeBoolean(true).getExpr());
-    
+    private ExprDigest digest = new E_SHA256(NodeValue.makeBoolean(true));
+
     @Override
     public NodeValue exec(NodeValue v) {
         return digest.eval(v);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/sse/builders/BuilderExpr.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/sse/builders/BuilderExpr.java
@@ -796,7 +796,7 @@ public class BuilderExpr
         if ( numArgs(list) == 2 ) {
             Expr expr1 = buildExpr(list.get(1));
             Expr expr2 = buildExpr(list.get(2));
-            return new E_URI2(expr1, null, expr2);
+            return new E_URI2(expr1, expr2);
         }
         String baseStr = asString(list.get(1));
         Expr expr1 = buildExpr(list.get(2));

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollector.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/TripleCollector.java
@@ -36,7 +36,7 @@ public interface TripleCollector
     // triples 0..(mark-1) before using a mark. That is, use marks in
     // LIFO (stack) order.
 
-    public default int mark() { throw new InternalErrorException("Mark no tsupported"); }
+    public default int mark() { throw new InternalErrorException("Mark not supported"); }
 
     public default void addTriple(int index, Triple t) { addTriple(t); }
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions2.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions2.java
@@ -245,7 +245,7 @@ public class TestExpressions2
     /*package*/ static void eval(String string, boolean result) {
         Expr expr = ExprUtils.parse(string) ;
         NodeValue nv = expr.eval(null, LibTestExpr.createTest()) ;
-        boolean b = XSDFuncOp.booleanEffectiveValue(nv) ;
+        boolean b = XSDFuncOp.effectiveBooleanValue(nv) ;
         assertEquals(string, result, b) ;
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions3.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions3.java
@@ -51,7 +51,7 @@ public class TestExpressions3
         Binding binding = binding(bindingStr) ;
         Expr expr = ExprUtils.parse(string) ;
         NodeValue nv = expr.eval(binding, LibTestExpr.createTest()) ;
-        boolean b = XSDFuncOp.booleanEffectiveValue(nv) ;
+        boolean b = XSDFuncOp.effectiveBooleanValue(nv) ;
         assertEquals(string, expected, b) ;
     }
 
@@ -60,7 +60,7 @@ public class TestExpressions3
         Binding binding = binding(bindingStr) ;
         Expr expr = SSE.parseExpr(exprString) ;
         NodeValue nv = expr.eval(binding, LibTestExpr.createTest()) ;
-        boolean b = XSDFuncOp.booleanEffectiveValue(nv) ;
+        boolean b = XSDFuncOp.effectiveBooleanValue(nv) ;
         assertEquals(exprString, expected, b) ;
     }
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
@@ -493,7 +493,7 @@ public class TestNodeValue
         assertTrue("Not a boolean: " + v, v.isBoolean());
         // assertTrue("Not a node: "+v, v.hasNode()) ;
         assertTrue("Not true: " + v, v.getBoolean());
-        assertTrue("Not true: " + v, XSDFuncOp.booleanEffectiveValue(v));
+        assertTrue("Not true: " + v, XSDFuncOp.effectiveBooleanValue(v));
     }
 
     @Test
@@ -502,7 +502,7 @@ public class TestNodeValue
         assertTrue("Not a boolean: " + v, v.isBoolean());
         // assertTrue("Not a node: "+v, v.hasNode()) ;
         assertFalse("Not false: " + v, v.getBoolean());
-        assertFalse("Not false: " + v, XSDFuncOp.booleanEffectiveValue(v));
+        assertFalse("Not false: " + v, XSDFuncOp.effectiveBooleanValue(v));
     }
 
     @Test
@@ -693,21 +693,21 @@ public class TestNodeValue
     public void testEBV1() {
         assertTrue("Not a boolean", NodeValue.TRUE.isBoolean());
         assertTrue("Not true", NodeValue.TRUE.getBoolean());
-        assertTrue("Not true", XSDFuncOp.booleanEffectiveValue(NodeValue.TRUE));
+        assertTrue("Not true", XSDFuncOp.effectiveBooleanValue(NodeValue.TRUE));
     }
 
     @Test
     public void testEBV2() {
         assertTrue("Not a boolean", NodeValue.FALSE.isBoolean());
         assertFalse("Not false", NodeValue.FALSE.getBoolean());
-        assertFalse("Not false", XSDFuncOp.booleanEffectiveValue(NodeValue.FALSE));
+        assertFalse("Not false", XSDFuncOp.effectiveBooleanValue(NodeValue.FALSE));
     }
 
     @Test
     public void testEBV3() {
         NodeValue v = NodeValue.makeInteger(1);
         assertFalse("It's a boolean: " + v, v.isBoolean());
-        assertTrue("Not EBV true: " + v, XSDFuncOp.booleanEffectiveValue(v));
+        assertTrue("Not EBV true: " + v, XSDFuncOp.effectiveBooleanValue(v));
     }
 
     @Test
@@ -719,7 +719,7 @@ public class TestNodeValue
             fail("getBoolean should fail");
         }
         catch (ExprEvalException e) {}
-        assertFalse("Not EBV false: " + v, XSDFuncOp.booleanEffectiveValue(v));
+        assertFalse("Not EBV false: " + v, XSDFuncOp.effectiveBooleanValue(v));
     }
 
     @Test
@@ -732,7 +732,7 @@ public class TestNodeValue
             fail("getBoolean should fail");
         }
         catch (ExprEvalException e) {}
-        assertTrue("Not EBV true: " + v, XSDFuncOp.booleanEffectiveValue(v));
+        assertTrue("Not EBV true: " + v, XSDFuncOp.effectiveBooleanValue(v));
     }
 
     @Test
@@ -744,7 +744,7 @@ public class TestNodeValue
             fail("getBoolean should fail");
         }
         catch (ExprEvalException e) {}
-        assertFalse("Not EBV false: " + v, XSDFuncOp.booleanEffectiveValue(v));
+        assertFalse("Not EBV false: " + v, XSDFuncOp.effectiveBooleanValue(v));
     }
 
     // EBV includes plain literals which includes language tagged literals.
@@ -752,18 +752,18 @@ public class TestNodeValue
     public void testEBV7() {
         Node x = NodeFactory.createLiteralLang("", "en");
         NodeValue v = NodeValue.makeNode(x);
-        assertFalse("Not EBV false: " + v, XSDFuncOp.booleanEffectiveValue(v));
+        assertFalse("Not EBV false: " + v, XSDFuncOp.effectiveBooleanValue(v));
     }
 
     @Test
     public void testEBV8() {
         Node x = NodeFactory.createLiteralLang("not empty", "en");
         NodeValue v = NodeValue.makeNode(x);
-        assertTrue("Not EBV true: " + v, XSDFuncOp.booleanEffectiveValue(v));
+        assertTrue("Not EBV true: " + v, XSDFuncOp.effectiveBooleanValue(v));
     }
 
     static boolean ebvDouble(double d) {
-        return XSDFuncOp.booleanEffectiveValue(NodeValue.makeDouble(d));
+        return XSDFuncOp.effectiveBooleanValue(NodeValue.makeDouble(d));
     }
 
     @Test
@@ -783,11 +783,11 @@ public class TestNodeValue
 
         Node x = NodeFactory.createLiteralDT("NaN", XSDDatatype.XSDdouble);
         NodeValue v = NodeValue.makeNode(x);
-        assertFalse(XSDFuncOp.booleanEffectiveValue(v));
+        assertFalse(XSDFuncOp.effectiveBooleanValue(v));
     }
 
     static boolean ebvFloat(float f) {
-        return XSDFuncOp.booleanEffectiveValue(NodeValue.makeFloat(f));
+        return XSDFuncOp.effectiveBooleanValue(NodeValue.makeFloat(f));
     }
 
     @Test
@@ -807,12 +807,12 @@ public class TestNodeValue
 
         Node x = NodeFactory.createLiteralDT("NaN", XSDDatatype.XSDfloat);
         NodeValue v = NodeValue.makeNode(x);
-        assertFalse(XSDFuncOp.booleanEffectiveValue(v));
+        assertFalse(XSDFuncOp.effectiveBooleanValue(v));
     }
 
     private static boolean filterEBV(NodeValue nv) {
         try {
-            return XSDFuncOp.booleanEffectiveValue(nv);
+            return XSDFuncOp.effectiveBooleanValue(nv);
         }
         catch (ExprEvalException ex) {
             return false;

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
@@ -335,29 +335,35 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
         return 0;
     }
 
+    protected IndentedWriter self() { return this; }
+
     /** Get indent from the left hand edge */
     public int getAbsoluteIndent()       { return currentIndent; }
 
     /** Set indent from the left hand edge. Returns {@code this}. */
-    public void setAbsoluteIndent(int x) { currentIndent = x; }
+    public IndentedWriter setAbsoluteIndent(int x) { currentIndent = x; return self(); }
 
     public boolean hasLineNumbers() {
         return lineNumbers;
     }
 
-    public void setLineNumbers(boolean lineNumbers) {
+    public IndentedWriter setLineNumbers(boolean lineNumbers) {
         this.lineNumbers = lineNumbers;
+        return self();
     }
 
     public String getEndOfLineMarker()              { return endOfLineMarker; }
 
     /** Set the marker included at end of line - set to null for "none".  Usually used for debugging. */
-    public void setEndOfLineMarker(String marker)  {  endOfLineMarker = marker; }
+    public IndentedWriter setEndOfLineMarker(String marker)  {  endOfLineMarker = marker; return self(); }
 
     /** Flat mode - print without NL, for a more compact representation */
     public boolean inFlatMode()                     { return flatMode; }
     /** Flat mode - print without NL, for a more compact representation*/
-    public void setFlatMode(boolean flatMode)       { this.flatMode = flatMode; }
+    public IndentedWriter setFlatMode(boolean flatMode) {
+        this.flatMode = flatMode;
+        return self();
+    }
 
     /** Flush on newline **/
     public boolean getFlushOnNewline()              { return flushOnNewline; }
@@ -367,11 +373,14 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
      * but not by default otherwise. The underlying output, if it is a {@link PrintStream}
      * may also have a flush on newline as well (e.g {@link System#out}).
      */
-    public void setFlushOnNewline(boolean flushOnNewline) { this.flushOnNewline = flushOnNewline; }
+    public IndentedWriter setFlushOnNewline(boolean flushOnNewline) {
+        this.flushOnNewline = flushOnNewline;
+        return self();
+    }
 
     public char getPadChar()                        { return padChar; }
 
-    public void setPadChar(char ch)                 { this.padChar = ch; }
+    public IndentedWriter setPadChar(char ch)       { this.padChar = ch; return self(); }
 
     public String getPadString()                    { return padString; }
 
@@ -386,14 +395,16 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     }
 
     /** Set the initial string printed at the start of each line. */
-    public void setLinePrefix(String str) {
+    public IndentedWriter setLinePrefix(String str) {
         this.linePrefix = str;
+        return self();
     }
 
     public int getUnitIndent()         { return unitIndent; }
 
-    public void setUnitIndent(int x) {
+    public IndentedWriter setUnitIndent(int x) {
         unitIndent = x;
+        return self();
     }
 
     private int widthLineNumber = 3;
@@ -404,8 +415,9 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     /** Set the width of the number field.
      * There is also a single space after the number not included in this setting.
      */
-    public void setNumberWidth(int widthOfNumbers) {
+    public IndentedWriter setNumberWidth(int widthOfNumbers) {
         widthLineNumber = widthOfNumbers;
+        return self();
     }
 
     private void insertLineNumber() {

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/IndentedWriter.java
@@ -26,9 +26,14 @@ import java.io.Writer;
 
 import org.apache.jena.atlas.lib.Closeable;
 
-/** A writer that records what the current indentation level is, and
- *  uses that to insert a prefix at each line.
- *  It can also insert line numbers at the beginning of lines. */
+/**
+ * A {@link AWriter} that records what the current indentation level is, and uses
+ * that to insert a prefix at each line.
+ * It can also insert line numbers at the beginning of lines.
+ * <p>
+ * An {@code IndentedWriter} flushed, bit does not close, the underlying output a
+ * stream on close.
+ */
 
 public class IndentedWriter extends AWriterBase implements AWriter, Closeable
 {
@@ -109,16 +114,23 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     public IndentedWriter clone() {
         return clone(this);
     }
+
     private static Writer makeWriter(OutputStream out) {
         return IO.asBufferedUTF8(out);
     }
 
-    /** Using Writers directly is discouraged */
+    /**
+     * Using {@link java.io.Writer Java I/O Writers} directly is discouraged
+     * and may case character encoding issues.
+     */
     protected IndentedWriter(Writer writer) {
         this(writer, false);
     }
 
-    /** Using Writers directly is discouraged */
+    /**
+     * Using {@link java.io.Writer Java I/O Writers} directly is discouraged
+     * and may case character encoding issues.
+     */
     protected IndentedWriter(Writer writer, boolean withLineNumbers) {
         out = writer;
         lineNumbers = withLineNumbers;
@@ -253,7 +265,11 @@ public class IndentedWriter extends AWriterBase implements AWriter, Closeable
     }
 
     @Override
-    public void close() { IO.close(out); }
+    public void close() {
+        // flush, not close.
+        // IndentedWriters wrap an underlying output, often a short term additional layer.
+        flush();
+    }
 
     @Override
     public void flush() { IO.flush(out); }

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetOperations.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetOperations.java
@@ -215,7 +215,6 @@ public class DatasetOperations {
                 dataset.end();
             }
         }
-
     }
 
     private static void prepareSpatialExtension(Dataset dataset, ArgsConfig argsConfig) throws SpatialIndexException {


### PR DESCRIPTION
Refinement of code in PR #3145 based on extending call-by-URI to support functional forms (e.g `IF`, `COALESCE` which are not pure functions).

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
