### PR TITLE
GH-3939: Workaround for bug in Jetty 12.1.9

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -1839,6 +1839,8 @@ public class FusekiServer {
                 DefaultServlet staticServlet = new DefaultServlet();
                 ServletHolder staticContent = new ServletHolder(staticServlet);
                 //staticContent.setInitParameter("cacheControl", "false");
+                // << Jetty 12.1.9 issue
+                // When a fixed Jetty is available, replace block with   staticContent.setInitParameter("baseResource", staticContentDir);
                 if ( staticContentDir.startsWith("jar:") ) {
                     staticContent.setInitParameter("baseResource", staticContentDir);
                 } else {
@@ -1854,6 +1856,7 @@ public class FusekiServer {
                         staticContent.setInitParameter("baseResource", staticContentDir);
                     }
                 }
+                //  >> Jetty 12.1.9 issue
                 context.addServlet(staticContent, "/");
             } else {
                 // Backstop servlet

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.jena.atlas.lib.PropertyUtils.loadFromFile;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Predicate;
@@ -70,15 +71,13 @@ import org.apache.jena.sparql.util.ContextAccumulator;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.system.G;
 import org.apache.jena.system.RDFDataException;
-import org.eclipse.jetty.ee11.servlet.DefaultServlet;
-import org.eclipse.jetty.ee11.servlet.FilterHolder;
-import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee11.servlet.ServletHolder;
+import org.eclipse.jetty.ee11.servlet.*;
 import org.eclipse.jetty.ee11.servlet.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.util.resource.Resource;
 import org.slf4j.Logger;
 
 /**
@@ -1839,8 +1838,22 @@ public class FusekiServer {
             if ( staticContentDir != null ) {
                 DefaultServlet staticServlet = new DefaultServlet();
                 ServletHolder staticContent = new ServletHolder(staticServlet);
-                staticContent.setInitParameter("baseResource", staticContentDir);
                 //staticContent.setInitParameter("cacheControl", "false");
+                if ( staticContentDir.startsWith("jar:") ) {
+                    staticContent.setInitParameter("baseResource", staticContentDir);
+                } else {
+                    try {
+                        // Use URLResourceFactory instead of ResourceFactory.of(context) (which yields PathResource)
+                        // to work around a Windows bug in Jetty 12.1.9 PathResource.resolve(URI) where
+                        // path.resolve(uri.getPath()) fails for absolute Windows paths.
+                        // See: https://github.com/jetty/jetty.project/pull/15020
+                        java.net.URL url = Path.of(staticContentDir).toUri().toURL();
+                        Resource base = new org.eclipse.jetty.util.resource.URLResourceFactory().newResource(url);
+                        context.setBaseResource(base);
+                    } catch (MalformedURLException e) {
+                        staticContent.setInitParameter("baseResource", staticContentDir);
+                    }
+                }
                 context.addServlet(staticContent, "/");
             } else {
                 // Backstop servlet


### PR DESCRIPTION
Workaround Jetty bug for Windows by using URLResourceFactory for baseResource

GitHub issue resolved #3939 

Pull request Description:

Workaround Jetty 12.1.9  bug (https://github.com/jetty/jetty.project/pull/15020) for Windows by using URLResourceFactory for baseResource.

ATTENTION: This workaround needs validation on a linux system. I tested only on windows.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
