### PR TITLE
schemagen: Allow versionInfo to be URI.

### DIFF
--- a/jena-cmds/src/main/java/jena/schemagen.java
+++ b/jena-cmds/src/main/java/jena/schemagen.java
@@ -752,7 +752,11 @@ public class schemagen {
                 Resource ont = i.nextStatement().getSubject();
                 StmtIterator j = m_source.getBaseModel().listStatements( ont, OWL.versionInfo, (RDFNode)null );
                 if (j.hasNext()) {
-                    versionInfo = j.nextStatement().getObject().asLiteral().getLexicalForm();
+                    RDFNode versionInfoObject = j.nextStatement().getObject();
+                    if (versionInfoObject.isResource())
+                        versionInfo = versionInfoObject.asResource().getURI();
+                    else
+                        versionInfo = versionInfoObject.asLiteral().getLexicalForm();
 
                     // check for ambiguous answers
                     if (j.hasNext()) {

--- a/jena-cmds/src/test/java/jena/Test_schemagen.java
+++ b/jena-cmds/src/test/java/jena/Test_schemagen.java
@@ -232,6 +232,24 @@ public class Test_schemagen
     }
 
     @Test
+    public void testVersionInfoURI() throws Exception {
+        String SOURCE =
+                "@prefix csvw: <http://www.w3.org/ns/csvw#> .\n" +
+                "@prefix dc: <http://purl.org/dc/terms/> .\n" +
+                "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n" +
+                "\n" +
+                "# CSVM Ontology definition\n" +
+                "csvw: a owl:Ontology;\n" +
+                "  dc:title \"CSVW Namespace Vocabulary Terms\"@en;\n" +
+                "  owl:versionInfo <https://github.com/w3c/csvw/commit/fcc9db20ba4de10e41e964eee1b5d01defa4c664>;\n" +
+                "  .";
+        testSchemagenOutput( SOURCE, null,
+                             new String[] {},
+                             new String[] {".*public static final String VERSION_INFO = \"https://github.com/w3c/csvw/commit/fcc9db20ba4de10e41e964eee1b5d01defa4c664\";*"},
+                             new String[] {} );
+    }
+
+    @Test
     public void testDatatype0() throws Exception {
         String SOURCE = PREFIX + "ex:d a rdfs:Datatype . ex:d rdfs:comment \"custom datatype\" .";
         testSchemagenOutput( SOURCE, null,


### PR DESCRIPTION
GitHub issue resolved #3597

Allow owl:versionInfo to be Resource in addition to Literal in schemagen.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
