### PR TITLE
GH-3668: Put back full start-up logging in Fuseki Server

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiCoreInfo.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/FusekiCoreInfo.java
@@ -36,6 +36,11 @@ public class FusekiCoreInfo {
         FmtLog.info(log, "%s %s", serverName, version);
     }
 
+    /** Details of the system runtime configuration. */
+    public static void logSystemDetails(Logger log) {
+        PlatformInfo.logSystemDetails(log);
+    }
+
     /** Log details - this function is about command line details */
     public static void logServerCmdSetup(Logger log, boolean verbose, DataAccessPointRegistry dapRegistry,
                                          String datasetPath, String datasetDescription, String serverConfigFile, String staticFiles) {
@@ -47,7 +52,7 @@ public class FusekiCoreInfo {
         FusekiCoreInfo.logDataAccessPointRegistry(log, dapRegistry, verbose);
         if ( staticFiles != null )
             FmtLog.info(log, "Static files: %s", staticFiles);
-        PlatformInfo.logDetailsSystem(log);
+        PlatformInfo.logSystemDetails(log);
         if ( verbose )
             PlatformInfo.logDetailsJVM(log);
     }
@@ -129,5 +134,4 @@ public class FusekiCoreInfo {
         others.stream().sorted(order).forEach(nice::add);
         return nice;
     }
-
 }

--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/PlatformInfo.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/server/PlatformInfo.java
@@ -24,7 +24,7 @@ import java.util.function.Function;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.slf4j.Logger;
 
-/** Platform inforamtion - OS and JVM */
+/** Platform information - OS and JVM */
 /*package*/ class PlatformInfo {
 
     public static void main(String ...args) throws IOException {
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
     }
 
     /** System details */
-    /*package*/ static void logDetailsSystem(Logger log) {
+    /*package*/ static void logSystemDetails(Logger log) {
         String prefix = "  ";
         long maxMem = Runtime.getRuntime().maxMemory();
         long totalMem = Runtime.getRuntime().totalMemory();
@@ -56,7 +56,7 @@ import org.slf4j.Logger;
 
     /** JVM details section. */
     /*package*/ static void logDetailsJVM(Logger log) {
-        String prefix = "  ";
+        String prefix = "    ";
         logOne(log, prefix, "java.vendor");
         logOne(log, prefix, "java.home");
         logOne(log, prefix, "java.runtime.version");

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiMainRunner.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiMainRunner.java
@@ -25,6 +25,8 @@ import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.main.cmds.FusekiMain;
 import org.apache.jena.fuseki.main.sys.FusekiModules;
 import org.apache.jena.fuseki.server.FusekiServerRunner;
+import org.apache.jena.sys.JenaSystem;
+import org.slf4j.Logger;
 
 /**
  * Functions for building and runner a {@link FusekiServer} configured from command line arguments.
@@ -33,6 +35,8 @@ import org.apache.jena.fuseki.server.FusekiServerRunner;
  */
 public class FusekiMainRunner {
 
+    static { JenaSystem.init(); }
+
     /**
      * Run a plain {@link FusekiServer}.
      * @param args line arguments.
@@ -40,6 +44,11 @@ public class FusekiMainRunner {
      */
     public static FusekiServer runAsync(String... args) {
         FusekiServer server = construct(args);
+        startAsync(server);
+        return server;
+    }
+
+    private static FusekiServer startAsync(FusekiServer server) {
         try {
             return server.start();
         } catch (FusekiException ex) {
@@ -58,7 +67,12 @@ public class FusekiMainRunner {
      * This function does not return.
      */
     public static void run(String... args) {
-        FusekiServer server = runAsync(args);
+        Logger log = Fuseki.fusekiLog;
+        FusekiRunner.logCode(log);
+        FusekiServer server = construct(args);
+        FusekiRunner.logServerSetup(log, server);
+        startAsync(server);
+        FusekiRunner.logServerStart(log, server);
         server.join();
     }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiRunner.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiRunner.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.fuseki.main;
+
+import org.apache.jena.fuseki.Fuseki;
+import org.apache.jena.fuseki.FusekiException;
+import org.apache.jena.fuseki.server.FusekiCoreInfo;
+import org.slf4j.Logger;
+
+public class FusekiRunner {
+
+    // ---- Logging fragments
+
+    public static void logCode(Logger log) {
+        FusekiCoreInfo.logCode(log);
+    }
+
+    public static void logServerSetup(Logger log, FusekiServer server) {
+        boolean verbose = Fuseki.getVerbose(server.getServletContext());
+        FusekiCoreInfo.logDataAccessPointRegistry(log, server.getDataAccessPointRegistry(), verbose);
+        FusekiCoreInfo.logSystemDetails(log);
+    }
+
+    public static void logServerStart(Logger log, FusekiServer server) {
+        if ( ! server.getJettyServer().isStarted() )
+            throw new FusekiException("FusekiServer not ready");
+        int httpPort = server.getHttpPort();
+        int httpsPort = server.getHttpsPort();
+        if ( httpsPort > 0 && httpPort > 0 )
+            Fuseki.serverLog.info("Start Fuseki (http="+httpPort+" https="+httpsPort+")");
+        else if ( httpsPort > 0 )
+            Fuseki.serverLog.info("Start Fuseki (https="+httpsPort+")");
+        else if ( httpPort > 0 )
+            Fuseki.serverLog.info("Start Fuseki (http="+httpPort+")");
+        else
+            Fuseki.serverLog.info("Start Fuseki");
+    }
+
+    public static void logServerStop(Logger log, FusekiServer server) {
+        log.info("Stopping Fuseki");
+    }
+}

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -339,6 +339,9 @@ public class FusekiServer {
      * To synchronise with the server stopping, call {@link #join}.
      */
     public FusekiServer start() {
+        if ( server.isRunning() )
+            return this;
+
         try {
             FusekiModuleStep.serverBeforeStarting(this);
             server.start();
@@ -373,18 +376,7 @@ public class FusekiServer {
 
         FusekiModuleStep.serverAfterStarting(this);
 
-        if ( httpsPort > 0 && httpPort > 0 )
-            Fuseki.serverLog.info("Start Fuseki (http="+httpPort+" https="+httpsPort+")");
-        else if ( httpsPort > 0 )
-            Fuseki.serverLog.info("Start Fuseki (https="+httpsPort+")");
-        else if ( httpPort > 0 )
-            Fuseki.serverLog.info("Start Fuseki (http="+httpPort+")");
-        else
-            Fuseki.serverLog.info("Start Fuseki");
-
         // Any post-startup configuration here.
-        // --
-        // Done!
         return this;
     }
 
@@ -418,7 +410,7 @@ public class FusekiServer {
     public void join() {
         try {
             if ( ! server.isStarted() && ! server.isStarting() )
-                server.start();
+                start();
             server.join(); }
         catch (FusekiException e) { throw e; }
         catch (Exception e) { throw new FusekiException(e); }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMainCmd.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiMainCmd.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.fuseki.main.cmds;
 
+import org.apache.jena.fuseki.main.FusekiMainRunner;
 import org.apache.jena.fuseki.system.FusekiLogging;
 
 /** Fuseki command that runs a Fuseki server without the admin UI, just SPARQL services.
@@ -43,7 +44,7 @@ public class FusekiMainCmd {
      * return. See {@link FusekiMain#build} to build a server using command line
      * syntax but not start it.
      */
-    static public void main(String... argv) {
-        FusekiMain.run(argv);
+    static public void main(String... args) {
+        FusekiMainRunner.run(args);
     }
 }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiServerCmd.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/FusekiServerCmd.java
@@ -47,7 +47,7 @@ public class FusekiServerCmd {
      * syntax but not start it.
      */
     static public void main(String... args) {
-        FusekiServerRunner.construct(args).join();
+        FusekiServerRunner.run(args);
     }
 }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/server/FusekiServerRunner.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/server/FusekiServerRunner.java
@@ -26,6 +26,7 @@ import org.apache.jena.cmd.CmdGeneral;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiException;
 import org.apache.jena.fuseki.main.FusekiMainRunner;
+import org.apache.jena.fuseki.main.FusekiRunner;
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.fuseki.main.cmds.FusekiMain;
 import org.apache.jena.fuseki.main.cmds.ServerArgs;
@@ -33,6 +34,8 @@ import org.apache.jena.fuseki.main.sys.FusekiModules;
 import org.apache.jena.fuseki.main.sys.FusekiServerArgsCustomiser;
 import org.apache.jena.fuseki.mgt.FusekiServerCtl;
 import org.apache.jena.fuseki.mod.FusekiServerModules;
+import org.apache.jena.sys.JenaSystem;
+import org.slf4j.Logger;
 
 /**
  * Functions for building and runner a {@link FusekiServer} configured from command line arguments
@@ -42,6 +45,8 @@ import org.apache.jena.fuseki.mod.FusekiServerModules;
  */
 public class FusekiServerRunner {
 
+    static { JenaSystem.init(); }
+
     /**
      * Run {@link FusekiServer} with {@link FusekiModules} as given by {@link FusekiServerModules#serverModules()}.
      * @param args Command line arguments.
@@ -49,6 +54,11 @@ public class FusekiServerRunner {
      */
     public static FusekiServer runAsync(String... args) {
         FusekiServer server = construct(args);
+        startAsync(server);
+        return server;
+    }
+
+    private static FusekiServer startAsync(FusekiServer server) {
         try {
             return server.start();
         } catch (FusekiException ex) {
@@ -67,7 +77,12 @@ public class FusekiServerRunner {
      * This function does not return.
      */
     public static void run(String... args) {
-        FusekiServer server = runAsync(args);
+        Logger log = Fuseki.fusekiLog;
+        FusekiRunner.logCode(log);
+        FusekiServer server = construct(args);
+        FusekiRunner.logServerSetup(log, server);
+        startAsync(server);
+        FusekiRunner.logServerStart(log, server);
         server.join();
     }
 


### PR DESCRIPTION
GitHub issue resolved #3668

This PR contains immediate fixes to Fuseki server startup logging.

Logging is not exactly the same as v5.5.0 (the logging isn't recording the command line details) but does include useful information like server version and the start up port which are missing in 5.6.0.

The whole area of startup benefit from some work; it is mostly hardcoded currently. That is a bigger task; this PR get something into 6.0.0 in case the larger task is not ready in time.

----

 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
