### PR TITLE
Add a cooldown period for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     groups:
       maven-patch-group:
         update-types:
@@ -30,6 +32,8 @@ updates:
       interval: monthly
       day: "tuesday"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/jena-fuseki2/jena-fuseki-ui"
@@ -37,6 +41,8 @@ updates:
       interval: "weekly"
       day: "wednesday"
     versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7
     groups:
       npm-patch-group:
         update-types:


### PR DESCRIPTION
GitHub issue resolved #

I thought maybe it would be useful to hold dependency updates a short period  before opening them using cooldowns.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-

Some relevant info from the the reference:

> The cooldown option is only available for version updates, not security updates.

`group/applies-to:` default value is: `version-updates` which I guess is all updates, and the `security-updates` is the subset which are marked as security-related.

> Dependabot checks for updates according to the defined schedule.interval settings.
Dependabot checks for any cooldown settings.
If a dependency’s new release falls within its cooldown period, Dependabot skips updating the version for that dependency.
Dependencies without a cooldown period, or those past their cooldown period, are updated to the latest version as per the configured versioning-strategy setting.
After a cooldown ends for a dependency, Dependabot resumes updating the dependency following the standard update strategy defined in dependabot.yml.


Pull request Description:

Adds a cooldown period for opening dependabot pull requests to allow time for version update incidents to surface. Searched apache org and the usual configuration when configured seems to be in the interval between 4-7 days.

https://github.com/search?q=org%3Aapache+cooldown++path%3A.github&type=code

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [ ] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).