### PR TITLE
update build java.version to 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
   <properties>
     <!-- Build -->
-    <java.version>17</java.version>
+    <java.version>21</java.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputTimestamp>2025-10-10T09:29:56Z</project.build.outputTimestamp>


### PR DESCRIPTION
GitHub issue resolved #

Pull request Description:

I wanted to update my HttpClient tests with close() or autoclosable to 6.x , but noticed that I got maven enforce compilation error. 

```
[INFO] -------------------------------------------------------------
Error:  COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
Error:  /home/runner/work/jena/jena/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/FileSender.java:[80,25] incompatible types: try-with-resources not applicable to variable type
    (java.net.http.HttpClient cannot be converted to java.lang.AutoCloseable)
Error:  /home/runner/work/jena/jena/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestCrossOriginFilter.java:[281,25] incompatible types: try-with-resources not applicable to variable type
    (java.net.http.HttpClient cannot be converted to java.lang.AutoCloseable)
Error:  /home/runner/work/jena/jena/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestQuery.java:[259,26] incompatible types: try-with-resources not applicable to variable type
    (java.net.http.HttpClient cannot be converted to java.lang.AutoCloseable)
Error:  /home/runner/work/jena/jena/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestSecurityBuilderSetup.java:[181,25] incompatible types: try-with-resources not applicable to variable type
    (java.net.http.HttpClient cannot be converted to java.lang.AutoCloseable)
Error:  /home/runner/work/jena/jena/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/access/TestSecurityBuilderSetup.java:[192,25] incompatible types: try-with-resources not applicable to variable type
    (java.net.http.HttpClient cannot be converted to java.lang.AutoCloseable)
``

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
