### PR TITLE
Allow Node_Ext to be wrapped as NodeValueNode without further checks.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -564,6 +564,11 @@ public abstract class NodeValue extends ExprNode
     // ---- Setting : used when a node is used to make a NodeValue
 
     private static NodeValue nodeToNodeValue(Node node) {
+        if ( node.isExt() ) {
+            // Don't judge custom extensions.
+            return new NodeValueNode(node);
+        }
+
         if ( ! node.isConcrete() ) {
             String msg;
             if ( node.isVariable() )

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeValue.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Node_Marker;
 import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -1286,5 +1287,14 @@ public class TestNodeValue
             Node n = SSE.parseNode("<<( :s :p <<( :x :y ?variable )>> )>>");
             NodeValue.makeNode(n);
         });
+    }
+
+    @Test
+    public void testCustomNode() {
+        Node expectedNode = Node_Marker.marker("test");
+        Expr expr = ExprLib.nodeToExpr(expectedNode);
+        NodeValue nv = expr.getConstant();
+        Node actualNode = nv.asNode();
+        assertEquals(expectedNode, actualNode);
     }
 }


### PR DESCRIPTION
Pull request Description: A recent change prevented `Node_Ext` instances to be used with `NodeValueNode` - and in consequence with machinery such as `NodeValue.makeNode()` and `ExprLib.nodeToExpr()`.
This PR restores this functionality and adds a simple test.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
