### PR TITLE
remove mixed decl  deprecation silence, add deprecation silence for if-function

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/vite.config.js
+++ b/jena-fuseki2/jena-fuseki-ui/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         api: "modern-compiler",
-        silenceDeprecations: ["import", "global-builtin","color-functions","mixed-decls"],
+        silenceDeprecations: ["import", "global-builtin","color-functions","if-function"],
       }
     },
   },


### PR DESCRIPTION
GitHub issue resolved  #3655

Pull request Description:

It looks like the new if-function warnings are well known for bootstrap and the temporary fix is silencing them.

https://github.com/twbs/bootstrap/issues/41915

I took a look in Jena UI, and think none of the deprecation warnings for if-function are native to Jena.


Also removed the obselete silence for mixed-decls https://sass-lang.com/documentation/breaking-changes/mixed-decls/

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
