### PR TITLE
Launch workflow when a PR is synchronized. Limit to one running job.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     types:
       - opened
+      - synchonized
       - reopened
     branches:
       - 'main'
       
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+  
 permissions:
   contents: read
 


### PR DESCRIPTION
Update the PR workflow to run when a PR is updated.
Cancel old jobs if synchronization overlaps.

----
By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
