### PR TITLE
Move SPARQL SameValue function to NodeFunctions

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_SameValue.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/E_SameValue.java
@@ -18,6 +18,7 @@
 
 package org.apache.jena.sparql.expr;
 
+import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
 import org.apache.jena.sparql.sse.Tags;
 
 public class E_SameValue extends ExprFunction2 {
@@ -29,29 +30,12 @@ public class E_SameValue extends ExprFunction2 {
 
     @Override
     public NodeValue eval(NodeValue x, NodeValue y) {
-        if ( isNaN(x) ) {
-            if ( isNaN(y) )
-                return NodeValue.TRUE;
-            return NodeValue.FALSE;
-        }
-        boolean b = NodeValue.sameValueAs(x, y) ;
-        return NodeValue.booleanReturn(b) ;
+        return NodeFunctions.sameValueFunction(x, y);
     }
+
 
     @Override
     public Expr copy(Expr e1, Expr e2) {
         return new E_SameValue(e1, e2);
-    }
-
-    private static boolean isNaN(NodeValue nv) {
-        if ( nv.isDouble() ) {
-            double d = nv.getDouble();
-            return Double.isNaN(d);
-        }
-        if ( nv.isFloat() ) {
-            float f = nv.getFloat();
-            return Float.isNaN(f);
-        }
-        return false;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/NVCompare.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/NVCompare.java
@@ -114,8 +114,8 @@ class NVCompare {
                 Node node2 = nv2.asNode();
 
                 if ( !SystemARQ.ValueExtensions )
-                    // No value extensions => raw rdfTermEquals
-                    return NodeFunctions.rdfTermEquals(node1, node2);
+                    // No value extensions => raw SameValue, value testing done.
+                    raise(new ExprEvalException("Unknown equality test: " + nv1 + " and " + nv2));
 
                 // Some "value spaces" are know to be not equal (no overlap).
                 // Like one literal with a language tag, and one without can't be
@@ -127,12 +127,21 @@ class NVCompare {
                     return false;
 
                 // Two literals at this point.
+                // Any known to be disjoint value spaces.
 
                 if ( NodeFunctions.sameTerm(node1, node2) )
                     return true;
 
-                if ( !node1.getLiteralLanguage().equals("") || !node2.getLiteralLanguage().equals("") )
-                    // One had lang tag but weren't sameNode => not equals
+                boolean hasLang1 = NodeFunctions.hasLang(node1);
+                boolean hasLang2 = NodeFunctions.hasLang(node2);
+                if ( hasLang1 != hasLang2 )
+                    // One had lang tag, one doeesn't
+                    return false;
+
+                boolean hasLangDir1 = NodeFunctions.hasLangDir(node1);
+                boolean hasLangDir2 = NodeFunctions.hasLangDir(node2);
+                if ( hasLangDir1 != hasLangDir2 )
+                    // One had lang direction, one doesn't
                     return false;
 
                 raise(new ExprEvalException("Unknown equality test: " + nv1 + " and " + nv2));

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TS_Expr.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TS_Expr.java
@@ -35,10 +35,11 @@ import org.apache.jena.sparql.expr.nodevalue.TestNodeValueSortKey;
     , TestExpressions4.class
     , TestCastXSD.class
     , TestNodeFunctions.class
+    , TestNodeFunctionsMisc.class
     , TestExpressionsMath.class
     , TestFunctions.class
     , TestStringArgCompatibility.class
-    , TestSparqlKeywordFunctions.class
+    , TestSPARQLKeywordFunctions.class
     , TestFunctionsByURI.class
     , TestExprTripleTerms.class
     , TestLeviathanFunctions.class

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeFunctions.java
@@ -29,7 +29,6 @@ import org.apache.jena.graph.TextDirection;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
 import org.apache.jena.sparql.graph.NodeConst;
-import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.vocabulary.XSD;
 
 public class TestNodeFunctions {
@@ -70,74 +69,6 @@ public class TestNodeFunctions {
         Node n1 = NodeFactory.createLiteralLang("xyz", "en");
         Node n2 = NodeFactory.createLiteralLang("xyz", "EN");
         assertTrue(NodeFunctions.sameTerm(n1, n2));
-    }
-
-    @Test public void testRDFtermEquals1() {
-        Node n1 = NodeFactory.createURI("xyz");
-        Node n2 = NodeFactory.createLiteralString("xyz");
-        assertFalse(NodeFunctions.rdfTermEquals(n1, n2));
-    }
-
-    @Test public void testRDFtermEquals2() {
-        Node n1 = NodeFactory.createLiteralLang("xyz", "en");
-        Node n2 = NodeFactory.createLiteralLang("xyz", "EN");
-        assertTrue(NodeFunctions.rdfTermEquals(n1, n2));
-    }
-
-    @Test
-    public void testRDFtermEquals3() {
-        // Unextended - not known to be same (no language tag support).
-        Node n1 = NodeFactory.createLiteralString("xyz");
-        Node n2 = NodeFactory.createLiteralLang("xyz", "en");
-        assertThrows(ExprEvalException.class,
-                     ()-> NodeFunctions.rdfTermEquals(n1, n2) );
-    }
-
-    @Test
-    public void testRDFtermEquals4() {
-        // Unextended - not known to be same.
-        Node n1 = NodeFactory.createLiteralDT("123", XSDDatatype.XSDinteger);
-        Node n2 = NodeFactory.createLiteralDT("456", XSDDatatype.XSDinteger);
-        assertThrows(ExprEvalException.class,
-                     ()-> assertTrue(NodeFunctions.rdfTermEquals(n1, n2)) );
-    }
-
-    @Test
-    public void testRDFtermEquals5() {
-        Node n1 = SSE.parseNode("<<(:s :p 123)>>");
-        Node n2 = SSE.parseNode("<<(:s :p 123)>>");
-        assertTrue(NodeFunctions.rdfTermEquals(n1, n2));
-    }
-
-    @Test
-    public void testRDFtermEquals6() {
-        Node n1 = SSE.parseNode("<<(:s :p1 123)>>");
-        Node n2 = SSE.parseNode("<<(:s :p2 123)>>");
-        assertFalse(NodeFunctions.rdfTermEquals(n1, n2));
-    }
-
-    @Test
-    public void testRDFtermEquals7() {
-        Node n1 = SSE.parseNode("<<(:s :p <<(:a :b 'abc')>>)>>");
-        Node n2 = SSE.parseNode("<<(:s :p <<(:a :b 123)>>)>>");
-        assertThrows(ExprEvalException.class,
-                     ()-> NodeFunctions.rdfTermEquals(n1, n2) );
-    }
-
-    @Test
-    public void testRDFtermEquals8() {
-        Node n1 = SSE.parseNode("<<(:s :p 123)>>");
-        Node n2 = SSE.parseNode("<<(:s :p 'xyz')>>");
-        assertThrows(ExprEvalException.class,
-                     ()-> assertFalse(NodeFunctions.rdfTermEquals(n2, n1)) );
-    }
-
-    @Test
-    public void testRDFtermEquals9() {
-        Node n1 = SSE.parseNode("<<(:s :p 123)>>");
-        Node n2 = SSE.parseNode("'xyz'");
-        assertFalse(NodeFunctions.rdfTermEquals(n1, n2));
-        assertFalse(NodeFunctions.rdfTermEquals(n2, n1));
     }
 
     @Test public void testStr1() {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeFunctionsMisc.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestNodeFunctionsMisc.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.sparql.expr;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.expr.nodevalue.NodeFunctions;
+import org.apache.jena.sparql.sse.SSE;
+
+/**
+ * Tests for "RDFterm-equal" - fallback function for testing for the '='operator.
+ * Extended for triple terms.
+ * Replaced in SPARQL 1.2 by sameValue.
+ */
+@SuppressWarnings("removal")
+public class TestNodeFunctionsMisc {
+    @Test public void testRDFtermEquals1() {
+        Node n1 = NodeFactory.createURI("xyz");
+        Node n2 = NodeFactory.createLiteralString("xyz");
+        assertFalse(NodeFunctions.rdfTermEqual11_legacy(n1, n2));
+    }
+
+    @Test public void testRDFtermEquals2() {
+        Node n1 = NodeFactory.createLiteralLang("xyz", "en");
+        Node n2 = NodeFactory.createLiteralLang("xyz", "EN");
+        assertTrue(NodeFunctions.rdfTermEqual11_legacy(n1, n2));
+    }
+
+    @Test public void testRDFtermEquals3() {
+        // Unextended - not known to be same (no language tag support).
+        Node n1 = NodeFactory.createLiteralString("xyz");
+        Node n2 = NodeFactory.createLiteralLang("xyz", "en");
+        assertThrows(ExprEvalException.class, ()-> NodeFunctions.rdfTermEqual11_legacy(n1, n2) );
+    }
+
+    @Test public void testRDFtermEquals4() {
+        // Unextended - not known to be same.
+        Node n1 = NodeFactory.createLiteralDT("123", XSDDatatype.XSDinteger);
+        Node n2 = NodeFactory.createLiteralDT("456", XSDDatatype.XSDinteger);
+        assertThrows(ExprEvalException.class, ()-> assertTrue(NodeFunctions.rdfTermEqual11_legacy(n1, n2)) );
+    }
+
+    @Test public void testRDFtermEquals5() {
+        Node n1 = SSE.parseNode("<<(:s :p 123)>>");
+        Node n2 = SSE.parseNode("<<(:s :p 123)>>");
+        assertTrue(NodeFunctions.rdfTermEqual11_legacy(n1, n2));
+    }
+
+    @Test public void testRDFtermEquals6() {
+        Node n1 = SSE.parseNode("<<(:s :p1 123)>>");
+        Node n2 = SSE.parseNode("<<(:s :p2 123)>>");
+        assertFalse(NodeFunctions.rdfTermEqual11_legacy(n1, n2));
+    }
+
+    @Test public void testRDFtermEquals7() {
+        Node n1 = SSE.parseNode("<<(:s :p <<(:a :b 'abc')>>)>>");
+        Node n2 = SSE.parseNode("<<(:s :p <<(:a :b 123)>>)>>");
+        assertThrows(ExprEvalException.class, ()-> NodeFunctions.rdfTermEqual11_legacy(n1, n2) );
+    }
+
+    @Test public void testRDFtermEquals8() {
+        Node n1 = SSE.parseNode("<<(:s :p 123)>>");
+        Node n2 = SSE.parseNode("<<(:s :p 'xyz')>>");
+        assertThrows(ExprEvalException.class, ()-> assertFalse(NodeFunctions.rdfTermEqual11_legacy(n2, n1)) );
+    }
+
+    @Test public void testRDFtermEquals9() {
+        Node n1 = SSE.parseNode("<<(:s :p 123)>>");
+        Node n2 = SSE.parseNode("'xyz'");
+        assertFalse(NodeFunctions.rdfTermEqual11_legacy(n1, n2));
+        assertFalse(NodeFunctions.rdfTermEqual11_legacy(n2, n1));
+    }
+}

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestSPARQLKeywordFunctions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestSPARQLKeywordFunctions.java
@@ -36,7 +36,7 @@ import org.apache.jena.sparql.util.ExprUtils;
 import org.apache.jena.sparql.util.NodeFactoryExtra;
 import org.apache.jena.sys.JenaSystem;
 
-public class TestSparqlKeywordFunctions
+public class TestSPARQLKeywordFunctions
 {
     static { JenaSystem.init(); }
     // Some overlap with TestFunctions except those are direct function calls and these are via SPARQL 1.1 syntax.


### PR DESCRIPTION
Internal improvements after 8f265909ff

(ARQ provides internal SPARQL function `SameValue`)

----

 - [x] Tests are included.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
