### PR TITLE
Fix 'occured' -> 'occurred' typos in 3 files

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/system/AsyncParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/system/AsyncParser.java
@@ -383,7 +383,7 @@ public class AsyncParser {
 
         private void parse(RDFParserBuilder parser) {
             try {
-                // If an error occured then all parser are invoked anyway because any
+                // If an error occurred then all parser are invoked anyway because any
                 // resources they own need yet to be closed.
                 // At this point, however, the parser's sink will always fail and
                 // any further errors will be suppressed.

--- a/jena-cmds/src/main/java/jena/RuleMap.java
+++ b/jena-cmds/src/main/java/jena/RuleMap.java
@@ -196,7 +196,7 @@ public class RuleMap {
                 }
             }
         } catch (Throwable t) {
-            System.err.println("An error occured: \n" + t);
+            System.err.println("An error occurred: \n" + t);
             t.printStackTrace();
         }
     }

--- a/jena-text/src/main/java/org/apache/jena/query/text/changes/TextQuadAction.java
+++ b/jena-text/src/main/java/org/apache/jena/query/text/changes/TextQuadAction.java
@@ -30,7 +30,7 @@ package org.apache.jena.query.text.changes;
  * if a quad was present.
  * <p>
  * A {@code QuadAction} can be an {@code ADD} or {@code DELETE}, indicating a change
- * to the {@code DatasetGraph} actually occured (this assumes checking is done -
+ * to the {@code DatasetGraph} actually occurred (this assumes checking is done -
  * {@link TextDatasetChanges} generators may not check - see implementation for details).
  * Otherwise a {@code NO_ADD}, {@code NO_DELETE} {@code QuadAction} is used.
  */


### PR DESCRIPTION
Trivial spelling fix in three source files — `occured` → `occurred`.

One is user-visible:

- `jena-cmds/.../RuleMap.java` — `System.err.println("An error occurred: \n" + t);` on uncaught throwable in the CLI tool.

The other two are code comments / Javadoc:

- `jena-text/.../changes/TextQuadAction.java` — class Javadoc.
- `jena-arq/.../riot/system/AsyncParser.java` — inline comment on `parse()`.

No functional changes.