### PR TITLE
GH-3845: gitattributes setting for rdf-tests CG tests - fix2

### DIFF
--- a/jena-arq/testing/rdf-tests-cg/rdf/.gitattributes
+++ b/jena-arq/testing/rdf-tests-cg/rdf/.gitattributes
@@ -12,4 +12,5 @@ rdf11/rdf-trig/trig-subm-16.trig             text eol=lf
 rdf11/rdf-trig/trig-subm-16.nq               text eol=lf
 rdf11/rdf-trig/literal_with_LINE_FEED.trig   text eol=lf
 
+rdf12/**/c14n/*-c14n.nq                      text eol=lf
 rdf12/**/c14n/*-c14n.nt                      text eol=lf


### PR DESCRIPTION
GitHub issue resolved #3845

Pull request Description:

Fixes git checkout line endings on windows for rdf12 nq test files.

Before: `org.apache.jena.riot.Scripts_C14N.testFactory_n_quads_c14n` did not succeed on windows due to "\r\n" line endings.

Adds forgotten line to `testing/rdf-tests-cg/rdf/.gitattributes`:
rdf12/**/c14n/*-c14n.nq                      text eol=lf

Additional fix to https://github.com/apache/jena/pull/3849

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
