### PR TITLE
Use NodeValue for concrete triple terms as expressions.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprLib.java
@@ -55,7 +55,7 @@ public class ExprLib
         // which overrides fillInStackTrace to be cheap but they loose the
         // general information for development.
         //
-        // Instead, pick out specal cases, the expression being a single variable
+        // Instead, pick out special cases, the expression being a single variable
         // being the important one.
         //
         // BOUND(?x) is a important case where the expression is often an exception
@@ -219,7 +219,7 @@ public class ExprLib
     public static Expr nodeToExpr(Node n) {
         if ( n.isVariable() )
             return new ExprVar(n);
-        if ( n.isTripleTerm() )
+        if ( n.isTripleTerm() && ! n.getTriple().isConcrete() )
             return new ExprTripleTerm(n);
         return NodeValue.makeNode(n);
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -20,7 +20,8 @@ package org.apache.jena.sparql.expr;
 
 import static javax.xml.datatype.DatatypeConstants.*;
 import static org.apache.jena.datatypes.xsd.XSDDatatype.*;
-import static org.apache.jena.sparql.expr.ValueSpace.*;
+import static org.apache.jena.sparql.expr.ValueSpace.VSPACE_DIFFERENT;
+import static org.apache.jena.sparql.expr.ValueSpace.VSPACE_UNKNOWN;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -563,8 +564,15 @@ public abstract class NodeValue extends ExprNode
     // ---- Setting : used when a node is used to make a NodeValue
 
     private static NodeValue nodeToNodeValue(Node node) {
-        if ( node.isVariable() )
-            Log.warn(NodeValue.class, "Variable passed to NodeValue.nodeToNodeValue");
+        if ( ! node.isConcrete() ) {
+            String msg;
+            if ( node.isVariable() )
+                throw new ExprException("Variable passed to NodeValue.nodeToNodeValue: "+node);
+            if ( node.isTripleTerm() )
+                throw new ExprException("Triple term with a variable passed to NodeValue.nodeToNodeValue: "+node);
+            // Should not happen.
+            throw new ExprException("Node is not a constant");
+        }
 
         if ( ! node.isLiteral() )
             // Not a literal - no value to extract

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
@@ -45,18 +45,6 @@ import org.apache.jena.sparql.util.NodeFactoryExtra;
  */
 public class TestNodeValue
 {
-
-//
-//static void assertTrue(boolean b, String msg) {}
-//static void assertFalse(boolean b, String msg) {}
-//static void assertEquals(Object a,  Object b, String msg) {}
-//
-//static void assertTrue(boolean b) {}
-//static void assertFalse(boolean b) {}
-//static void assertEquals(Object a, Object b) {}
-//
-
-
     static final double doubleAccuracy = 0.00000001d;
     static boolean warningSetting;
 
@@ -1274,5 +1262,29 @@ public class TestNodeValue
         NodeValue nv2 = NodeValue.makeNode(n2);
         int x = NodeValue.compareAlways(nv1, nv2);
         assertEquals(Expr.CMP_GREATER, x);
+    }
+
+    @Test
+    public void testBadNodeValue1() {
+        assertThrows(ExprException.class, ()-> {
+            Node n = SSE.parseNode("?variable");
+            NodeValue.makeNode(n);
+        });
+    }
+
+    @Test
+    public void testBadNodeValue2() {
+        assertThrows(ExprException.class, ()-> {
+            Node n = SSE.parseNode("<<(:s :p ?variable)>>");
+            NodeValue.makeNode(n);
+        });
+    }
+
+    @Test
+    public void testBadNodeValue3() {
+        assertThrows(ExprException.class, ()-> {
+            Node n = SSE.parseNode("<<( :s :p <<( :x :y ?variable )>> )>>");
+            NodeValue.makeNode(n);
+        });
     }
 }


### PR DESCRIPTION
GitHub issue resolved #3380

1. Put some checking in `NodeValue.nodeToNodevalue` to enforce the "no variables" rule. Adding this did not require any changes to Jena.
2. `ExprLib.nodeToExpr`, used by the SPARQL parsers, turns concrete triple terms into `NodeValue` objects.

----

 - [x] Tests are included.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
