### PR TITLE
Extend the names for each syntax

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/query/Syntax.java
+++ b/jena-arq/src/main/java/org/apache/jena/query/Syntax.java
@@ -63,17 +63,19 @@ public class Syntax extends Symbol {
     public static TranslationTable<Syntax> querySyntaxNames = new TranslationTable<>(true);
     static {
         querySyntaxNames.put("sparql", syntaxSPARQL);
+        querySyntaxNames.put("arq", syntaxARQ);
 
         querySyntaxNames.put("sparql10", syntaxSPARQL_10);
+        querySyntaxNames.put("sparql-10", syntaxSPARQL_11);
         querySyntaxNames.put("sparql_10", syntaxSPARQL_10);
 
         querySyntaxNames.put("sparql11", syntaxSPARQL_11);
+        querySyntaxNames.put("sparql-11", syntaxSPARQL_11);
         querySyntaxNames.put("sparql_11", syntaxSPARQL_11);
 
         querySyntaxNames.put("sparql12", syntaxSPARQL_12);
+        querySyntaxNames.put("sparql-12", syntaxSPARQL_12);
         querySyntaxNames.put("sparql_12", syntaxSPARQL_12);
-
-        querySyntaxNames.put("arq", syntaxARQ);
 
         querySyntaxNames.put("alg", syntaxAlgebra);
         querySyntaxNames.put("op", syntaxAlgebra);
@@ -82,9 +84,15 @@ public class Syntax extends Symbol {
     public static TranslationTable<Syntax> updateSyntaxNames = new TranslationTable<>(true);
     static {
         updateSyntaxNames.put("sparql", syntaxSPARQL);
-        updateSyntaxNames.put("sparql_11", syntaxSPARQL_11);
-        updateSyntaxNames.put("sparql_12", syntaxSPARQL_11);
         updateSyntaxNames.put("arq", syntaxARQ);
+
+        updateSyntaxNames.put("sparql11", syntaxSPARQL_11);
+        updateSyntaxNames.put("sparql-11", syntaxSPARQL_11);
+        updateSyntaxNames.put("sparql_11", syntaxSPARQL_11);
+
+        updateSyntaxNames.put("sparql12", syntaxSPARQL_12);
+        updateSyntaxNames.put("sparql-12", syntaxSPARQL_12);
+        updateSyntaxNames.put("sparql_12", syntaxSPARQL_12);
     }
 
     protected Syntax(String s) {


### PR DESCRIPTION
Add command line names `sparql-N` for query.

Make the update syntax names align with query syntax names.


----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
