### PR TITLE
GH-3806: Allow URIs as values of ja:cxtName.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/core/assembler/AssemblerUtils.java
@@ -36,6 +36,7 @@ import org.apache.jena.query.QuerySolutionMap;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.riot.RDFDataMgr;
@@ -232,9 +233,17 @@ public class AssemblerUtils
         while ( rs.hasNext() )
         {
             QuerySolution soln = rs.next();
-            String name = soln.getLiteral("name").getLexicalForm();
+            RDFNode key = soln.get("name");
+            String name;
+            if (key.isLiteral()) {
+                String rawName = key.asLiteral().getLexicalForm();
+                name = MappingRegistry.mapPrefixName(rawName);
+            } else if (key.isURIResource()) {
+                name = key.asResource().getURI();
+            } else {
+                throw new ARQException("Value of ja:cxtName must be a literal or URI.");
+            }
             String value = soln.getLiteral("value").getLexicalForm();  // Works for numbers as well!
-            name = MappingRegistry.mapPrefixName(name);
             Symbol symbol = Symbol.create(name);
             if ( "undef".equalsIgnoreCase(value) )
                 context.remove(symbol);

--- a/jena-arq/src/test/java/org/apache/jena/sparql/core/TestContext.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/core/TestContext.java
@@ -28,7 +28,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import org.apache.jena.assembler.JA;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sparql.ARQException;
+import org.apache.jena.sparql.core.assembler.AssemblerUtils;
 import org.apache.jena.sparql.util.Context;
 import org.apache.jena.sparql.util.Symbol;
 
@@ -113,5 +121,69 @@ public class TestContext {
         cxt.set(p1, 1L);
         // Bad. Long for Integer.
         assertThrows(ARQException.class, ()->cxt.getInt(p1, -2));
+    }
+
+    /**
+     * Test context parsing where the key is a literal.
+     *
+     * <pre>{@code
+     * PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
+     * PREFIX eg: <http://www.example.org/>
+     *
+     * [] ja:context [ ja:cxtName "key" ; ja:cxtValue true ] .
+     * }</pre>
+     */
+    @Test
+    public void testCxtAssemblerLiteral() {
+        Node keyNode = NodeFactory.createLiteralString("http://www.example.org/key");
+        Symbol keySym = Symbol.create(keyNode.getLiteralLexicalForm());
+        Context cxt = parseTestContext(keyNode);
+        assertTrue(cxt.isTrue(keySym));
+    }
+
+    /**
+     * Test context parsing where the key is a URI.
+     *
+     * <pre>{@code
+     * PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
+     * PREFIX eg: <http://www.example.org/>
+     *
+     * [] ja:context [ ja:cxtName eg:key ; ja:cxtValue true ] .
+     * }</pre>
+     */
+    @Test
+    public void testCxtAssemblerURI() {
+        Node keyNode = NodeFactory.createURI("http://www.example.org/key");
+        Symbol keySym = Symbol.create(keyNode.getURI());
+        Context cxt = parseTestContext(keyNode);
+        assertTrue(cxt.isTrue(keySym));
+    }
+
+    @Test
+    public void testCxtAssemblerInvalid() {
+        assertThrows(ARQException.class, () -> {
+            Node keyNode = NodeFactory.createBlankNode();
+            parseTestContext(keyNode);
+        });
+    }
+    /**
+     * Create a test context from the following RDF model.
+     *
+     * <pre>{@code
+     * PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
+     * PREFIX eg: <http://www.example.org/>
+     *
+     * [] ja:context [ ja:cxtName ${KEY_NODE} ; ja:cxtValue true ] .
+     * }</pre>
+     */
+    private static Context parseTestContext(Node key) {
+        Model model = ModelFactory.createDefaultModel();
+        RDFNode k = model.asRDFNode(key);
+        Resource cxtRes = model.createResource()
+            .addProperty(JA.cxtName, k)
+            .addLiteral(JA.cxtValue, true);
+        Resource r = model.createResource().addProperty(JA.context, cxtRes);
+        Context cxt = AssemblerUtils.parseContext(r);
+        return cxt;
     }
 }


### PR DESCRIPTION
GitHub issue resolved #3806 

Pull request Description: Support for URIs as values of `ja:cxtName`.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
