### PR TITLE
Deprecate now redundant GraphMemFactory.createGraphMem2. Code cleaning.

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/graph/GraphMemFactory.java
+++ b/jena-core/src/main/java/org/apache/jena/graph/GraphMemFactory.java
@@ -34,20 +34,19 @@ import org.apache.jena.util.iterator.NullIterator ;
 /**
  * A factory class for creating memory Graphs.
  * <p>
- * Apache Jena is migrating to term semantics graph for consistency across all in-memory and persistent storage graphs.
- * <p>
  * All the graphs that this factory creates are <strong>not thread-safe</strong>.
- * Note that if the memory Graph is structurally modified at any time after
- * the iterator has been created by any of the {@code find*} or {@code stream*} methods, the iterator may throw
- * a {@link java.util.ConcurrentModificationException ConcurrentModificationException}
- * if continued with it after this modification.
- * This may happen even if the queried data does not relate directly to the modified data
- * (i.e. when triple search pattern does not match added or deleted triple).
+ * Note that if the memory Graph is structurally modified at any time after the
+ * iterator has been created by any of the {@code find*} or {@code stream*} methods,
+ * the iterator may throw a {@link java.util.ConcurrentModificationException
+ * ConcurrentModificationException} if continued with it after this modification.
+ * This may happen even if the queried data does not relate directly to the modified
+ * data (i.e. when triple search pattern does not match added or deleted triple).
  * <p>
- * The good practice is to explicitly close any {@link ExtendedIterator} immediately after a read operation.
- * For GraphMem implementations {@code ExtendedIterator}'s materializing methods (such as {@link ExtendedIterator#toList()})
- * could be used safely without explicit close. The same is true for {@link java.util.stream.Stream Java Stream}'s
- * terminal operations.
+ * The good practice is to explicitly close any {@link ExtendedIterator} immediately
+ * after a read operation. For GraphMem implementations {@code ExtendedIterator}'s
+ * materializing methods (such as {@link ExtendedIterator#toList()}) could be used
+ * safely without explicit close. The same is true for {@link java.util.stream.Stream
+ * Java Stream}'s terminal operations.
  */
 public class GraphMemFactory
 {
@@ -58,6 +57,11 @@ public class GraphMemFactory
     /**
      * Answer a memory-based graph.
      * This is the system default.
+     * This implementation of {@link Graph} is not thread-safe;
+     * the application is responsible for thread control.
+     * <p>
+     * Use {@code GraphFactory.createTxnGraph} for a memory graph
+     * with transaction support.
      */
     public static Graph createDefaultGraph() {
         return createDefaultGraphSameTerm();
@@ -75,7 +79,7 @@ public class GraphMemFactory
     }
 
     /**
-     * Answer a memory-based graph with "same value" semantics
+     * Answer a memory-based graph with "same value" semantics.
      * used in Jena2, Jena3 and Jena4 for in-memory graphs.
      * Jena5 changed to "same term" semantics.
      * This method will continue to provide a "same value" graph.
@@ -88,7 +92,7 @@ public class GraphMemFactory
     }
 
     /**
-     * Answer a memory-based graph with "same term" semantics
+     * Answer a memory-based graph with "same term" semantics.
      * This method will continue to provide the preferred
      * general purpose "same term" graph.
      */
@@ -122,7 +126,9 @@ public class GraphMemFactory
      * This graph implementation provides improved performance with a minor increase in memory usage.
      * <p>
      * See {@link GraphMemFast} for details.
+     * @deprecated Use {@link #createDefaultGraph()}
      */
+    @Deprecated(forRemoval=true)
     public static Graph createGraphMem2() {
         return new GraphMemFast();
     }

--- a/jena-core/src/main/java/org/apache/jena/mem/GraphMemFast.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/GraphMemFast.java
@@ -27,14 +27,14 @@ import org.apache.jena.mem.store.fast.FastTripleStore;
 /**
  * A graph that stores triples in memory. This class is not thread-safe.
  * <p>
- * Purpose: GraphMem2Fast is a strong candidate for becoming the new default in-memory graph in the upcoming Jena 5,
- * thanks to its improved performance and relatively minor increase in memory usage.
- * <p>
- * Faster than {@link GraphMemLegacy} (specially Graph#add, Graph#find and Graph#stream)
- * Removing triples is a bit slower than {@link GraphMemLegacy}.
- * Memory consumption is about 6-35% higher than {@link GraphMemLegacy}
- * Maps and sets are based on {@link org.apache.jena.mem.collection.FastHashBase}
- * Benefits from multiple small optimizations. (see: {@link FastTripleStore})
+ * Compared to {@link GraphMemLegacy}:
+ * <ul>
+ * <li>Faster than {@link GraphMemLegacy} (specially Graph#add, Graph#find and Graph#stream)
+ * <li>Removing triples is a bit slower than {@link GraphMemLegacy}.
+ * <li>Memory consumption is about 6-35% higher than {@link GraphMemLegacy}
+ * <li>Maps and sets are based on {@link org.apache.jena.mem.collection.FastHashBase}
+ * <li>Benefits from multiple small optimizations. (see: {@link FastTripleStore})
+ * </ul>
  * <p>
  * The heritage of GraphMem:
  * <ul>

--- a/jena-core/src/main/java/org/apache/jena/mem/GraphMemLegacy.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/GraphMemLegacy.java
@@ -22,12 +22,15 @@
 package org.apache.jena.mem;
 
 import org.apache.jena.mem.store.TripleStore;
+import org.apache.jena.mem.store.legacy.ArrayBunch;
+import org.apache.jena.mem.store.legacy.HashedBunchMap;
 import org.apache.jena.mem.store.legacy.LegacyTripleStore;
 
 /**
  * A graph that stores triples in memory. This class is not thread-safe.
  * <p>
- * Purpose: Use this graph implementation if you want to maintain the 'old' behavior of GraphMem or if your memory
+ * Purpose: Use this graph implementation if you want to maintain the 'old' behavior of GraphMem,
+ * while being "same term", or if your memory
  * constraints prevent you from utilizing more memory-intensive solutions.
  * <p>
  * Slightly improved performance compared to {@link org.apache.jena.memvalue.GraphMemValue}
@@ -42,7 +45,7 @@ import org.apache.jena.mem.store.legacy.LegacyTripleStore;
  * <p>
  * This implementation is based on the original {@link org.apache.jena.memvalue.GraphMemValue} implementation.
  * The main difference is that it strictly uses term equality for all nodes.
- * The inner workings of the used structures like ArrayBunch and HashedBunchMap are not changed.
+ * The inner workings of the used structures like {@link ArrayBunch} and {@link HashedBunchMap} are not changed.
  */
 public class GraphMemLegacy extends GraphMem {
 

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/FastHashMap.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/FastHashMap.java
@@ -189,6 +189,7 @@ public abstract class FastHashMap<K, V> extends FastHashBase<K> implements JenaM
      * @param i index
      * @return value
      */
+    @Override
     public V getValueAt(int i) {
         return values[i];
     }

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/FastHashSet.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/FastHashSet.java
@@ -127,6 +127,7 @@ public abstract class FastHashSet<K> extends FastHashBase<K> implements JenaSetI
      * @param i the index
      * @return the key at the given index
      */
+    @Override
     public K getKeyAt(int i) {
         return keys[i];
     }

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/HashCommonBase.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/HashCommonBase.java
@@ -101,14 +101,15 @@ public abstract class HashCommonBase<E> implements JenaMapSetCommon<E> {
         threshold = (int) (keys.length * LOAD_FACTOR);
     }
 
+    @Override
     public int size() {
         return size;
     }
 
+    @Override
     public boolean isEmpty() {
         return size == 0;
     }
-
 
     /**
      * Subclasses must implement to answer a new Key[size] array.
@@ -155,6 +156,7 @@ public abstract class HashCommonBase<E> implements JenaMapSetCommon<E> {
      * Remove the object <code>key</code> from this hash's keys if it
      * is present (if it's absent, do nothing).
      */
+    @Override
     public boolean tryRemove(final E key) {
         int slot = findSlot(key);
         if (slot < 0) {
@@ -168,6 +170,7 @@ public abstract class HashCommonBase<E> implements JenaMapSetCommon<E> {
      * Remove the object <code>key</code> from this hash's keys if it
      * is present (if it's absent, do nothing).
      */
+    @Override
     public void removeUnchecked(final E key) {
         int slot = findSlot(key);
         if (slot < 0) {
@@ -192,10 +195,12 @@ public abstract class HashCommonBase<E> implements JenaMapSetCommon<E> {
         }
     }
 
+    @Override
     public boolean containsKey(final E key) {
         return findSlot(key) < 0;
     }
 
+    @Override
     public boolean anyMatch(final Predicate<E> predicate) {
         var pos = keys.length - 1;
         while (-1 < pos) {
@@ -207,10 +212,12 @@ public abstract class HashCommonBase<E> implements JenaMapSetCommon<E> {
         return false;
     }
 
+    @Override
     public ExtendedIterator<E> keyIterator() {
         return new SparseArrayIterator<>(keys, this);
     }
 
+    @Override
     public Spliterator<E> keySpliterator() {
         return new SparseArraySpliterator<>(keys, this);
     }


### PR DESCRIPTION
* Deprecate redundant `GraphMemFactory.createGraphMem2`
* Fix warning for missing `@Override`
* Update javadoc in `GraphMem`

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
