### PR TITLE
Move GH actions to Java21/Java25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java_version: ['17', '21']
+        java_version: ['21', '25']
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     - name: Build with Maven
       run: mvn -B --file pom.xml -Dmaven.javadoc.skip=true install

--- a/.github/workflows/maven_windows.yml
+++ b/.github/workflows/maven_windows.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     - name: copy checked out dir to /c/jena for windows-latest
       run: bash -c "cp -r /d/a/jena/jena /c/jena"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         jdk_distribution: ['temurin']
         os: [ubuntu-latest]
-        java_version: ['21']
+        java_version: ['25']
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Post Jena 5.6.0, drop Java17, include Java25 (LTS).

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
