### PR TITLE
GH-3475: Fix NPE in Quad.isConcrete() when graph is null.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/Quad.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/Quad.java
@@ -97,7 +97,7 @@ public class Quad implements Serializable
     }
 
     public boolean isConcrete() {
-        return subject.isConcrete() && predicate.isConcrete() && object.isConcrete() && graph.isConcrete();
+        return subject.isConcrete() && predicate.isConcrete() && object.isConcrete() && (graph == null || graph.isConcrete());
     }
 
     /**

--- a/jena-arq/src/test/java/org/apache/jena/util/TestNodeUtils.java
+++ b/jena-arq/src/test/java/org/apache/jena/util/TestNodeUtils.java
@@ -19,6 +19,7 @@
 package org.apache.jena.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -65,6 +66,8 @@ public class TestNodeUtils {
         Node s = triple.getSubject(), p = triple.getPredicate(), o = triple.getObject();
         assertEquals(expected, NodeUtils.isValidAsRDF(s, p, o));
     }
+
+    @Test public void concrete_triple_in_quad() { assertTrue(Quad.create(null, s, p, o).isConcrete()); }
 
     @Test public void valid_quad_01() { testValidityQuad(true, "(:g :s :p :o)"); }
     @Test public void valid_quad_02() { testValidityQuad(true, Quad.create(g, s, p, o)); }


### PR DESCRIPTION
GitHub issue resolved #3475

Pull request Description: Update `Quad.isConcrete()` to check for null graph.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
