### PR TITLE
Fix for E_Function.equals() and hashCode() to also consider the functionIRI

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Function.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Function.java
@@ -31,6 +31,7 @@ import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.FmtUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 /** SPARQL filter function */
 public class E_Function extends ExprFunctionN
@@ -123,5 +124,16 @@ public class E_Function extends ExprFunctionN
     @Override
     public Expr copy(ExprList newArgs) {
         return new E_Function(getFunctionIRI(), newArgs) ;
+    }
+
+    @Override
+    public boolean equals(Expr other, boolean bySyntax) {
+        return super.equals(other, bySyntax) &&
+            Objects.equals(getFunctionIRI(), ((E_Function)other).getFunctionIRI());
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() * Objects.hash(getFunctionIRI());
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExprLib.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExprLib.java
@@ -33,10 +33,10 @@ public class TestExprLib
     @Test public void safeEqualityNot_01()      { testSafeEquality("123", false) ;}
     @Test public void safeEqualityNot_02()      { testSafeEquality("?x != <y>", false) ;}
     @Test public void safeEqualityNot_03()      { testSafeEquality("<x> = <y>", false) ;}
-    
+
     @Test public void safeSameTerm_01()         { testSafeEquality("sameTerm(?x, <x>)", true) ;}
     @Test public void safeSameTerm_02()         { testSafeEquality("sameTerm(<x>, ?x)", true) ;}
-    
+
     @Test public void safeSameTerm_03()         { testSafeEquality("sameTerm(?x, 'xyz')", false, true, true) ;}
     @Test public void safeSameTerm_04()         { testSafeEquality("sameTerm(?x, 'xyz')", true, false, false) ;}
 
@@ -51,10 +51,10 @@ public class TestExprLib
 
     @Test public void safeSameTerm_11()         { testSafeEquality("sameTerm(?x, 'foo'^^<http://example>)", true, false, false) ;}
     @Test public void safeSameTerm_12()         { testSafeEquality("sameTerm(?x, 'foo'^^<http://example>)", true, true, true) ;}
-    
+
     @Test public void safeEquality_01()         { testSafeEquality("?x = <x>", true) ;}
     @Test public void safeEquality_02()         { testSafeEquality("<x> = ?x", true) ;}
-    
+
     @Test public void safeEquality_03()         { testSafeEquality("?x = 'xyz'", true, true, true) ;}
     @Test public void safeEquality_04()         { testSafeEquality("?x = 'xyz'", false, false, true) ;}
 
@@ -69,17 +69,24 @@ public class TestExprLib
 
     @Test public void safeEquality_11()         { testSafeEquality("?x = 'foo'^^<http://example>", true, false, false) ;}
     @Test public void safeEquality_12()         { testSafeEquality("?x = 'foo'^^<http://example>", true, true, true) ;}
-    
+
     private static void testSafeEquality(String string, boolean b)
     {
         Expr expr = ExprUtils.parse(string) ;
         Assert.assertEquals(string, b, ExprLib.isAssignmentSafeEquality(expr)) ;
     }
-    
+
     private static void testSafeEquality(String string, boolean b, boolean graphString, boolean graphNumber)
     {
         Expr expr = ExprUtils.parse(string) ;
         Assert.assertEquals(string, b, ExprLib.isAssignmentSafeEquality(expr, graphString, graphNumber)) ;
     }
 
+    /** E_Functions with different function IRIs must not be equals. */
+    @Test
+    public void test_E_Function_equals() {
+        Expr a = ExprUtils.parse("<http://www.opengis.net/def/function/geosparql/sfIntersects>(?a, ?b)");
+        Expr b = ExprUtils.parse("<http://www.opengis.net/def/function/geosparql/sfContains>(?a, ?b)");
+        Assert.assertNotEquals(a, b);
+    }
 }


### PR DESCRIPTION
Pull request Description: E_Function instances compared to equals regardless of their functionIRI field. This causes caching issues such as with the service enhancer, where the same cache hit is produced for queries that should actually be different.

In our case, two queries that differed only by the geosparql filter functions geof:sfIntersects and geof:sfContains were incorrectly considered to be equal.

----
 - [x] Tests are included.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
