### PR TITLE
change file to entrypoint for import and add option to remove warning

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/cypress.config.mjs
+++ b/jena-fuseki2/jena-fuseki-ui/cypress.config.mjs
@@ -16,7 +16,7 @@
  */
 
 import {defineConfig} from 'cypress'
-import codeCoverageTask from '@cypress/code-coverage/task.js'
+import codeCoverageTask from '@cypress/code-coverage/task'
 import vitePreprocessor from 'cypress-vite'
 import {resolve} from 'path'
 
@@ -24,6 +24,7 @@ const __dirname = resolve()
 
 export default defineConfig({
   video: false,
+  allowCypressEnv: false,
   defaultCommandTimeout: 20000,
   execTimeout: 30000,
   taskTimeout: 30000,


### PR DESCRIPTION
GitHub issue resolved #

Pull request Description:

changes for making code-coverage upgrade run and removing warning (https://www.cypress.io/blog/environment-variable-access-in-cypress-v15-10-0-migrating-to-cy-env-and-cypress-expose)

Waiting with lock file and package.json update.

Unrelated: I see there are (non-failing) errors on prefix.cc tests, but I think it may be due to expired certificate on the service. I also notice my autocomplete failed in our open sparql endpoint, probably due to the same reason.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
