### PR TITLE
Remove dependency management of commons-beanutils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -801,12 +801,6 @@
         <version>2.0.6.1</version>
       </dependency>
 
-      <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>1.11.0</version>
-      </dependency>
-
       <!-- END jena geosparql -->
 
       <!-- BEGIN jena-fuseki-mod-geosparql -->


### PR DESCRIPTION
commons-beanutils is now only a dependency of Shiro and doe snot need managing.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
