### PR TITLE
GH-2048: Remove left-over dependencies to expiring-map and rdf-tables.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -802,32 +802,6 @@
       </dependency>
 
       <dependency>
-        <groupId>io.github.galbiston</groupId>
-        <artifactId>expiring-map</artifactId>
-        <version>1.0.2</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.github.galbiston</groupId>
-        <artifactId>rdf-tables</artifactId>
-        <version>1.0.5</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.beust</groupId>
-            <artifactId>jcommander</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
         <version>1.11.0</version>


### PR DESCRIPTION
GitHub issue resolved #2048 

Pull request Description: Removed left-over deps in order to complete an issue that was done already.

According to the output of `grep --include '*.java' -Rai galbiston`:
* There are no more instances of `ExpiringMap` in the code.
* A copy of `rdf_tables` is only used in `jena-fuseki-geosparql`

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
