### PR TITLE
IRI3986: Remove legacyCompatibility; tidy code

### DIFF
--- a/jena-iri3986/src/main/java/org/apache/jena/rfc3986/AlgRelativizeIRI.java
+++ b/jena-iri3986/src/main/java/org/apache/jena/rfc3986/AlgRelativizeIRI.java
@@ -22,15 +22,9 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
- * More algorithms on IRI3986's.
- * The various forms of relativizing IRIs.
+ * More relativization algorithms on IRI3986's.
  */
 public class AlgRelativizeIRI {
-
-    // For compatibility with jena-iri ...
-    // relativeScheme: when only the scheme with no "//", then NETWORK does not abbreviate.
-    //    Strict, illegal because if there is a scheme, there must be //
-    /*package*/ static final boolean legacyCompatibility = false;
 
     /**
      * Calculate a "same scheme" relative URI, if possible.
@@ -43,8 +37,7 @@ public class AlgRelativizeIRI {
             return null;
         if ( ! Objects.equals(base.scheme(), target.scheme()) )
             return null;
-        if ( legacyCompatibility && ! base.hasAuthority() && base.path().isEmpty() )
-            return IRI3986.build(null, "", target.path(), target.query(), target.fragment());
+        // No scheme.
         return IRI3986.build(null, target.authority(), target.path(), target.query(), target.fragment());
     }
 
@@ -63,18 +56,6 @@ public class AlgRelativizeIRI {
         if ( ! Objects.equals(base.authority(), target.authority()) )
             return null;
         return IRI3986.build(null, null, target.path(), target.query(), target.fragment());
-    }
-
-    /**
-     * Calculate a relative URI as a absolute path, if possible.
-     * <p>
-     * That is, the IRIs have the same scheme and authority.
-     * The base does not have a query string.
-     * The relative URI is the path, query and fragment of the target.
-     */
-    public static IRI3986 relativeAbsolutePath(IRI base, IRI target) {
-        // Same as relativeLocalResource, using jena-iri naming.
-        return relativeResource(base, target);
     }
 
     /**
@@ -138,22 +119,10 @@ public class AlgRelativizeIRI {
                 return IRI3986.build(null, null, x, target.query(), target.fragment());
             }
 
-            if ( legacyCompatibility ) {
-                // Same path, no target query.
-                // This would be just a #frag which is "same document".
-                // For compatibility with jena-iri ...
-                String pathRel = lastSegment(targetPath);
-                if ( pathRel.isEmpty() )
-                    pathRel = ".";
-                return IRI3986.build(null, null, pathRel, null, target.fragment());
-            } else {
-                String pathRel = targetPath.endsWith("/") ?
-                    // Both "" and "." are possible when the two paths end "/".
-                    "." : "";
-                return IRI3986.build(null, null, pathRel, null, target.fragment());
-            }
+            // Both "" and "." are possible when the two paths end "/".
+            String pathRel = targetPath.endsWith("/") ? "." : "";
+            return IRI3986.build(null, null, pathRel, null, target.fragment());
         }
-
 
         String relPath = relativeChildPath(basePath, targetPath);
         if ( relPath == null )

--- a/jena-iri3986/src/main/java/org/apache/jena/rfc3986/AlgResolveIRI.java
+++ b/jena-iri3986/src/main/java/org/apache/jena/rfc3986/AlgResolveIRI.java
@@ -21,7 +21,7 @@ package org.apache.jena.rfc3986;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-/** Algorithms for IRIs : resolution */
+/** Algorithms for IRIs : resolution and relativize (reverse of resolution). */
 public class AlgResolveIRI {
 
     /**

--- a/jena-iri3986/src/main/java/org/apache/jena/rfc3986/ParseDNS.java
+++ b/jena-iri3986/src/main/java/org/apache/jena/rfc3986/ParseDNS.java
@@ -135,7 +135,6 @@ public class ParseDNS {
             // Must have one or more labels.
             error("No subdomains.");
 
-
         List<Integer> dots = new ArrayList<>(4);
 
         while (p < end) {
@@ -148,7 +147,6 @@ public class ParseDNS {
             // Separator dots
             dots.add(p-1);
         }
-        //System.out.println("Dots: "+dots);
     }
 
     // <label> ::= <letter> [ [ <ldh-str> ] <let-dig> ]

--- a/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestNormalize.java
+++ b/jena-iri3986/src/test/java/org/apache/jena/rfc3986/TestNormalize.java
@@ -55,5 +55,4 @@ public class TestNormalize {
         String s = iri2.toString();
         assertEquals(expected, s);
     }
-
 }


### PR DESCRIPTION
More clearing up after retiring `jena-iri`.

`legacyCompatibility` was set to false and was final.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
