### PR TITLE
GH-3941: Fixed spliterator characteristics

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/mem/collection/FastHashMap.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/FastHashMap.java
@@ -132,6 +132,8 @@ public abstract class FastHashMap<K, V> extends FastHashBase<K> implements JenaM
 
     @Override
     public boolean tryPut(K key, V value) {
+        assert(key != null);
+        assert(value != null);
         growPositionsArrayIfNeeded();
         final var hashCode = key.hashCode();
         final var pIndex = findPosition(key, hashCode);
@@ -150,6 +152,8 @@ public abstract class FastHashMap<K, V> extends FastHashBase<K> implements JenaM
 
     @Override
     public void put(K key, V value) {
+        assert(key != null);
+        assert(value != null);
         growPositionsArrayIfNeeded();
         final var hashCode = key.hashCode();
         final var pIndex = findPosition(key, hashCode);
@@ -166,6 +170,8 @@ public abstract class FastHashMap<K, V> extends FastHashBase<K> implements JenaM
 
     @Override
     public int putAndGetIndex(K key, V value) {
+        assert(key != null);
+        assert(value != null);
         growPositionsArrayIfNeeded();
         final int hashCode = key.hashCode();
         final var pIndex = findPosition(key, hashCode);

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/FastHashSet.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/FastHashSet.java
@@ -69,6 +69,7 @@ public abstract class FastHashSet<K> extends FastHashBase<K> implements JenaSetI
 
     @Override
     public boolean tryAdd(K key, int hashCode) {
+        assert(key != null);
         growPositionsArrayIfNeeded();
         final var pIndex = findPosition(key, hashCode);
         if (pIndex < 0) {
@@ -93,6 +94,7 @@ public abstract class FastHashSet<K> extends FastHashBase<K> implements JenaSetI
      */
     @Override
     public int addAndGetIndex(K key) {
+        assert(key != null);
         growPositionsArrayIfNeeded();
         final var hashCode = key.hashCode();
         final var pIndex = findPosition(key, hashCode);
@@ -113,10 +115,11 @@ public abstract class FastHashSet<K> extends FastHashBase<K> implements JenaSetI
     }
 
     @Override
-    public void addUnchecked(K value, int hashCode) {
+    public void addUnchecked(K key, int hashCode) {
+        assert(key != null);
         growPositionsArrayIfNeeded();
         final var eIndex = getFreeKeyIndex();
-        keys[eIndex] = value;
+        keys[eIndex] = key;
         hashCodesOrDeletedIndices[eIndex] = hashCode;
         positions[findEmptySlotWithoutEqualityCheck(hashCode)] = ~eIndex;
     }

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/HashCommonMap.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/HashCommonMap.java
@@ -84,6 +84,8 @@ public abstract class HashCommonMap<K, V> extends HashCommonBase<K> implements J
 
     @Override
     public boolean tryPut(K key, V value) {
+        assert(key != null);
+        assert(value != null);
         final var slot = findSlot(key);
         if (slot < 0) {
             values[~slot] = value;
@@ -97,6 +99,8 @@ public abstract class HashCommonMap<K, V> extends HashCommonBase<K> implements J
 
     @Override
     public void put(K key, V value) {
+        assert(key != null);
+        assert(value != null);
         final var slot = findSlot(key);
         if (slot < 0) {
             values[~slot] = value;
@@ -126,6 +130,7 @@ public abstract class HashCommonMap<K, V> extends HashCommonBase<K> implements J
         final var slot = findSlot(key);
         if (slot < 0) return values[~slot];
         final var value = absentValueSupplier.get();
+        assert(value != null);
         keys[slot] = key;
         values[slot] = value;
         if (++size > threshold) grow();

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/HashCommonSet.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/HashCommonSet.java
@@ -46,6 +46,7 @@ public abstract class HashCommonSet<K> extends HashCommonBase<K> implements Jena
 
     @Override
     public boolean tryAdd(K key) {
+        assert(key != null);
         final var slot = findSlot(key);
         if (slot < 0) return false;
         keys[slot] = key;
@@ -55,6 +56,7 @@ public abstract class HashCommonSet<K> extends HashCommonBase<K> implements Jena
 
     @Override
     public void addUnchecked(K key) {
+        assert(key != null);
         final var slot = findSlot(key);
         if (slot < 0) return;
         keys[slot] = key;

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/JenaMap.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/JenaMap.java
@@ -30,7 +30,8 @@ import java.util.stream.StreamSupport;
 
 /**
  * A map from keys of type {@code K} to values of type {@code V}.
- * Not thread-safe and does not allow {@code null} keys.
+ * Not thread-safe and does not allow {@code null} keys
+ * and does not allow {@code null} values.
  *
  * @param <K> the type of the keys in the map
  * @param <V> the type of the values in the map
@@ -40,8 +41,8 @@ public interface JenaMap<K, V> extends JenaMapSetCommon<K> {
     /**
      * Try to put a key-value pair into the map. If the key is already present, the value is updated.
      *
-     * @param key   the key to put
-     * @param value the value to put
+     * @param key   the key to put. ({@code null} is not allowed)
+     * @param value the value to put. ({@code null} is not allowed)
      * @return true if the key-value pair was put into the map, false if the key was already present
      */
     boolean tryPut(K key, V value);
@@ -49,8 +50,8 @@ public interface JenaMap<K, V> extends JenaMapSetCommon<K> {
     /**
      * Put a key-value pair into the map. If the key is already present, the value is updated.
      *
-     * @param key   the key to put
-     * @param value the value to put
+     * @param key   the key to put. ({@code null} is not allowed)
+     * @param value the value to put. ({@code null} is not allowed)
      */
     void put(K key, V value);
 

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/JenaMapIndexed.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/JenaMapIndexed.java
@@ -66,8 +66,8 @@ public interface JenaMapIndexed<K, V> extends JenaMap<K, V> {
      * If the key is already present, its value is updated and the existing
      * index is returned.
      *
-     * @param key   the key to put
-     * @param value the value to put
+     * @param key   the key to put. ({@code null} is not allowed)
+     * @param value the value to put. ({@code null} is not allowed)
      * @return the index of the entry holding {@code key}
      */
     int putAndGetIndex(K key, V value);

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/JenaSet.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/JenaSet.java
@@ -31,7 +31,7 @@ public interface JenaSet<E> extends JenaMapSetCommon<E> {
     /**
      * Add the key to the set if it is not already present.
      *
-     * @param key the key to add
+     * @param key the key to add. ({@code null} is not allowed)
      * @return {@code true} if the key was added, {@code false} if it was already present
      */
     boolean tryAdd(E key);
@@ -43,7 +43,7 @@ public interface JenaSet<E> extends JenaMapSetCommon<E> {
      * the key is not already in the set; otherwise the set's invariants will
      * break (duplicates may be inserted).
      *
-     * @param key the key to add
+     * @param key the key to add. ({@code null} is not allowed)
      */
     void addUnchecked(E key);
 }

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/JenaSetHashOptimized.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/JenaSetHashOptimized.java
@@ -36,8 +36,8 @@ public interface JenaSetHashOptimized<E> extends JenaSet<E> {
      * Add an element with the given precomputed hash code if it is not
      * already present.
      *
-     * @param key      the element to add
-     * @param hashCode {@code key.hashCode()}
+     * @param key      the element to add. ({@code null} is not allowed)
+     * @param hashCode {@code key.hashCode()}.
      * @return {@code true} if added, {@code false} if already present
      */
     boolean tryAdd(E key, int hashCode);
@@ -46,8 +46,8 @@ public interface JenaSetHashOptimized<E> extends JenaSet<E> {
      * Add an element with the given precomputed hash code without checking
      * whether it is already present. The caller MUST ensure the key is absent.
      *
-     * @param key      the element to add
-     * @param hashCode {@code key.hashCode()}
+     * @param key      the element to add. ({@code null} is not allowed)
+     * @param hashCode {@code key.hashCode()}. ({@code null} is not allowed)
      */
     void addUnchecked(E key, int hashCode);
 

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/JenaSetIndexed.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/JenaSetIndexed.java
@@ -35,7 +35,7 @@ public interface JenaSetIndexed<E> extends JenaSetHashOptimized<E> {
      * is already present, returns a negative value (typically the bitwise
      * complement of the existing index).
      *
-     * @param key      the element to add
+     * @param key      the element to add. ({@code null} is not allowed)
      * @return the index of the inserted element, or a negative value if the
      *         element was already present
      */

--- a/jena-core/src/main/java/org/apache/jena/mem/spliterator/ArraySpliterator.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/spliterator/ArraySpliterator.java
@@ -104,6 +104,6 @@ public class ArraySpliterator<E> implements Spliterator<E> {
 
     @Override
     public int characteristics() {
-        return DISTINCT | SIZED | SUBSIZED | NONNULL | IMMUTABLE;
+        return DISTINCT | SIZED | SUBSIZED | NONNULL ;
     }
 }

--- a/jena-core/src/main/java/org/apache/jena/mem/spliterator/ArraySubSpliterator.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/spliterator/ArraySubSpliterator.java
@@ -109,6 +109,6 @@ public class ArraySubSpliterator<E> implements Spliterator<E> {
 
     @Override
     public int characteristics() {
-        return DISTINCT | SIZED | SUBSIZED | NONNULL | IMMUTABLE;
+        return DISTINCT | SIZED | SUBSIZED | NONNULL ;
     }
 }

--- a/jena-core/src/main/java/org/apache/jena/mem/spliterator/SparseArraySpliterator.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/spliterator/SparseArraySpliterator.java
@@ -113,6 +113,6 @@ public class SparseArraySpliterator<E> implements Spliterator<E> {
 
     @Override
     public int characteristics() {
-        return DISTINCT | NONNULL | IMMUTABLE;
+        return DISTINCT | NONNULL ;
     }
 }

--- a/jena-core/src/main/java/org/apache/jena/mem/spliterator/SparseArraySubSpliterator.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/spliterator/SparseArraySubSpliterator.java
@@ -118,6 +118,6 @@ public class SparseArraySubSpliterator<E> implements Spliterator<E> {
 
     @Override
     public int characteristics() {
-        return DISTINCT | NONNULL | IMMUTABLE;
+        return DISTINCT | NONNULL ;
     }
 }

--- a/jena-core/src/test/java/org/apache/jena/mem/collection/AbstractJenaMapNodeTest.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/collection/AbstractJenaMapNodeTest.java
@@ -51,7 +51,7 @@ public abstract class AbstractJenaMapNodeTest {
     @Test
     public void isEmpty() {
         assertTrue(sut.isEmpty());
-        sut.tryPut(node("s"), null);
+        sut.tryPut(node("s"), "v");
         assertFalse(sut.isEmpty());
     }
 
@@ -89,7 +89,7 @@ public abstract class AbstractJenaMapNodeTest {
 
     @Test
     public void testTryRemove() {
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v");
         assertTrue(sut.tryRemove(node("s")));
         assertEquals(0, sut.size());
         assertFalse(sut.tryRemove(node("s")));
@@ -97,7 +97,7 @@ public abstract class AbstractJenaMapNodeTest {
 
     @Test
     public void testRemoveUnchecked() {
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v");
         sut.removeUnchecked(node("s"));
         assertEquals(0, sut.size());
     }
@@ -154,7 +154,7 @@ public abstract class AbstractJenaMapNodeTest {
 
     @Test
     public void testClear() {
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v");
         sut.clear();
         assertEquals(0, sut.size());
     }
@@ -162,7 +162,7 @@ public abstract class AbstractJenaMapNodeTest {
     @Test
     public void testContainKey() {
         assertFalse(sut.containsKey(node("s")));
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v");
         assertTrue(sut.containsKey(node("s")));
         assertFalse(sut.containsKey(node("s2")));
     }
@@ -183,34 +183,34 @@ public abstract class AbstractJenaMapNodeTest {
 
     @Test
     public void testKeyIteratorNextThrowsConcurrentModificationException() {
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v");
         var iter = sut.keyIterator();
-        sut.put(node("s2"), null);
+        sut.put(node("s2"), "v2");
         assertThrows(ConcurrentModificationException.class, iter::next);
     }
 
     @Test
     public void testKeySpliteratorAdvanceThrowsConcurrentModificationException() {
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v");
         var spliterator = sut.keySpliterator();
-        sut.put(node("s2"), null);
+        sut.put(node("s2"), "v1");
         assertThrows(ConcurrentModificationException.class, () -> spliterator.tryAdvance(t -> {
         }));
     }
 
     @Test
     public void testValueIteratorNextThrowsConcurrentModificationException() {
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v");
         var iter = sut.keyIterator();
-        sut.put(node("s2"), null);
+        sut.put(node("s2"), "v2");
         assertThrows(ConcurrentModificationException.class, iter::next);
     }
 
     @Test
     public void testValueSpliteratorAdvanceThrowsConcurrentModificationException() {
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v1");
         var spliterator = sut.valueSpliterator();
-        sut.put(node("s2"), null);
+        sut.put(node("s2"), "v2");
         assertThrows(ConcurrentModificationException.class, () -> spliterator.tryAdvance(t -> {
         }));
     }
@@ -219,7 +219,7 @@ public abstract class AbstractJenaMapNodeTest {
     public void testKeyIterator1() {
         final var n0 = node("s");
 
-        sut.put(n0, null);
+        sut.put(n0, "v");
 
         final var iter = sut.keyIterator();
         assertThat(iter.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0));
@@ -241,8 +241,8 @@ public abstract class AbstractJenaMapNodeTest {
         final var n0 = node("s");
         final var n1 = node("s2");
 
-        sut.put(n0, null);
-        sut.put(n1, null);
+        sut.put(n0, "v0");
+        sut.put(n1, "v1");
 
         final var iter = sut.keyIterator();
         assertThat(iter.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1));
@@ -266,9 +266,9 @@ public abstract class AbstractJenaMapNodeTest {
         final var n1 = node("s2");
         final var n2 = node("s3");
 
-        sut.put(n0, null);
-        sut.put(n1, null);
-        sut.put(n2, null);
+        sut.put(n0, "v0");
+        sut.put(n1, "v1");
+        sut.put(n2, "v2");
 
         final var iter = sut.keyIterator();
         assertThat(iter.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1, n2));
@@ -304,7 +304,7 @@ public abstract class AbstractJenaMapNodeTest {
     public void testKeySpliterator1() {
         final var n0 = node("s");
 
-        sut.put(n0, null);
+        sut.put(n0, "v0");
 
         final var spliterator = sut.keySpliterator();
         final var list = StreamSupport.stream(spliterator, false).toList();
@@ -325,8 +325,8 @@ public abstract class AbstractJenaMapNodeTest {
         final var n0 = node("s");
         final var n1 = node("s2");
 
-        sut.put(n0, null);
-        sut.put(n1, null);
+        sut.put(n0, "v0");
+        sut.put(n1, "v1");
 
         final var spliterator = sut.keySpliterator();
         final var list = StreamSupport.stream(spliterator, false).toList();
@@ -349,9 +349,9 @@ public abstract class AbstractJenaMapNodeTest {
         final var n1 = node("s2");
         final var n2 = node("s3");
 
-        sut.put(n0, null);
-        sut.put(n1, null);
-        sut.put(n2, null);
+        sut.put(n0, "v0");
+        sut.put(n1, "v1");
+        sut.put(n2, "v2");
 
         final var spliterator = sut.keySpliterator();
         final var list = StreamSupport.stream(spliterator, false).toList();
@@ -385,7 +385,7 @@ public abstract class AbstractJenaMapNodeTest {
     public void testKeyStream1() {
         final var n0 = node("s");
 
-        sut.put(n0, null);
+        sut.put(n0, "v");
 
         final var stream = sut.keyStream();
         assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0));
@@ -404,8 +404,8 @@ public abstract class AbstractJenaMapNodeTest {
         final var n0 = node("s");
         final var n1 = node("s2");
 
-        sut.put(n0, null);
-        sut.put(n1, null);
+        sut.put(n0, "v");
+        sut.put(n1, "v2");
 
         final var stream = sut.keyStream();
         assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1));
@@ -426,9 +426,9 @@ public abstract class AbstractJenaMapNodeTest {
         final var n1 = node("s2");
         final var n2 = node("s3");
 
-        sut.put(n0, null);
-        sut.put(n1, null);
-        sut.put(n2, null);
+        sut.put(n0, "v");
+        sut.put(n1, "v2");
+        sut.put(n2, "v3");
 
         final var stream = sut.keyStream();
         assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1, n2));
@@ -460,7 +460,7 @@ public abstract class AbstractJenaMapNodeTest {
     public void testKeyStreamParallel1() {
         final var n0 = node("s");
 
-        sut.put(n0, null);
+        sut.put(n0, "v");
 
         final var stream = sut.keyStreamParallel();
         assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0));
@@ -479,8 +479,8 @@ public abstract class AbstractJenaMapNodeTest {
         final var n0 = node("s");
         final var n1 = node("s2");
 
-        sut.put(n0, null);
-        sut.put(n1, null);
+        sut.put(n0, "v");
+        sut.put(n1, "v2");
 
         final var stream = sut.keyStreamParallel();
         assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1));
@@ -501,9 +501,9 @@ public abstract class AbstractJenaMapNodeTest {
         final var n1 = node("s2");
         final var n2 = node("s3");
 
-        sut.put(n0, null);
-        sut.put(n1, null);
-        sut.put(n2, null);
+        sut.put(n0, "v");
+        sut.put(n1, "v1");
+        sut.put(n2, "v2");
 
         final var stream = sut.keyStreamParallel();
         assertThat(stream.toList(), IsIterableContainingInAnyOrder.containsInAnyOrder(n0, n1, n2));
@@ -522,11 +522,11 @@ public abstract class AbstractJenaMapNodeTest {
     @Test
     public void testSize() {
         assertEquals(0, sut.size());
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v");
         assertEquals(1, sut.size());
-        sut.put(node("s2"), null);
+        sut.put(node("s2"), "v2");
         assertEquals(2, sut.size());
-        sut.put(node("s3"), null);
+        sut.put(node("s3"), "v3");
         assertEquals(3, sut.size());
     }
 
@@ -535,7 +535,7 @@ public abstract class AbstractJenaMapNodeTest {
         assertFalse(sut.anyMatch(t -> true));
         assertFalse(sut.anyMatch(t -> false));
 
-        sut.put(node("s"), null);
+        sut.put(node("s"), "v");
         assertTrue(sut.anyMatch(t -> true));
         assertFalse(sut.anyMatch(t -> false));
     }
@@ -546,9 +546,9 @@ public abstract class AbstractJenaMapNodeTest {
         final var n1 = node("s2");
         final var n2 = node("s3");
 
-        sut.put(n0, null);
-        sut.put(n1, null);
-        sut.put(n2, null);
+        sut.put(n0, "v");
+        sut.put(n1, "v1");
+        sut.put(n2, "v2");
 
         final var list = new ArrayList<Node>();
         sut.anyMatch(n -> {
@@ -561,7 +561,7 @@ public abstract class AbstractJenaMapNodeTest {
     @Test
     public void put1000Nodes() {
         for (int i = 0; i < 1000; i++) {
-            sut.put(node("s" + i), null);
+            sut.put(node("s" + i), "v" + i);
         }
         assertEquals(1000, sut.size());
     }
@@ -569,7 +569,7 @@ public abstract class AbstractJenaMapNodeTest {
     @Test
     public void tryPut1000Nodes() {
         for (int i = 0; i < 1000; i++) {
-            sut.tryPut(node("s" + i), null);
+            sut.tryPut(node("s" + i), "v" + i);
         }
         assertEquals(1000, sut.size());
     }
@@ -587,7 +587,7 @@ public abstract class AbstractJenaMapNodeTest {
         final var nodes = new ArrayList<Node>();
         for (int i = 0; i < 1000; i++) {
             final var n = node("s" + i);
-            sut.put(n, null);
+            sut.put(n, "v" + i);
             nodes.add(n);
         }
         assertEquals(1000, sut.size());
@@ -603,7 +603,7 @@ public abstract class AbstractJenaMapNodeTest {
         final var nodes = new ArrayList<Node>();
         for (int i = 0; i < 1000; i++) {
             final var n = node("s" + i);
-            sut.tryPut(n, null);
+            sut.tryPut(n, "v" + i);
             nodes.add(n);
         }
         assertEquals(1000, sut.size());

--- a/jena-core/src/test/java/org/apache/jena/mem/collection/FastHashMapTest2.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/collection/FastHashMapTest2.java
@@ -35,11 +35,11 @@ public class FastHashMapTest2 {
     @Test
     public void testConstructWithInitialSizeAndAdd() {
         var sut = new FastNodeHashMap(3);
-        sut.put(node("s"), null);
-        sut.put(node("s1"), null);
-        sut.put(node("s2"), null);
-        sut.put(node("s3"), null);
-        sut.put(node("s4"), null);
+        sut.put(node("s"), "v");
+        sut.put(node("s1"), "v1");
+        sut.put(node("s2"), "v2");
+        sut.put(node("s3"), "v3");
+        sut.put(node("s4"), "v4");
         assertEquals(5, sut.size());
     }
 

--- a/jena-core/src/test/java/org/apache/jena/mem/spliterator/ArraySpliteratorTest.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/spliterator/ArraySpliteratorTest.java
@@ -233,7 +233,7 @@ public class ArraySpliteratorTest {
     public void characteristics() {
         Integer[] array = new Integer[]{1, 2, 3, 4, 5};
         Spliterator<Integer> spliterator = new ArraySpliterator<>(array, dummySetForConcurrencyCheck);
-        assertEquals(DISTINCT | SIZED | SUBSIZED | NONNULL | IMMUTABLE, spliterator.characteristics());
+        assertEquals(DISTINCT | SIZED | SUBSIZED | NONNULL, spliterator.characteristics());
     }
 
     @Test

--- a/jena-core/src/test/java/org/apache/jena/mem/spliterator/ArraySubSpliteratorTest.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/spliterator/ArraySubSpliteratorTest.java
@@ -232,7 +232,7 @@ public class ArraySubSpliteratorTest {
     public void characteristics() {
         Integer[] array = new Integer[]{1, 2, 3, 4, 5};
         Spliterator<Integer> spliterator = new ArraySubSpliterator<>(array, dummySetForConcurrencyCheck);
-        assertEquals(DISTINCT | SIZED | SUBSIZED | NONNULL | IMMUTABLE, spliterator.characteristics());
+        assertEquals(DISTINCT | SIZED | SUBSIZED | NONNULL, spliterator.characteristics());
     }
 
     @Test

--- a/jena-core/src/test/java/org/apache/jena/mem/spliterator/SparseArraySpliteratorTest.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/spliterator/SparseArraySpliteratorTest.java
@@ -441,7 +441,7 @@ public class SparseArraySpliteratorTest {
     public void characteristics() {
         Integer[] array = new Integer[]{1, 2, 3, 4, 5};
         Spliterator<Integer> spliterator = new SparseArraySpliterator<>(array, dummySetForConcurrencyCheck);
-        assertEquals(DISTINCT | NONNULL | IMMUTABLE, spliterator.characteristics());
+        assertEquals(DISTINCT | NONNULL, spliterator.characteristics());
     }
 
     @Test

--- a/jena-core/src/test/java/org/apache/jena/mem/spliterator/SparseArraySubSpliteratorTest.java
+++ b/jena-core/src/test/java/org/apache/jena/mem/spliterator/SparseArraySubSpliteratorTest.java
@@ -444,7 +444,7 @@ public class SparseArraySubSpliteratorTest {
     public void characteristics() {
         Integer[] array = new Integer[]{1, 2, 3, 4, 5};
         Spliterator<Integer> spliterator = new SparseArraySubSpliterator<>(array, dummySetForConcurrencyCheck);
-        assertEquals(DISTINCT | NONNULL | IMMUTABLE, spliterator.characteristics());
+        assertEquals(DISTINCT | NONNULL, spliterator.characteristics());
     }
 
     @Test


### PR DESCRIPTION
The spliterators claim not NULL, which was not explicitly documented and checked in the set and map implementations for keys and values.

Now non-null key and value are ensured by assertions and documented in the interfaces.

Also: The Spliterator claimed IMMUTABLE, which is not correct since the spliterators may throw ConcurrentModificationException.

GitHub issue resolved #3941 

Pull request Description:

Two related corrections to the `jena-core` in-memory collection
spliterators and their backing maps/sets:

1. **Remove `IMMUTABLE` from spliterator characteristics.**
   `ArraySpliterator`, `ArraySubSpliterator`, `SparseArraySpliterator`,
   and `SparseArraySubSpliterator` detect concurrent modification
   (they snapshot `set.size()` and throw `ConcurrentModificationException`
   from `tryAdvance` / `forEachRemaining`). That is incompatible with
   `Spliterator.IMMUTABLE`, which requires that the element source
   cannot be structurally modified. The flag is dropped; tests that
   asserted on the characteristic value are updated.

2. **Document and assert non-null keys/values.**
   The spliterators report `NONNULL`, but the map and set
   implementations never documented or enforced that constraint. The
   `JenaMap`, `JenaMapIndexed`, `JenaSet`, `JenaSetHashOptimized`, and
   `JenaSetIndexed` interfaces now state that `null` keys (and, for
   maps, `null` values) are not allowed. `assert` checks were added
   to the write paths in `FastHashMap`, `FastHashSet`, `HashCommonMap`,
   and `HashCommonSet` so violations are caught during testing.

Tests in `AbstractJenaMapNodeTest` and `FastHashMapTest2` that were
passing `null` values are updated to use real values.

## Notes

- Enforcement is via `assert`, so production behavior is unchanged
  for callers running without `-ea`. No internal caller currently
  passes `null`, so no functional regression is expected.
- Cosmetic: `FastHashSet.addUnchecked` first parameter renamed
  `value` → `key` to match the interface and the new assertion.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
