### PR TITLE
Escaped surrogates

### DIFF
--- a/jena-arq/Grammar/Turtle/turtle.jj
+++ b/jena-arq/Grammar/Turtle/turtle.jj
@@ -108,10 +108,10 @@ String VersionSpecificer() : {  Token t; String verStr; }
 //   | t = <STRING_LITERAL_LONG2> { verStr = stripQuotes3(t.image) ; }
   )
     {
-      checkString(verStr, t.beginLine, t.beginColumn) ;
-      verStr = unescapeStr(verStr,  t.beginLine, t.beginColumn) ;
+      verStr = unescapeStr(verStr, t.beginLine, t.beginColumn) ;
+      checkRDFString(verStr, t.beginLine, t.beginColumn) ;
       return verStr ;
-    }  
+    } 
 }
 
 void DirectiveOld() : { Token t ; Token t2 ; String iri ; String verStr ; }
@@ -302,7 +302,6 @@ String String() : { Token t ; String lex ; }
   | t = <STRING_LITERAL_LONG2> { lex = stripQuotes3(t.image) ; }
   )
     {
-      checkString(lex, t.beginLine, t.beginColumn) ;
       lex = unescapeStr(lex,  t.beginLine, t.beginColumn) ;
       return lex ;
     }

--- a/jena-arq/Grammar/arq.jj
+++ b/jena-arq/Grammar/arq.jj
@@ -93,8 +93,8 @@ String VersionSpecifier() : { Token t ; String version ; }
     | t = <STRING_LITERAL2> { version = stripQuotes(t.image) ; }
     )
     {
-      checkString(version, t.beginLine, t.beginColumn) ;
       version = unescapeStr(version, t.beginLine, t.beginColumn) ;
+      checkRDFString(version, t.beginLine, t.beginColumn) ;
       return version;
     }
 }
@@ -1933,7 +1933,7 @@ String String() : { Token t ; String lex ; }
   | t = <STRING_LITERAL_LONG2> { lex = stripQuotes3(t.image) ; }
   )
     { lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
-      checkString(lex, t.beginLine, t.beginColumn) ;
+      checkRDFString(lex, t.beginLine, t.beginColumn) ;
       return lex ;
     }
 }

--- a/jena-arq/Grammar/main.jj
+++ b/jena-arq/Grammar/main.jj
@@ -188,8 +188,8 @@ String VersionSpecifier() : { Token t ; String version ; }
     | t = <STRING_LITERAL2> { version = stripQuotes(t.image) ; }
     )
     {
-      checkString(version, t.beginLine, t.beginColumn) ;
       version = unescapeStr(version,  t.beginLine, t.beginColumn) ;
+      checkRDFString(version,  t.beginLine, t.beginColumn) ;
       return version;
     }
 }
@@ -2631,7 +2631,7 @@ String String() : { Token t ; String lex ; }
   | t = <STRING_LITERAL_LONG2> { lex = stripQuotes3(t.image) ; }
   )
     { lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
-      checkString(lex, t.beginLine, t.beginColumn) ;
+      checkRDFString(lex,  t.beginLine, t.beginColumn) ;
       return lex ;
     }
 }

--- a/jena-arq/Grammar/sparql_12.jj
+++ b/jena-arq/Grammar/sparql_12.jj
@@ -83,8 +83,8 @@ String VersionSpecifier() : { Token t ; String version ; }
     | t = <STRING_LITERAL2> { version = stripQuotes(t.image) ; }
     )
     {
-      checkString(version, t.beginLine, t.beginColumn) ;
       version = unescapeStr(version, t.beginLine, t.beginColumn) ;
+      checkRDFString(version, t.beginLine, t.beginColumn) ;
       return version;
     }
 }
@@ -1646,7 +1646,7 @@ String String() : { Token t ; String lex ; }
   | t = <STRING_LITERAL_LONG2> { lex = stripQuotes3(t.image) ; }
   )
     { lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
-      checkString(lex, t.beginLine, t.beginColumn) ;
+      checkRDFString(lex, t.beginLine, t.beginColumn) ;
       return lex ;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/ParameterizedSparqlString.java
@@ -438,8 +438,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
      *            Node to append
      */
     public void appendNode(Node n) {
-        SerializationContext context = new SerializationContext(this.prefixes);
-        context.setBaseIRI(this.baseUri);
+        SerializationContext context = new SerializationContext(this.prefixes, this.baseUri);
         this.cmd.append(this.stringForNode(n, context));
     }
 
@@ -1393,8 +1392,7 @@ public class ParameterizedSparqlString implements PrefixMapping {
         Pattern p;
 
         // Go ahead and inject Variable Parameters
-        SerializationContext context = new SerializationContext(this.prefixes);
-        context.setBaseIRI(this.baseUri);
+        SerializationContext context = new SerializationContext(this.prefixes, this.baseUri);
         for (String var : this.params.keySet()) {
             Node n = this.params.get(var);
             if (n == null) {

--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/javacc/TurtleJavacc.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/extra/javacc/TurtleJavacc.java
@@ -151,8 +151,8 @@ verStr = stripQuotes(t.image) ;
       jj_consume_token(-1);
       throw new ParseException();
     }
-checkString(verStr, t.beginLine, t.beginColumn) ;
-      verStr = unescapeStr(verStr,  t.beginLine, t.beginColumn) ;
+verStr = unescapeStr(verStr, t.beginLine, t.beginColumn) ;
+      checkRDFString(verStr, t.beginLine, t.beginColumn) ;
       {if ("" != null) return verStr ;}
     throw new Error("Missing return statement in function");
 }
@@ -658,8 +658,7 @@ lex = stripQuotes3(t.image) ;
       jj_consume_token(-1);
       throw new ParseException();
     }
-checkString(lex, t.beginLine, t.beginColumn) ;
-      lex = unescapeStr(lex,  t.beginLine, t.beginColumn) ;
+lex = unescapeStr(lex,  t.beginLine, t.beginColumn) ;
       {if ("" != null) return lex ;}
     throw new Error("Missing return statement in function");
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/system/Prefixes.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/Prefixes.java
@@ -175,4 +175,8 @@ public class Prefixes {
         prefixMap.getMapping().forEach((p,u)->sj.add(format("  %-8s <%s>", p+":", u)));
         return sj.toString();
     }
+
+    public static PrefixMap emptyPrefixMap() {
+        return PrefixMapZero.empty;
+    }
 }

--- a/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizerTextBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/tokens/TokenizerTextBuilder.java
@@ -129,6 +129,6 @@ public class TokenizerTextBuilder {
             throw new IllegalStateException("No data source");
         }
 
-        return TokenizerText.internal(pr, singleLineMode, !utf8, errHandler);
+        return TokenizerText.internal(pr, singleLineMode, errHandler);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/Transformer.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/Transformer.java
@@ -18,16 +18,15 @@
 
 package org.apache.jena.sparql.algebra;
 
-import org.apache.jena.sparql.algebra.op.OpService ;
-import org.apache.jena.sparql.algebra.walker.ApplyTransformVisitor ;
-import org.apache.jena.sparql.algebra.walker.Walker ;
-import org.apache.jena.sparql.expr.ExprTransform ;
-import org.apache.jena.sparql.expr.ExprTransformCopy ;
+import org.apache.jena.sparql.algebra.op.OpService;
+import org.apache.jena.sparql.algebra.walker.ApplyTransformVisitor;
+import org.apache.jena.sparql.algebra.walker.Walker;
+import org.apache.jena.sparql.expr.ExprTransform;
+import org.apache.jena.sparql.expr.ExprTransformCopy;
 
 /** A bottom-top application of a transformation of SPARQL algebra */
 public class Transformer
 {
-
     private static Transformer singleton = new Transformer();
 
     /** Get the current transformer */
@@ -38,61 +37,61 @@ public class Transformer
 
     /** Transform an algebra expression */
     public static Op transform(Transform transform, Op op)
-    { return get().transformation(transform, op, null, null) ; }
+    { return get().transformation(transform, op, null, null); }
 
     /** Transform an algebra expression and the expressions */
     public static Op transform(Transform transform, ExprTransform exprTransform, Op op)
-    { return get().transformation(transform, exprTransform, op, null, null) ; }
+    { return get().transformation(transform, exprTransform, op, null, null); }
 
     /**
      * Transformation with specific Transform and default ExprTransform (apply transform
      * inside pattern expressions like NOT EXISTS)
      */
     public static Op transform(Transform transform, Op op, OpVisitor beforeVisitor, OpVisitor afterVisitor) {
-        return get().transformation(transform, op, beforeVisitor, afterVisitor) ;
+        return get().transformation(transform, op, beforeVisitor, afterVisitor);
     }
 
     /** Transformation with specific Transform and ExprTransform applied */
     public static Op transform(Transform transform, ExprTransform exprTransform, Op op,
                                OpVisitor beforeVisitor, OpVisitor afterVisitor) {
-        return get().transformation(transform, exprTransform, op, beforeVisitor, afterVisitor) ;
+        return get().transformation(transform, exprTransform, op, beforeVisitor, afterVisitor);
     }
 
     /** Transform an algebra expression except skip (leave alone) any OpService nodes */
     public static Op transformSkipService(Transform transform, Op op) {
-        return transformSkipService(transform, null, op, null, null) ;
+        return transformSkipService(transform, null, op, null, null);
     }
 
     /** Transform an algebra expression except skip (leave alone) any OpService nodes */
     public static Op transformSkipService(Transform transform, ExprTransform exprTransform, Op op) {
-        return transformSkipService(transform, exprTransform, op, null, null) ;
+        return transformSkipService(transform, exprTransform, op, null, null);
     }
 
     /** Transform an algebra expression except skip (leave alone) any OpService nodes */
     public static Op transformSkipService(Transform opTransform, ExprTransform exprTransform, Op op,
                                           OpVisitor beforeVisitor, OpVisitor afterVisitor) {
         if ( opTransform == null )
-            opTransform = new TransformCopy() ;
+            opTransform = new TransformCopy();
         if ( exprTransform == null )
-            exprTransform = new ExprTransformCopy() ;
-        Transform transform2 = new TransformSkipService(opTransform) ;
-        transform2 = opTransform ;
-        ApplyTransformVisitor atv = new ApplyTransformVisitor(transform2, exprTransform, false, beforeVisitor, afterVisitor) ;
-        return Walker.transformSkipService(op, atv, beforeVisitor, afterVisitor) ;
+            exprTransform = new ExprTransformCopy();
+        Transform transform2 = new TransformSkipService(opTransform);
+        transform2 = opTransform;
+        ApplyTransformVisitor atv = new ApplyTransformVisitor(transform2, exprTransform, false, beforeVisitor, afterVisitor);
+        return Walker.transformSkipService(op, atv, beforeVisitor, afterVisitor);
     }
 
     // To allow subclassing this class, we use a singleton pattern
     // and these protected methods.
     protected Op transformation(Transform transform, Op op, OpVisitor beforeVisitor, OpVisitor afterVisitor) {
-        return transformation(transform, null, op, beforeVisitor, afterVisitor) ;
+        return transformation(transform, null, op, beforeVisitor, afterVisitor);
     }
 
     protected Op transformation(Transform transform, ExprTransform exprTransform, Op op, OpVisitor beforeVisitor, OpVisitor afterVisitor) {
-        return transformation$(transform, exprTransform, op, beforeVisitor, afterVisitor) ;
+        return transformation$(transform, exprTransform, op, beforeVisitor, afterVisitor);
     }
 
     private Op transformation$(Transform transform, ExprTransform exprTransform, Op op, OpVisitor beforeVisitor, OpVisitor afterVisitor) {
-        return Walker.transform(op, transform, exprTransform, beforeVisitor, afterVisitor) ;
+        return Walker.transform(op, transform, exprTransform, beforeVisitor, afterVisitor);
     }
 
     // --------------------------------
@@ -103,11 +102,11 @@ public class Transformer
     {
         public TransformSkipService(Transform transform)
         {
-            super(transform) ;
+            super(transform);
         }
 
         @Override
         public Op transform(OpService opService, Op subOp)
-        { return opService ; }
+        { return opService; }
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/javacc/ARQParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/arq/javacc/ARQParser.java
@@ -149,8 +149,8 @@ version = stripQuotes(t.image) ;
       jj_consume_token(-1);
       throw new ParseException();
     }
-checkString(version, t.beginLine, t.beginColumn) ;
-      version = unescapeStr(version, t.beginLine, t.beginColumn) ;
+version = unescapeStr(version, t.beginLine, t.beginColumn) ;
+      checkRDFString(version, t.beginLine, t.beginColumn) ;
       {if ("" != null) return version;}
     throw new Error("Missing return statement in function");
 }
@@ -7520,7 +7520,7 @@ lex = stripQuotes3(t.image) ;
       throw new ParseException();
     }
 lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
-      checkString(lex, t.beginLine, t.beginColumn) ;
+      checkRDFString(lex, t.beginLine, t.beginColumn) ;
       {if ("" != null) return lex ;}
     throw new Error("Missing return statement in function");
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/javacc/SPARQLParser12.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/lang/sparql_12/javacc/SPARQLParser12.java
@@ -128,8 +128,8 @@ version = stripQuotes(t.image) ;
       jj_consume_token(-1);
       throw new ParseException();
     }
-checkString(version, t.beginLine, t.beginColumn) ;
-      version = unescapeStr(version, t.beginLine, t.beginColumn) ;
+version = unescapeStr(version, t.beginLine, t.beginColumn) ;
+      checkRDFString(version, t.beginLine, t.beginColumn) ;
       {if ("" != null) return version;}
     throw new Error("Missing return statement in function");
 }
@@ -5889,7 +5889,7 @@ lex = stripQuotes3(t.image) ;
       throw new ParseException();
     }
 lex = unescapeStr(lex, t.beginLine, t.beginColumn) ;
-      checkString(lex, t.beginLine, t.beginColumn) ;
+      checkRDFString(lex, t.beginLine, t.beginColumn) ;
       {if ("" != null) return lex ;}
     throw new Error("Missing return statement in function");
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/request/UpdateWriterVisitor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/request/UpdateWriterVisitor.java
@@ -31,6 +31,7 @@ import org.apache.jena.sparql.serializer.SerializationContext ;
 import org.apache.jena.sparql.syntax.Element ;
 import org.apache.jena.sparql.system.SinkQuadBracedOutput;
 import org.apache.jena.sparql.util.FmtUtils ;
+import org.apache.jena.sparql.util.NodeToLabelMap;
 import org.apache.jena.sparql.util.NodeToLabelMapBNode ;
 
 public class UpdateWriterVisitor implements UpdateVisitor {
@@ -249,9 +250,9 @@ public class UpdateWriterVisitor implements UpdateVisitor {
     }
 
     protected FormatterElement prepareElementFormatter() {
-        SerializationContext sCxt1 = new SerializationContext(sCxt);
         // The label prefix is different to the template writer just for clarity.
-        sCxt1.setBNodeMap(new NodeToLabelMapBNode("x", false));
+        NodeToLabelMap map2 = new NodeToLabelMapBNode("x", false);
+        SerializationContext sCxt1 = new SerializationContext(sCxt, map2);
         return new FormatterElement(out, sCxt1);
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/serializer/FmtExprSPARQL.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/serializer/FmtExprSPARQL.java
@@ -58,7 +58,7 @@ public class FmtExprSPARQL {
         SerializationContext context;
 
         public FmtExprARQVisitor(IndentedWriter writer, PrefixMapping pmap) {
-            this(writer, new SerializationContext(pmap, null));
+            this(writer, new SerializationContext(pmap));
         }
 
         public FmtExprARQVisitor(IndentedWriter writer, SerializationContext cxt) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/serializer/SerializationContext.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/serializer/SerializationContext.java
@@ -18,140 +18,116 @@
 
 package org.apache.jena.sparql.serializer;
 
-import org.apache.jena.shared.PrefixMapping ;
-import org.apache.jena.sparql.core.Prologue ;
-import org.apache.jena.sparql.util.NodeToLabelMap ;
+import org.apache.jena.shared.PrefixMapping;
+import org.apache.jena.sparql.core.Prologue;
+import org.apache.jena.sparql.util.NodeToLabelMap;
 
 /** Information needed to serialize things */
 
-public class SerializationContext
-{
-    // ?? Interface : WriterContext
-    
-    private Prologue prologue ;
-    private NodeToLabelMap bNodeMap ;
+public class SerializationContext {
+    private Prologue prologue;
+    private NodeToLabelMap bNodeMap;
     private boolean usePlainLiterals = true;
-    
-    public SerializationContext(SerializationContext cxt)
-    {
-        prologue = cxt.prologue ;
-        bNodeMap = cxt.bNodeMap ;
+
+    public SerializationContext(SerializationContext cxt) {
+        prologue = cxt.prologue;
+        bNodeMap = cxt.bNodeMap;
     }
 
-    public SerializationContext(Prologue prologue)
-    {
-        this(prologue, null) ;
-    }
-    
-    public SerializationContext(PrefixMapping prefixMap)
-    {
-        this(new Prologue(prefixMap)) ;
+    public SerializationContext(SerializationContext cxt, NodeToLabelMap bMap) {
+        prologue = cxt.prologue;
+        bNodeMap = bMap;
     }
 
-    public SerializationContext()
-    {
-        this((Prologue)null, null) ;
+    public SerializationContext(Prologue prologue) {
+        this(prologue, null);
     }
 
-    public SerializationContext(PrefixMapping prefixMap, NodeToLabelMap bMap)
-    {
-        this(new Prologue(prefixMap), bMap) ;
+    public SerializationContext(PrefixMapping prefixMap) {
+        this(new Prologue(prefixMap));
     }
-    
-    public SerializationContext(Prologue prologue, NodeToLabelMap bMap)
-    {
-        this.prologue = prologue ;
+
+    public SerializationContext(PrefixMapping prefixMap, String baseURI) {
+        this(new Prologue(prefixMap));
+        this.setBaseIRI(baseURI);
+    }
+
+
+    public SerializationContext() {
+        this((Prologue)null, null);
+    }
+
+    public SerializationContext(PrefixMapping prefixMap, NodeToLabelMap bMap) {
+        this(new Prologue(prefixMap), bMap);
+    }
+
+    public SerializationContext(Prologue prologue, NodeToLabelMap bMap) {
+        this.prologue = prologue;
         if ( this.prologue == null )
-            this.prologue = new Prologue() ;
-        
-        bNodeMap = bMap ;
+            this.prologue = new Prologue();
+
+        bNodeMap = bMap;
         if ( bMap == null )
-            bNodeMap = new NodeToLabelMap("b", false) ;
+            bNodeMap = new NodeToLabelMap("b", false);
     }
-    
-    public SerializationContext(boolean usePlainLiterals)
-    {
-    	this((Prologue)null, null, usePlainLiterals);
+
+    public SerializationContext(boolean usePlainLiterals) {
+        this((Prologue)null, null, usePlainLiterals);
     }
-    
-    public SerializationContext(PrefixMapping prefixMap, boolean usePlainLiterals)
-    {
-    	this(new Prologue(prefixMap), null);
-    	this.usePlainLiterals = usePlainLiterals;
+
+    public SerializationContext(PrefixMapping prefixMap, boolean usePlainLiterals) {
+        this(new Prologue(prefixMap), null);
+        this.usePlainLiterals = usePlainLiterals;
     }
-    
-    public SerializationContext(PrefixMapping prefixMap, NodeToLabelMap bMap, boolean usePlainLiterals)
-    {
-    	this(new Prologue(prefixMap), bMap);
-    	this.usePlainLiterals = usePlainLiterals;
+
+    public SerializationContext(PrefixMapping prefixMap, NodeToLabelMap bMap, boolean usePlainLiterals) {
+        this(new Prologue(prefixMap), bMap);
+        this.usePlainLiterals = usePlainLiterals;
     }
-    
-    public SerializationContext(Prologue prologue, boolean usePlainLiterals)
-    {
-    	this(prologue, null, usePlainLiterals);
+
+    public SerializationContext(Prologue prologue, boolean usePlainLiterals) {
+        this(prologue, null, usePlainLiterals);
     }
-    
-    public SerializationContext(Prologue prologue, NodeToLabelMap bMap, boolean usePlainLiterals)
-    {
-    	this(prologue, bMap);
-    	this.usePlainLiterals = usePlainLiterals;
+
+    public SerializationContext(Prologue prologue, NodeToLabelMap bMap, boolean usePlainLiterals) {
+        this(prologue, bMap);
+        this.usePlainLiterals = usePlainLiterals;
     }
-    
-    /**
-     * @return Returns the bNodeMap.
-     */
-    public NodeToLabelMap getBNodeMap()
-    {
+
+    public NodeToLabelMap getBNodeMap() {
         return bNodeMap;
     }
-    
-    /**
-     * @param nodeMap The bNodeMap to set.
-     */
-    public void setBNodeMap(NodeToLabelMap nodeMap)
-    {
-        bNodeMap = nodeMap;
-    }
-    
-    /**
-     * @return Returns the prefixMap.
-     */
-    public PrefixMapping getPrefixMapping()
-    {
+
+    public PrefixMapping getPrefixMapping() {
         return prologue.getPrefixMapping();
     }
-    
-    /**
-     * @param prefixMap The prefixMap to set.
-     */
-    public void setPrefixMapping(PrefixMapping prefixMap)
-    {
-        prologue.setPrefixMapping(prefixMap) ;
-    }
-    
-    /** @param baseIRI Set the base IRI */
-    public void setBaseIRI(String baseIRI) { prologue.setBaseURI(baseIRI) ; }
-    
-    public String getBaseIRI() { return prologue.getBaseURI() ; }
 
-    public Prologue getPrologue()
-    {
-        return prologue ;
+    /** @param baseIRI Set the base IRI */
+    private void setBaseIRI(String baseIRI) {
+        prologue.setBaseURI(baseIRI);
     }
-    
-    /**
-     * Gets whether Plain Literal forms should be used for appropriate typed literals (booleans, integers, decimals and doubles)
-     */
-    public boolean getUsePlainLiterals()
-    {
-    	return usePlainLiterals;
+
+    public String getBaseIRI() {
+        return prologue.getBaseURI();
     }
-    
+
+    public Prologue getPrologue() {
+        return prologue;
+    }
+
     /**
-     * Sets whether Plain Literal forms should be used for appropriate typed literals (booleans, integers, decimals and doubles)
+     * Gets whether Plain Literal forms should be used for appropriate typed literals
+     * (booleans, integers, decimals and doubles)
      */
-    public void setUsePlainLiterals(boolean usePlainLiterals)
-    {
-    	this.usePlainLiterals = usePlainLiterals;
+    public boolean getUsePlainLiterals() {
+        return usePlainLiterals;
+    }
+
+    /**
+     * Sets whether Plain Literal forms should be used for appropriate typed literals
+     * (booleans, integers, decimals and doubles)
+     */
+    public void setUsePlainLiterals(boolean usePlainLiterals) {
+        this.usePlainLiterals = usePlainLiterals;
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/riot/ParseForTest.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/riot/ParseForTest.java
@@ -25,13 +25,37 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.jena.riot.*;
 import org.apache.jena.riot.system.*;
 
+/**
+ * Manage parsers used for tests, separate from the overall system setup.
+ */
 public class ParseForTest {
 
     public static void parse(StreamRDF destination, String uri, Lang lang, boolean ignoreWarnings) {
         parse(destination, uri, uri, lang, ignoreWarnings);
     }
 
-    public static Map<Lang, ReaderRIOTFactory> alternativeReaderFactories = new ConcurrentHashMap<>();
+    /**
+     * Map of {@link Lang} to {@link ReaderRIOTFactory} that is consulted before
+     * defaulting to the standard system parser.
+     */
+    private static Map<Lang, ReaderRIOTFactory> alternativeReaderFactories = new ConcurrentHashMap<>();
+
+    /**
+     * Add an alternative language implementation to
+     * {@link #alternativeReaderFactories} map. This map of {@link Lang} to
+     * {@link ReaderRIOTFactory} is consulted before defaulting to the standard
+     * system parser.
+     */
+    public static void registerAlternative(Lang lang, ReaderRIOTFactory factory) {
+        alternativeReaderFactories.put(lang, factory);
+    }
+
+    /**
+     * Remove an registration of an alternative for {@link Lang}.
+     */
+    public static void unregisterAlternative(Lang lang) {
+        alternativeReaderFactories.remove(lang);
+    }
 
     public static void parse(StreamRDF destination, String uri, String base, Lang lang, boolean ignoreWarnings) {
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/Scripts_AltTurtle.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/Scripts_AltTurtle.java
@@ -38,7 +38,7 @@ import org.junit.runner.RunWith ;
 
     // rdf-tests CG
     "testing/rdf-tests-cg/turtle/manifest.ttl"
-    
+
     // [rdf-star CG] RDF star CG tests. No longer valid
 //    "testing/rdf-star-cg/turtle/syntax/manifest.ttl",
 //    "testing/rdf-star-cg/turtle/eval/manifest.ttl"
@@ -52,11 +52,11 @@ public class Scripts_AltTurtle
         JenaSystem.init();
         // Register language and parser factory.
         TurtleJCC.register();
-        ParseForTest.alternativeReaderFactories.put(Lang.TURTLE, TurtleJCC.factory);
+        ParseForTest.registerAlternative(Lang.TURTLE, TurtleJCC.factory);
     }
 
     @AfterClass public static void afterClass() {
-        ParseForTest.alternativeReaderFactories.remove(Lang.TURTLE);
+        ParseForTest.unregisterAlternative(Lang.TURTLE);
     }
 }
 

--- a/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTurtle.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/lang/TestLangTurtle.java
@@ -18,33 +18,33 @@
 
 package org.apache.jena.riot.lang;
 
-import static org.apache.jena.riot.system.ErrorHandlerFactory.errorHandlerNoLogging ;
-import static org.apache.jena.riot.system.ErrorHandlerFactory.getDefaultErrorHandler ;
-import static org.apache.jena.riot.system.ErrorHandlerFactory.setDefaultErrorHandler ;
+import static org.apache.jena.riot.system.ErrorHandlerFactory.errorHandlerNoLogging;
+import static org.apache.jena.riot.system.ErrorHandlerFactory.getDefaultErrorHandler;
+import static org.apache.jena.riot.system.ErrorHandlerFactory.setDefaultErrorHandler;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.StringReader ;
+import java.io.StringReader;
 
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
-import org.apache.jena.graph.Graph ;
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.rdf.model.Model ;
-import org.apache.jena.rdf.model.ModelFactory ;
-import org.apache.jena.rdf.model.Property ;
-import org.apache.jena.rdf.model.Resource ;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.ErrorHandlerTestLib.ExError;
-import org.apache.jena.riot.ErrorHandlerTestLib.ExFatal ;
-import org.apache.jena.riot.ErrorHandlerTestLib.ExWarning ;
-import org.apache.jena.riot.Lang ;
-import org.apache.jena.riot.RDFDataMgr ;
-import org.apache.jena.riot.RDFLanguages ;
-import org.apache.jena.riot.system.ErrorHandler ;
-import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.riot.ErrorHandlerTestLib.ExFatal;
+import org.apache.jena.riot.ErrorHandlerTestLib.ExWarning;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.riot.system.ErrorHandler;
+import org.apache.jena.sparql.sse.SSE;
 
 public class TestLangTurtle
 {
@@ -140,63 +140,63 @@ public class TestLangTurtle
     }
 
     @Test
-    public void triple()                { parse("<s> <p> <o> .") ; }
+    public void triple()                { parse("<s> <p> <o> ."); }
 
     @Test(expected=ExFatal.class)
-    public void errorJunk_1()           { parse("<p>") ; }
+    public void errorJunk_1()           { parse("<p>"); }
 
     @Test(expected=ExFatal.class)
-    public void errorJunk_2()           { parse("<r> <p>") ; }
+    public void errorJunk_2()           { parse("<r> <p>"); }
 
     @Test(expected=ExFatal.class)
-    public void errorNoPrefixDef()      { parse("x:p <p> 'q' .") ; }
+    public void errorNoPrefixDef()      { parse("x:p <p> 'q' ."); }
 
     @Test(expected=ExFatal.class)
-    public void errorNoPrefixDefDT()    { parse("<p> <p> 'q'^^x:foo .") ; }
+    public void errorNoPrefixDefDT()    { parse("<p> <p> 'q'^^x:foo ."); }
 
     @Test(expected=ExFatal.class)
-    public void errorBadDatatype()      { parse("<p> <p> 'q'^^.") ; }
+    public void errorBadDatatype()      { parse("<p> <p> 'q'^^."); }
 
     @Test(expected=ExError.class)
-    public void errorBadURI_1()         { parse("<http://example/a b> <http://example/p> 123 .") ; }
+    public void errorBadURI_1()         { parse("<http://example/a b> <http://example/p> 123 ."); }
 
     @Test(expected=ExWarning.class)
     // Passes tokenization but fails IRI parsing.
-    public void errorBadURI_2()         { parse("<http://example/a%XAb> <http://example/p> 123 .") ; }
+    public void errorBadURI_2()         { parse("<http://example/a%XAb> <http://example/p> 123 ."); }
 
     // Bad URIs
     @Test (expected=ExError.class)
-    public void errorBadURI_3()         { parse("@prefix ex:  <bad iri> .  ex:s ex:p 123 ") ; }
+    public void errorBadURI_3()         { parse("@prefix ex:  <bad iri> .  ex:s ex:p 123 "); }
 
     @Test (expected=ExError.class)
-    public void errorBadURI_4()         { parse("<x> <p> 'number'^^<bad uri> ") ; }
+    public void errorBadURI_4()         { parse("<x> <p> 'number'^^<bad uri> "); }
 
     // Structural errors.
     @Test (expected=ExFatal.class)
-    public void errorBadList_1()        { parse("<x> <p> (") ; }
+    public void errorBadList_1()        { parse("<x> <p> ("); }
 
     @Test (expected=ExFatal.class)
-    public void errorBadList_2()        { parse("<x> <p> ( <z>") ; }
+    public void errorBadList_2()        { parse("<x> <p> ( <z>"); }
 
     @Test
     public void turtle_01() {
-        Triple t = parseOneTriple("<s> <p> 123 . ") ;
-        Triple t2 = SSE.parseTriple("(<http://base/s> <http://base/p> 123)") ;
-        assertEquals(t2, t) ;
+        Triple t = parseOneTriple("<s> <p> 123 . ");
+        Triple t2 = SSE.parseTriple("(<http://base/s> <http://base/p> 123)");
+        assertEquals(t2, t);
     }
 
     @Test
     public void turtle_02() {
-        Triple t = parseOneTriple("@base <http://example/> . <s> <p> 123 . ") ;
-        Triple t2 = SSE.parseTriple("(<http://example/s> <http://example/p> 123)") ;
-        assertEquals(t2, t) ;
+        Triple t = parseOneTriple("@base <http://example/> . <s> <p> 123 . ");
+        Triple t2 = SSE.parseTriple("(<http://example/s> <http://example/p> 123)");
+        assertEquals(t2, t);
     }
 
     @Test
     public void turtle_03() {
-        Triple t = parseOneTriple("@prefix ex: <http://example/x/> . ex:s ex:p 123 . ") ;
-        Triple t2 = SSE.parseTriple("(<http://example/x/s> <http://example/x/p> 123)") ;
-        assertEquals(t2, t) ;
+        Triple t = parseOneTriple("@prefix ex: <http://example/x/> . ex:s ex:p 123 . ");
+        Triple t2 = SSE.parseTriple("(<http://example/x/s> <http://example/x/p> 123)");
+        assertEquals(t2, t);
     }
 
     // RDF 1.2 (some basic testing)
@@ -205,13 +205,13 @@ public class TestLangTurtle
 
     @Test
     public void turtle_rdf12_01() {
-        Graph graph = parse(PREFIXES, "<< :s :p 123 >> . ") ;
+        Graph graph = parse(PREFIXES, "<< :s :p 123 >> . ");
         assertEquals(1, graph.size());
     }
 
     @Test
     public void turtle_rdf12_02() {
-        Graph graph = parse(PREFIXES, "<< :s :p 123 >> :q 'abc' ") ;
+        Graph graph = parse(PREFIXES, "<< :s :p 123 >> :q 'abc' ");
         assertEquals(2, graph.size());
     }
 
@@ -235,42 +235,105 @@ public class TestLangTurtle
 
     @Test
     public void turtle_rdf12_11() {
-        Triple t = parseOneTriple("VERSION \"1.2\" <x:s> <x:p> 123 . ") ;
+        parseOneTriple("VERSION \"1.2\" <x:s> <x:p> 123 . ");
     }
 
     @Test
     public void turtle_rdf12_12() {
-        Triple t = parseOneTriple("VERSION '1.2' <x:s> <x:p> 123 . ") ;
+        parseOneTriple("VERSION '1.2' <x:s> <x:p> 123 . ");
     }
 
     @Test
     public void turtle_rdf12_13() {
-        Triple t = parseOneTriple("@version '1.2' . <x:s> <x:p> 123 . ") ;
+        parseOneTriple("@version '1.2' . <x:s> <x:p> 123 . ");
     }
 
     public void turtle_rdf12_14() {
-        Triple t = parseOneTriple("@version \"1.2\" . <x:s> <x:p> 123 . ") ;
+        parseOneTriple("@version \"1.2\" . <x:s> <x:p> 123 . ");
     }
 
     @Test (expected=ExFatal.class)
     public void turtle_rdf12_bad_11() {
-        Triple t = parseOneTriple("VERSION '1.2' . <x:s> <x:p> 123 . ") ;
+        parseOneTriple("VERSION '1.2' . <x:s> <x:p> 123 . ");
     }
 
     @Test (expected=ExFatal.class)
     public void turtle_rdf12_bad_12() {
-        Triple t = parseOneTriple("VERSION '''1.2''' <x:s> <x:p> 123 . ") ;
+        parseOneTriple("VERSION '''1.2''' <x:s> <x:p> 123 . ");
     }
 
     @Test (expected=ExFatal.class)
     public void turtle_rdf12_bad_13() {
-        Triple t = parseOneTriple("@version \"\"\"1.2\"\"\" <x:s> <x:p> 123 . ") ;
+        parseOneTriple("@version \"\"\"1.2\"\"\" <x:s> <x:p> 123 . ");
+    }
+
+    // U+D800-U+DBFF is a high surrogate (first part of a pair)
+    // U+DC00-U+DFFF is a low surrogate (second part of a pair)
+    // so D800-DC00 is legal.
+
+    @Test public void turtle_surrogate_1() {
+        // escaped high, escaped low
+        parseOneTriple("<x:s> <x:p> '\\ud800\\udc00' . ");
+    }
+
+    @Test public void turtle_surrogate_2() {
+        // escaped high, raw low
+        parseOneTriple("<x:s> <x:p> '\\ud800\udc00' . ");
+    }
+
+    // Compilation failure. (maven+openjdk - OK in Eclipse, and test correct)
+//    @Test public void turtle_surrogate_3() {
+//        // raw high, escaped low
+//        parseOneTriple("<x:s> <x:p> '\ud800\\udc00' . ");
+//    }
+
+    @Test public void turtle_surrogate_4() {
+        // raw high, raw low
+        parseOneTriple("<x:s> <x:p> '\ud800\udc00' . ");
+    }
+
+    @Test (expected=ExFatal.class)
+    public void turtle_bad_surrogate_1() {
+        parseOneTriple("<x:s> <x:p> '\\ud800' . ");
+    }
+
+    @Test (expected=ExFatal.class)
+    public void turtle_bad_surrogate_2() {
+        parseOneTriple("<x:s> <x:p> '\\udfff' . ");
+    }
+    @Test (expected=ExFatal.class)
+    public void turtle_bad_surrogate_3() {
+        parseOneTriple("<x:s> <x:p> '\\U0000d800' . ");
+    }
+
+    @Test (expected=ExFatal.class)
+    public void turtle_bad_surrogate_4() {
+        parseOneTriple("<x:s> <x:p> '\\U0000dfff' . ");
+    }
+
+    @Test (expected=ExFatal.class)
+    public void turtle_bad_surrogate_5() {
+        // Wrong way round: low-high
+        parseOneTriple("<x:s> <x:p> '\\uc800\\ud800' . ");
+    }
+
+    // Compilation failure. Can't write \ud800
+//    @Test (expected=ExFatal.class)
+//    public void turtle_bad_surrogate_6() {
+//        // raw low - escaped high
+//        parseOneTriple("<x:s> <x:p> '\ud800\\ud800' . ");
+//    }
+
+    @Test (expected=ExFatal.class)
+    public void turtle_bad_surrogate_7() {
+        // escaped low - raw high
+        parseOneTriple("<x:s> <x:p> '\\uc800\ud800' . ");
     }
 
     // No Formulae. Not trig.
     @Test (expected=ExFatal.class)
-    public void turtle_50()     { parse("@prefix ex:  <http://example/> .  { ex:s ex:p 123 . } ") ; }
+    public void turtle_50()     { parse("@prefix ex:  <http://example/> .  { ex:s ex:p 123 . } "); }
 
     @Test (expected=ExWarning.class)
-    public void turtle_60()     { parse("@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> . <x> <p> 'number'^^xsd:byte }") ; }
+    public void turtle_60()     { parse("@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> . <x> <p> 'number'^^xsd:byte }"); }
 }

--- a/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizerText.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizerText.java
@@ -1356,46 +1356,140 @@ public class TestTokenizerText {
     // U+DC00-U+DFFF is a low surrogate (second part of a pair)
     // so D800-DC00 is legal.
 
-    @Test public void turtle_surrogate_pair_01() {
+    @Test public void turtle_surrogate_pair_esc_esc_01() {
         // escaped high, escaped low
         surrogate("'\\ud800\\udc00'");
     }
 
-    @Test public void turtle_surrogate_pair_02() {
+    @Test public void turtle_surrogate_pair_esc_esc_02() {
+        // escaped high, escaped low
+        surrogate("'''\\ud800\\udc00'''");
+    }
+
+    @Test public void turtle_surrogate_pair_esc_esc_03() {
+        // escaped high, escaped low
+        surrogate("<\\ud800\\udc00>");
+    }
+
+    @Test public void turtle_surrogate_pair_esc_raw_01() {
         // escaped high, raw low
         surrogate("'\\ud800\udc00'");
     }
 
+    @Test public void turtle_surrogate_pair_esc_raw_02() {
+        // escaped high, raw low
+        surrogate("'''\\ud800\udc00'''");
+    }
+    @Test public void turtle_surrogate_pair_esc_raw_03() {
+        // escaped high, raw low
+        surrogate("<\\ud800\udc00>");
+    }
+    @Test public void turtle_surrogate_pair_esc_raw_04() {
+        // escaped high, raw low
+        surrogate("_:b\ud800\udc00");
+    }
+
     // Compilation failure - illegal escape character
-//    @Test public void turtle_surrogate_pair_03() {
+//    @Test public void turtle_surrogate_pair_raw_esc_01() {
 //        // raw high, escaped low
 //        surrogate("'\ud800\\udc00'");
 //    }
 
-    @Test public void turtle_surrogate_pair_04() {
+    @Test public void turtle_surrogate_pair_raw_raw_01() {
         // raw high, raw low
         surrogate("'\ud800\udc00'");
     }
 
-    @Test public void turtle_surrogate_pair_05() {
+    @Test public void turtle_surrogate_pair_raw_raw_02() {
+        // raw high, raw low
+        surrogate("'''\ud800\udc00'''");
+    }
+
+    @Test public void turtle_surrogate_pair_raw_raw_03() {
+        // raw high, raw low
+        surrogate("<\ud800\udc00>");
+    }
+
+    // Blank nodes label allow unicode but not unicode escapes.
+    @Test public void turtle_surrogate_pair_raw_raw_04() {
+        // raw high, raw low
+        surrogate("_:b\ud800\udc00");
+    }
+
+    @Test public void turtle_surrogate_pair_raw_raw_05() {
+        // escaped high, escaped low
+        surrogate("ns:\ud800\udc00");
+    }
+
+    @Test public void turtle_surrogate_pair_raw_raw_06() {
+        // escaped high, escaped low
+        surrogate("\ud800\udc00:local");
+    }
+
+    @Test public void turtle_surrogate_pair_esc_esc_internal_01() {
         // escaped high, escaped low
         surrogate("'a\\ud800\\udc00x'");
     }
 
-    @Test public void turtle_surrogate_pair_06() {
+    @Test public void turtle_surrogate_pair_esc_esc_internal_02() {
+        // escaped high, escaped low
+        surrogate("'''a\\ud800\\udc00x'''");
+    }
+
+    @Test public void turtle_surrogate_pair_esc_esc_internal_03() {
+        // escaped high, escaped low
+        surrogate("<a\\ud800\\udc00x>");
+    }
+
+    @Test public void turtle_surrogate_pair_esc_raw_internal_01() {
         // escaped high, raw low
-        surrogate("'z\\ud800\udc00'z");
+        surrogate("'z\\ud800\udc00z'");
+    }
+
+    @Test public void turtle_surrogate_pair_esc_raw_internal_02() {
+        // escaped high, raw low
+        surrogate("'''z\\ud800\udc00z'''");
+    }
+
+    @Test public void turtle_surrogate_pair_esc_raw_internal_03() {
+        // escaped high, raw low
+        surrogate("<z\\ud800\udc00z>");
     }
 
     // Compilation failure - illegal escape character
-//    @Test public void turtle_surrogate_pair_07() {
+//    @Test public void turtle_surrogate_pair_raw_esc() {
 //        // raw high, escaped low
 //        surrogate("'a\ud800\\udc00'z");
 //    }
 
-    @Test public void turtle_surrogate_pair_08() {
+    @Test public void turtle_surrogate_pair_raw_raw_internal_01() {
         // raw high, raw low
-        surrogate("'a\ud800\udc00'z");
+        surrogate("'a\ud800\udc00z'");
+    }
+
+    @Test public void turtle_surrogate_pair_raw_raw_internal_02() {
+        // raw high, raw low
+        surrogate("'''a\ud800\udc00z'''");
+    }
+
+    @Test public void turtle_surrogate_pair_raw_raw_internal_03() {
+        // raw high, raw low
+        surrogate("<a\ud800\udc00z>");
+    }
+
+    @Test public void turtle_surrogate_pair_raw_raw_internal_04() {
+        // raw high, raw low
+        surrogate("_:ba\ud800\udc00z");
+    }
+
+    @Test public void turtle_surrogate_pair_raw_raw__internal05() {
+        // escaped high, escaped low
+        surrogate("ns:x\ud800\udc00y");
+    }
+
+    @Test public void turtle_surrogate_pair_raw_raw__internal06() {
+        // escaped high, escaped low
+        surrogate("x\ud800\udc00y:local");
     }
 
     @Test (expected=RiotParseException.class)
@@ -1404,8 +1498,23 @@ public class TestTokenizerText {
     }
 
     @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_01a() {
+        surrogate("'''\\ud800''''");
+    }
+
+    @Test (expected=RiotParseException.class)
     public void turtle_bad_surrogate_02() {
         surrogate("'a\\ud800z'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_02a() {
+        surrogate("'''a\\ud800z'''");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_02b() {
+        surrogate("<a\\ud800z>");
     }
 
     @Test (expected=RiotParseException.class)
@@ -1477,8 +1586,9 @@ public class TestTokenizerText {
 
     private void surrogate(String string) {
         Tokenizer tokenizer = tokenizer(string);
-        tokenizer.hasNext();
+        assertTrue(tokenizer.hasNext());
         tokenizer.next();
+        assertFalse(tokenizer.hasNext());
     }
 
     @Test

--- a/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizerText.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/tokens/TestTokenizerText.java
@@ -1352,6 +1352,135 @@ public class TestTokenizerText {
         assertFalse(tokenizer.hasNext());
     }
 
+    // U+D800-U+DBFF is a high surrogate (first part of a pair)
+    // U+DC00-U+DFFF is a low surrogate (second part of a pair)
+    // so D800-DC00 is legal.
+
+    @Test public void turtle_surrogate_pair_01() {
+        // escaped high, escaped low
+        surrogate("'\\ud800\\udc00'");
+    }
+
+    @Test public void turtle_surrogate_pair_02() {
+        // escaped high, raw low
+        surrogate("'\\ud800\udc00'");
+    }
+
+    // Compilation failure - illegal escape character
+//    @Test public void turtle_surrogate_pair_03() {
+//        // raw high, escaped low
+//        surrogate("'\ud800\\udc00'");
+//    }
+
+    @Test public void turtle_surrogate_pair_04() {
+        // raw high, raw low
+        surrogate("'\ud800\udc00'");
+    }
+
+    @Test public void turtle_surrogate_pair_05() {
+        // escaped high, escaped low
+        surrogate("'a\\ud800\\udc00x'");
+    }
+
+    @Test public void turtle_surrogate_pair_06() {
+        // escaped high, raw low
+        surrogate("'z\\ud800\udc00'z");
+    }
+
+    // Compilation failure - illegal escape character
+//    @Test public void turtle_surrogate_pair_07() {
+//        // raw high, escaped low
+//        surrogate("'a\ud800\\udc00'z");
+//    }
+
+    @Test public void turtle_surrogate_pair_08() {
+        // raw high, raw low
+        surrogate("'a\ud800\udc00'z");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_01() {
+        surrogate("'\\ud800'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_02() {
+        surrogate("'a\\ud800z'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_03() {
+        surrogate("'\\udfff'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_04() {
+        surrogate("'a\\udfffz'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_05() {
+        surrogate("'\\U0000d800'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_06() {
+        surrogate("'a\\U0000d800z'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_07() {
+        surrogate("'\\U0000dfff'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_08() {
+        surrogate("'a\\U0000dfffz'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_09() {
+        // Wrong way round: low-high
+        surrogate("'\\uc800\\ud800'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_10() {
+        // Wrong way round: low-high
+        surrogate("'a\\uc800\\ud800z'");
+    }
+
+    // Compilation failure - illegal escape character
+//    @Test (expected=RiotParseException.class)
+//    public void turtle_bad_surrogate_11() {
+//        // raw low - escaped high
+//        surrogate("'\ud800\\ud800'");
+//    }
+//
+//    @Test (expected=RiotParseException.class)
+//    public void turtle_bad_surrogate_12() {
+//        // raw low - escaped high
+//        surrogate("'a\ud800\\ud800z'");
+//    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_13() {
+        // escaped low - raw high
+        surrogate("'\\uc800\ud800'");
+    }
+
+    @Test (expected=RiotParseException.class)
+    public void turtle_bad_surrogate_14() {
+        // escaped low - raw high
+        surrogate("'a\\uc800\ud800z'");
+    }
+
+    private void surrogate(String string) {
+        Tokenizer tokenizer = tokenizer(string);
+        tokenizer.hasNext();
+        tokenizer.next();
+    }
+
     @Test
     public void token_rdf_star_reified_1() {
         Tokenizer tokenizer = tokenizer("<<");

--- a/jena-arq/src/test/java/org/apache/jena/sparql/syntax/TestQueryParser.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/syntax/TestQueryParser.java
@@ -70,7 +70,7 @@ public class TestQueryParser {
 
     @Test
     public void syntax_unicode_surrogate_pair_by_unicode_escape() {
-        // Allow - because Java strings may have surrogate pairs so we allow then in unicode escapes if paired.
+        // Allow - because Java strings may have surrogate pairs so we allow them in unicode escapes if paired.
         testParse("SELECT * { ?s ?p '\\uD801\\uDC37'}");
 
 //        QueryParseException ex = assertThrows(QueryParseException.class,  ()->testParse("SELECT * { ?s ?p '\\uD801\\uDC37'}"));

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/CharStream.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/CharStream.java
@@ -21,7 +21,6 @@ package org.apache.jena.atlas.io;
 
 /**
  * A simplified reader interface without IOExceptions.
- * It's an interface, not an abstract class
  */
 public interface CharStream
 {

--- a/jena-base/src/main/java/org/apache/jena/atlas/io/PeekReader.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/io/PeekReader.java
@@ -34,11 +34,8 @@ import org.apache.jena.atlas.lib.Chars;
 public final class PeekReader extends Reader {
     // Remember to apply fixes to PeekInputStream as well.
 
-    // Buffering is done by a CharStream - does it make difference?
-    // Yes. A lot (Java6).
-
-    // Using a Reader here seems to have zero cost or benefit but CharStream
-    // allows fast String handling.
+    // Buffering is done by a CharStream - it makes a difference
+    // CharStream faster than a Reader.
     private final CharStream source;
 
     private static final int PUSHBACK_SIZE = 10;

--- a/jena-core/src/main/java/org/apache/jena/mem2/iterator/SparseArrayIndexedIterator.java
+++ b/jena-core/src/main/java/org/apache/jena/mem2/iterator/SparseArrayIndexedIterator.java
@@ -36,7 +36,7 @@ import java.util.function.Consumer;
  *
  * @param <E> the type of the array elements
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("all")
 public class SparseArrayIndexedIterator<E> extends NiceIterator<FastHashSet.IndexedKey<E>> implements Iterator<FastHashSet.IndexedKey<E>> {
 
     private final E[] entries;

--- a/jena-core/src/main/java/org/apache/jena/mem2/spliterator/SparseArrayIndexedSpliterator.java
+++ b/jena-core/src/main/java/org/apache/jena/mem2/spliterator/SparseArrayIndexedSpliterator.java
@@ -38,7 +38,7 @@ import java.util.function.Consumer;
  *
  * @param <E> the type of the array elements
  */
-@SuppressWarnings("javadoc")
+@SuppressWarnings("all")
 public class SparseArrayIndexedSpliterator<E> implements Spliterator<FastHashSet.IndexedKey<E>> {
 
     private final E[] entries;

--- a/jena-fuseki2/jena-fuseki-mod-geosparql/src/test/resources/log4j2-test.properties
+++ b/jena-fuseki2/jena-fuseki-mod-geosparql/src/test/resources/log4j2-test.properties
@@ -32,6 +32,9 @@ logger.fuseki-fuseki.level = ERROR
 logger.fuseki-autoload.name  = org.apache.jena.fuseki.main.sys.FusekiAutoModules
 logger.fuseki-autoload.level = ERROR
 
+logger.geosparql-spatial-index.name  = org.apache.jena.geosparql.spatial.index
+logger.geosparql-spatial-index.level = WARN
+
 logger.http.name  = org.apache.jena.http
 logger.http.level = INFO
 

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/SpatialIndexLib.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/SpatialIndexLib.java
@@ -274,7 +274,7 @@ public class SpatialIndexLib {
                 // If NOT in replace mode, add all graph-indexes from the previous index
                 if (isEffectiveUpdate) {
                     // Copy the old index into a new one.
-                    SpatialIndexPerGraph oldIndex = (SpatialIndexPerGraph)rawOldIndex;
+                    SpatialIndexPerGraph oldIndex = rawOldIndex;
                     if (oldIndex != null) {
                         Map<Node, STRtree> oldTreeMap = oldIndex.getIndex().getTreeMap();
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelControls.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelControls.java
@@ -131,7 +131,6 @@ public enum OntModelControls {
      * {@link OntClass.Named#addDisjointUnion(OntClass...) OntClass.Named#addDisjointUnion(OntClass...)},
      * will throw {@link OntJenaException.Unsupported OntJenaException.Unsupported} exception.
      */
-    @SuppressWarnings("javadoc")
     USE_OWL2_NAMED_CLASS_DISJOINT_UNION_FEATURE,
     /**
      * Controls {@link OWL2#disjointWith owl:disjointWith} functionality.

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntObjectPersonalityBuilder.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntObjectPersonalityBuilder.java
@@ -127,7 +127,6 @@ public class OntObjectPersonalityBuilder {
      * @param factory {@link EnhNodeFactory} the factory to produce the instances of the {@code type}
      * @return this builder
      */
-    @SuppressWarnings("javadoc")
     public OntObjectPersonalityBuilder add(Class<? extends OntObject> type, EnhNodeFactory factory) {
         return add(type, config -> factory);
     }
@@ -148,7 +147,6 @@ public class OntObjectPersonalityBuilder {
      * @param factory {@code Function}, providing {@link EnhNodeFactory} by the {@link OntConfig}
      * @return this builder
      */
-    @SuppressWarnings("javadoc")
     public OntObjectPersonalityBuilder add(Class<? extends OntObject> type, Function<OntConfig, EnhNodeFactory> factory) {
         extFactories.put(type, factory);
         return this;

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/UnionGraphImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/UnionGraphImpl.java
@@ -119,7 +119,6 @@ public class UnionGraphImpl extends CompositionBase implements UnionGraph {
      * @param eventManager {@link UnionGraph.EventManager} or {@code null} to use default fresh event manager
      * @param distinct     if {@code true} a distinct graph is created
      */
-    @SuppressWarnings("javadoc")
     public UnionGraphImpl(Graph base, EventManager eventManager, boolean distinct) {
         this(base, new SubGraphs(), eventManager, distinct);
     }

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntClassImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntClassImpl.java
@@ -1634,7 +1634,6 @@ public abstract class OntClassImpl extends OntObjectImpl implements OntClass {
     /**
      * Base for all {@link Restriction} impls.
      */
-    @SuppressWarnings("javadoc")
     public static class RestrictionImpl extends OntClassImpl implements Restriction {
 
         public RestrictionImpl(Node n, EnhGraph m) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntDisjointImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntDisjointImpl.java
@@ -69,7 +69,6 @@ public abstract class OntDisjointImpl<O extends OntObject> extends OntObjectImpl
      * @return {@link Individuals}
      * @see <a href="https://www.w3.org/TR/owl2-quick-reference/#Additional_Vocabulary_in_OWL_2_RDF_Syntax">4.2 Additional Vocabulary in OWL 2 RDF Syntax</a>
      */
-    @SuppressWarnings("javadoc")
     public static Individuals createDifferentIndividuals(OntGraphModelImpl model, Stream<OntIndividual> individuals) {
         Property membersPredicate = OntGraphModelImpl.configValue(model, OntModelControls.USE_OWL1_DISTINCT_MEMBERS_PREDICATE_FEATURE) ?
                 OWL2.distinctMembers :

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntIndividualImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntIndividualImpl.java
@@ -267,7 +267,6 @@ public abstract class OntIndividualImpl extends OntObjectImpl implements OntIndi
      * <p>
      * for notations see <a href="https://www.w3.org/TR/owl2-quick-reference/">OWL2 Quick Refs</a>
      */
-    @SuppressWarnings("javadoc")
     public static class AnonymousImpl extends OntIndividualImpl implements Anonymous {
 
         public AnonymousImpl(Node n, EnhGraph m) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntObjectImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntObjectImpl.java
@@ -260,7 +260,6 @@ public class OntObjectImpl extends ResourceImpl implements OntObject {
      * that an {@code OntObject} can be also a {@code Literal}
      * (but in only single case when it is {@link OntSWRL.DArg}).
      */
-    @SuppressWarnings("javadoc")
     @Override
     public <X extends RDFNode> X getAs(Class<X> type) {
         return getNodeAs(this, type);

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntSimpleClassImpl.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/objects/OntSimpleClassImpl.java
@@ -245,7 +245,6 @@ public class OntSimpleClassImpl extends OntObjectImpl implements OntClass {
      * In jena OWL1, class expressions, such as {@link OntClass.ComplementOf}
      * can also be named.
      */
-    @SuppressWarnings("javadoc")
     public static class NamedImpl extends OntSimpleClassImpl implements OntClass.Named {
 
         public NamedImpl(Node n, EnhGraph eg) {

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntClass.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntClass.java
@@ -235,7 +235,6 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
      * @return {@link OntList} of {@link OntRelationalProperty}s
      * @see #addHasKey(Collection, Collection)
      */
-    @SuppressWarnings("javadoc")
     OntList<OntRelationalProperty> createHasKey(Collection<OntObjectProperty> objectProperties,
                                                 Collection<OntDataProperty> dataProperties);
 
@@ -1027,7 +1026,6 @@ public interface OntClass extends OntObject, AsNamed<OntClass.Named>, HasDisjoin
          * @see #addDisjointUnionOfStatement(OntClass...)
          * @see #removeDisjointUnion(Resource)
          */
-        @SuppressWarnings("javadoc")
         OntList<OntClass> createDisjointUnion(Collection<OntClass> classes);
 
         /**

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntEntity.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntEntity.java
@@ -98,7 +98,6 @@ public interface OntEntity extends OntObject {
      * @see OWL2
      * @see OntPersonality.Builtins
      */
-    @SuppressWarnings("javadoc")
     boolean isBuiltIn();
 
 }

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntList.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntList.java
@@ -61,7 +61,6 @@ import java.util.stream.Stream;
  * @param <E> the type of {@link RDFNode rdf-node}s in this list
  * @see RDFNodeList
  */
-@SuppressWarnings("javadoc")
 public interface OntList<E extends RDFNode> extends RDFNodeList<E>, OntResource {
 
     /**

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntModel.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntModel.java
@@ -236,7 +236,6 @@ public interface OntModel extends Model,
      * @return {@link OntEntity} or {@code null}
      * @see #fetchOntEntity(Class, String)
      */
-    @SuppressWarnings("javadoc")
     <E extends OntEntity> E getOntEntity(Class<E> type, String uri);
 
     /**

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntObjectProperty.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/model/OntObjectProperty.java
@@ -105,7 +105,6 @@ public interface OntObjectProperty extends OntRelationalProperty, AsNamed<OntObj
      * @see #propertyChains()
      * @see #findPropertyChain(RDFNode)
      */
-    @SuppressWarnings("javadoc")
     OntList<OntObjectProperty> createPropertyChain(Collection<OntObjectProperty> properties);
 
     /**

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/utils/OntModels.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/utils/OntModels.java
@@ -94,7 +94,6 @@ public class OntModels {
      * @return {@link OntIndividual.Anonymous}
      * @throws OntJenaException if the node cannot be present as anonymous individual
      */
-    @SuppressWarnings("javadoc")
     public static OntIndividual.Anonymous asAnonymousIndividual(RDFNode inModel) {
         return OntIndividualImpl.createAnonymousIndividual(inModel);
     }

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntPropertyTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntPropertyTest.java
@@ -50,7 +50,6 @@ import static org.apache.jena.ontapi.TestModelFactory.NS;
  * {@link OntRelationalProperty},
  * {@link OntAnnotationProperty}.
  */
-@SuppressWarnings("javadoc")
 public class OntPropertyTest {
 
     @Test

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/TestOntPersonalities.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/TestOntPersonalities.java
@@ -28,7 +28,6 @@ import org.apache.jena.ontapi.model.OntDataProperty;
 import org.apache.jena.ontapi.model.OntDataRange;
 import org.apache.jena.ontapi.model.OntObjectProperty;
 
-@SuppressWarnings("javadoc")
 class TestOntPersonalities {
     /**
      * OWL2 Personality, that has default settings and does not care about the owl-entities "punnings"

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/nodetable/TestNodec.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/nodetable/TestNodec.java
@@ -80,12 +80,8 @@ public class TestNodec
     @Test public void nodec_lit_22()    { test ("''^^<>"); }
 
     // Bad Unicode.
-    static private final String binaryStr1  = "abc\uD800xyz";    // A single surrogate, without it's pair.
-    static private final String binaryStr2  = "\uD800";          // A single surrogate, without it's pair.
-    static private final String binaryStr3  = "\u0000";          // A zero character
+    static private final String binaryStr3  = "\u0000";                 // A zero character
 
-    @Test public void nodec_lit_30()    { test ("'"+binaryStr1+"'"); }
-    @Test public void nodec_lit_31()    { test ("'"+binaryStr2+"'"); }
     @Test public void nodec_lit_32()    { test ("'"+binaryStr3+"'"); }
 
     @Test public void nodec_lit_33()    { test("'\uFFFD'"); }


### PR DESCRIPTION
GitHub issue resolved #3281
and a few clean-ups.

This implements the simpler separate check of RDF string in `TokenizerText`, not the more complicated check described in #3281.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
