### PR TITLE
Add graph-level robust list handling `GList`. Add tests for `G`.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/system/G.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/G.java
@@ -40,8 +40,6 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.engine.iterator.IterAbortable;
 import org.apache.jena.sparql.graph.NodeConst;
-import org.apache.jena.sparql.util.graph.GNode;
-import org.apache.jena.sparql.util.graph.GraphList;
 import org.apache.jena.util.iterator.ExtendedIterator;
 import org.apache.jena.util.iterator.WrappedIterator;
 
@@ -270,7 +268,7 @@ public class G {
      */
     public static Node getPO(Graph graph, Node predicate, Node object) {
         Objects.requireNonNull(graph, "graph");
-        return object(first(find(graph, Node.ANY, predicate, object)));
+        return subject(first(find(graph, Node.ANY, predicate, object)));
     }
 
     /**
@@ -287,7 +285,7 @@ public class G {
      */
     public static boolean hasOnePO(Graph graph, Node predicate, Node object) {
         Objects.requireNonNull(graph, "graph");
-        return findUniqueTriple(graph, Node.ANY, predicate, object) != null;
+        return findZeroOneTriple(graph, Node.ANY, predicate, object) != null;
     }
 
     /**
@@ -374,6 +372,12 @@ public class G {
         return iterSP(graph, subject, predicate).toList();
     }
 
+    /** Return a set of all objects for subject-predicate */
+    public static Set<Node> allSP(Graph graph, Node subject, Node predicate) {
+        Objects.requireNonNull(graph, "graph");
+        return find(graph, subject, predicate, null).mapWith(Triple::getObject).toSet();
+    }
+
     /** Count matches of subject-predicate (which can be wildcards). */
     public static long countSP(Graph graph, Node subject, Node predicate) {
         Objects.requireNonNull(graph, "graph");
@@ -397,6 +401,12 @@ public class G {
     public static List<Node> listPO(Graph graph, Node predicate, Node object) {
         Objects.requireNonNull(graph, "graph");
         return iterPO(graph, predicate, object).toList();
+    }
+
+    /** Return a set of all subjects for predicate-object */
+    public static Set<Node> allPO(Graph graph, Node predicate, Node object) {
+        Objects.requireNonNull(graph, "graph");
+        return find(graph, null, predicate, object).mapWith(Triple::getSubject).toSet();
     }
 
     /** Count matches of predicate-object (which can be wildcards). */
@@ -499,34 +509,30 @@ public class G {
     public static List<Node> rdfList(Graph graph, Node node) {
         Objects.requireNonNull(graph, "graph");
         Objects.requireNonNull(node, "node");
-        GNode gNode = GNode.create(graph, node);
-        if ( ! GraphList.isListNode(gNode) )
-            return null;
-        return GraphList.members(gNode);
+        List<Node> nodes = GList.members(graph, node);
+        return nodes;
     }
 
     /** Return a the length of an RDF list. */
     public static int listLength(Graph graph, Node node) {
         Objects.requireNonNull(graph, "graph");
         Objects.requireNonNull(node, "node");
-        GNode gNode = GNode.create(graph, node);
-        if ( ! GraphList.isListNode(gNode) )
+        if ( ! GList.isListNode(graph, node) )
             return -1;
-        return GraphList.length(gNode);
+        return (int)GList.listLength(graph, node);
     }
 
     /**
-     * Return a java list where the {@code node} is an RDF list of nodes or a single
-     * node (returned a singleton list).
+     * Return a java list where the {@code node} is an RDF list of nodes,
+     * of if the node is not a list, return the node as a list of one.
      */
     public static List<Node> getOneOrList(Graph graph, Node node) {
         Objects.requireNonNull(graph, "graph");
         Objects.requireNonNull(node, "node");
-        GNode gNode = GNode.create(graph, node);
         // An element on its own is a list of one
-        if ( ! GraphList.isListNode(gNode) )
+        if ( ! GList.isListNode(graph, node) )
             return List.of(node);
-        return GraphList.members(gNode);
+        return GList.members(graph, node);
     }
 
     // Sub-class / super-class
@@ -645,18 +651,6 @@ public class G {
         types.forEach(t->
             find(graph, null, rdfType, t).mapWith(Triple::getSubject).forEach(acc::add)
             );
-    }
-
-    /** Return a set of all objects for subject-predicate */
-    public static Set<Node> allSP(Graph graph, Node subject, Node predicate) {
-        Objects.requireNonNull(graph, "graph");
-        return find(graph, subject, predicate, null).mapWith(Triple::getObject).toSet();
-    }
-
-    /** Return a set of all subjects for predicate-object */
-    public static Set<Node> allPO(Graph graph, Node predicate, Node object) {
-        Objects.requireNonNull(graph, "graph");
-        return find(graph, null, predicate, object).mapWith(Triple::getSubject).toSet();
     }
 
     // --- Graph walking.
@@ -841,15 +835,15 @@ public class G {
 
     /**
      * Creates a copy of the given graph.
-     * If the graph implements Copyable<Graph> then the copy method is called.
+     * If the graph implements {@code Copyable<Graph>} then the copy method is called.
      * Otherwise, a new system default memory-based graph is created and the triples are copied
      * into it.
      * @param src the graph to copy
      * @return a copy of the graph
      */
-    @SuppressWarnings("unchecked")
     public static Graph copy(Graph src) {
         if(src instanceof Copyable<?> copyable) {
+            @SuppressWarnings("unchecked")
             Copyable<Graph> copyableGraph = (Copyable<Graph>)copyable;
             return copyableGraph.copy();
         }

--- a/jena-arq/src/main/java/org/apache/jena/system/GList.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/GList.java
@@ -316,6 +316,13 @@ public class GList {
         return elt;
     }
 
+    public static boolean isListNode(Graph graph, Node node) {
+        if ( node.equals(NIL) )
+            return true;
+        // Well-formedness check.
+        return isCons(graph, node);
+    }
+
     /**
      * Run over a list, checking for cycles and well-formed list cons cells.
      * Call an action on each element if {@ocde elementAction} is not null.
@@ -470,15 +477,6 @@ public class GList {
 //                return elt;
 //            }
 //        }
-    }
-
-
-
-    private static boolean isListNode(Graph graph, Node node) {
-        if ( node.equals(NIL) )
-            return true;
-        // Well-formedness check.
-        return isCons(graph, node);
     }
 
     private static boolean isCons (Graph graph, Node node) {

--- a/jena-arq/src/main/java/org/apache/jena/system/GList.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/GList.java
@@ -1,0 +1,501 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.system;
+
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.util.graph.GNode;
+import org.apache.jena.sparql.util.graph.GraphList;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.util.iterator.ExtendedIterator;
+import org.apache.jena.vocabulary.RDF;
+
+/**
+ * Operations on RDF Collections (RDF Lists).
+ * <p>
+ * Operations may throw {@link RDFDataException} if the list is not well-formed.
+ * <p>
+ * Operations check for exactly {@code rdf:first}, and exactly one {@code rdf:rest},
+ * but do not check for cycles unless noted in their javadoc.
+ * <p>
+ * To get a list of all the items in a list, use {@link #members} operations, which
+ * does check for cycles, or if the list is known to be well-formed, one of the {@link #elements}
+ * operations, which do not check for cycles.
+ * <p>
+ * The {@link #contains} operation does not check for cycles so that repeated use on
+ * a list does not perform duplicate checking work repeatedly.
+ * <p>
+ * If a list is potentially mal-formed by having a cycle, check first with
+ * {@link #isWellformedList(Graph, Node)} or
+ * {@link #isWellformedListEx(Graph, Node)}.
+ * <p>
+ * List validation only needs to be performed once.
+ * <p>
+ * List arising from parsing Turtle or TriG syntax for lists will be cycle-free.
+ * <p>
+ * <b>This class is <em>not</em> public API</b>.
+ *
+ * @see GraphList - uses a findable abstaction ({@link GNode}to work on a graph or lists of triples.
+ */
+public class GList {
+
+    static { JenaSystem.init(); }
+
+    private static final Node CAR = RDF.Nodes.first;
+    private static final Node CDR = RDF.Nodes.rest;
+    private static final Node NIL = RDF.Nodes.nil;
+    private static final Node RDF_TYPE = RDF.Nodes.type;
+    private static final long BAD_LIST = -1;
+    private static final Function<String, RuntimeException> stdExceptionMaker = RDFDataException::new;
+
+    // forEach (unchecked).
+
+//    occurs(GNode, Node)
+//    contains(GNode, Node)
+//    get(GNode, int)
+//    index(GNode, Node)
+//    indexes(GNode, Node)
+//    triples(GNode, Collection<Triple>)
+//    allTriples(GNode)
+//    allTriples(GNode, Collection<Triple>)
+//    findAllLists(Graph)
+//    listToTriples(List<Node>, BasicPattern)
+
+
+    /**
+     * Check for a valid list; throw a {@link RDFDataException} if the list is bad in some way.
+     * The {@link RDFDataException} message indicates the problem with the list.
+     * @param graph
+     * @param list
+     */
+    public static void isWellformedListEx(Graph graph, Node list) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        forEachMember(graph, list, false, null, stdExceptionMaker);
+    }
+
+    /** Check for a valid list; throw a {@link RDFDataException} if the list is bad in some way.
+     * The {@link RDFDataException} message indicates the problem with the list.
+     * @param graph
+     * @param list
+     * @param closedCells - whether to check that only {@code rdf:first} and {@code rdf:next} are used on a list cell
+     */
+    public static void isWellformedListEx(Graph graph, Node list, boolean closedCells) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        forEachMember(graph, list, closedCells, null, stdExceptionMaker);
+    }
+
+    /**
+     * Check for a valid list; return true if well-formed else return false.
+     * Use {@link #isWellformedListEx(Graph, Node)} to get an except with an
+     * informational message about the problem detected.
+     *
+     * @param graph
+     * @param list
+     */
+    public static boolean isWellformedList(Graph graph, Node list) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        return forEachMember(graph, list, false, null, null) != BAD_LIST;
+    }
+
+    /** Check for a valid list; return true if well-formed else return false.
+     * Use {@link #isWellformedListEx(Graph, Node, boolean)} to get an except with an
+     * informational message about the problem detected.
+     * @param graph
+     * @param list
+     * @param closedCells - whether to check that only rdf:first and rdf:next are used on a list cell
+     */
+    public static boolean isWellformedList(Graph graph, Node list, boolean closedCells) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        return forEachMember(graph, list, closedCells, null, null) != BAD_LIST;
+    }
+
+    /**
+     * Return the members of a well-formed RDF list.
+     * @throws RDFDataException if the list is not well-formed, including if it has a cycle.
+     */
+    public static List<Node> members(Graph graph, Node list) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        if ( list.equals(NIL) )
+            return List.of();
+        List<Node> acc = new ArrayList<>();
+        forEachMember(graph, list, false, acc::add, stdExceptionMaker);
+        return acc;
+    }
+
+    /**
+     * Accumulate the members of a well-formed RDF list.
+     * @throws RDFDataException if the list is not well-formed, including if it has a cycle.
+     */
+    public static void members(Graph graph, Node list, Collection<Node> acc) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        if ( list.equals(NIL) )
+            return;
+        forEachMember(graph, list, false, acc::add, stdExceptionMaker);
+    }
+
+    /**
+     * Return the elements of a well-formed RDF list.
+     * This operation does not check for cycles.
+     * {@link #members} is has the same result and incorporates a well-formness cycle check.
+     */
+    public static List<Node> elements(Graph graph, Node list) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+
+        if ( list.equals(NIL) )
+            return List.of();
+        List<Node> acc = new ArrayList<>();
+        elements(graph, list, acc);
+        return acc;
+    }
+
+    /**
+     * Accumulate the elements of a well-formed RDF list.
+     * This operation does not check for cycles.
+     */
+    public static void elements(Graph graph, Node list, Collection<Node> acc) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        Objects.requireNonNull(acc);
+        if ( list.equals(NIL) )
+            return;
+        Node cell = list;
+        while ( ! listEnd(graph, cell) ) {
+            Node elt = G.getOneSP(graph, cell, CAR);
+            Node next = G.getOneSP(graph, cell, CDR);
+            acc.add(elt);
+            cell = next;
+        }
+    }
+
+    /**
+     * Run an action on each element of a list, in order.
+     * @see #iterator(Graph, Node)
+     */
+    public static void forEach(Graph graph, Node list, Consumer<Node> action) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        Objects.requireNonNull(action);
+        if ( list.equals(NIL) )
+            return;
+        // No cycle checking.
+        long countElts = 0;
+        Node cell = list;
+        while(!listEnd(graph, cell) ) {
+            Node elt = G.getOneSP(graph, cell, CAR);
+            Node next = G.getOneSP(graph, cell, CDR);
+            cell = next;
+            action.accept(elt);
+        }
+    }
+
+    /**
+     * Return the length of a well-formed list.
+     * This operations assumes the list is well-formed.
+     * See {@link #isWellformedList(Graph, Node)} for check a list.
+     */
+    public static long listLength(Graph graph, Node list) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        if ( list.equals(NIL) )
+            return 0;
+        // No cycle checking.
+        long countElts = 0;
+        Node cell = list;
+        while(!listEnd(graph, cell) ) {
+            // Check integrity.
+            G.hasOneSP(graph, cell, CDR);
+            Node next = G.getOneSP(graph, cell, CDR);
+            cell = next;
+            countElts++;
+        }
+        return countElts;
+    }
+
+    // --------
+
+    /**
+     * Return an iterator over the list.
+     * The iterator does not check for well-formed lists.
+     * Ensure the list is well-formed - {@link #isWellformedListEx(Graph, Node)}.
+     *
+     * @see #forEach
+     */
+    public static Iterator<Node> iterator(Graph graph, Node list) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        return new RDFListIterator(graph, list);
+    }
+
+    /**
+     * Return the first index of an occurrence of a node in a list.
+     * Return -1 for not in list.
+     * Indexes start at 0.
+     * @param graph
+     * @param list
+     * @param item to check
+     */
+    public static int indexOf(Graph graph, Node list, Node item) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        Objects.requireNonNull(item);
+        Node cell = list;
+        int index = 0;
+        while( !listEnd(graph, cell) ) {
+            Node elt = G.getOneSP(graph, cell, CAR);
+            Node next = G.getOneSP(graph, cell, CDR);
+            cell = next;
+            if ( item.sameTermAs(elt) )
+                return index;
+            index++;
+        }
+        return -1;
+    }
+
+    /**
+     * Return whether an item is in the list.
+     * Return for not in list.
+     * @param graph
+     * @param list
+     * @param item to check for
+     */
+    public static boolean contains(Graph graph, Node list, Node item) {
+        return indexOf(graph, list, item) >= 0;
+    }
+
+    /**
+     * Return the list element at an index (indexes start at 0).
+     * <p>
+     * Do not use this to iterate over a list - consider using {@link #members} to
+     * collect the list in a single pass.
+     */
+    public static Node get(Graph graph, Node list, int index) {
+        Objects.requireNonNull(graph);
+        Objects.requireNonNull(list);
+        if ( index < 0 )
+            return null;
+        Node cell = list;
+        Node elt = null ;
+        for ( int i = 0 ; i <= index ; i++ ) {
+            if ( listEnd(graph, cell) )
+                return null;
+            elt = G.getOneSP(graph, cell, CAR);
+            Node next = G.getOneSP(graph, cell, CDR);
+            cell = next;
+        }
+        return elt;
+    }
+
+    /**
+     * Run over a list, checking for cycles and well-formed list cons cells.
+     * Call an action on each element if {@ocde elementAction} is not null.
+     * For a bad list, throw an exception or return -1 if {@code exceptionMaker} is null.
+     */
+    private static long forEachMember(Graph graph, Node node,
+                                      boolean closedCells,
+                                      Consumer<Node> elementAction,
+                                      Function<String, RuntimeException> exceptionMaker) {
+        Node cell = node;
+        Set<Node> visited = new HashSet<>();
+        long numListElements = 0 ;
+        while (!listEnd(graph, cell)) {
+            if ( visited.contains(cell) ) {
+                badListEx("Cyclic list", cell, exceptionMaker);
+                return -1;
+            }
+            visited.add(cell);
+            // rdf:first elt;  rdf:rest next;
+            Node elt = null;
+            Node next = null;
+            ExtendedIterator<Triple> iterSP = G.find(graph, cell, null, null);
+            try {
+                while(iterSP.hasNext()) {
+                    Triple t = iterSP.next();
+                    Node predicate = t.getPredicate();
+
+                    if ( CAR.equals(predicate) ) {
+                        if ( elt != null ) {
+                            badListEx("List contains an element with two rdf:first", cell, exceptionMaker);
+                            return -1;
+                        }
+                        elt = t.getObject();
+                        continue;
+                    }
+                    if ( CDR.equals(predicate) ) {
+                        if ( next != null ) {
+                            badListEx("List contains an element with two rdf:next", cell, exceptionMaker);
+                            return -1;
+                        }
+                        next = t.getObject();
+                        continue;
+                    }
+                    if ( RDF_TYPE.equals(predicate) ) {
+                        // Allow rdf:type on a list cons cell.
+                        continue;
+                    }
+
+                    if ( closedCells ) {
+                        badListEx("List contains non-list triples", cell, exceptionMaker);
+                        return -1;
+                    }
+                }
+
+                if ( elt == null ) {
+                    badListEx("List contains an element with no rdf:first", node, exceptionMaker);
+                    return -1;
+                }
+                if ( next == null ) {
+                    badListEx("List contains an element with no rdf:next", node, exceptionMaker);
+                    return -1;
+                }
+                // Valid list element
+                numListElements++;
+                if ( elementAction != null )
+                    elementAction.accept(elt);
+                cell = next;
+            } finally { iterSP.close(); }
+        }
+        return numListElements;
+    }
+
+    private static class RDFListIterator implements Iterator<Node> {
+
+        private Function<String, RuntimeException> exceptionMaker = RDFDataException::new;
+        private final Graph graph;
+        private Node current = null;
+
+        RDFListIterator(Graph graph, Node node) {
+            this.graph = graph;
+            this.current = node;
+            //isWellformedListEx(graph, node);
+        }
+
+        @Override
+        public boolean hasNext() {
+            return ! listEnd(graph, current);
+        }
+
+        @Override
+        public Node next() {
+            // Assume well-formed.
+            Node elt = G.getOneSP(graph, current, CAR);
+            Node next = G.getOneSP(graph, current, CDR);
+            current = next;
+            return elt;
+        }
+
+        // Very complicated for the sake of walking the list once.
+        // Instead, expect the caller to have validated the list once before list operations.
+//        @Override
+//        public Node next() {
+//            if ( listEnd(graph, current) )
+//                throw new NoSuchElementException();
+//            if ( true ) {
+//                // Checking.
+//                ExtendedIterator<Triple> iterSP = G.find(graph, current, null, null);
+//                try {
+//                    Node elt = null;
+//                    Node next = null;
+//                    boolean closedCells = true;
+//
+//                    while(iterSP.hasNext()) {
+//                        Triple t = iterSP.next();
+//                        Node predicate = t.getPredicate();
+//
+//                        if ( CAR.equals(predicate) ) {
+//                            if ( elt != null ) {
+//                                badListEx("List contains an element with two rdf:first", null, exceptionMaker);
+//                                throw new NoSuchElementException();
+//                            }
+//                            elt = t.getObject();
+//                            continue;
+//                        }
+//                        if ( CDR.equals(predicate) ) {
+//                            if ( next != null ) {
+//                                badListEx("List contains an element with two rdf:next", null, exceptionMaker);
+//                                throw new NoSuchElementException();
+//                            }
+//                            next = t.getObject();
+//                            continue;
+//                        }
+//                        if ( RDF_TYPE.equals(predicate) ) {
+//                            // Allow rdf:type on a list cons cell.
+//                            continue;
+//                        }
+//
+//                        if ( closedCells ) {
+//                            badListEx("List contains non-list triples", null, exceptionMaker);
+//                            throw new NoSuchElementException();
+//                        }
+//                    }
+//                    current = next;
+//                    return elt;
+//                } finally { iterSP.close(); }
+//
+//            } else {
+//                // Assume well-formed.
+//                Node elt = G.getOneSP(graph, current, CAR);
+//                Node next = G.getOneSP(graph, current, CDR);
+//                current = next;
+//                return elt;
+//            }
+//        }
+    }
+
+
+
+    private static boolean isListNode(Graph graph, Node node) {
+        if ( node.equals(NIL) )
+            return true;
+        // Well-formedness check.
+        return isCons(graph, node);
+    }
+
+    private static boolean isCons (Graph graph, Node node) {
+        return G.hasOneSP(graph, node, CDR) && G.hasOneSP(graph, node, CAR);
+    }
+
+    private static boolean listEnd(Graph graph, Node node) {
+        return node == null || node.equals(NIL);
+    }
+
+    /** Check for a valid list; return true if the list is well-formed else return false
+     * @param graph
+     * @param node
+     * @param closedCells - whether to check that only rdf:first and rdf:next are used on a list cell
+     */
+    private static void badListEx(String msg, Node node, Function<String, RuntimeException> exceptionMaker ) {
+        if ( exceptionMaker != null )
+            throw exceptionMaker.apply(msg);
+    }
+}

--- a/jena-arq/src/main/java/org/apache/jena/system/ThreadTxn.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/ThreadTxn.java
@@ -33,18 +33,17 @@ import org.apache.jena.sparql.core.Transactional ;
  * forked transaction sees is outside the creating thread which may itself be in a
  * transaction. Warning: creating a write transaction inside a write transaction
  * will cause deadlock.
- */ 
+ */
 public class ThreadTxn {
 
-    /** Create a thread-backed delayed transaction action. 
+    /** Create a thread-backed delayed transaction action.
      * Call {@link ThreadAction#run} to perform the read transaction.
      */
     public static ThreadAction threadTxn(Transactional trans, TxnType txnType, Runnable action) {
         return create(trans, txnType, action, true, true) ;
     }
 
-
-    /** Create a thread-backed delayed READ transaction action. 
+    /** Create a thread-backed delayed READ transaction action.
      * Call {@link ThreadAction#run} to perform the read transaction.
      */
     public static ThreadAction threadTxnRead(Transactional trans, Runnable action) {
@@ -59,7 +58,7 @@ public class ThreadTxn {
     public static ThreadAction threadTxnWrite(Transactional trans, Runnable action) {
         return threadTxn(trans, TxnType.WRITE, action) ;
     }
-   
+
     /** Create a thread-backed delayed WRITE-abort action (mainly for testing). */
     public static ThreadAction threadTxnWriteAbort(Transactional trans, Runnable action) {
         return create(trans, TxnType.WRITE, action, true, false) ;
@@ -71,11 +70,11 @@ public class ThreadTxn {
             , action
             , afterAction(trans, txnType, isCommitAfter) ) ;
     }
-    
+
     private static Runnable beforeAction(Transactional trans, TxnType txnType, boolean isCommit) {
         return ()-> trans.begin(txnType) ;
     }
-    
+
     private static Runnable afterAction(Transactional trans, TxnType txnType, boolean isCommit) {
         return () -> {
             // Finish transaction (if no throwable)

--- a/jena-arq/src/main/java/org/apache/jena/system/Vocab.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/Vocab.java
@@ -21,24 +21,20 @@
 
 package org.apache.jena.system;
 
-import org.apache.jena.rdf.model.Property ;
-import org.apache.jena.rdf.model.Resource ;
-import org.apache.jena.rdf.model.ResourceFactory ;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
 
-public class Vocab
-{
-    public static Resource type(String namespace, String localName)
-    { 
-        return ResourceFactory.createResource(namespace+localName) ;
-    }
-    
-    public static Resource resource(String namespace, String localName)
-    {
-        return ResourceFactory.createResource(namespace+localName) ;
+public class Vocab {
+    public static Resource type(String namespace, String localName) {
+        return ResourceFactory.createResource(namespace + localName);
     }
 
-    public static Property property(String namespace, String localName)
-    {
-        return ResourceFactory.createProperty(namespace+localName) ;
+    public static Resource resource(String namespace, String localName) {
+        return ResourceFactory.createResource(namespace + localName);
+    }
+
+    public static Property property(String namespace, String localName) {
+        return ResourceFactory.createProperty(namespace + localName);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/system/TS_System.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TS_System.java
@@ -26,15 +26,16 @@ import org.junit.platform.suite.api.Suite;
 
 @Suite
 @SelectClasses({
-    TestCounter.class
+    TestPrefixes.class
+    , TestPrefixLib.class
+
+    , TestTxnCounter.class
     , TestThreadAction.class
     , TestTxnLifecycle.class
     , TestTxnOp.class
     , TestTxn.class
     , TestTxnThread.class
     , TestReadXML.class
-    , TestPrefixes.class
-    , TestPrefixLib.class
     , TestRDFStarTranslation.class
     , TestFindNamespaces.class
 })

--- a/jena-arq/src/test/java/org/apache/jena/system/TS_System.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TS_System.java
@@ -29,12 +29,21 @@ import org.junit.platform.suite.api.Suite;
     TestPrefixes.class
     , TestPrefixLib.class
 
-    , TestTxnCounter.class
+    , TestG_Basic.class
+    , TestG_SP .class
+    , TestG_PO .class
+    , TestG_Triple.class
+    , TestG_Quad.class
+    , TestG_Classes.class
+
+    , TestGCopy.class
+
+    , TestTxn.class
     , TestThreadAction.class
     , TestTxnLifecycle.class
     , TestTxnOp.class
-    , TestTxn.class
     , TestTxnThread.class
+    , TestTxnCounter.class
     , TestReadXML.class
     , TestRDFStarTranslation.class
     , TestFindNamespaces.class

--- a/jena-arq/src/test/java/org/apache/jena/system/TestGCopy.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestGCopy.java
@@ -33,7 +33,7 @@ import org.apache.jena.mem.GraphMemFast;
 import org.apache.jena.memvalue.GraphMemValue;
 import org.apache.jena.sparql.sse.SSE;
 
-public class GTest {
+public class TestGCopy {
 
     @Test
     public void copy() {

--- a/jena-arq/src/test/java/org/apache/jena/system/TestGList.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestGList.java
@@ -1,0 +1,469 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.system;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.function.BiConsumer;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.sparql.graph.GraphZero;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.vocabulary.RDF;
+
+public class TestGList {
+
+    static { JenaSystem.init(); }
+
+    private static Node x = SSE.parseNode(":x");
+    private static Node p = SSE.parseNode(":p");
+    private static Node elt1 = SSE.parseNode("'A'");
+    private static Node elt2 = SSE.parseNode("'B'");
+
+    @Test public void glist_members_01() {
+        Graph graph = GraphZero.instance();
+        List<Node> members = members(graph, RDF.Nodes.nil);
+        assertTrue(members.isEmpty());
+   }
+
+    @Test public void glist_members_02() {
+        test("()", (graph, list)->{
+            List<Node> members = members(graph, list);
+            assertTrue(members.isEmpty());
+        });
+    }
+
+    @Test public void glist_members_03() {
+        test("('A')", (graph, list)->{
+            List<Node> members = members(graph, list);
+            assertEquals(1, members.size());
+            assertEquals(elt1, members.getFirst());
+        });
+    }
+
+    @Test public void glist_members_04() {
+        test("('A' 'B')", (graph, list)->{
+            List<Node> members = members(graph, list);
+            assertEquals(2, members.size());
+            assertEquals(elt1, members.getFirst());
+            assertEquals(elt2, members.getLast());
+        });
+    }
+
+    @Test public void glist_members_05() {
+        test("((:a :b :c))", (graph, list)->{
+            List<Node> members = members(graph, list);
+            assertEquals(1, members.size());
+            assertTrue(members.getFirst().isBlank());
+
+            Node listInner = members.getFirst();
+            List<Node> membersInner = members(graph, listInner);
+            assertEquals(3, membersInner.size());
+        });
+    }
+
+    @Test public void glist_members_bad_01() {
+        testEx("[ rdf:first 1 ]", (graph, list)->members(graph, list));
+    }
+
+    @Test public void glist_members_bad_02() {
+        testEx("[ rdf:rest rdf:nil ]", (graph, list)->members(graph, list));
+    }
+
+    @Test public void glist_members_bad_03() {
+        testWellformed("[ rdf:first 1 ; rdf:rest () ]");
+        testEx("[ rdf:first 1 ; rdf:first 2 ; rdf:rest () ]", (graph, list)->members(graph, list));
+    }
+
+    @Test public void glist_members_bad_04() {
+        testWellformed("[ rdf:first 1 ; rdf:rest ('A') ]");
+        testEx("[ rdf:first 1 ; rdf:rest ('A') ; rdf:rest () ]", (graph, list)->members(graph, list));
+    }
+
+    @Test public void glist_wellformed_01() {
+        testWellformed("()");
+    }
+
+    @Test public void glist_wellformed_02() {
+        testWellformed("('A')");
+    }
+
+    // Allow rdf:type
+    @Test public void glist_wellformed_03() {
+        testWellformed("[ rdf:first 1 ; rdf:rest rdf:nil; rdf:type :Cell]");
+    }
+
+    // Allow rdf:type
+    @Test public void glist_wellformed_04() {
+        testWellformed("""
+                [ rdf:first 1 ;
+                  rdf:rest [
+                      rdf:first 1 ;
+                      rdf:rest rdf:nil ;
+                      rdf:type :Cell
+                  ]
+                ]
+                """);
+    }
+
+    @Test public void glist_wellformed_bad_01() {
+        testNotWellformed("[ rdf:first 1 ]");
+    }
+
+    @Test public void glist_wellformed_bad_02() {
+        testNotWellformed("[ rdf:rest rdf:nil ]");
+    }
+
+    @Test public void glist_wellformed_bad_03() {
+        testWellformed("[ rdf:first 1 ; rdf:rest () ]");
+        testNotWellformed("[ rdf:first 1 ; rdf:first 2 ; rdf:rest () ]");
+    }
+
+    @Test public void glist_wellformed_bad_04() {
+        testWellformed("[ rdf:first 1 ; rdf:rest ('A') ]");
+        testNotWellformed("[ rdf:first 1 ; rdf:rest ('A') ; rdf:rest () ]");
+    }
+
+    @Test public void glist_wellformed_bad_10() {
+        testWellformed("[ rdf:first 1 ; rdf:rest [ rdf:first 'A' ; rdf:rest rdf:nil ] ]");
+        testNotWellformed("""
+                [ rdf:first 1 ;
+                  rdf:rest [
+                      rdf:first 'A' ;
+                      rdf:first 'B' ;
+                      rdf:rest rdf:nil
+                      ]
+                ]
+                """);
+    }
+
+    @Test public void glist_wellformed_bad_11() {
+        testWellformed("""
+                [ rdf:first 1 ;
+                  rdf:rest [
+                      rdf:first 'A' ;
+                      rdf:rest rdf:nil
+                    ]
+                ]
+                """);
+        testNotWellformed("""
+                [ rdf:first 1 ;
+                  rdf:rest [
+                      rdf:first 'A' ;
+                      rdf:rest 'B' ;
+                      rdf:rest rdf:nil ]
+                ]
+                """);
+    }
+
+    @Test public void glist_wellformed_bad_12() {
+        testWellformed("[ rdf:first 1 ; rdf:rest [ rdf:first 'A' ; rdf:rest rdf:nil ] ]");
+        testNotWellformed("[ rdf:first 1 ; rdf:rest [ rdf:first 'A' ; ] ]");
+    }
+
+    @Test public void glist_wellformed_bad_13() {
+        testWellformed("[ rdf:first 1 ; rdf:rest [ rdf:first 'A' ; rdf:rest rdf:nil ] ]");
+        testNotWellformed("[ rdf:first 1 ; rdf:rest [ rdf:rest rdf:nil ] ]");
+    }
+
+    @Test public void glist_wellformed_bad_14() {
+        testWellformed("[ rdf:first 1 ; rdf:rest [ rdf:first 'A' ; rdf:rest rdf:nil ] ]");
+        testNotWellformed("[ rdf:first 1 ; rdf:rest [ ] ]");
+    }
+
+    @Test public void glist_wellformed_cyclic_01() {
+        String graphStr = """
+                :head rdf:first 0 ; rdf:rest :x .
+                :x rdf:first 1 ; rdf:rest :y .
+                :y rdf:first 1 ; rdf:rest :x .
+                """;
+        Graph graph = graph(graphStr);
+        Node list = x;
+        boolean b = GList.isWellformedList(graph, list);
+        assertFalse(b);
+        assertThrows(RDFDataException.class,  ()->GList.isWellformedListEx(graph, list));
+    }
+
+    @Test public void glist_isWellformedEx_message_no_rest() {
+        // A cell with rdf:first but no rdf:rest should cause the "no rdf:next" error message
+        String s = "[ rdf:first 1 ]";
+        String g = """
+                PREFIX :     <http://example/>
+                PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                :x :p """ + s;
+        Graph graph = RDFParser.fromString(g, Lang.TURTLE).toGraph();
+        Node list = G.getOneSP(graph, SSE.parseNode(":x"), SSE.parseNode(":p"));
+        RDFDataException ex = assertThrows(RDFDataException.class, ()->GList.isWellformedListEx(graph, list));
+        String msg = ex.getMessage();
+        assertTrue(msg != null && msg.contains("no rdf:next"), "Expected exception message to mention 'no rdf:next', got: " + msg);
+    }
+
+    @Test public void glist_length_01() {
+        testlength("()", 0);
+    }
+
+    @Test public void glist_length_02() {
+        testlength("(1 2 3)", 3);
+    }
+
+    @Test public void glist_length_03() {
+        testlength("( () )", 1);
+    }
+
+    @Test public void glist_length_04() {
+        testlength("( (:a :b) )", 1);
+    }
+
+    @Test public void glist_length_05() {
+        testlength("( :A (:a :b) )", 2);
+    }
+
+    @Test public void glist_length_06() {
+        testlength("( (:a :b) :Z)", 2);
+    }
+
+    @Test public void glist_length_bad_01() {
+        assertThrows(RDFDataException.class,  ()->testlength("[ rdf:first 1 ; rdf:rest [ rdf:first 'A' ; ] ]", -1));
+    }
+
+    @Test public void glist_indexOf_01() {
+        test("('A')", (graph, list)->{
+            Node elt = NodeFactory.createLiteralString("A");
+            int idx = GList.indexOf(graph, list, elt);
+            assertEquals(0, idx);
+        });
+    }
+
+    @Test public void glist_indexOf_02() {
+        test("('A')", (graph, list)->{
+            Node elt = NodeFactory.createLiteralString("B");
+            int idx = GList.indexOf(graph, list, elt);
+            assertEquals(-1, idx);
+        });
+    }
+
+    @Test public void glist_indexOf_03() {
+        test("('A' 'A' 'A')", (graph, list)->{
+            Node elt = NodeFactory.createLiteralString("A");
+            int idx = GList.indexOf(graph, list, elt);
+            assertEquals(0, idx);
+        });
+    }
+
+
+    @Test public void glist_indexOf_04() {
+        // Does not recurse in lists in lists.
+        test("(('A'))", (graph, list)->{
+            Node elt = NodeFactory.createLiteralString("A");
+            int idx = GList.indexOf(graph, list, elt);
+            assertEquals(-1, idx);
+        });
+    }
+
+    @Test public void glist_indexOf_05() {
+        test("()", (graph, list)->{
+            Node elt = NodeFactory.createLiteralString("A");
+            int idx = GList.indexOf(graph, list, elt);
+            assertEquals(-1, idx);
+        });
+    }
+
+    @Test public void glist_get_01() {
+        test("('A')", (graph, list)->{
+            Node x = GList.get(graph, list, 0);
+            assertEquals("A", x.getLiteral().getLexicalForm());
+        });
+    }
+
+    @Test public void glist_get_02() {
+        test("('A')", (graph, list)->{
+            Node x = GList.get(graph, list, 1);
+            assertNull(x);
+        });
+    }
+
+    @Test public void glist_get_03() {
+        test("()", (graph, list)->{
+            Node x = GList.get(graph, list, 0);
+            assertNull(x);
+        });
+    }
+
+    @Test public void glist_get_04() {
+        test("('A' 'B' 'C')", (graph, list)->{
+            Node x = GList.get(graph, list, 1);
+            assertEquals("B", x.getLiteral().getLexicalForm());
+        });
+    }
+
+    @Test public void glist_get_negative_index() {
+        test("('A')", (graph, list)->{
+            assertNull(GList.get(graph, list, -1));
+        });
+    }
+
+    @Test public void glist_forEach_01() {
+        test("()", (graph, list)->{
+            StringBuilder sb = new StringBuilder();
+            GList.forEach(graph, list, n -> {
+                // numeric literals; use lexical form
+                sb.append(n.getLiteral().getLexicalForm()).append(",");
+            });
+            assertEquals("", sb.toString());
+        });
+    }
+
+    @Test public void glist_forEach_02() {
+        test("(1 2 3)", (graph, list)->{
+            StringBuilder sb = new StringBuilder();
+            GList.forEach(graph, list, n -> {
+                // numeric literals; use lexical form
+                sb.append(n.getLiteral().getLexicalForm()).append(",");
+            });
+            assertEquals("1,2,3,", sb.toString());
+        });
+    }
+
+    @Test public void glist_iterator_traverse() {
+        test("('A' 'B' 'C')", (graph, list)->{
+            List<Node> seen = new ArrayList<>();
+            Iterator<Node> it = GList.iterator(graph, list);
+            while (it.hasNext()) {
+                seen.add(it.next());
+            }
+            List<Node> expected = GList.elements(graph, list);
+            assertEquals(expected, seen);
+        });
+    }
+
+    @Test public void glist_iterator_empty() {
+        Graph graph = graph(":s :p :o");
+        Iterator<Node> it = GList.iterator(graph, RDF.Nodes.nil);
+        assertFalse(it.hasNext());
+    }
+
+    @Test public void glist_closedCells_reject_extra_predicate() {
+        // Create a list cell that has an extra non-list triple :p :o
+        // Use closedCells = true to exercise that branch.
+        test("[ rdf:first 1 ; rdf:rest rdf:nil ; :p :o ]", (graph, list)->{
+            assertFalse(GList.isWellformedList(graph, list, true));
+            assertThrows(RDFDataException.class, ()->GList.isWellformedListEx(graph, list, true));
+        });
+    }
+
+    @Test public void glist_indexOf_blanknode_identity() {
+        // Outer list contains one inner list (a blank node). indexOf should handle blank-node identity.
+        test("((:a :b :c))", (graph, list)->{
+            // get the actual inner blank node from the members method
+            List<Node> members = members(graph, list);
+            assertEquals(1, members.size());
+            Node inner = members.get(0);
+
+            // Searching for the same blank node returns 0
+            assertEquals(0, GList.indexOf(graph, list, inner));
+
+            // Searching for a different (not-equal) blank node returns -1
+            Node otherBNode = NodeFactory.createBlankNode();
+            assertEquals(-1, GList.indexOf(graph, list, otherBNode));
+        });
+    }
+
+    @Test public void glist_contains_01() {
+        test("()", (graph, list)->{
+            Node c = NodeFactory.createLiteralString("C");
+            assertFalse(GList.contains(graph, list, c));
+        });
+    }
+
+    @Test public void glist_contains_02() {
+        test("('A' 'B')", (graph, list)->{
+            Node a = NodeFactory.createLiteralString("A");
+            Node c = NodeFactory.createLiteralString("C");
+            assertTrue(GList.contains(graph, list, a));
+            assertFalse(GList.contains(graph, list, c));
+        });
+    }
+
+    // ----
+
+    private List<Node> members(Graph graph, Node list) {
+        // Do the checking form first in case it throws RDFDataException.
+        List<Node> x1 = GList.members(graph, list);
+        List<Node> x2 = GList.elements(graph, list);
+        assertEquals(x1,  x2);
+        return x1;
+    }
+
+    private static void testWellformed(String string) {
+        test(string, (graph, list)->{
+            assertTrue(GList.isWellformedList(graph, list));
+        });
+    }
+
+    private static void testNotWellformed(String string) {
+        test(string, (graph, list)->{
+            assertFalse(GList.isWellformedList(graph, list));
+            assertThrows(RDFDataException.class, ()->GList.isWellformedListEx(graph, list));
+        });
+    }
+
+    private static void testlength(String string, int expected) {
+        test(string, (graph, list)->{
+            long actual = GList.listLength(graph, list);
+            assertEquals(expected, actual);
+        });
+    }
+
+    private static void test(String string, BiConsumer<Graph, Node> action) {
+        String graphStr = ":x :p "+string;
+        Graph graph = graph(graphStr);
+        Node list = G.getOneSP(graph, x, p);
+        action.accept(graph,  list);
+    }
+
+    private static void testEx(String string, BiConsumer<Graph, Node> action) {
+        String graphStr = ":x :p "+string;
+        Graph graph = graph(graphStr);
+        Node list = G.getOneSP(graph, x, p);
+        assertThrows(RDFDataException.class, ()->action.accept(graph,  list));
+    }
+
+
+    private static Graph graph(String str) {
+        String setup = """
+                PREFIX :     <http://example/>
+                PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                """;
+        return RDFParser.fromString(setup+str, Lang.TURTLE).toGraph();
+    }
+
+}

--- a/jena-arq/src/test/java/org/apache/jena/system/TestG_Basic.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestG_Basic.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.system;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sys.JenaSystem;
+
+public class TestG_Basic {
+
+	static { JenaSystem.init(); }
+
+	@Test
+	public void contains_true_and_false() {
+		Graph g = graph(":s :p :o .");
+		Node s = SSE.parseNode(":s");
+		Node p = SSE.parseNode(":p");
+		Node o = SSE.parseNode(":o");
+
+		assertTrue(G.contains(g, s, p, o));
+		// different predicate -> false
+		assertFalse(G.contains(g, s, SSE.parseNode(":q"), o));
+	}
+
+	@Test
+	public void containsNode_detects_nodes() {
+		Graph g = graph(":s :p :o . _:b :p :o .");
+		Node s = SSE.parseNode(":s");
+		Node o = SSE.parseNode(":o");
+		Node missing = SSE.parseNode(":x");
+
+		assertTrue(G.containsNode(g, s));
+		assertTrue(G.containsNode(g, o));
+		assertFalse(G.containsNode(g, missing));
+	}
+
+	@Test
+	public void hasProperty_true_false() {
+		Graph g = graph(":s :p :o .");
+		Node s = SSE.parseNode(":s");
+		Node p = SSE.parseNode(":p");
+		Node q = SSE.parseNode(":q");
+
+		assertTrue(G.hasProperty(g, s, p));
+		assertFalse(G.hasProperty(g, s, q));
+	}
+
+	@Test
+	public void containsOne_single_none_multiple() {
+		Node s = SSE.parseNode(":s");
+		Node p = SSE.parseNode(":p");
+		Node o = SSE.parseNode(":o");
+
+		Graph gSingle = graph(":s :p :o .");
+		assertTrue(G.containsOne(gSingle, s, p, o));
+
+		Graph gNone = graph(":s :q :o .");
+		assertFalse(G.containsOne(gNone, s, p, o));
+
+		Graph gMulti = graph(":s :p :o1 . :s :p :o2 .");
+		assertFalse(G.containsOne(gMulti, s, p, Node.ANY));
+	}
+
+	@Test
+	public void hasType_direct() {
+		Graph g = graph(":x rdf:type :A .");
+		Node x = SSE.parseNode(":x");
+		Node A = SSE.parseNode(":A");
+		assertTrue(G.hasType(g, x, A));
+		assertFalse(G.hasType(g, x, SSE.parseNode(":B")));
+	}
+
+	@Test
+	public void isOfType_with_subclass() {
+		String body = """
+		        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+		        PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+		        PREFIX : <http://example/>
+
+				:A rdfs:subClassOf :B .
+				:x rdf:type :A .
+				""";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+		Node x = SSE.parseNode(":x");
+		Node B = SSE.parseNode(":B");
+		Node C = SSE.parseNode(":C");
+		assertTrue(G.isOfType(g, x, B));
+		assertFalse(G.isOfType(g, x, C));
+	}
+
+	private static Graph graph(String ttlBody) {
+		String setup = "PREFIX :     <http://example/>\n" +
+					   "PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n";
+		return RDFParser.fromString(setup+ttlBody, Lang.TURTLE).toGraph();
+	}
+}

--- a/jena-arq/src/test/java/org/apache/jena/system/TestG_Classes.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestG_Classes.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.system;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+
+public class TestG_Classes {
+
+	static { JenaSystem.init(); }
+
+	@Test
+	public void listSubClasses_includes_transitive_subclasses_and_self() {
+		String body = """
+				PREFIX : <http://example/>
+				PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+				:A rdfs:subClassOf :B .
+				:C rdfs:subClassOf :A .
+				:D rdfs:subClassOf :B .
+				:E rdfs:subClassOf :C .
+				""";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+
+		Node B = SSE.parseNode(":B");
+		List<Node> subs = G.listSubClasses(g, B);
+		Set<Node> set = new HashSet<>(subs);
+		assertEquals(5, set.size());
+		assertTrue(set.contains(SSE.parseNode(":B")));
+		assertTrue(set.contains(SSE.parseNode(":A")));
+		assertTrue(set.contains(SSE.parseNode(":C")));
+		assertTrue(set.contains(SSE.parseNode(":D")));
+		assertTrue(set.contains(SSE.parseNode(":E")));
+	}
+
+	@Test
+	public void listSuperClasses_includes_transitive_superclasses_and_self() {
+		String body = """
+				PREFIX : <http://example/>
+				PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+				:A rdfs:subClassOf :B .
+				:C rdfs:subClassOf :A .
+				:E rdfs:subClassOf :C .
+				""";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+
+		Node E = SSE.parseNode(":E");
+		List<Node> supers = G.listSuperClasses(g, E);
+		Set<Node> set = new HashSet<>(supers);
+		assertEquals(4, set.size());
+		assertTrue(set.contains(SSE.parseNode(":E")));
+		assertTrue(set.contains(SSE.parseNode(":C")));
+		assertTrue(set.contains(SSE.parseNode(":A")));
+		assertTrue(set.contains(SSE.parseNode(":B")));
+	}
+
+	@Test
+	public void subClasses_return_set_equivalent_to_list() {
+		String body = """
+				PREFIX : <http://example/>
+				PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+				:A rdfs:subClassOf :B .
+				:C rdfs:subClassOf :A .
+				""";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+
+		Node B = SSE.parseNode(":B");
+		List<Node> subsList = G.listSubClasses(g, B);
+		Set<Node> subsSet = G.subClasses(g, B);
+		assertEquals(new HashSet<>(subsList), subsSet);
+	}
+
+	@Test
+	public void superClasses_return_set_equivalent_to_list() {
+		String body = "PREFIX : <http://example/>\n" +
+					  "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
+					  ":A rdfs:subClassOf :B . :C rdfs:subClassOf :A .";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+
+		Node C = SSE.parseNode(":C");
+		List<Node> supersList = G.listSuperClasses(g, C);
+		Set<Node> supersSet = G.superClasses(g, C);
+		assertEquals(new HashSet<>(supersList), supersSet);
+	}
+
+	@Test
+	public void listSubClasses_no_relations_contains_self_only() {
+		String body = """
+				PREFIX : <http://example/>
+				PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				:Z a :U .
+				""";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+		Node Z = SSE.parseNode(":Z");
+		List<Node> subs = G.listSubClasses(g, Z);
+		assertEquals(1, subs.size());
+		assertEquals(Z, subs.get(0));
+	}
+
+	@Test
+	public void listTypesOfNodeRDFS_includes_direct_and_superclasses() {
+		String body = """
+				PREFIX : <http://example/>
+				PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+				:A rdfs:subClassOf :B .
+				:x rdf:type :A .
+				""";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+		Node x = SSE.parseNode(":x");
+		List<Node> types = G.listTypesOfNodeRDFS(g, x);
+		Set<Node> set = new HashSet<>(types);
+		assertTrue(set.contains(SSE.parseNode(":A")));
+		assertTrue(set.contains(SSE.parseNode(":B")));
+	}
+
+	@Test
+	public void listNodesOfTypeRDFS_includes_nodes_of_subclasses() {
+		String body = """
+				PREFIX : <http://example/>
+				PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+				:C rdfs:subClassOf :A .
+				:x rdf:type :A .
+				:y rdf:type :C .
+				""";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+		Node A = SSE.parseNode(":A");
+		List<Node> nodes = G.listNodesOfTypeRDFS(g, A);
+		Set<Node> set = new HashSet<>(nodes);
+		assertTrue(set.contains(SSE.parseNode(":x")));
+		assertTrue(set.contains(SSE.parseNode(":y")));
+	}
+
+	@Test
+	public void allTypesOfNodeRDFS_returns_set_of_types_including_superclasses() {
+		String body = """
+				PREFIX : <http://example/>
+				PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+				:A rdfs:subClassOf :B .
+				:x rdf:type :A .
+				""";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+		Node x = SSE.parseNode(":x");
+		Set<Node> types = G.allTypesOfNodeRDFS(g, x);
+		assertTrue(types.contains(SSE.parseNode(":A")));
+		assertTrue(types.contains(SSE.parseNode(":B")));
+	}
+
+	@Test
+	public void allNodesOfTypeRDFS_returns_set_of_nodes_including_subclass_instances() {
+		String body = """
+				PREFIX : <http://example/>
+				PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+				PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+				:C rdfs:subClassOf :A .
+				:x rdf:type :A .
+				:y rdf:type :C .
+				""";
+		Graph g = RDFParser.fromString(body, Lang.TURTLE).toGraph();
+		Node A = SSE.parseNode(":A");
+		Set<Node> nodes = G.allNodesOfTypeRDFS(g, A);
+		assertTrue(nodes.contains(SSE.parseNode(":x")));
+		assertTrue(nodes.contains(SSE.parseNode(":y")));
+	}
+}

--- a/jena-arq/src/test/java/org/apache/jena/system/TestG_PO.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestG_PO.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.system;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+public class TestG_PO {
+
+	static { JenaSystem.init(); }
+
+	private static final Node s1 = SSE.parseNode(":s1");
+	private static final Node s2 = SSE.parseNode(":s2");
+	private static final Node x = SSE.parseNode(":x");
+	private static final Node p = SSE.parseNode(":p");
+	private static final Node o1 = SSE.parseNode(":o1");
+	private static final Node o2 = SSE.parseNode(":o2");
+
+	@Test
+	public void getPO_many_returns_one_of_subjects() {
+		Graph g = graph(":s1 :p :o . :s2 :p :o .");
+		Node got = G.getPO(g, p, SSE.parseNode(":o"));
+		assertTrue(s1.sameTermAs(got) || s2.sameTermAs(got));
+	}
+
+	@Test
+	public void getOnePO_single_ok() {
+		Graph g = graph(":s :p :o1 .");
+		Node got = G.getOnePO(g, p, o1);
+		assertEquals(SSE.parseNode(":s"), got);
+	}
+
+	@Test
+	public void getOnePO_none_throws() {
+		Graph g = graph(":s :q :o1 .");
+		assertThrows(RDFDataException.class, ()->G.getOnePO(g, p, o1));
+	}
+
+	@Test
+	public void getOnePO_multiple_throws() {
+		Graph g = graph(":s1 :p :o1 . :s2 :p :o1 .");
+		assertThrows(RDFDataException.class, ()->G.getOnePO(g, p, o1));
+	}
+
+	@Test
+	public void getZeroOrOnePO_none_null() {
+		Graph g = graph(":s :q :o1 .");
+		Node got = G.getZeroOrOnePO(g, p, o1);
+		assertNull(got);
+	}
+
+	@Test
+	public void getZeroOrOnePO_one_ok() {
+		Graph g = graph(":s :p :o1 .");
+		Node got = G.getZeroOrOnePO(g, p, o1);
+		assertEquals(SSE.parseNode(":s"), got);
+	}
+
+	@Test
+	public void getZeroOrOnePO_multiple_throws() {
+		Graph g = graph(":s1 :p :o1 . :s2 :p :o1 .");
+		assertThrows(RDFDataException.class, ()->G.getZeroOrOnePO(g, p, o1));
+	}
+
+	@Test
+	public void hasOnePO_none_false() {
+		Graph g = graph(":s :q :o1 .");
+		assertFalse(G.hasOnePO(g, p, o1));
+	}
+
+	@Test
+	public void hasOnePO_one_true() {
+		Graph g = graph(":s :p :o1 .");
+		assertTrue(G.hasOnePO(g, p, o1));
+	}
+
+	@Test
+	public void hasOnePO_multiple_throws() {
+		Graph g = graph(":s1 :p :o1 . :s2 :p :o1 .");
+		assertThrows(RDFDataException.class, ()->G.hasOnePO(g, p, o1));
+	}
+
+	// Wildcard tests similar to TestG_SP
+	@Test
+	public void getPO_objectAny_returns_one_of_subjects() {
+		Graph g = graph(":s1 :p :o1 . :s2 :p :o2 .");
+		Node got = G.getPO(g, p, Node.ANY);
+		assertTrue(SSE.parseNode(":s1").sameTermAs(got) || SSE.parseNode(":s2").sameTermAs(got));
+	}
+
+	@Test
+	public void getOnePO_objectAny_single_ok() {
+		Graph g = graph(":s1 :p :o1 .");
+		Node got = G.getOnePO(g, p, Node.ANY);
+		assertEquals(SSE.parseNode(":s1"), got);
+	}
+
+	@Test
+	public void getOnePO_objectAny_multiple_throws() {
+		Graph g = graph(":s1 :p :o1 . :s2 :p :o2 .");
+		assertThrows(RDFDataException.class, ()->G.getOnePO(g, p, Node.ANY));
+	}
+
+	@Test
+	public void getZeroOrOnePO_objectAny_single_ok() {
+		Graph g = graph(":s1 :p :o1 .");
+		Node got = G.getZeroOrOnePO(g, p, Node.ANY);
+		assertEquals(SSE.parseNode(":s1"), got);
+	}
+
+	@Test
+	public void getZeroOrOnePO_objectAny_multiple_throws() {
+		Graph g = graph(":s1 :p :o1 . :s2 :p :o2 .");
+		assertThrows(RDFDataException.class, ()->G.getZeroOrOnePO(g, p, Node.ANY));
+	}
+
+	@Test
+	public void hasOnePO_objectAny_true_false_and_throws() {
+		// none -> false
+		Graph g0 = graph(":s :q :o1 .");
+		assertFalse(G.hasOnePO(g0, p, Node.ANY));
+
+		// single -> true
+		Graph g1 = graph(":s1 :p :o1 .");
+		assertTrue(G.hasOnePO(g1, p, Node.ANY));
+
+		// multiple -> throws
+		Graph g2 = graph(":s1 :p :o1 . :s2 :p :o2 .");
+		assertThrows(RDFDataException.class, ()->G.hasOnePO(g2, p, Node.ANY));
+	}
+
+	@Test
+	public void iterPO_returns_subjects() {
+		Graph g = graph(":s1 :p :o . :s2 :p :o . :s3 :q :o .");
+		ExtendedIterator<Node> iter = G.iterPO(g, p, SSE.parseNode(":o"));
+		try {
+			List<Node> seen = iter.toList();
+			assertEquals(2, seen.size());
+			assertTrue(seen.contains(SSE.parseNode(":s1")) && seen.contains(SSE.parseNode(":s2")));
+		} finally { iter.close(); }
+	}
+
+	@Test
+	public void listPO_returns_list_of_subjects() {
+		Graph g = graph(":s1 :p :o . :s2 :p :o . :s3 :q :o .");
+		List<Node> list = G.listPO(g, p, SSE.parseNode(":o"));
+		assertEquals(2, list.size());
+		assertTrue(list.contains(SSE.parseNode(":s1")) && list.contains(SSE.parseNode(":s2")));
+	}
+
+	@Test
+	public void countPO_counts_matches() {
+		Graph g = graph(":s1 :p :o . :s2 :p :o . :s3 :q :o .");
+		long count = G.countPO(g, p, SSE.parseNode(":o"));
+		assertEquals(2, count);
+	}
+
+	@Test
+	public void allPO_returns_set_of_subjects() {
+		Graph g = graph(":s1 :p :o . :s2 :p :o . :s3 :q :o .");
+		Set<Node> all = G.allPO(g, p, SSE.parseNode(":o"));
+		assertEquals(2, all.size());
+		assertTrue(all.contains(SSE.parseNode(":s1")) && all.contains(SSE.parseNode(":s2")));
+	}
+
+	private static Graph graph(String ttlBody) {
+		String setup = "PREFIX :     <http://example/>\n";
+		return RDFParser.fromString(setup+ttlBody, Lang.TURTLE).toGraph();
+	}
+}

--- a/jena-arq/src/test/java/org/apache/jena/system/TestG_Quad.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestG_Quad.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sys.JenaSystem;
+
+public class TestG_Quad {
+
+	static { JenaSystem.init(); }
+
+	private static final Node s = SSE.parseNode(":s");
+	private static final Node p = SSE.parseNode(":p");
+	private static final Node o = SSE.parseNode(":o");
+
+	// DatasetGraph getOne (quads)
+	@Test
+	public void getOne_datasetgraph_single_ok() {
+		DatasetGraph dsg = dataset(":g { :s :p :o } ");
+		Node gname = SSE.parseNode(":g");
+		Quad q = G.getOne(dsg, gname, s, p, o);
+		assertEquals(Quad.create(gname, s, p, o), q);
+	}
+
+	@Test
+	public void getOne_datasetgraph_none_throws() {
+		DatasetGraph dsg = dataset("");
+		Node gname = SSE.parseNode(":g");
+		assertThrows(RDFDataException.class, ()->G.getOne(dsg, gname, s, p, o));
+	}
+
+	@Test
+	public void getOne_datasetgraph_multiple_throws_with_wildcard() {
+		DatasetGraph dsg = dataset(":g1 { :s :p :o } :g2 { :s :p :o } ");
+		// Use graph wildcard to match multiple quad locations
+		assertThrows(RDFDataException.class, ()->G.getOne(dsg, Node.ANY, s, p, o));
+	}
+
+	private static DatasetGraph dataset(String trigBody) {
+		String setup = "PREFIX :     <http://example/>\n";
+		return RDFParser.fromString(setup+trigBody, Lang.TRIG).toDatasetGraph();
+	}
+}

--- a/jena-arq/src/test/java/org/apache/jena/system/TestG_SP.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestG_SP.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.system;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.util.iterator.ExtendedIterator;
+
+public class TestG_SP {
+
+	static { JenaSystem.init(); }
+
+	private static final Node s = SSE.parseNode(":s");
+	private static final Node x = SSE.parseNode(":x");
+	private static final Node p = SSE.parseNode(":p");
+	private static final Node o1 = SSE.parseNode(":o1");
+	private static final Node o2 = SSE.parseNode(":o2");
+
+	@Test
+	public void getSP_many_returns_one_of_objects() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 .");
+		Node got = G.getSP(g, s, p);
+		assertTrue(o1.sameTermAs(got) || o2.sameTermAs(got), "getSP should return one of the objects when multiple exist");
+	}
+
+	@Test
+	public void getOneSP_single_ok() {
+		Graph g = graph(":s :p :o1 .");
+		Node got = G.getOneSP(g, s, p);
+		assertEquals(o1, got);
+	}
+
+	@Test
+	public void getOneSP_none_throws() {
+		Graph g = graph(":s :q :o1 .");
+		assertThrows(RDFDataException.class, ()->G.getOneSP(g, s, p));
+	}
+
+	@Test
+	public void getOneSP_multiple_throws() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 .");
+		assertThrows(RDFDataException.class, ()->G.getOneSP(g, s, p));
+	}
+
+	@Test
+	public void getZeroOrOneSP_none_null() {
+		Graph g = graph(":s :q :o1 .");
+		Node got = G.getZeroOrOneSP(g, s, p);
+		assertNull(got);
+	}
+
+	@Test
+	public void getZeroOrOneSP_one_ok() {
+		Graph g = graph(":s :p :o1 .");
+		Node got = G.getZeroOrOneSP(g, s, p);
+		assertEquals(o1, got);
+	}
+
+	@Test
+	public void getZeroOrOneSP_multiple_throws() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 .");
+		assertThrows(RDFDataException.class, ()->G.getZeroOrOneSP(g, s, p));
+	}
+
+	@Test
+	public void hasOneSP_none_false() {
+		Graph g = graph(":s :q :o1 .");
+		assertFalse(G.hasOneSP(g, s, p));
+	}
+
+	@Test
+	public void hasOneSP_one_true() {
+		Graph g = graph(":s :p :o1 .");
+		assertTrue(G.hasOneSP(g, s, p));
+	}
+
+	@Test
+	public void hasOneSP_multiple_throws() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 .");
+		assertThrows(RDFDataException.class, ()->G.hasOneSP(g, s, p));
+	}
+
+	private static Graph graph(String ttlBody) {
+		String setup = "PREFIX :     <http://example/>\n";
+		return RDFParser.fromString(setup+ttlBody, Lang.TURTLE).toGraph();
+	}
+
+	// --- Wildcard (Node.ANY) handling tests
+
+	@Test
+	public void getSP_subjectAny_returns_one_of_objects() {
+		Graph g = graph(":s1 :p :o1 . :s2 :p :o2 .");
+		Node got = G.getSP(g, Node.ANY, p);
+		assertTrue(o1.sameTermAs(got) || o2.sameTermAs(got));
+	}
+
+	@Test
+	public void getOneSP_subjectAny_single_ok() {
+		Graph g = graph(":s1 :p :o1 .");
+		Node got = G.getOneSP(g, Node.ANY, p);
+		assertEquals(o1, got);
+	}
+
+	@Test
+	public void getOneSP_subjectAny_multiple_throws() {
+		Graph g = graph(":s1 :p :o1 . :s2 :p :o2 .");
+		assertThrows(RDFDataException.class, ()->G.getOneSP(g, Node.ANY, p));
+	}
+
+	@Test
+	public void getZeroOrOneSP_predicateAny_single_ok() {
+		Graph g = graph(":s :p1 :o1 .");
+		Node got = G.getZeroOrOneSP(g, s, Node.ANY);
+		assertEquals(o1, got);
+	}
+
+	@Test
+	public void getZeroOrOneSP_predicateAny_multiple_throws() {
+		Graph g = graph(":s :p1 :o1 . :s :p2 :o2 .");
+		assertThrows(RDFDataException.class, ()->G.getZeroOrOneSP(g, s, Node.ANY));
+	}
+
+	@Test
+	public void hasOneSP_predicateAny_true_false_and_throws() {
+		// none -> false
+		Graph g0 = graph(":s :q :o1 .");
+		assertFalse(G.hasOneSP(g0, x, Node.ANY));
+
+		// single -> true
+		Graph g1 = graph(":s :p1 :o1 .");
+		assertTrue(G.hasOneSP(g1, s, Node.ANY));
+
+		// multiple -> throws
+		Graph g2 = graph(":s :p1 :o1 . :s :p2 :o2 .");
+		assertThrows(RDFDataException.class, ()->G.hasOneSP(g2, s, Node.ANY));
+	}
+
+	@Test
+	public void iterSP_returns_objects() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 . :s2 :p :o2 .");
+		ExtendedIterator<Node> iter = G.iterSP(g, s, p);
+		try {
+			List<Node> seen = iter.toList();
+			assertEquals(2, seen.size());
+			assertTrue(seen.contains(o1) && seen.contains(o2));
+		} finally { iter.close(); }
+	}
+
+	@Test
+	public void listSP_returns_list_of_objects() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 . :s2 :p :o2 .");
+		List<Node> list = G.listSP(g, s, p);
+		assertEquals(2, list.size());
+		assertTrue(list.contains(o1) && list.contains(o2));
+	}
+
+	@Test
+	public void countSP_counts_matches() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 . :s2 :p :o2 .");
+		long count = G.countSP(g, s, p);
+		assertEquals(2, count);
+	}
+
+	@Test
+	public void allSP_returns_set_of_objects() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 . :s2 :p :o2 .");
+		Set<Node> all = G.allSP(g, s, p);
+		assertEquals(2, all.size());
+		assertTrue(all.contains(o1) && all.contains(o2));
+	}
+}

--- a/jena-arq/src/test/java/org/apache/jena/system/TestG_Triple.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestG_Triple.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sys.JenaSystem;
+
+public class TestG_Triple {
+
+	static { JenaSystem.init(); }
+
+	private static final Node s = SSE.parseNode(":s");
+	private static final Node p = SSE.parseNode(":p");
+	private static final Node o = SSE.parseNode(":o");
+
+	@Test
+	public void getOne_single_ok() {
+		Graph g = graph(":s :p :o .");
+		Triple t = G.getOne(g, s, p, o);
+		assertEquals(SSE.parseTriple("(:s :p :o)"), t);
+	}
+
+	@Test
+	public void getOne_none_throws() {
+		Graph g = graph(":s :q :o .");
+		assertThrows(RDFDataException.class, ()->G.getOne(g, s, p, o));
+	}
+
+	@Test
+	public void getOne_multiple_throws_with_wildcard() {
+		Graph g = graph(":s1 :p :o1 . :s2 :p :o2 .");
+		// Use wildcard for object to match multiple objects
+		assertThrows(RDFDataException.class, ()->G.getOne(g, s, p, Node.ANY));
+	}
+
+	@Test
+	public void getZeroOrOne_none_null() {
+		Graph g = graph(":s :q :o .");
+		Triple t = G.getZeroOrOne(g, s, p, o);
+		assertNull(t);
+	}
+
+	@Test
+	public void getZeroOrOne_one_ok() {
+		Graph g = graph(":s :p :o .");
+		Triple t = G.getZeroOrOne(g, s, p, o);
+		assertEquals(SSE.parseTriple("(:s :p :o)"), t);
+	}
+
+	@Test
+	public void getZeroOrOne_multiple_throws() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 .");
+		assertThrows(RDFDataException.class, ()->G.getZeroOrOne(g, s, p, Node.ANY));
+	}
+
+	@Test
+	public void getOneOrNull_none_null() {
+		Graph g = graph(":s :q :o .");
+		Triple t = G.getOneOrNull(g, s, p, o);
+		assertNull(t);
+	}
+
+	@Test
+	public void getOneOrNull_multiple_null() {
+		Graph g = graph(":s :p :o1 . :s :p :o2 .");
+		Triple t = G.getOneOrNull(g, s, p, Node.ANY);
+		assertNull(t);
+	}
+	private static Graph graph(String ttlBody) {
+		String setup = "PREFIX :     <http://example/>\n";
+		return RDFParser.fromString(setup+ttlBody, Lang.TURTLE).toGraph();
+	}
+}

--- a/jena-arq/src/test/java/org/apache/jena/system/TestTxnCounter.java
+++ b/jena-arq/src/test/java/org/apache/jena/system/TestTxnCounter.java
@@ -31,7 +31,7 @@ import org.apache.jena.query.ReadWrite ;
 import org.apache.jena.sparql.JenaTransactionException ;
 
 // TestTxn also tests counters.
-public class TestCounter {
+public class TestTxnCounter {
     private TxnCounter counter = new TxnCounter(0) ;
 
     @Test


### PR DESCRIPTION
`GList` provides robust RDF list handling at the `Graph` level. It is neded to make writing SHALC 1.2 list validation.
Unlike `GNode` + `GraphList`, it is not working on generalized"findable" concept. It is executing with no unnecessary object creation.

It has checks for well-formed lists (one `rdf:first`, one `rdf:rest` per list cell, no cycles). It provides operations for accessing lists which check integrity but assume no cycles (cycle checking is moderately expensive for such low-level operations.

As part of this, creating tests has been an experiment in using the most basic, free co-pilot setup to generate tests. The task is not difficult and it is easy to check and review.

For `GList`, tests were first hand-written then copilot used to check coverage and add tests to be more comprehensive.

The class `G` has been around for a while. It is a low level internal API for wrapping up getting data out of graphs, such as checking one object is present for an SP lookup and always closing iterators, to reduce boilerplate in graph access code. The idea is to have a static import of the class so the functions become words available for writing code. DSL-ish.

`G` originally started small and testing was by usage. But its grown. It would benefit from its own tests.  `G` should be easy because it is many small, self-contained functions, no class state, with javadoc. It should not be a not very demanding task, it is (human) time consuming.

The experiment is to use the default, free, co-pilot setup in Eclipse to see how it feels for individuals without enterprise-paid-for accounts.

And does it save time?

Learnings:

For increasing the coverage for `GList`, it has been sucessful.

My first attempt was building a single test file for `G` started OK. I was adding in groups of related operations to allow for review, e.g. all the SP accessors. But as more chunks were added, copilot "decided" to revise the earlier tests, lost track of coverage, lost earlier work and I could get it to backtrack and recover. It seems it lost the basic context. I threw the work away, got it to forget the last 24 hours (elapsed) and started again with one file per chunk.

That has been reasonably successful. Not a massive time saving but it was task that needed doing and wasn't happening. It still needs reviewing but the biggest advantage is that it is easier to spend my time in chunks on it across a few days with little (human) context-switching costs.

In one case, it found one bug. I fixed it manually.  I didn't let copilot change any `src/main` code because ...
In another case, it confidently offered to change the implementation to match the test but the test was wrong.

----

 - [x] Tests are included.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
