### PR TITLE
Support CONSTRUCT_JSON query type in RDFLinkHTTP.

### DIFF
--- a/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTP.java
+++ b/jena-rdfconnection/src/main/java/org/apache/jena/rdflink/RDFLinkHTTP.java
@@ -29,6 +29,7 @@ import org.apache.jena.http.HttpEnv;
 import org.apache.jena.query.*;
 import org.apache.jena.rdfconnection.JenaConnectionException;
 import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.WebContent;
 import org.apache.jena.sparql.ARQException;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Transactional;
@@ -341,7 +342,10 @@ public class RDFLinkHTTP implements RDFLink {
                                 requestAcceptHeader = RDFLinkHTTP.this.acceptGraph;
                         }
                         break;
-                    case UNKNOWN:
+                    case CONSTRUCT_JSON :
+                        requestAcceptHeader = WebContent.contentTypeJSON;
+                        break;
+                    case UNKNOWN :
                         // All-purpose content type.
                         if ( acceptSparqlResults != null ) {
                             requestAcceptHeader = RDFLinkHTTP.this.acceptSparqlResults;

--- a/jena-rdfconnection/src/test/java/org/apache/jena/rdflink/AbstractTestRDFLink.java
+++ b/jena-rdfconnection/src/test/java/org/apache/jena/rdflink/AbstractTestRDFLink.java
@@ -33,6 +33,8 @@ import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.compose.Union;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.JenaTransactionException;
@@ -433,6 +435,18 @@ public abstract class AbstractTestRDFLink {
         }
     }
 
+    @Test public void query_json_01() {
+        try ( RDFLink link = link() ) {
+            Txn.executeWrite(link, ()->link.loadDataset(DIR+"data.trig"));
+            int actual = Txn.calculateRead(link, ()-> {
+                try (QueryExec qe = link.query("JSON { 's': ?s } { ?s ?p ?o }")) {
+                    return qe.execJson().size();
+                }
+            });
+            assertEquals(2, actual);
+        }
+    }
+
     @Test public void update_01() {
         try ( RDFLink link = link() ) {
             link.update("INSERT DATA { <urn:x:s> <urn:x:p> <urn:x:o>}");
@@ -446,16 +460,16 @@ public abstract class AbstractTestRDFLink {
     }
 
     @Test public void update_03() {
-    	UpdateRequest update = new UpdateRequest();
-    	update.add("INSERT DATA { <urn:x:s> <urn:x:p> <urn:x:o>}");
+        UpdateRequest update = new UpdateRequest();
+        update.add("INSERT DATA { <urn:x:s> <urn:x:p> <urn:x:o>}");
         try ( RDFLink link = link() ) {
             link.update(update);
         }
     }
 
     @Test public void update_04() {
-    	UpdateRequest update = new UpdateRequest();
-    	update.add("INSERT DATA { <urn:x:s> <urn:x:p> <urn:x:o>}");
+        UpdateRequest update = new UpdateRequest();
+        update.add("INSERT DATA { <urn:x:s> <urn:x:p> <urn:x:o>}");
         try ( RDFLink link = link() ) {
             Txn.executeWrite(link, ()->link.update(update));
         }


### PR DESCRIPTION
Pull request Description: A small fix + test case to allow sending of the CONSTRUCT_JSON query type via RDFLinkHTTP.
Use case is to send a JSON query via RDFLinkHTTP to a remote Fuseki instance. Without this PR, the request fails due to no accept header having been set (in the client inside of RDFLinkHTTP). The fix sets a json accept header for the CONSTRUCT_JSON query type.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
