### PR TITLE
Update jena-benchmarks POMs for new version

### DIFF
--- a/jena-benchmarks/jena-benchmarks-jmh/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-jmh/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-benchmarks</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <name>Apache Jena - Benchmarks JMH</name>
@@ -57,28 +57,28 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-base</artifactId>
-            <version>6.1.0-SNAPSHOT</version>
+            <version>6.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>6.1.0-SNAPSHOT</version>
+            <version>6.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
-            <version>6.1.0-SNAPSHOT</version>
+            <version>6.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-geosparql</artifactId>
-            <version>6.1.0-SNAPSHOT</version>
+            <version>6.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
@@ -86,14 +86,14 @@
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-arq</artifactId>
             <classifier>tests</classifier>
-            <version>6.1.0-SNAPSHOT</version>
+            <version>6.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-benchmarks-shadedJena560</artifactId>
-            <version>6.1.0-SNAPSHOT</version>
+            <version>6.2.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/jena-benchmarks/jena-benchmarks-shadedJena560/pom.xml
+++ b/jena-benchmarks/jena-benchmarks-shadedJena560/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-benchmarks</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
 
     <name>Apache Jena - Benchmarks Shaded Jena 5.6.0</name>

--- a/jena-benchmarks/pom.xml
+++ b/jena-benchmarks/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
   </parent>
 
   <name>Apache Jena - Benchmark Suite</name>


### PR DESCRIPTION
The POMs under `jena-benchmarks` do not get update by a release build.

@arne-bdt --
Should they be set to current development or latest release?

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
