### PR TITLE
GH-3310: protect against zero array split

### DIFF
--- a/jena-iri3986/src/main/java/org/apache/jena/rfc3986/AlgResolveIRI.java
+++ b/jena-iri3986/src/main/java/org/apache/jena/rfc3986/AlgResolveIRI.java
@@ -189,9 +189,14 @@ public class AlgResolveIRI {
             return "";
         if ( path.equals("/") )
             return "/";
+        // String.split -- "Trailing empty strings are not included in the results."
         String[] segments = path.split("/");
-
         int N = segments.length;
+        if ( N == 0 ) {
+            // If the path is two or more "/" and nothing else, then no segments.
+            return path;
+        }
+
         boolean initialSlash = segments[0].isEmpty();
         boolean trailingSlash = false;
         // Trailing slash if it isn't the initial "/" and it ends in "/" or "/." or "/.."

--- a/jena-iri3986/src/main/java/org/apache/jena/rfc3986/ParseURN.java
+++ b/jena-iri3986/src/main/java/org/apache/jena/rfc3986/ParseURN.java
@@ -215,7 +215,6 @@ public class ParseURN {
             handler.accept(Issue.urn_bad_nid, "No namespace id");
             return -1;
         }
-
         if ( ch == ':' ) {
             handler.accept(Issue.urn_bad_nid, "Missing namespace id");
             return -1;

--- a/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestNormalize.java
+++ b/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestNormalize.java
@@ -40,6 +40,11 @@ public class TestNormalize {
     @Test public void normalize_14() { testNormalize("http://host/foobar?q=s%74", "http://host/foobar?q=st"); }
     @Test public void normalize_15() { testNormalize("http://host/foobar#%7E", "http://host/foobar#~"); }
 
+    @Test public void normalize_21() { testNormalize("http://host/foobar///", "http://host/foobar/"); }
+    @Test public void normalize_22() { testNormalize("http://host//", "http://host//"); }
+    @Test public void normalize_23() { testNormalize("http://host//..", "http://host/"); }
+    @Test public void normalize_24() { testNormalize("http://host/abc//..", "http://host/abc/"); }
+
     private void testNormalize(String input, String expected) {
         IRI3986 iri = RFC3986.create(input);
         IRI3986 iri2 = iri.normalize();


### PR DESCRIPTION
GitHub issue resolved #3310

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
