### PR TITLE
Use kryo-shaded instead of kryo in order to avoid conflicts with asm.

### DIFF
--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -66,7 +66,7 @@
 
     <dependency>
       <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
+      <artifactId>kryo-shaded</artifactId>
     </dependency>
 
     <!-- Non-free; testing only -->

--- a/pom.xml
+++ b/pom.xml
@@ -754,7 +754,7 @@
 
       <dependency>
         <groupId>com.esotericsoftware</groupId>
-        <artifactId>kryo</artifactId>
+        <artifactId>kryo-shaded</artifactId>
         <version>${ver.kryo}</version>
       </dependency>
 


### PR DESCRIPTION
Pull request Description: Use `kyro-shaded` instead of `kryo` because of dependency conflicts due to `asm`. For example, it breaks the nashorn javascript engine.

`kryo-shaded` was exactly [published](https://central.sonatype.com/artifact/com.esotericsoftware/kryo-shaded) for that reason:

> Fast, efficient Java serialization. **This contains the shaded reflectasm jar to prevent conflicts with other versions of asm.**

The spark dependencies in https://github.com/apache/jena/pull/3256 are actually also `kryo-shaded` ones.

The diff in the `mvn dependency:tree` is essentially:

```diff
< [INFO] |  \- com.esotericsoftware:kryo:jar:4.0.3:test
< [INFO] |     +- com.esotericsoftware:reflectasm:jar:1.11.3:test
< [INFO] |     |  \- org.ow2.asm:asm:jar:5.0.4:test
> [INFO] |  \- com.esotericsoftware:kryo-shaded:jar:4.0.3:compile
```

Existing spatial indexes are unaffected and load as usual (tested on our deployment).

----

 - [x] Commits have been squashed to remove intermediate development commit messages.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
