### PR TITLE
GH-3368: Deprecate OntModel

### DIFF
--- a/jena-arq/src/test/java/org/apache/jena/riot/adapters/TestFileManager.java
+++ b/jena-arq/src/test/java/org/apache/jena/riot/adapters/TestFileManager.java
@@ -38,7 +38,7 @@ import org.apache.jena.util.LocationMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 public class TestFileManager
 {
     static Logger log = LoggerFactory.getLogger(TestFileManager.class);

--- a/jena-cmds/src/main/java/jena/schemagen.java
+++ b/jena-cmds/src/main/java/jena/schemagen.java
@@ -76,6 +76,7 @@ import static org.apache.jena.atlas.logging.LogCtl.setLogging;
  * Designed to be highly flexible and customisable.
  * </p>
  */
+@SuppressWarnings("removal")
 public class schemagen {
 
     static { setLogging(); }

--- a/jena-core/src/main/java/org/apache/jena/assembler/Assembler.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/Assembler.java
@@ -77,6 +77,8 @@ public interface Assembler {
 
     public static final Assembler infModel = ConstAssembler.infModel();
 
+    /** @deprecated Use org.apache.hena.ontapi */
+    @Deprecated(forRemoval=true)
     public static final Assembler ontModel = ConstAssembler.ontModel();
 
     public static final Assembler reasonerFactory = ConstAssembler.reasonerFactory();
@@ -87,6 +89,8 @@ public interface Assembler {
 
     public static final Assembler unionModel = ConstAssembler.unionModel();
 
+    /** @deprecated Use org.apache.hena.ontapi */
+    @Deprecated(forRemoval=true)
     public static final Assembler ontModelSpec = ConstAssembler.ontModelSpec();
 
     public static final Assembler ruleSet = ConstAssembler.ruleSet();

--- a/jena-core/src/main/java/org/apache/jena/assembler/ConstAssembler.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/ConstAssembler.java
@@ -54,6 +54,7 @@ import org.apache.jena.assembler.assemblers.* ;
 	}
 
     private static Assembler ontModel = null ;
+    @Deprecated(forRemoval=true)
 	public static Assembler ontModel() {
 		if ( ontModel == null )
 			ontModel = new OntModelAssembler();
@@ -89,6 +90,7 @@ import org.apache.jena.assembler.assemblers.* ;
 	}
 
     private static Assembler ontModelSpec = null ;
+    @Deprecated(forRemoval=true)
 	public static Assembler ontModelSpec() {
 		if ( ontModelSpec == null )
 			ontModelSpec = new OntModelSpecAssembler();

--- a/jena-core/src/main/java/org/apache/jena/assembler/assemblers/OntModelAssembler.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/assemblers/OntModelAssembler.java
@@ -24,6 +24,7 @@ import org.apache.jena.assembler.* ;
 import org.apache.jena.ontology.* ;
 import org.apache.jena.rdf.model.* ;
 
+@Deprecated(forRemoval=true)
 public class OntModelAssembler extends InfModelAssembler implements Assembler
     {
     @Override public Model openEmptyModel( Assembler a, Resource root, Mode mode )

--- a/jena-core/src/main/java/org/apache/jena/assembler/assemblers/OntModelSpecAssembler.java
+++ b/jena-core/src/main/java/org/apache/jena/assembler/assemblers/OntModelSpecAssembler.java
@@ -36,6 +36,7 @@ import org.apache.jena.shared.NotFoundException ;
     unless the root is ja:SPOO for some constant SPOO of OntModelSpec,
     in which case the defaults are taken from there.
 */
+@Deprecated(forRemoval=true)
 public class OntModelSpecAssembler extends AssemblerBase implements Assembler
 {
     @Override
@@ -53,7 +54,7 @@ public class OntModelSpecAssembler extends AssemblerBase implements Assembler
         if (source != null) spec.setImportModelGetter( source );
         return spec;
         }
-    
+
     private ModelGetter getModelSource( Assembler a, Resource root )
         {
         Resource source = getUniqueResource( root, JA.importSource );
@@ -74,7 +75,7 @@ public class OntModelSpecAssembler extends AssemblerBase implements Assembler
         if (ru != null) return ReasonerFactoryAssembler.getReasonerFactoryByURL( root, ru );
         return rf == null ? null : (ReasonerFactory) a.open( rf );
         }
-    
+
     private OntDocumentManager getDocumentManager( Assembler a, Resource root )
         {
         Resource dm = getUniqueResource( root, JA.documentManager );
@@ -101,7 +102,7 @@ public class OntModelSpecAssembler extends AssemblerBase implements Assembler
             return like == null ? DEFAULT : getRequiredOntModelSpecField( like.getLocalName() );
             }
         }
-    
+
     private OntModelSpec getRequiredOntModelSpecField( String name )
         {
         OntModelSpec result = getOntModelSpecField( name );
@@ -115,15 +116,15 @@ public class OntModelSpecAssembler extends AssemblerBase implements Assembler
     */
     public static OntModelSpec getOntModelSpecField( String name )
         {
-        try 
-            { 
+        try
+            {
             Class<OntModelSpec> omc = OntModelSpec.class;
-            Field f = omc.getField( name ); 
+            Field f = omc.getField( name );
             int mods = f.getModifiers();
-            if (f.getType() == omc && isConstant( mods )) 
-                return (OntModelSpec) f.get( null );            
+            if (f.getType() == omc && isConstant( mods ))
+                return (OntModelSpec) f.get( null );
             }
-        catch (Exception e) 
+        catch (Exception e)
             {}
         return null;
         }

--- a/jena-core/src/main/java/org/apache/jena/ontology/OntDocumentManager.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/OntDocumentManager.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory ;
  * dm.setFileManager( FileManager.get() );
  * </pre>
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 public class OntDocumentManager
 {
     // @SuppressWarnings - FileManager model caching.

--- a/jena-core/src/main/java/org/apache/jena/ontology/OntModel.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/OntModel.java
@@ -67,7 +67,9 @@ import org.apache.jena.util.iterator.ExtendedIterator ;
  * may result in a runtime exception, though the typical behaviour is that such
  * calls will be silently ignored.
  * </p>
+ * @deprecated Use org.apache.jena.ontapi.
  */
+@Deprecated(forRemoval = true)
 public interface OntModel
     extends InfModel
 {
@@ -1514,7 +1516,6 @@ public interface OntModel
      * @param writer A writer to which the XML will be written
      * @return this model
      */
-    @SuppressWarnings("deprecation")
     @Override
     public Model write( Writer writer ) ;
 

--- a/jena-core/src/main/java/org/apache/jena/ontology/OntModelSpec.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/OntModelSpec.java
@@ -49,7 +49,9 @@ import java.util.Objects;
  * Encapsulates a description of the components of an ontology model, including the
  * storage scheme, reasoner and language profile.
  * </p>
+ * @deprecated Use org.apache.jena.ontapi.
  */
+@Deprecated(forRemoval = true)
 public class OntModelSpec {
     // Constants
     //////////////////////////////////

--- a/jena-core/src/main/java/org/apache/jena/ontology/OntResource.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/OntResource.java
@@ -53,6 +53,7 @@ public interface OntResource
      * answer null.</p>
      * @return The ont model that this resource is attached to, or null.
      */
+    @SuppressWarnings("removal")
     public OntModel getOntModel();
 
     /**

--- a/jena-core/src/main/java/org/apache/jena/ontology/OntTools.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/OntTools.java
@@ -43,6 +43,7 @@ import org.apache.jena.shared.JenaException ;
  * <a href="http://tech.groups.yahoo.com/group/jena-dev">Jena support email list</a>.
  * </p>
  */
+@SuppressWarnings("removal")
 public class OntTools
 {
     // Constants

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/AllDifferentImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/AllDifferentImpl.java
@@ -65,6 +65,7 @@ public class AllDifferentImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an AllDifferent facet if it has rdf:type owl:AllDifferent or equivalent
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/AllValuesFromRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/AllValuesFromRestrictionImpl.java
@@ -63,6 +63,7 @@ public class AllValuesFromRestrictionImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being a AllValuesFromRestriction facet if it has rdf:type owl:Restriction or equivalent
             // and the combination of owl:onProperty and owl:allValuesFrom (or equivalents)
@@ -116,6 +117,7 @@ public class AllValuesFromRestrictionImpl
      * @exception ProfileException If the {@link Profile#ALL_VALUES_FROM()} property is not supported in the current language profile.
      */
     @Override
+    @SuppressWarnings("removal")
     public Resource getAllValuesFrom() {
         checkProfile( getProfile().ALL_VALUES_FROM(), "ALL_VALUES_FROM" );
         Resource r = (Resource) getRequiredProperty( getProfile().ALL_VALUES_FROM() ).getObject();

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/AnnotationPropertyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/AnnotationPropertyImpl.java
@@ -62,6 +62,7 @@ public class AnnotationPropertyImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an AnnotationProperty facet if it has rdf:type owl:AnnotationProperty or equivalent
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/CardinalityQRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/CardinalityQRestrictionImpl.java
@@ -65,6 +65,7 @@ public class CardinalityQRestrictionImpl
             { return isCardinalityQRestriction( node, eg ); }
     };
 
+    @SuppressWarnings("removal")
     public static boolean isCardinalityQRestriction( Node node, EnhGraph eg ) {
         // node will support being a QualifiedRestriction facet if it has rdf:type owl:Restriction or equivalent
         Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/CardinalityRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/CardinalityRestrictionImpl.java
@@ -62,6 +62,7 @@ public class CardinalityRestrictionImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being a CardinalityRestriction facet if it has rdf:type owl:Restriction or equivalent
             // and the combination of owl:onProperty and owl:cardinality (or equivalents)

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/ComplementClassImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/ComplementClassImpl.java
@@ -65,6 +65,7 @@ public class ComplementClassImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an ComplementClass facet if it has rdf:type owl:Class and an owl:complementOf statement (or equivalents)
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/DataRangeImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/DataRangeImpl.java
@@ -66,6 +66,7 @@ public class DataRangeImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an DataRange facet if it has rdf:type owl:Datarange and is a bNode
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/DatatypePropertyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/DatatypePropertyImpl.java
@@ -63,6 +63,7 @@ public class DatatypePropertyImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an DatatypeProperty facet if it has rdf:type owl:DatatypeProperty or equivalent
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/EnumeratedClassImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/EnumeratedClassImpl.java
@@ -65,6 +65,7 @@ public class EnumeratedClassImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an EnumeratedClass facet if it has rdf:type owl:Class and an owl:oneOf statement (or equivalents)
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/FunctionalPropertyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/FunctionalPropertyImpl.java
@@ -63,6 +63,7 @@ public class FunctionalPropertyImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an FunctionalProperty facet if it has rdf:type owl:FunctionalProperty or equivalent
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/HasValueRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/HasValueRestrictionImpl.java
@@ -24,10 +24,13 @@ package org.apache.jena.ontology.impl;
 
 // Imports
 ///////////////
-import org.apache.jena.enhanced.* ;
-import org.apache.jena.graph.* ;
+import org.apache.jena.enhanced.EnhGraph;
+import org.apache.jena.enhanced.EnhNode;
+import org.apache.jena.enhanced.Implementation;
+import org.apache.jena.graph.Node;
 import org.apache.jena.ontology.* ;
-import org.apache.jena.rdf.model.* ;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.RDFNode;
 
 
 /**
@@ -63,6 +66,7 @@ public class HasValueRestrictionImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being a HasValueRestriction facet if it has rdf:type owl:Restriction or equivalent
             // and the combination of owl:onProperty and owl:hasValue (or equivalents)

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/IndividualImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/IndividualImpl.java
@@ -63,6 +63,7 @@ public class IndividualImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an Individual facet if it is a URI node or bNode
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/IntersectionClassImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/IntersectionClassImpl.java
@@ -62,6 +62,7 @@ public class IntersectionClassImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an IntersectionClass facet if it has rdf:type owl:Class and an owl:intersectionOf statement (or equivalents)
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/InverseFunctionalPropertyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/InverseFunctionalPropertyImpl.java
@@ -63,6 +63,7 @@ public class InverseFunctionalPropertyImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an InverseFunctionalProperty facet if it has rdf:type owl:InverseFunctionalProperty or equivalent
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/MaxCardinalityQRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/MaxCardinalityQRestrictionImpl.java
@@ -66,6 +66,7 @@ public class MaxCardinalityQRestrictionImpl
     };
 
 
+    @SuppressWarnings("removal")
     public static boolean isMaxCardinalityQRestriction( Node node, EnhGraph eg )
         {
         // node will support being a QualifiedRestriction facet if it has rdf:type owl:Restriction or equivalent

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/MaxCardinalityRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/MaxCardinalityRestrictionImpl.java
@@ -62,6 +62,7 @@ public class MaxCardinalityRestrictionImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being a MaxCardinalityRestriction facet if it has rdf:type owl:Restriction or equivalent
             // and the combination of owl:onProperty and owl:cardinality (or equivalents)

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/MinCardinalityQRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/MinCardinalityQRestrictionImpl.java
@@ -65,6 +65,7 @@ public class MinCardinalityQRestrictionImpl
             { return isMinCardinalityQRestriction( node, eg ); }
     };
 
+    @SuppressWarnings("removal")
     public static boolean isMinCardinalityQRestriction( Node node, EnhGraph eg )
         {
         // node will support being a QualifiedRestriction facet if it has rdf:type owl:Restriction or equivalent

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/MinCardinalityRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/MinCardinalityRestrictionImpl.java
@@ -62,6 +62,7 @@ public class MinCardinalityRestrictionImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being a MinCardinalityRestriction facet if it has rdf:type owl:Restriction or equivalent
             // and the combination of owl:onProperty and owl:cardinality (or equivalents)

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OWLDLProfile.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OWLDLProfile.java
@@ -104,6 +104,7 @@ public class OWLDLProfile
     // Internal implementation methods
     //////////////////////////////////
 
+    @SuppressWarnings("removal")
     protected static Object[][] s_supportsCheckData = new Object[][] {
             // Resource (key),              check method
             {  AllDifferent.class,          new SupportsCheck() {
@@ -278,7 +279,7 @@ public class OWLDLProfile
             {  Individual.class,    new SupportsCheck() {
                 @Override
                 public boolean doCheck( Node n, EnhGraph g ) {
-                    if ( n.isURI() || n.isBlank() ) { 
+                    if ( n.isURI() || n.isBlank() ) {
                         return !hasType( n, g, new Resource[] {RDFS.Class, RDF.Property, OWL.Class,
                                                                OWL.ObjectProperty, OWL.DatatypeProperty, OWL.TransitiveProperty,
                                                                OWL.FunctionalProperty, OWL.InverseFunctionalProperty} );

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OWLLiteProfile.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OWLLiteProfile.java
@@ -139,6 +139,7 @@ public class OWLLiteProfile
             },
             {  AnnotationProperty.class,    new SupportsCheck() {
                 @Override
+                @SuppressWarnings("removal")
                 public boolean doCheck( Node n, EnhGraph g ) {
                     for (Iterator<Resource> i = ((OntModel) g).getProfile().getAnnotationProperties();  i.hasNext(); ) {
                         if (i.next().asNode().equals( n )) {

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OWLProfile.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OWLProfile.java
@@ -73,6 +73,7 @@ import java.util.Set;
  * Ontology language profile implementation for the Full variant of the OWL 2002/07 language.
  * </p>
  */
+@SuppressWarnings("removal")
 public class OWLProfile
     extends AbstractProfile
 {

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/ObjectPropertyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/ObjectPropertyImpl.java
@@ -39,6 +39,7 @@ import org.apache.jena.util.iterator.WrappedIterator ;
  * Implementation of the object property abstraction
  * </p>
  */
+@SuppressWarnings("removal")
 public class ObjectPropertyImpl
     extends OntPropertyImpl
     implements ObjectProperty

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OntClassImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OntClassImpl.java
@@ -69,6 +69,7 @@ import java.util.Set;
  * Implementation of the ontology abstraction representing ontology classes.
  * </p>
  */
+@SuppressWarnings("removal")
 public class OntClassImpl
     extends OntResourceImpl
     implements OntClass

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OntModelImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OntModelImpl.java
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory ;
  * and similar languages.
  * </p>
  */
+@SuppressWarnings("removal")
 public class OntModelImpl extends ModelCom implements OntModel
 {
     // Constants

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OntPropertyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OntPropertyImpl.java
@@ -37,6 +37,7 @@ import org.apache.jena.util.iterator.* ;
  * Implementation of the abstraction representing a general ontology property.
  * </p>
  */
+@SuppressWarnings("removal")
 public class OntPropertyImpl
     extends OntResourceImpl
     implements OntProperty

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OntResourceImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OntResourceImpl.java
@@ -91,6 +91,7 @@ import java.util.function.Predicate;
  * resources.
  * </p>
  */
+@SuppressWarnings("removal")
 public class OntResourceImpl
     extends ResourceImpl
     implements OntResource

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/OntologyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/OntologyImpl.java
@@ -36,6 +36,7 @@ import org.apache.jena.util.iterator.ExtendedIterator ;
  * meta-data about whole ontologies.
  * </p>
  */
+@SuppressWarnings("removal")
 public class OntologyImpl
     extends OntResourceImpl
     implements Ontology

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/QualifiedRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/QualifiedRestrictionImpl.java
@@ -66,6 +66,7 @@ public class QualifiedRestrictionImpl
             { return isValidQualifiedRestriction( node, eg ); }
     };
 
+    @SuppressWarnings("removal")
     private static boolean isValidQualifiedRestriction( Node node, EnhGraph eg )
         {
         // node will support being a QualifiedRestriction facet if it has rdf:type owl:Restriction or equivalent

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/RDFSProfile.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/RDFSProfile.java
@@ -236,6 +236,7 @@ public class RDFSProfile
      * viewed according to the facet resource <code>res</code>
      */
     @Override
+    @SuppressWarnings("removal")
     public <T> boolean isSupported( Node n, EnhGraph g, Class<T> type ) {
         if (g instanceof OntModel) {
             OntModel m = (OntModel) g;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/RestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/RestrictionImpl.java
@@ -63,6 +63,7 @@ public class RestrictionImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an Restriction facet if it has rdf:type owl:Restriction or equivalent
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/SomeValuesFromRestrictionImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/SomeValuesFromRestrictionImpl.java
@@ -35,6 +35,7 @@ import org.apache.jena.rdf.model.Resource ;
  * Implementation of the someValuesFrom restriction abstraction.
  * </p>
  */
+@SuppressWarnings("removal")
 public class SomeValuesFromRestrictionImpl
     extends RestrictionImpl
     implements SomeValuesFromRestriction

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/SymmetricPropertyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/SymmetricPropertyImpl.java
@@ -35,6 +35,7 @@ import org.apache.jena.ontology.* ;
  * Implementation of the symmetric property abstraction
  * </p>
  */
+@SuppressWarnings("removal")
 public class SymmetricPropertyImpl
     extends ObjectPropertyImpl
     implements SymmetricProperty

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/TransitivePropertyImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/TransitivePropertyImpl.java
@@ -35,6 +35,7 @@ import org.apache.jena.ontology.* ;
  * Implementation of the transitive property abstraction
  * </p>
  */
+@SuppressWarnings("removal")
 public class TransitivePropertyImpl
     extends ObjectPropertyImpl
     implements TransitiveProperty

--- a/jena-core/src/main/java/org/apache/jena/ontology/impl/UnionClassImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/ontology/impl/UnionClassImpl.java
@@ -62,6 +62,7 @@ public class UnionClassImpl
         }
 
         @Override
+        @SuppressWarnings("removal")
         public boolean canWrap( Node node, EnhGraph eg ) {
             // node will support being an UnionClass facet if it has rdf:type owl:Class and an owl:unionOf statement (or equivalents)
             Profile profile = (eg instanceof OntModel) ? ((OntModel) eg).getProfile() : null;

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/ModelFactory.java
@@ -86,11 +86,13 @@ public class ModelFactory extends ModelFactoryBase
     }
 
     /**
-        Answer a ModelMaker that constructs memory-based Models that do
-        not persist past JVM termination.
-
-        @return a ModelMaker that constructs memory-based models
-    */
+     * Answer a ModelMaker that constructs memory-based Models that do not persist
+     * past JVM termination.
+     *
+     * @return a ModelMaker that constructs memory-based models
+     * @deprecated Use org.apache.jena.ontapi.
+     */
+    @Deprecated(forRemoval = true)
     public static ModelMaker createMemModelMaker() {
         return new ModelMakerImpl(new SimpleGraphMaker());
     }
@@ -181,7 +183,10 @@ public class ModelFactory extends ModelFactoryBase
      * @return A new ontology model
      * @see OntModelSpec#getDefaultSpec
      * @see #createOntologyModel(OntModelSpec, Model)
+     *
+     * @deprecated Use org.apache.jena.ontapi.
      */
+    @Deprecated(forRemoval = true)
     public static OntModel createOntologyModel() {
         return createOntologyModel( ProfileRegistry.OWL_LANG );
     }
@@ -232,7 +237,9 @@ public class ModelFactory extends ModelFactoryBase
      * @param languageURI The URI specifying the ontology language we want to process
      * @return A new ontology model
      * @see OntModelSpec#getDefaultSpec
+     * @deprecated Use org.apache.jena.ontapi.
      */
+    @Deprecated(forRemoval = true)
     public static OntModel createOntologyModel( String languageURI ) {
         return createOntologyModel( OntModelSpec.getDefaultSpec( languageURI ), null );
     }
@@ -252,7 +259,9 @@ public class ModelFactory extends ModelFactoryBase
      * @param base The base model, which contains the contents of the ontology to be processed
      * @return A new ontology model
      * @see OntModelSpec
+     * @deprecated Use org.apache.jena.ontapi.
      */
+    @Deprecated(forRemoval = true)
     public static OntModel createOntologyModel( OntModelSpec spec, ModelMaker maker, Model base ) {
         OntModelSpec _spec = new OntModelSpec( spec );
         _spec.setImportModelMaker( maker );
@@ -271,7 +280,9 @@ public class ModelFactory extends ModelFactoryBase
      * @param base An existing model to treat as an ontology model, or null.
      * @return A new ontology model
      * @see OntModelSpec
+     * @deprecated Use org.apache.jena.ontapi.
      */
+    @Deprecated(forRemoval = true)
     public static OntModel createOntologyModel( OntModelSpec spec, Model base ) {
         return new OntModelImpl( spec, base );
     }
@@ -279,7 +290,9 @@ public class ModelFactory extends ModelFactoryBase
     /**
      * Answer a new ontology model constructed according to the specification, which includes
      * a ModelMaker which will create the necessary base model.
-    */
+     * @deprecated Use org.apache.jena.ontapi.
+     */
+    @Deprecated(forRemoval = true)
     public static OntModel createOntologyModel(OntModelSpec spec) {
         return new OntModelImpl(spec);
     }

--- a/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFListImpl.java
+++ b/jena-core/src/main/java/org/apache/jena/rdf/model/impl/RDFListImpl.java
@@ -26,13 +26,18 @@ package org.apache.jena.rdf.model.impl;
 import java.util.*;
 import java.util.function.Function;
 
-import org.apache.jena.enhanced.* ;
-import org.apache.jena.graph.* ;
-import org.apache.jena.ontology.* ;
+import org.apache.jena.enhanced.EnhGraph;
+import org.apache.jena.enhanced.EnhNode;
+import org.apache.jena.enhanced.Implementation;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.ontology.OntModel;
+import org.apache.jena.ontology.Profile;
 import org.apache.jena.rdf.model.* ;
-import org.apache.jena.shared.* ;
-import org.apache.jena.util.iterator.* ;
-import org.apache.jena.vocabulary.* ;
+import org.apache.jena.shared.JenaException;
+import org.apache.jena.util.iterator.ExtendedIterator;
+import org.apache.jena.util.iterator.NiceIterator;
+import org.apache.jena.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,19 +61,25 @@ public class RDFListImpl
     /**
      * A factory for generating RDFList facets from nodes in enhanced graphs.
      */
-    @SuppressWarnings("hiding")
+    @SuppressWarnings({"hiding", "removal"})
     public static Implementation factory = new Implementation() {
+        // The machinery does not seem to do anything.
+        // Temporarily retained for reference (Jena 5.6.0)
+        private static final boolean OntListVocabulary = false;
+
         @Override public EnhNode wrap( Node n, EnhGraph eg ) {
             if (canWrap( n, eg )) {
                 RDFListImpl impl = new RDFListImpl( n, eg );
 
-                // pass on the vocabulary terms, if available
-                if (eg instanceof OntModel) {
-                    Profile prof = ((OntModel) eg).getProfile();
-                    impl.m_listFirst = prof.FIRST();
-                    impl.m_listRest = prof.REST();
-                    impl.m_listNil = prof.NIL();
-                    impl.m_listType = prof.LIST();
+                if ( false ) {
+                    // pass on the vocabulary terms, if available
+                    if (eg instanceof OntModel ontModel) {
+                        Profile prof = ontModel.getProfile();
+                        impl.m_listFirst = prof.FIRST();
+                        impl.m_listRest = prof.REST();
+                        impl.m_listNil = prof.NIL();
+                        impl.m_listType = prof.LIST();
+                    }
                 }
 
                 return impl;
@@ -86,11 +97,13 @@ public class RDFListImpl
             Resource rest = RDF.rest;
             Resource nil = RDF.nil;
 
-            if (eg instanceof OntModel) {
-                Profile prof = ((OntModel) eg).getProfile();
-                first = prof.FIRST();
-                rest = prof.REST();
-                nil = prof.NIL();
+            if ( false ) {
+                if (eg instanceof OntModel ontModel) {
+                    Profile prof = ontModel.getProfile();
+                    first = prof.FIRST();
+                    rest = prof.REST();
+                    nil = prof.NIL();
+                }
             }
 
             // node will support being an RDFList facet if it has rdf:type rdf:List, is nil, or is in the domain of a list property

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/OWLFBRuleReasonerFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/OWLFBRuleReasonerFactory.java
@@ -31,7 +31,7 @@ import org.apache.jena.vocabulary.ReasonerVocabulary;
  * Factory class for creating blank instances of the OWL Reasoner.
  * <p>
  * The reasoner can be configured using three properties (set as
- * properties of the base reasonder URI in a configuration model). These are:
+ * properties of the base reasoner URI in a configuration model). These are:
  * <ul>
  * <li><b>derivationLogging</b> - if set to true this causes all derivations to
  * be recorded in an internal data structure for replay through the {@link org.apache.jena.reasoner.InfGraph#getDerivation getDerivation}
@@ -41,26 +41,26 @@ import org.apache.jena.vocabulary.ReasonerVocabulary;
  * </ul>
  */
 public class OWLFBRuleReasonerFactory implements ReasonerFactory {
-    
+
     /** Single global instance of this factory */
     private static ReasonerFactory theInstance = new OWLFBRuleReasonerFactory();
-    
+
     /** Static URI for this reasoner type */
     public static final String URI = "http://jena.hpl.hp.com/2003/OWLFBRuleReasoner";
-    
+
     /** Cache of the capabilities description */
     protected Model capabilities;
-    
+
     /**
      * Return the single global instance of this factory
      */
     public static ReasonerFactory theInstance() {
         return theInstance;
     }
-    
+
     /**
      * Constructor method that builds an instance of the associated Reasoner
-     * @param configuration a set of arbitrary configuration information to be 
+     * @param configuration a set of arbitrary configuration information to be
      * passed the reasoner encoded within an RDF graph
      */
     @Override
@@ -78,7 +78,7 @@ public class OWLFBRuleReasonerFactory implements ReasonerFactory {
         }
         return reasoner;
     }
-   
+
     /**
      * Return a description of the capabilities of this reasoner encoded in
      * RDF. This method is normally called by the ReasonerRegistry which caches
@@ -117,12 +117,12 @@ public class OWLFBRuleReasonerFactory implements ReasonerFactory {
                 .addProperty(ReasonerVocabulary.supportsP, OWL.sameAs )
                 .addProperty(ReasonerVocabulary.supportsP, OWL.differentFrom )
                 .addProperty(ReasonerVocabulary.supportsP, OWL.disjointWith )
-                
+
                 .addProperty(ReasonerVocabulary.versionP, "0.1");
         }
         return capabilities;
     }
-    
+
     /**
      * Return the URI labelling this type of reasoner
      */
@@ -130,5 +130,5 @@ public class OWLFBRuleReasonerFactory implements ReasonerFactory {
     public String getURI() {
         return URI;
     }
-    
+
 }

--- a/jena-core/src/main/java/org/apache/jena/vocabulary/OntEventsVocab.java
+++ b/jena-core/src/main/java/org/apache/jena/vocabulary/OntEventsVocab.java
@@ -31,20 +31,21 @@ import org.apache.jena.rdf.model.* ;
 /**
  * Vocabulary definitions from file:vocabularies/ont-event.rdf
  */
+@SuppressWarnings("removal")
 public class OntEventsVocab {
     /** <p>The ontology model that holds the vocabulary terms</p> */
     private static final OntModel m_model = ModelFactory.createOntologyModel( OntModelSpec.OWL_MEM, null );
-    
+
     /** <p>The namespace of the vocabulary as a string ({@value})</p> */
     public static final String NS = "http://jena.hpl.hp.com/schemas/2003/03/ont-event#";
-    
+
     /** <p>The namespace of the vocabulary as a string</p>
      *  @see #NS */
     public static String getURI() {return NS;}
-    
+
     /** <p>The namespace of the vocabulary as a resource</p> */
     public static final Resource NAMESPACE = m_model.createResource( NS );
-    
+
 
     // Vocabulary properties
     ///////////////////////////
@@ -55,231 +56,231 @@ public class OntEventsVocab {
 
     /** <p>A class representing observable events in an ontology model</p> */
     public static final OntClass OntEvent = m_model.createClass( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#OntEvent" );
-    
+
 
     // Vocabulary individuals
     ///////////////////////////
 
-    /** <p>Event representing the declaration of one ontology individual being related 
+    /** <p>Event representing the declaration of one ontology individual being related
      *  to another by some named predicate.</p>
      */
     public static final Individual related = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#related", OntEvent );
-    
-    /** <p>Event representing the declaration of a property as having a given class, 
+
+    /** <p>Event representing the declaration of a property as having a given class,
      *  datatype or datarange as the range</p>
      */
     public static final Individual range = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#range", OntEvent );
-    
+
     /** <p>Event representing the declaration of a resource as an ontology Class.</p> */
     public static final Individual classDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#classDeclaration", OntEvent );
-    
+
     /** <p>Event representing the declaration that a restriction applies to a given property</p> */
     public static final Individual onProperty = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#onProperty", OntEvent );
-    
-    /** <p>Event representing the declaration of that a qualified restriction has the 
+
+    /** <p>Event representing the declaration of that a qualified restriction has the
      *  given class or datatype for the qualification restriction</p>
      */
     public static final Individual hasClassQ = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#hasClassQ", OntEvent );
-    
+
     /** <p>Event representing the declaration of one class being the sub-class of another.</p> */
     public static final Individual subClassOf = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#subClassOf", OntEvent );
-    
-    /** <p>Event representing the declaration of a class expression being composed of 
+
+    /** <p>Event representing the declaration of a class expression being composed of
      *  a finite enumeration of identified individuals.</p>
      */
     public static final Individual oneOf = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#oneOf", OntEvent );
-    
-    /** <p>Event representing the declaration of a property as being the inverse of another 
+
+    /** <p>Event representing the declaration of a property as being the inverse of another
      *  property</p>
      */
     public static final Individual inverseOf = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#inverseOf", OntEvent );
-    
-    /** <p>Event representing the declaration of a resource of type owl:Ontology, 
+
+    /** <p>Event representing the declaration of a resource of type owl:Ontology,
      *  representing meta-data about the ontology.</p>
      */
     public static final Individual ontologyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#ontologyDeclaration", OntEvent );
-    
+
     /** <p>Event representing the declaration of a property as being functional.</p> */
     public static final Individual functionalPropertyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#functionalPropertyDeclaration", OntEvent );
-    
-    /** <p>Event representing the declaration that a restriction constrains the property 
+
+    /** <p>Event representing the declaration that a restriction constrains the property
      *  to have a given value</p>
      */
     public static final Individual hasValue = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#hasValue", OntEvent );
-    
-    /** <p>Event representing the declaration of that a restriction has the given minimum 
+
+    /** <p>Event representing the declaration of that a restriction has the given minimum
      *  cardinality on the restricted property</p>
      */
     public static final Individual minCardinality = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#minCardinality", OntEvent );
-    
+
     /** <p>Event representing a label on an ontology element</p> */
     public static final Individual label = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#label", OntEvent );
-    
+
     /** <p>Event representing the declaration of a class as being deprecated.</p> */
     public static final Individual DeprecatedClass = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#DeprecatedClass", OntEvent );
-    
-    /** <p>Event representing the declaration of a property as having a given class, 
+
+    /** <p>Event representing the declaration of a property as having a given class,
      *  datatype or datarange as the domain</p>
      */
     public static final Individual domain = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#domain", OntEvent );
-    
-    /** <p>Event representing the declaration of one class expression being disjoint 
+
+    /** <p>Event representing the declaration of one class expression being disjoint
      *  with another.</p>
      */
     public static final Individual disjointWith = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#disjointWith", OntEvent );
-    
-    /** <p>Event representing the declaration that a restriction constrains at least 
+
+    /** <p>Event representing the declaration that a restriction constrains at least
      *  one value of the property to have some class or datatype</p>
      */
     public static final Individual someValuesFrom = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#someValuesFrom", OntEvent );
-    
-    /** <p>Event representing the declaration that one ontology is imported into another 
+
+    /** <p>Event representing the declaration that one ontology is imported into another
      *  ontology.</p>
      */
     public static final Individual imports = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#imports", OntEvent );
-    
-    /** <p>Event representing the declaration of a class expression being a union of 
+
+    /** <p>Event representing the declaration of a class expression being a union of
      *  class descriptions.</p>
      */
     public static final Individual unionOf = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#unionOf", OntEvent );
-    
+
     /** <p>Event representing the declaration of an ontology property.</p> */
     public static final Individual ontologyPropertyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#ontologyPropertyDeclaration", OntEvent );
-    
+
     /** <p>Event representing the declaration of a property as being deprecated.</p> */
     public static final Individual DeprecatedProperty = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#DeprecatedProperty", OntEvent );
-    
+
     /** <p>Event representing the declaration of a resource being a Restriction</p> */
     public static final Individual restrictionDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#restrictionDeclaration", OntEvent );
-    
+
     /** <p>Event representing the declaration of a property as being symmetric</p> */
     public static final Individual symmetricPropertyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#symmetricPropertyDeclaration", OntEvent );
-    
-    /** <p>Event representing the declaration of that a restriction has the given maximum 
+
+    /** <p>Event representing the declaration of that a restriction has the given maximum
      *  cardinality on the restricted property</p>
      */
     public static final Individual maxCardinality = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#maxCardinality", OntEvent );
-    
-    /** <p>Event representing the declaration of one ontology individual being distinct 
+
+    /** <p>Event representing the declaration of one ontology individual being distinct
      *  from another</p>
      */
     public static final Individual differentFrom = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#differentFrom", OntEvent );
-    
+
     /** <p>Event representing a comment on an ontology element</p> */
     public static final Individual comment = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#comment", OntEvent );
-    
-    /** <p>Event representing the declaration of one class expression being equivalent 
+
+    /** <p>Event representing the declaration of one class expression being equivalent
      *  to another.</p>
      */
     public static final Individual equivalentClass = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#equivalentClass", OntEvent );
-    
-    /** <p>Event representing a catch-all category of user-specified data, ie triples 
-     *  in the graph that relate to the use of ontology terms on instances, rather 
+
+    /** <p>Event representing a catch-all category of user-specified data, ie triples
+     *  in the graph that relate to the use of ontology terms on instances, rather
      *  than the definition of ontology terms.</p>
      */
     public static final Individual userData = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#userData", OntEvent );
-    
-    /** <p>Event representing the declaration of a class expression being an intersection 
+
+    /** <p>Event representing the declaration of a class expression being an intersection
      *  of class descriptions.</p>
      */
     public static final Individual intersectionOf = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#intersectionOf", OntEvent );
-    
-    /** <p>Event representing the declaration of that a restriction has the given cardinality 
+
+    /** <p>Event representing the declaration of that a restriction has the given cardinality
      *  on the restricted property</p>
      */
     public static final Individual cardinality = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#cardinality", OntEvent );
-    
+
     /** <p>Event representing the declaration of a resource as a Datarange.</p> */
     public static final Individual datarangeDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#datarangeDeclaration", OntEvent );
-    
-    /** <p>Event representing the declaration of a prior version of a given ontology, 
+
+    /** <p>Event representing the declaration of a prior version of a given ontology,
      *  which the ontology is compatible with.</p>
      */
     public static final Individual backwardCompatibleWith = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#backwardCompatibleWith", OntEvent );
-    
-    /** <p>Event representing the declaration of a prior version of a given ontology, 
+
+    /** <p>Event representing the declaration of a prior version of a given ontology,
      *  which the ontology is not compatible with.</p>
      */
     public static final Individual incompatibleWith = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#incompatibleWith", OntEvent );
-    
-    /** <p>Event representing the declaration of one ontology individual being the same 
+
+    /** <p>Event representing the declaration of one ontology individual being the same
      *  as another</p>
      */
     public static final Individual sameIndividualAs = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#sameIndividualAs", OntEvent );
-    
-    /** <p>Event representing the declaration of a set of individuals being pairwise 
+
+    /** <p>Event representing the declaration of a set of individuals being pairwise
      *  distinct.</p>
      */
     public static final Individual allDifferentDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#allDifferentDeclaration", OntEvent );
-    
+
     /** <p>Event representing the declaration of a resource as an annotation property.</p> */
     public static final Individual annotationPropertyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#annotationPropertyDeclaration", OntEvent );
-    
-    /** <p>Event representing the identification of a set of individuals that are in 
+
+    /** <p>Event representing the identification of a set of individuals that are in
      *  the scope of an AllDifferent declaration.</p>
      */
     public static final Individual distinctMembers = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#distinctMembers", OntEvent );
-    
+
     /** <p>Event representing the declaration of an ontology individual</p> */
     public static final Individual individualDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#individualDeclaration", OntEvent );
-    
+
     /** <p>Event representing the declaration of version information on an ontology resource.</p> */
     public static final Individual versionInfo = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#versionInfo", OntEvent );
-    
+
     /** <p>Event representing the declaration of a resource as a plain property.</p> */
     public static final Individual propertyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#propertyDeclaration", OntEvent );
-    
-    /** <p>Event representing the declaration of that a qualified restriction has the 
+
+    /** <p>Event representing the declaration of that a qualified restriction has the
      *  given cardinality on the restricted property</p>
      */
     public static final Individual cardinalityQ = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#cardinalityQ", OntEvent );
-    
+
     /** <p>Event representing the declaration of a resource as an object property.</p> */
     public static final Individual objectPropertyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#objectPropertyDeclaration", OntEvent );
-    
+
     /** <p>Event representing the declaration of a prior version of a given ontology.</p> */
     public static final Individual priorVersion = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#priorVersion", OntEvent );
-    
-    /** <p>Event representing the declaration of a property as being equivalent to another 
+
+    /** <p>Event representing the declaration of a property as being equivalent to another
      *  property</p>
      */
     public static final Individual equivalentProperty = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#equivalentProperty", OntEvent );
-    
-    /** <p>Event representing the declaration of that a qualified restriction has the 
+
+    /** <p>Event representing the declaration of that a qualified restriction has the
      *  given minimum cardinality on the restricted property</p>
      */
     public static final Individual minCardinalityQ = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#minCardinalityQ", OntEvent );
-    
-    /** <p>Event representing the declaration of a property as being the sub-property 
+
+    /** <p>Event representing the declaration of a property as being the sub-property
      *  of another property</p>
      */
     public static final Individual subPropertyOf = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#subPropertyOf", OntEvent );
-    
-    /** <p>Event representing the declaration of a class expression being the complement 
+
+    /** <p>Event representing the declaration of a class expression being the complement
      *  of another class description.</p>
      */
     public static final Individual complementOf = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#complementOf", OntEvent );
-    
+
     /** <p>Event representing a declaration that one resource is the same as another.</p> */
     public static final Individual sameAs = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#sameAs", OntEvent );
-    
-    /** <p>Event representing the declaration that a restriction constrains all values 
+
+    /** <p>Event representing the declaration that a restriction constrains all values
      *  of the property to have some class or datatype</p>
      */
     public static final Individual allValuesFrom = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#allValuesFrom", OntEvent );
-    
+
     /** <p>Event representing the declaration of a property as being inverse functional.</p> */
     public static final Individual inverseFunctionalPropertyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#inverseFunctionalPropertyDeclaration", OntEvent );
-    
+
     /** <p>Event representing the declaration of a property as being transitive.</p> */
     public static final Individual transitivePropertyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#transitivePropertyDeclaration", OntEvent );
-    
+
     /** <p>Event representing the declaration of a resource as a datatype property.</p> */
     public static final Individual datatypePropertyDeclaration = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#datatypePropertyDeclaration", OntEvent );
-    
-    /** <p>Event representing the declaration of that a qualified restriction has the 
+
+    /** <p>Event representing the declaration of that a qualified restriction has the
      *  given maximum cardinality on the restricted property</p>
      */
     public static final Individual maxCardinalityQ = m_model.createIndividual( "http://jena.hpl.hp.com/schemas/2003/03/ont-event#maxCardinalityQ", OntEvent );
-    
+
 }

--- a/jena-core/src/test/java/org/apache/jena/assembler/test/TestBuiltinAssemblerGroup.java
+++ b/jena-core/src/test/java/org/apache/jena/assembler/test/TestBuiltinAssemblerGroup.java
@@ -31,6 +31,7 @@ public class TestBuiltinAssemblerGroup extends AssemblerTestBase
     @Override protected Class<? extends Assembler> getAssemblerClass()
         { return null; }
 
+    @SuppressWarnings("removal")
     public void testGeneralRegistration()
         {
         assertAssemblerClass( JA.DefaultModel, DefaultModelAssembler.class );
@@ -48,6 +49,7 @@ public class TestBuiltinAssemblerGroup extends AssemblerTestBase
         assertAssemblerClass( JA.UnionModel, UnionModelAssembler.class );
         }
 
+    @SuppressWarnings("removal")
     public void testVariables()
         {
         assertInstanceOf( DefaultModelAssembler.class, Assembler.defaultModel );

--- a/jena-core/src/test/java/org/apache/jena/assembler/test/TestOntModelAcceptance.java
+++ b/jena-core/src/test/java/org/apache/jena/assembler/test/TestOntModelAcceptance.java
@@ -21,6 +21,7 @@ package org.apache.jena.assembler.test;
 import org.apache.jena.ontology.* ;
 import org.apache.jena.rdf.model.* ;
 
+@SuppressWarnings("removal")
 public class TestOntModelAcceptance extends AssemblerTestBase
     {
     public TestOntModelAcceptance( String name )

--- a/jena-core/src/test/java/org/apache/jena/assembler/test/TestOntModelAssembler.java
+++ b/jena-core/src/test/java/org/apache/jena/assembler/test/TestOntModelAssembler.java
@@ -27,12 +27,13 @@ import org.apache.jena.assembler.assemblers.* ;
 import org.apache.jena.ontology.* ;
 import org.apache.jena.rdf.model.* ;
 
+@SuppressWarnings("removal")
 public class TestOntModelAssembler extends AssemblerTestBase
     {
     public TestOntModelAssembler( String name )
         { super( name ); }
 
-    public static TestSuite suite() 
+    public static TestSuite suite()
         {
         TestSuite result = new TestSuite();
         result.addTestSuite( TestOntModelAssembler.class );
@@ -45,8 +46,8 @@ public class TestOntModelAssembler extends AssemblerTestBase
 
     public void testOntModelAssemblerType()
         { testDemandsMinimalType( new OntModelAssembler(), JA.OntModel );  }
-    
-    protected static void addParameterisedTests( TestSuite result ) 
+
+    protected static void addParameterisedTests( TestSuite result )
         {
         Field [] fields = OntModelSpec.class.getFields();
             for ( Field f : fields )
@@ -64,20 +65,20 @@ public class TestOntModelAssembler extends AssemblerTestBase
                     }
                 }
             }
-        }    
-    
+        }
+
     protected static Test createTest( final OntModelSpec spec, final String name )
         {
         return new TestOntModelAssembler( name )
             {
             @Override
             public void runBare()
-                { 
+                {
                 Assembler a = new OntModelAssembler();
                 Model m = (Model) a.open( new FixedObjectAssembler( spec ), resourceInModel( "x rdf:type ja:OntModel; x ja:ontModelSpec ja:" + name ) );
                 assertInstanceOf( OntModel.class, m );
                 OntModel om = (OntModel) m;
-                assertSame( spec, om.getSpecification() ); 
+                assertSame( spec, om.getSpecification() );
                 }
             };
         }
@@ -90,7 +91,7 @@ public class TestOntModelAssembler extends AssemblerTestBase
         OntModel om = (OntModel) m;
         assertSame( OntModelSpec.OWL_MEM_RDFS_INF, om.getSpecification() );
         }
-    
+
     public void testBaseModel()
         {
         final Model baseModel = model( "a P b" );
@@ -99,9 +100,9 @@ public class TestOntModelAssembler extends AssemblerTestBase
             {
             @Override
             protected Model openEmptyModel( Assembler a, Resource root, Mode irrelevant )
-                { 
+                {
                 assertEquals( resource( "y" ), root );
-                return baseModel;  
+                return baseModel;
                 }
             };
         Object m = a.open( aa, resourceInModel( "x rdf:type ja:OntModel; x ja:baseModel y" ) );
@@ -109,7 +110,7 @@ public class TestOntModelAssembler extends AssemblerTestBase
         OntModel om = (OntModel) m;
         assertSame( baseModel.getGraph(), om.getBaseModel().getGraph() );
         }
-    
+
     public void testSubModels()
         {
         final Model baseModel = model( "a P b" );
@@ -118,9 +119,9 @@ public class TestOntModelAssembler extends AssemblerTestBase
             {
             @Override
             protected Model openEmptyModel( Assembler a, Resource root, Mode irrelevant )
-                { 
+                {
                 assertEquals( resource( "y" ), root );
-                return baseModel;  
+                return baseModel;
                 }
             };
         Object m = a.open( aa, resourceInModel( "x rdf:type ja:OntModel; x ja:subModel y" ) );
@@ -130,7 +131,7 @@ public class TestOntModelAssembler extends AssemblerTestBase
         assertEquals( 1, subModels.size() );
         assertSame( baseModel.getGraph(), subModels.get( 0 ).getBaseModel().getGraph() );
         }
-    
+
     public void testDefaultDocumentManager()
         {
         Assembler a = new OntModelAssembler();
@@ -138,7 +139,7 @@ public class TestOntModelAssembler extends AssemblerTestBase
         OntModel om = (OntModel) a.openModel( root );
         assertSame( OntDocumentManager.getInstance(), om.getDocumentManager() );
         }
-    
+
     public void testUsesOntModelSpec()
         {
         Assembler a = new OntModelAssembler();

--- a/jena-core/src/test/java/org/apache/jena/assembler/test/TestOntModelSpecAssembler.java
+++ b/jena-core/src/test/java/org/apache/jena/assembler/test/TestOntModelSpecAssembler.java
@@ -31,6 +31,7 @@ import org.apache.jena.reasoner.* ;
 import org.apache.jena.reasoner.rulesys.* ;
 import org.apache.jena.shared.CannotCreateException ;
 
+@SuppressWarnings("removal")
 public class TestOntModelSpecAssembler extends AssemblerTestBase
     {
     public TestOntModelSpecAssembler( String name )
@@ -41,7 +42,7 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
 
     public void testOntModelSpecAssemblerType()
         { testDemandsMinimalType( new OntModelSpecAssembler(), JA.OntModelSpec );  }
-    
+
     public static TestSuite suite()
         {
         TestSuite result = new TestSuite();
@@ -49,8 +50,8 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
         addParameterisedTests( result );
         return result;
         }
-    
-    protected static void addParameterisedTests( TestSuite result ) 
+
+    protected static void addParameterisedTests( TestSuite result )
         {
         Field [] fields = OntModelSpec.class.getFields();
             for ( Field f : fields )
@@ -68,8 +69,8 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
                     }
                 }
             }
-        }    
-    
+        }
+
     protected void testBuiltinSpec( OntModelSpec ontModelSpec, String specName )
         {
         testBuiltinSpecAsRootName( ontModelSpec, specName );
@@ -87,7 +88,7 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
         Resource root = resourceInModel( JA.getURI() + specName + " rdf:type ja:OntModelSpec" );
         assertEquals( ontModelSpec, new OntModelSpecAssembler().open( root ) );
         }
-    
+
     protected static Test createTest( final OntModelSpec spec, final String name )
         {
         return new TestOntModelSpecAssembler( name )
@@ -97,16 +98,16 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
                 { testBuiltinSpec( spec, name ); }
             };
         }
-    
+
     public void testOntModelSpecVocabulary()
         {
         assertDomain( JA.OntModelSpec, JA.ontLanguage );
         assertDomain( JA.OntModelSpec, JA.documentManager );
         assertDomain( JA.OntModelSpec, JA.likeBuiltinSpec );
         }
-    
-    public void testCreateFreshDocumentManager() 
-        { 
+
+    public void testCreateFreshDocumentManager()
+        {
         Assembler a = new OntModelSpecAssembler();
         Resource root = resourceInModel( "x rdf:type ja:OntModelSpec; x ja:documentManager y" );
         OntDocumentManager dm = new OntDocumentManager();
@@ -114,7 +115,7 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
         OntModelSpec om = (OntModelSpec) a.open( mock, root );
         assertSame( dm, om.getDocumentManager() );
         }
-    
+
     public void testUseSpecifiedReasoner()
         {
         Assembler a = new OntModelSpecAssembler();
@@ -124,7 +125,7 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
         OntModelSpec om = (OntModelSpec) a.open( mock, root );
         assertSame( rf, om.getReasonerFactory() );
         }
-    
+
     public void testUseSpecifiedImpliedReasoner()
         {
         testUsedSpecifiedImpliedReasoner( OWLFBRuleReasonerFactory.URI );
@@ -140,7 +141,7 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
         OntModelSpec om = (OntModelSpec) a.open( mock, root );
         assertSame( rf, om.getReasonerFactory() );
         }
-    
+
     public void testDetectsClashingImpliedAndExplicitReasoners()
         {
         Assembler a = new OntModelSpecAssembler();
@@ -149,7 +150,7 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
         try { a.open( mock, root ); fail( "should detect reasoner clash" ); }
         catch (ReasonerClashException e) { pass(); }
         }
-    
+
     public void testUseSpecifiedLanguage()
         {
         testSpecifiedLanguage( ProfileRegistry.OWL_DL_LANG );
@@ -165,12 +166,12 @@ public class TestOntModelSpecAssembler extends AssemblerTestBase
         OntModelSpec om = (OntModelSpec) a.open( root );
         assertEquals( lang, om.getLanguage() );
         }
-    
+
     public void testSpecifiedModelGetter()
         {
         Assembler a = new OntModelSpecAssembler();
-        ModelGetter getter = new ModelGetter() 
-            { 
+        ModelGetter getter = new ModelGetter()
+            {
             @Override
             public Model getModel( String URL ) { return null; }
 

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/OntTestBase.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/OntTestBase.java
@@ -36,6 +36,7 @@ import org.apache.jena.reasoner.test.TestUtil ;
  * Generic test case for ontology unit testing
  * </p>
  */
+@SuppressWarnings("removal")
 public abstract class OntTestBase
     extends TestSuite
 {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TS3_ont.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TS3_ont.java
@@ -25,14 +25,14 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     TestOntGraph.class,
-    TestResource.class,
+    TestOntResource.class,
     TestAxioms.class,
     TestClassExpression.class,
     TestOntDocumentManager.class,
     TestOntology.class,
     TestProperty.class,
     TestListSyntaxCategories.class,
-    TestCreate.class,
+    TestCreateInOntModel.class,
     TestIndividual.class,
     TestAllDifferent.class,
     TestOntModelSpec.class,

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestAllDifferent.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestAllDifferent.java
@@ -20,22 +20,20 @@
 ///////////////
 package org.apache.jena.ontology.impl;
 
-
-
 // Imports
 ///////////////
 import junit.framework.*;
 import org.apache.jena.ontology.* ;
 import org.apache.jena.rdf.model.RDFNode ;
 
-
 /**
  * <p>
  * Unit tests for the AllDifferent declaration.
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestAllDifferent
-    extends OntTestBase 
+    extends OntTestBase
 {
     // Constants
     //////////////////////////////////
@@ -48,15 +46,15 @@ public class TestAllDifferent
 
     // Constructors
     //////////////////////////////////
-    
+
     static public TestSuite suite() {
         return new TestAllDifferent( "TestAllDifferent" );
     }
-    
+
     public TestAllDifferent( String name ) {
         super( name );
     }
-    
+
 
     // External signature methods
     //////////////////////////////////
@@ -71,33 +69,33 @@ public class TestAllDifferent
                     AllDifferent a = m.createAllDifferent();
                     OntResource b = m.getResource( NS + "b" ).as( OntResource.class );
                     OntResource c = m.getResource( NS + "c" ).as( OntResource.class );
-                    
+
                     a.addDistinctMember( b );
                     assertEquals( "Cardinality should be 1", 1, a.getCardinality( prof.DISTINCT_MEMBERS() ) );
                     assertEquals( "List size should be 1", 1, a.getDistinctMembers().size() );
                     assertTrue( "a should have b as distinct", a.hasDistinctMember( b ) );
-                    
+
                     a.addDistinctMember( c );
                     assertEquals( "Cardinality should be 1", 1, a.getCardinality( prof.DISTINCT_MEMBERS() ) );
                     assertEquals( "List size should be 2", 2, a.getDistinctMembers().size() );
                     iteratorTest( a.listDistinctMembers(), new Object[] {b, c} );
-                    
+
                     assertTrue( "a should have b as distinct", a.hasDistinctMember( b ) );
                     assertTrue( "a should have c as distinct", a.hasDistinctMember( c ) );
-                    
+
                     a.setDistinctMembers( m.createList( new RDFNode[] {b} ) );
                     assertEquals( "Cardinality should be 1", 1, a.getCardinality( prof.DISTINCT_MEMBERS() ) );
                     assertEquals( "List size should be 1", 1, a.getDistinctMembers().size() );
                     assertTrue( "a should have b as distinct", a.hasDistinctMember( b ) );
                     assertTrue( "a should not have c as distinct", !a.hasDistinctMember( c ) );
-                    
+
                     a.removeDistinctMember( b );
                     assertTrue( "a should have not b as distinct", !a.hasDistinctMember( b ) );
                 }
             },
         };
     }
-    
+
     // Internal implementation methods
     //////////////////////////////////
 

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestClassExpression.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestClassExpression.java
@@ -37,6 +37,7 @@ import org.apache.jena.vocabulary.* ;
  * Unit tests for OntClass and other class expressions.
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestClassExpression
     extends OntTestBase
 {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestCreateInOntModel.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestCreateInOntModel.java
@@ -66,7 +66,8 @@ import org.apache.jena.vocabulary.OWL;
  * Unit test cases for creating values in ontology models
  * </p>
  */
-public class TestCreate
+@SuppressWarnings("removal")
+public class TestCreateInOntModel
     extends TestCase
 {
     // Constants
@@ -398,7 +399,7 @@ public class TestCreate
     // Constructors
     //////////////////////////////////
 
-    public TestCreate( String name ) {
+    public TestCreateInOntModel( String name ) {
         super( name );
     }
 

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestFrameView.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestFrameView.java
@@ -35,6 +35,7 @@ import org.apache.jena.reasoner.test.TestUtil ;
  * Unit-tests for frame-like views of OWL and RDFS-classes, especially listDeclaredProperties
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestFrameView
     extends TestCase
 {
@@ -165,9 +166,9 @@ public class TestFrameView
         System.gc();
         System.gc();
         Runtime r = Runtime.getRuntime();
-        System.out.println( getName() + 
-                            " memory = " + r.freeMemory() + 
-                            ", alloc = " + r.totalMemory() + 
+        System.out.println( getName() +
+                            " memory = " + r.freeMemory() +
+                            ", alloc = " + r.totalMemory() +
                             ", % = " + Math.round( 100.0 * (double) r.freeMemory() / (double) r.totalMemory() ));
         */
         mInf.close();
@@ -175,7 +176,7 @@ public class TestFrameView
         mNoInf.close();
         mNoInf = null;
     }
-    
+
     // OntClass.listDeclaredProperties() tests ...
 
     public void testLDP_noinfA_nodirect() {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestIndividual.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestIndividual.java
@@ -46,6 +46,7 @@ import java.util.Iterator;
  * Unit tests for ontology individuals
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestIndividual
     extends OntTestBase
 {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestListSyntaxCategories.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestListSyntaxCategories.java
@@ -20,7 +20,6 @@
 ///////////////
 package org.apache.jena.ontology.impl;
 
-
 // Imports
 ///////////////
 
@@ -55,13 +54,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-
-
 /**
  * <p>
  * Unit tests for listXXX methods on ontmodel
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestListSyntaxCategories
     extends TestCase
 {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntClass.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntClass.java
@@ -43,6 +43,7 @@ import org.apache.jena.vocabulary.RDFS;
  * {@link TestClassExpression}
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestOntClass
     extends ModelTestBase
 {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntDocumentManager.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntDocumentManager.java
@@ -62,6 +62,7 @@ import java.util.Set;
  * Unit tests for document manager
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestOntDocumentManager
     extends TestCase
 {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntGraph.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntGraph.java
@@ -32,11 +32,12 @@ public class TestOntGraph extends AbstractTestGraph
     {
     public TestOntGraph( String name )
         { super( name ); }
-        
+
     public static TestSuite suite()
         { return new TestSuite( TestOntGraph.class ); }
 
     @Override
+    @SuppressWarnings("removal")
     public Graph getNewGraph()
         { return ModelFactory.createOntologyModel().getGraph(); }
     }

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntModel.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntModel.java
@@ -69,6 +69,7 @@ import java.util.Map;
  * abstractions' unit tests.
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestOntModel
     extends ModelTestBase
 {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntModelSpec.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntModelSpec.java
@@ -21,6 +21,7 @@ package org.apache.jena.ontology.impl;
 import org.apache.jena.ontology.OntModelSpec ;
 import org.apache.jena.rdf.model.test.ModelTestBase ;
 
+@SuppressWarnings("removal")
 public class TestOntModelSpec extends ModelTestBase
     {
     public TestOntModelSpec( String name )
@@ -46,17 +47,17 @@ public class TestOntModelSpec extends ModelTestBase
         testEqualityAndDifference( OntModelSpec.RDFS_MEM_TRANS_INF );
         testEqualityAndDifference( OntModelSpec.RDFS_MEM_RDFS_INF );
         }
-    
+
     private void testEqualityAndDifference( OntModelSpec os )
         {
         assertEquals( os, new OntModelSpec( os ) );
         }
-    
+
     public void testAssembleRoot()
         {
         // TODO OntModelSpec.assemble( Resource root )
         }
-    
+
     public void testAssembleModel()
         {
         // TODO OntModelSpec.assemble( Model model )

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntReasoning.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntReasoning.java
@@ -42,6 +42,7 @@ import junit.framework.TestCase;
  * Unit tests on ont models with reasoning
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestOntReasoning
     extends TestCase
 {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntResource.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntResource.java
@@ -38,7 +38,8 @@ import org.apache.jena.vocabulary.RDF ;
  * Unit test cases for ontology resources
  * </p>
  */
-public class TestResource extends OntTestBase
+@SuppressWarnings("removal")
+public class TestOntResource extends OntTestBase
 {
     // Constants
     //////////////////////////////////
@@ -54,10 +55,10 @@ public class TestResource extends OntTestBase
     //////////////////////////////////
 
     static public TestSuite suite() {
-        return new TestResource( "TestResource" );
+        return new TestOntResource( "TestResource" );
     }
 
-    public TestResource( String name ) {
+    public TestOntResource( String name ) {
         super( name );
     }
 

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntTools.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntTools.java
@@ -44,6 +44,7 @@ import java.util.function.Predicate;
  * Unit tests for experimental ontology tools class.
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestOntTools
     extends TestCase
 {

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntology.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestOntology.java
@@ -32,8 +32,9 @@ import org.apache.jena.ontology.* ;
  * Unit test cases for the Ontology class
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestOntology
-    extends OntTestBase 
+    extends OntTestBase
 {
     // Constants
     //////////////////////////////////
@@ -52,14 +53,14 @@ public class TestOntology
     static public TestSuite suite() {
         return new TestOntology( "TestOntology" );
     }
-    
+
     public TestOntology( String name ) {
         super( name );
     }
-    
-    
-    
-    
+
+
+
+
     // External signature methods
     //////////////////////////////////
 
@@ -73,19 +74,19 @@ public class TestOntology
                     Ontology x = m.createOntology( NS + "x" );
                     Ontology y = m.createOntology( NS + "y" );
                     Ontology z = m.createOntology( NS + "z" );
-                        
+
                     x.addImport( y );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.IMPORTS() ) );
                     assertEquals( "x should import y", y, x.getImport() );
-                        
+
                     x.addImport( z );
                     assertEquals( "Cardinality should be 2", 2, x.getCardinality( prof.IMPORTS() ) );
                     iteratorTest( x.listImports(), new Object[] {y,z} );
-                        
+
                     x.setImport( z );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.IMPORTS() ) );
                     assertEquals( "x should import z", z, x.getImport() );
-                    
+
                     x.removeImport( y );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.IMPORTS() ) );
                     x.removeImport( z );
@@ -99,19 +100,19 @@ public class TestOntology
                     Ontology x = m.createOntology( NS + "x" );
                     Ontology y = m.createOntology( NS + "y" );
                     Ontology z = m.createOntology( NS + "z" );
-                        
+
                     x.addBackwardCompatibleWith( y );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.BACKWARD_COMPATIBLE_WITH() ) );
                     assertEquals( "x should be back comp with y", y, x.getBackwardCompatibleWith() );
-                        
+
                     x.addBackwardCompatibleWith( z );
                     assertEquals( "Cardinality should be 2", 2, x.getCardinality( prof.BACKWARD_COMPATIBLE_WITH() ) );
                     iteratorTest( x.listBackwardCompatibleWith(), new Object[] {y,z} );
-                        
+
                     x.setBackwardCompatibleWith( z );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.BACKWARD_COMPATIBLE_WITH() ) );
                     assertEquals( "x should be back comp with z", z, x.getBackwardCompatibleWith() );
-                    
+
                     x.removeBackwardCompatibleWith( y );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.BACKWARD_COMPATIBLE_WITH() ) );
                     x.removeBackwardCompatibleWith( z );
@@ -125,19 +126,19 @@ public class TestOntology
                     Ontology x = m.createOntology( NS + "x" );
                     Ontology y = m.createOntology( NS + "y" );
                     Ontology z = m.createOntology( NS + "z" );
-                        
+
                     x.addPriorVersion( y );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.PRIOR_VERSION() ) );
                     assertEquals( "x should have prior y", y, x.getPriorVersion() );
-                        
+
                     x.addPriorVersion( z );
                     assertEquals( "Cardinality should be 2", 2, x.getCardinality( prof.PRIOR_VERSION() ) );
                     iteratorTest( x.listPriorVersion(), new Object[] {y,z} );
-                        
+
                     x.setPriorVersion( z );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.PRIOR_VERSION() ) );
                     assertEquals( "x should have prior z", z, x.getPriorVersion() );
-                    
+
                     x.removePriorVersion( y );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.PRIOR_VERSION() ) );
                     x.removePriorVersion( z );
@@ -151,19 +152,19 @@ public class TestOntology
                     Ontology x = m.createOntology( NS + "x" );
                     Ontology y = m.createOntology( NS + "y" );
                     Ontology z = m.createOntology( NS + "z" );
-                        
+
                     x.addIncompatibleWith( y );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.INCOMPATIBLE_WITH() ) );
                     assertEquals( "x should be in comp with y", y, x.getIncompatibleWith() );
-                        
+
                     x.addIncompatibleWith( z );
                     assertEquals( "Cardinality should be 2", 2, x.getCardinality( prof.INCOMPATIBLE_WITH() ) );
                     iteratorTest( x.listIncompatibleWith(), new Object[] {y,z} );
-                        
+
                     x.setIncompatibleWith( z );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.INCOMPATIBLE_WITH() ) );
                     assertEquals( "x should be incomp with z", z, x.getIncompatibleWith() );
-                    
+
                     x.removeIncompatibleWith( y );
                     assertEquals( "Cardinality should be 1", 1, x.getCardinality( prof.INCOMPATIBLE_WITH() ) );
                     x.removeIncompatibleWith( z );
@@ -172,7 +173,7 @@ public class TestOntology
             },
         };
     }
-    
+
     // Internal implementation methods
     //////////////////////////////////
 

--- a/jena-core/src/test/java/org/apache/jena/ontology/impl/TestProperty.java
+++ b/jena-core/src/test/java/org/apache/jena/ontology/impl/TestProperty.java
@@ -40,6 +40,7 @@ import org.apache.jena.vocabulary.RDF ;
  * Unit test cases for the OntProperty class
  * </p>
  */
+@SuppressWarnings("removal")
 public class TestProperty
     extends OntTestBase
 {

--- a/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput1/TestsARP.java
+++ b/jena-core/src/test/java/org/apache/jena/rdfxml/xmlinput1/TestsARP.java
@@ -106,7 +106,6 @@ public class TestsARP extends TestCase implements RDFErrorHandler, ARPErrorNumbe
 
 	public void testWineDefaultNS() throws IOException {
 		testWineNS(createMemModel());
-		testWineNS(ModelFactory.createOntologyModel());
 	}
 
     private void testWineNS(Model m) throws FileNotFoundException, IOException {

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestOWLMisc.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestOWLMisc.java
@@ -49,6 +49,7 @@ import java.util.Iterator;
  * Misc. tests of the OWL rule engine configurations which
  * have arisen from bug reports or user questions.
  */
+@SuppressWarnings("removal")
 public class TestOWLMisc extends TestCase  {
 
     /**

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRestrictionsDontNeedTyping.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRestrictionsDontNeedTyping.java
@@ -26,19 +26,20 @@ import org.apache.jena.shared.PrefixMapping ;
 import org.apache.jena.vocabulary.* ;
 
 /**
-    Test that restriction inference works even when the restriction isn't given an 
+    Test that restriction inference works even when the restriction isn't given an
     explicit type (ie we're not caught in a forward rule -> backward rule
     layering problem).
 */
+@SuppressWarnings("removal")
 public class TestRestrictionsDontNeedTyping extends ModelTestBase
     {
-    
+
     public static TestSuite suite() {
-        return new TestSuite( TestRestrictionsDontNeedTyping.class ); 
-    } 
-    
+        return new TestSuite( TestRestrictionsDontNeedTyping.class );
+    }
+
     static final Property ANY = null;
-    
+
     public TestRestrictionsDontNeedTyping( String name )
         { super( name ); }
 
@@ -51,7 +52,7 @@ public class TestRestrictionsDontNeedTyping extends ModelTestBase
     public void testAllValuesFromMicroRules()
         {
         /* micro doesn't support this anyway */
-        // testAllValuesFrom( OntModelSpec.OWL_MEM_MICRO_RULE_INF ); 
+        // testAllValuesFrom( OntModelSpec.OWL_MEM_MICRO_RULE_INF );
         }
 
     private void testAllValuesFrom( OntModelSpec owlSpec )
@@ -60,7 +61,7 @@ public class TestRestrictionsDontNeedTyping extends ModelTestBase
         OntModel ont = ModelFactory.createOntologyModel( owlSpec, m );
         assertTrue( ont.contains( resource( "t" ), RDF.type, resource( "T" ) ) );
         }
-    
+
     public void testSomeValuesFromMiniRules()
         { testSomeValuesFrom( OntModelSpec.OWL_MEM_MINI_RULE_INF ); }
 
@@ -76,13 +77,13 @@ public class TestRestrictionsDontNeedTyping extends ModelTestBase
         OntModel ont = ModelFactory.createOntologyModel( owlSpec, m );
         assertTrue( ont.contains( resource( "X" ), RDF.type, resource( "V" ) ) );
         }
-    
+
     public void testCardinalityFullRules()
         { testCardinality( OntModelSpec.OWL_MEM_RULE_INF ); }
-    
+
 //    public void testCardinalityMiniRules()
 //        { testCardinality( OntModelSpec.OWL_MEM_MINI_RULE_INF ); }
-//    
+//
 //    public void testCardinalityMicroRules()
 //        { testCardinality( OntModelSpec.OWL_MEM_MICRO_RULE_INF ); }
 
@@ -92,9 +93,9 @@ public class TestRestrictionsDontNeedTyping extends ModelTestBase
         OntModel ont = ModelFactory.createOntologyModel( owlSpec, m );
         assertEquals( 1, ont.listStatements( resource( "X" ), property( "P" ), ANY ).toList().size() );
         }
-    
+
     Model model( String statements )
-        { 
+        {
         Model result = ModelFactory.createDefaultModel();
         result.setNsPrefixes( PrefixMapping.Extended );
         return modelAdd( result, statements );

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRuleSystemBugs.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestRuleSystemBugs.java
@@ -86,6 +86,7 @@ import java.util.Set;
 /**
  * Unit tests for reported bugs in the rule system.
  */
+@SuppressWarnings("removal")
 public class TestRuleSystemBugs extends TestCase {
 
     /**

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/WebOntTestHarness.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/WebOntTestHarness.java
@@ -446,6 +446,7 @@ public class WebOntTestHarness {
      * Load the premises or conclusions for the test, optional performing
      * import processing.
      */
+    @SuppressWarnings("removal")
     public Model getDoc(Resource test, Property docType, boolean processImports) throws IOException {
         if (processImports) {
             Model result = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM, null);

--- a/jena-core/src/test/java/org/apache/jena/reasoner/test/TestInfGraph.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/test/TestInfGraph.java
@@ -34,19 +34,20 @@ public class TestInfGraph extends AbstractTestGraph
     {
     public TestInfGraph( String name )
         { super( name ); }
-    
+
     public static TestSuite suite()
         { return new TestSuite( TestInfGraph.class ); }
-    
+
+    @SuppressWarnings("removal")
     private InfGraph getInfGraph()
         {
         return (InfGraph) ModelFactory.createOntologyModel().getGraph();
         }
-    
+
     @Override
     public Graph getNewGraph()
         { return getInfGraph(); }
-    
+
     public void testInfGraph()
         {
         InfGraph ig = getInfGraph();

--- a/jena-core/src/test/java/org/apache/jena/reasoner/test/TestInfModel.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/test/TestInfModel.java
@@ -28,29 +28,30 @@ import org.apache.jena.util.PrintUtil ;
 import org.apache.jena.vocabulary.RDFS ;
 
 /**
- * Test machinery in InfModel which is not associated with any 
+ * Test machinery in InfModel which is not associated with any
  * particular reasoner.
  */
 
 public class TestInfModel extends TestCase {
     /**
      * Boilerplate for junit
-     */ 
+     */
     public TestInfModel( String name ) {
-        super( name ); 
+        super( name );
     }
-    
+
     /**
      * Boilerplate for junit.
      * This is its own test suite
      */
     public static TestSuite suite() {
         return new TestSuite(TestInfModel.class);
-    }  
+    }
 
     /**
      * Check interface extensions which had an earlier bug with null handling
      */
+    @SuppressWarnings("removal")
     public void testListWithPosits() {
         String NS = PrintUtil.egNS;
         Model data = ModelFactory.createDefaultModel();
@@ -67,7 +68,7 @@ public class TestInfModel extends TestCase {
                     data.createStatement(c1, RDFS.subClassOf, c3),
                     data.createStatement(c1, RDFS.subClassOf, c1)
                 });
-        
+
         OntModel om = ModelFactory.createOntologyModel(OntModelSpec.RDFS_MEM_RDFS_INF, data);
         TestUtil.assertIteratorValues(this, om.listStatements(c1, RDFS.subClassOf, null, premise),
                 new Object[] {

--- a/jena-core/src/test/java/org/apache/jena/reasoner/test/TestInfPrefixMapping.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/test/TestInfPrefixMapping.java
@@ -32,15 +32,16 @@ public class TestInfPrefixMapping extends ModelTestBase
     {
     public TestInfPrefixMapping( String name )
         { super( name ); }
-    
+
     public static TestSuite suite()
         { return new TestSuite( TestInfPrefixMapping.class ); }
-    
+
+    @SuppressWarnings("removal")
     private InfGraph getInfGraph()
         {
         return (InfGraph) ModelFactory.createOntologyModel().getGraph();
         }
-    
+
     public void testInfGraph()
         {
         InfGraph ig = getInfGraph();

--- a/jena-core/src/test/java/org/apache/jena/reasoner/test/TestReasoners.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/test/TestReasoners.java
@@ -59,8 +59,8 @@ import junit.framework.TestSuite;
 /**
  * Test cases for transitive reasoner (includes some early RDFS reasoner checks)
  */
+@SuppressWarnings("removal")
 public class TestReasoners extends TestCase {
-
     /**
      * Boilerplate for junit
      */

--- a/jena-examples/src/main/java/org/apache/jena/example/pizza/PizzaSparqlNoInf.java
+++ b/jena-examples/src/main/java/org/apache/jena/example/pizza/PizzaSparqlNoInf.java
@@ -37,9 +37,7 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDFS;
 
-/**
- * <p>TODO class comment</p>
- */
+@SuppressWarnings("removal")
 public class PizzaSparqlNoInf extends Base
 {
     /***********************************/


### PR DESCRIPTION
GitHub issue resolved #3368

Pull request Description:
Deprecate `OntModel` in jena-core to indicate that the new ontapi package is preferred and a replacment.


----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
