### PR TITLE
Bump Apache parent POM from 37 to 38. Update Apache Thrift from 0.22.0 to 0.23.0.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryExceptionHTTP.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/http/QueryExceptionHTTP.java
@@ -63,7 +63,7 @@ public class QueryExceptionHTTP extends QueryException
         }
     }
 
-    /** @deprecated Use {@ink #wrap(HttpException)} */
+    /** @deprecated Use {@link #rewrap(HttpException)} */
     @Deprecated
     public QueryExceptionHTTP(int responseCode, String messageBody, final HttpException ex) {
         super(ex.getMessage(), ex.getCause());
@@ -80,7 +80,7 @@ public class QueryExceptionHTTP extends QueryException
 
     /** The message for the reason for this exception
      * @return message
-     * @deprecate Use {@link #getResponseBody}
+     * @deprecated Use {@link #getResponseBody}
      */
     @Deprecated
     public String getResponseMessage() { return responseBody; }
@@ -91,7 +91,7 @@ public class QueryExceptionHTTP extends QueryException
 
     /** The response for this exception if available from HTTP
      * @return response or {@code null} if no HTTP response was received
-     * @deprecate Use {@link #getResponseBody}
+     * @deprecated Use {@link #getResponseBody}
      */
     @Deprecated
     public String getResponse() { return getResponseBody(); }

--- a/jena-arq/src/main/java/org/apache/jena/system/GList.java
+++ b/jena-arq/src/main/java/org/apache/jena/system/GList.java
@@ -58,8 +58,9 @@ import org.apache.jena.vocabulary.RDF;
  * List arising from parsing Turtle or TriG syntax for lists will be cycle-free.
  * <p>
  * <b>This class is <em>not</em> public API</b>.
- *
- * @see GraphList - uses a findable abstaction ({@link GNode}to work on a graph or lists of triples.
+ *  <p>
+ *  See also {@link GraphList} which uses a "findable" abstraction in combination
+ *  with {@link GNode} to work on a graph or lists of triples.
  */
 public class GList {
 

--- a/jena-fuseki2/pom.xml
+++ b/jena-fuseki2/pom.xml
@@ -28,11 +28,11 @@
     <version>6.2.0-SNAPSHOT</version>
   </parent> 
 
-  <name>Apache Jena - Fuseki - A SPARQL 1.1 Server</name>
+  <name>Apache Jena - Fuseki</name>
   <artifactId>jena-fuseki</artifactId>
   <version>6.2.0-SNAPSHOT</version>
 
-  <description>Fuseki is a SPARQL 1.1 Server which provides the SPARQL query, 
+  <description>Fuseki is a SPARQL Server which provides the SPARQL query, 
   SPARQL update and SPARQL graph store protocols.
   </description>
 

--- a/jena-querybuilder/pom.xml
+++ b/jena-querybuilder/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>jena-querybuilder</artifactId>
-  <name>Apache Jena - Extras - Query Builder</name>
+  <name>Apache Jena - Query Builder</name>
   <description>A utility package to simplify the building of ARQ queries in code.  Provides both a simple builder interface for queries as well as simple prepared statement processing.</description>
 
   <parent>

--- a/jena-serviceenhancer/pom.xml
+++ b/jena-serviceenhancer/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>jena-serviceenhancer</artifactId>
-  <name>Apache Jena - Extras - Service Enhancer</name>
+  <name>Apache Jena - Service Enhancer</name>
   <description>A plugin that extends the sparql SERVICE clauses with bulk requests, lateral joins and advanced result set caching.</description>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>37</version>
+    <version>38</version>
   </parent>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <ver.shiro>2.1.0</ver.shiro>
 
     <ver.protobuf>4.34.1</ver.protobuf>
-    <ver.libthrift>0.22.0</ver.libthrift>
+    <ver.libthrift>0.23.0</ver.libthrift>
 
     <ver.caffeine>3.2.3</ver.caffeine>
     <!-- Most of Jena uses other libraries for equivalent functionality. -->


### PR DESCRIPTION
* Update Apache parent POM
* Update for Apache Thrift
* Tidy up module names.
* Fix some javadoc

---

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
