### PR TITLE
Fixed bug in TDB2's NodeId.compare.

### DIFF
--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/NodeId.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/store/NodeId.java
@@ -222,8 +222,8 @@ public class NodeId implements Comparable<NodeId>
     /** Compare - provides an ordering of {@code NodeIds}. */
     public static int compare(NodeId n1, NodeId n2) {
         int x = Integer.compare(n1.value1, n2.value1);
-        if ( x == 0 )
-            return CMP_EQUAL;
+        if ( x != 0 )
+            return x;
         return Long.compare(n1.value2, n2.value2);
     }
 

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/store/TestNodeId.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/store/TestNodeId.java
@@ -23,6 +23,7 @@ package org.apache.jena.tdb2.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
 
@@ -129,4 +130,37 @@ public class TestNodeId
         assertEquals(expected, nid1);
     }
 
+    @Test public void nodeId_compare_01() {
+        // Same value - should be equal (0)
+        NodeId n1 = NodeIdFactory.createPtrLong(42, 100L);
+        NodeId n2 = NodeIdFactory.createPtrLong(42, 100L);
+        assertEquals(0, NodeId.compare(n1, n2));
+        assertEquals(0, n1.compareTo(n2));
+        assertTrue(n1.equals(n2));
+    }
+
+    @Test public void nodeId_compare_02() {
+        // Different value1 - value2 should not affect ordering
+        NodeId n1 = NodeIdFactory.createPtrLong(3, 1000L);
+        NodeId n2 = NodeIdFactory.createPtrLong(7, 50L);
+        assertTrue(NodeId.compare(n1, n2) < 0);
+        assertTrue(n1.compareTo(n2) < 0);
+
+        // Reverse direction
+        assertTrue(NodeId.compare(n2, n1) > 0);
+        assertTrue(n2.compareTo(n1) > 0);
+    }
+
+    @Test public void nodeId_compare_03() {
+        // Same value1, different value2 - should compare on value2
+        NodeId n1 = NodeIdFactory.createPtrLong(5, 100L);
+        NodeId n2 = NodeIdFactory.createPtrLong(5, 200L);
+        assertTrue(NodeId.compare(n1, n2) < 0);
+        assertTrue(n1.compareTo(n2) < 0);
+
+        // Reverse direction
+        assertTrue(NodeId.compare(n2, n1) > 0);
+        assertTrue(n2.compareTo(n1) > 0);
+    }
 }
+


### PR DESCRIPTION
Pull request Description: Fix for TDB2's NodeId.compare method which incorrectly states equality for different NodeIds.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [ ] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
