### PR TITLE
Revert "Bump @fortawesome/vue-fontawesome from 3.0.8 to 3.1.0 in /jena-fuseki2/jena-fuseki-ui"

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/yarn.lock
+++ b/jena-fuseki2/jena-fuseki-ui/yarn.lock
@@ -1166,9 +1166,9 @@
     "@fortawesome/fontawesome-common-types" "7.0.0"
 
 "@fortawesome/vue-fontawesome@^3.0.3":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.1.0.tgz#e20f931c83c9d27d84adf23dcb3ffd7a62e6599b"
-  integrity sha512-0YW5ZJ68p90R2T5UHaoojBbh7S33SXUb584yKcBgdq+zs2or3OtLQzCEhozDFhYHcg2UF+ah3GZa5Xp4xaU7/A==
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.8.tgz#1e8032df151173d8174ac9f5a28da3c0f5a495e4"
+  integrity sha512-yyHHAj4G8pQIDfaIsMvQpwKMboIZtcHTUvPqXjOHyldh1O1vZfH4W03VDPv5RvI9P6DLTzJQlmVgj9wCf7c2Fw==
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
   version "9.3.0"


### PR DESCRIPTION
Reverts apache/jena#3339

This PR breaks the Fuseki UI directly under e.g. http://localhost:3030 which then only shows a blank page with the following error in the console.
I used the Fuseki bundle built under `jena-fuseki2/apache-jena-fuseki/target/apache-jena-fuseki-5.6.0-SNAPSHOT.tar.gz`.

I removed the node_modules prior to the build with `rm -rf ./jena-fuseki2/jena-fuseki-ui/node_modules`.

<img width="354" height="156" alt="image" src="https://github.com/user-attachments/assets/c79f18fd-cec7-44ba-b920-0c29b8c5fc05" />

<img width="909" height="169" alt="image" src="https://github.com/user-attachments/assets/15a299e8-6aca-41a6-a00b-e0fe03023d92" />
