### PR TITLE
Permit injecting UNDEF in ParameterizedSparqlString (GH-3268)

### DIFF
--- a/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
+++ b/jena-arq/src/test/java/org/apache/jena/query/TestParameterizedSparqlString.java
@@ -1674,7 +1674,6 @@ public class TestParameterizedSparqlString {
         queryStr.asQuery();
     }
 
-
     @Test
     public void test_param_string_non_injection_03() {
         String prefixes="PREFIX : <http://purl.bdrc.io/ontology/core/>\n" +
@@ -1982,8 +1981,7 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { VALUES ?o {(\"test\")} ?s ?p ?o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+
         Assert.assertEquals(exp, res);
     }
 
@@ -1996,8 +1994,20 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { VALUES $o {(\"test\")} $s $p $o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_undef() {
+        // Tests a single value being added using '$' variable syntax - always adding parenthesis.
+        String str = "SELECT * WHERE { VALUES $o {$objs} $s $p $o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        pss.setValues("objs", pss.undef());
+
+        String exp = "SELECT * WHERE { VALUES $o {(UNDEF)} $s $p $o }";
+        String res = pss.toString();
+
         Assert.assertEquals(exp, res);
     }
 
@@ -2010,8 +2020,7 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { ?o {?objs} ?s ?p ?o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+
         Assert.assertEquals(exp, res);
     }
 
@@ -2024,8 +2033,7 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { VALUES ?o ?objs ?s ?p ?o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+
         Assert.assertEquals(exp, res);
     }
 
@@ -2038,8 +2046,7 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { VALUES ?o {?objs} ?s ?p ?o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+
         Assert.assertEquals(exp, res);
     }
 
@@ -2055,8 +2062,7 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { VALUES (?o) {(\"obj_A\") (\"obj_B\")} ?s ?p ?o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+
         Assert.assertEquals(exp, res);
     }
 
@@ -2071,8 +2077,6 @@ public class TestParameterizedSparqlString {
         String exp = "SELECT * WHERE { VALUES (?o) {} ?s ?p ?o }";
         String res = pss.toString();
 
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
         Assert.assertEquals(exp, res);
     }
 
@@ -2088,8 +2092,23 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { VALUES (?p ?o) {(<http://example.org/prop_A> \"obj_A\")} ?s ?p ?o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+
+        Assert.assertEquals(exp, res);
+    }
+
+    @Test
+    public void test_set_values_multiple_variables_including_undef() {
+        // Tests two values for same variable.
+        String str = "SELECT * WHERE { VALUES (?p ?o) {?vars} ?s ?p ?o }";
+        ParameterizedSparqlString pss = new ParameterizedSparqlString(str);
+        List<RDFNode> vars = new ArrayList<>();
+        vars.add(ResourceFactory.createProperty("http://example.org/prop_A"));
+        vars.add(pss.undef());
+        pss.setValues("vars", vars);
+
+        String exp = "SELECT * WHERE { VALUES (?p ?o) {(<http://example.org/prop_A> UNDEF)} ?s ?p ?o }";
+        String res = pss.toString();
+
         Assert.assertEquals(exp, res);
     }
 
@@ -2133,13 +2152,13 @@ public class TestParameterizedSparqlString {
 
         List<RDFNode> props = new ArrayList<>();
         props.add(ResourceFactory.createProperty("http://example.org/prop_A"));
+        props.add(pss.undef());
         props.add(ResourceFactory.createProperty("http://example.org/prop_B"));
         pss.setValues("props", props);
 
-        String exp = "SELECT * WHERE { VALUES ?p {(<http://example.org/prop_A>) (<http://example.org/prop_B>)} VALUES ?o {(\"obj_A\") (\"obj_B\")} ?s ?p ?o }";
+        String exp = "SELECT * WHERE { VALUES ?p {(<http://example.org/prop_A>) (UNDEF) (<http://example.org/prop_B>)} VALUES ?o {(\"obj_A\") (\"obj_B\")} ?s ?p ?o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+
         Assert.assertEquals(exp, res);
     }
 
@@ -2164,8 +2183,7 @@ public class TestParameterizedSparqlString {
 
         String exp = "SELECT * WHERE { VALUES (?p ?o) {(<http://example.org/prop_A> \"obj_A\") (<http://example.org/prop_B> \"obj_B\")} ?s ?p ?o }";
         String res = pss.toString();
-        //System.out.println("Exp: " + exp);
-        //System.out.println("Res: " + res);
+
         Assert.assertEquals(exp, res);
     }
 
@@ -2188,8 +2206,6 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{"o"};
 
-        //System.out.println("Exp: " + String.join(",", exp));
-        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2201,8 +2217,6 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{"p", "o"};
 
-        ///System.out.println("Exp: " + String.join(",", exp));
-        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2214,8 +2228,6 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{"o"};
 
-        //System.out.println("Exp: " + String.join(",", exp));
-        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2227,8 +2239,6 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
-        //System.out.println("Exp: " + String.join(",", exp));
-        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2240,8 +2250,6 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
-        //System.out.println("Exp: " + String.join(",", exp));
-        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2253,8 +2261,6 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
-        //System.out.println("Exp: " + String.join(",", exp));
-        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2266,8 +2272,6 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
-        //System.out.println("Exp: " + String.join(",", exp));
-        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2279,8 +2283,6 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
-        //System.out.println("Exp: " + String.join(",", exp));
-        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
 
@@ -2292,9 +2294,6 @@ public class TestParameterizedSparqlString {
         String[] res = ParameterizedSparqlString.extractTargetVars(cmd, valueName);
         String[] exp = new String[]{};
 
-        //System.out.println("Exp: " + String.join(",", exp));
-        //System.out.println("Res: " + String.join(",", res));
         Assert.assertArrayEquals(exp, res);
     }
-
 }


### PR DESCRIPTION
This commit adds the ability for `ParameterizedSparqlString` to support injecting the `UNDEF` keyword into `VALUES` clauses as needed.  A new `undef()` method is added to the class that provides access to a special instance level constant `RDFNode` that is used to indicate that the caller wants to inject `UNDEF`.

Under the hood this is just a wrapper around a `Node` constant but due to the `setValues()`/`setRowValues()` part of the API working in `RDFNode`'s rather than `Node`'s went with this approach.  I considered refactoring further to allow that part of the API to take `Node` and `RDFNode` interchangeably **but** given the limitations of Java type erasure generics (several of the methods in that part of the API use `Collection<? extends RDFNode>` and similar) that would effectively introduce a breaking API change so probably best done for a major release in a separate PR.

GitHub issue resolved #3268 

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
