### PR TITLE
GH-3336: Don't override the omnifaces version

### DIFF
--- a/jena-fuseki2/jena-fuseki-webapp/pom.xml
+++ b/jena-fuseki2/jena-fuseki-webapp/pom.xml
@@ -89,18 +89,6 @@
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-jakarta-ee</artifactId>
       <classifier>jakarta</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.omnifaces</groupId>
-          <artifactId>omnifaces</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- Include omnifaces -->
-    <dependency>
-      <groupId>org.omnifaces</groupId>
-      <artifactId>omnifaces</artifactId>
-      <version>${ver.omnifaces}</version>
     </dependency>
 
     <!-- frontend assets (HTML, JS, CSS, images, etc.) -->

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
          See jena-fuseki-webapp and https://shiro.apache.org/jakarta-ee.html
     -->
     <ver.shiro>2.0.5</ver.shiro>
-    <ver.omnifaces>4.6.5</ver.omnifaces>
 
     <ver.protobuf>4.31.1</ver.protobuf>
     <ver.libthrift>0.22.0</ver.libthrift>


### PR DESCRIPTION
GitHub issue resolved #3336

There does not seem to be a need to override the omnifaces version anymore.

Apach Shiro 2.0.0 depends 3.x.x and 4.x.x does not work.


----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
