### PR TITLE
Fix handling FUSEKI_BASE for during restart

### DIFF
--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/Cache.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/Cache.java
@@ -69,7 +69,7 @@ public interface Cache<Key, Value>
      * Get from cache; if not present, call the {@link Function}
      * to fill the cache slot. This operation should be atomic.
      * @param key The key, for which the value should be returned or calculated. The key must not be null.
-     * @param callable If the cache does not contain the key, the callable is called to calculate a value.
+     * @param function If the cache does not contain the key, the callable is called to calculate a value.
      *                 If the callable returns null, the key is not associated with hat value,
      *                 as nulls are not accepted as values.
      *                 The callable must not be null.

--- a/jena-base/src/main/java/org/apache/jena/atlas/lib/Lib.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/lib/Lib.java
@@ -181,6 +181,15 @@ public class Lib
         System.getProperties().setProperty(sysPropName, value);
     }
 
+    /**
+     * Remove the system property.
+     * The process environment variables are immutable.).
+     * {@link #getenv(String)} looks in the system properties as well as the process environment variables.
+     */
+    public static void unsetenv(String sysPropName) {
+        System.getProperties().remove(sysPropName);
+    }
+
     /** Test whether a property (environment variable or system property) is true. */
     public static boolean isPropertyOrEnvVarSetToTrue(String name) {
         return isPropertyOrEnvVarSetToTrue(name, name);

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiMainRunner.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiMainRunner.java
@@ -24,17 +24,18 @@ import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.main.cmds.FusekiMain;
 import org.apache.jena.fuseki.main.sys.FusekiModules;
+import org.apache.jena.fuseki.server.FusekiServerRunner;
 
 /**
  * Functions for building and runner a {@link FusekiServer} configured from command line arguments.
  *
- * @see {@link FusekiServerRunner0} for similar functionality except it is also initialized with {@link FusekiModules} as well.
+ * @see FusekiServerRunner for similar functionality except it is also initialized with {@link FusekiModules} as well.
  */
 public class FusekiMainRunner {
 
     /**
      * Run a plain {@link FusekiServer}.
-     * @param Command line arguments.
+     * @param args line arguments.
      * @return Return the running server.
      */
     public static FusekiServer runAsync(String... args) {

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/mgt/FusekiServerCtl.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/mgt/FusekiServerCtl.java
@@ -384,8 +384,8 @@ public class FusekiServerCtl {
 
     /** Running a full-features server sets some global state. Clear this up. (mainly for tests.)*/
     public static void clearUpSystemState() {
-        System.getProperties().remove(FusekiServerCtl.envFusekiShiro);
-        System.getProperties().remove(FusekiServerCtl.envFusekiBase);
+        Lib.unsetenv(FusekiServerCtl.envFusekiShiro);
+        Lib.unsetenv(FusekiServerCtl.envFusekiBase);
         FusekiMain.resetCustomisers();
     }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/mod/FusekiServerRunner.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/mod/FusekiServerRunner.java
@@ -29,7 +29,7 @@ public class FusekiServerRunner {
 
     /**
      * Run {@link FusekiServer} with {@link FusekiModules} as given by {@link #serverModules()}.
-     *  @deprecated Use from new location {@link org.apache.jena.fuseki.server.FusekiServerRunner#runASync}.
+     *  @deprecated Use from new location {@link org.apache.jena.fuseki.server.FusekiServerRunner#runAsync}.
      */
     @Deprecated(forRemoval = true)
     public static FusekiServer runAsync(String... args) {
@@ -46,7 +46,7 @@ public class FusekiServerRunner {
     }
 
     /**
-     * @deprecated Use from new location {@link org.apache.jena.fuseki.server.FusekiServerModules#serverModules}.
+     * @deprecated Use from new location {@link FusekiServerModules#serverModules}.
      */
     @Deprecated(forRemoval = true)
     public static FusekiModules serverModules() {

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/server/FusekiServerRunner.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/server/FusekiServerRunner.java
@@ -38,13 +38,13 @@ import org.apache.jena.fuseki.mod.FusekiServerModules;
  * Functions for building and runner a {@link FusekiServer} configured from command line arguments
  * and system {@link FusekiModules}.
  *
- * @see {@link FusekiMainRunner} for similar functionality except without the configuring with {@link FusekiModules}.
+ * @see FusekiMainRunner for similar functionality except without the configuring with {@link FusekiModules}.
  */
 public class FusekiServerRunner {
 
     /**
-     * Run {@link FusekiServer} with {@link FusekiModules} as given by {@link #serverModules()}.
-     * @param Command line arguments.
+     * Run {@link FusekiServer} with {@link FusekiModules} as given by {@link FusekiServerModules#serverModules()}.
+     * @param args Command line arguments.
      * @return Return the running server.
      */
     public static FusekiServer runAsync(String... args) {
@@ -63,7 +63,7 @@ public class FusekiServerRunner {
     }
 
     /**
-     * Run {@link FusekiServer} with {@link FusekiModules} as given by {@link #serverModules()}.
+     * Run {@link FusekiServer} with {@link FusekiModules} as given by {@link FusekiServerModules#serverModules()}.
      * This function does not return.
      */
     public static void run(String... args) {
@@ -72,7 +72,7 @@ public class FusekiServerRunner {
     }
 
     /**
-     * Build but do not start, a {@link FusekiServer} with {@link FusekiModules} as given by {@link #serverModules()}.
+     * Build but do not start, a {@link FusekiServer} with {@link FusekiModules} as given by {@link FusekiServerModules#serverModules()}.
      */
     public static FusekiServer construct(String... args) {
         FusekiServer.Builder builder = builder(args);
@@ -80,7 +80,7 @@ public class FusekiServerRunner {
     }
 
     /**
-     * Create a {@link FusekiServer.Builder} that has the FusekiServer with
+     * Create a {@code FusekiServer.Builder} that has the FusekiServer with
      * server modules setup and the command line args processed.
      */
     public static FusekiServer.Builder builder(String... args) {

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/server/TestFusekiServerCmd.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/server/TestFusekiServerCmd.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,19 +41,14 @@ import org.apache.jena.sparql.exec.http.Params;
  */
 public class TestFusekiServerCmd {
 
-    static String basearea = "target/run";
-    static {
-        Lib.setenv("FUSEKI_BASE", basearea);
-    }
+    private static String FUSEKI_BASE = FusekiServerCtl.envFusekiBase;
+
+    private static String basearea = "target/run";
 
     private static void deleteFusekiDir() throws IOException {
         File file = new File(basearea);
         if ( file.exists() )
             FileUtils.deleteDirectory(file);
-    }
-
-    @BeforeAll static void beforeAll() throws IOException {
-        deleteFusekiDir();
     }
 
     @BeforeEach void setup() throws IOException {
@@ -68,6 +62,8 @@ public class TestFusekiServerCmd {
     static void clearUp() throws IOException {
         deleteFusekiDir();
         FusekiServerCtl.clearUpSystemState();
+        // Put back the FUSEKI_BASE setting.
+        Lib.setenv(FUSEKI_BASE, basearea);
     }
 
     @Test public void plainStart() {
@@ -80,7 +76,6 @@ public class TestFusekiServerCmd {
         // Create a persistent configuration.
 
         String dbName = "/ds93" ;
-
         FusekiServer server0 = FusekiServerRunner.construct();
         server0.start();
         addDataset(server0, dbName);
@@ -105,7 +100,7 @@ public class TestFusekiServerCmd {
         String actionDataset = serverURL+"$/datasets";
         String datasetURL = server.datasetURL(dbName);
         Params params = Params.create().add("dbName", dbName).add("dbType", "mem");
-        // Use the template form of adding a dataset.s
+        // Use the template form of adding a dataset.
         HttpOp.httpPostForm(actionDataset, params);
     }
 

--- a/jena-iri3986/src/main/java/org/apache/jena/rfc3986/IRI3986.java
+++ b/jena-iri3986/src/main/java/org/apache/jena/rfc3986/IRI3986.java
@@ -408,10 +408,12 @@ public class IRI3986 implements IRI {
 
     @Override
     public String path() {
+        // Assigning to a object member is atomic and even if two part/assignment
+        // overlap, they are the same value-equals string.
         if ( hasPath() && path == null )
             path = part(iriStr, path0, path1);
         if ( path == null )
-            return "";
+            path = "";
         return path;
     }
 
@@ -511,8 +513,6 @@ public class IRI3986 implements IRI {
 
     /**
      * Don't make the parts during parsing but wait until needed, if at all.
-     * Assigning to a object member is atomic and even if two part/assignment
-     * overlap, they are the same value-equals string.
      */
     private static String part(String str, int start, int finish) {
         if ( start >= 0 ) {
@@ -743,7 +743,7 @@ public class IRI3986 implements IRI {
 //        if ( strictResolver && ! this.hasScheme() )
 //            return other;
         // Be lax - don't require base to have scheme.
-        // Rel path resolves against rel path.
+        // Relative path resolves against relative path.
         /* 5.2.2. Transform References */
         IRI3986 iri = AlgResolveIRI.resolve(this, other);
         if ( iri != other )
@@ -1510,21 +1510,6 @@ public class IRI3986 implements IRI {
             if ( containsUppercase(iriStr, host0, host1) )
                 schemeReport(this, Issue.iri_host_not_lowercase, URIScheme.GENERAL, "Host name should be lowercase");
         }
-
-        // Done HTTP/HTTPS
-//        if ( hasHost() ) {
-//            String host = host();
-//            if ( containsUppercase(host) ) {
-//                schemeReport(this, Issue.iri_host_not_lowercase, URIScheme.GENERAL, "Host name includes uppercase characters: '"+host+"'");
-//            }
-//        }
-
-        // Done HTTP/HTTPS
-//        if ( hasUserInfo() ) {
-//            schemeReport(this, Issue.iri_user_info_present, URIScheme.GENERAL, "userinfo (e.g. user:password) in authority section");
-//            if ( userInfo().contains(":") )
-//                schemeReport(this, Issue.iri_user_password, scheme, "userinfo contains password in authority section");
-//        }
 
         // RFC 3986 section 2.1
         /* If two URIs differ only in the case of hexadecimal digits used in


### PR DESCRIPTION
Pull request Description:

javadoc clean up, IRI3986 clean-up
Fix handling FUSEKI_BASE for during restart
(second build/tests at same file system location will fail)


----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
