### PR TITLE
Update version of node

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/pom.xml
+++ b/jena-fuseki2/jena-fuseki-ui/pom.xml
@@ -32,17 +32,18 @@
         <version>6.2.0-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <node.version>v20.19.3</node.version>
+    <properties> 
+        <node.version>v22.18.0</node.version>
+        <!--<node.version>v24.11.0</node.version>-->
         <yarn.version>v1.22.17</yarn.version>
         <automatic.module.name>org.apache.jena.fuseki.ui</automatic.module.name>
 
         <!-- 
              Allow for skipping the tests.
-             The test frameworks need various software compoents to 
+             The test frameworks need various software components to 
              be available on the host running maven. This isn't always 
-             practical. This property allows the UI to be built on such machines
-             by skipping the tests.
+             practical. This property allows the UI to be built on suchi
+	     machines by skipping the tests.
              It is set "true" by profile "ui-skip-tests"
         -->
         <skip.ui.tests>false</skip.ui.tests>


### PR DESCRIPTION
This is a precursor for PR #3949
Specifically `"@babel/generator@^8.0.0-rc.4"`

However, updating the node version may break some CI (some jenkins nodes) because the local platform is node 20 . 
The proper fix is a container build, which I'd need some help setting up.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
