### PR TITLE
GH-3008: Rename as HttpLib.finishInputStream. Handle HTTP request errors.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/http/AsyncHttpRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/AsyncHttpRDF.java
@@ -136,7 +136,13 @@ public class AsyncHttpRDF {
         CompletableFuture<HttpResponse<InputStream>> cf = asyncGetToInput(httpClient, url, modifier);
         Transactional transact = ( _transactional == null ) ? TransactionalNull.create() : _transactional;
         return cf.thenApply(httpResponse->{
-            transact.executeWrite(()->HttpRDF.httpResponseToStreamRDF(url, httpResponse, dest));
+            transact.executeWrite(()->{
+                try {
+                    HttpRDF.httpResponseToStreamRDF(url, httpResponse, dest);
+                } finally {
+                    HttpLib.finishResponse(httpResponse);
+                }
+            });
             return null;
         });
     }

--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -135,7 +135,7 @@ public class HttpLib {
 
     /**
      * Get the InputStream from an HttpResponse, handling possible compression settings.
-     * The application must consume or close the {@code InputStream} (see {@link #finish(InputStream)}).
+     * The application must consume or close the {@code InputStream} (see {@link #finishInputStream(InputStream)}).
      * Closing the InputStream may close the HTTP connection.
      * Assumes the status code has been handled e.g. {@link #handleHttpStatusCode} has been called.
      */
@@ -238,7 +238,7 @@ public class HttpLib {
      */
     public static void handleResponseNoBody(HttpResponse<InputStream> response) {
         handleHttpStatusCode(response);
-        finish(response);
+        finishResponse(response);
     }
 
     /**
@@ -265,8 +265,11 @@ public class HttpLib {
         }
         try {
             return IO.readWholeFileAsUTF8(input);
-        } catch (RuntimeIOException e) { throw new HttpException(e); }
-        finally { IO.close(input); }
+        } catch (RuntimeIOException e) {
+            throw new HttpException(e);
+        } finally {
+            finishInputStream(input);
+        }
     }
 
     /**
@@ -307,18 +310,18 @@ public class HttpLib {
      * {@code close} may close the underlying HTTP connection.
      *  See {@link BodySubscribers#ofInputStream()}.
      */
-    private static void finish(HttpResponse<InputStream> response) {
+    public static void finishResponse(HttpResponse<InputStream> response) {
         InputStream input = response.body();
         if ( input == null )
             return;
-        finish(input);
+        finishInputStream(input);
     }
 
     /** Read to end of {@link InputStream}.
      *  {@code close} may close the underlying HTTP connection.
      *  See {@link BodySubscribers#ofInputStream()}.
      */
-    public static void finish(InputStream input) {
+    public static void finishInputStream(InputStream input) {
         consumeAndClose(input);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/http/HttpRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpRDF.java
@@ -149,13 +149,13 @@ public class HttpRDF {
             throw ex;
         } finally {
             // Even if parsing finished, it is possible we only read part of the input stream (e.g. RDF/XML).
-            finish(in);
+            finishInputStream(in);
         }
     }
 
     /**
      * MUST consume or close the input stream
-     * @see HttpLib#finish(HttpResponse)
+     * @see HttpLib#finishResponse(HttpResponse)
      */
     private static HttpResponse<InputStream> execGetToInput(HttpClient client, String url, Consumer<HttpRequest.Builder> modifier) {
         Objects.requireNonNull(client);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/QueryExecHTTP.java
@@ -241,10 +241,13 @@ public class QueryExecHTTP implements QueryExec {
         if (lang == null) {
             raiseException("Endpoint returned Content-Type: " + actualContentType + " which is not supported for ASK queries", request, response, in);
         }
-        boolean result = ResultSetMgr.readBoolean(in, lang);
-        finish(in);
-        return result;
-    }
+        try {
+            boolean result = ResultSetMgr.readBoolean(in, lang);
+            return result;
+        } finally {
+            finishInputStream(in);
+        }
+   }
 
     private String removeCharset(String contentType) {
         if ( contentType == null )
@@ -307,9 +310,8 @@ public class QueryExecHTTP implements QueryExec {
         Lang lang = p.getRight();
         try {
             RDFDataMgr.read(graph, in, lang);
-        } catch (RiotException ex) {
-            finish(in);
-            throw ex;
+        } finally {
+            finishInputStream(in);
         }
         return graph;
     }
@@ -320,9 +322,8 @@ public class QueryExecHTTP implements QueryExec {
         Lang lang = p.getRight();
         try {
             RDFDataMgr.read(dataset, in, lang);
-        } catch (RiotException ex) {
-            finish(in);
-            throw ex;
+        } finally {
+            finishInputStream(in);
         }
         return dataset;
     }
@@ -387,7 +388,7 @@ public class QueryExecHTTP implements QueryExec {
         InputStream in = HttpLib.getInputStream(response);
         try {
             return JSON.parseAny(in).getAsArray();
-        } finally { finish(in); }
+        } finally { finishInputStream(in); }
     }
 
     @Override


### PR DESCRIPTION
Code tidy in HttpLib.
Catch errors in reading a string response and clean the input stream.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
