### PR TITLE
Allow transform from NodeValue to Var.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NodeValue.java
@@ -379,7 +379,7 @@ public abstract class NodeValue extends ExprNode
     public Expr applyNodeTransform(NodeTransform transform) {
         Node n = asNode();
         n = transform.apply(n);
-        return makeNode(n);
+        return ExprLib.nodeToExpr(n);
     }
 
     public Node evalNode(Binding binding, ExecutionContext execCxt) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/ExprTransformNodeElement.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/ExprTransformNodeElement.java
@@ -66,7 +66,7 @@ public class ExprTransformNodeElement extends ExprTransformCopy {
         Node n = nodeTransform.apply(nv.asNode());
         if ( n == nv.asNode() )
             return nv;
-        return NodeValue.makeNode(n);
+        return ExprLib.nodeToExpr(n);
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
@@ -59,8 +59,8 @@ public class QueryTransformOps {
             List<Var> projectVars = query2.getProjectVars();
             substitutions.forEach((v, n) -> {
                 if ( ! projectVars.contains(v) ) {
-                    var nv = NodeValue.makeNode(n);
-                    query2.getProject().update(v, NodeValue.makeNode(n));
+                    NodeValue nv = NodeValue.makeNode(n);
+                    query2.getProject().update(v, nv);
                 }
             });
         }
@@ -112,13 +112,18 @@ public class QueryTransformOps {
         });
         QuerySyntaxSubstituteScope.scopeCheck(query, varsForConst);
 
-        ElementTransform eltrans = new ElementTransformSubst(substitutions);
         NodeTransform nodeTransform = new NodeTransformSubst(substitutions);
-        ExprTransform exprTrans = new ExprTransformNodeElement(nodeTransform, eltrans);
-        return transform(query, eltrans, exprTrans);
+        return transform(query, nodeTransform);
     }
 
     // ----------------
+
+    /** Transform a query using a generic NodeTransform. */
+    public static Query transform(Query query, NodeTransform transform) {
+        ElementTransform eltrans = new ElementTransformSubst(transform);
+        ExprTransform exprTrans = new ExprTransformNodeElement(transform, eltrans);
+        return QueryTransformOps.transform(query, eltrans, exprTrans);
+    }
 
     public static Query transform(Query query, ElementTransform transform) {
         ExprTransform noop = new ExprTransformApplyElementTransform(transform);


### PR DESCRIPTION
Pull request Description:  Allow transform of nodes to variables.
This transform used to work (albeit with a warning) but started to raise an exception after https://github.com/apache/jena/issues/3380 was adressed with https://github.com/apache/jena/commit/0477e4d1629cc1e5111a00cf6756f6257799a683 .

* The essential change is to pass the node transform outcome through `ExprLib.nodeToExpr` rather than `NodeValue.makeNode`.
* I also factored out a `QueryTransformOps.transform(Query, NodeTransform)` method.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 
By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
