### PR TITLE
GH-3852: Fixing Fuseki UI test:e2e:win32

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/package.json
+++ b/jena-fuseki2/jena-fuseki-ui/package.json
@@ -13,7 +13,7 @@
     "test:unit": "vitest run --pool=threads --environment jsdom",
     "test:e2e": "run-script-os",
     "test:e2e:nix": "cross-env FUSEKI_PORT=\"${FUSEKI_PORT:=3030}\" PORT=\"${PORT:=8080}\" concurrently  --names 'SERVER,CLIENT,TESTS' --prefix-colors 'yellow,blue,green' --success 'first' --kill-others \"yarn run serve:fuseki\" \"yarn wait-on http://localhost:${FUSEKI_PORT}/$/ping && yarn run dev\" \"yarn wait-on http-get://localhost:${PORT}/index.html && cypress run $@\"",
-    "test:e2e:win32": "SET /a (FUSEKI_PORT=FUSEKI_PORT ^ 3030) & SET /a (PORT=PORT ^ 8080) & cross-env concurrently --names 'SERVER,CLIENT,TESTS' --prefix-colors 'yellow,blue,green' --success 'first' --kill-others \"yarn run serve:fuseki\" \"yarn wait-on http://localhost:${FUSEKI_PORT}/$/ping && yarn run dev\" \"yarn wait-on http-get://localhost:${PORT}/index.html && cypress run $@\"",
+    "test:e2e:win32": "powershell -NoProfile -ExecutionPolicy Bypass -Command \"if (-not $env:FUSEKI_PORT) { $env:FUSEKI_PORT='3030' }; if (-not $env:PORT) { $env:PORT='8080' }; $extra = $args -join ' '; concurrently --names SERVER,CLIENT,TESTS --prefix-colors yellow,blue,green --success first --kill-others 'yarn run serve:fuseki' ('yarn wait-on http://localhost:' + $env:FUSEKI_PORT + '/$/ping && yarn run dev') ('yarn wait-on http-get://localhost:' + $env:PORT + '/index.html && cypress run ' + $extra)\" --",
     "lint": "eslint --fix src",
     "coverage:unit": "yarn run test:unit --coverage",
     "coverage:e2e": "cross-env-shell CYPRESS_COVERAGE=true yarn run test:e2e",


### PR DESCRIPTION
GitHub issue resolved #3852

Pull request Description:

Fixed "test:e2e:win32" in jena-fuseki2/jena-fuseki-ui/package.json:

`SET /a (FUSEKI_PORT=FUSEKI_PORT ^ 3030)`
--> produced: missing brackets

`${FUSEKI_PORT}`
--> is unix syntax, not windows

Same with `PORT`.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
