### PR TITLE
Fuseki GeoSPARQL Jena initialization

### DIFF
--- a/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetOperations.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/main/java/org/apache/jena/fuseki/geosparql/DatasetOperations.java
@@ -39,12 +39,15 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.tdb2.TDB2Factory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DatasetOperations {
+
+    static { JenaSystem.init(); }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/EmptyTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/EmptyTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
+import org.junit.*;
+
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
@@ -37,12 +39,7 @@ import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.apache.jena.update.UpdateExecution;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
-import org.junit.*;
 
-/**
- *
- *
- */
 public class EmptyTest {
 
     private static GeosparqlServer SERVER;

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/MainTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/MainTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
+import org.junit.*;
+
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
 import org.apache.jena.query.Dataset;
@@ -34,12 +36,6 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.sys.JenaSystem;
 
-import org.junit.*;
-
-/**
- *
- *
- */
 public class MainTest {
 
     static { JenaSystem.init(); }

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDB2Test.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDB2Test.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
+import org.junit.*;
+
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
 import org.apache.jena.query.Dataset;
@@ -35,12 +37,7 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
-import org.junit.*;
 
-/**
- *
- *
- */
 public class TDB2Test {
 
     private static GeosparqlServer SERVER;

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDBTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDBTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
+import org.junit.*;
+
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
 import org.apache.jena.query.Dataset;
@@ -35,12 +37,7 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
-import org.junit.*;
 
-/**
- *
- *
- */
 public class TDBTest {
 
     private static GeosparqlServer SERVER;

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/cli/RDFFileParameterTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/cli/RDFFileParameterTest.java
@@ -29,10 +29,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-/**
- *
- *
- */
 public class RDFFileParameterTest {
 
     public RDFFileParameterTest() {

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/cli/TabFileParameterTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/cli/TabFileParameterTest.java
@@ -28,10 +28,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-/**
- *
- * @author Gerg
- */
 public class TabFileParameterTest {
 
     public TabFileParameterTest() {


### PR DESCRIPTION
The tests for `jena-fuseki-geosparql` fail on Apache JIRA (I have not observed it fail anywhere else).

#3594 fixed one cause of these failures but fixing that shows another route to failure and also an unprotected test clearup (the other tests have had this code protection code for over two years).

Use of `jena-fuseki-geosparql` in deployment via the `main` entry point is not affected - it does `JenaSystem.init();`

This PR adds explicit Jena initial in `DatasetOperations` which all the tests call.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
