### PR TITLE
GH-3516: Fix NPE in AbstractIterHashJoin.close()

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/join/AbstractIterHashJoin.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/join/AbstractIterHashJoin.java
@@ -44,14 +44,16 @@ public abstract class AbstractIterHashJoin extends QueryIter2 {
     // See also stats in the probe table.
 
     protected JoinKey                   joinKey ;
-    protected MultiHashProbeTable       hashTable ;
+
+    // HashTable is initialized lazily.
+    protected MultiHashProbeTable       hashTable   = null ;
 
     private QueryIterator               iterStream ;
-    private Binding                     rowStream       = null ;
+    private Binding                     rowStream   = null ;
     private Iterator<Binding>           iterCurrent ;
     private boolean                     yielded ;       // Flag to note when current probe causes a result.
     // Hanlde any "post join" additions.
-    private Iterator<Binding>           iterTail        = null ;
+    private Iterator<Binding>           iterTail    = null ;
 
     enum Phase { INIT, HASH , STREAM, TRAILER, DONE }
     Phase state = Phase.INIT ;
@@ -234,13 +236,15 @@ public abstract class AbstractIterHashJoin extends QueryIter2 {
         if ( JoinLib.JOIN_EXPLAIN ) {
             String x = String.format(
                          "HashJoin: LHS=%d RHS=%d Results=%d Table=%s",
-                         s_countProbe, s_countScan, s_countResults,
-                         hashTable.toString()) ;
+                         s_countProbe, s_countScan, s_countResults, hashTable) ;
             System.out.println(x) ;
         }
         // In case it's a peek iterator.
         iterStream.close() ;
-        hashTable.clear();
+        if ( hashTable != null ) {
+            hashTable.clear() ;
+            hashTable = null ;
+        }
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/join/JoinIndex.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/join/JoinIndex.java
@@ -41,14 +41,21 @@ import org.slf4j.LoggerFactory;
 
 /**
  * This class indexes a set of rows w.r.t. a join key, referred to as the <i>main join key</i>.
- * <p />
+ * <p>
  * Consider the main join key [?x, ?y, ?z]:
- * <p />
  * All rows that bind all three variables will be placed into the main table.
  *
+ * <p>
  * Any rows that only bind a sub set of the variables, such as [?x, ?z] or [?y],
  * are placed into respective skew tables.
  *
+ * <p>
+ * The super join determines the bit set representation of the the main and skew join keys.
+ * It and must declare at least all variables of the main join key.
+ * For example, given the super join key [?a, ?x, ?y, ?b ?z] the aforementioned main join key
+ * becomes represented with the bit pattern [0, 1, 1, 0, 1].
+ *
+ * <p>
  * JoinIndex instances are dynamically created by {@link MultiHashProbeTable} based on the
  * variables of the bindings used in lookup requests for matching rows.
  *
@@ -82,6 +89,10 @@ class JoinIndex
             mainJoinKey = JoinKey.create(BitSetMapper.toList(superJoinKey, mainJoinKeyBitSet));
         }
         this.mainTable = new HashProbeTable(mainJoinKey);
+    }
+
+    public JoinKey getSuperJoinKey() {
+        return superJoinKey;
     }
 
     public BitSet getMainJoinKeyBitSet() {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/join/AbstractTestInnerJoin.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/join/AbstractTestInnerJoin.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.jena.sparql.algebra.Table;
 import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.expr.ExprList;
 
 /** Tests for inner/equi joins */
@@ -80,6 +81,10 @@ public abstract class AbstractTestInnerJoin extends AbstractTestJoin {
     @Test public void join_skew_02b() { testJoin("w", tableS1b(), tableS2(), tableS1J2()); }
     @Test public void join_skew_03b() { testJoin(null, tableS1b(), tableS2(), tableS1J2()); }
 
+    @Test public void testCloseOfUnusedIterator() {
+        QueryIterator qIter = join(null, table1() , table1(), null);
+        qIter.close();
+    }
 
     @Test
     public void join_skew_04() {


### PR DESCRIPTION
GitHub issue resolved #3516 

Pull request Description: Adds an NPE check for the hash table to the close method of AbstractIterHashJoin.

Perhaps there is a suggestion for a better place for the test case?

----

 - [x] Tests are included.
 - ~[ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)~
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
