### PR TITLE
Fuseki GeoSPARQL TypeMapper initialization

### DIFF
--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/datatypes/DatatypeController.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/datatypes/DatatypeController.java
@@ -19,6 +19,8 @@ package org.apache.jena.ext.io.github.galbiston.rdf_tables.datatypes;
 
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.jena.datatypes.BaseDatatype;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.TypeMapper;
@@ -30,16 +32,14 @@ import org.slf4j.LoggerFactory;
 
 public class DatatypeController {
 
-    //TODO load from file
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final HashMap<String, String> DATATYPE_PREFIXES = new HashMap<>();
-    private static final TypeMapper TYPE_MAPPER = TypeMapper.getInstance();
-
+    private static final Map<String, String> DATATYPE_PREFIXES = new HashMap<>();
     public static final String HTTP_PREFIX = "http://";
-    public static final String BOOLEAN_URI = XSDBaseNumericType.XSDboolean.getURI();
 
-    public static HashMap<String, String> getDatatypePrefixes() {
+    private static TypeMapper typeMapper() { return TypeMapper.getInstance(); }
+
+    public static Map<String, String> getDatatypePrefixes() {
 
         if (DATATYPE_PREFIXES.isEmpty()) {
             loadXSDDatatypePrefixes();
@@ -48,7 +48,6 @@ public class DatatypeController {
     }
 
     private static void loadXSDDatatypePrefixes() {
-
         DATATYPE_PREFIXES.put("string", XSDBaseNumericType.XSDstring.getURI());
         DATATYPE_PREFIXES.put("int", XSDBaseNumericType.XSDint.getURI());
         DATATYPE_PREFIXES.put("integer", XSDBaseNumericType.XSDinteger.getURI());
@@ -116,7 +115,7 @@ public class DatatypeController {
         String datatypeURI = datatype.getURI();
         if (PrefixController.checkURI(datatypeURI)) {
             DATATYPE_PREFIXES.put(prefix, datatypeURI);
-            TYPE_MAPPER.registerDatatype(datatype);
+            typeMapper().registerDatatype(datatype);
         } else {
             LOGGER.error("Datatype URI is not a URI: {} {}", prefix, datatypeURI);
             throw new AssertionError();
@@ -141,7 +140,7 @@ public class DatatypeController {
         } else {
             String datatypeURI = PrefixController.lookupURI(datatypeLabel, baseURI);
             DATATYPE_PREFIXES.put(datatypeLabel, datatypeURI);
-            TYPE_MAPPER.registerDatatype(new BaseDatatype(datatypeURI));
+            typeMapper().registerDatatype(new BaseDatatype(datatypeURI));
             return datatypeURI;
         }
     }
@@ -154,7 +153,7 @@ public class DatatypeController {
      */
     public static RDFDatatype lookupDatatype(String datatypeURI) {
         getDatatypePrefixes();
-        RDFDatatype datatype = TYPE_MAPPER.getTypeByName(datatypeURI);
+        RDFDatatype datatype = typeMapper().getTypeByName(datatypeURI);
 
         if (datatype != null) {
             return datatype;
@@ -173,7 +172,7 @@ public class DatatypeController {
      */
     public static Literal createLiteral(String data, String datatypeURI) {
         getDatatypePrefixes();
-        RDFDatatype datatype = TYPE_MAPPER.getTypeByName(datatypeURI);
+        RDFDatatype datatype = typeMapper().getTypeByName(datatypeURI);
 
         if (datatype != null) {
             String tidyData = tidyDatatype(data, datatypeURI);
@@ -195,7 +194,7 @@ public class DatatypeController {
     private static String tidyDatatype(String untidyData, String dataTypeURI) {
         String tidyData = untidyData.trim();
 
-        if (dataTypeURI.equals(DatatypeController.BOOLEAN_URI)) {
+        if (dataTypeURI.equals(XSDBaseNumericType.XSDboolean.getURI())) {
             tidyData = tidyData.toLowerCase();
         }
 

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/datatypes/PrefixController.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/datatypes/PrefixController.java
@@ -25,10 +25,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- *
- * @author Gerg
- */
 public class PrefixController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetException.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetException.java
@@ -17,10 +17,6 @@
  */
 package org.apache.jena.fuseki.geosparql;
 
-/**
- *
- *
- */
 public class DatasetException extends Exception {
 
     public DatasetException(String msg) {

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetOperations.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetOperations.java
@@ -44,10 +44,6 @@ import org.apache.jena.tdb2.TDB2Factory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- *
- *
- */
 public class DatasetOperations {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/ArgsConfig.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/ArgsConfig.java
@@ -25,10 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import static org.apache.jena.fuseki.geosparql.DatasetOperations.SPATIAL_INDEX_FILE;
 
-/**
- *
- *
- */
 public class ArgsConfig {
 
     //1) Port

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/FileGraphDelimiter.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/FileGraphDelimiter.java
@@ -20,10 +20,6 @@ package org.apache.jena.fuseki.geosparql.cli;
 import java.io.File;
 import java.util.Objects;
 
-/**
- *
- *
- */
 public class FileGraphDelimiter {
 
     private final File tabFile;

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/FileGraphFormat.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/FileGraphFormat.java
@@ -21,10 +21,6 @@ import java.io.File;
 import java.util.Objects;
 import org.apache.jena.riot.RDFFormat;
 
-/**
- *
- *
- */
 public class FileGraphFormat {
 
     private final File rdfFile;

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/IntegerListConverter.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/IntegerListConverter.java
@@ -21,10 +21,6 @@ import com.beust.jcommander.IStringConverter;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- *
- *
- */
 public class IntegerListConverter implements IStringConverter<List<Integer>> {
 
     @Override

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/LongListConverter.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/LongListConverter.java
@@ -21,10 +21,6 @@ import com.beust.jcommander.IStringConverter;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- *
- *
- */
 public class LongListConverter implements IStringConverter<List<Long>> {
 
     @Override

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/RDFFileParameter.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/RDFFileParameter.java
@@ -28,10 +28,6 @@ import java.util.List;
 import org.apache.jena.ext.io.github.galbiston.rdf_tables.cli.FormatParameter;
 import org.apache.jena.riot.RDFFormat;
 
-/**
- *
- *
- */
 public class RDFFileParameter implements IStringConverter<List<FileGraphFormat>>, IParameterValidator {
 
     private static final FormatParameter FORMAT_PARAMETER = new FormatParameter();

--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/TabFileParameter.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/cli/TabFileParameter.java
@@ -27,10 +27,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- *
- *
- */
 public class TabFileParameter implements IStringConverter<List<FileGraphDelimiter>>, IParameterValidator {
 
     private static final DelimiterValidator DELIMITER_VALIDATOR = new DelimiterValidator();

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/datatype/GeometryDatatype.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/datatype/GeometryDatatype.java
@@ -56,7 +56,6 @@ public abstract class GeometryDatatype extends BaseDatatype {
             throw new DatatypeFormatException(ex.getMessage() + " - Illegal Geometry Literal: " + lexicalForm);
         }
     }
-
     public static void registerDatatypes() {
         Types.init();
     }
@@ -74,6 +73,8 @@ public abstract class GeometryDatatype extends BaseDatatype {
         }
         public static void init() {}
     }
+    private static TypeMapper typeMapper() { return Types.MAPPER; }
+
 
     public static final GeometryDatatype get(RDFDatatype rdfDatatype) throws DatatypeFormatException {
         if (rdfDatatype instanceof GeometryDatatype) {
@@ -85,12 +86,12 @@ public abstract class GeometryDatatype extends BaseDatatype {
 
     public static final GeometryDatatype get(String datatypeURI) {
         checkURI(datatypeURI);
-        RDFDatatype rdfDatatype = Types.MAPPER.getTypeByName(datatypeURI);
+        RDFDatatype rdfDatatype = typeMapper().getTypeByName(datatypeURI);
         return GeometryDatatype.get(rdfDatatype);
     }
 
     public static final boolean checkURI(String datatypeURI) throws DatatypeFormatException {
-        RDFDatatype rdfDatatype = Types.MAPPER.getTypeByName(datatypeURI);
+        RDFDatatype rdfDatatype = typeMapper().getTypeByName(datatypeURI);
         if (rdfDatatype != null) {
             return rdfDatatype instanceof GeometryDatatype;
         } else {


### PR DESCRIPTION
jena-fuseki-geosparql testing can trigger GeoSPARQL functions before Jena initialization of the system type mapper.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
