### PR TITLE
kryo5 upgrade

### DIFF
--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -65,8 +65,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo-shaded</artifactId>
+      <groupId>com.esotericsoftware.kryo</groupId>
+      <artifactId>kryo5</artifactId>
     </dependency>
 
     <!-- Non-free; testing only -->

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/kryo/EnvelopeSerializer.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/kryo/EnvelopeSerializer.java
@@ -20,10 +20,10 @@ package org.apache.jena.geosparql.kryo;
 
 import org.locationtech.jts.geom.Envelope;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 public class EnvelopeSerializer extends Serializer<Envelope> {
     @Override
@@ -35,7 +35,7 @@ public class EnvelopeSerializer extends Serializer<Envelope> {
     }
 
     @Override
-    public Envelope read(Kryo kryo, Input input, Class<Envelope> type) {
+    public Envelope read(Kryo kryo, Input input, Class<? extends Envelope> type) {
         double xMin = input.readDouble();
         double xMax = input.readDouble();
         double yMin = input.readDouble();

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/kryo/GeometrySerializerJtsWkb.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/kryo/GeometrySerializerJtsWkb.java
@@ -23,10 +23,10 @@ import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKBReader;
 import org.locationtech.jts.io.WKBWriter;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 /** Geometry de-/serialization via the WKB facilities of JTS. */
 public class GeometrySerializerJtsWkb
@@ -57,7 +57,7 @@ public class GeometrySerializerJtsWkb
     }
 
     @Override
-    public Geometry read(Kryo kryo, Input input, Class<Geometry> type) {
+    public Geometry read(Kryo kryo, Input input, Class<? extends Geometry> type) {
         byte[] bytes = kryo.readObject(input, byte[].class);
         Geometry geometry;
         try {

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/kryo/NodeSerializer.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/kryo/NodeSerializer.java
@@ -43,10 +43,10 @@ import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.XSD;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 /**
  * An RDF 1.2 node serializer for kryo.
@@ -262,7 +262,7 @@ public class NodeSerializer
     }
 
     @Override
-    public Node read(Kryo kryo, Input input, Class<Node> cls) {
+    public Node read(Kryo kryo, Input input, Class<? extends Node> cls) {
         Node result;
         String v1, v2;
         Triple t;

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/kryo/TripleSerializer.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/kryo/TripleSerializer.java
@@ -20,10 +20,10 @@ package org.apache.jena.geosparql.kryo;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 /** Kryo serializer for {@link Triple}. Depends on registered {@link Node} serializers. */
 public class TripleSerializer extends Serializer<Triple> {
@@ -35,7 +35,7 @@ public class TripleSerializer extends Serializer<Triple> {
     }
 
     @Override
-    public Triple read(Kryo kryo, Input input, Class<Triple> objClass) {
+    public Triple read(Kryo kryo, Input input, Class<? extends Triple> objClass) {
         Node s = (Node)kryo.readClassAndObject(input);
         Node p = (Node)kryo.readClassAndObject(input);
         Node o = (Node)kryo.readClassAndObject(input);

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/KryoRegistratorSpatialIndexV2.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/KryoRegistratorSpatialIndexV2.java
@@ -20,6 +20,7 @@ package org.apache.jena.geosparql.spatial.index.v2;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.jena.geosparql.kryo.EnvelopeSerializer;
 import org.apache.jena.geosparql.kryo.NodeSerializer;
@@ -40,9 +41,9 @@ import org.locationtech.jts.index.strtree.STRtreeSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.serializers.MapSerializer;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.serializers.MapSerializer;
 
 /**
  * The class is used to configure the kryo serialization
@@ -58,10 +59,10 @@ public class KryoRegistratorSpatialIndexV2 {
         LOGGER.debug("Registering kryo serializers for spatial index v2.");
 
         // Java
-        Serializer<?> mapSerializer = new MapSerializer();
+        Serializer<?> mapSerializer = new MapSerializer<>();
         kryo.register(Map.class, mapSerializer);
         kryo.register(HashMap.class, mapSerializer);
-        kryo.register(LinkedHashMap.class, mapSerializer);
+        kryo.register(ConcurrentHashMap.class, mapSerializer);
 
         // Jena
         NodeSerializer.register(kryo);

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/STRtreePerGraphSerializer.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/STRtreePerGraphSerializer.java
@@ -22,10 +22,10 @@ import java.util.Map;
 import org.apache.jena.graph.Node;
 import org.locationtech.jts.index.strtree.STRtree;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 public class STRtreePerGraphSerializer
     extends Serializer<STRtreePerGraph>
@@ -37,7 +37,7 @@ public class STRtreePerGraphSerializer
     }
 
     @Override
-    public STRtreePerGraph read(Kryo kryo, Input input, Class<STRtreePerGraph> type) {
+    public STRtreePerGraph read(Kryo kryo, Input input, Class<? extends STRtreePerGraph> type) {
         boolean isBuilt = input.readBoolean();
         @SuppressWarnings("unchecked")
         Map<Node, STRtree> treeMap = (Map<Node, STRtree>)kryo.readClassAndObject(input);

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/STRtreeUtils.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/STRtreeUtils.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.iterator.IteratorCloseable;
@@ -54,7 +55,7 @@ public class STRtreeUtils {
 
     // XXX This method overlaps function-wise with SpatialIndexerComputation. Consolidate?
     public static STRtreePerGraph buildSpatialIndexTree(DatasetGraph datasetGraph, String srsURI) throws SpatialIndexException {
-        Map<Node, STRtree> treeMap = new LinkedHashMap<>();
+        Map<Node, STRtree> treeMap = new ConcurrentHashMap<>();
 
         // Process default graph.
         // LOGGER.info("building spatial index for default graph ...");

--- a/jena-geosparql/src/main/java/org/locationtech/jts/index/strtree/STRtreeSerializer.java
+++ b/jena-geosparql/src/main/java/org/locationtech/jts/index/strtree/STRtreeSerializer.java
@@ -23,10 +23,10 @@ import java.util.List;
 
 import org.locationtech.jts.geom.Envelope;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 /*
  * This file is an adapted copy of org.locationtech.jts.index.strtree.IndexSerde from
@@ -53,7 +53,7 @@ public class STRtreeSerializer
     extends Serializer<STRtree>
 {
     @Override
-    public STRtree read(Kryo kryo, Input input, Class<STRtree> type) {
+    public STRtree read(Kryo kryo, Input input, Class<? extends STRtree> type) {
         int nodeCapacity = input.readInt();
         boolean notEmpty = (input.readByte() & 0x01) == 1;
         if (notEmpty) {

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/spatial/index/v2/SimpleGraphSerializer.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/spatial/index/v2/SimpleGraphSerializer.java
@@ -22,10 +22,10 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.util.iterator.ExtendedIterator;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 /** Only used for testing Node_Graph serialization. */
 public class SimpleGraphSerializer
@@ -43,7 +43,7 @@ public class SimpleGraphSerializer
     }
 
     @Override
-    public Graph read(Kryo kryo, Input input, Class<Graph> type) {
+    public Graph read(Kryo kryo, Input input, Class<? extends Graph> type) {
         Graph result = GraphFactory.createDefaultGraph();
         for (;;) {
             Triple t = kryo.readObjectOrNull(input, Triple.class);

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/spatial/index/v2/TestNodeSerializer.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/spatial/index/v2/TestNodeSerializer.java
@@ -37,10 +37,10 @@ import org.apache.jena.vocabulary.RDF;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 public class TestNodeSerializer {
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <ver.org.openjdk.jmh>1.37</ver.org.openjdk.jmh>
 
     <!-- GeoSPARQL related -->
-    <ver.kryo>4.0.3</ver.kryo>
+    <ver.kryo>5.6.2</ver.kryo>
     <ver.jaxb-api>2.3.1</ver.jaxb-api>
     <ver.jakarta-xml-bind>4.0.4</ver.jakarta-xml-bind>
     <ver.jcommander>1.82</ver.jcommander>
@@ -745,8 +745,8 @@
       <!-- jena-geosparql, jena-fuseki-geosparql related -->
 
       <dependency>
-        <groupId>com.esotericsoftware</groupId>
-        <artifactId>kryo-shaded</artifactId>
+        <groupId>com.esotericsoftware.kryo</groupId>
+        <artifactId>kryo5</artifactId>
         <version>${ver.kryo}</version>
       </dependency>
 


### PR DESCRIPTION
GitHub issue resolved (no issue created yet).

Pull request Description: Upgrade to kryo5. ~~Need yet to test whether spatial indexes created with kryo4 can be loaded with kryo5. Also, there was an inconsistent use of `ConcurrentHashMap` and `LinkedHashMap` that was revealed when a test case failed with kryo5.~~
In my first experiments I was not able to load a spatial index created with kryo4 using kryo5.

----

 - ~~[ ] Tests are included.~~
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
