### PR TITLE
GH-3533: Fix operation name for prefixes-rw

### DIFF
--- a/jena-fuseki2/examples/config-prefixes.ttl
+++ b/jena-fuseki2/examples/config-prefixes.ttl
@@ -13,7 +13,7 @@ PREFIX tdb2:    <http://jena.apache.org/2016/tdb#>
     fuseki:endpoint [ fuseki:operation fuseki:update ; ] ;
 
     fuseki:endpoint [ fuseki:operation fuseki:prefixes-r ; fuseki:name "prefixes" ] ;
-    fuseki:endpoint [ fuseki:operation fuseki:prefixes-ws ; fuseki:name "updatePrefixes" ] ;
+    fuseki:endpoint [ fuseki:operation fuseki:prefixes-rw ; fuseki:name "updatePrefixes" ] ;
     fuseki:dataset :dataset ;
     .
 


### PR DESCRIPTION
GitHub issue resolved #3533

----
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
