### PR TITLE
GH-3472: Restore log4j artifacts at runtime

### DIFF
--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -80,15 +80,16 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <scope>test</scope>
+        <scope>runtime</scope>
       </dependency>
 
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j2-impl</artifactId>
-        <scope>test</scope>
+        <scope>runtime</scope>
       </dependency>
 
+      <!-- Tests are JUnit4 -->
       <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
@@ -124,6 +125,10 @@
             <transformers>
               <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                 <mainClass>org.apache.jena.fuseki.geosparql.Main</mainClass>
+                <!-- https://issues.apache.org/jira/browse/LOG4J2-2537 -->
+                <manifestEntries>
+                  <Multi-Release>true</Multi-Release>
+                </manifestEntries>
               </transformer>
               <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />


### PR DESCRIPTION
GitHub issue resolved #3472

Pull request Description:

A workaround of adding the missing log4j jars and running with `-cp`, with explicit `org.apache.jena.fuseki.geosparql.Main` does _not_ work.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
