### PR TITLE
GH-3322: [jena-ontapi] add assemblers

### DIFF
--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelFactory.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntModelFactory.java
@@ -342,7 +342,7 @@ public class OntModelFactory {
                 OntModelFactory::createUnionGraph,
                 n -> createOntGraph(n, repository),
                 /*ignoreUnresolvedImports*/ true);
-        if (!ontUnionGraphRepository.contains(name)) {
+        if (!ontUnionGraphRepository.hasGraph(name)) {
             return null;
         }
         UnionGraph union = ontUnionGraphRepository.get(name);

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntSpecification.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/OntSpecification.java
@@ -57,78 +57,6 @@ import java.util.Objects;
 @SuppressWarnings("ClassCanBeRecord")
 public class OntSpecification {
 
-    private static final OntPersonality OWL2_FULL_PERSONALITY =
-            OntPersonalities.OWL2_ONT_PERSONALITY()
-                    .setBuiltins(OntPersonalities.OWL2_FULL_BUILTINS)
-                    .setReserved(OntPersonalities.OWL2_RESERVED)
-                    .setPunnings(OntPersonalities.OWL_NO_PUNNINGS)
-                    .setConfig(OntConfigs.OWL2_CONFIG)
-                    .build();
-
-    private static final OntPersonality OWL2_DL_PERSONALITY =
-            OntPersonalities.OWL2_ONT_PERSONALITY()
-                    .setBuiltins(OntPersonalities.OWL2_FULL_BUILTINS)
-                    .setReserved(OntPersonalities.OWL2_RESERVED)
-                    .setPunnings(OntPersonalities.OWL_DL2_PUNNINGS)
-                    .setConfig(OntConfigs.OWL2_CONFIG)
-                    .build();
-
-    private static final OntPersonality OWL2_EL_PERSONALITY =
-            OntPersonalities.OWL2_EL_ONT_PERSONALITY()
-                    .setBuiltins(OntPersonalities.OWL2_EL_BUILTINS)
-                    .setReserved(OntPersonalities.OWL2_RESERVED)
-                    .setPunnings(OntPersonalities.OWL_DL2_PUNNINGS)
-                    .setConfig(OntConfigs.OWL2_EL_CONFIG)
-                    .build();
-
-    private static final OntPersonality OWL2_QL_PERSONALITY =
-            OntPersonalities.OWL2_QL_ONT_PERSONALITY()
-                    .setBuiltins(OntPersonalities.OWL2_QL_BUILTINS)
-                    .setReserved(OntPersonalities.OWL2_RESERVED)
-                    .setPunnings(OntPersonalities.OWL_DL2_PUNNINGS)
-                    .setConfig(OntConfigs.OWL2_QL_CONFIG)
-                    .build();
-
-    private static final OntPersonality OWL2_RL_PERSONALITY =
-            OntPersonalities.OWL2_RL_ONT_PERSONALITY()
-                    .setBuiltins(OntPersonalities.OWL2_RL_BUILTINS)
-                    .setReserved(OntPersonalities.OWL2_RESERVED)
-                    .setPunnings(OntPersonalities.OWL_DL2_PUNNINGS)
-                    .setConfig(OntConfigs.OWL2_RL_CONFIG)
-                    .build();
-
-    private static final OntPersonality OWL1_DL_PERSONALITY =
-            OntPersonalities.OWL1_ONT_PERSONALITY()
-                    .setBuiltins(OntPersonalities.OWL1_FULL_BUILTINS)
-                    .setReserved(OntPersonalities.OWL1_RESERVED)
-                    .setPunnings(OntPersonalities.OWL_DL1_PUNNINGS)
-                    .setConfig(OntConfigs.OWL1_CONFIG)
-                    .build();
-
-    private static final OntPersonality OWL1_FULL_PERSONALITY =
-            OntPersonalities.OWL1_ONT_PERSONALITY()
-                    .setBuiltins(OntPersonalities.OWL1_FULL_BUILTINS)
-                    .setReserved(OntPersonalities.OWL1_RESERVED)
-                    .setPunnings(OntPersonalities.OWL_NO_PUNNINGS)
-                    .setConfig(OntConfigs.OWL1_CONFIG)
-                    .build();
-
-    private static final OntPersonality OWL1_LITE_PERSONALITY =
-            OntPersonalities.OWL1_LITE_ONT_PERSONALITY()
-                    .setBuiltins(OntPersonalities.OWL1_LITE_BUILTINS)
-                    .setReserved(OntPersonalities.OWL1_RESERVED)
-                    .setPunnings(OntPersonalities.OWL_DL1_PUNNINGS)
-                    .setConfig(OntConfigs.OWL1_LITE_CONFIG)
-                    .build();
-
-    private static final OntPersonality RDFS_PERSONALITY =
-            OntPersonalities.RDFS_ONT_PERSONALITY()
-                    .setBuiltins(OntPersonalities.RDFS_BUILTINS)
-                    .setReserved(OntPersonalities.RDFS_RESERVED)
-                    .setPunnings(OntPersonalities.OWL_NO_PUNNINGS)
-                    .setConfig(OntConfigs.RDFS_CONFIG)
-                    .build();
-
     /*
      * *****************************************************************************************************************
      * OWL 2 DL
@@ -157,7 +85,7 @@ public class OntSpecification {
      * that are stored in memory and do no additional entailment reasoning.
      */
     public static final OntSpecification OWL2_DL_MEM = new OntSpecification(
-            OWL2_DL_PERSONALITY, null
+            OntPersonalities.OWL2_DL_PERSONALITY, null
     );
 
     /**
@@ -165,7 +93,7 @@ public class OntSpecification {
      * that are stored in memory and use the RDFS inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_DL_MEM_RDFS_INF = new OntSpecification(
-            OWL2_DL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_DL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -173,7 +101,7 @@ public class OntSpecification {
      * that are stored in memory and use the transitive inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_DL_MEM_TRANS_INF = new OntSpecification(
-            OWL2_DL_PERSONALITY, TransitiveReasonerFactory.theInstance()
+            OntPersonalities.OWL2_DL_PERSONALITY, TransitiveReasonerFactory.theInstance()
     );
 
     /**
@@ -181,7 +109,7 @@ public class OntSpecification {
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
      */
     public static final OntSpecification OWL2_DL_MEM_RULES_INF = new OntSpecification(
-            OWL2_DL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_DL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
     );
 
     /*
@@ -195,21 +123,21 @@ public class OntSpecification {
      * Full support for the OWL v2 specification.
      */
     public static final OntSpecification OWL2_FULL_MEM = new OntSpecification(
-            OWL2_FULL_PERSONALITY, null
+            OntPersonalities.OWL2_FULL_PERSONALITY, null
     );
 
     /**
      * A specification for OWL2 models that are stored in memory and use the RDFS inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_FULL_MEM_RDFS_INF = new OntSpecification(
-            OWL2_FULL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_FULL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
     );
 
     /**
      * A specification for OWL2 models that are stored in memory and use the transitive inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_FULL_MEM_TRANS_INF = new OntSpecification(
-            OWL2_FULL_PERSONALITY, TransitiveReasonerFactory.theInstance()
+            OntPersonalities.OWL2_FULL_PERSONALITY, TransitiveReasonerFactory.theInstance()
     );
 
     /**
@@ -217,7 +145,7 @@ public class OntSpecification {
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
      */
     public static final OntSpecification OWL2_FULL_MEM_RULES_INF = new OntSpecification(
-            OWL2_FULL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_FULL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -225,7 +153,7 @@ public class OntSpecification {
      * that are stored in memory and use the micro OWL rules inference engine for additional entailments.
      */
     public static final OntSpecification OWL2_FULL_MEM_MICRO_RULES_INF = new OntSpecification(
-            OWL2_FULL_PERSONALITY, OWLMicroReasonerFactory.theInstance()
+            OntPersonalities.OWL2_FULL_PERSONALITY, OWLMicroReasonerFactory.theInstance()
     );
 
     /**
@@ -233,7 +161,7 @@ public class OntSpecification {
      * that are stored in memory and use the mini OWL rules inference engine for additional entailments.
      */
     public static final OntSpecification OWL2_FULL_MEM_MINI_RULES_INF = new OntSpecification(
-            OWL2_FULL_PERSONALITY, OWLMiniReasonerFactory.theInstance()
+            OntPersonalities.OWL2_FULL_PERSONALITY, OWLMiniReasonerFactory.theInstance()
     );
 
     /*
@@ -246,7 +174,7 @@ public class OntSpecification {
      * A specification for OWL2 EL Ontology models that are stored in memory and do no additional entailment reasoning.
      */
     public static final OntSpecification OWL2_EL_MEM = new OntSpecification(
-            OWL2_EL_PERSONALITY, null
+            OntPersonalities.OWL2_EL_PERSONALITY, null
     );
 
     /**
@@ -254,7 +182,7 @@ public class OntSpecification {
      * and use the RDFS inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_EL_MEM_RDFS_INF = new OntSpecification(
-            OWL2_EL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_EL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -262,7 +190,7 @@ public class OntSpecification {
      * and use the transitive inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_EL_MEM_TRANS_INF = new OntSpecification(
-            OWL2_EL_PERSONALITY, TransitiveReasonerFactory.theInstance()
+            OntPersonalities.OWL2_EL_PERSONALITY, TransitiveReasonerFactory.theInstance()
     );
 
     /**
@@ -270,7 +198,7 @@ public class OntSpecification {
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
      */
     public static final OntSpecification OWL2_EL_MEM_RULES_INF = new OntSpecification(
-            OWL2_EL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_EL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
     );
 
     /*
@@ -283,7 +211,7 @@ public class OntSpecification {
      * A specification for OWL2 QL Ontology models that are stored in memory and do no additional entailment reasoning.
      */
     public static final OntSpecification OWL2_QL_MEM = new OntSpecification(
-            OWL2_QL_PERSONALITY, null
+            OntPersonalities.OWL2_QL_PERSONALITY, null
     );
 
     /**
@@ -291,7 +219,7 @@ public class OntSpecification {
      * and use the RDFS inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_QL_MEM_RDFS_INF = new OntSpecification(
-            OWL2_QL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_QL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -299,7 +227,7 @@ public class OntSpecification {
      * and use the transitive inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_QL_MEM_TRANS_INF = new OntSpecification(
-            OWL2_QL_PERSONALITY, TransitiveReasonerFactory.theInstance()
+            OntPersonalities.OWL2_QL_PERSONALITY, TransitiveReasonerFactory.theInstance()
     );
 
     /**
@@ -307,7 +235,7 @@ public class OntSpecification {
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
      */
     public static final OntSpecification OWL2_QL_MEM_RULES_INF = new OntSpecification(
-            OWL2_QL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_QL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
     );
 
     /*
@@ -320,7 +248,7 @@ public class OntSpecification {
      * A specification for OWL2 RL Ontology models that are stored in memory and do no additional entailment reasoning.
      */
     public static final OntSpecification OWL2_RL_MEM = new OntSpecification(
-            OWL2_RL_PERSONALITY, null
+            OntPersonalities.OWL2_RL_PERSONALITY, null
     );
 
     /**
@@ -328,7 +256,7 @@ public class OntSpecification {
      * and use the RDFS inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_RL_MEM_RDFS_INF = new OntSpecification(
-            OWL2_RL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_RL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -336,7 +264,7 @@ public class OntSpecification {
      * and use the transitive inferencer for additional entailments.
      */
     public static final OntSpecification OWL2_RL_MEM_TRANS_INF = new OntSpecification(
-            OWL2_RL_PERSONALITY, TransitiveReasonerFactory.theInstance()
+            OntPersonalities.OWL2_RL_PERSONALITY, TransitiveReasonerFactory.theInstance()
     );
 
     /**
@@ -344,7 +272,7 @@ public class OntSpecification {
      * that are stored in memory and use the OWL rules inference engine for additional entailments.
      */
     public static final OntSpecification OWL2_RL_MEM_RULES_INF = new OntSpecification(
-            OWL2_RL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL2_RL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
     );
 
     /*
@@ -359,7 +287,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL DL v1.1 specification.
      */
     public static final OntSpecification OWL1_DL_MEM = new OntSpecification(
-            OWL1_DL_PERSONALITY, null
+            OntPersonalities.OWL1_DL_PERSONALITY, null
     );
 
     /**
@@ -368,7 +296,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
      */
     public static final OntSpecification OWL1_DL_MEM_RDFS_INF = new OntSpecification(
-            OWL1_DL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL1_DL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -377,7 +305,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
      */
     public static final OntSpecification OWL1_DL_MEM_TRANS_INF = new OntSpecification(
-            OWL1_DL_PERSONALITY, TransitiveReasonerFactory.theInstance()
+            OntPersonalities.OWL1_DL_PERSONALITY, TransitiveReasonerFactory.theInstance()
     );
 
     /**
@@ -386,7 +314,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
      */
     public static final OntSpecification OWL1_DL_MEM_RULES_INF = new OntSpecification(
-            OWL1_DL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL1_DL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
     );
 
     /*
@@ -401,7 +329,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
      */
     public static final OntSpecification OWL1_FULL_MEM = new OntSpecification(
-            OWL1_FULL_PERSONALITY, null
+            OntPersonalities.OWL1_FULL_PERSONALITY, null
     );
 
     /**
@@ -410,7 +338,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
      */
     public static final OntSpecification OWL1_FULL_MEM_RDFS_INF = new OntSpecification(
-            OWL1_FULL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL1_FULL_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -419,7 +347,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
      */
     public static final OntSpecification OWL1_FULL_MEM_TRANS_INF = new OntSpecification(
-            OWL1_FULL_PERSONALITY, TransitiveReasonerFactory.theInstance()
+            OntPersonalities.OWL1_FULL_PERSONALITY, TransitiveReasonerFactory.theInstance()
     );
 
     /**
@@ -428,7 +356,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
      */
     public static final OntSpecification OWL1_FULL_MEM_RULES_INF = new OntSpecification(
-            OWL1_FULL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL1_FULL_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -437,7 +365,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
      */
     public static final OntSpecification OWL1_FULL_MEM_MICRO_RULES_INF = new OntSpecification(
-            OWL1_FULL_PERSONALITY, OWLMicroReasonerFactory.theInstance()
+            OntPersonalities.OWL1_FULL_PERSONALITY, OWLMicroReasonerFactory.theInstance()
     );
 
     /**
@@ -446,7 +374,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1.1 specification.
      */
     public static final OntSpecification OWL1_FULL_MEM_MINI_RULES_INF = new OntSpecification(
-            OWL1_FULL_PERSONALITY, OWLMiniReasonerFactory.theInstance()
+            OntPersonalities.OWL1_FULL_PERSONALITY, OWLMiniReasonerFactory.theInstance()
     );
 
     /*
@@ -461,7 +389,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1 Lite specification.
      */
     public static final OntSpecification OWL1_LITE_MEM = new OntSpecification(
-            OWL1_LITE_PERSONALITY, null
+            OntPersonalities.OWL1_LITE_PERSONALITY, null
     );
 
     /**
@@ -470,7 +398,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1 Lite specification.
      */
     public static final OntSpecification OWL1_LITE_MEM_RDFS_INF = new OntSpecification(
-            OWL1_LITE_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL1_LITE_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -479,7 +407,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1 Lite specification.
      */
     public static final OntSpecification OWL1_LITE_MEM_TRANS_INF = new OntSpecification(
-            OWL1_LITE_PERSONALITY, TransitiveReasonerFactory.theInstance()
+            OntPersonalities.OWL1_LITE_PERSONALITY, TransitiveReasonerFactory.theInstance()
     );
 
     /**
@@ -488,7 +416,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of OWL v1 Lite specification.
      */
     public static final OntSpecification OWL1_LITE_MEM_RULES_INF = new OntSpecification(
-            OWL1_LITE_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
+            OntPersonalities.OWL1_LITE_PERSONALITY, OWLFBRuleReasonerFactory.theInstance()
     );
 
     /*
@@ -502,7 +430,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of RDFS specification.
      */
     public static final OntSpecification RDFS_MEM = new OntSpecification(
-            RDFS_PERSONALITY, null
+            OntPersonalities.RDFS_PERSONALITY, null
     );
 
     /**
@@ -511,7 +439,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of RDFS specification.
      */
     public static final OntSpecification RDFS_MEM_RDFS_INF = new OntSpecification(
-            RDFS_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
+            OntPersonalities.RDFS_PERSONALITY, RDFSRuleReasonerFactory.theInstance()
     );
 
     /**
@@ -520,7 +448,7 @@ public class OntSpecification {
      * Supposed to be a replacement for the original legacy Jena interpretation of RDFS specification.
      */
     public static final OntSpecification RDFS_MEM_TRANS_INF = new OntSpecification(
-            RDFS_PERSONALITY, TransitiveReasonerFactory.theInstance()
+            OntPersonalities.RDFS_PERSONALITY, TransitiveReasonerFactory.theInstance()
     );
 
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/DocumentGraphRepositoryAssembler.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/DocumentGraphRepositoryAssembler.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.ontapi.assemblers;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.assembler.Mode;
+import org.apache.jena.assembler.assemblers.AssemblerBase;
+import org.apache.jena.ontapi.impl.repositories.DocumentGraphRepository;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+
+public class DocumentGraphRepositoryAssembler extends AssemblerBase {
+
+    /**
+     * example:
+     * <pre>{@code
+     * @prefix : <http://ex.com#> .
+     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+     *
+     * :repo a oa:DocumentGraphRepository ;
+     *      oa:graph :g1, :g2 .
+     *
+     * :g1 a oa:Graph ;
+     *      oa:graphIRI "vocab1" ;
+     *      oa:graphLocation "file:ontologies/vocab1.ttl" .
+     *
+     * :g2 a oa:Graph ;
+     *      oa:graphIRI "vocab2" ;
+     *      oa:graphLocation "file:ontologies/vocab2.ttl" .
+     * }</pre>
+     */
+    @Override
+    public Object open(Assembler a, Resource root, Mode mode) {
+        checkType(root, OA.DocumentGraphRepository);
+        DocumentGraphRepository repo = new DocumentGraphRepository();
+
+        Model model = root.getModel();
+
+        model.listStatements(root, OA.graph, (RDFNode) null)
+                .mapWith(stmt -> stmt.getObject().asResource())
+                .forEach(graph -> {
+                    String id = graph.getProperty(OA.graphIRI).getString();
+                    String location = graph.getProperty(OA.graphLocation).getString();
+                    repo.addMapping(id, location);
+                });
+
+        return repo;
+    }
+}

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OA.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OA.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.ontapi.assemblers;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+
+public class OA {
+    public static final String NS = "https://jena.apache.org/ontapi/Assembler#";
+
+    public static final Property graph = property("graph");
+    public static final Property graphIRI = property("graphIRI");
+    public static final Property graphLocation = property("graphLocation");
+    public static final Property specificationName = property("specificationName");
+    public static final Property personalityName = property("personalityName");
+    public static final Property schema = property("schema");
+    public static final Property reasonerURL = property("reasonerURL");
+    public static final Property reasonerClass = property("reasonerClass");
+    public static final Property reasonerFactory = property("reasonerFactory");
+    public static final Property rules = property("rules");
+    public static final Property rulesFrom = property("rulesFrom");
+    public static final Property rule = property("rule");
+    public static final Property ontModelSpec = property("ontModelSpec");
+    public static final Property baseModel = property("baseModel");
+    public static final Property importModels = property("importModels");
+    public static final Property documentGraphRepository = property("documentGraphRepository");
+
+    public static final Resource DocumentGraphRepository = resource("DocumentGraphRepository");
+    public static final Resource OntSpecification = resource("OntSpecification");
+    public static final Resource OntModel = resource("OntModel");
+    public static final Resource ReasonerFactory = resource("ReasonerFactory");
+    public static final Resource RuleSet = resource("RuleSet");
+
+    private static Resource resource(String localName) {
+        return ResourceFactory.createResource(NS + localName);
+    }
+
+    private static Property property(String localName) {
+        return ResourceFactory.createProperty(NS + localName);
+    }
+}

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntModelAssembler.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntModelAssembler.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.ontapi.assemblers;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.assembler.Mode;
+import org.apache.jena.assembler.assemblers.AssemblerBase;
+import org.apache.jena.ontapi.OntModelFactory;
+import org.apache.jena.ontapi.OntSpecification;
+import org.apache.jena.ontapi.impl.repositories.DocumentGraphRepository;
+import org.apache.jena.ontapi.model.OntModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+
+public class OntModelAssembler extends AssemblerBase {
+    /**
+     * examples:
+     * <pre>{@code
+     * @prefix : <http://ex.com#> .
+     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+     * @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+     *
+     * :spec a oa:OntSpecification ;
+     *      oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
+     *
+     * :base a ja:MemoryModel ;
+     *      ja:content [
+     *          ja:literalContent """
+     *              @prefix : <http://ex.com#> .
+     *              @prefix owl: <http://www.w3.org/2002/07/owl#> .
+     *              :C a owl:Class .
+     *          """ ;
+     *          ja:contentEncoding "TTL"
+     *      ] .
+     *
+     * :model a oa:OntModel ;
+     *      oa:ontModelSpec :spec ;
+     *      oa:baseModel :base .
+     * }</pre>
+     * <pre>{@code
+     * @prefix : <http://ex.com#> .
+     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+     * @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+     *
+     * :repo a oa:DocumentGraphRepository ;
+     *      oa:graph :g .
+     * :g a oa:Graph ;
+     *      oa:graphIRI "urn:food" ;
+     *      oa:graphLocation "file:wine.ttl" .
+     * :base a ja:MemoryModel ;
+     *      ja:externalContent <file:food.ttl> .
+     * :model a oa:OntModel ;
+     *      oa:baseModel :base ;
+     *      oa:documentGraphRepository :repo .
+     * }</pre>
+     */
+    @Override
+    public Object open(Assembler a, Resource root, Mode mode) {
+        checkType(root, OA.OntModel);
+        var baseModel = getBase(a, root, mode);
+        var specification = getOntModelSpec(a, root);
+        var graphRepository = getDocumentGraphRepositoryOrNull(a, root);
+        var res = graphRepository == null ?
+                OntModelFactory.createModel(baseModel.getGraph(), specification) :
+                OntModelFactory.createModel(baseModel.getGraph(), specification, graphRepository);
+        root.listProperties(OA.importModels)
+                .mapWith(Statement::getResource)
+                .mapWith(resource -> {
+                    checkType(resource, OA.OntModel);
+                    return (OntModel) a.open(resource);
+                })
+                .forEach(res::addImport);
+        return res;
+    }
+
+    private Model getBase(Assembler a, Resource root, Mode mode) {
+        var base = getUniqueResource(root, OA.baseModel);
+        return base == null ? ModelFactory.createDefaultModel() : a.openModel(base, mode);
+    }
+
+    private OntSpecification getOntModelSpec(Assembler a, Resource root) {
+        var r = getUniqueResource(root, OA.ontModelSpec);
+        return r == null ? OntSpecification.OWL2_DL_MEM_BUILTIN_RDFS_INF : (OntSpecification) a.open(r);
+    }
+
+    private DocumentGraphRepository getDocumentGraphRepositoryOrNull(Assembler a, Resource root) {
+        var r = getUniqueResource(root, OA.documentGraphRepository);
+        return r == null ? null : (DocumentGraphRepository) a.open(r);
+    }
+
+}

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntReasonerFactoryAssembler.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntReasonerFactoryAssembler.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.ontapi.assemblers;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.assembler.Mode;
+import org.apache.jena.assembler.assemblers.AssemblerBase;
+import org.apache.jena.assembler.exceptions.AssemblerException;
+import org.apache.jena.assembler.exceptions.CannotHaveRulesException;
+import org.apache.jena.assembler.exceptions.NotExpectedTypeException;
+import org.apache.jena.assembler.exceptions.UnknownReasonerException;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.GraphMemFactory;
+import org.apache.jena.graph.GraphUtil;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.reasoner.Reasoner;
+import org.apache.jena.reasoner.ReasonerFactory;
+import org.apache.jena.reasoner.ReasonerRegistry;
+import org.apache.jena.reasoner.rulesys.GenericRuleReasoner;
+import org.apache.jena.reasoner.rulesys.GenericRuleReasonerFactory;
+
+import java.util.ArrayList;
+
+/**
+ * Copy-paste of ReasonerFactoryAssembler due to conflict.
+ *
+ * @see org.apache.jena.assembler.assemblers.ReasonerFactoryAssembler
+ */
+public class OntReasonerFactoryAssembler extends AssemblerBase {
+
+    @Override
+    public Object open(Assembler a, Resource root, Mode irrelevant) {
+        checkType(root, OA.ReasonerFactory);
+        return addSchema(root, a, addRules(root, a, getReasonerFactory(root)));
+    }
+
+    private ReasonerFactory addSchema(Resource root, Assembler a, final ReasonerFactory rf) {
+        if (!root.hasProperty(OA.schema)) {
+            return rf;
+        }
+        var schema = loadSchema(root, a);
+        return new ReasonerFactory() {
+            @Override
+            public Reasoner create(Resource configuration) {
+                return rf.create(configuration).bindSchema(schema);
+            }
+
+            @Override
+            public Model getCapabilities() {
+                return rf.getCapabilities();
+            }
+
+            @Override
+            public String getURI() {
+                return rf.getURI();
+            }
+        };
+    }
+
+    private Graph loadSchema(Resource root, Assembler a) {
+        var result = GraphMemFactory.createDefaultGraph();
+        root.listProperties(OA.schema).forEach(statement -> loadSchema(result, a, getResource(statement)));
+        return result;
+    }
+
+    private void loadSchema(Graph result, Assembler a, Resource root) {
+        Model m = a.openModel(root);
+        Graph g = m.getGraph();
+        g.getTransactionHandler().executeAlways(() -> GraphUtil.addInto(result, m.getGraph()));
+    }
+
+    private ReasonerFactory addRules(Resource root, Assembler a, final ReasonerFactory r) {
+        var rules = OntRuleSetAssembler.addRules(new ArrayList<>(), a, root);
+        if (rules.isEmpty()) {
+            return r;
+        }
+        if (!(r instanceof GenericRuleReasonerFactory)) {
+            throw new CannotHaveRulesException(root);
+        }
+        return new ReasonerFactory() {
+            @Override
+            public Reasoner create(Resource configuration) {
+                GenericRuleReasoner result = (GenericRuleReasoner) r.create(configuration);
+                result.addRules(rules);
+                return result;
+            }
+
+            @Override
+            public Model getCapabilities() {
+                return r.getCapabilities();
+            }
+
+            @Override
+            public String getURI() {
+                return r.getURI();
+            }
+        };
+    }
+
+    protected Reasoner getReasoner(Resource root) {
+        return getReasonerFactory(root).create(root);
+    }
+
+    protected static ReasonerFactory getReasonerFactory(Resource root) {
+        Resource reasonerURL = getUniqueResource(root, OA.reasonerURL);
+        String className = getOptionalClassName(root);
+        return className != null ? getReasonerFactoryByClassName(root, className)
+                : reasonerURL == null ? GenericRuleReasonerFactory.theInstance()
+                : getReasonerFactoryByURL(root, reasonerURL);
+    }
+
+    private static ReasonerFactory getReasonerFactoryByClassName(Resource root, String className) {
+        Class<?> c = loadClass(root, className);
+        mustBeReasonerFactory(root, c);
+        ReasonerFactory theInstance = resultFromStatic(c, "theInstance");
+        return theInstance == null ? createInstance(root, c) : theInstance;
+    }
+
+    private static ReasonerFactory createInstance(Resource root, Class<?> c) {
+        try {
+            return (ReasonerFactory) c.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw new AssemblerException(root, "could not create instance of " + c.getName(), e);
+        }
+    }
+
+    private static ReasonerFactory resultFromStatic(Class<?> c, @SuppressWarnings("SameParameterValue") String methodName) {
+        try {
+            return (ReasonerFactory) c.getMethod(methodName, (Class<?>[]) null).invoke(null, (Object[]) null);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Throws a <code>NotExpectedTypeException</code> if <code>c</code>
+     * isn't a subclass of <code>ReasonerFactory</code>.
+     */
+    private static void mustBeReasonerFactory(Resource root, Class<?> c) {
+        if (!ReasonerFactory.class.isAssignableFrom(c))
+            throw new NotExpectedTypeException(root, ReasonerFactory.class, c);
+    }
+
+    /**
+     * Answers the string described by the value of the unique optional
+     * <code>OA.reasonerClass</code> property of <code>root</code>,
+     * or null if there's no such property. The value may be a URI, in which case
+     * it must be a <b>java:</b> URI with content the class name; or it may
+     * be a literal, in which case its lexical form is its class name; otherwise, BOOM.
+     */
+    private static String getOptionalClassName(Resource root) {
+        return getOptionalClassName(root, OA.reasonerClass);
+    }
+
+    /**
+     * Answers a ReasonerFactory which delivers reasoners with the given
+     * URL <code>reasonerURL</code>. If there is no such reasoner, throw
+     * an <code>UnknownReasonerException</code>.
+     */
+    public static ReasonerFactory getReasonerFactoryByURL(Resource root, Resource reasonerURL) {
+        String url = reasonerURL.getURI();
+        ReasonerFactory factory = ReasonerRegistry.theRegistry().getFactory(url);
+        if (factory == null) throw new UnknownReasonerException(root, reasonerURL);
+        return factory;
+    }
+
+}

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntRuleSetAssembler.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntRuleSetAssembler.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.ontapi.assemblers;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.assembler.Mode;
+import org.apache.jena.assembler.RuleSet;
+import org.apache.jena.assembler.assemblers.AssemblerBase;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.reasoner.rulesys.Rule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OntRuleSetAssembler extends AssemblerBase {
+    @Override
+    public Object open(Assembler a, Resource root, Mode irrelevant) {
+        checkType(root, OA.RuleSet);
+        return createRuleSet(a, root);
+    }
+
+    public static RuleSet createRuleSet(Assembler a, Resource root) {
+        return RuleSet.create(addRules(new ArrayList<>(), a, root));
+    }
+
+    public static List<Rule> addRules(List<Rule> result, Assembler a, Resource root) {
+        addLiteralRules(root, result);
+        addIndirectRules(a, root, result);
+        addExternalRules(root, result);
+        return result;
+    }
+
+    private static void addIndirectRules(Assembler a, Resource root, List<Rule> result) {
+        root.listProperties(OA.rules).forEach(statement -> {
+            Resource r = getResource(statement);
+            result.addAll(((RuleSet) a.open(r)).getRules());
+        });
+    }
+
+    static private void addExternalRules(Resource root, List<Rule> result) {
+        root.listProperties(OA.rulesFrom).forEach(statement -> {
+            Resource s = getResource(statement);
+            result.addAll(Rule.rulesFromURL(s.getURI()));
+        });
+    }
+
+    private static void addLiteralRules(Resource root, List<Rule> result) {
+        root.listProperties(OA.rule).forEach(statement -> {
+            String s = getString(statement);
+            result.addAll(Rule.parseRules(s));
+        });
+    }
+}

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntSpecificationAssembler.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntSpecificationAssembler.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.ontapi.assemblers;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.assembler.Mode;
+import org.apache.jena.assembler.assemblers.AssemblerBase;
+import org.apache.jena.assembler.assemblers.ReasonerFactoryAssembler;
+import org.apache.jena.assembler.exceptions.AssemblerException;
+import org.apache.jena.assembler.exceptions.ReasonerClashException;
+import org.apache.jena.ontapi.OntSpecification;
+import org.apache.jena.ontapi.common.OntPersonalities;
+import org.apache.jena.ontapi.common.OntPersonality;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.reasoner.ReasonerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class OntSpecificationAssembler extends AssemblerBase {
+
+    /**
+     * examples:
+     * <pre>{@code
+     * @prefix : <http://ex.com#> .
+     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+     * <p>
+     * :spec a oa:OntSpecification ;
+     *      oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
+     * }</pre>
+     * <pre>{@code
+     * @prefix : <http://ex.com#> .
+     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+     *
+     * :reasoner a oa:ReasonerFactory ;
+     *      oa:reasonerURL <http://jena.hpl.hp.com/2003/RDFSExptRuleReasoner> .
+     *
+     * :spec a oa:OntSpecification ;
+     *      oa:personalityName "RDFS_PERSONALITY" ;
+     *      oa:reasonerFactory :reasoner .
+     * }</pre>
+     * <pre>{@code
+     * @prefix : <http://ex.com#> .
+     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+     * @prefix owl: <http://www.w3.org/2002/07/owl#> .
+     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+     * @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+     *
+     * :content a ja:Content ;
+     *      ja:literalContent """
+     *          @prefix : <http://ex.com#> .
+     *          @prefix owl: <http://www.w3.org/2002/07/owl#> .
+     *          @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+     *          :Person a owl:Class .
+     *          :Employee a owl:Class ; rdfs:subClassOf :Person .
+     *      """ ;
+     *      ja:contentEncoding "TTL" .
+     *
+     * :schema a ja:DefaultModel ;
+     *      ja:content :content .
+     *
+     * :reasoner a oa:ReasonerFactory ;
+     *      oa:reasonerURL <http://jena.hpl.hp.com/2003/OWLFBRuleReasoner> ;
+     *      oa:schema :schema .
+     *
+     * :spec a oa:OntSpecification ;
+     *      oa:reasonerFactory :reasoner .
+     * }</pre>
+     */
+    @Override
+    public Object open(Assembler a, Resource root, Mode mode) {
+        checkType(root, OA.OntSpecification);
+
+        var specificationName = getLiteralString(root, OA.specificationName);
+        var personalityName = getLiteralString(root, OA.personalityName);
+        if (specificationName != null) {
+            if (personalityName != null) {
+                throw new AssemblerException(root,
+                        "Both personality and specification are specified. There should be only one."
+                );
+            }
+            var s = Components.BUILTIN_SPECIFICATIONS.get(specificationName);
+            if (s == null) {
+                throw new AssemblerException(root, "Unknown specification: '" + specificationName + "'. " +
+                        "Must be one of the following:\n" + String.join("\n", Components.BUILTIN_SPECIFICATIONS.keySet())
+                );
+            }
+            return s;
+        }
+
+        OntPersonality p;
+        if (personalityName != null) {
+            p = Components.BUILTIN_PERSONALITIES.get(personalityName);
+            if (p == null) {
+                throw new AssemblerException(root, "Unknown personality: '" + personalityName + "'. " +
+                        "Must be one of the following:\n" + String.join("\n", Components.BUILTIN_PERSONALITIES.keySet())
+                );
+            }
+        } else {
+            p = Objects.requireNonNull(Components.BUILTIN_PERSONALITIES.get("OWL2_DL_PERSONALITY"));
+        }
+
+        var r = getReasonerFactory(a, root);
+        return new OntSpecification(p, r);
+    }
+
+    private ReasonerFactory getReasonerFactory(Assembler a, Resource root) {
+        Resource rf = getUniqueResource(root, OA.reasonerFactory);
+        Resource ru = getUniqueResource(root, OA.reasonerURL);
+        if (ru != null && rf != null) throw new ReasonerClashException(root);
+        if (ru != null) return ReasonerFactoryAssembler.getReasonerFactoryByURL(root, ru);
+        return rf == null ? null : (ReasonerFactory) a.open(rf);
+    }
+
+    private static String getLiteralString(Resource root, Property p) {
+        Statement s = root.getProperty(p);
+        if (s == null) {
+            return null;
+        }
+        if (!s.getObject().isLiteral()) {
+            throw new AssemblerException(root, "Invalid string property: " + p);
+        }
+        return s.getString().trim();
+    }
+
+    private static class Components {
+        private static final Map<String, OntPersonality> BUILTIN_PERSONALITIES = Map.of(
+                "OWL2_EL_PERSONALITY", OntPersonalities.OWL2_EL_PERSONALITY,
+                "OWL2_RL_PERSONALITY", OntPersonalities.OWL2_RL_PERSONALITY,
+                "OWL1_LITE_PERSONALITY", OntPersonalities.OWL1_LITE_PERSONALITY,
+                "OWL2_DL_PERSONALITY", OntPersonalities.OWL2_DL_PERSONALITY,
+                "OWL1_DL_PERSONALITY", OntPersonalities.OWL1_DL_PERSONALITY,
+                "RDFS_PERSONALITY", OntPersonalities.RDFS_PERSONALITY,
+                "OWL1_FULL_PERSONALITY", OntPersonalities.OWL1_FULL_PERSONALITY,
+                "OWL2_QL_PERSONALITY", OntPersonalities.OWL2_QL_PERSONALITY,
+                "OWL2_FULL_PERSONALITY", OntPersonalities.OWL2_FULL_PERSONALITY
+        );
+        private static final Map<String, OntSpecification> BUILTIN_SPECIFICATIONS = Map.ofEntries(
+                Map.entry("OWL1_FULL_MEM", OntSpecification.OWL1_FULL_MEM),
+                Map.entry("OWL2_RL_MEM_RDFS_INF", OntSpecification.OWL2_RL_MEM_RDFS_INF),
+                Map.entry("OWL1_DL_MEM_RULES_INF", OntSpecification.OWL1_DL_MEM_RULES_INF),
+                Map.entry("OWL1_LITE_MEM_TRANS_INF", OntSpecification.OWL1_LITE_MEM_TRANS_INF),
+                Map.entry("OWL1_FULL_MEM_RDFS_INF", OntSpecification.OWL1_FULL_MEM_RDFS_INF),
+                Map.entry("OWL1_FULL_MEM_MINI_RULES_INF", OntSpecification.OWL1_FULL_MEM_MINI_RULES_INF),
+                Map.entry("OWL2_RL_MEM", OntSpecification.OWL2_RL_MEM),
+                Map.entry("RDFS_MEM", OntSpecification.RDFS_MEM),
+                Map.entry("OWL2_RL_MEM_RULES_INF", OntSpecification.OWL2_RL_MEM_RULES_INF),
+                Map.entry("OWL2_DL_MEM_RDFS_INF", OntSpecification.OWL2_DL_MEM_RDFS_INF),
+                Map.entry("OWL1_FULL_MEM_RULES_INF", OntSpecification.OWL1_FULL_MEM_RULES_INF),
+                Map.entry("OWL2_FULL_MEM_RULES_INF", OntSpecification.OWL2_FULL_MEM_RULES_INF),
+                Map.entry("OWL2_FULL_MEM", OntSpecification.OWL2_FULL_MEM),
+                Map.entry("OWL2_FULL_MEM_MICRO_RULES_INF", OntSpecification.OWL2_FULL_MEM_MICRO_RULES_INF),
+                Map.entry("OWL2_FULL_MEM_MINI_RULES_INF", OntSpecification.OWL2_FULL_MEM_MINI_RULES_INF),
+                Map.entry("OWL2_QL_MEM_RDFS_INF", OntSpecification.OWL2_QL_MEM_RDFS_INF),
+                Map.entry("OWL1_FULL_MEM_TRANS_INF", OntSpecification.OWL1_FULL_MEM_TRANS_INF),
+                Map.entry("OWL1_FULL_MEM_MICRO_RULES_INF", OntSpecification.OWL1_FULL_MEM_MICRO_RULES_INF),
+                Map.entry("OWL1_DL_MEM_TRANS_INF", OntSpecification.OWL1_DL_MEM_TRANS_INF),
+                Map.entry("OWL2_FULL_MEM_TRANS_INF", OntSpecification.OWL2_FULL_MEM_TRANS_INF),
+                Map.entry("OWL1_LITE_MEM", OntSpecification.OWL1_LITE_MEM),
+                Map.entry("OWL2_EL_MEM_RULES_INF", OntSpecification.OWL2_EL_MEM_RULES_INF),
+                Map.entry("OWL1_DL_MEM_RDFS_INF", OntSpecification.OWL1_DL_MEM_RDFS_INF),
+                Map.entry("RDFS_MEM_TRANS_INF", OntSpecification.RDFS_MEM_TRANS_INF),
+                Map.entry("OWL2_DL_MEM", OntSpecification.OWL2_DL_MEM),
+                Map.entry("OWL2_EL_MEM_RDFS_INF", OntSpecification.OWL2_EL_MEM_RDFS_INF),
+                Map.entry("OWL2_DL_MEM_TRANS_INF", OntSpecification.OWL2_DL_MEM_TRANS_INF),
+                Map.entry("OWL2_FULL_MEM_RDFS_INF", OntSpecification.OWL2_FULL_MEM_RDFS_INF),
+                Map.entry("OWL2_EL_MEM", OntSpecification.OWL2_EL_MEM),
+                Map.entry("OWL2_EL_MEM_TRANS_INF", OntSpecification.OWL2_EL_MEM_TRANS_INF),
+                Map.entry("OWL2_DL_MEM_RULES_INF", OntSpecification.OWL2_DL_MEM_RULES_INF),
+                Map.entry("OWL2_QL_MEM_TRANS_INF", OntSpecification.OWL2_QL_MEM_TRANS_INF),
+                Map.entry("OWL1_LITE_MEM_RDFS_INF", OntSpecification.OWL1_LITE_MEM_RDFS_INF),
+                Map.entry("OWL1_LITE_MEM_RULES_INF", OntSpecification.OWL1_LITE_MEM_RULES_INF),
+                Map.entry("OWL1_DL_MEM", OntSpecification.OWL1_DL_MEM),
+                Map.entry("OWL2_DL_MEM_BUILTIN_RDFS_INF", OntSpecification.OWL2_DL_MEM_BUILTIN_RDFS_INF),
+                Map.entry("OWL2_QL_MEM", OntSpecification.OWL2_QL_MEM),
+                Map.entry("RDFS_MEM_RDFS_INF", OntSpecification.RDFS_MEM_RDFS_INF),
+                Map.entry("OWL2_RL_MEM_TRANS_INF", OntSpecification.OWL2_RL_MEM_TRANS_INF),
+                Map.entry("OWL2_QL_MEM_RULES_INF", OntSpecification.OWL2_QL_MEM_RULES_INF)
+        );
+    }
+}

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalities.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/common/OntPersonalities.java
@@ -573,6 +573,78 @@ public class OntPersonalities {
             .add(OntDisjoint.Individuals.class, OWL1ObjectFactories.DIFFERENT_INDIVIDUALS_DISJOINT)
             .add(OntDisjoint.class, OWL1ObjectFactories.ANY_DISJOINT);
 
+    public static final OntPersonality OWL2_FULL_PERSONALITY =
+            OWL2_ONT_PERSONALITY()
+                    .setBuiltins(OWL2_FULL_BUILTINS)
+                    .setReserved(OWL2_RESERVED)
+                    .setPunnings(OWL_NO_PUNNINGS)
+                    .setConfig(OntConfigs.OWL2_CONFIG)
+                    .build();
+
+    public static final OntPersonality OWL2_DL_PERSONALITY =
+            OWL2_ONT_PERSONALITY()
+                    .setBuiltins(OWL2_FULL_BUILTINS)
+                    .setReserved(OWL2_RESERVED)
+                    .setPunnings(OWL_DL2_PUNNINGS)
+                    .setConfig(OntConfigs.OWL2_CONFIG)
+                    .build();
+
+    public static final OntPersonality OWL2_EL_PERSONALITY =
+            OWL2_EL_ONT_PERSONALITY()
+                    .setBuiltins(OWL2_EL_BUILTINS)
+                    .setReserved(OWL2_RESERVED)
+                    .setPunnings(OWL_DL2_PUNNINGS)
+                    .setConfig(OntConfigs.OWL2_EL_CONFIG)
+                    .build();
+
+    public static final OntPersonality OWL2_QL_PERSONALITY =
+            OWL2_QL_ONT_PERSONALITY()
+                    .setBuiltins(OWL2_QL_BUILTINS)
+                    .setReserved(OWL2_RESERVED)
+                    .setPunnings(OWL_DL2_PUNNINGS)
+                    .setConfig(OntConfigs.OWL2_QL_CONFIG)
+                    .build();
+
+    public static final OntPersonality OWL2_RL_PERSONALITY =
+            OWL2_RL_ONT_PERSONALITY()
+                    .setBuiltins(OWL2_RL_BUILTINS)
+                    .setReserved(OWL2_RESERVED)
+                    .setPunnings(OWL_DL2_PUNNINGS)
+                    .setConfig(OntConfigs.OWL2_RL_CONFIG)
+                    .build();
+
+    public static final OntPersonality OWL1_DL_PERSONALITY =
+            OWL1_ONT_PERSONALITY()
+                    .setBuiltins(OWL1_FULL_BUILTINS)
+                    .setReserved(OWL1_RESERVED)
+                    .setPunnings(OWL_DL1_PUNNINGS)
+                    .setConfig(OntConfigs.OWL1_CONFIG)
+                    .build();
+
+    public static final OntPersonality OWL1_FULL_PERSONALITY =
+            OWL1_ONT_PERSONALITY()
+                    .setBuiltins(OWL1_FULL_BUILTINS)
+                    .setReserved(OWL1_RESERVED)
+                    .setPunnings(OWL_NO_PUNNINGS)
+                    .setConfig(OntConfigs.OWL1_CONFIG)
+                    .build();
+
+    public static final OntPersonality OWL1_LITE_PERSONALITY =
+            OWL1_LITE_ONT_PERSONALITY()
+                    .setBuiltins(OWL1_LITE_BUILTINS)
+                    .setReserved(OWL1_RESERVED)
+                    .setPunnings(OWL_DL1_PUNNINGS)
+                    .setConfig(OntConfigs.OWL1_LITE_CONFIG)
+                    .build();
+
+    public static final OntPersonality RDFS_PERSONALITY =
+            RDFS_ONT_PERSONALITY()
+                    .setBuiltins(RDFS_BUILTINS)
+                    .setReserved(RDFS_RESERVED)
+                    .setPunnings(OWL_NO_PUNNINGS)
+                    .setConfig(OntConfigs.RDFS_CONFIG)
+                    .build();
+
     /**
      * Creates (mutable) {@link OntObjectPersonalityBuilder} for RDFS Ontologies.
      *
@@ -592,8 +664,7 @@ public class OntPersonalities {
      * @return {@link OntObjectPersonalityBuilder}
      */
     public static OntObjectPersonalityBuilder OWL2_ONT_PERSONALITY() {
-        return OWL2_OBJECT_FACTORIES
-                .copy()
+        return OWL2_OBJECT_FACTORIES.copy()
                 .setBuiltins(OntPersonalities.OWL2_FULL_BUILTINS)
                 .setReserved(OntPersonalities.OWL2_RESERVED)
                 .setPunnings(OntPersonalities.OWL_NO_PUNNINGS)

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/repositories/DocumentGraphRepository.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/repositories/DocumentGraphRepository.java
@@ -210,8 +210,7 @@ public class DocumentGraphRepository implements GraphRepository {
      *
      * @return distinct {@code Stream} of {@link Graph}s
      */
-    @Override
-    public Stream<Graph> graphs() {
+    public Stream<Graph> loadedGraphs() {
         return sourceToGraph.values().stream();
     }
 

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/repositories/OntUnionGraphRepository.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/repositories/OntUnionGraphRepository.java
@@ -135,8 +135,20 @@ public class OntUnionGraphRepository {
      * @param node {@link Node} graph's ontology name ({@code owl:Ontology} or {@code owl:versionIRI}).
      * @return boolean
      */
-    public boolean contains(Node node) {
-        return repository.contains(node.toString());
+    public boolean hasGraph(Node node) {
+        Objects.requireNonNull(node);
+        if (repository.contains(node.toString())) {
+            return true;
+        }
+        return repository.ids().toList().stream().anyMatch(id -> {
+            var g = repository.get(id);
+            var header = Graphs.findOntologyNameNode(g).orElse(null);
+            if (Objects.equals(header, node)) {
+                repository.put(header.toString(), g);
+                return true;
+            }
+            return false;
+        });
     }
 
     /**

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/sys/InitOntAPI.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/sys/InitOntAPI.java
@@ -18,12 +18,21 @@
 
 package org.apache.jena.ontapi.sys;
 
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.ontapi.assemblers.DocumentGraphRepositoryAssembler;
+import org.apache.jena.ontapi.assemblers.OA;
+import org.apache.jena.ontapi.assemblers.OntModelAssembler;
+import org.apache.jena.ontapi.assemblers.OntReasonerFactoryAssembler;
+import org.apache.jena.ontapi.assemblers.OntRuleSetAssembler;
+import org.apache.jena.ontapi.assemblers.OntSpecificationAssembler;
+import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sys.JenaSubsystemLifecycle;
 
 public class InitOntAPI implements JenaSubsystemLifecycle {
 
     @Override
     public void start() {
+        Initializer.init();
     }
 
     @Override
@@ -33,5 +42,25 @@ public class InitOntAPI implements JenaSubsystemLifecycle {
     @Override
     public int level() {
         return 15;
+    }
+
+    private static class Initializer {
+        static volatile boolean initialized = false;
+
+        static void init() {
+            if (initialized)
+                return;
+            synchronized (Initializer.class) {
+                if (initialized)
+                    return;
+                initialized = true;
+                AssemblerUtils.init();
+                Assembler.general().implementWith(OA.DocumentGraphRepository, new DocumentGraphRepositoryAssembler());
+                Assembler.general().implementWith(OA.OntSpecification, new OntSpecificationAssembler());
+                Assembler.general().implementWith(OA.ReasonerFactory, new OntReasonerFactoryAssembler());
+                Assembler.general().implementWith(OA.RuleSet, new OntRuleSetAssembler());
+                Assembler.general().implementWith(OA.OntModel, new OntModelAssembler());
+            }
+        }
     }
 }

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/DocumentGraphRepositoryAssemblerTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/DocumentGraphRepositoryAssemblerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.ontapi;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.ontapi.impl.repositories.DocumentGraphRepository;
+import org.apache.jena.ontapi.testutils.RDFIOTestUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class DocumentGraphRepositoryAssemblerTest {
+
+    @Test
+    public void testAssemblerWithNoGraphs() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        
+                        :repo a oa:DocumentGraphRepository .
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#repo");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(DocumentGraphRepository.class, result);
+        var repo = (DocumentGraphRepository) result;
+        Assertions.assertEquals(0, repo.count());
+    }
+
+    @Test
+    public void testAssemblerWithTwoGraphs() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        
+                        :repo a oa:DocumentGraphRepository ;
+                            oa:graph :g1, :g2 .
+                        
+                        :g1 a oa:Graph ;
+                            oa:graphIRI "vocab1" ;
+                            oa:graphLocation "file:ontologies/vocab1.ttl" .
+                        
+                        :g2 a oa:Graph ;
+                            oa:graphIRI "vocab2" ;
+                            oa:graphLocation "file:ontologies/vocab2.ttl" .
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#repo");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(DocumentGraphRepository.class, result);
+        var repo = (DocumentGraphRepository) result;
+        Assertions.assertEquals(4, repo.count());
+        Assertions.assertEquals(
+                Set.of("vocab1", "vocab2", "file:ontologies/vocab1.ttl", "file:ontologies/vocab2.ttl"),
+                new HashSet<>(repo.ids().toList())
+        );
+    }
+}

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/DocumentGraphRepositoryTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/DocumentGraphRepositoryTest.java
@@ -52,7 +52,7 @@ public class DocumentGraphRepositoryTest {
         Assertions.assertFalse(((UnionGraph) g1).hasSubGraph());
         Graph g2 = repository.get("builtins-owl.rdf");
         Assertions.assertSame(g1, g2);
-        Assertions.assertEquals(List.of(g1), repository.graphs().toList());
+        Assertions.assertEquals(List.of(g1), repository.loadedGraphs().toList());
 
         Graph g3 = repository.get("X");
         Assertions.assertEquals(163, g3.size());
@@ -60,7 +60,7 @@ public class DocumentGraphRepositoryTest {
         Assertions.assertFalse(((UnionGraph) g3).hasSubGraph());
         Graph g4 = repository.get("builtins-rdfs.rdf");
         Assertions.assertSame(g3, g4);
-        Assertions.assertEquals(Set.of(g1, g3), repository.graphs().collect(Collectors.toSet()));
+        Assertions.assertEquals(Set.of(g1, g3), repository.loadedGraphs().collect(Collectors.toSet()));
 
         Assertions.assertEquals(
                 List.of("X", "Y", "builtins-owl.rdf", "builtins-rdfs.rdf", "http://www.w3.org/2002/07/owl#"),

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelAssemblerTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelAssemblerTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.ontapi;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.ontapi.impl.repositories.DocumentGraphRepository;
+import org.apache.jena.ontapi.model.OntModel;
+import org.apache.jena.ontapi.testutils.RDFIOTestUtils;
+import org.apache.jena.riot.Lang;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class OntModelAssemblerTest {
+
+    @Test
+    public void testAssembleSimpleOntModel() {
+        var assembler = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        
+                        :model a oa:OntModel .
+                        """, "ttl"
+        );
+        var root = assembler.getResource("http://ex.com#model");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(OntModel.class, result);
+        var model = (OntModel) result;
+        Assertions.assertEquals(0, model.size());
+    }
+
+    @Test
+    public void testAssembleOntModelWithBaseModelAndSpec() {
+        var assembler = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+                        
+                        :spec a oa:OntSpecification ;
+                            oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
+                        
+                        :base a ja:MemoryModel ;
+                            ja:content [
+                                ja:literalContent ""\"
+                                    @prefix : <http://ex.com#> .
+                                    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                                    :C a owl:Class .
+                                ""\" ;
+                                ja:contentEncoding "TTL"
+                            ] .
+                        
+                        :model a oa:OntModel ;
+                            oa:ontModelSpec :spec ;
+                            oa:baseModel :base .
+                        """, "ttl"
+        );
+        var root = assembler.getResource("http://ex.com#model");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(OntModel.class, result);
+        var model = (OntModel) result;
+        Assertions.assertEquals(41, model.size());
+    }
+
+    @Test
+    public void testAssembleOntModelWithHierarchy() {
+        var assembler = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+                        
+                        :spec a oa:OntSpecification ;
+                            oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
+                        
+                        :base1 a ja:MemoryModel ;
+                            ja:content [
+                                ja:literalContent ""\"
+                                    @prefix : <http://ex.com#> .
+                                    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                                    : a owl:Ontology .
+                                    :A a owl:Class .
+                                ""\" ;
+                                ja:contentEncoding "TTL"
+                            ] .
+                        
+                        :base2 a ja:MemoryModel ;
+                            ja:content [
+                                ja:literalContent ""\"
+                                    @prefix : <http://ex.com/v1#> .
+                                    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                                    : a owl:Ontology .
+                                    :B a owl:Class .
+                                ""\" ;
+                                ja:contentEncoding "TTL"
+                            ] .
+                        
+                        :model1 a oa:OntModel ;
+                            oa:baseModel :base1 ;
+                            oa:importModels :model2 .
+                        :model2 a oa:OntModel ;
+                            oa:baseModel :base2 .
+                        """, "ttl"
+        );
+        var root = assembler.getResource("http://ex.com#model1");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(OntModel.class, result);
+        var model1 = (OntModel) result;
+        var imports = model1.imports().toList();
+        Assertions.assertEquals(1, imports.size());
+        var model2 = model1.imports().findFirst().orElseThrow();
+        Assertions.assertEquals("http://ex.com#", model1.getID().getURI());
+        Assertions.assertEquals("http://ex.com/v1#", model2.getID().getURI());
+        Assertions.assertEquals(5, model1.size());
+        Assertions.assertEquals(2, model2.size());
+    }
+
+    @Test
+    public void testAssembleWithDocumentManager(@TempDir Path dir) throws IOException {
+        var src1 = Files.createTempFile(dir, "wine.", ".ttl");
+        RDFIOTestUtils.save(RDFIOTestUtils.loadResourceAsModel("/wine.ttl", Lang.TURTLE), src1, Lang.TURTLE);
+        var srcUri1 = src1.toUri();
+        var src2 = Files.createTempFile(dir, "food.", ".ttl");
+        RDFIOTestUtils.save(RDFIOTestUtils.loadResourceAsModel("/food.ttl", Lang.TURTLE), src2, Lang.TURTLE);
+        var srcUri2 = src2.toUri();
+        var assembler = RDFIOTestUtils.readStringAsModel(
+                String.format("""
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+                        
+                        :repo a oa:DocumentGraphRepository ;
+                            oa:graph :g .
+                        :g a oa:Graph ;
+                            oa:graphIRI "urn:food" ;
+                            oa:graphLocation "%s" .
+                        :base a ja:MemoryModel ;
+                            ja:externalContent <%s> .
+                        :model a oa:OntModel ;
+                            oa:baseModel :base ;
+                            oa:documentGraphRepository :repo .
+                        """, srcUri2, srcUri1), "ttl"
+        );
+        var resultModel = Assembler.general().open(assembler.getResource("http://ex.com#model"));
+        Assertions.assertInstanceOf(OntModel.class, resultModel);
+        var model = (OntModel) resultModel;
+        Assertions.assertEquals("http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine", model.getID().getImportsIRI());
+        var imports = model.imports().toList();
+        Assertions.assertEquals(1, imports.size());
+        Assertions.assertEquals("http://www.w3.org/TR/2003/PR-owl-guide-20031209/food", imports.get(0).getID().getImportsIRI());
+
+        var resultRepository = Assembler.general().open(assembler.getResource("http://ex.com#repo"));
+        Assertions.assertInstanceOf(DocumentGraphRepository.class, resultRepository);
+        var repo = (DocumentGraphRepository) resultRepository;
+        Assertions.assertEquals(2, repo.count());
+    }
+}

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntSpecificationAssemblerTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntSpecificationAssemblerTest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.jena.ontapi;
+
+import org.apache.jena.assembler.Assembler;
+import org.apache.jena.assembler.exceptions.AssemblerException;
+import org.apache.jena.ontapi.common.OntPersonalities;
+import org.apache.jena.ontapi.testutils.RDFIOTestUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.reasoner.Reasoner;
+import org.apache.jena.reasoner.ReasonerFactory;
+import org.apache.jena.reasoner.rulesys.GenericRuleReasoner;
+import org.apache.jena.reasoner.rulesys.RDFSRuleReasoner;
+import org.apache.jena.reasoner.rulesys.RDFSRuleReasonerFactory;
+import org.apache.jena.reasoner.rulesys.Rule;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class OntSpecificationAssemblerTest {
+
+    @Test
+    public void testAssemblerWithBuiltinSpecification() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        
+                        :spec a oa:OntSpecification ;
+                            oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#spec");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(OntSpecification.class, result);
+        var spec = (OntSpecification) result;
+        Assertions.assertSame(OntSpecification.OWL1_LITE_MEM_RDFS_INF, spec);
+    }
+
+    @Test
+    public void testAssemblerWithWrongSpecification() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        
+                        :spec a oa:OntSpecification ;
+                            oa:specificationName "XXX" .
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#spec");
+        Assertions.assertThrows(AssemblerException.class, () -> Assembler.general().open(root));
+    }
+
+    @Test
+    public void testAssemblerWithBuiltinSpecificationAndPersonality() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        
+                        :spec a oa:OntSpecification ;
+                            oa:specificationName "OWL1_LITE_MEM_RDFS_INF" ;
+                            oa:personalityName "RDFS_PERSONALITY" ;
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#spec");
+        Assertions.assertThrows(AssemblerException.class, () -> Assembler.general().open(root));
+    }
+
+
+    @Test
+    public void testAssemblerWithBuiltinSpecificationAndReasonerURL() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        
+                        :reasoner a oa:ReasonerFactory ;
+                            oa:reasonerURL <http://jena.hpl.hp.com/2003/RDFSExptRuleReasoner> .
+                        
+                        :spec a oa:OntSpecification ;
+                            oa:personalityName "RDFS_PERSONALITY" ;
+                            oa:reasonerFactory :reasoner .
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#spec");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(OntSpecification.class, result);
+        var spec = (OntSpecification) result;
+
+        Assertions.assertInstanceOf(RDFSRuleReasonerFactory.class, spec.getReasonerFactory());
+        Assertions.assertEquals(OntPersonalities.RDFS_PERSONALITY, spec.getPersonality());
+    }
+
+    @Test
+    public void testAssemblerWithReasonerURLAndRule() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        
+                        :simple-rules a oa:RuleSet ;
+                            oa:rule "[rdfs1: (?a rdfs:subClassOf ?b) -> (?a rdf:type owl:Class)]" .
+                        
+                        :reasoner a oa:ReasonerFactory ;
+                            oa:reasonerURL <http://jena.hpl.hp.com/2003/GenericRuleReasoner> ;
+                            oa:rules :simple-rules .
+                        
+                        :spec a oa:OntSpecification ;
+                            oa:reasonerFactory :reasoner .
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#spec");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(OntSpecification.class, result);
+        var spec = (OntSpecification) result;
+
+        Assertions.assertEquals("http://jena.hpl.hp.com/2003/GenericRuleReasoner", spec.getReasonerFactory().getURI());
+        Assertions.assertEquals(OntPersonalities.OWL2_DL_PERSONALITY, spec.getPersonality());
+
+        var reasoner = spec.getReasonerFactory().create(null);
+        Assertions.assertInstanceOf(GenericRuleReasoner.class, reasoner);
+        GenericRuleReasoner grr = (GenericRuleReasoner) reasoner;
+
+        List<Rule> rules = grr.getRules();
+        Assertions.assertTrue(rules.stream().anyMatch(r -> r.getName().equals("rdfs1")));
+    }
+
+    @Test
+    public void testAssemblerWithReasonerURLAndSchema() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+                        @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+                        
+                        :content a ja:Content ;
+                            ja:literalContent ""\"
+                                @prefix : <http://ex.com#> .
+                                @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                                @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+                                :Person a owl:Class .
+                                :Employee a owl:Class ; rdfs:subClassOf :Person .
+                            ""\" ;
+                            ja:contentEncoding "TTL" .
+                        
+                        :schema a ja:DefaultModel ;
+                            ja:content :content .
+                        
+                        :reasoner a oa:ReasonerFactory ;
+                            oa:reasonerURL <http://jena.hpl.hp.com/2003/OWLFBRuleReasoner> ;
+                            oa:schema :schema .
+                        
+                        :spec a oa:OntSpecification ;
+                            oa:reasonerFactory :reasoner .
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#spec");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(OntSpecification.class, result);
+        var spec = (OntSpecification) result;
+
+        Assertions.assertEquals("http://jena.hpl.hp.com/2003/OWLFBRuleReasoner", spec.getReasonerFactory().getURI());
+        Assertions.assertEquals(OntPersonalities.OWL2_DL_PERSONALITY, spec.getPersonality());
+    }
+
+    @Test
+    public void testAssemblerWithReasonerClass() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                String.format("""
+                        @prefix : <http://ex.com#> .
+                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+                        
+                        :reasoner a oa:ReasonerFactory ;
+                            oa:reasonerClass "%s" .
+                        
+                        :spec a oa:OntSpecification ;
+                            oa:reasonerFactory :reasoner .
+                        """, MockFactory.class.getName()), "ttl"
+        );
+        var root = m.getResource("http://ex.com#spec");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(OntSpecification.class, result);
+        var spec = (OntSpecification) result;
+
+        Assertions.assertEquals("test", spec.getReasonerFactory().getURI());
+        Assertions.assertEquals(OntPersonalities.OWL2_DL_PERSONALITY, spec.getPersonality());
+
+        var reasoner = spec.getReasonerFactory().create(null);
+        Assertions.assertInstanceOf(RDFSRuleReasoner.class, reasoner);
+    }
+
+    @SuppressWarnings("unused")
+    public static class MockFactory implements ReasonerFactory {
+        @Override
+        public Reasoner create(Resource configuration) {
+            return new RDFSRuleReasoner(this);
+        }
+
+        @Override
+        public Model getCapabilities() {
+            return null;
+        }
+
+        @Override
+        public String getURI() {
+            return "test";
+        }
+    }
+
+}

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntUnionGraphRepositoryTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntUnionGraphRepositoryTest.java
@@ -674,4 +674,18 @@ public class OntUnionGraphRepositoryTest {
                 repo2.graphs().collect(Collectors.toSet()));
     }
 
+    @Test
+    public void testLoadRealModelWithMappingDifferentFromIri() {
+        var documentPath = "pizza.ttl";
+        var repository = GraphRepository.createGraphDocumentRepositoryMem();
+        repository.addMapping(
+                "XXXX",
+                documentPath);
+        var m = OntModelFactory.getModelOrNull(
+                "http://www.co-ode.org/ontologies/pizza/pizza.owl",
+                OntSpecification.OWL2_DL_MEM_BUILTIN_RDFS_INF,
+                repository);
+        Assertions.assertNotNull(m.getOntClass("http://www.co-ode.org/ontologies/pizza/pizza.owl#VegetarianTopping"));
+    }
+
 }

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/testutils/RDFIOTestUtils.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/testutils/RDFIOTestUtils.java
@@ -25,6 +25,7 @@ import org.apache.jena.riot.Lang;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -61,5 +62,12 @@ public class RDFIOTestUtils {
         } catch (IOException e) {
             throw new IllegalStateException();
         }
+    }
+
+    public static Model readStringAsModel(String content, String lang) {
+        var r = new StringReader(content);
+        var m = ModelFactory.createDefaultModel();
+        m.read(r, null, lang);
+        return m;
     }
 }


### PR DESCRIPTION
GitHub issue resolved #3322

Pull request Description:

Due to a conflict (`assembler.ttl`) I had to copy-paste some components from jena-arq (`ReasonerFactoryAssembler`, etc), so it may not be possible to merge this MR right now and we need to wait until the old API is completely removed.


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
