### PR TITLE
jena-base does not need to depend on Google Guava

### DIFF
--- a/jena-base/pom.xml
+++ b/jena-base/pom.xml
@@ -92,13 +92,6 @@
       <artifactId>caffeine</artifactId>
     </dependency>
 
-    <!--
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    -->
-
     <!-- supports persistent data structures -->
     <dependency>
       <groupId>com.github.andrewoma.dexx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -458,8 +458,8 @@
           Either explicitly depend here or choose one
           route and exclude from the others or exclude
           systematically. If the dependency plugin is being used,
-    it will likely report errors because it is stricter than
-    the maven resolution rule.
+          it will likely report errors because it is stricter than
+          the maven resolution rule.
 
           Gson is probably the one to choose as the preferred route.
           https://github.com/google/gson/issues/2681#issuecomment-2125845040


### PR DESCRIPTION
Remove unused dependency.

jena-serviceenhancer does have a dependency on guava.

Guava has been quite sensitive to versioning so this makes Jena a little easier to use as a library by only having a dependency where necessary,

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
