### PR TITLE
Add literals true, false, and null to Java keywords in schemagen

### DIFF
--- a/jena-cmds/src/main/java/jena/schemagen.java
+++ b/jena-cmds/src/main/java/jena/schemagen.java
@@ -104,7 +104,9 @@ public class schemagen {
         "const",       "float",       "native",      "super",       "while",
 
         // And distinguished names.
-        "var", "record"
+        "var", "record",
+        // And literals
+        "true", "false", "null"
     };
 
 


### PR DESCRIPTION
GitHub issue resolved #3598

Add Java literals (`true`, `false`, `null`) to the keyword list to avoid generating invalid member names.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
