### PR TITLE
Async HTTP

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/atlas/web/HttpException.java
+++ b/jena-arq/src/main/java/org/apache/jena/atlas/web/HttpException.java
@@ -34,14 +34,15 @@ public class HttpException extends RuntimeException {
     }
 
     public HttpException(int statusCode, String statusLine) {
-        super(exMessage(statusCode, statusLine));
-        this.statusCode = statusCode;
-        this.statusLine = statusLine ;
-        this.response = null;
+        this(statusCode, statusLine, null, null);
     }
 
     public HttpException(int statusCode, String statusLine, String responseMessage) {
-        super(exMessage(statusCode, statusLine));
+        this(statusCode, statusLine, responseMessage, null);
+    }
+
+    public HttpException(int statusCode, String statusLine, String responseMessage, Throwable cause) {
+        super(exMessage(statusCode, statusLine), cause);
         this.statusCode = statusCode;
         this.statusLine = statusLine ;
         this.response = responseMessage;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/Service.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/Service.java
@@ -227,7 +227,7 @@ public class Service {
         // -- End setup
 
         // Build the execution
-        QueryExecHTTP qExec = QueryExecHTTP.newBuilder()
+        try (QueryExecHTTP qExec = QueryExecHTTP.newBuilder()
                 .endpoint(serviceURL)
                 .timeout(timeoutMillis, TimeUnit.MILLISECONDS)
                 .httpHeader(HttpNames.hUserAgent, HttpEnv.UserAgent)
@@ -236,8 +236,8 @@ public class Service {
                 .context(context)
                 .httpClient(httpClient)
                 .sendMode(querySendMode)
-                .build();
-        try {
+                .build()) {
+
             // Detach from the network stream.
             RowSet rowSet = qExec.select().materialize();
             QueryIterator qIter = QueryIterPlainWrapper.create(rowSet);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/UpdateExecHTTP.java
@@ -54,7 +54,9 @@ public class UpdateExecHTTP implements UpdateExec {
 
     private final Context context;
     private final String service;
-    // Not used private final UpdateRequest update;
+
+    // UpdateRequest as an object - may be null.
+    private final UpdateRequest update;
     private final String updateString;
     private final Map<String, String> httpHeaders;
     private final HttpClient httpClient;
@@ -77,7 +79,7 @@ public class UpdateExecHTTP implements UpdateExec {
                                long timeout, TimeUnit timeoutUnit) {
         this.context = context;
         this.service = serviceURL;
-        //this.update = update;
+        this.update = update;
         // Builder ensures one or the other is set.
         this.updateString = ( updateString != null ) ? updateString : update.toString();
         this.httpClient = dft(httpClient, HttpEnv.getDftHttpClient());
@@ -93,6 +95,16 @@ public class UpdateExecHTTP implements UpdateExec {
     @Override
     public Context getContext() {
         return context;
+    }
+
+    @Override
+    public UpdateRequest getUpdateRequest() {
+        return update;
+    }
+
+    @Override
+    public String getUpdateRequestString() {
+        return updateString;
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/update/UpdateProcessor.java
+++ b/jena-arq/src/main/java/org/apache/jena/update/UpdateProcessor.java
@@ -26,6 +26,19 @@ import org.apache.jena.sparql.util.Context;
  */
 public interface UpdateProcessor
 {
+    /**
+     * The update request associated with this update execution. May be null.
+     */
+    default public UpdateRequest getUpdateRequest() { return null; }
+
+    /**
+     * The update request as a string. May be null.
+     * The string may contain syntax extensions that can not be parsed by Jena.
+     * If {@link #getUpdateRequest()} is not null then this is a corresponding
+     * string that parses to the same update request.
+     */
+    default public String getUpdateRequestString() { return null; }
+
     /** Execute */
     public void execute() ;
 


### PR DESCRIPTION
GitHub issue resolved #3471

This is the async HTTP part factored out from #3184 .

Pull request Description:
* Update HTTP(s) machinery to use async requests. This allows for `QueryExecHTTP.abort()` to immediately return even if the server has not yet responded to the connection request.
* Fixes resource leak in `Service.java`
* Adds (nullable) `getUpdateString` and `getUpdateRequest` methods to UpdateProcessor so that the underlying request may be exposed.

----

 - ~~[ ] Tests are included~~ (no additional tests added)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
