### PR TITLE
jena-dboe-index-tests: Remove javadoc plugin, instead of using <skip>

### DIFF
--- a/jena-db/jena-dboe-index-test/pom.xml
+++ b/jena-db/jena-dboe-index-test/pom.xml
@@ -90,21 +90,6 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <!--
-              java11 issue - 
-              For generating javadoc, the javadoc tool needs org.hamcrest:hamcrest
-              in scope compile in this module.
-              Either skip javadoc or (despite junit using hamcrest-core)
-              use the dependency commented out up-file.
-          -->
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
     </plugins>
   </build>
 


### PR DESCRIPTION
Having the javadoc plugin, and setting skip, is causing build failures in some places. (ASF JIRA, and locally on some of my branches, but it is not failing in Github Actions).

The module is for tests, and not runtime usage, so remove the plugin.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
