### PR TITLE
Look for test external failure signature

### DIFF
--- a/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
+++ b/jena-fuseki2/jena-fuseki-webapp/src/main/java/org/apache/jena/fuseki/cmd/JettyFusekiWebapp.java
@@ -102,6 +102,7 @@ public class JettyFusekiWebapp {
             mgtConnector = serverConnector;
 
         if ( config.enableCompression ) {
+            @SuppressWarnings("all")
             GzipHandler gzipHandler = new GzipHandler();
             gzipHandler.setHandler(server.getHandler());
             server.setHandler(gzipHandler);


### PR DESCRIPTION
This PR looks for the signature of the recurring failure seen in github actions. The signature is a pattern of exceptions and causes.

The failure is not new but it is inferring with the CI builds in unrelated areas. The failures are in module `jena-webapp` (WAR file form of Fuseki) which proposed for removal in Jena 6. 

Also - address a warning.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
