### PR TITLE
GH-3888: SHACL list constraints

### DIFF
--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ListMaxLength.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ListMaxLength.java
@@ -30,12 +30,19 @@ import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
+import org.apache.jena.system.GList;
+import org.apache.jena.system.RDFDataException;
 
 /** sh:memberShape */
 
 public class ListMaxLength extends ConstraintList {
 
-    public ListMaxLength(Node node) {}
+    private final long maxLength;
+
+    public ListMaxLength(int maxLength) {
+        this.maxLength = maxLength;
+    }
+
 
     @Override
     public void visit(ConstraintVisitor visitor){
@@ -48,8 +55,19 @@ public class ListMaxLength extends ConstraintList {
     }
 
     @Override
-    protected ReportItem validateList(ValidationContext vCxt, Graph data, Node headNode) {
-        throw new NotImplemented();
+    protected ReportItem validateList(ValidationContext vCxt, Graph data, Node listNode) {
+        try {
+            GList.isWellformedListEx(data, listNode);
+        } catch (RDFDataException ex) {
+            return new ReportItem(ex.getMessage());
+        }
+
+        long listLength = GList.listLength(data, listNode);
+        if ( listLength > maxLength ) {
+            String msg = toString()+": Invalid list length: expected max "+maxLength+": Got length = "+listLength;
+            return new ReportItem(msg);
+        }
+        return null;
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ListMemberShape.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ListMemberShape.java
@@ -37,8 +37,8 @@ import org.apache.jena.shacl.parser.Shape;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.validation.ValidationProc;
 import org.apache.jena.shacl.vocabulary.SHACL;
-import org.apache.jena.sparql.util.graph.GNode;
-import org.apache.jena.sparql.util.graph.GraphList;
+import org.apache.jena.system.GList;
+import org.apache.jena.system.RDFDataException;
 
 /** sh:memberShape */
 
@@ -61,7 +61,7 @@ public class ListMemberShape extends ConstraintList {
     }
 
     @Override
-    protected ReportItem validateList(ValidationContext vCxt, Graph data, Node headNode) {
+    protected ReportItem validateList(ValidationContext vCxt, Graph data, Node listNode) {
         Shape memberShape = vCxt.getShapes().getShape(shape);
         if ( memberShape == null ) {
             // XXX
@@ -69,14 +69,29 @@ public class ListMemberShape extends ConstraintList {
             // No shape. Error?
             return null;
         }
-        // XXX Check for valid lists.
-        GNode gNode = GNode.create(data, headNode);
-        List<Node> members = GraphList.members(gNode);
+        // Checks for valid lists.
+        List<Node> members;
+        try {
+            members = GList.members(data, listNode);
+        } catch (RDFDataException ex) {
+            String errMsg = ex.getMessage();
+            return new ReportItem(errMsg);
+        }
 
-        members.forEach(x->{
-            ValidationProc.execValidateShape(vCxt, data, memberShape, x);
-        });
+        // DRY : execute in isolated context e.g. sh:xone (etc), sh:node, QualifiedValueShape,
+        ValidationContext vCxt2 = ValidationContext.create(vCxt);
         // XXX Isolate validation and wrap violations?
+        // 1 - ensure the base focusNode
+        // 2 - stop at first violation?
+        members.forEach(x->{
+            ValidationProc.execValidateShape(vCxt2, data, memberShape, x);
+        });
+        boolean innerConforms = vCxt2.generateReport().conforms();
+        if ( ! innerConforms ) {
+            // XXX sh:detail
+            return new ReportItem("One or more members does not conform to shape "+memberShape);
+        }
+
         return null;
     }
 

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ListMinLength.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/engine/constraint/ListMinLength.java
@@ -30,12 +30,18 @@ import org.apache.jena.shacl.engine.ValidationContext;
 import org.apache.jena.shacl.parser.ConstraintVisitor;
 import org.apache.jena.shacl.validation.ReportItem;
 import org.apache.jena.shacl.vocabulary.SHACL;
+import org.apache.jena.system.GList;
+import org.apache.jena.system.RDFDataException;
 
 /** sh:memberShape */
 
 public class ListMinLength extends ConstraintList {
 
-    public ListMinLength(Node node) { }
+    private final long minLength;
+
+    public ListMinLength(int minLength) {
+        this.minLength = minLength;
+    }
 
     @Override
     public void visit(ConstraintVisitor visitor){
@@ -48,8 +54,19 @@ public class ListMinLength extends ConstraintList {
     }
 
     @Override
-    protected ReportItem validateList(ValidationContext vCxt, Graph data, Node headNode) {
-        throw new NotImplemented();
+    protected ReportItem validateList(ValidationContext vCxt, Graph data, Node listNode) {
+        try {
+            GList.isWellformedListEx(data, listNode);
+        } catch (RDFDataException ex) {
+            return new ReportItem(ex.getMessage());
+        }
+
+        long listLength = GList.listLength(data, listNode);
+        if ( listLength < minLength ) {
+            String msg = toString()+": Invalid list length: expected min "+minLength+": Got length = "+listLength;
+            return new ReportItem(msg);
+        }
+        return null;
     }
 
     @Override

--- a/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Constraints.java
+++ b/jena-shacl/src/main/java/org/apache/jena/shacl/parser/Constraints.java
@@ -109,8 +109,8 @@ public class Constraints {
         dispatch.put( SHACL.closed,            (g, s, p, o) -> new ClosedConstraint(g,s,booleanValue(o)) );
 
         dispatch.put( SHACL.memberShape,       (g, s, p, o) -> new ListMemberShape(o));
-        dispatch.put( SHACL.minListLength,     (g, s, p, o) -> new ListMinLength(o));
-        dispatch.put( SHACL.maxListLength,     (g, s, p, o) -> new ListMaxLength(o));
+        dispatch.put( SHACL.minListLength,     (g, s, p, o) -> new ListMinLength(intValue(o)) );
+        dispatch.put( SHACL.maxListLength,     (g, s, p, o) -> new ListMaxLength(intValue(o)) );
         dispatch.put( SHACL.uniqueMembers,     (g, s, p, o) -> new ListUniqueMembers(o));
 
         // Below


### PR DESCRIPTION
After #3889, proper implementation of the SHACL 1.2 list costraints (`sh:minListLength`, `sh:maxListLength`, `sh:memberShape`).

Unfortunately, the SHACL test format from the working group has changed enough that the jena-shacl test framework is broken for SHACL 1.2 testing. So while these constraints have been tested manually, the relevent WG tests are not suitable to put in the Jena repository yet.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
