### PR TITLE
GH-3679: Return HttpHeaders in ExceptionHTTP and QueryExceptionHTTP

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/atlas/web/HttpException.java
+++ b/jena-arq/src/main/java/org/apache/jena/atlas/web/HttpException.java
@@ -21,6 +21,9 @@
 
 package org.apache.jena.atlas.web;
 
+import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
+
 import org.apache.jena.web.HttpSC;
 
 /**
@@ -29,26 +32,122 @@ import org.apache.jena.web.HttpSC;
 public class HttpException extends RuntimeException {
     private final int statusCode;
     private final String statusLine;
-    private final String response;
+    // The body of the response, if any.
+    private final HttpHeaders responseHeaders;
+    private final String responseBody;
+
+    /** System error setting up the HTTP request */
+    public static HttpException error(String exceptionMessage) {
+        return new HttpException(exceptionMessage);
+    }
+
+    /** System error setting up the HTTP request */
+    public static HttpException error(String exceptionMessage, Throwable cause) {
+        return new HttpException(exceptionMessage, cause);
+    }
+
+    /** HTTP error */
+    public static HttpException create(int httpStatusCode) {
+        return HttpException.builder()
+                .statusCode(httpStatusCode)
+                .build();
+    }
+
+    /** HTTP error */
+    public static HttpException create(HttpResponse<?> response) {
+        return HttpException.builder()
+                .statusCode(response.statusCode())
+                .httpHeaders(response.headers())
+                .build();
+    }
+
+    /**
+     * Replicate the details of an {@code HttpException};
+     * the stacktrace will be the callers location.
+     */
+    public static HttpException create(HttpException other) {
+        return HttpException.builder()
+                .statusCode(other.getStatusCode())
+                .statusLine(other.getStatusLine())
+                .responseMessage(other.getResponse())
+                .cause(other.getCause())
+                .build();
+    }
+
+    public static Builder builder() {
+        return new HttpException.Builder();
+    }
+
+    public static class Builder {
+        private int statusCode = -1;
+        private String statusLine = null;
+        private String responseMessage = null;
+        private Throwable cause = null;
+        private HttpHeaders httpHeaders = null;
+
+        public Builder() {}
+
+        public Builder statusCode(int statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public Builder statusLine(String statusLine) {
+            this.statusLine = statusLine;
+            return this;
+        }
+
+        public Builder responseMessage(String responseMessage) {
+            this.responseMessage = responseMessage;
+            return this;
+        }
+
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        public Builder httpHeaders(HttpHeaders httpHeaders) {
+            this.httpHeaders = httpHeaders;
+            return this;
+        }
+        public HttpException build() {
+            return new HttpException(statusCode, statusLine, responseMessage, cause);
+        }
+    }
 
     // HTTP/2 does not have an information message.
+
+    /** @deprecated Use {@link HttpException#create(int)} */
+    @Deprecated
     public HttpException(int statusCode) {
-        this(statusCode, null);
+        this(statusCode, null, null, null, null);
     }
 
+    /** @deprecated Use {@link HttpException#builder()} */
+    @Deprecated
     public HttpException(int statusCode, String statusLine) {
-        this(statusCode, statusLine, null, null);
+        this(statusCode, statusLine, null, null, null);
     }
 
+    /** @deprecated Use {@link HttpException#create(HttpResponse)} or {@link HttpException#builder()} */
+    @Deprecated
     public HttpException(int statusCode, String statusLine, String responseMessage) {
-        this(statusCode, statusLine, responseMessage, null);
+        this(statusCode, statusLine, null, responseMessage, null);
     }
 
+    /** @deprecated Use {@link HttpException#create(HttpResponse)} or {@link HttpException#builder()} */
+    @Deprecated
     public HttpException(int statusCode, String statusLine, String responseMessage, Throwable cause) {
+        this(statusCode, statusLine, null, responseMessage, cause);
+    }
+
+    private HttpException(int statusCode, String statusLine, HttpHeaders responseHttpHeaders, String responseBody, Throwable cause) {
         super(exMessage(statusCode, statusLine), cause);
         this.statusCode = statusCode;
         this.statusLine = statusLine ;
-        this.response = responseMessage;
+        this.responseHeaders = responseHttpHeaders;
+        this.responseBody = responseBody;
     }
 
     private static String exMessage(int statusCode, String statusLine) {
@@ -57,25 +156,34 @@ public class HttpException extends RuntimeException {
         return statusCode+" - "+HttpSC.getMessage(statusCode);
     }
 
-    public HttpException(String message) {
+    /** @deprecated Use {@link HttpException#error(String)} */
+    @Deprecated
+    private HttpException(String message) {
         super(message);
         this.statusCode = -1;
         this.statusLine = null ;
-        this.response = null;
+        this.responseHeaders = null;
+        this.responseBody = null;
     }
 
-    public HttpException(String message, Throwable cause) {
+    /** @deprecated Use {@link HttpException#error(String, Throwable)} */
+    @Deprecated
+    private HttpException(String message, Throwable cause) {
         super(message, cause);
         this.statusCode = -1;
         this.statusLine = null ;
-        this.response = null;
+        this.responseHeaders = null;
+        this.responseBody = null;
     }
 
+    /** @deprecated Use {@link HttpException#builder()} */
+    @Deprecated
     public HttpException(Throwable cause) {
         super(cause);
         this.statusCode = -1;
         this.statusLine = null ;
-        this.response = null;
+        this.responseHeaders = null;
+        this.responseBody = null;
     }
 
     /**
@@ -100,6 +208,14 @@ public class HttpException extends RuntimeException {
      * @return The payload, or null if no payload
      */
     public String getResponse() {
-        return response;
+        return responseBody;
     }
+
+    /**
+     * The response headers.
+     */
+    public HttpHeaders getHttpResponseHeader() {
+        return responseHeaders;
+    }
+
 }

--- a/jena-arq/src/main/java/org/apache/jena/atlas/web/HttpException.java
+++ b/jena-arq/src/main/java/org/apache/jena/atlas/web/HttpException.java
@@ -57,7 +57,7 @@ public class HttpException extends RuntimeException {
     public static HttpException create(HttpResponse<?> response) {
         return HttpException.builder()
                 .statusCode(response.statusCode())
-                .httpHeaders(response.headers())
+                .httpResponseHeaders(response.headers())
                 .build();
     }
 
@@ -69,6 +69,7 @@ public class HttpException extends RuntimeException {
         return HttpException.builder()
                 .statusCode(other.getStatusCode())
                 .statusLine(other.getStatusLine())
+                .httpResponseHeaders(other.getHttpResponseHeaders())
                 .responseMessage(other.getResponse())
                 .cause(other.getCause())
                 .build();
@@ -107,40 +108,16 @@ public class HttpException extends RuntimeException {
             return this;
         }
 
-        public Builder httpHeaders(HttpHeaders httpHeaders) {
+        public Builder httpResponseHeaders(HttpHeaders httpHeaders) {
             this.httpHeaders = httpHeaders;
             return this;
         }
         public HttpException build() {
-            return new HttpException(statusCode, statusLine, responseMessage, cause);
+            return new HttpException(statusCode, statusLine, httpHeaders, responseMessage, cause);
         }
     }
 
     // HTTP/2 does not have an information message.
-
-    /** @deprecated Use {@link HttpException#create(int)} */
-    @Deprecated
-    public HttpException(int statusCode) {
-        this(statusCode, null, null, null, null);
-    }
-
-    /** @deprecated Use {@link HttpException#builder()} */
-    @Deprecated
-    public HttpException(int statusCode, String statusLine) {
-        this(statusCode, statusLine, null, null, null);
-    }
-
-    /** @deprecated Use {@link HttpException#create(HttpResponse)} or {@link HttpException#builder()} */
-    @Deprecated
-    public HttpException(int statusCode, String statusLine, String responseMessage) {
-        this(statusCode, statusLine, null, responseMessage, null);
-    }
-
-    /** @deprecated Use {@link HttpException#create(HttpResponse)} or {@link HttpException#builder()} */
-    @Deprecated
-    public HttpException(int statusCode, String statusLine, String responseMessage, Throwable cause) {
-        this(statusCode, statusLine, null, responseMessage, cause);
-    }
 
     private HttpException(int statusCode, String statusLine, HttpHeaders responseHttpHeaders, String responseBody, Throwable cause) {
         super(exMessage(statusCode, statusLine), cause);
@@ -156,9 +133,33 @@ public class HttpException extends RuntimeException {
         return statusCode+" - "+HttpSC.getMessage(statusCode);
     }
 
+    /** @deprecated Use {@link HttpException#create(int)} */
+    @Deprecated(forRemoval = true)
+    public HttpException(int statusCode) {
+        this(statusCode, null, null, null, null);
+    }
+
+    /** @deprecated Use {@link HttpException#builder()} */
+    @Deprecated(forRemoval = true)
+    public HttpException(int statusCode, String statusLine) {
+        this(statusCode, statusLine, null, null, null);
+    }
+
+    /** @deprecated Use {@link HttpException#create(HttpResponse)} or {@link HttpException#builder()} */
+    @Deprecated(forRemoval = true)
+    public HttpException(int statusCode, String statusLine, String responseMessage) {
+        this(statusCode, statusLine, null, responseMessage, null);
+    }
+
+    /** @deprecated Use {@link HttpException#create(HttpResponse)} or {@link HttpException#builder()} */
+    @Deprecated(forRemoval = true)
+    public HttpException(int statusCode, String statusLine, String responseMessage, Throwable cause) {
+        this(statusCode, statusLine, null, responseMessage, cause);
+    }
+
     /** @deprecated Use {@link HttpException#error(String)} */
     @Deprecated
-    private HttpException(String message) {
+    public HttpException(String message) {
         super(message);
         this.statusCode = -1;
         this.statusLine = null ;
@@ -168,7 +169,7 @@ public class HttpException extends RuntimeException {
 
     /** @deprecated Use {@link HttpException#error(String, Throwable)} */
     @Deprecated
-    private HttpException(String message, Throwable cause) {
+    public HttpException(String message, Throwable cause) {
         super(message, cause);
         this.statusCode = -1;
         this.statusLine = null ;
@@ -214,7 +215,7 @@ public class HttpException extends RuntimeException {
     /**
      * The response headers.
      */
-    public HttpHeaders getHttpResponseHeader() {
+    public HttpHeaders getHttpResponseHeaders() {
         return responseHeaders;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/http/AsyncHttpRDF.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/AsyncHttpRDF.java
@@ -182,10 +182,9 @@ public class AsyncHttpRDF {
         } catch (CompletionException ex) {
             Throwable cause = ex.getCause();
             if ( cause != null ) {
-
                 // Pass on our own HttpException instances such as 401 Unauthorized.
                 if ( cause instanceof HttpException httpEx ) {
-                    throw new HttpException(httpEx.getStatusCode(), httpEx.getStatusLine(), httpEx.getResponse(), cause);
+                    throw HttpException.create(httpEx);
                 }
 
                 final String msg = cause.getMessage();
@@ -195,17 +194,17 @@ public class AsyncHttpRDF {
                     if ( msg != null &&
                             ( msg.contains("too many authentication attempts") ||
                               msg.contains("No credentials provided") ) ) {
-                        throw new HttpException(401, HttpSC.getMessage(401), null, cause);
+                        throw HttpException.builder().statusCode(HttpSC.UNAUTHORIZED_401).cause(cause).build();
                     }
                     if (httpRequest != null) {
-                        throw new HttpException(httpRequest.method()+" "+httpRequest.uri().toString(), cause);
+                        throw HttpException.error(httpRequest.method()+" "+httpRequest.uri().toString(), cause);
                     }
                 }
 
-                throw new HttpException(msg, cause);
+                throw HttpException.error(msg, cause);
             }
             // Note: CompletionException without cause should never happen.
-            throw new HttpException(ex);
+            throw HttpException.builder().cause(ex).build();
         }
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -283,7 +283,7 @@ public class HttpLib {
     static HttpException exception(HttpResponse<InputStream> response, int httpStatusCode) {
         InputStream in = response.body();
         if ( in == null )
-            return HttpException.create(httpStatusCode);
+            return HttpException.create(response);
         try {
             String msg;
             try {
@@ -293,7 +293,11 @@ public class HttpLib {
             } catch (RuntimeIOException e) {
                 msg = null;
             }
-            return HttpException.builder().statusCode(httpStatusCode).responseMessage(msg).build();
+            return HttpException.builder()
+                    .statusCode(httpStatusCode)
+                    .responseMessage(msg)
+                    .httpResponseHeaders(response.headers())
+                    .build();
         } finally { IO.close(in); }
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/HttpLib.java
@@ -62,7 +62,6 @@ import org.apache.jena.query.ARQ;
 import org.apache.jena.riot.web.HttpNames;
 import org.apache.jena.sparql.exec.http.Params;
 import org.apache.jena.sparql.util.Context;
-import org.apache.jena.web.HttpSC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +96,9 @@ public class HttpLib {
             InputStream in = r.body();
             String msg = IO.readWholeFileAsUTF8(in);
             return msg;
-        } catch (Throwable ex) { throw new HttpException(ex); }
+        } catch (Throwable ex) {
+            throw HttpException.builder().cause(ex).build();
+        }
     };
 
     /**
@@ -183,7 +184,7 @@ public class HttpLib {
         int httpStatusCode = response.statusCode();
         // There is no status message in HTTP/2.
         if ( ! inRange(httpStatusCode, 100, 599) ) {
-            throw new HttpException("Status code out of range: "+httpStatusCode);
+            throw HttpException.error("Status code out of range: "+httpStatusCode);
         }
         if ( inRange(httpStatusCode, 100, 199) ) {
             // Informational
@@ -269,7 +270,7 @@ public class HttpLib {
         try {
             return IO.readWholeFileAsUTF8(input);
         } catch (RuntimeIOException e) {
-            throw new HttpException(e);
+            throw HttpException.builder().cause(e).build();
         } finally {
             finishInputStream(input);
         }
@@ -282,7 +283,7 @@ public class HttpLib {
     static HttpException exception(HttpResponse<InputStream> response, int httpStatusCode) {
         InputStream in = response.body();
         if ( in == null )
-            return new HttpException(httpStatusCode, HttpSC.getMessage(httpStatusCode));
+            return HttpException.create(httpStatusCode);
         try {
             String msg;
             try {
@@ -292,7 +293,7 @@ public class HttpLib {
             } catch (RuntimeIOException e) {
                 msg = null;
             }
-            return new HttpException(httpStatusCode, HttpSC.getMessage(httpStatusCode), msg);
+            return HttpException.builder().statusCode(httpStatusCode).responseMessage(msg).build();
         } finally { IO.close(in); }
     }
 
@@ -360,14 +361,14 @@ public class HttpLib {
         try {
             URI uri = new URI(uriStr);
             if ( ! uri.isAbsolute() )
-                throw new HttpException("Not an absolute URL: <"+uriStr+">");
+                throw HttpException.error("Not an absolute URL: <"+uriStr+">");
             return uri;
         } catch (URISyntaxException ex) {
             int idx = ex.getIndex();
             String msg = (idx<0)
                 ? String.format("Bad URL: %s", uriStr)
                 : String.format("Bad URL: %s starting at character %d", uriStr, idx);
-            throw new HttpException(msg, ex);
+            throw HttpException.error(msg, ex);
         }
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthCredentials.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthCredentials.java
@@ -43,7 +43,7 @@ public class AuthCredentials {
         // Checks.
         URI uri = location.getURI();
         if ( uri.getRawQuery() != null || uri.getRawFragment() != null )
-            throw new HttpException("Endpoint URI must not have query string or fragment: "+uri);
+            throw HttpException.error("Endpoint URI must not have query string or fragment: "+uri);
         authRegistry.put(location, pwRecord);
         prefixes.add(uri.toString(), location);
     }

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthLib.java
@@ -40,7 +40,6 @@ import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.http.AsyncHttpRDF;
 import org.apache.jena.http.HttpLib;
 import org.apache.jena.riot.web.HttpNames;
-import org.apache.jena.web.HttpSC;
 
 public class AuthLib {
     /**
@@ -101,7 +100,7 @@ public class AuthLib {
             passwordRecord = AuthEnv.get().getUsernamePassword(request.uri());
             if ( passwordRecord == null )
                 // No entry.
-                throw HttpException.create(HttpSC.UNAUTHORIZED_401);
+                throw HttpException.create(httpResponse401);
         }
 
         // Request target - no query string.

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/AuthLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/AuthLib.java
@@ -101,7 +101,7 @@ public class AuthLib {
             passwordRecord = AuthEnv.get().getUsernamePassword(request.uri());
             if ( passwordRecord == null )
                 // No entry.
-                throw new HttpException(HttpSC.UNAUTHORIZED_401);
+                throw HttpException.create(HttpSC.UNAUTHORIZED_401);
         }
 
         // Request target - no query string.
@@ -126,7 +126,7 @@ public class AuthLib {
                 // Not handled. Pass back the 401.
                 return CompletableFuture.completedFuture(httpResponse401);
             default:
-                throw new HttpException("Not an authentication scheme -- "+aHeader.authScheme);
+                throw HttpException.error("Not an authentication scheme -- "+aHeader.authScheme);
         }
 
         // Failed to generate a request modifier for a retry.

--- a/jena-arq/src/main/java/org/apache/jena/http/auth/DigestLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/http/auth/DigestLib.java
@@ -77,7 +77,7 @@ class DigestLib {
     private static Pair<String, String> getUserNameAndPassword(HttpClient httpClient) {
         Optional<Authenticator> optAuth = httpClient.authenticator();
         if ( optAuth.isEmpty() )
-            throw new HttpException("Username/password required but not present in HttpClient");
+            throw HttpException.error("Username/password required but not present in HttpClient");
         // We just want the PasswordAuthentication!
         PasswordAuthentication x = optAuth.orElseThrow().requestPasswordAuthenticationInstance(null,
                                                                                                null,

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryExceptionHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryExceptionHTTP.java
@@ -21,24 +21,25 @@
 
 package org.apache.jena.sparql.engine.http;
 
+import java.net.http.HttpHeaders;
+
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.query.QueryException;
 import org.apache.jena.web.HttpSC;
 
 /**
- * Exception class for all operations in the SPARQL client library. Error codes are
- * as HTTP status codes.
+ * Exception class for all HTTP operations in the SPARQL client library.
+ * Error codes are as HTTP status codes.
  */
 public class QueryExceptionHTTP extends QueryException
 {
     public static final int noStatusCode = -1234;
     private int statusCode = noStatusCode;
-    private final String responseMessage;
-    private String statusLine;
-    private String response;
+    private final String statusLine;
 
-    // Codes for extra errors.  We use HTTP error codes so
-    // these are negative to avoid clashes
+    private final String responseBody;
+    private final HttpHeaders responseHeaders;
+    // Codes for extra errors. We use HTTP error codes so these are negative to avoid clashes
     public static final int NoServer = -404;
 
     public static QueryExceptionHTTP rewrap(HttpException httpEx) {
@@ -46,8 +47,8 @@ public class QueryExceptionHTTP extends QueryException
         // ARQ machinery we use these days means the internal HTTP errors come back as HttpException
         // Therefore we need to wrap appropriately
         int responseCode = httpEx.getStatusCode();
-        if (responseCode != -1) {
-            // Was an actual HTTP error
+        if (responseCode > 0) {
+            // It was an actual HTTP error
             String responseLine = httpEx.getStatusLine() != null ? httpEx.getStatusLine() : HttpSC.getMessage(responseCode);
             return new QueryExceptionHTTP(responseCode, responseLine, httpEx);
         } else if (httpEx.getMessage() != null) {
@@ -62,25 +63,14 @@ public class QueryExceptionHTTP extends QueryException
         }
     }
 
-    /**
-     * Constructor for QueryExceptionHTTP.
-     * @param responseCode
-     * @param responseMessage
-     */
-    public QueryExceptionHTTP(int responseCode, String responseMessage) {
-        super(responseMessage);
+    /** @deprecated Use {@ink #wrap(HttpException)} */
+    @Deprecated
+    public QueryExceptionHTTP(int responseCode, String messageBody, final HttpException ex) {
+        super(ex.getMessage(), ex.getCause());
         this.statusCode = responseCode;
-        this.responseMessage = responseMessage;
-    }
-
-    /**
-     * Constructor for QueryExceptionHTTP.
-     * @param responseCode
-     */
-    public QueryExceptionHTTP(int responseCode) {
-        super();
-        this.statusCode = responseCode;
-        this.responseMessage = null;
+        this.statusLine = ex.getStatusLine();
+        this.responseBody = ex.getResponse();
+        this.responseHeaders = ex.getHttpResponseHeaders();
     }
 
     /** The code for the reason for this exception
@@ -90,52 +80,33 @@ public class QueryExceptionHTTP extends QueryException
 
     /** The message for the reason for this exception
      * @return message
+     * @deprecate Use {@link #getResponseBody}
      */
-    public String getResponseMessage() { return responseMessage; }
+    @Deprecated
+    public String getResponseMessage() { return responseBody; }
+
+    public HttpHeaders getResponseHeaders() { return responseHeaders; }
+
+    public String getResponseBody() { return responseBody; }
 
     /** The response for this exception if available from HTTP
      * @return response or {@code null} if no HTTP response was received
+     * @deprecate Use {@link #getResponseBody}
      */
-    public String getResponse() { return response; }
+    @Deprecated
+    public String getResponse() { return getResponseBody(); }
 
     /** The status line for the response for this exception if available from HTTP
      * @return status line or {@code null} if no HTTP response was received
      */
     public String getStatusLine() { return statusLine; }
 
-    /**
-     * Constructor for HttpException used for some unexpected execution error.
-     * @param cause
-     */
-    public QueryExceptionHTTP(Throwable cause) {
-        super(cause);
-        this.statusCode = noStatusCode;
-        this.responseMessage = null;
-    }
-
-    public QueryExceptionHTTP(String msg, Throwable cause) {
-        super(msg, cause);
-        this.statusCode = noStatusCode;
-        this.responseMessage = msg;
-    }
-
-    public QueryExceptionHTTP(int responseCode, String message, Throwable cause) {
-        this(message, cause);
-        this.statusCode = responseCode;
-    }
-
-    public QueryExceptionHTTP(int responseCode, String message, final HttpException ex) {
-        this(responseCode, message, ex.getCause());
-        this.statusLine = ex.getStatusLine();
-        this.response = ex.getResponse();
-    }
-
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("HttpException: ");
         int code = getStatusCode();
-        if ( code != QueryExceptionHTTP.noStatusCode ) {
+        if ( code > 0 ) {
             sb.append(code);
             if ( getResponseMessage() != null ) {
                 sb.append(" ");
@@ -145,5 +116,52 @@ public class QueryExceptionHTTP extends QueryException
             sb.append(getCause().toString() + ": " + getMessage());
         }
         return sb.toString();
+    }
+
+    // Older constructors, no longer used.
+
+    @Deprecated(forRemoval = true)
+    public QueryExceptionHTTP(int responseCode, String responseMessage) {
+        super(responseMessage);
+        this.statusCode = responseCode;
+        this.statusLine = responseMessage;
+        this.responseHeaders = null;
+        this.responseBody = null;
+    }
+
+    @Deprecated(forRemoval = true)
+    public QueryExceptionHTTP(int responseCode) {
+        super();
+        this.statusCode = responseCode;
+        this.statusLine = null;
+        this.responseHeaders = null;
+        this.responseBody = null;
+    }
+
+    @Deprecated(forRemoval = true)
+    public QueryExceptionHTTP(Throwable cause) {
+        super(cause);
+        this.statusCode = noStatusCode;
+        this.statusLine = null;
+        this.responseHeaders = null;
+        this.responseBody = null;
+    }
+
+    @Deprecated(forRemoval = true)
+    public QueryExceptionHTTP(String msg, Throwable cause) {
+        super(msg, cause);
+        this.statusCode = noStatusCode;
+        this.statusLine = null;
+        this.responseHeaders = null;
+        this.responseBody = null;
+    }
+
+    @Deprecated(forRemoval = true)
+    public QueryExceptionHTTP(int responseCode, String message, Throwable cause) {
+        super(message, cause);
+        this.statusCode = responseCode;
+        this.statusLine = null;
+        this.responseHeaders = null;
+        this.responseBody = null;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/StoreProtocol.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/http/StoreProtocol.java
@@ -183,7 +183,7 @@ public abstract class StoreProtocol<X extends StoreProtocol<X>> {
 
     // Setup problems.
     protected static RuntimeException exception(String msg) {
-        return new HttpException(msg);
+        return HttpException.error(msg);
     }
 
     final protected String service() { return serviceEndpoint; }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiCustomOperation.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiCustomOperation.java
@@ -248,7 +248,7 @@ public class TestFusekiCustomOperation {
         // Service endpoint name : GET
         String s1 = HttpOp.httpGetString(svcCall);
         if ( s1 == null )
-            throw new HttpException(HttpSC.NOT_FOUND_404, "Not Found");
+            throw HttpException.create(HttpSC.NOT_FOUND_404);
         assertValidResponseBody(customHandlerBodyGet, s1);
 
         // Service endpoint name : POST

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/test/HttpTest.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/test/HttpTest.java
@@ -98,7 +98,7 @@ public class HttpTest {
     public static void expectQuery(Runnable action, int expected) {
         try {
             action.run();
-            throw new HttpException("Expected QueryExceptionHTTP["+expected+"]");
+            throw HttpException.error("Expected QueryExceptionHTTP["+expected+"]");
         } catch (QueryExceptionHTTP ex) {
             if ( ex.getStatusCode() != expected )
                 throw ex;

--- a/jena-integration-tests/src/test/java/org/apache/jena/sparql/exec/http/TestQueryExecCleanServer.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/sparql/exec/http/TestQueryExecCleanServer.java
@@ -24,6 +24,7 @@ package org.apache.jena.sparql.exec.http;
 import static org.apache.jena.atlas.lib.StrUtils.strjoinNL;
 import static org.apache.jena.sparql.sse.SSE.parseQuad;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.TimeUnit;
@@ -43,7 +44,7 @@ import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 
 /**
  * Tests for {@link QueryExecHTTP} with no authentication.
- * See  {@link TestQueryExecHTTP} for most of the tests.
+ * See {@link TestQueryExecHTTP} for most of the tests.
  */
 public class TestQueryExecCleanServer {
     // Unlike TestQueryExecutionHTTP these tests run a clean server each time.
@@ -104,10 +105,12 @@ public class TestQueryExecCleanServer {
                                             // Short!
                                             .timeout(10, TimeUnit.MILLISECONDS)
                                             .build() ) {
-            assertThrows(QueryExceptionHTTP.class, ()->{
+            QueryExceptionHTTP ex = assertThrows(QueryExceptionHTTP.class, ()->{
                 long x = Iter.count(qExec.select());
                 assertEquals(2, x);
             });
+            // Client side timeout.
+            assertNull(ex.getResponseHeaders());
         }
     }
 }

--- a/jena-integration-tests/src/test/java/org/apache/jena/sparql/exec/http/TestQueryExecHTTP.java
+++ b/jena-integration-tests/src/test/java/org/apache/jena/sparql/exec/http/TestQueryExecHTTP.java
@@ -24,11 +24,14 @@ package org.apache.jena.sparql.exec.http;
 import static org.apache.jena.sparql.sse.SSE.parseQuad;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.http.HttpHeaders;
 import java.util.Iterator;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -42,10 +45,13 @@ import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.Syntax;
+import org.apache.jena.riot.web.HttpNames;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.apache.jena.sparql.exec.RowSet;
+import org.apache.jena.web.HttpSC;
 
 /**
  * Tests for {@link QueryExecHTTP} with no authentication.
@@ -97,6 +103,25 @@ public class TestQueryExecHTTP {
             assertFalse(rs.hasNext());
             assertTrue(qExec.getHttpResponseContentType().startsWith("application/sparql-results+json"));
         }
+    }
+
+    @Test
+    public void query_select_bad_01() {
+        LogCtl.withLevel(Fuseki.actionLog, "ERROR", ()->{
+
+            // Make a bad request
+            try ( QueryExecHTTP qExec = QueryExecHTTP.newBuilder().endpoint(dsURL).queryString("SELECT * { JUNK }").build() ) {
+                QueryExceptionHTTP ex = Assertions.assertThrows(QueryExceptionHTTP.class, ()->qExec.select());
+                assertEquals(HttpSC.BAD_REQUEST_400, ex.getStatusCode());
+                assertNotNull(ex.getResponseHeaders());
+                HttpHeaders headers = ex.getResponseHeaders();
+                // Fuseki includes the parse error.
+                assertNotNull(headers);
+                var x = headers.firstValue(HttpNames.hContentType);
+                assertFalse(x.isEmpty());
+                assertNotNull(x.get());
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
GitHub issue resolved #3679

Pull request Description: See #3679

Reworked `HttpException` and, by naming, have "HTTP subsystem" and "HTTP network" static methods.

----

 - [x] Tests are included.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
