### PR TITLE
GH-3437: Initialize fields of Cmds.java before JenaSystem.init()

### DIFF
--- a/jena-cmds/src/main/java/org/apache/jena/cmd/Cmds.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/Cmds.java
@@ -30,10 +30,10 @@ import org.apache.jena.sys.JenaSystem;
  */
 public class Cmds {
 
-    static { JenaSystem.init(); }
-
     private static Map<String, Consumer<String[]>> cmds = new ConcurrentHashMap<>();
     private static Object lock = new Object();
+
+    static { JenaSystem.init(); }
 
     // Initialize via JenaSubsystemLifecycle and not rely on class initialization.
     static void init() {}


### PR DESCRIPTION
GitHub issue resolved #3437

Pull request Description: Moved `static { JenaSystem.init() }` after the init of other static fields to get rid of an NPE.

I didn't realize in the issue that I used both `-cp` and `-jar` to run the command. The output of either variant no longer raises an NPE:

```bash
➜ java -cp fuseki-server.jar jena.textindexer
No assembler description given
java -cp fuseki-server.jar jena.textindexer  0,99s user 0,11s system 251% cpu 0,441 total

➜ java -jar fuseki-server.jar jena.textindexer
Exception in thread "main" org.apache.jena.cmd.CmdException: Dataset name provided but 'no dataset' flag given
	at org.apache.jena.fuseki.main.cmds.FusekiMain.processStdArguments(FusekiMain.java:396)
[...]
```

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
