### PR TITLE
Fix line endings in c14n test files for n-triples and n-quads

### DIFF
--- a/jena-arq/testing/rdf-tests-cg/rdf/.gitattributes
+++ b/jena-arq/testing/rdf-tests-cg/rdf/.gitattributes
@@ -11,3 +11,6 @@ rdf11/rdf-trig/trig-subm-15.nq               text eol=lf
 rdf11/rdf-trig/trig-subm-16.trig             text eol=lf
 rdf11/rdf-trig/trig-subm-16.nq               text eol=lf
 rdf11/rdf-trig/literal_with_LINE_FEED.trig   text eol=lf
+
+rdf12/rdf-n-triples/c14n/*.nt               text eol=lf
+rdf12/rdf-n-quads/c14n/*.nq                 text eol=lf


### PR DESCRIPTION
GitHub issue resolved #3845

Pull request Description:

The canonicalization tests for n-triples and n-quads were failing on Windows due to line ending inconsistencies. Git was normalizing line endings differently across platforms, which caused the test comparisons to fail.

This adds `.gitattributes` entries to enforce `text eol=lf` for the canonicalization test files in both `rdf12/rdf-n-triples/c14n/` and `rdf12/rdf-n-quads/c14n/`, matching the pattern already used for other test files in the repo.

Tests pass locally on both platforms after the change.

----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the Apache Jena website.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the Contributor's Agreement.