### PR TITLE
GH-3410: Quote or omit  "$LOGGING" in command invocation

### DIFF
--- a/apache-jena/bin/arq
+++ b/apache-jena/bin/arq
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.arq "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.arq "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.arq "$@"
+fi

--- a/apache-jena/bin/infer
+++ b/apache-jena/bin/infer
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.infer "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" riotcmd.infer "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" riotcmd.infer "$@"
+fi

--- a/apache-jena/bin/iri
+++ b/apache-jena/bin/iri
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.iri "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" jena.iri "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" jena.iri "$@"
+fi

--- a/apache-jena/bin/jena.version
+++ b/apache-jena/bin/jena.version
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.version "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" jena.version "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" jena.version "$@"
+fi

--- a/apache-jena/bin/juuid
+++ b/apache-jena/bin/juuid
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.juuid "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.juuid "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.juuid "$@"
+fi

--- a/apache-jena/bin/langtag
+++ b/apache-jena/bin/langtag
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.langtag "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" jena.langtag "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" jena.langtag "$@"
+fi

--- a/apache-jena/bin/nquads
+++ b/apache-jena/bin/nquads
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.nquads "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" riotcmd.nquads "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" riotcmd.nquads "$@"
+fi

--- a/apache-jena/bin/ntriples
+++ b/apache-jena/bin/ntriples
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.ntriples "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" riotcmd.ntriples "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" riotcmd.ntriples "$@"
+fi

--- a/apache-jena/bin/qparse
+++ b/apache-jena/bin/qparse
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.qparse "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.qparse "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.qparse "$@"
+fi

--- a/apache-jena/bin/rdfcat
+++ b/apache-jena/bin/rdfcat
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.rdfcat "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" jena.rdfcat "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" jena.rdfcat "$@"
+fi

--- a/apache-jena/bin/rdfcompare
+++ b/apache-jena/bin/rdfcompare
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.rdfcompare "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" jena.rdfcompare "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" jena.rdfcompare "$@"
+fi

--- a/apache-jena/bin/rdfcopy
+++ b/apache-jena/bin/rdfcopy
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.rdfcopy "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" jena.rdfcopy "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" jena.rdfcopy "$@"
+fi

--- a/apache-jena/bin/rdfdiff
+++ b/apache-jena/bin/rdfdiff
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.rdfdiff "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.rdfdiff "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.rdfdiff "$@"
+fi

--- a/apache-jena/bin/rdfparse
+++ b/apache-jena/bin/rdfparse
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.rdfparse "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" jena.rdfparse "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" jena.rdfparse "$@"
+fi

--- a/apache-jena/bin/rdfpatch
+++ b/apache-jena/bin/rdfpatch
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" rdfpatch.rdfpatch "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" rdfpatch.rdfpatch "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" rdfpatch.rdfpatch "$@"
+fi

--- a/apache-jena/bin/rdfxml
+++ b/apache-jena/bin/rdfxml
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.rdfxml "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" riotcmd.rdfxml "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" riotcmd.rdfxml "$@"
+fi

--- a/apache-jena/bin/riot
+++ b/apache-jena/bin/riot
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.riot "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" riotcmd.riot "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" riotcmd.riot "$@"
+fi

--- a/apache-jena/bin/rset
+++ b/apache-jena/bin/rset
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.rset "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.rset "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.rset "$@"
+fi

--- a/apache-jena/bin/rsparql
+++ b/apache-jena/bin/rsparql
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.rsparql "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.rsparql "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.rsparql "$@"
+fi

--- a/apache-jena/bin/rupdate
+++ b/apache-jena/bin/rupdate
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.rupdate "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.rupdate "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.rupdate "$@"
+fi

--- a/apache-jena/bin/schemagen
+++ b/apache-jena/bin/schemagen
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" jena.schemagen "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" jena.schemagen "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" jena.schemagen "$@"
+fi

--- a/apache-jena/bin/shacl
+++ b/apache-jena/bin/shacl
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" shacl.shacl "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" shacl.shacl "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" shacl.shacl "$@"
+fi

--- a/apache-jena/bin/shex
+++ b/apache-jena/bin/shex
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" shex.shex "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" shex.shex "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" shex.shex "$@"
+fi

--- a/apache-jena/bin/sparql
+++ b/apache-jena/bin/sparql
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.sparql "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.sparql "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.sparql "$@"
+fi

--- a/apache-jena/bin/tdb2.tdbbackup
+++ b/apache-jena/bin/tdb2.tdbbackup
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbbackup "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb2.tdbbackup "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb2.tdbbackup "$@"
+fi

--- a/apache-jena/bin/tdb2.tdbcompact
+++ b/apache-jena/bin/tdb2.tdbcompact
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbcompact "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb2.tdbcompact "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb2.tdbcompact "$@"
+fi

--- a/apache-jena/bin/tdb2.tdbdump
+++ b/apache-jena/bin/tdb2.tdbdump
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbdump "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb2.tdbdump "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb2.tdbdump "$@"
+fi

--- a/apache-jena/bin/tdb2.tdbloader
+++ b/apache-jena/bin/tdb2.tdbloader
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbloader "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb2.tdbloader "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb2.tdbloader "$@"
+fi

--- a/apache-jena/bin/tdb2.tdbquery
+++ b/apache-jena/bin/tdb2.tdbquery
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbquery "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb2.tdbquery "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb2.tdbquery "$@"
+fi

--- a/apache-jena/bin/tdb2.tdbstats
+++ b/apache-jena/bin/tdb2.tdbstats
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbstats "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb2.tdbstats "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb2.tdbstats "$@"
+fi

--- a/apache-jena/bin/tdb2.tdbupdate
+++ b/apache-jena/bin/tdb2.tdbupdate
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb2.tdbupdate "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb2.tdbupdate "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb2.tdbupdate "$@"
+fi

--- a/apache-jena/bin/tdbbackup
+++ b/apache-jena/bin/tdbbackup
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbbackup "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb.tdbbackup "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb.tdbbackup "$@"
+fi

--- a/apache-jena/bin/tdbdump
+++ b/apache-jena/bin/tdbdump
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbdump "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb.tdbdump "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb.tdbdump "$@"
+fi

--- a/apache-jena/bin/tdbloader
+++ b/apache-jena/bin/tdbloader
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbloader "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb.tdbloader "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb.tdbloader "$@"
+fi

--- a/apache-jena/bin/tdbquery
+++ b/apache-jena/bin/tdbquery
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbquery "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb.tdbquery "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb.tdbquery "$@"
+fi

--- a/apache-jena/bin/tdbstats
+++ b/apache-jena/bin/tdbstats
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbstats "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb.tdbstats "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb.tdbstats "$@"
+fi

--- a/apache-jena/bin/tdbupdate
+++ b/apache-jena/bin/tdbupdate
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" tdb.tdbupdate "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" tdb.tdbupdate "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" tdb.tdbupdate "$@"
+fi

--- a/apache-jena/bin/trig
+++ b/apache-jena/bin/trig
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.trig "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" riotcmd.trig "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" riotcmd.trig "$@"
+fi

--- a/apache-jena/bin/turtle
+++ b/apache-jena/bin/turtle
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.turtle "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" riotcmd.turtle "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" riotcmd.turtle "$@"
+fi

--- a/apache-jena/bin/uparse
+++ b/apache-jena/bin/uparse
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.uparse "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.uparse "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.uparse "$@"
+fi

--- a/apache-jena/bin/update
+++ b/apache-jena/bin/update
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.update "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.update "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.update "$@"
+fi

--- a/apache-jena/bin/utf8
+++ b/apache-jena/bin/utf8
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" riotcmd.utf8 "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" riotcmd.utf8 "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" riotcmd.utf8 "$@"
+fi

--- a/apache-jena/bin/wwwdec
+++ b/apache-jena/bin/wwwdec
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.wwwdec "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.wwwdec "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.wwwdec "$@"
+fi

--- a/apache-jena/bin/wwwenc
+++ b/apache-jena/bin/wwwenc
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" arq.wwwenc "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" arq.wwwenc "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" arq.wwwenc "$@"
+fi

--- a/apache-jena/template.bin
+++ b/apache-jena/template.bin
@@ -102,4 +102,10 @@ then
     JENA_CP="$JENA_CP:$CLASSPATH"
 fi
 
-"$JAVA" $JVM_ARGS $LOGGING -cp "$JENA_CP" JENA_CMD "$@" 
+if [ -n "$LOGGING" ]
+then
+    "$JAVA" $JVM_ARGS "$LOGGING" -cp "$JENA_CP" JENA_CMD "$@"
+else
+    ## LOGGING is empty or unset.
+    "$JAVA" $JVM_ARGS -cp "$JENA_CP" JENA_CMD "$@"
+fi

--- a/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlLog4j2.java
+++ b/jena-base/src/main/java/org/apache/jena/atlas/logging/LogCtlLog4j2.java
@@ -85,7 +85,6 @@ public class LogCtlLog4j2 {
         if ( level != null )
             return level.toString();
         return null;
-
     }
 
     /** Set logging level of a Logger */


### PR DESCRIPTION
GitHub issue resolved #3410

Deal with the situation where `$LOGGING` , maybe via `$JENA_HOME`, includes directories with a space their path name.

----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
