### PR TITLE
If condition

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Conditional.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Conditional.java
@@ -18,51 +18,45 @@
 
 package org.apache.jena.sparql.expr;
 
-import org.apache.jena.sparql.ARQInternalErrorException ;
-import org.apache.jena.sparql.engine.binding.Binding ;
-import org.apache.jena.sparql.function.FunctionEnv ;
-import org.apache.jena.sparql.sse.Tags ;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.function.FunctionEnv;
+import org.apache.jena.sparql.sse.Tags;
 
-/** IF(expr, expr, expr) */ 
+/** IF(expr, expr, expr) */
 
-public class E_Conditional extends ExprFunction3
-{
-    private static final String functionName = Tags.tagIf ;
-    
-    private final Expr condition ;
-    private final Expr thenExpr ;
-    private final Expr elseExpr ;
-    
-    public E_Conditional(Expr condition, Expr thenExpr, Expr elseExpr)
-    {
-        // Don't let the parent eval the theEpxr or ifExpr.
-        super(condition, thenExpr, elseExpr, functionName) ;
-        // Better names,
-        this.condition = condition ;
-        this.thenExpr = thenExpr ;
-        this.elseExpr = elseExpr ;
+public class E_Conditional extends ExprFunction3 {
+    private static final String functionName = Tags.tagIf;
+
+    private final Expr condition;
+    private final Expr thenExpr;
+    private final Expr elseExpr;
+
+    public E_Conditional(Expr condition, Expr thenExpr, Expr elseExpr) {
+        super(condition, thenExpr, elseExpr, functionName);
+        // Better names that arg1, arg2, arg3.
+        this.condition = condition;
+        this.thenExpr = thenExpr;
+        this.elseExpr = elseExpr;
     }
 
     @Override
-    public Expr copy(Expr arg1, Expr arg2, Expr arg3)
-    {
-        return new E_Conditional(arg1, arg2, arg3) ;
+    public Expr copy(Expr arg1, Expr arg2, Expr arg3) {
+        return new E_Conditional(arg1, arg2, arg3);
     }
 
-    /** Special form evaluation (example, don't eval the arguments first) */
+    /** Functional form evaluation */
     @Override
-    protected NodeValue evalSpecial(Binding binding, FunctionEnv env)
-    {
-        NodeValue nv = condition.eval(binding, env) ;
+    protected NodeValue evalSpecial(Binding binding, FunctionEnv env) {
+        NodeValue nv = condition.eval(binding, env);
         if ( condition.isSatisfied(binding, env) )
-            return thenExpr.eval(binding, env) ;
+            return thenExpr.eval(binding, env);
         else
-            return elseExpr.eval(binding, env) ;
+            return elseExpr.eval(binding, env);
     }
-    
+
     @Override
-    public NodeValue eval(NodeValue x, NodeValue y, NodeValue z)
-    {
-        throw new ARQInternalErrorException() ;
+    public NodeValue eval(NodeValue x, NodeValue y, NodeValue z) {
+        throw new ARQInternalErrorException();
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Conditional.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_Conditional.java
@@ -48,7 +48,6 @@ public class E_Conditional extends ExprFunction3 {
     /** Functional form evaluation */
     @Override
     protected NodeValue evalSpecial(Binding binding, FunctionEnv env) {
-        NodeValue nv = condition.eval(binding, env);
         if ( condition.isSatisfied(binding, env) )
             return thenExpr.eval(binding, env);
         else

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions2.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions2.java
@@ -81,8 +81,7 @@ public class TestExpressions2
 
     public void gregorian_cast_01()             { eval("xsd:gYear('2010-03-22'^^xsd:date) = '2010'^^xsd:gYear", true ); }
 
-    @Test
-    public void coalesce_01()                   { assertThrows(ExprEvalException.class, ()-> eval("COALESCE()") ); }
+    @Test public void coalesce_01()             { assertThrows(ExprEvalException.class, ()-> eval("COALESCE()") ); }
     @Test public void coalesce_02()             { eval("COALESCE(1) = 1", true); }
     @Test public void coalesce_03()             { eval("COALESCE(?x,1) = 1", true); }
     @Test public void coalesce_04()             { eval("COALESCE(9,1) = 9", true); }
@@ -90,9 +89,14 @@ public class TestExpressions2
     // IF
     @Test public void if_01()                   { eval("IF(1+2=3, 'yes', 'no') = 'yes'", true); }
     @Test public void if_02()                   { eval("IF(1+2=4, 'yes', 'no') = 'no'", true); }
-    @Test public void if_03()                   { eval("IF(true, 'yes', 1/0) = 'yes'", true); }
-    @Test
-    public void if_04()                         { assertThrows(ExprEvalException.class, ()-> eval("IF(true, 1/0, 'no') = 'no'") ); }
+    @Test public void if_03()                   { eval("IF(true, 'then', 1/0) = 'then'", true); }
+    @Test public void if_04()                   { eval("IF(false, 1/0, 'else') = 'else'", true); }
+    @Test public void if_05()                   { assertThrows(ExprEvalException.class, ()-> eval("IF(true, 1/0, 'no') = 'no'") ); }
+    @Test public void if_06()                   { assertThrows(ExprEvalException.class, ()-> eval("IF(false, 'yes', 1/0) = 'yes'") ); }
+    // EBV in the condition
+    @Test public void if_10()                   { eval("IF(?unbound, 'yes', 'no') = 'no'"); }
+    @Test public void if_11()                   { eval("IF(! (?unbound), 'yes', 'no') = 'no'"); }
+    @Test public void if_12()                   { eval("IF(1/0, 'yes', 'no') = 'no'"); }
 
     // NOT IN, IN
     @Test public void in_01()                   { eval("1 IN(1,2,3)", true); }


### PR DESCRIPTION
GitHub issue resolved #3416

The implementation of IF had a stray, unused statement in `evalSpecial`.
It has been there a very long time!

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
