### PR TITLE
GH-3926: handle unrecognized syntax (riot)

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParser.java
@@ -314,12 +314,21 @@ public class RDFParser {
         return dataset;
     }
 
+    public static class SetupException extends RiotException {
+        public SetupException(String msg)                { super(msg) ; }
+        public SetupException(String msg, Throwable th)  { super(msg, th) ; }
+    }
+
+    private static RiotException setupException(String msg) {
+        return new SetupException(msg);
+    }
+
     /**
      * Parse the source, sending the results to a {@link StreamRDF}.
      */
     public void parse(StreamRDF destination) {
         if ( !canUseThisParser )
-            throw new RiotException("Parser has been used once and can not be used again");
+            throw setupException("Parser has been used once and can not be used again");
         // Consuming mode.
         canUseThisParser = (inputStream == null && javaReader == null);
         // FactoryRDF is stateful in the LabelToNode mapping.
@@ -357,7 +366,7 @@ public class RDFParser {
             if ( forceLang != null ) {
                 ReaderRIOTFactory r = RDFParserRegistry.getFactory(forceLang);
                 if ( r == null )
-                    throw new RiotException("No parser registered for language: " + forceLang);
+                    throw setupException("No parser registered for language: " + forceLang);
                 ct = forceLang.getContentType();
                 readerRiot = createReader(r, forceLang);
             } else {
@@ -377,11 +386,16 @@ public class RDFParser {
                 else
                     target = baseURI;
                 ct = WebContent.determineCT(input.getContentType(), hintLang, target);
-                if ( ct == null )
-                    throw new RiotException("Failed to determine the content type: (URI=" + baseURI + " : stream=" + input.getContentType()+")");
+                if ( ct == null ) {
+                    String inputCT = input.getContentType();
+                    String msg = (inputCT != null)
+                            ? "Failed to determine the content type for " + baseURI + " : stream=" + input.getContentType()
+                            : "Failed to determine the content type for " + baseURI;
+                    throw setupException(msg);
+                }
                 readerRiot = createReader(ct);
                 if ( readerRiot == null )
-                    throw new RiotException("No parser registered for content type: " + ct.getContentTypeStr());
+                    throw setupException("No parser registered for content type: " + ct.getContentTypeStr());
             }
             read(readerRiot, input, null, baseURI, context, ct, destination);
         }
@@ -395,11 +409,11 @@ public class RDFParser {
             lang = forceLang;
         ContentType ct = WebContent.determineCT(null, lang, baseURI);
         if ( ct == null )
-            throw new RiotException("Failed to determine the RDF syntax (.lang or .base required)");
+            throw setupException("Failed to determine the RDF syntax (.lang or .base required)");
 
         ReaderRIOT readerRiot = createReader(ct);
         if ( readerRiot == null )
-            throw new RiotException("No parser registered for content type: " + ct.getContentTypeStr());
+            throw setupException("No parser registered for content type: " + ct.getContentTypeStr());
         Reader jr = javaReader;
         if ( stringToParse != null )
             jr = new StringReader(stringToParse);

--- a/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/RDFParserBuilder.java
@@ -232,9 +232,10 @@ public class RDFParserBuilder {
     }
 
     /**
-     * Set the hint {@link Lang}. This is the RDF syntax used when there is no way to
-     * deduce the syntax (e.g. read from a InputStream, not recognized file extension, no
-     * recognized HTTP Content-Type provided).
+     * Set the hint {@link Lang}. This is the RDF syntax used when there is no other way to
+     * deduce the syntax (e.g. read from a InputStream, or the file extension is not recognized,
+     * or the HTTP Content-Type does not make sense).
+     * To force the choice of language, use {@link #forceLang(Lang)}
      *
      * @param lang
      * @return this

--- a/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
+++ b/jena-cmds/src/main/java/riotcmd/CmdLangParse.java
@@ -56,6 +56,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sys.JenaSystem;
+import org.slf4j.Logger;
 
 /** Common framework for running RIOT parsers */
 public abstract class CmdLangParse extends CmdMain {
@@ -162,8 +163,7 @@ public abstract class CmdLangParse extends CmdMain {
 
         try {
             exec$();
-        }
-        finally {
+        } finally {
             SysRIOT.setStrictMode(oldStrictValue);
         }
     }
@@ -265,8 +265,9 @@ public abstract class CmdLangParse extends CmdMain {
         // pr.success is true if the indicates the parser completed it's run
         // (no failure-on-error or unexpected exceptions).
         for ( ParseRecord pr : outcomes ) {
-            if ( !pr.success || pr.errHandler.hadErrors() )
+            if ( !pr.success || pr.errHandler.hadErrors() ) {
                 throw new TerminationException(1);
+            }
         }
     }
 
@@ -363,28 +364,29 @@ public abstract class CmdLangParse extends CmdMain {
 
         // Build parser output additions.
         StreamRDFCounting parserOut;
-        {
-            StreamRDF s = parserOutputStream;
-            if ( setupRDFS != null ) {
-                // Remove literals as subjects
-                s = RDFSFactory.removeGeneralizedRDF(s);
-                // Generate RDFS (this feeds into the stream created above).
-                s = RDFSFactory.streamRDFS(s, setupRDFS);
-                // Parser sends data to RDFS, which goes to the filter, then to parserOutputStream
-            }
-            // If added here, count is quads and triples seen in the input.
-            if ( modLangParse.mergeQuads() )
-                s = new QuadsToTriples(s);
-            parserOut = StreamRDFLib.count(s);
-            s = null;
+        StreamRDF s = parserOutputStream;
+        if ( setupRDFS != null ) {
+            // Remove literals as subjects
+            s = RDFSFactory.removeGeneralizedRDF(s);
+            // Generate RDFS (this feeds into the stream created above).
+            s = RDFSFactory.streamRDFS(s, setupRDFS);
+            // Parser sends data to RDFS, which goes to the filter, then to parserOutputStream
         }
+        // If added here, count is quads and triples seen in the input.
+        if ( modLangParse.mergeQuads() )
+            s = new QuadsToTriples(s);
+        parserOut = StreamRDFLib.count(s);
+        // Not used beyond this point.
+        s = null;
 
-        ErrorHandlerCLI errHandler = ErrorHandlerCLI.errorHandlerTracking(ErrorHandlerFactory.stdLogger,
-                                                                          passRelativeURIs,         // Silent warnings if allowing relative URIs.
-                                                                          true,                     // Fail on error
-                                                                          stopOnWarnings,           // Fail on warnings
-                                                                          ()->parserOut.finish()    // Flush to align log messages
-                                                                          );
+        Logger logger = ErrorHandlerFactory.stdLogger;
+        ErrorHandlerCLI errHandler = ErrorHandlerCLI
+                .errorHandlerTracking(logger,
+                                      passRelativeURIs,         // Silence warnings if allowing relative URIs.
+                                      true,                     // Fail on error
+                                      stopOnWarnings,           // Fail on warnings
+                                      ()->parserOut.finish()    // Flush to align log messages
+                                      );
         builder.errorHandler(errHandler);
         boolean successful = true;
 
@@ -395,7 +397,13 @@ public abstract class CmdLangParse extends CmdMain {
             parser.parse(parserOut);
             successful = true;
         } catch (RiotNotFoundException ex) {
-            errHandler.error(ex.getMessage(), -1, -1);
+            logger.error(ex.getMessage(), -1, -1);
+            successful = false;
+        } catch (RDFParser.SetupException ex) {
+            logger.error(ex.getMessage());
+            successful = false;
+        } catch (RiotParseException ex) {
+            // is this reliable enough?
             successful = false;
         } catch (RiotException ex) {
             successful = false;


### PR DESCRIPTION
GitHub issue resolved #3926

Pull request Description: see issue



----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
