### PR TITLE
GH-3236: Convert jena-text and jena-tdb1 to JUnit6.

### DIFF
--- a/jena-tdb1/pom.xml
+++ b/jena-tdb1/pom.xml
@@ -66,13 +66,6 @@
       <artifactId>junit-platform-suite</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/TestTDB1Factory.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/TestTDB1Factory.java
@@ -21,10 +21,10 @@
 
 package org.apache.jena.tdb1;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.sparql.core.DatasetGraph ;
@@ -34,9 +34,9 @@ import org.apache.jena.tdb1.base.file.Location;
 import org.apache.jena.tdb1.sys.TDBInternal;
 import org.apache.jena.tdb1.sys.TDBMaker;
 import org.apache.jena.tdb1.transaction.DatasetGraphTransaction;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class TestTDB1Factory
@@ -46,14 +46,13 @@ public class TestTDB1Factory
     static Quad quad1 = SSE.parseQuad("(_ <s> <p> 1)") ;
     static Quad quad2 = SSE.parseQuad("(_ <s> <p> 1)") ;
 
-    @Before
+    @BeforeEach
     public void before() {
         TDBInternal.reset();
         FileOps.clearDirectory(DIR);
     }
 
-    @After
-    public void after() {
+    @AfterEach     public void after() {
         TDBInternal.reset();
         FileOps.clearDirectory(DIR);
     }
@@ -112,33 +111,33 @@ public class TestTDB1Factory
 
     @Test public void testTDBFresh01() {
         boolean b = TDB1Factory.inUseLocation(DIR) ;
-        assertFalse("Expect false before any creation attempted", b) ;
+        assertFalse(b, "Expect false before any creation attempted") ;
     }
 
     @Test public void testTDBFresh02() {
         boolean b = TDB1Factory.inUseLocation(DIR) ;
-        assertFalse("Expect false before any creation attempted", b) ;
+        assertFalse(b, "Expect false before any creation attempted") ;
         TDB1Factory.createDataset(DIR) ;
         b = TDB1Factory.inUseLocation(DIR) ;
-        assertTrue("Expected true after creation attempted", b) ;
+        assertTrue(b, "Expected true after creation attempted") ;
         TDBInternal.expel(Location.create(DIR), true);
     }
 
     @Test public void testTDBFresh03() {
         boolean b = TDB1Factory.inUseLocation(DIR) ;
-        assertFalse("Expect true before any creation attempted", b) ;
+        assertFalse(b, "Expect true before any creation attempted") ;
         TDB1Factory.createDataset(DIR) ;
         b = TDB1Factory.inUseLocation(DIR) ;
-        assertTrue("Expected true after creation attempted", b) ;
+        assertTrue(b, "Expected true after creation attempted") ;
         TDBInternal.expel(Location.create(DIR), true);
         b = TDB1Factory.inUseLocation(DIR) ;
-        assertTrue("Expected true even after StoreConenction reset", b) ;
+        assertTrue(b, "Expected true even after StoreConenction reset") ;
     }
 
     @Test public void testTDBFresh11() {
         Location loc = Location.mem() ;
         boolean b = TDB1Factory.inUseLocation(loc) ;
-        assertFalse("Expect false before any creation attempted", b) ;
+        assertFalse(b, "Expect false before any creation attempted") ;
     }
 
     @Test public void testTDBFresh22() {
@@ -146,7 +145,7 @@ public class TestTDB1Factory
         boolean b = TDB1Factory.inUseLocation(loc) ;
         TDB1Factory.createDataset(loc) ;
         b = TDB1Factory.inUseLocation(loc) ;
-        assertFalse("Expected false for a unique memory location", b) ;
+        assertFalse(b, "Expected false for a unique memory location") ;
     }
 
     @Test public void testTDBFresh23() {
@@ -154,6 +153,6 @@ public class TestTDB1Factory
         boolean b = TDB1Factory.inUseLocation(loc) ;
         TDB1Factory.createDataset(loc) ;
         b = TDB1Factory.inUseLocation(loc) ;
-        assertTrue("Expected true for a named memory location", b) ;
+        assertTrue(b, "Expected true for a named memory location") ;
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/assembler/TS_TDB1Assembler.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/assembler/TS_TDB1Assembler.java
@@ -21,11 +21,11 @@
 
 package org.apache.jena.tdb1.assembler;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
      TestTDB1Assembler.class
 })
 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/TC_Base.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/TC_Base.java
@@ -21,15 +21,16 @@
 
 package org.apache.jena.tdb1.base;
 
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
 import org.apache.jena.tdb1.base.block.TS_Block;
 import org.apache.jena.tdb1.base.file.TS_File;
 import org.apache.jena.tdb1.base.record.TS_Record;
 import org.apache.jena.tdb1.base.recordfile.TS_RecordFile;
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
       TS_Block.class
     , TS_File.class
     , TS_Record.class

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/AbstractTestBlockMgr.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/AbstractTestBlockMgr.java
@@ -25,24 +25,24 @@ package org.apache.jena.tdb1.base.block;
 import java.nio.ByteBuffer ;
 
 import static org.apache.jena.atlas.lib.ByteBufferLib.fill ;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractTestBlockMgr
 {
     static final public int BlkSize = 256 ;
-    
+
     protected BlockMgr blockMgr = null ;
-    
-    @Before public void before()
-    { 
+
+    @BeforeEach public void before()
+    {
        blockMgr = make() ;
        blockMgr.beginUpdate() ;
     }
-    @After  public void after()
+    @AfterEach  public void after()
     {
         if (blockMgr != null)
         {
@@ -50,7 +50,7 @@ public abstract class AbstractTestBlockMgr
             blockMgr.close() ;
         }
     }
-    
+
     @Test public void file01()
     {
         Block block = blockMgr.allocate(BlkSize) ;
@@ -59,7 +59,7 @@ public abstract class AbstractTestBlockMgr
         blockMgr.write(block) ;
         blockMgr.release(block) ;
     }
-    
+
     @Test public void file02()
     {
         Block block = blockMgr.allocate(BlkSize) ;
@@ -68,7 +68,7 @@ public abstract class AbstractTestBlockMgr
         long id = block.getId() ;
         blockMgr.write(block) ;
         blockMgr.release(block) ;
-        
+
         Block block2 = blockMgr.getRead(id) ;
         ByteBuffer bb2 = block2.getByteBuffer() ;
         assertEquals(bb2.capacity(), BlkSize) ;
@@ -76,7 +76,7 @@ public abstract class AbstractTestBlockMgr
         assertEquals(bb2.get(BlkSize-1), (byte)1) ;
         blockMgr.release(block2) ;
     }
-    
+
     @Test public void file03()
     {
         Block block = blockMgr.allocate(BlkSize) ;
@@ -100,37 +100,37 @@ public abstract class AbstractTestBlockMgr
         Block block2 = blockMgr.allocate(BlkSize) ;
         long id1 = block1.getId() ;
         long id2 = block2.getId() ;
-        
+
         ByteBuffer bb1 = block1.getByteBuffer() ;
         ByteBuffer bb2 = block2.getByteBuffer() ;
-        
+
         fill(bb1, (byte)1) ;
         fill(bb2, (byte)2) ;
-        
+
         blockMgr.write(block1) ;
         blockMgr.write(block2) ;
         blockMgr.release(block1) ;
         blockMgr.release(block2) ;
-        
+
         Block block3 = blockMgr.getRead(id1) ;
         Block block4 = blockMgr.getRead(id2) ;
-        
+
         ByteBuffer bb_1 = block3.getByteBuffer() ;
         ByteBuffer bb_2 = block4.getByteBuffer() ;
 
         contains(bb_1, (byte)1) ;
         contains(bb_2, (byte)2) ;
-        
+
         blockMgr.release(block3) ;
         blockMgr.release(block4) ;
     }
-    
-    
-    protected abstract BlockMgr make() ; 
-    
+
+
+    protected abstract BlockMgr make() ;
+
     protected static void contains(ByteBuffer bb, byte fillValue)
     {
         for ( int i = 0; i < bb.limit(); i++ )
-            assertEquals("Index: "+i, bb.get(i), fillValue ) ;
+            assertEquals(bb.get(i), fillValue, "Index: "+i) ;
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/TS_Block.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/TS_Block.java
@@ -21,11 +21,11 @@
 
 package org.apache.jena.tdb1.base.block;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestBlockMgrMem.class
     , TestBlockMgrDirect.class
     , TestBlockMgrMapped.class

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/TestBlockMgrDirect.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/TestBlockMgrDirect.java
@@ -25,15 +25,15 @@ import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.base.file.BlockAccess;
 import org.apache.jena.tdb1.base.file.BlockAccessDirect;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TestBlockMgrDirect extends AbstractTestBlockMgr
 {
     static final String filename = ConfigTest.getTestingDir()+"/block-mgr" ;
     
-    @BeforeClass static public void remove1() { FileOps.delete(filename) ; } 
-    @AfterClass  static public void remove2() { FileOps.delete(filename) ; }
+    @BeforeAll static public void remove1() { FileOps.delete(filename) ; } 
+    @AfterAll  static public void remove2() { FileOps.delete(filename) ; }
     
     @Override
     protected BlockMgr make()

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/TestBlockMgrMapped.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/TestBlockMgrMapped.java
@@ -25,9 +25,9 @@ import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.base.file.BlockAccess;
 import org.apache.jena.tdb1.base.file.BlockAccessMapped;
-import org.junit.After ;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TestBlockMgrMapped extends AbstractTestBlockMgr
 {
@@ -35,7 +35,7 @@ public class TestBlockMgrMapped extends AbstractTestBlockMgr
     
     // Windows is iffy about deleting memory mapped files.
     
-    @After public void after1()     { clearBlockMgr() ; }
+    @AfterEach public void after1()     { clearBlockMgr() ; }
     
     private void clearBlockMgr()
     {
@@ -47,8 +47,8 @@ public class TestBlockMgrMapped extends AbstractTestBlockMgr
         }
     }
     
-    @BeforeClass static public void remove1() { FileOps.deleteSilent(filename) ; }
-    @AfterClass  static public void remove2() { FileOps.deleteSilent(filename) ; }
+    @BeforeAll static public void remove1() { FileOps.deleteSilent(filename) ; }
+    @AfterAll  static public void remove2() { FileOps.deleteSilent(filename) ; }
     
     @Override
     protected BlockMgr make()

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/TestBlockMgrTracked.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/block/TestBlockMgrTracked.java
@@ -21,126 +21,118 @@
 
 package org.apache.jena.tdb1.base.block;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.nio.ByteBuffer ;
+import java.nio.ByteBuffer;
 
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-public class TestBlockMgrTracked
-{
+public class TestBlockMgrTracked {
     // Mainly testing the tracking
 
-    static boolean b ;
+    static boolean b;
 
-    @BeforeClass
-    static public void beforeClass()
-    {
-        b = BlockMgrTracker.verbose ;
-        BlockMgrTracker.verbose = false ;
+    @BeforeAll
+    static public void beforeClass() {
+        b = BlockMgrTracker.verbose;
+        BlockMgrTracker.verbose = false;
     }
 
-    @AfterClass
-    static public void afterClass()
-    {
-        BlockMgrTracker.verbose = b ;
-    }    
-    
-    @Test public void track_01()
-    {
-        BlockMgr mgr = BlockMgrFactory.createMem("BPTRecord", 4) ;
-        mgr = BlockMgrFactory.tracker(mgr) ;
-        mgr.beginUpdate() ;
-        Block block = mgr.allocate(4) ;
-        ByteBuffer bb = block.getByteBuffer() ;
-        bb.putInt(0,1234) ;
-        mgr.write(block) ;
-        mgr.release(block) ;
+    @AfterAll
+    static public void afterClass() {
+        BlockMgrTracker.verbose = b;
+    }
+
+    @Test
+    public void track_01() {
+        BlockMgr mgr = BlockMgrFactory.createMem("BPTRecord", 4);
+        mgr = BlockMgrFactory.tracker(mgr);
+        mgr.beginUpdate();
+        Block block = mgr.allocate(4);
+        ByteBuffer bb = block.getByteBuffer();
+        bb.putInt(0, 1234);
+        mgr.write(block);
+        mgr.release(block);
         // -----
-        Block block2 = mgr.getRead(block.getId()) ;
-        ByteBuffer bb2 = block2.getByteBuffer() ;
-        assertArrayEquals(bb.array(), bb2.array()) ;
-        mgr.release(block2) ;
-        mgr.endUpdate() ;
+        Block block2 = mgr.getRead(block.getId());
+        ByteBuffer bb2 = block2.getByteBuffer();
+        assertArrayEquals(bb.array(), bb2.array());
+        mgr.release(block2);
+        mgr.endUpdate();
     }
 
     // Multiple overlapping read operations.
-    static BlockMgr setup()
-    {
-        BlockMgr mgr = BlockMgrFactory.createMem("BPTRecord", 4) ;
-        mgr = BlockMgrFactory.tracker(mgr) ;
-        return mgr ;
-    }
-    
-    static void write(BlockMgr mgr, int value)
-    {
-        mgr.beginUpdate() ;
-        Block block = mgr.allocate(4) ;
-        ByteBuffer bb = block.getByteBuffer() ;
-        bb.putInt(0,value) ;
-        mgr.write(block) ;
-        mgr.release(block) ;
-        mgr.endUpdate() ;
-    }
-    
-    @Test public void track_02()
-    {
-        BlockMgr mgr = setup() ;
-        write(mgr, 1234) ;
-        write(mgr, 5678) ;
-
-        mgr.beginRead() ;
-        mgr.beginRead() ;
-
-        Block b0 = mgr.getRead(0) ;
-        Block b1 = mgr.getRead(1) ;
-        
-        mgr.release(b1) ;
-        mgr.release(b0) ;
-        
-        mgr.endRead() ;
-        mgr.endRead() ;
-    }
-    
-    @Test(expected=BlockException.class)
-    public void track_03()
-    {
-        BlockMgr mgr = setup() ;
-        write(mgr, 1234) ;
-        write(mgr, 5678) ;
-
-        mgr.beginRead() ;
-        Block b0 = mgr.getWrite(0) ;
-        mgr.endRead() ;
+    static BlockMgr setup() {
+        BlockMgr mgr = BlockMgrFactory.createMem("BPTRecord", 4);
+        mgr = BlockMgrFactory.tracker(mgr);
+        return mgr;
     }
 
-    @Test(expected=BlockException.class)
-    public void track_04()
-    {
-        BlockMgr mgr = setup() ;
-        write(mgr, 1234) ;
-        mgr.beginRead() ;
-        Block b0 = mgr.getRead(0) ;
-        mgr.promote(b0) ;
-        mgr.endRead() ;
+    static void write(BlockMgr mgr, int value) {
+        mgr.beginUpdate();
+        Block block = mgr.allocate(4);
+        ByteBuffer bb = block.getByteBuffer();
+        bb.putInt(0, value);
+        mgr.write(block);
+        mgr.release(block);
+        mgr.endUpdate();
     }
 
-    @Test(expected=BlockException.class)
-    public void track_05()
-    {
-        BlockMgr mgr = setup() ;
-        mgr.beginRead() ;
-        mgr.endUpdate() ;
+    @Test
+    public void track_02() {
+        BlockMgr mgr = setup();
+        write(mgr, 1234);
+        write(mgr, 5678);
+
+        mgr.beginRead();
+        mgr.beginRead();
+
+        Block b0 = mgr.getRead(0);
+        Block b1 = mgr.getRead(1);
+
+        mgr.release(b1);
+        mgr.release(b0);
+
+        mgr.endRead();
+        mgr.endRead();
     }
 
-    @Test(expected=BlockException.class)
-    public void track_06()
-    {
-        BlockMgr mgr = setup() ;
-        mgr.beginUpdate() ;
-        mgr.endRead() ;
+    @Test
+    public void track_03() {
+        BlockMgr mgr = setup();
+        write(mgr, 1234);
+        write(mgr, 5678);
+
+        mgr.beginRead();
+        assertThrows(BlockException.class, ()->mgr.getWrite(0));
+        mgr.endRead();
+    }
+
+    @Test
+    public void track_04() {
+        BlockMgr mgr = setup();
+        write(mgr, 1234);
+        mgr.beginRead();
+        Block b0 = mgr.getRead(0);
+        assertThrows(BlockException.class, ()->mgr.promote(b0));
+        mgr.endRead();
+    }
+
+    @Test
+    public void track_05() {
+        BlockMgr mgr = setup();
+        mgr.beginRead();
+        assertThrows(BlockException.class, ()->mgr.endUpdate());
+    }
+
+    @Test
+    public void track_06() {
+        BlockMgr mgr = setup();
+        mgr.beginUpdate();
+        assertThrows(BlockException.class, ()->mgr.endRead());
     }
 
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/buffer/TestPtrBuffer.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/buffer/TestPtrBuffer.java
@@ -21,301 +21,298 @@
 
 package org.apache.jena.tdb1.base.buffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
 
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-public class TestPtrBuffer
-{
-    static boolean originalNullOut ; 
-    @BeforeClass static public void beforeClass()
-    {
-        originalNullOut = SystemTDB.NullOut ;
-        SystemTDB.NullOut = true ;    
+public class TestPtrBuffer {
+    static boolean originalNullOut;
+    @BeforeAll
+    static public void beforeClass() {
+        originalNullOut = SystemTDB.NullOut;
+        SystemTDB.NullOut = true;
     }
-    
-    @AfterClass static public void afterClass()
-    {
-        SystemTDB.NullOut = originalNullOut ;    
+
+    @AfterAll
+    static public void afterClass() {
+        SystemTDB.NullOut = originalNullOut;
     }
-    
+
     // Testing the test framework!
-    @Test public void ptrbuffer01()
-    {
-        PtrBuffer pb = make(4) ;
-        contains(pb, 2, 4, 6, 8) ;
+    @Test
+    public void ptrbuffer01() {
+        PtrBuffer pb = make(4);
+        contains(pb, 2, 4, 6, 8);
     }
-    
-    // No BinarySearch test
-    
-    // Shift at LHS
-    @Test public void ptrbuffer03()
-    {
-        PtrBuffer pb = make(4,5) ;
-        contains(pb, 2, 4, 6, 8) ;
-        
-        pb.shiftUp(0) ;
-        pb.set(0, 99) ;
-        contains(pb, 99, 2, 4, 6, 8) ;
-        
-        pb.shiftDown(0) ;
-        contains(pb, 2, 4, 6, 8) ;
-    }    
-    
-    @Test public void ptrbuffer04()
-    {
-        PtrBuffer pb = make(4,5) ;
-        contains(pb, 2, 4, 6, 8) ;
-        pb.shiftDown(0) ;
-        
-        contains(pb, 4, 6, 8) ;
-        pb.shiftUp(0) ;
 
-        pb.set(0,1) ;
-        contains(pb, 1, 4, 6, 8) ;
-    }    
-    
+    // No BinarySearch test
+
+    // Shift at LHS
+    @Test
+    public void ptrbuffer03() {
+        PtrBuffer pb = make(4, 5);
+        contains(pb, 2, 4, 6, 8);
+
+        pb.shiftUp(0);
+        pb.set(0, 99);
+        contains(pb, 99, 2, 4, 6, 8);
+
+        pb.shiftDown(0);
+        contains(pb, 2, 4, 6, 8);
+    }
+
+    @Test
+    public void ptrbuffer04() {
+        PtrBuffer pb = make(4, 5);
+        contains(pb, 2, 4, 6, 8);
+        pb.shiftDown(0);
+
+        contains(pb, 4, 6, 8);
+        pb.shiftUp(0);
+
+        pb.set(0, 1);
+        contains(pb, 1, 4, 6, 8);
+    }
 
     // Shift at middle
-    @Test public void ptrbuffer05()
-    {
-        PtrBuffer pb = make(4,5) ;
-        contains(pb, 2, 4, 6, 8) ;
-        pb.shiftUp(2) ;
-        pb.set(2, 0) ;
-        contains(pb, 2, 4, 0, 6, 8) ;
-        pb.shiftDown(2) ;
-        contains(pb, 2, 4, 6, 8) ;
-    }    
+    @Test
+    public void ptrbuffer05() {
+        PtrBuffer pb = make(4, 5);
+        contains(pb, 2, 4, 6, 8);
+        pb.shiftUp(2);
+        pb.set(2, 0);
+        contains(pb, 2, 4, 0, 6, 8);
+        pb.shiftDown(2);
+        contains(pb, 2, 4, 6, 8);
+    }
 
-    @Test public void ptrbuffer06()
-    {
-        PtrBuffer pb = make(4,5) ;
-        contains(pb, 2, 4, 6, 8) ;
-        pb.shiftDown(2) ;
-        contains(pb, 2, 4, 8) ;
-        pb.shiftUp(2) ;
-        assertTrue(pb.isClear(2)) ;
-        contains(pb, 2, 4, -1, 8) ;
-    }    
+    @Test
+    public void ptrbuffer06() {
+        PtrBuffer pb = make(4, 5);
+        contains(pb, 2, 4, 6, 8);
+        pb.shiftDown(2);
+        contains(pb, 2, 4, 8);
+        pb.shiftUp(2);
+        assertTrue(pb.isClear(2));
+        contains(pb, 2, 4, -1, 8);
+    }
 
     // Shift RHS - out of bounds
-    @Test public void ptrbuffer07()
-    {
-        PtrBuffer pb = make(4,5) ;
-        contains(pb, 2, 4, 6, 8) ;
-        pb.shiftUp(3) ;
-        pb.set(3, 1) ;
-        contains(pb, 2, 4, 6, 1, 8) ;
-        pb.shiftDown(3) ;
-        contains(pb, 2, 4, 6, 8) ;
-    }    
+    @Test
+    public void ptrbuffer07() {
+        PtrBuffer pb = make(4, 5);
+        contains(pb, 2, 4, 6, 8);
+        pb.shiftUp(3);
+        pb.set(3, 1);
+        contains(pb, 2, 4, 6, 1, 8);
+        pb.shiftDown(3);
+        contains(pb, 2, 4, 6, 8);
+    }
 
-    @Test public void ptrbuffer08()
-    {
-        PtrBuffer pb = make(4,5) ;
-        contains(pb, 2, 4, 6, 8) ;
-        pb.shiftDown(3) ;
-        contains(pb, 2, 4, 6) ;
-        pb.shiftUp(2) ;
-        contains(pb, 2, 4, -1, 6) ;
-    }    
+    @Test
+    public void ptrbuffer08() {
+        PtrBuffer pb = make(4, 5);
+        contains(pb, 2, 4, 6, 8);
+        pb.shiftDown(3);
+        contains(pb, 2, 4, 6);
+        pb.shiftUp(2);
+        contains(pb, 2, 4, -1, 6);
+    }
 
     // Errors - IllegalArgumentException
-    @Test(expected=BufferException.class) 
-    public void ptrbuffer09()
-    {
-        PtrBuffer pb = make(4,5) ;
-        contains(pb, 2, 4, 6, 8) ;
-        pb.shiftDown(4) ;
-    }  
-    
-    @Test(expected=BufferException.class) 
-    public void ptrbuffer10()
-    {
-        PtrBuffer pb = make(4,5) ;
-        contains(pb, 2, 4, 6, 8) ;
-        pb.shiftUp(4) ;
-    }  
+    @Test
+    public void ptrbuffer09() {
+        PtrBuffer pb = make(4, 5);
+        contains(pb, 2, 4, 6, 8);
+        assertThrows(BufferException.class, () -> pb.shiftDown(4));
+    }
 
-    @Test(expected=BufferException.class) 
-    public void ptrbuffer11()
-    {
-        PtrBuffer pb = make(5,5) ;
-        contains(pb, 2, 4, 6, 8, 10) ;
-        pb.add(12) ;
-    }  
-    
+    @Test
+    public void ptrbuffer10() {
+        PtrBuffer pb = make(4, 5);
+        contains(pb, 2, 4, 6, 8);
+        assertThrows(BufferException.class, () -> pb.shiftUp(4));
+    }
+
+    @Test
+    public void ptrbuffer11() {
+        PtrBuffer pb = make(5, 5);
+        contains(pb, 2, 4, 6, 8, 10);
+        assertThrows(BufferException.class, () -> pb.add(12));
+    }
+
     // Copy, duplicate, clear
-    @Test public void ptrbuffer12()
-    {
-        PtrBuffer pb = make(5,5) ;
-        contains(pb, 2, 4, 6, 8, 10) ;
-        PtrBuffer pb2 = pb.duplicate() ;
-        pb2.set(1, 99) ;
-        contains(pb, 2, 4, 6, 8, 10) ;
-        contains(pb2, 2, 99, 6, 8, 10) ;
+    @Test
+    public void ptrbuffer12() {
+        PtrBuffer pb = make(5, 5);
+        contains(pb, 2, 4, 6, 8, 10);
+        PtrBuffer pb2 = pb.duplicate();
+        pb2.set(1, 99);
+        contains(pb, 2, 4, 6, 8, 10);
+        contains(pb2, 2, 99, 6, 8, 10);
     }
-    
-    @Test public void ptrbuffer13()
-    {
-        PtrBuffer pb = make(5,5) ;
-        contains(pb, 2, 4, 6, 8, 10) ;
-        pb.clear(1, 3) ;
-        contains(pb, 2, -1, -1, -1, 10) ;
+
+    @Test
+    public void ptrbuffer13() {
+        PtrBuffer pb = make(5, 5);
+        contains(pb, 2, 4, 6, 8, 10);
+        pb.clear(1, 3);
+        contains(pb, 2, -1, -1, -1, 10);
     }
-    
-    @Test public void ptrbuffer14()
-    {
-        PtrBuffer pb = make(5,5) ;
-        contains(pb, 2, 4, 6, 8, 10) ;
-        
-        PtrBuffer pb2 = make(5,5) ;
-        contains(pb2, 2, 4, 6, 8, 10) ;
-        
-        pb.copy(0, pb2, 1, 4) ;
-        contains(pb2, 2, 2, 4, 6, 8) ;
+
+    @Test
+    public void ptrbuffer14() {
+        PtrBuffer pb = make(5, 5);
+        contains(pb, 2, 4, 6, 8, 10);
+
+        PtrBuffer pb2 = make(5, 5);
+        contains(pb2, 2, 4, 6, 8, 10);
+
+        pb.copy(0, pb2, 1, 4);
+        contains(pb2, 2, 2, 4, 6, 8);
     }
 
     // Remove tests
 
-    @Test public void ptrbuffer15()
-    {
-        PtrBuffer pb = make(5,5) ;
-        contains(pb, 2, 4, 6, 8, 10) ;
-        pb.removeTop() ;
-        contains(pb, 2, 4, 6, 8) ;
-        pb.remove(1) ;
-        contains(pb, 2, 6, 8) ;
-        pb.remove(2) ;
-        contains(pb, 2, 6) ;
-        pb.remove(0) ;
-        contains(pb, 6) ;
-        pb.remove(0) ;
-        contains(pb) ;
-    }
-    
-    @Test public void ptrbuffer20()
-    {
-        PtrBuffer pb1 = make(5,5) ;
-        contains(pb1, 2, 4, 6, 8, 10) ;
-        PtrBuffer pb2 = make(0,5) ;
-        contains(pb2) ;
-        
-        pb1.shiftRight(pb2) ;
-        contains(pb1, 2, 4, 6, 8) ;
-        contains(pb2, 10) ;
-    }
-    
-    @Test public void ptrbuffer21()
-    {
-        PtrBuffer pb1 = make(3,5) ;
-        contains(pb1, 2, 4, 6) ;
-        PtrBuffer pb2 = make(0,5) ;
-        contains(pb2) ;
-        
-        pb1.shiftRight(pb2) ;
-        contains(pb1, 2, 4) ;
-        contains(pb2, 6) ;
-    }
-    
-    @Test public void ptrbuffer22()
-    {
-        PtrBuffer pb1 = make(3,5) ;
-        contains(pb1, 2, 4, 6) ;
-        PtrBuffer pb2 = make(2,5) ;
-        contains(pb2, 2, 4) ;
-        
-        pb1.shiftRight(pb2) ;
-        contains(pb1, 2, 4) ;
-        contains(pb2, 6, 2, 4) ;
-    }
-    
-    @Test public void ptrbuffer24()
-    {
-        PtrBuffer pb1 = make(0,5) ;
-        contains(pb1) ;
-        PtrBuffer pb2 = make(5,5) ;
-        contains(pb2, 2, 4, 6, 8, 10) ;
-        
-        pb1.shiftLeft(pb2) ;
-        contains(pb1, 2) ;
-        contains(pb2, 4, 6, 8, 10) ;
-    }
-    
-    @Test public void ptrbuffer25()
-    {
-        PtrBuffer pb1 = make(0,5) ;
-        contains(pb1) ;
-        PtrBuffer pb2 = make(3,5) ;
-        contains(pb2, 2, 4, 6) ;
-        
-        pb1.shiftLeft(pb2) ;
-        contains(pb1, 2) ;
-        contains(pb2, 4, 6) ;
-    }
-    
-    @Test public void ptrbuffer26()
-    {
-        PtrBuffer pb1 = make(2,5) ;
-        contains(pb1, 2, 4) ;
-        PtrBuffer pb2 = make(3,5) ;
-        contains(pb2, 2, 4, 6) ;
-        
-        pb1.shiftLeft(pb2) ;
-        contains(pb1, 2, 4, 2) ;
-        contains(pb2, 4, 6) ;
-    }
-    
-    @Test public void ptrbuffer27()
-    {
-        PtrBuffer pb1 = make(2,4) ;
-        PtrBuffer pb2 = make(2,4) ; 
-        pb1.copyToTop(pb2) ;
-        contains(pb2, 2,4,2,4) ;
-    }
-    
-    @Test public void ptrbuffer28()
-    {
-        PtrBuffer pb1 = make(0,5) ;
-        PtrBuffer pb2 = make(2,4) ; 
-        pb1.copyToTop(pb2) ;
-        contains(pb2, 2,4) ;
+    @Test
+    public void ptrbuffer15() {
+        PtrBuffer pb = make(5, 5);
+        contains(pb, 2, 4, 6, 8, 10);
+        pb.removeTop();
+        contains(pb, 2, 4, 6, 8);
+        pb.remove(1);
+        contains(pb, 2, 6, 8);
+        pb.remove(2);
+        contains(pb, 2, 6);
+        pb.remove(0);
+        contains(pb, 6);
+        pb.remove(0);
+        contains(pb);
     }
 
-    @Test public void ptrbuffer29()
-    {
-        PtrBuffer pb1 = make(0,5) ;
-        PtrBuffer pb2 = make(2,4) ; 
-        pb2.copyToTop(pb1) ;
-        contains(pb1, 2,4) ;
+    @Test
+    public void ptrbuffer20() {
+        PtrBuffer pb1 = make(5, 5);
+        contains(pb1, 2, 4, 6, 8, 10);
+        PtrBuffer pb2 = make(0, 5);
+        contains(pb2);
+
+        pb1.shiftRight(pb2);
+        contains(pb1, 2, 4, 6, 8);
+        contains(pb2, 10);
+    }
+
+    @Test
+    public void ptrbuffer21() {
+        PtrBuffer pb1 = make(3, 5);
+        contains(pb1, 2, 4, 6);
+        PtrBuffer pb2 = make(0, 5);
+        contains(pb2);
+
+        pb1.shiftRight(pb2);
+        contains(pb1, 2, 4);
+        contains(pb2, 6);
+    }
+
+    @Test
+    public void ptrbuffer22() {
+        PtrBuffer pb1 = make(3, 5);
+        contains(pb1, 2, 4, 6);
+        PtrBuffer pb2 = make(2, 5);
+        contains(pb2, 2, 4);
+
+        pb1.shiftRight(pb2);
+        contains(pb1, 2, 4);
+        contains(pb2, 6, 2, 4);
+    }
+
+    @Test
+    public void ptrbuffer24() {
+        PtrBuffer pb1 = make(0, 5);
+        contains(pb1);
+        PtrBuffer pb2 = make(5, 5);
+        contains(pb2, 2, 4, 6, 8, 10);
+
+        pb1.shiftLeft(pb2);
+        contains(pb1, 2);
+        contains(pb2, 4, 6, 8, 10);
+    }
+
+    @Test
+    public void ptrbuffer25() {
+        PtrBuffer pb1 = make(0, 5);
+        contains(pb1);
+        PtrBuffer pb2 = make(3, 5);
+        contains(pb2, 2, 4, 6);
+
+        pb1.shiftLeft(pb2);
+        contains(pb1, 2);
+        contains(pb2, 4, 6);
+    }
+
+    @Test
+    public void ptrbuffer26() {
+        PtrBuffer pb1 = make(2, 5);
+        contains(pb1, 2, 4);
+        PtrBuffer pb2 = make(3, 5);
+        contains(pb2, 2, 4, 6);
+
+        pb1.shiftLeft(pb2);
+        contains(pb1, 2, 4, 2);
+        contains(pb2, 4, 6);
+    }
+
+    @Test
+    public void ptrbuffer27() {
+        PtrBuffer pb1 = make(2, 4);
+        PtrBuffer pb2 = make(2, 4);
+        pb1.copyToTop(pb2);
+        contains(pb2, 2, 4, 2, 4);
+    }
+
+    @Test
+    public void ptrbuffer28() {
+        PtrBuffer pb1 = make(0, 5);
+        PtrBuffer pb2 = make(2, 4);
+        pb1.copyToTop(pb2);
+        contains(pb2, 2, 4);
+    }
+
+    @Test
+    public void ptrbuffer29() {
+        PtrBuffer pb1 = make(0, 5);
+        PtrBuffer pb2 = make(2, 4);
+        pb2.copyToTop(pb1);
+        contains(pb1, 2, 4);
     }
 
     // ---- Support
-    private static void contains(PtrBuffer pb, int... vals)
-    {
-        assertEquals("Length mismatch: ", vals.length, pb.size()) ;
+    private static void contains(PtrBuffer pb, int...vals) {
+        assertEquals(vals.length, pb.size(), "Length mismatch: ");
         for ( int i = 0 ; i < vals.length ; i++ )
             if ( vals[i] == -1 )
-                assertTrue(pb.isClear(i))  ;
+                assertTrue(pb.isClear(i));
             else
-                assertEquals("Value mismatch: ", vals[i], pb.get(i)) ;
+                assertEquals(vals[i], pb.get(i), "Value mismatch: ");
     }
 
     // Make : 2,4,6,8, ..
-    private static PtrBuffer make(int n) { return make(n,n) ; }
-    private static PtrBuffer make(int n, int len)
-    { 
-        ByteBuffer bb = ByteBuffer.allocate(4*len) ;
-        PtrBuffer pb = new PtrBuffer(bb, 0) ;
+    private static PtrBuffer make(int n) {
+        return make(n, n);
+    }
+
+    private static PtrBuffer make(int n, int len) {
+        ByteBuffer bb = ByteBuffer.allocate(4 * len);
+        PtrBuffer pb = new PtrBuffer(bb, 0);
         for ( int i = 0 ; i < n ; i++ )
-            pb.add(2+2*i) ;
-        return pb ;
+            pb.add(2 + 2 * i);
+        return pb;
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/buffer/TestRecordBuffer.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/buffer/TestRecordBuffer.java
@@ -23,326 +23,315 @@ package org.apache.jena.tdb1.base.buffer;
 
 import static org.apache.jena.tdb1.base.record.RecordLib.intToRecord;
 import static org.apache.jena.tdb1.base.record.RecordLib.r;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.tdb1.base.record.Record;
 import org.apache.jena.tdb1.base.record.RecordFactory;
 import org.apache.jena.tdb1.base.record.RecordLib;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
-public class TestRecordBuffer
-{
-    static RecordFactory recordFactory = new RecordFactory(RecordLib.TestRecordLength, 0) ;
-    
-    static boolean originalNullOut ; 
-    @BeforeClass static public void beforeClass()
-    {
-        originalNullOut = SystemTDB.NullOut ;
-        SystemTDB.NullOut = true ;    
-    }
-    
-    @AfterClass static public void afterClass()
-    {
-        SystemTDB.NullOut = originalNullOut ;    
+public class TestRecordBuffer {
+    static RecordFactory recordFactory = new RecordFactory(RecordLib.TestRecordLength, 0);
+
+    static boolean originalNullOut;
+    @BeforeAll
+    static public void beforeClass() {
+        originalNullOut = SystemTDB.NullOut;
+        SystemTDB.NullOut = true;
     }
 
-    @Test public void recBuffer01()
-    {
-        RecordBuffer rb = make(4, 4) ;
-        contains(rb, 2, 4, 6, 8) ;
+    @AfterAll
+    static public void afterClass() {
+        SystemTDB.NullOut = originalNullOut;
     }
-    
-    @Test public void recBuffer02()
-    {
-        RecordBuffer rb = make(4, 4) ;
-        int idx = -1 ;
-        idx = find(rb, 6) ;
-        assertEquals(2, idx) ;
-        idx = find(rb, 8) ;
-        
-        assertEquals(3, idx) ;
-        idx = find(rb, 4) ;
-        assertEquals(1, idx) ;
-        idx = find(rb, 2) ;
-        assertEquals(0, idx) ;
 
-        idx = find(rb, 3) ;
-        assertEquals(-2, idx) ;
-        idx = find(rb, 0) ;
-        assertEquals(-1, idx) ;
-        idx = find(rb, 10) ;
-        assertEquals(-5, idx) ;
+    @Test
+    public void recBuffer01() {
+        RecordBuffer rb = make(4, 4);
+        contains(rb, 2, 4, 6, 8);
+    }
+
+    @Test
+    public void recBuffer02() {
+        RecordBuffer rb = make(4, 4);
+        int idx = -1;
+        idx = find(rb, 6);
+        assertEquals(2, idx);
+        idx = find(rb, 8);
+
+        assertEquals(3, idx);
+        idx = find(rb, 4);
+        assertEquals(1, idx);
+        idx = find(rb, 2);
+        assertEquals(0, idx);
+
+        idx = find(rb, 3);
+        assertEquals(-2, idx);
+        idx = find(rb, 0);
+        assertEquals(-1, idx);
+        idx = find(rb, 10);
+        assertEquals(-5, idx);
     }
 
     // Shift at LHS
-    @Test public void recBuffer03()
-    {
-        RecordBuffer rb = make(4,5) ;
-        contains(rb, 2, 4, 6, 8) ;
-        rb.shiftUp(0) ;
-        rb.set(0, r(0)) ;
-        contains(rb, 0, 2, 4, 6, 8) ;
-        rb.shiftDown(0) ;
-        contains(rb, 2, 4, 6, 8) ;
-    }    
-    
-    @Test public void recBuffer04()
-    {
-        RecordBuffer rb = make(4,5) ;
-        contains(rb, 2, 4, 6, 8) ;
-        rb.shiftDown(0) ;
-        
-        contains(rb, 4, 6, 8) ;
-        rb.shiftUp(0) ;
+    @Test
+    public void recBuffer03() {
+        RecordBuffer rb = make(4, 5);
+        contains(rb, 2, 4, 6, 8);
+        rb.shiftUp(0);
+        rb.set(0, r(0));
+        contains(rb, 0, 2, 4, 6, 8);
+        rb.shiftDown(0);
+        contains(rb, 2, 4, 6, 8);
+    }
 
-        rb.set(0,r(1)) ;
-        contains(rb, 1, 4, 6, 8) ;
-    }    
-    
+    @Test
+    public void recBuffer04() {
+        RecordBuffer rb = make(4, 5);
+        contains(rb, 2, 4, 6, 8);
+        rb.shiftDown(0);
+
+        contains(rb, 4, 6, 8);
+        rb.shiftUp(0);
+
+        rb.set(0, r(1));
+        contains(rb, 1, 4, 6, 8);
+    }
 
     // Shift at middle
-    @Test public void recBuffer05()
-    {
-        RecordBuffer rb = make(4,5) ;
-        contains(rb, 2, 4, 6, 8) ;
-        rb.shiftUp(2) ;
-        rb.set(2, r(0)) ;
-        contains(rb, 2, 4, 0, 6, 8) ;
-        rb.shiftDown(2) ;
-        contains(rb, 2, 4, 6, 8) ;
-    }    
+    @Test
+    public void recBuffer05() {
+        RecordBuffer rb = make(4, 5);
+        contains(rb, 2, 4, 6, 8);
+        rb.shiftUp(2);
+        rb.set(2, r(0));
+        contains(rb, 2, 4, 0, 6, 8);
+        rb.shiftDown(2);
+        contains(rb, 2, 4, 6, 8);
+    }
 
-    @Test public void recBuffer06()
-    {
-        RecordBuffer rb = make(4,5) ;
-        contains(rb, 2, 4, 6, 8) ;
-        rb.shiftDown(2) ;
-        contains(rb, 2, 4, 8) ;
-        rb.shiftUp(2) ;
-        contains(rb, 2, 4, -1, 8) ;
-    }    
+    @Test
+    public void recBuffer06() {
+        RecordBuffer rb = make(4, 5);
+        contains(rb, 2, 4, 6, 8);
+        rb.shiftDown(2);
+        contains(rb, 2, 4, 8);
+        rb.shiftUp(2);
+        contains(rb, 2, 4, -1, 8);
+    }
 
     // Shift RHS - out of bounds
-    @Test public void recBuffer07()
-    {
-        RecordBuffer rb = make(4,5) ;
-        contains(rb, 2, 4, 6, 8) ;
-        rb.shiftUp(3) ;
-        rb.set(3, r(1)) ;
-        contains(rb, 2, 4, 6, 1, 8) ;
-        rb.shiftDown(3) ;
-        contains(rb, 2, 4, 6, 8) ;
-    }    
+    @Test
+    public void recBuffer07() {
+        RecordBuffer rb = make(4, 5);
+        contains(rb, 2, 4, 6, 8);
+        rb.shiftUp(3);
+        rb.set(3, r(1));
+        contains(rb, 2, 4, 6, 1, 8);
+        rb.shiftDown(3);
+        contains(rb, 2, 4, 6, 8);
+    }
 
-    @Test public void recBuffer08()
-    {
-        RecordBuffer rb = make(4,5) ;
-        contains(rb, 2, 4, 6, 8) ;
-        rb.shiftDown(3) ;
-        contains(rb, 2, 4, 6) ;
-        rb.shiftUp(2) ;
-        contains(rb, 2, 4, -1, 6) ;
-    }    
+    @Test
+    public void recBuffer08() {
+        RecordBuffer rb = make(4, 5);
+        contains(rb, 2, 4, 6, 8);
+        rb.shiftDown(3);
+        contains(rb, 2, 4, 6);
+        rb.shiftUp(2);
+        contains(rb, 2, 4, -1, 6);
+    }
 
     // Errors
-    
-    @Test(expected=BufferException.class) 
-    public void recBuffer09()
-    {
-        RecordBuffer rb = make(4,5) ;
-        contains(rb, 2, 4, 6, 8) ;
-        rb.shiftDown(4) ;
-    }  
-    
-    @Test(expected=BufferException.class) 
-    public void recBuffer10()
-    {
-        RecordBuffer rb = make(4,5) ;
-        contains(rb, 2, 4, 6, 8) ;
-        rb.shiftUp(4) ;
-    }  
 
-    @Test(expected=BufferException.class) 
-    public void recBuffer11()
-    {
-        RecordBuffer rb = make(5,5) ;
-        contains(rb, 2, 4, 6, 8, 10) ;
-        rb.add(r(12)) ;
-    }  
-    
+    @Test
+    public void recBuffer09() {
+        RecordBuffer rb = make(4, 5);
+        contains(rb, 2, 4, 6, 8);
+        assertThrows(BufferException.class, () -> rb.shiftDown(4));
+    }
+
+    @Test
+    public void recBuffer10() {
+        RecordBuffer rb = make(4, 5);
+        contains(rb, 2, 4, 6, 8);
+        assertThrows(BufferException.class, () -> rb.shiftUp(4));
+    }
+
+    @Test
+    public void recBuffer11() {
+        RecordBuffer rb = make(5, 5);
+        contains(rb, 2, 4, 6, 8, 10);
+        assertThrows(BufferException.class, () -> rb.add(r(12)));
+    }
+
     // Copy, duplicate, clear
-    @Test public void recBuffer12()
-    {
-        RecordBuffer rb = make(5,5) ;
-        contains(rb, 2, 4, 6, 8, 10) ;
-        RecordBuffer rb2 = rb.duplicate() ;
-        rb2.set(1, r(99)) ;
-        contains(rb, 2, 4, 6, 8, 10) ;
-        contains(rb2, 2, 99, 6, 8, 10) ;
+    @Test
+    public void recBuffer12() {
+        RecordBuffer rb = make(5, 5);
+        contains(rb, 2, 4, 6, 8, 10);
+        RecordBuffer rb2 = rb.duplicate();
+        rb2.set(1, r(99));
+        contains(rb, 2, 4, 6, 8, 10);
+        contains(rb2, 2, 99, 6, 8, 10);
     }
-    
-    @Test public void recBuffer13()
-    {
-        RecordBuffer rb = make(5,5) ;
-        contains(rb, 2, 4, 6, 8, 10) ;
-        rb.clear(1, 3) ;
-        contains(rb, 2, -1, -1, -1, 10) ;
+
+    @Test
+    public void recBuffer13() {
+        RecordBuffer rb = make(5, 5);
+        contains(rb, 2, 4, 6, 8, 10);
+        rb.clear(1, 3);
+        contains(rb, 2, -1, -1, -1, 10);
     }
-    
-    @Test public void recBuffer14()
-    {
-        RecordBuffer rb = make(5,5) ;
-        contains(rb, 2, 4, 6, 8, 10) ;
-        RecordBuffer rb2 = make(5,5) ;
-        contains(rb2, 2, 4, 6, 8, 10) ;
-        rb.copy(0, rb2, 1, 4) ;
-        contains(rb2, 2, 2, 4, 6, 8) ;
+
+    @Test
+    public void recBuffer14() {
+        RecordBuffer rb = make(5, 5);
+        contains(rb, 2, 4, 6, 8, 10);
+        RecordBuffer rb2 = make(5, 5);
+        contains(rb2, 2, 4, 6, 8, 10);
+        rb.copy(0, rb2, 1, 4);
+        contains(rb2, 2, 2, 4, 6, 8);
     }
 
     // Remove tests
-    
-    @Test public void recBuffer15()
-    {
-        RecordBuffer rb = make(5,5) ;
-        contains(rb, 2, 4, 6, 8, 10) ;
-        rb.removeTop() ;
-        contains(rb, 2, 4, 6, 8) ;
-        rb.remove(1) ;
-        contains(rb, 2, 6, 8) ;
-        rb.remove(2) ;
-        contains(rb, 2, 6) ;
-        rb.remove(0) ;
-        contains(rb, 6) ;
-        rb.remove(0) ;
-        contains(rb) ;
+
+    @Test
+    public void recBuffer15() {
+        RecordBuffer rb = make(5, 5);
+        contains(rb, 2, 4, 6, 8, 10);
+        rb.removeTop();
+        contains(rb, 2, 4, 6, 8);
+        rb.remove(1);
+        contains(rb, 2, 6, 8);
+        rb.remove(2);
+        contains(rb, 2, 6);
+        rb.remove(0);
+        contains(rb, 6);
+        rb.remove(0);
+        contains(rb);
     }
 
-    @Test public void recBufferIterate01()
-    {
-        RecordBuffer rb = make(5,5) ;
-        same(rb.iterator(), 2,4,6,8,10) ;
+    @Test
+    public void recBufferIterate01() {
+        RecordBuffer rb = make(5, 5);
+        same(rb.iterator(), 2, 4, 6, 8, 10);
     }
 
-    @Test public void recBufferIterate02()
-    {
-        RecordBuffer rb = make(3,5) ;
-        Iterator<Record> iter = rb.iterator() ;
-        same(iter, 2, 4, 6) ;
+    @Test
+    public void recBufferIterate02() {
+        RecordBuffer rb = make(3, 5);
+        Iterator<Record> iter = rb.iterator();
+        same(iter, 2, 4, 6);
     }
 
-    @Test public void recBufferIterate03()
-    {
-        RecordBuffer rb = make(3,5) ;
-        Iterator<Record> iter = rb.iterator( intToRecord(4), null) ;
-        same(iter, 4, 6) ;
+    @Test
+    public void recBufferIterate03() {
+        RecordBuffer rb = make(3, 5);
+        Iterator<Record> iter = rb.iterator(intToRecord(4), null);
+        same(iter, 4, 6);
     }
 
-    @Test public void recBufferIterate04()
-    {
-        RecordBuffer rb = make(3,5) ;
-        Iterator<Record> iter = rb.iterator( intToRecord(3), null) ;
-        same(iter, 4, 6) ;
+    @Test
+    public void recBufferIterate04() {
+        RecordBuffer rb = make(3, 5);
+        Iterator<Record> iter = rb.iterator(intToRecord(3), null);
+        same(iter, 4, 6);
     }
 
-    @Test public void recBufferIterate05()
-    {
-        RecordBuffer rb = make(3,5) ;
-        Iterator<Record> iter = rb.iterator( intToRecord(1), null) ;
-        same(iter, 2, 4, 6) ;
+    @Test
+    public void recBufferIterate05() {
+        RecordBuffer rb = make(3, 5);
+        Iterator<Record> iter = rb.iterator(intToRecord(1), null);
+        same(iter, 2, 4, 6);
     }
 
-    @Test public void recBufferIterate06()
-    {
-        RecordBuffer rb = make(3,5) ;
-        Iterator<Record> iter = rb.iterator( null, intToRecord(1)) ;
-        same(iter) ;
+    @Test
+    public void recBufferIterate06() {
+        RecordBuffer rb = make(3, 5);
+        Iterator<Record> iter = rb.iterator(null, intToRecord(1));
+        same(iter);
     }
 
-    @Test public void recBufferIterate07()
-    {
-        RecordBuffer rb = make(3,5) ;
-        Iterator<Record> iter = rb.iterator( null, intToRecord(2)) ;
-        same(iter ) ;
+    @Test
+    public void recBufferIterate07() {
+        RecordBuffer rb = make(3, 5);
+        Iterator<Record> iter = rb.iterator(null, intToRecord(2));
+        same(iter);
     }
 
-    @Test public void recBufferIterate08()
-    {
-        RecordBuffer rb = make(3,5) ;
-        Iterator<Record> iter = rb.iterator( null, intToRecord(3)) ;
-        same(iter,2 ) ;
-    }
-    
-    @Test public void recBufferIterate09()
-    {
-        RecordBuffer rb = make(5,5) ;
-        Iterator<Record> iter = rb.iterator( null, intToRecord(99)) ;
-        same(iter, 2, 4, 6, 8, 10) ;
+    @Test
+    public void recBufferIterate08() {
+        RecordBuffer rb = make(3, 5);
+        Iterator<Record> iter = rb.iterator(null, intToRecord(3));
+        same(iter, 2);
     }
 
-    @Test public void recBufferIterate10()
-    {
-        RecordBuffer rb = make(5,5) ;
-        Iterator<Record> iter = rb.iterator( intToRecord(4), intToRecord(8)) ;
-        same(iter, 4, 6 ) ;
+    @Test
+    public void recBufferIterate09() {
+        RecordBuffer rb = make(5, 5);
+        Iterator<Record> iter = rb.iterator(null, intToRecord(99));
+        same(iter, 2, 4, 6, 8, 10);
     }
 
-    @Test public void recBufferIterate11()
-    {
-        RecordBuffer rb = make(5,5) ;
-        Iterator<Record> iter = rb.iterator( intToRecord(3), intToRecord(9)) ;
-        same(iter, 4, 6, 8 ) ;
+    @Test
+    public void recBufferIterate10() {
+        RecordBuffer rb = make(5, 5);
+        Iterator<Record> iter = rb.iterator(intToRecord(4), intToRecord(8));
+        same(iter, 4, 6);
     }
-    
+
+    @Test
+    public void recBufferIterate11() {
+        RecordBuffer rb = make(5, 5);
+        Iterator<Record> iter = rb.iterator(intToRecord(3), intToRecord(9));
+        same(iter, 4, 6, 8);
+    }
+
     // ---- Support
-    private static void contains(RecordBuffer rb, int... vals)
-    {
-        assertEquals("Length mismatch: ", vals.length, rb.size()) ;
-        
+    private static void contains(RecordBuffer rb, int...vals) {
+        assertEquals(vals.length, rb.size(), "Length mismatch: ");
+
         for ( int i = 0 ; i < vals.length ; i++ )
             if ( vals[i] == -1 )
-                assertTrue(rb.isClear(i))  ;
-            else
-            {
-                Record r = RecordLib.intToRecord(vals[i]) ;
-                Record r2 = rb.get(i) ;
-                int x = RecordLib.recordToInt(r2) ;
-                assertEquals("Value mismatch: ", vals[i], x) ;
-            }
-    }
-    
-    private static void same(Iterator<Record> iter, int... vals)
-    {
-        List<Integer> list = RecordLib.toIntList(iter) ;
-        assertEquals("Length mismatch: ", vals.length, list.size()) ;
-        
-        for ( int i = 0 ; i < vals.length ; i++ )
-        {
-            int x = list.get(i) ;
-            assertEquals("Value mismatch: ", vals[i], x) ;
+                assertTrue(rb.isClear(i));
+            else {
+                Record r = RecordLib.intToRecord(vals[i]);
+                Record r2 = rb.get(i);
+                int x = RecordLib.recordToInt(r2);
+                assertEquals(vals[i], x, "Value mismatch: ");
             }
     }
 
-    
-    public int find(RecordBuffer rb, int v)
-    {
-        return rb.find(r(v)) ;
-    }
+    private static void same(Iterator<Record> iter, int...vals) {
+        List<Integer> list = RecordLib.toIntList(iter);
+        assertEquals(vals.length, list.size(), "Length mismatch: ");
 
-    private static RecordBuffer make(int n, int len)
-    { 
-        RecordBuffer rb = new RecordBuffer(recordFactory, len) ;
-        for ( int i = 0 ; i < n ; i++ )
-        {
-            Record r = RecordLib.intToRecord(2*i+2) ;  
-            rb.add(r) ;
+        for ( int i = 0 ; i < vals.length ; i++ ) {
+            int x = list.get(i);
+            assertEquals(vals[i], x, "Value mismatch: ");
         }
-        return rb ;
+    }
+
+    public int find(RecordBuffer rb, int v) {
+        return rb.find(r(v));
+    }
+
+    private static RecordBuffer make(int n, int len) {
+        RecordBuffer rb = new RecordBuffer(recordFactory, len);
+        for ( int i = 0 ; i < n ; i++ ) {
+            Record r = RecordLib.intToRecord(2 * i + 2);
+            rb.add(r);
+        }
+        return rb;
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/AbstractTestBlockAccessFixedSize.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/AbstractTestBlockAccessFixedSize.java
@@ -22,84 +22,79 @@
 package org.apache.jena.tdb1.base.file;
 
 import static org.apache.jena.tdb1.base.BufferTestLib.sameValue;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.tdb1.base.block.Block;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
 
-public abstract class AbstractTestBlockAccessFixedSize
-{
+public abstract class AbstractTestBlockAccessFixedSize {
     // Fixed block tests.
-    
-    int blkSize ;
-    
-    protected AbstractTestBlockAccessFixedSize(int blkSize)
-    {
-        this.blkSize = blkSize ;
-    }
-    
-    protected abstract BlockAccess make() ;
-    protected static Block data(BlockAccess file, int len)
-    {
-        Block b = file.allocate(len) ;
-        for (int i = 0 ; i < len ; i++ )
-            b.getByteBuffer().put((byte)(i&0xFF)) ;
-        return b ;
+
+    int blkSize;
+
+    protected AbstractTestBlockAccessFixedSize(int blkSize) {
+        this.blkSize = blkSize;
     }
 
-    private BlockAccess file ;
-    @Before public void before() { file = make() ; }
-    @After  public void after()  { file.close() ; }
+    protected abstract BlockAccess make();
 
-    @Test public void fileaccess_01()
-    {
-        assertTrue(file.isEmpty()) ;
-    }
-    
-    @Test public void fileaccess_02()
-    {
-        Block b = data(file, blkSize) ;
-        file.write(b) ;
+    protected static Block data(BlockAccess file, int len) {
+        Block b = file.allocate(len);
+        for ( int i = 0 ; i < len ; i++ )
+            b.getByteBuffer().put((byte)(i & 0xFF));
+        return b;
     }
 
-    @Test public void fileaccess_03()
-    {
-        Block b1 = data(file, blkSize) ;
-        file.write(b1) ;
-        long x = b1.getId() ;
-        Block b9 = file.read(x) ;
-        assertNotSame(b1, b9) ;
-        assertTrue(sameValue(b1, b9)) ;
-        b9 = file.read(x) ;
-        assertNotSame(b1, b9) ;
-        assertTrue(sameValue(b1, b9)) ;
+    private BlockAccess file;
+    @BeforeEach
+    public void before() {
+        file = make();
     }
-    
-    @Test public void fileaccess_04()
-    {
-        Block b1 = data(file, blkSize) ;
-        Block b2 = data(file, blkSize) ;
-        file.write(b1) ;
-        file.write(b2) ;
-        
-        long x = b1.getId() ;
-        Block b8 = file.read(b1.getId()) ;
-        Block b9 = file.read(b1.getId()) ;
-        assertNotSame(b8, b9) ;
-        assertTrue(b8.getId() == b9.getId()) ;
+
+    @AfterEach
+    public void after() {
+        file.close();
     }
-    
-    @Test(expected=FileException.class)
-    public void fileaccess_05()
-    {
-        Block b1 = data(file, 10) ;
-        Block b2 = data(file, 20) ;
-        file.write(b1) ;
-        
-        // Should not work. b2 not written.   
-        Block b2a = file.read(b2.getId()) ;
-    }    
+
+    @Test
+    public void fileaccess_01() {
+        assertTrue(file.isEmpty());
+    }
+
+    @Test
+    public void fileaccess_02() {
+        Block b = data(file, blkSize);
+        file.write(b);
+    }
+
+    @Test
+    public void fileaccess_03() {
+        Block b1 = data(file, blkSize);
+        file.write(b1);
+        long x = b1.getId();
+        Block b9 = file.read(x);
+        assertNotSame(b1, b9);
+        assertTrue(sameValue(b1, b9));
+        b9 = file.read(x);
+        assertNotSame(b1, b9);
+        assertTrue(sameValue(b1, b9));
+    }
+
+    @Test
+    public void fileaccess_04() {
+        Block b1 = data(file, blkSize);
+        Block b2 = data(file, blkSize);
+        file.write(b1);
+        file.write(b2);
+
+        long x = b1.getId();
+        Block b8 = file.read(b1.getId());
+        Block b9 = file.read(b1.getId());
+        assertNotSame(b8, b9);
+        assertTrue(b8.getId() == b9.getId());
+    }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/AbstractTestBlockAccessVarSize.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/AbstractTestBlockAccessVarSize.java
@@ -21,10 +21,10 @@
 
 package org.apache.jena.tdb1.base.file;
 
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.jena.tdb1.base.BufferTestLib.*;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import org.apache.jena.tdb1.base.block.Block;
 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/AbstractTestChannel.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/AbstractTestChannel.java
@@ -21,22 +21,22 @@
 
 package org.apache.jena.tdb1.base.file;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer ;
 
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractTestChannel
 {
     protected abstract BufferChannel open() ;
     
     private BufferChannel store ;
-    @Before public void before() { store = open() ; }
-    @After  public void after()  { store.close() ; }
+    @BeforeEach public void before() { store = open() ; }
+    @AfterEach  public void after()  { store.close() ; }
     
     static final int blkSize = 100 ;
     

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TS_File.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TS_File.java
@@ -21,11 +21,11 @@
 
 package org.apache.jena.tdb1.base.file;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestMetaFile.class
     , TestChannelMem.class
     , TestChannelFile.class

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestBlockAccessDirect.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestBlockAccessDirect.java
@@ -23,7 +23,7 @@ package org.apache.jena.tdb1.base.file;
 
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb1.ConfigTest;
-import org.junit.AfterClass ;
+import org.junit.jupiter.api.AfterAll;
 
 public class TestBlockAccessDirect extends AbstractTestBlockAccessFixedSize
 {
@@ -35,7 +35,7 @@ public class TestBlockAccessDirect extends AbstractTestBlockAccessFixedSize
         super(BlockSize) ;
     }
 
-    @AfterClass public static void cleanup() { FileOps.deleteSilent(filename) ; } 
+    @AfterAll public static void cleanup() { FileOps.deleteSilent(filename) ; } 
     
     @Override
     protected BlockAccess make()

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestBlockAccessMapped.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestBlockAccessMapped.java
@@ -23,7 +23,7 @@ package org.apache.jena.tdb1.base.file;
 
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb1.ConfigTest;
-import org.junit.AfterClass ;
+import org.junit.jupiter.api.AfterAll;
 
 public class TestBlockAccessMapped extends AbstractTestBlockAccessFixedSize
 {
@@ -35,7 +35,7 @@ public class TestBlockAccessMapped extends AbstractTestBlockAccessFixedSize
         super(BlockSize) ;
     }
 
-    @AfterClass public static void cleanup() { FileOps.deleteSilent(filename) ; } 
+    @AfterAll public static void cleanup() { FileOps.deleteSilent(filename) ; } 
     
     static int counter = 0 ;
     

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestChannelFile.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestChannelFile.java
@@ -23,13 +23,13 @@ package org.apache.jena.tdb1.base.file;
 
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb1.ConfigTest;
-import org.junit.AfterClass ;
+import org.junit.jupiter.api.AfterAll;
 
 public class TestChannelFile extends AbstractTestChannel
 {
     static String filename = ConfigTest.getTestingDir()+"/test-storage" ;
 
-    @AfterClass public static void cleanup() { FileOps.deleteSilent(filename) ; } 
+    @AfterAll public static void cleanup() { FileOps.deleteSilent(filename) ; } 
     
     @Override
     protected BufferChannel open()

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestLocationLock.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestLocationLock.java
@@ -21,19 +21,24 @@
 
 package org.apache.jena.tdb1.base.file;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.jena.tdb1.TDB1Exception;
 import org.apache.jena.tdb1.sys.ProcessUtils;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 /**
  * Tests for {@link LocationLock}
@@ -42,10 +47,10 @@ public class TestLocationLock {
 
     private static boolean negativePidsTreatedAsAlive = false;
 
-    @Rule
-    public TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir
+    public Path tempDir;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         negativePidsTreatedAsAlive = ProcessUtils.negativePidsTreatedAsAlive();
     }
@@ -54,111 +59,111 @@ public class TestLocationLock {
     public void location_lock_mem() {
         Location mem = Location.mem();
         LocationLock lock = mem.getLock();
-        Assert.assertFalse(lock.canLock());
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertFalse(lock.canObtain());
+        assertFalse(lock.canLock());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertFalse(lock.canObtain());
     }
 
     @Test
     public void location_lock_dir_01() {
-        Location dir = Location.create(tempDir.getRoot().getAbsolutePath());
+        Location dir = Location.create(tempDir.toAbsolutePath().toString());
         LocationLock lock = dir.getLock();
-        Assert.assertTrue(lock.canLock());
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertTrue(lock.canObtain());
+        assertTrue(lock.canLock());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertTrue(lock.canObtain());
 
         // Try to obtain the lock
         lock.obtain();
-        Assert.assertTrue(lock.isLocked());
-        Assert.assertTrue(lock.isOwned());
+        assertTrue(lock.isLocked());
+        assertTrue(lock.isOwned());
 
         // Release the lock
         lock.release();
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
     }
 
     @Test
     public void location_lock_dir_02() throws IOException {
-        Assume.assumeTrue(negativePidsTreatedAsAlive);
+        assumeTrue(negativePidsTreatedAsAlive);
 
-        Location dir = Location.create(tempDir.getRoot().getAbsolutePath());
+        Location dir = Location.create(tempDir.toAbsolutePath().toString());
         LocationLock lock = dir.getLock();
-        Assert.assertTrue(lock.canLock());
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertTrue(lock.canObtain());
+        assertTrue(lock.canLock());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertTrue(lock.canObtain());
 
         // Write a fake PID to the lock file
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(dir.getPath("tdb.lock"), StandardCharsets.UTF_8))) {
             writer.write(Integer.toString(-1234)); // Fake PID that would never
                                                    // be valid
         }
-        Assert.assertTrue(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertFalse(lock.canObtain());
+        assertTrue(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertFalse(lock.canObtain());
     }
 
-    @Test(expected = TDB1Exception.class)
+    @Test
     public void location_lock_dir_error_01() throws IOException {
-        Assume.assumeTrue(negativePidsTreatedAsAlive);
+        assumeTrue(negativePidsTreatedAsAlive);
 
-        Location dir = Location.create(tempDir.getRoot().getAbsolutePath());
+        Location dir = Location.create(tempDir.toAbsolutePath().toString());
         LocationLock lock = dir.getLock();
-        Assert.assertTrue(lock.canLock());
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertTrue(lock.canObtain());
+        assertTrue(lock.canLock());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertTrue(lock.canObtain());
 
         // Write a fake PID to the lock file
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(dir.getPath("tdb.lock"), StandardCharsets.UTF_8))) {
             // Fake PID that would never be valid
             writer.write(Integer.toString(-1234));
         }
-        Assert.assertTrue(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
+        assertTrue(lock.isLocked());
+        assertFalse(lock.isOwned());
 
         // Attempting to obtain the lock should now error
-        Assert.assertFalse(lock.canObtain());
-        lock.obtain();
+        assertFalse(lock.canObtain());
+        assertThrows(TDB1Exception.class, ()->lock.obtain());
     }
 
-    @Test(expected = TDB1Exception.class)
+    @Test
     public void location_lock_dir_error_02() throws IOException {
-        Assume.assumeTrue(negativePidsTreatedAsAlive);
+        assumeTrue(negativePidsTreatedAsAlive);
 
-        Location dir = Location.create(tempDir.getRoot().getAbsolutePath());
+        Location dir = Location.create(tempDir.toAbsolutePath().toString());
         LocationLock lock = dir.getLock();
-        Assert.assertTrue(lock.canLock());
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertTrue(lock.canObtain());
+        assertTrue(lock.canLock());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertTrue(lock.canObtain());
 
         // Write a fake PID to the lock file
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(dir.getPath("tdb.lock"), StandardCharsets.UTF_8))) {
             // Fake PID that would never be valid
             writer.write(Integer.toString(-1234));
         }
-        Assert.assertTrue(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
+        assertTrue(lock.isLocked());
+        assertFalse(lock.isOwned());
 
         // Attempting to release a lock we don't own should error
-        Assert.assertFalse(lock.canObtain());
-        lock.release();
+        assertFalse(lock.canObtain());
+        assertThrows(TDB1Exception.class, ()->lock.release());
     }
 
     @Test
     public void location_lock_dir_error_03() throws IOException {
-        Assume.assumeTrue(negativePidsTreatedAsAlive);
+        assumeTrue(negativePidsTreatedAsAlive);
 
-        Location dir = Location.create(tempDir.getRoot().getAbsolutePath());
+        Location dir = Location.create(tempDir.toAbsolutePath().toString());
         LocationLock lock = dir.getLock();
-        Assert.assertTrue(lock.canLock());
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertTrue(lock.canObtain());
+        assertTrue(lock.canLock());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertTrue(lock.canObtain());
 
         // Write a TDB1 format lock file
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(dir.getPath("tdb.lock"), StandardCharsets.UTF_8))) {
@@ -168,13 +173,9 @@ public class TestLocationLock {
         }
 
         // Trying to get the owner should error accordingly
-        try {
-            lock.canObtain();
-            Assert.fail("Expected the lock file to be considered invalid");
-        } catch (FileException e) {
-            String errMsg = e.getMessage();
-            Assert.assertNotNull(errMsg);
-            Assert.assertTrue(errMsg.contains("appear to be for a TDB2 database"));
-        }
+        FileException e = assertThrows(FileException.class, ()->lock.canObtain());
+        String errMsg = e.getMessage();
+        assertNotNull(errMsg);
+        assertTrue(errMsg.contains("appear to be for a TDB2 database"));
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestMetaFile.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/file/TestMetaFile.java
@@ -21,25 +21,25 @@
 
 package org.apache.jena.tdb1.base.file;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File ;
 
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.sys.Names;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestMetaFile
 {
     String testfile = null ;
     String testfileMeta = null ;
     
-    @Before public void before()
+    @BeforeEach public void before()
     {
         testfile = ConfigTest.getTestingDir()+"/file" ;
         testfileMeta = ConfigTest.getTestingDir()+"/file."+Names.extMeta ;
@@ -70,7 +70,7 @@ public class TestMetaFile
 
     // Test MetaBase
     
-    @After public void afterClass()
+    @AfterEach public void afterClass()
     { clear() ; }
     
     private void clear()

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/AbstractTestObjectFile.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/AbstractTestObjectFile.java
@@ -22,23 +22,23 @@
 package org.apache.jena.tdb1.base.objectfile;
 
 import static org.apache.jena.tdb1.base.BufferTestLib.sameValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer ;
 
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractTestObjectFile
 {
     ObjectFile file ;
 
-    @Before public void before() { file = make() ; }
-    @After public void after() { release(file); }
+    @BeforeEach public void before() { file = make() ; }
+    @AfterEach public void after() { release(file); }
 
     // Test 02 and 04 were for alloc-write.
     

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/AbstractTestStringFile.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/AbstractTestStringFile.java
@@ -21,129 +21,135 @@
 
 package org.apache.jena.tdb1.base.objectfile;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public abstract class AbstractTestStringFile
-{
-    StringFile f = null ;
-    
-    @Before public void setup() { f = createStringFile() ; }
-    @After public void teardown() { removeStringFile(f) ; }
-    
-    protected abstract StringFile createStringFile() ;
-    protected abstract void removeStringFile(StringFile f) ;
+public abstract class AbstractTestStringFile {
+    StringFile f = null;
 
-    @Test public void object_file_01()
-    {
-        String x1 = "abc" ;
-        long id1 = f.write(x1) ;
-        test(id1, x1) ;
-        test(0, x1) ;
+    @BeforeEach
+    public void setup() {
+        f = createStringFile();
     }
 
-    @Test public void object_file_02()
-    {
-        String x1 = "" ;
-        
-        long id1 = f.write(x1) ;
-        test(id1, x1) ;
-        test(0, x1) ;
+    @AfterEach
+    public void teardown() {
+        removeStringFile(f);
     }
 
-    @Test public void object_file_03()
-    {
-        String x1 = "abbbbbbc" ;
-        String x2 = "deeeef" ;
-        
-        long id1 = f.write(x1) ;
-        long id2 = f.write(x2) ;
-        
-        assertNotEquals("Node Ids", id1, id2) ;
-        
-        test(id1, x1) ;
-        test(id2, x2) ;
-        test(0, x1) ;
+    protected abstract StringFile createStringFile();
+
+    protected abstract void removeStringFile(StringFile f);
+
+    @Test
+    public void object_file_01() {
+        String x1 = "abc";
+        long id1 = f.write(x1);
+        test(id1, x1);
+        test(0, x1);
     }
-    
-    @Test public void object_file_04()
-    {
-        String x1 = "abbbbbbc" ;
-        String x2 = "deeeef" ;
-        
-        long id1 = f.write(x1) ;
-        long id2 = f.write(x2) ;
+
+    @Test
+    public void object_file_02() {
+        String x1 = "";
+
+        long id1 = f.write(x1);
+        test(id1, x1);
+        test(0, x1);
+    }
+
+    @Test
+    public void object_file_03() {
+        String x1 = "abbbbbbc";
+        String x2 = "deeeef";
+
+        long id1 = f.write(x1);
+        long id2 = f.write(x2);
+
+        assertNotEquals(id1, id2, "Node Ids");
+
+        test(id1, x1);
+        test(id2, x2);
+        test(0, x1);
+    }
+
+    @Test
+    public void object_file_04() {
+        String x1 = "abbbbbbc";
+        String x2 = "deeeef";
+
+        long id1 = f.write(x1);
+        long id2 = f.write(x2);
         // Read in opposite order
-        test(id2, x2) ;
-        test(id1, x1) ;
+        test(id2, x2);
+        test(id1, x1);
     }
 
-    @Test public void object_file_05()
-    {
-        String x = "孫子兵法" ;
-        
-        long id = f.write(x) ;
-        test(0, x) ;
+    @Test
+    public void object_file_05() {
+        String x = "孫子兵法";
+
+        long id = f.write(x);
+        test(0, x);
     }
-    
-    @Test public void object_file_06()
-    {
-        String x1 = "abbbbbbc" ;
-        String x2 = "孫子兵法" ;
-        
-        long id1 = f.write(x1) ;
-        f.flush() ;
-        long id2 = f.write(x2) ;
+
+    @Test
+    public void object_file_06() {
+        String x1 = "abbbbbbc";
+        String x2 = "孫子兵法";
+
+        long id1 = f.write(x1);
+        f.flush();
+        long id2 = f.write(x2);
         // No flush.
-       
-        assertNotEquals("Node Ids", id1, id2) ;
-        String z = f.read(id2) ;
-        
-        test(id2, x2) ;
-        test(id1, x1) ;
-        test(0, x1) ;
-    }
-    
-    @Test public void object_file_07()
-    {
-        String x1 = "abbbbbbc" ;
-        String x2 = "孫子兵法" ;
-        
-        long id1 = f.write(x1) ;
-        long id2 = f.write(x2) ;
-        f.flush() ;
-        
-        assertNotEquals("Node Ids", id1, id2) ;
-        
-        test(id2, x2) ;
-        test(id1, x1) ;
-        test(0, x1) ;
+
+        assertNotEquals(id1, id2, "Node Ids");
+        String z = f.read(id2);
+
+        test(id2, x2);
+        test(id1, x1);
+        test(0, x1);
     }
 
-    @Test public void object_file_08()
-    {
-        String x1 = "abbbbbbc" ;
-        String x2 = "孫子兵法" ;
-        
-        long id1 = f.write(x1) ;
-        f.flush() ;
-        long id2 = f.write(x2) ;
-        f.flush() ;
-        
-        assertNotEquals("Node Ids", id1, id2) ;
-        
-        test(id2, x2) ;
-        test(id1, x1) ;
-        test(0, x1) ;
+    @Test
+    public void object_file_07() {
+        String x1 = "abbbbbbc";
+        String x2 = "孫子兵法";
+
+        long id1 = f.write(x1);
+        long id2 = f.write(x2);
+        f.flush();
+
+        assertNotEquals(id1, id2, "Node Ids");
+
+        test(id2, x2);
+        test(id1, x1);
+        test(0, x1);
     }
 
-    private void test(long id, String x)
-    {
-        String y = f.read(id) ;
-        assertEquals(x, y) ;
+    @Test
+    public void object_file_08() {
+        String x1 = "abbbbbbc";
+        String x2 = "孫子兵法";
+
+        long id1 = f.write(x1);
+        f.flush();
+        long id2 = f.write(x2);
+        f.flush();
+
+        assertNotEquals(id1, id2, "Node Ids");
+
+        test(id2, x2);
+        test(id1, x1);
+        test(0, x1);
+    }
+
+    private void test(long id, String x) {
+        String y = f.read(id);
+        assertEquals(x, y);
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/TS_ObjectFile.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/TS_ObjectFile.java
@@ -21,15 +21,15 @@
 
 package org.apache.jena.tdb1.base.objectfile;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestObjectFileMem.class
     , TestObjectFileDisk.class
     , TestObjectFileBuffering.class
-    , TestStringFileMem.class 
+    , TestStringFileMem.class
     , TestStringFileDisk.class
 })
 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/TestObjectFileBuffering.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/TestObjectFileBuffering.java
@@ -23,13 +23,13 @@ package org.apache.jena.tdb1.base.objectfile;
 
 import static org.apache.jena.tdb1.base.BufferTestLib.sameValue;
 import static org.apache.jena.tdb1.base.objectfile.AbstractTestObjectFile.fill;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 import java.nio.ByteBuffer ;
 
 import org.apache.jena.tdb1.base.file.BufferChannel;
 import org.apache.jena.tdb1.base.file.BufferChannelMem;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 public class TestObjectFileBuffering
 {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/TestObjectFileDisk.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/objectfile/TestObjectFileDisk.java
@@ -25,13 +25,13 @@ import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.base.file.BufferChannel;
 import org.apache.jena.tdb1.base.file.BufferChannelFile;
-import org.junit.AfterClass ;
+import org.junit.jupiter.api.AfterAll;
 
 public class TestObjectFileDisk extends AbstractTestObjectFile
 {
     static String filename = ConfigTest.getTestingDir()+"/test-objectfile" ;
 
-    @AfterClass public static void cleanup() { FileOps.deleteSilent(filename) ; } 
+    @AfterAll public static void cleanup() { FileOps.deleteSilent(filename) ; } 
     
     @Override
     protected ObjectFile make()

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/record/TS_Record.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/record/TS_Record.java
@@ -21,16 +21,18 @@
 
 package org.apache.jena.tdb1.base.record;
 
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
 import org.apache.jena.tdb1.base.buffer.TestPtrBuffer;
 import org.apache.jena.tdb1.base.buffer.TestRecordBuffer;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
+
     TestRecord.class ,
     TestPtrBuffer.class ,
-    TestRecordBuffer.class 
+    TestRecordBuffer.class
 })
 
 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/record/TestRecord.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/record/TestRecord.java
@@ -23,11 +23,11 @@ package org.apache.jena.tdb1.base.record;
 
 import static org.apache.jena.tdb1.base.record.RecordLib.intToRecord;
 import static org.apache.jena.tdb1.base.record.RecordLib.recordToInt;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestRecord
 {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/recordfile/TS_RecordFile.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/recordfile/TS_RecordFile.java
@@ -21,15 +21,10 @@
 
 package org.apache.jena.tdb1.base.recordfile;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
-    TestRecordBufferPage.class
-})
+@Suite
+@SelectClasses({TestRecordBufferPage.class})
 
-public class TS_RecordFile
-{
-
-}
+public class TS_RecordFile {}

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/recordfile/TestRecordBufferPage.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/base/recordfile/TestRecordBufferPage.java
@@ -21,7 +21,7 @@
 
 package org.apache.jena.tdb1.base.recordfile;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.jena.tdb1.base.block.BlockMgr;
 import org.apache.jena.tdb1.base.block.BlockMgrFactory;
@@ -31,9 +31,9 @@ import org.apache.jena.tdb1.base.record.RecordFactory;
 import org.apache.jena.tdb1.base.recordbuffer.RecordBufferPage;
 import org.apache.jena.tdb1.base.recordbuffer.RecordBufferPageMgr;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestRecordBufferPage
 {
@@ -44,13 +44,13 @@ public class TestRecordBufferPage
     static RecordFactory factory = new RecordFactory(2, 0) ; 
     
     static boolean originalNullOut ; 
-    @BeforeClass static public void beforeClass()
+    @BeforeAll static public void beforeClass()
     {
         originalNullOut = SystemTDB.NullOut ;
         SystemTDB.NullOut = true ;    
     }
     
-    @AfterClass static public void afterClass()
+    @AfterAll static public void afterClass()
     {
         SystemTDB.NullOut = originalNullOut ;    
     }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/AbstractTestGraphsTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/AbstractTestGraphsTDB1.java
@@ -27,21 +27,21 @@ import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation ;
 import org.apache.jena.sparql.graph.GraphsTests ;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 @SuppressWarnings("removal")
 public abstract class AbstractTestGraphsTDB1 extends GraphsTests
 {
     private static ReorderTransformation reorder  ;
 
-    @BeforeClass public static void setupClass()
+    @BeforeAll public static void setupClass()
     {
         reorder = SystemTDB.defaultReorderTransform ;
         SystemTDB.defaultReorderTransform = ReorderLib.identity() ;
     }
 
-    @AfterClass public static void afterClass() {  SystemTDB.defaultReorderTransform = reorder ; }
+    @AfterAll public static void afterClass() {  SystemTDB.defaultReorderTransform = reorder ; }
 
     @Override
     protected Dataset createDataset()

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/TS_GraphTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/TS_GraphTDB1.java
@@ -21,11 +21,11 @@
 
 package org.apache.jena.tdb1.graph;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestPrefixMapTDB1.class
     , TestPrefixMappingTDB1.class
     , TestDatasetGraphTDB1.class
@@ -33,7 +33,4 @@ import org.junit.runners.Suite ;
     , TestGraphsTDB1_insideTxn.class
     , TestGraphOverDatasetTDB1.class
 })
-public class TS_GraphTDB1
-{
-
-}
+public class TS_GraphTDB1 {}

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/TestGraphsTDB1_insideTxn.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/TestGraphsTDB1_insideTxn.java
@@ -22,17 +22,17 @@
 package org.apache.jena.tdb1.graph;
 
 import org.apache.jena.query.ReadWrite ;
-import org.junit.After ;
-import org.junit.Before ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TestGraphsTDB1_insideTxn extends AbstractTestGraphsTDB1
 {
-    @Before public void before() 
+    @BeforeEach public void before() 
     {
         getDataset().begin(ReadWrite.READ) ;
     }
 
-    @After public void after() 
+    @AfterEach public void after() 
     {
         getDataset().end() ;
     }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/TestGraphsTDB1_nonTxn.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/TestGraphsTDB1_nonTxn.java
@@ -21,17 +21,17 @@
 
 package org.apache.jena.tdb1.graph;
 
-import org.junit.After ;
-import org.junit.Before ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TestGraphsTDB1_nonTxn extends AbstractTestGraphsTDB1
 {
     // Non-transactional.
-    @Before public void before()
+    @BeforeEach public void before()
     {
     }
 
-    @After public void after()
+    @AfterEach public void after()
     {
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/TestPrefixMappingTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/graph/TestPrefixMappingTDB1.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.tdb1.graph;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map ;
 
@@ -42,18 +42,18 @@ import org.apache.jena.tdb1.sys.DatasetControl;
 import org.apache.jena.tdb1.sys.DatasetControlMRSW;
 import org.apache.jena.tdb1.sys.SystemTDB;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.* ;
+import  org.junit.jupiter.api.*;
 
 @SuppressWarnings("removal")
 public class TestPrefixMappingTDB1 extends AbstractTestPrefixMappingView
 {
     static DatasetPrefixesTDB last = null ;
 
-    @BeforeClass public static void beforeClass() {}
-    @AfterClass public static void afterClass()   { TDBInternal.reset() ; ConfigTest.deleteTestingDir() ; }
+    @BeforeAll public static void beforeClass() {}
+    @AfterAll public static void afterClass()   { TDBInternal.reset() ; ConfigTest.deleteTestingDir() ; }
 
-    @Before public void before() { TDBInternal.reset() ; create(); }
-    @After public  void after()  { }
+    @BeforeEach public void before() { TDBInternal.reset() ; create(); }
+    @AfterEach public  void after()  { }
 
     @Override
     protected PrefixMapping create() {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/AbstractTestIndex.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/AbstractTestIndex.java
@@ -23,20 +23,20 @@ package org.apache.jena.tdb1.index;
 
 import static org.apache.jena.tdb1.base.record.RecordLib.intToRecord;
 import static org.apache.jena.tdb1.index.IndexTestLib.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.jena.tdb1.base.record.Record;
 import org.apache.jena.tdb1.base.record.RecordLib;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractTestIndex 
 {
     Index index = null ;
     
-    @After public void afterTest()
+    @AfterEach public void afterTest()
     { 
         if ( index != null )
             index.close();

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/AbstractTestRangeIndex.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/AbstractTestRangeIndex.java
@@ -27,22 +27,21 @@ import static org.apache.jena.tdb1.index.IndexTestLib.add;
 import static org.apache.jena.tdb1.index.IndexTestLib.randTest;
 import static org.apache.jena.tdb1.index.IndexTestLib.testInsert;
 import static org.apache.jena.tdb1.index.IndexTestLib.testInsertDelete;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List ;
 
 import org.apache.jena.tdb1.base.record.RecordLib;
-import org.junit.After ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractTestRangeIndex {
     private RangeIndex rIndex = null ;
 
-    @After
-    public void afterTest() {
+    @AfterEach     public void afterTest() {
         if ( rIndex != null )
             rIndex.close() ;
         rIndex = null ;

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/IndexTestLib.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/IndexTestLib.java
@@ -21,206 +21,176 @@
 
 package org.apache.jena.tdb1.index;
 
-import static java.lang.String.format ;
-import static org.apache.jena.atlas.lib.ListUtils.asList ;
-import static org.apache.jena.atlas.lib.ListUtils.unique ;
-import static org.apache.jena.atlas.lib.RandomLib.random ;
-import static org.apache.jena.atlas.test.Gen.permute ;
-import static org.apache.jena.atlas.test.Gen.rand ;
-import static org.apache.jena.atlas.test.Gen.strings ;
+import static java.lang.String.format;
+import static org.apache.jena.atlas.lib.ListUtils.asList;
+import static org.apache.jena.atlas.lib.ListUtils.unique;
+import static org.apache.jena.atlas.lib.RandomLib.random;
+import static org.apache.jena.atlas.test.Gen.permute;
+import static org.apache.jena.atlas.test.Gen.rand;
+import static org.apache.jena.atlas.test.Gen.strings;
 import static org.apache.jena.tdb1.base.record.RecordLib.intToRecord;
 import static org.apache.jena.tdb1.base.record.RecordLib.r;
 import static org.apache.jena.tdb1.base.record.RecordLib.toIntList;
-import static org.junit.Assert.assertEquals ;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull ;
-import static org.junit.Assert.fail ;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.ArrayList ;
-import java.util.List ;
-import java.util.SortedSet ;
-import java.util.TreeSet ;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.jena.tdb1.base.record.Record;
 import org.apache.jena.tdb1.base.record.RecordLib;
 
-public class IndexTestLib
-{
+public class IndexTestLib {
 
     // ---------- Utilities
 
-//    public static RangeIndex buildRangeIndex(RangeIndexMaker maker, int[] keys)
-//    {
-//        RangeIndex index = maker.make() ;
-//        IndexTestLib.add(index, keys) ;
-//        return index ;
-//    }
-
-    public static Index buildIndex(IndexMaker maker, int[] keys)
-    {
-        Index index = maker.makeIndex() ;
-        IndexTestLib.add(index, keys) ;
-        return index ;
+    public static Index buildIndex(IndexMaker maker, int[] keys) {
+        Index index = maker.makeIndex();
+        IndexTestLib.add(index, keys);
+        return index;
     }
 
-
-    public static void testIteration(RangeIndex index, int[] keys, int numIterations)
-    {
+    public static void testIteration(RangeIndex index, int[] keys, int numIterations) {
         // Shared across test-lets
-        SortedSet<Integer> x = new TreeSet<>() ;
+        SortedSet<Integer> x = new TreeSet<>();
         for ( int v : keys )
-            x.add(v) ;
+            x.add(v);
 
-        for ( int i = 0 ; i < numIterations ; i++ )
-        {
-            int lo = random.nextInt(keys.length) ;
-            int hi = random.nextInt(keys.length) ;
-            if ( lo > hi )
-            {
-                int t = lo ;
-                lo = hi ;
-                hi = t ;
+        for ( int i = 0 ; i < numIterations ; i++ ) {
+            int lo = random.nextInt(keys.length);
+            int hi = random.nextInt(keys.length);
+            if ( lo > hi ) {
+                int t = lo;
+                lo = hi;
+                hi = t;
             }
             // Does not consider nulls - assumed to be part of functional testing.
             // Tweak lo and hi
             if ( lo != 0 && random.nextFloat() < 0.5 )
-                lo-- ;  // Negatives confuse the int/record code.
+                lo--;  // Negatives confuse the int/record code.
             if ( random.nextFloat() < 0.5 )
-                hi++ ;
+                hi++;
 
-            List<Integer> slice = r(index.iterator(r(lo), r(hi))) ;
-            List<Integer> expected = new ArrayList<>(keys.length) ;
+            List<Integer> slice = r(index.iterator(r(lo), r(hi)));
+            List<Integer> expected = new ArrayList<>(keys.length);
             for ( Integer ii : x.subSet(lo, hi) )
-                expected.add(ii) ;
-            assertEquals(format("(%d,%d)",lo, hi), expected, slice) ;
+                expected.add(ii);
+            assertEquals(expected, slice, format("(%d,%d)", lo, hi));
         }
     }
 
     /* One random test : print the keys if there was a problem */
 
-    public static void randTest(Index index, int maxValue, int numKeys)
-    {
+    public static void randTest(Index index, int maxValue, int numKeys) {
         if ( numKeys >= 5000 )
-            System.err.printf("Warning: too many keys\n") ;
+            System.err.printf("Warning: too many keys\n");
 
-        int[] keys1 = rand(numKeys, 0, maxValue) ;
-        int[] keys2 = permute(keys1) ;
+        int[] keys1 = rand(numKeys, 0, maxValue);
+        int[] keys2 = permute(keys1);
         try {
             testInsert(index, keys1);
-            if ( true )
-            {
+            if ( true ) {
                 // Checking tests.
                 testIndexContents(index, keys2);
                 // Test iteration - quite expensive.
                 if ( index instanceof RangeIndex rIdx )
-                    testIteration(rIdx, keys1, 10) ;
+                    testIteration(rIdx, keys1, 10);
             }
-            testDelete(index, keys2) ;
-            index.close() ;
-        } catch (RuntimeException ex)
-        {
-            System.err.printf("Index : %s\n", index.getClass().getName()) ;
-            System.err.printf("int[] keys1 = {%s} ;\n", strings(keys1)) ;
-            System.err.printf("int[] keys2 = {%s}; \n", strings(keys2)) ;
-            throw ex ;
+            testDelete(index, keys2);
+            index.close();
+        } catch (RuntimeException ex) {
+            System.err.printf("Index : %s\n", index.getClass().getName());
+            System.err.printf("int[] keys1 = {%s} ;\n", strings(keys1));
+            System.err.printf("int[] keys2 = {%s}; \n", strings(keys2));
+            throw ex;
         }
     }
 
     // ---- Test utils
 
-    public static void testInsert(Index index, int[] keys)
-    {
-        IndexTestLib.add(index, keys) ;
+    public static void testInsert(Index index, int[] keys) {
+        IndexTestLib.add(index, keys);
         testIndexContents(index, keys);
     }
 
-    public static Index testInsert(IndexMaker maker, int[] keys)
-    {
-        Index index = maker.makeIndex() ;
+    public static Index testInsert(IndexMaker maker, int[] keys) {
+        Index index = maker.makeIndex();
         testInsert(index, keys);
-        return index ;
+        return index;
     }
 
-    public static void testInsertDelete(Index index, int[] buildKeys, int[] deleteKeys)
-    {
-        testInsert(index, buildKeys) ;
-        testDelete(index, deleteKeys) ;
+    public static void testInsertDelete(Index index, int[] buildKeys, int[] deleteKeys) {
+        testInsert(index, buildKeys);
+        testDelete(index, deleteKeys);
     }
 
-    public static void testDelete(Index index, int[] vals)
-    {
-        long size1 = index.size() ;
+    public static void testDelete(Index index, int[] vals) {
+        long size1 = index.size();
 
-        int count = 0 ;
-        count = delete(index, vals) ;
+        int count = 0;
+        count = delete(index, vals);
 
-        List<Record> x =  intToRecord(vals, RecordLib.TestRecordLength) ;
-        for ( Record r : x )
-        {
-            boolean b = index.delete(r) ;
+        List<Record> x = intToRecord(vals, RecordLib.TestRecordLength);
+        for ( Record r : x ) {
+            boolean b = index.delete(r);
             if ( b )
-                count ++ ;
+                count++;
         }
 
         for ( Record r : x )
-            assertFalse(index.contains(r)) ;
-        long size2 = index.size() ;
+            assertFalse(index.contains(r));
+        long size2 = index.size();
 
-        assertEquals(size1-count, size2) ;
+        assertEquals(size1 - count, size2);
     }
 
-    public static int delete(Index index, int[] vals)
-    {
-        int count = 0 ;
-        for ( int v : vals )
-        {
-            boolean b = index.delete(r(v)) ;
+    public static int delete(Index index, int[] vals) {
+        int count = 0;
+        for ( int v : vals ) {
+            boolean b = index.delete(r(v));
             if ( b )
-                count ++ ;
+                count++;
         }
-        return count ;
+        return count;
     }
 
-    public static void add(Index index, int[] vals)
-    {
-        //System.out.println("Add: "+Arrays.toString(vals)) ;
-        List<Record> x = intToRecord(vals, RecordLib.TestRecordLength) ;
-        for ( Record r : x )
-        {
-            //System.out.println("  Add: "+r) ;
-            index.add(r) ;
+    public static void add(Index index, int[] vals) {
+        // System.out.println("Add: "+Arrays.toString(vals)) ;
+        List<Record> x = intToRecord(vals, RecordLib.TestRecordLength);
+        for ( Record r : x ) {
+            // System.out.println(" Add: "+r) ;
+            index.add(r);
         }
     }
 
-    public static void testIndexContents(Index index, int[] records)
-    {
+    public static void testIndexContents(Index index, int[] records) {
         List<Integer> x = toIntList(index.iterator());
 
-        // Make a unique list of expected records.  Remove duplicates
-        List<Integer> y = unique(asList(records)) ;
+        // Make a unique list of expected records. Remove duplicates
+        List<Integer> y = unique(asList(records));
 
-        assertEquals("Expected records size and tree size different", y.size(), index.size()) ;
-        assertEquals("Expected records size and iteration over all keys are of different sizes", y.size(), x.size()) ;
+        assertEquals(y.size(), index.size(), "Expected records size and tree size different");
+        assertEquals(y.size(), x.size(), "Expected records size and iteration over all keys are of different sizes");
 
-        if ( index instanceof RangeIndex )
-        {
+        if ( index instanceof RangeIndex ) {
             // Check sorted order
-            for ( int i = 0 ; i < x.size()-2 ; i++ )
-            {
-                if ( x.get(i) > x.get(i+1) )
-                {
-                    fail("check failed: "+strings(records)) ;
-                    return ;
+            for ( int i = 0 ; i < x.size() - 2 ; i++ ) {
+                if ( x.get(i) > x.get(i + 1) ) {
+                    fail("check failed: " + strings(records));
+                    return;
                 }
             }
         }
 
         // Check each expected record is in the tree
-        for ( int k : y)
-        {
-            Record rec = intToRecord(k) ;
-            Record r2 = index.find(rec) ;
-            assertNotNull("Finding "+rec, r2) ;
+        for ( int k : y ) {
+            Record rec = intToRecord(k);
+            Record r2 = index.find(rec);
+            assertNotNull(r2, "Finding " + rec);
         }
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/TS_Index.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/TS_Index.java
@@ -21,23 +21,23 @@
 
 package org.apache.jena.tdb1.index;
 
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
 import org.apache.jena.tdb1.index.bplustree.TestBPTreeRecords;
 import org.apache.jena.tdb1.index.bplustree.TestBPlusTree;
 import org.apache.jena.tdb1.index.bplustree.TestBPlusTreeRewriter;
 import org.apache.jena.tdb1.index.ext.TestExtHash;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
-
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestBPlusTree.class,
     TestBPTreeRecords.class,
     TestBPlusTreeRewriter.class,
-    
+
     TestExtHash.class,
     TestIndexMem.class
-    
+
 } )
 
 public class TS_Index

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/bplustree/TestBPTreeRecords.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/bplustree/TestBPTreeRecords.java
@@ -21,10 +21,10 @@
 
 package org.apache.jena.tdb1.index.bplustree;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.jena.tdb1.base.block.BlockMgr;
 import org.apache.jena.tdb1.base.block.BlockMgrFactory;
@@ -35,49 +35,49 @@ import org.apache.jena.tdb1.base.record.RecordLib;
 import org.apache.jena.tdb1.base.recordbuffer.RecordBufferPage;
 import org.apache.jena.tdb1.base.recordbuffer.RecordBufferPageMgr;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.After ;
-import org.junit.AfterClass;
-import org.junit.Before ;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestBPTreeRecords
 {
     static private boolean oldNullOut ;
     static private boolean oldCheckingNode ;
     static private boolean oldCheckingBTree ;
-    
+
     static private int blockSize ;
     static private RecordFactory recordFactory ;
-    
+
     static private int bufSizeRecord ;
     static private BlockMgr blkMgrRecords  ;
     static private RecordBufferPageMgr recordBufferPageMgr  ;
     static private BPlusTree bPlusTree ;
-    
-    @BeforeClass public static void beforeClass()
+
+    @BeforeAll public static void beforeClass()
     {
         oldNullOut = SystemTDB.NullOut ;
         SystemTDB.NullOut = true ;
-        
+
         oldCheckingNode = BPlusTreeParams.CheckingNode ;
         BPlusTreeParams.CheckingNode = true ;
-        
+
         oldCheckingBTree = BPlusTreeParams.CheckingTree ;
         BPlusTreeParams.CheckingTree = true ;
-        
+
         blockSize =  4*8 ;  // Which is 6 int records
         recordFactory = new RecordFactory(4, 0) ;
-        
+
         bufSizeRecord = RecordBufferPage.calcRecordSize(recordFactory, blockSize) ;
         blkMgrRecords = BlockMgrFactory.createMem("BPTreeRecords", blockSize) ;
         recordBufferPageMgr = new RecordBufferPageMgr(recordFactory, blkMgrRecords) ;
-        
+
         // B+Tree order does not matter.
         bPlusTree = BPlusTree.attach(new BPlusTreeParams(3, recordFactory), null, blkMgrRecords) ;
     }
-    
-    @AfterClass public static void afterClass()
+
+    @AfterAll public static void afterClass()
     {
         SystemTDB.NullOut = oldNullOut ;
         BPlusTreeParams.CheckingTree = oldCheckingNode ;
@@ -91,10 +91,10 @@ public class TestBPTreeRecords
         check(bpr) ;
         bpr.release() ;
     }
-    
-    @Before public void before() { blkMgrRecords.beginUpdate() ; }
-    @After public void after() { blkMgrRecords.endUpdate() ; }
-    
+
+    @BeforeEach public void before() { blkMgrRecords.beginUpdate() ; }
+    @AfterEach public void after() { blkMgrRecords.endUpdate() ; }
+
 
     @Test public void bpt_records_2()
     {
@@ -119,7 +119,7 @@ public class TestBPTreeRecords
         check(bpr) ;
         bpr.release() ;
     }
-    
+
     @Test public void bpt_records_4()
     {
         BPTreeRecords bpr = make() ;
@@ -128,15 +128,15 @@ public class TestBPTreeRecords
         check(bpr) ;
         bpr.release() ;
     }
-    
+
     @Test public void bpt_records_5()
     {
         BPTreeRecords bpr = make() ;
         int N =  bpr.getMaxSize() ;
-        
+
         for ( int i = bpr.getMaxSize()-1 ; i >= 0 ; i-- )
             insert(bpr, (i+0x20)) ;
-        
+
         delete(bpr, (1+0x20)) ;
         assertEquals(N-1, bpr.getCount()) ;
         check(bpr) ;
@@ -144,7 +144,7 @@ public class TestBPTreeRecords
         delete(bpr, (2+0x20)) ;
         assertEquals(N-2, bpr.getCount()) ;
         check(bpr) ;
-        
+
         delete(bpr, bpr.getLowRecord()) ;
         assertEquals(N-3, bpr.getCount()) ;
         check(bpr) ;
@@ -152,15 +152,15 @@ public class TestBPTreeRecords
         bpr.internalDelete(bpr.getHighRecord()) ;
         assertEquals(N-4, bpr.getCount()) ;
         check(bpr) ;
-        
+
         bpr.release() ;
     }
-    
+
     @Test public void bpt_records_6()
     {
         BPTreeRecords bpr = make() ;
         fill(bpr) ;
-        
+
         // No match.
         assertNull(bpr.internalSearch(RecordLib.intToRecord(0x20))) ;
 
@@ -171,14 +171,14 @@ public class TestBPTreeRecords
         r = bpr.getLowRecord() ;
         r2 = search(bpr, r) ;
         assertTrue(Record.keyEQ(r, r2)) ;
-        
+
         r = bpr.getHighRecord() ;
         r2 = search(bpr, r) ;
         assertTrue(Record.keyEQ(r, r2)) ;
-        
+
         bpr.release() ;
     }
-    
+
     @Test public void bpt_shift_1()
     {
         BPTreeRecords bpr1 = make() ;
@@ -190,20 +190,20 @@ public class TestBPTreeRecords
         //assertTrue(Record.keyEQ(r, RecordTestLib.intToRecord(10))) ;
         contains(bpr1) ;
         contains(bpr2, 10) ;
-        
+
         bpr1.release() ;
         bpr2.release() ;
 
     }
-    
+
     @Test public void bpt_shift_2()
     {
         BPTreeRecords bpr1 = make() ;
         BPTreeRecords bpr2 = make() ;
-        
+
         insert(bpr1, 10) ;
         Record r = bpr2.shiftLeft(bpr1, null) ;
-        
+
         assertTrue(Record.keyEQ(r, RecordLib.intToRecord(10))) ;
         contains(bpr1) ;
         contains(bpr2, 10) ;
@@ -215,13 +215,13 @@ public class TestBPTreeRecords
     {
         BPTreeRecords bpr1 = make() ;
         BPTreeRecords bpr2 = make() ;
-        
+
         insert(bpr1, 10, 20) ;
         insert(bpr2, 99) ;
-        
+
         Record r = bpr1.shiftRight(bpr2, null) ;
 
-        assertTrue(r+" != "+RecordLib.intToRecord(10), Record.keyEQ(r, RecordLib.intToRecord(10))) ;
+        assertTrue(Record.keyEQ(r, RecordLib.intToRecord(10)), r+" != "+RecordLib.intToRecord(10)) ;
         contains(bpr1, 10) ;
         contains(bpr2, 20, 99) ;
         bpr1.release() ;
@@ -232,27 +232,27 @@ public class TestBPTreeRecords
     {
         BPTreeRecords bpr1 = make() ;
         BPTreeRecords bpr2 = make() ;
-        
+
         insert(bpr1, 10, 20) ;
         insert(bpr2, 5) ;
-        
+
         Record r = bpr2.shiftLeft(bpr1, null) ;
         assertTrue(Record.keyEQ(r, RecordLib.intToRecord(10))) ;
-        
+
         contains(bpr1, 20) ;
         contains(bpr2, 5, 10) ;
         bpr1.release() ;
         bpr2.release() ;
     }
-    
+
     @Test public void bpt_merge_1()
     {
         BPTreeRecords bpr1 = make() ;
         BPTreeRecords bpr2 = make() ;
-        
+
         insert(bpr1, 10, 20) ;
         insert(bpr2, 99) ;
-        
+
         BPTreeRecords bpr3 = (BPTreeRecords)bpr1.merge(bpr2, null) ;
         contains(bpr1, 10, 20, 99) ;
         contains(bpr2) ;
@@ -265,10 +265,10 @@ public class TestBPTreeRecords
     {
         BPTreeRecords bpr1 = make() ;
         BPTreeRecords bpr2 = make() ;
-        
+
         insert(bpr1, 10, 20) ;
         insert(bpr2, 5) ;
-        
+
         BPTreeRecords bpr3 = (BPTreeRecords)bpr2.merge(bpr1, null) ;
         contains(bpr1) ;
         contains(bpr2, 5, 10, 20) ;
@@ -276,15 +276,15 @@ public class TestBPTreeRecords
         bpr1.release() ;
         bpr2.release() ;
     }
-    
+
     private static void check(BPTreeRecords bpr)
     {
         assertTrue(bpr.getCount() >= 0 ) ;
         assertTrue(bpr.getCount() <= bpr.getMaxSize() ) ;
-        
+
         assertEquals(bpr.getRecordBuffer().getLow(), bpr.getLowRecord()) ;
         assertEquals(bpr.getRecordBuffer().getHigh(), bpr.getHighRecord()) ;
-        
+
         for ( int i = 1 ; i < bpr.getCount() ; i++ )
         {
             Record r1 = bpr.getRecordBuffer().get(i-1) ;
@@ -298,7 +298,7 @@ public class TestBPTreeRecords
         return search(bpr, RecordLib.intToRecord(x)) ;
     }
 
-    
+
     private static Record search(BPTreeRecords bpr, Record r)
     {
         return bpr.internalSearch(r) ;
@@ -311,12 +311,12 @@ public class TestBPTreeRecords
             bpr.internalInsert( RecordLib.intToRecord( value ) );
         }
     }
-    
+
     private static void insert(BPTreeRecords bpr, Record r)
     {
         bpr.internalInsert(r) ;
     }
-    
+
 
     private static void delete(BPTreeRecords bpr, int ... values)
     {
@@ -325,12 +325,12 @@ public class TestBPTreeRecords
             delete( bpr, RecordLib.intToRecord( value ) );
         }
     }
-    
+
     private static void delete(BPTreeRecords bpr, Record r)
     {
         bpr.internalDelete(r) ;
     }
-    
+
 
     private static void contains(BPTreeRecords bpr, int ... values)
     {
@@ -344,7 +344,7 @@ public class TestBPTreeRecords
         RecordBufferPage page = recordBufferPageMgr.create() ;
         return new BPTreeRecords(bPlusTree, page) ;
     }
-    
+
     private static void fill(BPTreeRecords bpr)
     {
         RecordBuffer rb = bpr.getRecordBuffer() ;

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/bplustree/TestBPlusTree.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/bplustree/TestBPlusTree.java
@@ -25,13 +25,13 @@ import org.apache.jena.tdb1.base.record.RecordLib;
 import org.apache.jena.tdb1.index.AbstractTestRangeIndex;
 import org.apache.jena.tdb1.index.RangeIndex;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TestBPlusTree extends AbstractTestRangeIndex
 {
     static boolean originalNullOut ; 
-    @BeforeClass static public void beforeClass()
+    @BeforeAll static public void beforeClass()
     {
         BPlusTreeParams.CheckingNode = true ;
         //BPlusTreeParams.CheckingTree = true ;   // Breaks with block tracking.
@@ -39,7 +39,7 @@ public class TestBPlusTree extends AbstractTestRangeIndex
         SystemTDB.NullOut = true ;    
     }
     
-    @AfterClass static public void afterClass()
+    @AfterAll static public void afterClass()
     {
         SystemTDB.NullOut = originalNullOut ;    
     }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/bplustree/TestBPlusTreeRewriter.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/bplustree/TestBPlusTreeRewriter.java
@@ -34,9 +34,9 @@ import org.apache.jena.tdb1.base.record.Record;
 import org.apache.jena.tdb1.base.record.RecordFactory;
 import org.apache.jena.tdb1.index.SetupIndex;
 import org.apache.jena.tdb1.sys.Names;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestBPlusTreeRewriter
 {
@@ -48,8 +48,8 @@ public class TestBPlusTreeRewriter
     
     // The BPlusTreeRewriter works directly on storage.
     static boolean b ; 
-    @BeforeClass public static void beforeClass()   { b = BlockMgrFactory.AddTracker ; BlockMgrFactory.AddTracker = false ; }
-    @AfterClass  public static void afterClass()    { BlockMgrFactory.AddTracker = b  ;}
+    @BeforeAll public static void beforeClass()   { b = BlockMgrFactory.AddTracker ; BlockMgrFactory.AddTracker = false ; }
+    @AfterAll  public static void afterClass()    { BlockMgrFactory.AddTracker = b  ;}
     
     @Test public void bpt_rewrite_01()  { runTest(2, 0) ; }
     @Test public void bpt_rewrite_02()  { runTest(3, 0) ; }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/ext/ExtHashTestBase.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/ext/ExtHashTestBase.java
@@ -26,10 +26,10 @@ import static org.apache.jena.atlas.lib.RandomLib.random ;
 import static org.apache.jena.atlas.test.Gen.permute ;
 import static org.apache.jena.atlas.test.Gen.rand ;
 import static org.apache.jena.atlas.test.Gen.strings ;
-import static org.junit.Assert.assertEquals ;
-import static org.junit.Assert.assertFalse ;
-import static org.junit.Assert.assertNotNull ;
-import static org.junit.Assert.assertTrue ;
+import static org.junit.jupiter.api.Assertions.assertEquals ;
+import static org.junit.jupiter.api.Assertions.assertFalse ;
+import static org.junit.jupiter.api.Assertions.assertNotNull ;
+import static org.junit.jupiter.api.Assertions.assertTrue ;
 
 import java.util.Iterator ;
 import java.util.List ;
@@ -43,13 +43,13 @@ import org.apache.jena.tdb1.base.record.RecordFactory;
 public class ExtHashTestBase
 {
     public static final RecordFactory factory = new RecordFactory(4, 4) ;
-    
+
     public static void randTests(int maxValue, int maxNumKeys, int iterations, boolean showProgess)
     {
         ExtHashTest test = new ExtHashTest(maxValue, maxNumKeys) ;
         RepeatExecution.repeatExecutions(test, iterations, showProgess) ;
     }
-    
+
     static class ExtHashTest implements ExecGenerator
     {
         int maxNumKeys ;
@@ -58,10 +58,10 @@ public class ExtHashTestBase
         {
             if ( maxValue <= maxNumKeys )
                 throw new IllegalArgumentException("ExtHashTest: Max value less than number of keys") ;
-            this.maxValue = maxValue ; 
+            this.maxValue = maxValue ;
             this.maxNumKeys = maxNumKeys ;
         }
-        
+
         @Override
         public void executeOneTest()
         {
@@ -79,7 +79,7 @@ public class ExtHashTestBase
         int[] r2 = permute(r1) ;
         runTest(r1, r2) ;
     }
-        
+
     public static void runTest(int[] r1, int[] r2)
     {
         try {
@@ -100,20 +100,20 @@ public class ExtHashTestBase
     {
         return ExtHash.createMem(factory, 128) ;
     }
-    
+
     public static Record intToRecord(int v)
     {
         byte[] key = Bytes.packInt(v) ;
         byte[] val = Bytes.packInt(v+100) ;
         return factory.create(key, val) ;
     }
-    
+
     public static Record intToRecordKey(int v)
     {
         byte[] key = Bytes.packInt(v) ;
         return factory.create(key) ;
     }
-    
+
     public static ExtHash create(int...recs)
     {
         ExtHash extHash = make() ;
@@ -121,7 +121,7 @@ public class ExtHashTestBase
         {
             Record r = intToRecord(i) ;
             extHash.add(r) ;
-            
+
             if ( false ) extHash.dump() ;
         }
         return extHash ;
@@ -137,7 +137,7 @@ public class ExtHashTestBase
         return extHash ;
     }
 
-    
+
     public static void check(ExtHash extHash, int...recs)
     {
         extHash.check();
@@ -148,18 +148,18 @@ public class ExtHashTestBase
         }
         List<Integer> y = unique(asList(recs)) ;
         int x = (int)extHash.size() ;
-        assertEquals(y.size(), x); 
+        assertEquals(y.size(), x);
     }
 
-    
+
     public static void check(Iterator<Integer> iter, int...recs)
     {
         for ( int i : recs )
         {
-            assertTrue("Iterator shorter than test answers", iter.hasNext()) ;
+            assertTrue(iter.hasNext(), "Iterator shorter than test answers") ;
             int j = iter.next() ;
             assertEquals(i,j) ;
         }
-        assertFalse("Iterator longer than test answers", iter.hasNext()) ;
+        assertFalse(iter.hasNext(), "Iterator longer than test answers") ;
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/ext/TestExtHash.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/index/ext/TestExtHash.java
@@ -28,8 +28,8 @@ import org.apache.jena.tdb1.base.record.RecordFactory;
 import org.apache.jena.tdb1.index.AbstractTestIndex;
 import org.apache.jena.tdb1.index.Index;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TestExtHash extends AbstractTestIndex
 {
@@ -37,7 +37,7 @@ public class TestExtHash extends AbstractTestIndex
     static boolean originalNullOut ; 
     static boolean b ; 
 
-    @BeforeClass static public void setup()
+    @BeforeAll static public void setup()
     {
         originalNullOut = SystemTDB.NullOut ;
         SystemTDB.NullOut = true ;
@@ -47,7 +47,7 @@ public class TestExtHash extends AbstractTestIndex
         BlockMgrFactory.AddTracker = false ;
     }
     
-    @AfterClass static public void teardown()
+    @AfterAll static public void teardown()
     {
         BlockMgrFactory.AddTracker = b  ;
         SystemTDB.NullOut = originalNullOut ;

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/lib/TS_LibTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/lib/TS_LibTDB1.java
@@ -21,11 +21,11 @@
 
 package org.apache.jena.tdb1.lib;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestNodeLib.class
     , TestStringAbbrev.class
     , TestColumnMap.class

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/lib/TestColumnMap.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/lib/TestColumnMap.java
@@ -22,11 +22,11 @@
 package org.apache.jena.tdb1.lib;
 
 import static org.apache.jena.atlas.lib.tuple.TupleFactory.* ;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.jena.atlas.lib.tuple.Tuple ;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 public class TestColumnMap
 {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/lib/TestNodeLib.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/lib/TestNodeLib.java
@@ -22,12 +22,12 @@
 package org.apache.jena.tdb1.lib;
 
 import static org.apache.jena.tdb1.lib.NodeLib.hash;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.apache.jena.graph.Node ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 public class TestNodeLib
 {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/lib/TestStringAbbrev.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/lib/TestStringAbbrev.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.tdb1.lib;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestStringAbbrev
 {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TS_TDB1Setup.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TS_TDB1Setup.java
@@ -21,16 +21,16 @@
 
 package org.apache.jena.tdb1.setup;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestStoreParams.class
     , TestStoreParamsChoose.class
     , TestStoreParamsCreate.class
 })
 public class TS_TDB1Setup {
-    
+
 }
 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TestStoreParams.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TestStoreParams.java
@@ -21,32 +21,30 @@
 
 package org.apache.jena.tdb1.setup;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.atlas.json.JSON ;
 import org.apache.jena.atlas.json.JsonObject ;
 import org.apache.jena.tdb1.TDB1Exception;
 import org.apache.jena.tdb1.base.block.FileMode;
-import org.junit.Test ;
 
 public class TestStoreParams {
 
     @Test public void store_params_01() {
-        assertEqualsStoreParams(StoreParams.getDftStoreParams(), StoreParams.getDftStoreParams()) ; 
+        assertEqualsStoreParams(StoreParams.getDftStoreParams(), StoreParams.getDftStoreParams()) ;
     }
-    
+
     @Test public void store_params_02() {
         StoreParams input = StoreParams.getDftStoreParams() ;
         StoreParams sp = StoreParams.builder(input).build() ;
-        assertEqualsStoreParams(StoreParams.getDftStoreParams(), sp) ; 
+        assertEqualsStoreParams(StoreParams.getDftStoreParams(), sp) ;
     }
 
     @Test public void store_params_03() {
         StoreParams sp = StoreParams.builder().build() ;
-        assertEqualsStoreParams(StoreParams.getDftStoreParams(), sp) ; 
+        assertEqualsStoreParams(StoreParams.getDftStoreParams(), sp) ;
     }
 
     @Test public void store_params_04() {
@@ -54,7 +52,7 @@ public class TestStoreParams {
         StoreParams params2 = roundTrip(params) ;
         assertEqualsStoreParams(params,params2) ;
     }
-    
+
     @Test public void store_params_05() {
         Double initialCapacityFactor = Double.valueOf(0.125);
         StoreParams params = StoreParams.builder().nodeCacheInitialCapacityFactor(initialCapacityFactor).build();
@@ -74,7 +72,7 @@ public class TestStoreParams {
     }
 
     // ----
-    
+
     @Test public void store_params_10() {
         StoreParams params = StoreParams.builder().fileMode(FileMode.direct).blockSize(1024).build() ;
         StoreParams params2 = roundTrip(params) ;
@@ -100,20 +98,22 @@ public class TestStoreParams {
     }
 
     @Test public void store_params_13() {
-        String xs = "{ \"tdb.triple_indexes\" : [ \"POS\" , \"PSO\"] } " ; 
+        String xs = "{ \"tdb.triple_indexes\" : [ \"POS\" , \"PSO\"] } " ;
         JsonObject x = JSON.parse(xs) ;
         StoreParams params = StoreParamsCodec.decode(x) ;
         String[] expected =  { "POS" , "PSO" } ;
         assertArrayEquals(expected, params.getTripleIndexes()) ;
     }
 
-    @Test(expected=TDB1Exception.class)
+    @Test
     public void store_params_14() {
-        String xs = "{ \"tdb.triples_indexes\" : [ \"POS\" , \"PSO\"] } " ; // Misspelt. 
+        String xs = "{ \"tdb.triples_indexes\" : [ \"POS\" , \"PSO\"] } " ; // Misspelt.
         JsonObject x = JSON.parse(xs) ;
-        StoreParams params = StoreParamsCodec.decode(x) ;
-        String[] expected =  { "POS" , "PSO" } ;
-        assertArrayEquals(expected, params.getTripleIndexes()) ;
+        assertThrows(TDB1Exception.class, ()-> {
+            StoreParams params = StoreParamsCodec.decode(x) ;
+        });
+//        String[] expected =  { "POS" , "PSO" } ;
+//        assertArrayEquals(expected, params.getTripleIndexes()) ;
     }
 
     // Check that setting gets recorded and propagated.
@@ -123,7 +123,7 @@ public class TestStoreParams {
         assertTrue(params.isSetBlockReadCacheSize()) ;
         assertFalse(params.isSetBlockWriteCacheSize()) ;
     }
-    
+
     @Test public void store_params_21() {
         StoreParams params1 = StoreParams.builder().blockReadCacheSize(0).build();
         assertTrue(params1.isSetBlockReadCacheSize()) ;
@@ -149,18 +149,18 @@ public class TestStoreParams {
         assertTrue(params3.isSetBlockWriteCacheSize()) ;
         assertEquals(5, params3.getBlockReadCacheSize().intValue()) ;   // From params2
         assertEquals(1, params3.getBlockWriteCacheSize().intValue()) ;  // From params1, not params2(unset)
-        
+
     }
 
-    
+
     // --------
-    
+
     private static StoreParams roundTrip(StoreParams params) {
         JsonObject obj = StoreParamsCodec.encodeToJson(params) ;
         StoreParams params2 = StoreParamsCodec.decode(obj) ;
         return params2 ;
     }
-    
+
     private static void assertEqualsStoreParams(StoreParams params1, StoreParams params2) {
         assertTrue(StoreParams.sameValues(params1, params2)) ;
     }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TestStoreParamsChoose.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TestStoreParamsChoose.java
@@ -21,14 +21,14 @@
 
 package org.apache.jena.tdb1.setup;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.base.file.Location;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 //TestParamsCreate
 /** This test suite uses on-disk structures and can be slow */ 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TestStoreParamsCreate.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/setup/TestStoreParamsCreate.java
@@ -22,7 +22,7 @@
 package org.apache.jena.tdb1.setup;
 
 import static org.apache.jena.tdb1.setup.StoreParamsConst.TDB_CONFIG_FILE;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.file.Files ;
 import java.nio.file.Path ;
@@ -32,9 +32,9 @@ import org.apache.jena.atlas.lib.FileOps ;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.base.file.Location;
 import org.apache.jena.tdb1.sys.StoreConnection;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test suite uses on-disk structures, does a lot of clean/create/sync
@@ -53,28 +53,28 @@ public class TestStoreParamsCreate {
         .blockReadCacheSize(4)
         .build();
 
-    @Before public void clearupTest() {
+    @BeforeEach public void clearupTest() {
         // Flush and clean.
         StoreConnection.expel(loc, true) ;
         FileOps.clearAll(DB_DIR);
     }
 
-    @After public void expelDatabase() {
+    @AfterEach public void expelDatabase() {
         StoreConnection.expel(loc, true) ;
     }
 
     @Test public void params_create_01() {
         StoreConnection.make(loc, null) ;
         // Check.  Default setup, no params.
-        assertTrue("DB directory", Files.exists(db)) ;
-        assertFalse("Config file unexpectedly found", Files.exists(cfg)) ;
+        assertTrue(Files.exists(db), "DB directory") ;
+        assertFalse(Files.exists(cfg), "Config file unexpectedly found") ;
     }
 
     @Test public void params_create_02() {
         StoreConnection.make(loc, pApp) ;
         // Check.  Custom setup.
-        assertTrue("DB directory", Files.exists(db)) ;
-        assertTrue("Config file not found: "+cfg, Files.exists(cfg)) ;
+        assertTrue(Files.exists(db), "DB directory") ;
+        assertTrue(Files.exists(cfg), "Config file not found: "+cfg) ;
         StoreParams pLoc = StoreParamsCodec.read(loc) ;
         assertTrue(StoreParams.sameValues(pLoc, pApp)) ;
     }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/solver/TS_SolverTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/solver/TS_SolverTDB1.java
@@ -21,11 +21,12 @@
 
 package org.apache.jena.tdb1.solver;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({
     TestSolverTDB1.class
     , TestStats.class
 })

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/solver/TestSolverTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/solver/TestSolverTDB1.java
@@ -21,14 +21,14 @@
 
 package org.apache.jena.tdb1.solver;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
@@ -58,7 +58,7 @@ public class TestSolverTDB1 {
     static Dataset dataset = null;
     static PrefixMapping pmap = null;
 
-    @BeforeClass
+    @BeforeAll
     static public void beforeClass() {
         dataset = TDB1Factory.createDataset();
         dataset.begin(ReadWrite.WRITE);
@@ -130,7 +130,7 @@ public class TestSolverTDB1 {
     // ------
 
     private static void equals(RowSet rs1, RowSet rs2) {
-//        same(rs1, rs2, true);
+// same(rs1, rs2, true);
     }
 
     private static void same(RowSet rs1, RowSet rs2, boolean result) {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/solver/TestStats.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/solver/TestStats.java
@@ -21,7 +21,7 @@
 
 package org.apache.jena.tdb1.solver;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Iterator;
 
@@ -37,7 +37,7 @@ import org.apache.jena.tdb1.store.NodeId;
 import org.apache.jena.tdb1.store.nodetable.NodeTable;
 import org.apache.jena.tdb1.store.nodetupletable.NodeTupleTable;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class TestStats {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/AbstractStoreConnections.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/AbstractStoreConnections.java
@@ -21,9 +21,14 @@
 
 package org.apache.jena.tdb1.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.query.Dataset ;
@@ -34,15 +39,12 @@ import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.TDB1;
+import org.apache.jena.tdb1.TDB1Exception;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.tdb1.base.file.Location;
 import org.apache.jena.tdb1.sys.StoreConnection;
 import org.apache.jena.tdb1.sys.TDBInternal;
 import org.apache.jena.tdb1.transaction.DatasetGraphTxn;
-import org.apache.jena.tdb1.transaction.TDBTransactionException;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
 
 @SuppressWarnings("removal")
 public abstract class AbstractStoreConnections
@@ -61,13 +63,13 @@ public abstract class AbstractStoreConnections
 
     String DIR = null ;
 
-    @Before public void before()
+    @BeforeEach public void before()
     {
         TDBInternal.reset() ;
         DIR = ConfigTest.getCleanDir() ;
     }
 
-    @After public void after() {}
+    @AfterEach public void after() {}
 
     protected StoreConnection getStoreConnection() {
         return StoreConnection.make(DIR) ;
@@ -103,20 +105,20 @@ public abstract class AbstractStoreConnections
         assertTrue(sConn2.isValid());
     }
 
-    @Test(expected = TDBTransactionException.class)
+    @Test
     public void store_2() {
         // Expel.
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgR1 = sConn.begin(TxnType.READ) ;
-        StoreConnection.release(sConn.getLocation()) ;
+        assertThrows(TDB1Exception.class, ()->StoreConnection.release(sConn.getLocation())) ;
     }
 
-    @Test(expected = TDBTransactionException.class)
+    @Test
     public void store_3() {
         // Expel.
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgR1 = sConn.begin(TxnType.WRITE) ;
-        StoreConnection.release(sConn.getLocation()) ;
+        assertThrows(TDB1Exception.class, ()->StoreConnection.release(sConn.getLocation())) ;
     }
 
     @Test

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TS_Store.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TS_Store.java
@@ -21,16 +21,17 @@
 
 package org.apache.jena.tdb1.store;
 
+    import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
 import org.apache.jena.tdb1.base.block.FileMode;
 import org.apache.jena.tdb1.sys.LibTestOps;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestNodeId.class
     , TestTripleTable.class
     , TestGraphTDB1.class
@@ -52,18 +53,16 @@ import org.junit.runners.Suite ;
 } )
 public class TS_Store
 {
-    static FileMode mode ;
+    static FileMode mode;
 
-    @BeforeClass
-    public static void beforeClass()
-    {
-        mode = SystemTDB.fileMode() ;
+    @BeforeAll
+    public static void beforeClass() {
+        mode = SystemTDB.fileMode();
     }
 
-    @AfterClass
-    public static void afterClass()
-    {
-        if ( ! SystemTDB.fileMode().equals(mode) )
-            LibTestOps.setFileMode(mode) ;
+    @AfterAll
+    public static void afterClass() {
+        if ( !SystemTDB.fileMode().equals(mode) )
+            LibTestOps.setFileMode(mode);
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestConcurrentAccess.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestConcurrentAccess.java
@@ -21,198 +21,179 @@
 
 package org.apache.jena.tdb1.store;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.ConcurrentModificationException ;
-import java.util.Iterator ;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
 
-import org.apache.jena.atlas.lib.StrUtils ;
-import org.apache.jena.graph.Graph ;
-import org.apache.jena.graph.GraphUtil ;
-import org.apache.jena.graph.Triple ;
-import org.apache.jena.query.* ;
-import org.apache.jena.rdf.model.Model ;
-import org.apache.jena.rdf.model.RDFNode ;
-import org.apache.jena.rdf.model.Resource ;
-import org.apache.jena.rdf.model.Statement ;
-import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.sparql.core.Quad ;
-import org.apache.jena.sparql.sse.Item ;
-import org.apache.jena.sparql.sse.SSE ;
-import org.apache.jena.sparql.sse.builders.BuilderGraph ;
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.atlas.lib.StrUtils;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.GraphUtil;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.sse.Item;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sparql.sse.builders.BuilderGraph;
 import org.apache.jena.tdb1.TDB1Factory;
-import org.apache.jena.util.iterator.ExtendedIterator ;
-import org.junit.Test ;
+import org.apache.jena.util.iterator.ExtendedIterator;
 
 @SuppressWarnings("removal")
-public class TestConcurrentAccess
-{
-    static String data = StrUtils.strjoinNL(
-       "(graph",
-       "  (<x> <p> 1)" ,
-       "  (<x> <p> 2)" ,
-       "  (<x> <p> 3)" ,
-       "  (<x> <p> 4)" ,
-       "  (<x> <p> 5)" ,
-       "  (<x> <p> 6)" ,
-       "  (<x> <p> 7)" ,
-       "  (<x> <p> 8)" ,
-       "  (<x> <p> 9)" ,
-        ")") ;
+public class TestConcurrentAccess {
+    static String data = StrUtils.strjoinNL("(graph", "  (<x> <p> 1)", "  (<x> <p> 2)", "  (<x> <p> 3)", "  (<x> <p> 4)", "  (<x> <p> 5)",
+                                            "  (<x> <p> 6)", "  (<x> <p> 7)", "  (<x> <p> 8)", "  (<x> <p> 9)", ")");
 
-    private static Graph buildGraph()
-    {
-        Item item = SSE.parse(data) ;
-        Graph g = BuilderGraph.buildGraph(item) ;
-        return g ;
+    private static Graph buildGraph() {
+        Item item = SSE.parse(data);
+        Graph g = BuilderGraph.buildGraph(item);
+        return g;
     }
 
-    private static Dataset create()
-    {
-        Graph g = buildGraph() ;
-        Dataset ds = TDB1Factory.createDataset() ;
-        GraphUtil.addInto(ds.getDefaultModel().getGraph(), g) ;
-        return ds ;
+    private static Dataset create() {
+        Graph g = buildGraph();
+        Dataset ds = TDB1Factory.createDataset();
+        GraphUtil.addInto(ds.getDefaultModel().getGraph(), g);
+        return ds;
     }
 
-    @Test public void mrswGraph1()
-    {
-        Model m = create().getDefaultModel() ;
-        Resource r = m.createResource("x") ;
-        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null) ;
-        assertNotNull(iter1.next()) ;
+    @Test
+    public void mrswGraph1() {
+        Model m = create().getDefaultModel();
+        Resource r = m.createResource("x");
+        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null);
+        assertNotNull(iter1.next());
 
-        ExtendedIterator<Statement> iter2 = m.listStatements(r, null, (RDFNode)null) ;
-        assertNotNull(iter2.next()) ;
+        ExtendedIterator<Statement> iter2 = m.listStatements(r, null, (RDFNode)null);
+        assertNotNull(iter2.next());
 
-        for ( ; iter2.hasNext() ; ) iter2.next() ;
+        for ( ; iter2.hasNext() ; )
+            iter2.next();
 
-        assertNotNull(iter1.next()) ;
+        assertNotNull(iter1.next());
     }
 
-    @Test(expected=ConcurrentModificationException.class)
-    public void mrswGraph2()
-    {
-        Model m = create().getDefaultModel() ;
-        Resource r = m.createResource("x") ;
-        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null) ;
-        assertNotNull(iter1.next()) ;
+    @Test
+    public void mrswGraph2() {
+        Model m = create().getDefaultModel();
+        Resource r = m.createResource("x");
+        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null);
+        assertNotNull(iter1.next());
 
-        Triple t = SSE.parseTriple("(<y> <p> 99)") ;
-        m.getGraph().add(t) ;
+        Triple t = SSE.parseTriple("(<y> <p> 99)");
+        m.getGraph().add(t);
 
         // Bad
-        iter1.hasNext();
+        assertThrows(ConcurrentModificationException.class, () -> iter1.hasNext());
     }
 
-    @Test(expected=ConcurrentModificationException.class)
-    public void mrswGraph3()
-    {
-        Model m = create().getDefaultModel() ;
-        Resource r = m.createResource("x") ;
-        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null) ;
-        assertNotNull(iter1.next()) ;
+    @Test
+    public void mrswGraph3() {
+        Model m = create().getDefaultModel();
+        Resource r = m.createResource("x");
+        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null);
+        assertNotNull(iter1.next());
 
-        Triple t = SSE.parseTriple("(<y> <p> 99)") ;
-        m.getGraph().delete(t) ;
+        Triple t = SSE.parseTriple("(<y> <p> 99)");
+        m.getGraph().delete(t);
 
         // Bad
-        iter1.hasNext();
+        assertThrows(ConcurrentModificationException.class, () -> iter1.hasNext());
     }
 
-    @Test(expected=ConcurrentModificationException.class)
-    public void mrswGraph4()
-    {
-        Model m = create().getDefaultModel() ;
-        Resource r = m.createResource("x") ;
-        ExtendedIterator<Statement> iter1 = m.listLiteralStatements(r, null, 1) ;
-        assertNotNull(iter1.next()) ;
+    @Test
+    public void mrswGraph4() {
+        Model m = create().getDefaultModel();
+        Resource r = m.createResource("x");
+        ExtendedIterator<Statement> iter1 = m.listLiteralStatements(r, null, 1);
+        assertNotNull(iter1.next());
         // and now the iterator has implicitly finished.
 
-        Triple t = SSE.parseTriple("(<y> <p> 99)") ;
-        m.getGraph().add(t) ;
+        Triple t = SSE.parseTriple("(<y> <p> 99)");
+        m.getGraph().add(t);
 
         // Bad - modification of the dataset occurred.
+        assertThrows(ConcurrentModificationException.class, () -> iter1.hasNext());
+    }
+
+    @Test
+    public void mrswGraph5() {
+        Dataset d = TDB1Factory.createDataset();
+        Model m = d.getNamedModel("http://example");
+        GraphUtil.addInto(m.getGraph(), buildGraph());
+        Resource r = m.createResource("x");
+        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null);
+        while (iter1.hasNext())
+            iter1.next();
+        Triple t = SSE.parseTriple("(<y> <p> 99)");
+        m.getGraph().delete(t);
         iter1.hasNext();
     }
 
     @Test
-    public void mrswGraph5()
-    {
-        Dataset d = TDB1Factory.createDataset() ;
-        Model m = d.getNamedModel("http://example") ;
-        GraphUtil.addInto(m.getGraph(), buildGraph()) ;
-        Resource r = m.createResource("x") ;
-        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null) ;
-        while(iter1.hasNext())
-            iter1.next();
-        Triple t = SSE.parseTriple("(<y> <p> 99)") ;
-        m.getGraph().delete(t) ;
-        iter1.hasNext() ;
-    }
+    public void mrswGraph6() {
+        Dataset d = TDB1Factory.createDataset();
+        Model m = d.getNamedModel("http://example");
+        GraphUtil.addInto(m.getGraph(), buildGraph());
+        Resource r = m.createResource("x");
+        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null);
+        assertNotNull(iter1.next());
 
-    @Test(expected=ConcurrentModificationException.class)
-    public void mrswGraph6()
-    {
-        Dataset d = TDB1Factory.createDataset() ;
-        Model m = d.getNamedModel("http://example") ;
-        GraphUtil.addInto(m.getGraph(), buildGraph()) ;
-        Resource r = m.createResource("x") ;
-        ExtendedIterator<Statement> iter1 = m.listStatements(r, null, (RDFNode)null) ;
-        assertNotNull(iter1.next()) ;
-
-        Triple t = SSE.parseTriple("(<y> <p> 99)") ;
-        m.getGraph().delete(t) ;
-        iter1.next() ;
+        Triple t = SSE.parseTriple("(<y> <p> 99)");
+        m.getGraph().delete(t);
+        assertThrows(ConcurrentModificationException.class, () -> iter1.next());
     }
 
     @Test
-    public void mrswSPARQL1()
-    {
+    public void mrswSPARQL1() {
         Dataset ds = create();
-        Query query = QueryFactory.create("SELECT * { ?s ?p ?o}") ;
-        try(QueryExecution qExec = QueryExecutionFactory.create(query, ds)) {
-            ResultSet rs = qExec.execSelect() ;
-            while(rs.hasNext())
+        Query query = QueryFactory.create("SELECT * { ?s ?p ?o}");
+        try (QueryExecution qExec = QueryExecutionFactory.create(query, ds)) {
+            ResultSet rs = qExec.execSelect();
+            while (rs.hasNext())
                 rs.next();
         }
 
-        DatasetGraph dsg = ds.asDatasetGraph() ;
-        Quad quad = SSE.parseQuad("(<g> <y> <p> 99)") ;
-        dsg.add(quad) ;
+        DatasetGraph dsg = ds.asDatasetGraph();
+        Quad quad = SSE.parseQuad("(<g> <y> <p> 99)");
+        dsg.add(quad);
 
-        Iterator<Quad> iter = dsg.find() ;
-        iter.hasNext() ;
-        iter.next() ;
+        Iterator<Quad> iter = dsg.find();
+        iter.hasNext();
+        iter.next();
     }
 
-    @Test(expected=ConcurrentModificationException.class)
-    public void mrswSPARQL2()
-    {
+    @Test
+    public void mrswSPARQL2() {
         Dataset ds = create();
-        DatasetGraph dsg = ds.asDatasetGraph() ;
-        Query query = QueryFactory.create("SELECT * { ?s ?p ?o}") ;
-        QueryExecution qExec = QueryExecutionFactory.create(query, ds) ;
-        ResultSet rs = qExec.execSelect() ;
-        rs.hasNext() ;
+        DatasetGraph dsg = ds.asDatasetGraph();
+        Query query = QueryFactory.create("SELECT * { ?s ?p ?o}");
+        QueryExecution qExec = QueryExecutionFactory.create(query, ds);
+        ResultSet rs = qExec.execSelect();
+        rs.hasNext();
         rs.next();
-        Quad quad = SSE.parseQuad("(<g> <y> <p> 99)") ;
-        dsg.add(quad) ;
-        rs.hasNext() ;  // <<--- Here.
-        rs.next();
+        Quad quad = SSE.parseQuad("(<g> <y> <p> 99)");
+        dsg.add(quad);
+        assertThrows(ConcurrentModificationException.class, () -> rs.hasNext());
+        assertThrows(ConcurrentModificationException.class, () -> rs.next());
     }
 
-
-    @Test(expected=ConcurrentModificationException.class)
-    public void mrswDataset1()
-    {
-        DatasetGraph dsg = create().asDatasetGraph() ;
-        Quad quad = SSE.parseQuad("(<g> <y> <p> 99)") ;
-        Iterator<Quad> iter = dsg.find() ;
-        dsg.add(quad) ;
+    @Test
+    public void mrswDataset1() {
+        DatasetGraph dsg = create().asDatasetGraph();
+        Quad quad = SSE.parseQuad("(<g> <y> <p> 99)");
+        Iterator<Quad> iter = dsg.find();
+        dsg.add(quad);
         // Bad - after an update.
-        iter.hasNext() ;
-        iter.next() ;
+        assertThrows(ConcurrentModificationException.class, () -> iter.hasNext());
+        assertThrows(ConcurrentModificationException.class, () -> iter.next());
     }
 
     // More DSG tests ..

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestDatasetTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestDatasetTDB1.java
@@ -21,8 +21,8 @@
 
 package org.apache.jena.tdb1.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.jena.query.* ;
 import org.apache.jena.rdf.model.Model ;
@@ -35,7 +35,7 @@ import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.apache.jena.tdb1.TDB1;
 import org.apache.jena.tdb1.TDB1Factory;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 /** Tests of datasets, prefixes, special URIs etc (see also {@link org.apache.jena.sparql.graph.GraphsTests} */
 @SuppressWarnings("removal")

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestDatasetTDB1Persist.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestDatasetTDB1Persist.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.tdb1.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays ;
 import java.util.List ;
@@ -38,10 +38,10 @@ import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.base.file.Location;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.After ;
-import org.junit.AfterClass ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Testing persistence  */
 @SuppressWarnings("removal")
@@ -57,7 +57,7 @@ public class TestDatasetTDB1Persist
 
     GraphLocation graphLocation = null ;
 
-    @Before public void before()
+    @BeforeEach public void before()
     {
         TDBInternal.reset() ;
     	String dirname = ConfigTest.getCleanDir() ;
@@ -65,14 +65,14 @@ public class TestDatasetTDB1Persist
         graphLocation.createDataset() ;
     }
 
-    @After public void after()
+    @AfterEach public void after()
     {
     	if ( graphLocation != null )
     		graphLocation.release() ;
     	graphLocation.clearDirectory() ;	// Does not have the desired effect on Windows.
     }
 
-    @AfterClass public static void afterClass() { TDBInternal.reset() ; }
+    @AfterAll public static void afterClass() { TDBInternal.reset() ; }
 
     @Test public void dataset1()
     {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestGraphTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestGraphTDB1.java
@@ -26,10 +26,10 @@ import org.apache.jena.sparql.graph.AbstractTestGraphAddDelete ;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.base.file.Location;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 
 /** Programmatic tests on persistent graph */
 @SuppressWarnings("removal")
@@ -37,7 +37,7 @@ public class TestGraphTDB1 extends AbstractTestGraphAddDelete
 {
     static GraphLocation graphLocation = null ;
 
-    @BeforeClass public static void beforeClass()
+    @BeforeAll public static void beforeClass()
     {
         TDBInternal.reset() ;
         graphLocation = new GraphLocation(Location.create(ConfigTest.getCleanDir())) ;
@@ -48,7 +48,7 @@ public class TestGraphTDB1 extends AbstractTestGraphAddDelete
     }
     // ----------
 
-    @AfterClass public static void afterClass()
+    @AfterAll public static void afterClass()
     {
         graphLocation.release() ;
         TDBInternal.reset() ;
@@ -57,13 +57,13 @@ public class TestGraphTDB1 extends AbstractTestGraphAddDelete
     }
 
     static Graph graph = null ;
-    @Before public void before()
+    @BeforeEach public void before()
     {
         if ( graph != null )
             graph.clear() ;
     }
 
-    @After public void after()
+    @AfterEach public void after()
     {
     }
 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestGraphTDB1_Prefixes.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestGraphTDB1_Prefixes.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.tdb1.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
@@ -35,7 +35,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.tdb1.transaction.DatasetGraphTransaction;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class TestGraphTDB1_Prefixes {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestLoader.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestLoader.java
@@ -21,8 +21,8 @@
 
 package org.apache.jena.tdb1.store ;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream ;
 import java.util.List ;
@@ -42,9 +42,9 @@ import org.apache.jena.tdb1.TDB1Loader;
 import org.apache.jena.tdb1.base.file.Location;
 import org.apache.jena.tdb1.setup.DatasetBuilderStd;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class TestLoader {
@@ -54,15 +54,14 @@ public class TestLoader {
     private static final Node   p   = NodeFactory.createURI("p") ;
     private static final Node   o   = NodeFactory.createURI("o") ;
 
-    @BeforeClass
+    @BeforeAll
     static public void beforeClass() {
         DIR = ConfigTest.getTestingDataRoot()+"/Loader/" ;
         LogCtl.disable(ARQ.logExecName) ;
         LogCtl.disable(TDB1.logLoaderName) ;
     }
 
-    @AfterClass
-    static public void afterClass() {
+    @AfterAll     static public void afterClass() {
         LogCtl.enable(ARQ.logExecName) ;
         LogCtl.enable(TDB1.logLoaderName) ;
         TDBInternal.reset();

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestLocationLockStoreConnection.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestLocationLockStoreConnection.java
@@ -21,70 +21,74 @@
 
 package org.apache.jena.tdb1.store;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.apache.jena.tdb1.TDB1Exception;
 import org.apache.jena.tdb1.base.file.Location;
 import org.apache.jena.tdb1.base.file.LocationLock;
 import org.apache.jena.tdb1.sys.ProcessUtils;
 import org.apache.jena.tdb1.sys.StoreConnection;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 /**
- * Tests for {@link LocationLock} inconjucntion with {@link StoreConnection}s
+ * Tests for {@link LocationLock} in conjunction with {@link StoreConnection}s
  */
 public class TestLocationLockStoreConnection {
 
     private static boolean negativePidsTreatedAsAlive = false;
 
-    @Rule
-    public TemporaryFolder tempDir = new TemporaryFolder();
+    @TempDir
+    public Path tempDir;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         negativePidsTreatedAsAlive = ProcessUtils.negativePidsTreatedAsAlive();
     }
 
     @Test
     public void location_lock_store_connection_01() {
-        Location dir = Location.create(tempDir.getRoot().getAbsolutePath());
+        Location dir = Location.create(tempDir.toAbsolutePath().toString());
         LocationLock lock = dir.getLock();
-        Assert.assertTrue(lock.canLock());
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertTrue(lock.canObtain());
+        assertTrue(lock.canLock());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertTrue(lock.canObtain());
 
         // Creating a StoreConnection on the location will obtain the lock
         StoreConnection.make(dir);
-        Assert.assertTrue(lock.isLocked());
-        Assert.assertTrue(lock.isOwned());
-        Assert.assertTrue(lock.canObtain());
+        assertTrue(lock.isLocked());
+        assertTrue(lock.isOwned());
+        assertTrue(lock.canObtain());
 
         // Releasing the connection releases the lock
         StoreConnection.release(dir);
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertTrue(lock.canObtain());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertTrue(lock.canObtain());
     }
 
-    @Test(expected = TDB1Exception.class)
+    @Test
     public void location_lock_store_connection_02() throws IOException {
-        Assume.assumeTrue(negativePidsTreatedAsAlive);
+        assumeTrue(negativePidsTreatedAsAlive);
 
-        Location dir = Location.create(tempDir.getRoot().getAbsolutePath());
+        Location dir = Location.create(tempDir.toAbsolutePath().toString());
         LocationLock lock = dir.getLock();
-        Assert.assertTrue(lock.canLock());
-        Assert.assertFalse(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
-        Assert.assertTrue(lock.canObtain());
+        assertTrue(lock.canLock());
+        assertFalse(lock.isLocked());
+        assertFalse(lock.isOwned());
+        assertTrue(lock.canObtain());
 
         // Write a fake PID to the lock file
         try(BufferedWriter writer =
@@ -92,10 +96,10 @@ public class TestLocationLockStoreConnection {
             // Fake PID that would never be valid
             writer.write(Integer.toString(-1234));
         }
-        Assert.assertTrue(lock.isLocked());
-        Assert.assertFalse(lock.isOwned());
+        assertTrue(lock.isLocked());
+        assertFalse(lock.isOwned());
 
         // Attempting to create a connection on this location should error
-        StoreConnection.make(dir);
+        assertThrows(TDB1Exception.class, ()->StoreConnection.make(dir));
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestNodeId.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestNodeId.java
@@ -21,21 +21,21 @@
 
 package org.apache.jena.tdb1.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.jena.datatypes.xsd.XSDDatatype ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.graph.NodeFactory ;
 import org.apache.jena.sparql.expr.NodeValue ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 public class TestNodeId
 {
-//    @BeforeClass public static void beforeClass() {
+//    @BeforeAll public static void beforeClass() {
 //        // If running just this test suite, then this happens before SystemTDB initialization.
 //        Lib.setenv("tdb:store.enableInlineLiterals", "true") ;
 //    }
@@ -234,9 +234,8 @@ public class TestNodeId
 
     private void test(String x) { test(x, x) ; }
 
-    private void test(String x, String expected)
-    {
-        test(x, NodeFactoryExtra.parseNode(expected)) ;
+    private void test(String x, String expected) {
+        test(x, NodeFactoryExtra.parseNode(expected));
     }
 
     private void test(String x, Node correct)
@@ -246,22 +245,22 @@ public class TestNodeId
         boolean b = NodeId.hasInlineDatatype(n) ;
 
         if ( nodeId != null )
-            assertTrue("Converted NodeId but datatype test was false", b) ;
+            assertTrue(b, "Converted NodeId but datatype test was false") ;
 
         if ( correct == null )
         {
-            assertNull("Expected no encoding: got: "+nodeId, nodeId) ;
+            assertNull(nodeId, "Expected no encoding: got: "+nodeId) ;
             return ;
         }
-        assertNotNull("Expected inlining: "+n, nodeId) ;
+        assertNotNull(nodeId, "Expected inlining: "+n) ;
         Node n2 = NodeId.extract(nodeId) ;
-        assertNotNull("Expected recovery", n2) ;
+        assertNotNull(n2, "Expected recovery") ;
 
         String s = "("+correct.getLiteralLexicalForm()+","+n2.getLiteralLexicalForm()+")" ;
 
-        assertTrue("Not same value: "+s, correct.sameValueAs(n2)) ;
+        assertTrue(correct.sameValueAs(n2), "Not same value: "+s) ;
 
         // Term equality.
-        assertEquals("Not same term", correct, n2) ;
+        assertEquals(correct, n2, "Not same term") ;
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestQuadFilter.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestQuadFilter.java
@@ -21,8 +21,8 @@
 
 package org.apache.jena.tdb1.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.function.Predicate;
 
@@ -38,7 +38,7 @@ import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.tdb1.store.nodetable.NodeTable;
 import org.apache.jena.tdb1.sys.SystemTDB;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class TestQuadFilter

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestStoreConnectionsDirect.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestStoreConnectionsDirect.java
@@ -24,24 +24,20 @@ package org.apache.jena.tdb1.store;
 import org.apache.jena.tdb1.base.block.FileMode;
 import org.apache.jena.tdb1.sys.LibTestOps;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
-public class TestStoreConnectionsDirect extends AbstractStoreConnections
-{
-    static FileMode mode ;   
+public class TestStoreConnectionsDirect extends AbstractStoreConnections {
+    static FileMode mode;
 
-    @BeforeClass
-    public static void beforeClassFileMode()
-    {
-        mode = SystemTDB.fileMode() ;
-        LibTestOps.setFileMode(FileMode.direct) ;
+    @BeforeAll
+    public static void beforeClassFileMode() {
+        mode = SystemTDB.fileMode();
+        LibTestOps.setFileMode(FileMode.direct);
     }
 
-    @AfterClass
-    public static void afterClassFileMode()
-    {
-        LibTestOps.setFileMode(mode) ;
+    @AfterAll
+    public static void afterClassFileMode() {
+        LibTestOps.setFileMode(mode);
     }
 }
-

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestStoreConnectionsMapped.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestStoreConnectionsMapped.java
@@ -25,23 +25,22 @@ import org.apache.jena.tdb1.base.block.FileMode;
 import org.apache.jena.tdb1.sys.LibTestOps;
 import org.apache.jena.tdb1.sys.SystemTDB;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 @SuppressWarnings("removal")
 public class TestStoreConnectionsMapped extends AbstractStoreConnections
 {
     static FileMode mode ;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClassFileMode()
     {
         mode = SystemTDB.fileMode() ;
         LibTestOps.setFileMode(FileMode.mapped) ;
     }
 
-    @AfterClass
-    public static void afterClassFileMode()
+    @AfterAll     public static void afterClassFileMode()
     {
         LibTestOps.setFileMode(mode) ;
         TDBInternal.reset();

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestTripleTable.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/TestTripleTable.java
@@ -21,10 +21,10 @@
 
 package org.apache.jena.tdb1.store;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator ;
 
@@ -34,16 +34,16 @@ import org.apache.jena.graph.Triple ;
 import org.apache.jena.sparql.util.NodeFactoryExtra ;
 import org.apache.jena.tdb1.base.file.Location;
 import org.apache.jena.tdb1.setup.DatasetBuilderStd;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestTripleTable
 {
     private static String levelInfo;  
     private static String levelExec;  
     
-    @BeforeClass public static void beforeClass() {
+    @BeforeAll public static void beforeClass() {
         levelInfo = LogCtl.getLevel("org.apache.jena.tdb.info");
         levelExec = LogCtl.getLevel("org.apache.jena.tdb.exec");
         
@@ -51,7 +51,7 @@ public class TestTripleTable
         LogCtl.setLevel("org.apache.jena.tdb.exec", "WARN");
         
     }
-    @AfterClass public static void afterClass() {
+    @AfterAll public static void afterClass() {
         LogCtl.setLevel("org.apache.jena.tdb.info", levelInfo);
         LogCtl.setLevel("org.apache.jena.tdb.exec", levelExec);
     }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/Test_SPARQL_TDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/Test_SPARQL_TDB1.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.tdb1.store;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Graph ;
@@ -221,7 +221,7 @@ public class Test_SPARQL_TDB1
         UpdateAction.execute(req, ds);
 
         Model m = ds.getNamedModel("http://example/g2");
-        assertEquals("Did not find 1 statement in named graph", 1, m.size());
+        assertEquals(1, m.size(), "Did not find 1 statement in named graph");
     }
 
     private int count(Dataset dataset) {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/nodetable/AbstractTestNodeTable.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/nodetable/AbstractTestNodeTable.java
@@ -21,17 +21,17 @@
 
 package org.apache.jena.tdb1.store.nodetable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.sparql.util.NodeFactoryExtra;
 import org.apache.jena.tdb1.TDB1Exception;
 import org.apache.jena.tdb1.store.NodeId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractTestNodeTable
 {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/nodetable/TS_NodeTable.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/nodetable/TS_NodeTable.java
@@ -21,11 +21,11 @@
 
 package org.apache.jena.tdb1.store.nodetable;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestNodec.class
     , TestNodeTableStored.class
     , TestNodeTable.class

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/nodetable/TestNodec.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/nodetable/TestNodec.java
@@ -21,24 +21,24 @@
 
 package org.apache.jena.tdb1.store.nodetable;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.jena.atlas.lib.ByteBufferLib;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.sse.SSE;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized.class)
-public class TestNodec
-{
+@ParameterizedClass
+@MethodSource("provideArgs")
+public class TestNodec {
     static private final String asciiBase             = "abc";
     static private final String latinBase             = "Àéíÿ";
     static private final String latinExtraBase        = "ỹﬁﬂ";      // fi-ligature, fl-ligature
@@ -49,9 +49,8 @@ public class TestNodec
     static private final String chineseBase           = "孫子兵法"; // The Art of War
     static private final String japaneseBase          = "日本";     // Japanese
 
-    @Parameters(name="{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{{"NodecSSE", new NodecSSE()}});
+    public static Stream<Arguments> provideArgs() {
+        return Stream.of(Arguments.of("NodecSSE", new NodecSSE()));
     }
 
     private Nodec nodec;

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/tupletable/AbstractTestTupleIndex.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/tupletable/AbstractTestTupleIndex.java
@@ -21,10 +21,10 @@
 
 package org.apache.jena.tdb1.store.tupletable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator ;
 import java.util.Set ;
@@ -33,7 +33,7 @@ import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.tuple.Tuple ;
 import org.apache.jena.atlas.lib.tuple.TupleFactory ;
 import org.apache.jena.tdb1.store.NodeId;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 /** Test TupleIndexes (general) */
 public abstract class AbstractTestTupleIndex
@@ -43,76 +43,76 @@ public abstract class AbstractTestTupleIndex
     protected static NodeId n3 = new NodeId(3) ;
     protected static NodeId n4 = new NodeId(0x4040404040404040L) ;
     protected static NodeId n5 = new NodeId(0x5555555555555555L) ;
-    protected static NodeId n6 = new NodeId(0x6666666666666666L) ; 
-    
+    protected static NodeId n6 = new NodeId(0x6666666666666666L) ;
+
     protected abstract TupleIndex createIndex(String description) ;
-    
+
     protected static void add(TupleIndex index, NodeId x1, NodeId x2, NodeId x3)
     {
         Tuple<NodeId> tuple = TupleFactory.tuple(x1, x2, x3) ;
         index.add(tuple) ;
     }
-    
+
     @Test public void TupleIndex_1()
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
     }
-    
+
     @Test public void TupleIndexRecordSPO_1()
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, n3) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertTrue(iter.hasNext()) ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
- 
+
     @Test public void TupleIndexRecordSPO_2()
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, null) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertTrue(iter.hasNext()) ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
     @Test public void TupleIndexRecordSPO_3()
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, null, n3) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertTrue(iter.hasNext()) ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
     @Test public void TupleIndexRecordSPO_4()
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, NodeId.NodeIdAny, NodeId.NodeIdAny) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertTrue(iter.hasNext()) ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
     @Test public void TupleIndexRecordSPO_5()
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n2, n4) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, n3) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         Set<Tuple<NodeId>> x = Iter.toSet(iter) ;
@@ -126,7 +126,7 @@ public abstract class AbstractTestTupleIndex
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n2, n4) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, NodeId.NodeIdAny) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         Set<Tuple<NodeId>> x = Iter.toSet(iter) ;
@@ -140,7 +140,7 @@ public abstract class AbstractTestTupleIndex
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n2, n4) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, NodeId.NodeIdAny, NodeId.NodeIdAny) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         Set<Tuple<NodeId>> x = Iter.toSet(iter) ;
@@ -178,32 +178,32 @@ public abstract class AbstractTestTupleIndex
         add(index, n1, n2, n3) ;
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, n3) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
-        assertTrue("Can't find tuple", iter.hasNext()) ;
+        assertTrue(iter.hasNext(), "Can't find tuple") ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
- 
+
     @Test public void TupleIndexRecordPOS_2()
     {
         TupleIndex index = createIndex("POS") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(null, n2, null) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
-        assertTrue("Can't find tuple",iter.hasNext()) ;
+        assertTrue(iter.hasNext(),"Can't find tuple") ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
 
     @Test public void TupleIndexRecordPOS_3()
     {
         TupleIndex index = createIndex("POS") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(null, n2, n3) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
-        assertTrue("Can't find tuple", iter.hasNext()) ;
+        assertTrue(iter.hasNext(), "Can't find tuple") ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
@@ -212,18 +212,18 @@ public abstract class AbstractTestTupleIndex
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n4, n5, n6) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertNotNull(iter) ;
         assertFalse(iter.hasNext()) ;
    }
-    
+
     @Test public void TupleIndexRecordFindNot_2()
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n5, n6) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertFalse(iter.hasNext()) ;
@@ -233,7 +233,7 @@ public abstract class AbstractTestTupleIndex
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, null, n6) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertFalse(iter.hasNext()) ;
@@ -244,18 +244,18 @@ public abstract class AbstractTestTupleIndex
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n5, n6) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n4, n5, n6) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertFalse(iter.hasNext()) ;
    }
-    
+
     @Test public void TupleIndexRecordFindNot_5()
     {
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n5, n6) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n2, n5, n6) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertFalse(iter.hasNext()) ;
@@ -266,11 +266,11 @@ public abstract class AbstractTestTupleIndex
         TupleIndex index = createIndex("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n4, n5, n6) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, null, n6) ;
         Iterator<Tuple<NodeId>> iter = index.find(tuple2) ;
         assertFalse(iter.hasNext()) ;
    }
 
-    
+
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/tupletable/TS_TupleTable.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/tupletable/TS_TupleTable.java
@@ -21,11 +21,11 @@
 
 package org.apache.jena.tdb1.store.tupletable;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
     TestTupleIndexRecord.class,
     TestTupleIndexRecordDirect.class,
     TestTupleTable.class

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/tupletable/TestTupleIndexRecordDirect.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/tupletable/TestTupleIndexRecordDirect.java
@@ -21,7 +21,7 @@
 
 package org.apache.jena.tdb1.store.tupletable;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Iterator ;
 import java.util.Set ;
@@ -38,7 +38,7 @@ import org.apache.jena.tdb1.lib.ColumnMap;
 import org.apache.jena.tdb1.setup.StoreParams;
 import org.apache.jena.tdb1.store.NodeId;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 public class TestTupleIndexRecordDirect
 {
@@ -48,58 +48,58 @@ public class TestTupleIndexRecordDirect
     static NodeId n3 = new NodeId(3) ;
     static NodeId n4 = new NodeId(0x4040404040404040L) ;
     static NodeId n5 = new NodeId(0x5555555555555555L) ;
-    static NodeId n6 = new NodeId(0x6666666666666666L) ; 
-    
+    static NodeId n6 = new NodeId(0x6666666666666666L) ;
+
     static TupleIndexRecord create(String description)
     {
-        IndexParams indexParams = StoreParams.getDftStoreParams() ; 
+        IndexParams indexParams = StoreParams.getDftStoreParams() ;
         RangeIndex rIdx = IndexFactory.buildRangeIndex(FileSet.mem(), factory, indexParams) ;
         ColumnMap cmap = new ColumnMap("SPO", description) ;
         TupleIndexRecord index = new TupleIndexRecord(3, cmap, description, factory, rIdx) ;
         return index ;
     }
-    
+
     static void add(TupleIndexRecord index, NodeId x1, NodeId x2, NodeId x3)
     {
         Tuple<NodeId> tuple = TupleFactory.tuple(x1, x2, x3) ;
         index.add(tuple) ;
     }
-    
+
     @Test public void TupleIndexRecord_1()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
     }
-    
+
     @Test public void TupleIndexRecordSPO_1()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, n3) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         assertTrue(iter.hasNext()) ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
- 
+
     @Test public void TupleIndexRecordSPO_2()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, null) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         assertTrue(iter.hasNext()) ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
     @Test public void TupleIndexRecordSPO_3()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, null, n3) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         assertNull(iter) ;
@@ -108,25 +108,25 @@ public class TestTupleIndexRecordDirect
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
     @Test public void TupleIndexRecordSPO_4()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, NodeId.NodeIdAny, NodeId.NodeIdAny) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         assertTrue(iter.hasNext()) ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
     @Test public void TupleIndexRecordSPO_5()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n2, n4) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, n3) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         Set<Tuple<NodeId>> x = Iter.toSet(iter) ;
@@ -140,7 +140,7 @@ public class TestTupleIndexRecordDirect
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n2, n4) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, NodeId.NodeIdAny) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         Set<Tuple<NodeId>> x = Iter.toSet(iter) ;
@@ -154,7 +154,7 @@ public class TestTupleIndexRecordDirect
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n2, n4) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, NodeId.NodeIdAny, NodeId.NodeIdAny) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         Set<Tuple<NodeId>> x = Iter.toSet(iter) ;
@@ -192,32 +192,32 @@ public class TestTupleIndexRecordDirect
         add(index, n1, n2, n3) ;
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n2, n3) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
-        assertTrue("Can't find tuple", iter.hasNext()) ;
+        assertTrue(iter.hasNext(), "Can't find tuple") ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
- 
+
     @Test public void TupleIndexRecordPOS_2()
     {
         TupleIndexRecord index = create("POS") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(null, n2, null) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
-        assertTrue("Can't find tuple",iter.hasNext()) ;
+        assertTrue(iter.hasNext(),"Can't find tuple") ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
 
     @Test public void TupleIndexRecordPOS_3()
     {
         TupleIndexRecord index = create("POS") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(null, n2, n3) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
-        assertTrue("Can't find tuple", iter.hasNext()) ;
+        assertTrue(iter.hasNext(), "Can't find tuple") ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
@@ -234,43 +234,43 @@ public class TestTupleIndexRecordDirect
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
     @Test public void TupleIndexRecordFindScan_2()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n2, n4) ;
-        
-        
+
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(null, null, n3) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         assertNull(iter) ;
-        
+
         iter = index.findOrPartialScan(tuple2) ;
         assertNull(iter) ;
-        
+
         iter = index.findOrScan(tuple2) ;
         assertTrue(iter.hasNext()) ;
         iter.next();
         assertFalse(iter.hasNext()) ;
     }
-    
+
     @Test public void TupleIndexRecordFindNot_1()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n4, n5, n6) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         assertNotNull(iter) ;
         assertFalse(iter.hasNext()) ;
    }
-    
+
     @Test public void TupleIndexRecordFindNot_2()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, n5, n6) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         assertFalse(iter.hasNext()) ;
@@ -280,7 +280,7 @@ public class TestTupleIndexRecordDirect
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, null, n6) ;
         Iterator<Tuple<NodeId>> iter = index.findOrPartialScan(tuple2) ;
         assertFalse(iter.hasNext()) ;
@@ -291,18 +291,18 @@ public class TestTupleIndexRecordDirect
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n5, n6) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n4, n5, n6) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         assertFalse(iter.hasNext()) ;
    }
-    
+
     @Test public void TupleIndexRecordFindNot_5()
     {
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n1, n5, n6) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n2, n5, n6) ;
         Iterator<Tuple<NodeId>> iter = index.findByIndex(tuple2) ;
         assertFalse(iter.hasNext()) ;
@@ -313,11 +313,11 @@ public class TestTupleIndexRecordDirect
         TupleIndexRecord index = create("SPO") ;
         add(index, n1, n2, n3) ;
         add(index, n4, n5, n6) ;
-        
+
         Tuple<NodeId> tuple2 = TupleFactory.tuple(n1, null, n6) ;
         Iterator<Tuple<NodeId>> iter = index.findOrPartialScan(tuple2) ;
         assertFalse(iter.hasNext()) ;
    }
 
-    
+
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/tupletable/TestTupleTable.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/store/tupletable/TestTupleTable.java
@@ -21,8 +21,8 @@
 
 package org.apache.jena.tdb1.store.tupletable;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Iterator;
 import java.util.List;
@@ -33,7 +33,7 @@ import org.apache.jena.atlas.lib.tuple.TupleFactory ;
 import org.apache.jena.tdb1.base.record.RecordFactory;
 import org.apache.jena.tdb1.store.NodeId;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class TestTupleTable

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/AbstractTestObjectFileTrans.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/AbstractTestObjectFileTrans.java
@@ -21,143 +21,136 @@
 
 package org.apache.jena.tdb1.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.ByteBuffer ;
-import java.util.Iterator ;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
 
-import org.apache.jena.atlas.lib.Pair ;
-import org.apache.jena.atlas.lib.StrUtils ;
-import org.apache.jena.query.ReadWrite ;
+import org.apache.jena.atlas.lib.Pair;
+import org.apache.jena.atlas.lib.StrUtils;
+import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.tdb1.base.objectfile.ObjectFile;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public abstract class AbstractTestObjectFileTrans
-{
-    static long count = 0 ;
-    ObjectFile file1 ;
-    ObjectFileTrans file ;
-    Transaction txn ;
-    
-    abstract ObjectFile createFile(String basename) ;
-    abstract void deleteFile(String basename) ;
-    
-    TransactionManager tm = null ;
-    
-    @Before
-    public void setup()
-    {
-        txn = new Transaction(null, 5, TxnType.WRITE, ReadWrite.WRITE, ++count, TxnType.WRITE, null, tm) ;
-        file1 = createFile("base") ;
-        //file2 = createFile("log") ;
+public abstract class AbstractTestObjectFileTrans {
+    static long count = 0;
+    ObjectFile file1;
+    ObjectFileTrans file;
+    Transaction txn;
+
+    abstract ObjectFile createFile(String basename);
+
+    abstract void deleteFile(String basename);
+
+    TransactionManager tm = null;
+
+    @BeforeEach
+    public void setup() {
+        txn = new Transaction(null, 5, TxnType.WRITE, ReadWrite.WRITE, ++count, TxnType.WRITE, null, tm);
+        file1 = createFile("base");
+        // file2 = createFile("log") ;
     }
 
-    @After
-    public void teardown()
-    {
-        deleteFile("base") ;
-        deleteFile("log") ;
+    @AfterEach
+    public void teardown() {
+        deleteFile("base");
+        deleteFile("log");
     }
-    
-    static void write(ObjectFile file, String str)
-    {
-        byte b[] = StrUtils.asUTF8bytes(str) ;
-        ByteBuffer bb = ByteBuffer.wrap(b) ;
-        file.write(bb) ;
+
+    static void write(ObjectFile file, String str) {
+        byte b[] = StrUtils.asUTF8bytes(str);
+        ByteBuffer bb = ByteBuffer.wrap(b);
+        file.write(bb);
     }
-    
-    private static void contains(ObjectFile f, String... contents) 
-    {
-        Iterator<Pair<Long, ByteBuffer>> iter = f.all() ; 
-        for ( String s : contents )
-        {
-            assertTrue(iter.hasNext()) ;
-            Pair<Long, ByteBuffer> p = iter.next() ;
-            String s2 = StrUtils.fromUTF8bytes(p.cdr().array()) ;
-            assertEquals(s, s2) ;
+
+    private static void contains(ObjectFile f, String...contents) {
+        Iterator<Pair<Long, ByteBuffer>> iter = f.all();
+        for ( String s : contents ) {
+            assertTrue(iter.hasNext());
+            Pair<Long, ByteBuffer> p = iter.next();
+            String s2 = StrUtils.fromUTF8bytes(p.cdr().array());
+            assertEquals(s, s2);
         }
-        
-        assertFalse(iter.hasNext()) ;
-    }
-    
 
-    private void init() { 
-        //file = new ObjectFileTransComplex(null, file1, file2) ;
-        file = new ObjectFileTrans(null, file1) ;
+        assertFalse(iter.hasNext());
     }
-    
-    static void fill(ObjectFile file, String... contents)
-    {
+
+    private void init() {
+        // file = new ObjectFileTransComplex(null, file1, file2) ;
+        file = new ObjectFileTrans(null, file1);
+    }
+
+    static void fill(ObjectFile file, String...contents) {
         for ( String s : contents )
-            write(file, s) ;
-    }
-    
-    @Test public void objFileTrans_01()
-    {
-        init() ;
-        contains(file) ;
-    }
-    
-    @Test public void objFileTrans_02()
-    {
-        fill(file1, "ABC") ;
-        init() ;
-        
-        file.begin(txn) ; 
-        //contains(file2) ;
-        file.commitPrepare(txn) ;
-        file.enactCommitted(txn) ;
-        contains(file1, "ABC") ;
-        file.clearupCommitted(txn) ;
+            write(file, s);
     }
 
-    @Test public void objFileTrans_03()
-    {
-        fill(file1, "ABC") ;
-        init() ;
-        file.begin(txn) ; 
-        write(file, "X") ;
-        file.commitPrepare(txn) ;
-        file.enactCommitted(txn) ;
-        contains(file1, "ABC", "X") ;
-        file.clearupCommitted(txn) ;
+    @Test
+    public void objFileTrans_01() {
+        init();
+        contains(file);
     }
 
-    @Test public void objFileTrans_04()
-    {
-        fill(file1, "ABC", "ABC") ;
-        init() ;
-        file.begin(txn) ; 
-        write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
-        file.commitPrepare(txn) ;
-        file.enactCommitted(txn) ;
-        contains(file1, "ABC", "ABC", "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
-        file.clearupCommitted(txn) ;
+    @Test
+    public void objFileTrans_02() {
+        fill(file1, "ABC");
+        init();
+
+        file.begin(txn);
+        // contains(file2) ;
+        file.commitPrepare(txn);
+        file.enactCommitted(txn);
+        contains(file1, "ABC");
+        file.clearupCommitted(txn);
     }
 
-    @Test public void objFileTrans_05()
-    {
-        fill(file1, "ABC") ;
-        init() ;
-        file.begin(txn) ; 
-        write(file, "ABCDEF") ;
-        file.abort(txn) ;
-        contains(file1, "ABC") ;
-        file.clearupCommitted(txn) ;
+    @Test
+    public void objFileTrans_03() {
+        fill(file1, "ABC");
+        init();
+        file.begin(txn);
+        write(file, "X");
+        file.commitPrepare(txn);
+        file.enactCommitted(txn);
+        contains(file1, "ABC", "X");
+        file.clearupCommitted(txn);
     }
 
-    @Test public void objFileTrans_06()
-    {
-        fill(file1, "ABC", "123") ;
-        init() ;
-        file.begin(txn) ; 
-        write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
-        file.abort(txn) ;
-        contains(file1, "ABC", "123") ;
+    @Test
+    public void objFileTrans_04() {
+        fill(file1, "ABC", "ABC");
+        init();
+        file.begin(txn);
+        write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        file.commitPrepare(txn);
+        file.enactCommitted(txn);
+        contains(file1, "ABC", "ABC", "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        file.clearupCommitted(txn);
+    }
+
+    @Test
+    public void objFileTrans_05() {
+        fill(file1, "ABC");
+        init();
+        file.begin(txn);
+        write(file, "ABCDEF");
+        file.abort(txn);
+        contains(file1, "ABC");
+        file.clearupCommitted(txn);
+    }
+
+    @Test
+    public void objFileTrans_06() {
+        fill(file1, "ABC", "123");
+        init();
+        file.begin(txn);
+        write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        file.abort(txn);
+        contains(file1, "ABC", "123");
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/AbstractTestObjectFileTransComplex.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/AbstractTestObjectFileTransComplex.java
@@ -21,145 +21,142 @@
 
 package org.apache.jena.tdb1.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.ByteBuffer ;
-import java.util.Iterator ;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
 
-import org.apache.jena.atlas.lib.Pair ;
-import org.apache.jena.atlas.lib.StrUtils ;
-import org.apache.jena.query.ReadWrite ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.atlas.lib.Pair;
+import org.apache.jena.atlas.lib.StrUtils;
+import org.apache.jena.query.ReadWrite;
 import org.apache.jena.query.TxnType;
 import org.apache.jena.tdb1.base.objectfile.ObjectFile;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
 
-/** Clone of AbstractTestObjectFileTrans that understands 2-file ObjectFileTransComplex */
-public abstract class AbstractTestObjectFileTransComplex
-{
-    static long count = 0 ;
-    ObjectFile file1 ;
-    ObjectFile file2 ;
-    ObjectFileTransComplex file ;
-    Transaction txn ;
-    
-    abstract ObjectFile createFile(String basename) ;
-    abstract void deleteFile(String basename) ;
-    
-    TransactionManager tm = null ;
-    
-    @Before
-    public void setup()
-    {
-        txn = new Transaction(null, 5, TxnType.WRITE, ReadWrite.WRITE, ++count, TxnType.WRITE, null, tm) ;
-        file1 = createFile("base") ;
-        file2 = createFile("log") ;
+/**
+ * Clone of AbstractTestObjectFileTrans that understands 2-file
+ * ObjectFileTransComplex
+ */
+public abstract class AbstractTestObjectFileTransComplex {
+    static long count = 0;
+    ObjectFile file1;
+    ObjectFile file2;
+    ObjectFileTransComplex file;
+    Transaction txn;
+
+    abstract ObjectFile createFile(String basename);
+
+    abstract void deleteFile(String basename);
+
+    TransactionManager tm = null;
+
+    @BeforeEach
+    public void setup() {
+        txn = new Transaction(null, 5, TxnType.WRITE, ReadWrite.WRITE, ++count, TxnType.WRITE, null, tm);
+        file1 = createFile("base");
+        file2 = createFile("log");
     }
 
-    @After
-    public void teardown()
-    {
-        deleteFile("base") ;
-        deleteFile("log") ;
+    @AfterEach
+    public void teardown() {
+        deleteFile("base");
+        deleteFile("log");
     }
-    
-    static void write(ObjectFile file, String str)
-    {
-        byte b[] = StrUtils.asUTF8bytes(str) ;
-        ByteBuffer bb = ByteBuffer.wrap(b) ;
-        file.write(bb) ;
+
+    static void write(ObjectFile file, String str) {
+        byte b[] = StrUtils.asUTF8bytes(str);
+        ByteBuffer bb = ByteBuffer.wrap(b);
+        file.write(bb);
     }
-    
-    private static void contains(ObjectFile f, String... contents) 
-    {
-        Iterator<Pair<Long, ByteBuffer>> iter = f.all() ; 
-        for ( String s : contents )
-        {
-            assertTrue(iter.hasNext()) ;
-            Pair<Long, ByteBuffer> p = iter.next() ;
-            String s2 = StrUtils.fromUTF8bytes(p.cdr().array()) ;
-            assertEquals(s, s2) ;
+
+    private static void contains(ObjectFile f, String...contents) {
+        Iterator<Pair<Long, ByteBuffer>> iter = f.all();
+        for ( String s : contents ) {
+            assertTrue(iter.hasNext());
+            Pair<Long, ByteBuffer> p = iter.next();
+            String s2 = StrUtils.fromUTF8bytes(p.cdr().array());
+            assertEquals(s, s2);
         }
-        
-        assertFalse(iter.hasNext()) ;
-    }
-    
 
-    private void init() { 
-        file = new ObjectFileTransComplex(null, file1, file2) ;
+        assertFalse(iter.hasNext());
     }
-    
-    static void fill(ObjectFile file, String... contents)
-    {
+
+    private void init() {
+        file = new ObjectFileTransComplex(null, file1, file2);
+    }
+
+    static void fill(ObjectFile file, String...contents) {
         for ( String s : contents )
-            write(file, s) ;
-    }
-    
-    @Test public void objFileTrans_01()
-    {
-        init() ;
-        contains(file) ;
-    }
-    
-    @Test public void objFileTrans_02()
-    {
-        fill(file1, "ABC") ;
-        init() ;
-        
-        file.begin(txn) ; 
-        // Test empty. 
-        contains(file2) ;
-        file.commitPrepare(txn) ;
-        file.enactCommitted(txn) ;
-        contains(file1, "ABC") ;
-        file.clearupCommitted(txn) ;
+            write(file, s);
     }
 
-    @Test public void objFileTrans_03()
-    {
-        fill(file1, "ABC") ;
-        init() ;
-        file.begin(txn) ; 
-        write(file, "X") ;
-        file.commitPrepare(txn) ;
-        file.enactCommitted(txn) ;
-        contains(file1, "ABC", "X") ;
-        file.clearupCommitted(txn) ;
+    @Test
+    public void objFileTrans_01() {
+        init();
+        contains(file);
     }
 
-    @Test public void objFileTrans_04()
-    {
-        fill(file1, "ABC", "ABC") ;
-        init() ;
-        file.begin(txn) ; 
-        write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
-        file.commitPrepare(txn) ;
-        file.enactCommitted(txn) ;
-        contains(file1, "ABC", "ABC", "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
-        file.clearupCommitted(txn) ;
+    @Test
+    public void objFileTrans_02() {
+        fill(file1, "ABC");
+        init();
+
+        file.begin(txn);
+        // Test empty.
+        contains(file2);
+        file.commitPrepare(txn);
+        file.enactCommitted(txn);
+        contains(file1, "ABC");
+        file.clearupCommitted(txn);
     }
 
-    @Test public void objFileTrans_05()
-    {
-        fill(file1, "ABC") ;
-        init() ;
-        file.begin(txn) ; 
-        write(file, "ABCDEF") ;
-        file.abort(txn) ;
-        contains(file1, "ABC") ;
-        file.clearupCommitted(txn) ;
+    @Test
+    public void objFileTrans_03() {
+        fill(file1, "ABC");
+        init();
+        file.begin(txn);
+        write(file, "X");
+        file.commitPrepare(txn);
+        file.enactCommitted(txn);
+        contains(file1, "ABC", "X");
+        file.clearupCommitted(txn);
     }
 
-    @Test public void objFileTrans_06()
-    {
-        fill(file1, "ABC", "123") ;
-        init() ;
-        file.begin(txn) ; 
-        write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") ;
-        file.abort(txn) ;
-        contains(file1, "ABC", "123") ;
+    @Test
+    public void objFileTrans_04() {
+        fill(file1, "ABC", "ABC");
+        init();
+        file.begin(txn);
+        write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        file.commitPrepare(txn);
+        file.enactCommitted(txn);
+        contains(file1, "ABC", "ABC", "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        file.clearupCommitted(txn);
+    }
+
+    @Test
+    public void objFileTrans_05() {
+        fill(file1, "ABC");
+        init();
+        file.begin(txn);
+        write(file, "ABCDEF");
+        file.abort(txn);
+        contains(file1, "ABC");
+        file.clearupCommitted(txn);
+    }
+
+    @Test
+    public void objFileTrans_06() {
+        fill(file1, "ABC", "123");
+        init();
+        file.begin(txn);
+        write(file, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+        file.abort(txn);
+        contains(file1, "ABC", "123");
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/AbstractTestTransSeq.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/AbstractTestTransSeq.java
@@ -22,8 +22,13 @@
 package org.apache.jena.tdb1.transaction;
 
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.atlas.logging.LogCtl ;
 import org.apache.jena.query.TxnType;
@@ -35,16 +40,13 @@ import org.apache.jena.tdb1.TDB1Exception;
 import org.apache.jena.tdb1.store.DatasetGraphTDB;
 import org.apache.jena.tdb1.sys.StoreConnection;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
 
 /** Basic tests and tests of ordering (single thread) */
 public abstract class AbstractTestTransSeq
 {
-    @BeforeClass public static void beforeClassLoggingOff() { LogCtl.disable(SystemTDB.errlog.getName()) ; } 
-    @AfterClass public static void afterClassLoggingOn()    { LogCtl.setInfo(SystemTDB.errlog.getName()) ; }
-    
+    @BeforeAll public static void beforeClassLoggingOff() { LogCtl.disable(SystemTDB.errlog.getName()) ; }
+    @AfterAll public static void afterClassLoggingOn()    { LogCtl.setInfo(SystemTDB.errlog.getName()) ; }
+
     // Per test unique-ish.
     long x = System.currentTimeMillis() ;
 
@@ -53,20 +55,20 @@ public abstract class AbstractTestTransSeq
     Quad q2 = SSE.parseQuad("(<g> <s> <p> '2-"+x+"')") ;
     Quad q3 = SSE.parseQuad("(<g> <s> <p> '3-"+x+"')") ;
     Quad q4 = SSE.parseQuad("(<g> <s> <p> '4-"+x+"')") ;
-   
+
     private StoreConnection sConn ;
 
     protected abstract StoreConnection getStoreConnection() ;
 
     // Basics.
-    
+
     @Test public void trans_01()
     {
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsg = sConn.begin(TxnType.READ) ;
         dsg.end() ;
     }
-    
+
 
     @Test public void trans_02()
     {
@@ -78,48 +80,48 @@ public abstract class AbstractTestTransSeq
             dsg.commit() ;
         } finally { dsg.end() ; }
     }
-    
+
     @Test public void trans_03()
     {
         // WRITE-commit-READ-check
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgW = sConn.begin(TxnType.WRITE) ;
-        
+
         dsgW.add(q) ;
         assertTrue(dsgW.contains(q)) ;
         dsgW.commit() ;
         dsgW.end() ;
-        
+
         DatasetGraphTxn dsg2 = sConn.begin(TxnType.READ) ;
         assertTrue(dsg2.contains(q)) ;
         dsg2.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q)) ;
-        
+
     }
-    
+
     @Test public void trans_04()
     {
         // WRITE-abort-READ-check
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgW = sConn.begin(TxnType.WRITE) ;
-        
+
         dsgW.add(q) ;
         assertTrue(dsgW.contains(q)) ;
         dsgW.abort() ;
         dsgW.end() ;
-        
+
         DatasetGraphTxn dsg2 = sConn.begin(TxnType.READ) ;
         assertFalse(dsg2.contains(q)) ;
         dsg2.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertFalse(dsg.contains(q)) ;
     }
-    
+
     @Test public void trans_05()
     {
         // WRITE(commit)-WRITE(commit)-READ-check
@@ -138,23 +140,23 @@ public abstract class AbstractTestTransSeq
         assertTrue(dsgR2.contains(q1)) ;
         assertTrue(dsgR2.contains(q2)) ;
         dsgR2.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q1)) ;
         assertTrue(dsg.contains(q2)) ;
     }
-    
+
     @Test public void trans_06()
     {
         // READ(start)-READ(finish)-WRITE(start)-WRITE(commit)-check
         StoreConnection sConn = getStoreConnection() ;
-        
+
         DatasetGraphTxn dsgR2 = sConn.begin(TxnType.READ) ;
         assertFalse(dsgR2.contains(q1)) ;
         assertFalse(dsgR2.contains(q2)) ;
         dsgR2.end() ;
-        
+
         DatasetGraphTxn dsgW1 = sConn.begin(TxnType.WRITE) ;
         dsgW1.add(q1) ;
         dsgW1.add(q2) ;
@@ -166,68 +168,68 @@ public abstract class AbstractTestTransSeq
         assertTrue(dsg.contains(q1)) ;
         assertTrue(dsg.contains(q2)) ;
     }
-    
+
     @Test public void trans_readBlock_01()
     {
         // READ(start)-WRITE(commit)-READ(finish)-check
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgR1 = sConn.begin(TxnType.READ) ;
-        
+
         DatasetGraphTxn dsgW = sConn.begin(TxnType.WRITE) ;
-        
+
         dsgW.add(q) ;
         dsgW.commit() ;
         dsgW.end() ;
-        
+
         assertFalse(dsgR1.contains(q)) ;
         dsgR1.end() ;
 
         DatasetGraphTxn dsgR2 = sConn.begin(TxnType.READ) ;
         assertTrue(dsgR2.contains(q)) ;
         dsgR2.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q)) ;
     }
 
-    
+
     @Test public void trans_readBlock_02()
     {
         // READ(start)-WRITE(abort)-READ(finish)-check
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgR1 = sConn.begin(TxnType.READ) ;
-        
+
         DatasetGraphTxn dsgW = sConn.begin(TxnType.WRITE) ;
-        
+
         dsgW.add(q) ;
         dsgW.abort() ;
         dsgW.end() ;
-        
+
         assertFalse(dsgR1.contains(q)) ;
         dsgR1.end() ;
 
         DatasetGraphTxn dsgR2 = sConn.begin(TxnType.READ) ;
         assertFalse(dsgR2.contains(q)) ;
         dsgR2.end() ;
-        
+
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertFalse(dsg.contains(q)) ;
     }
-    
+
     @Test public void trans_readBlock_03()
     {
         // READ(start)-WRITE(commit)-WRITE(commit)-READ(finish)-check
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgR1 = sConn.begin(TxnType.READ) ;
-        
+
         DatasetGraphTxn dsgW1 = sConn.begin(TxnType.WRITE) ;
         dsgW1.add(q1) ;
         dsgW1.commit() ;
         dsgW1.end() ;
 
         assertFalse(dsgR1.contains(q1)) ;
-        
+
         DatasetGraphTxn dsgW2 = sConn.begin(TxnType.WRITE) ;
         dsgW2.add(q2) ;
         dsgW2.commit() ;
@@ -242,7 +244,7 @@ public abstract class AbstractTestTransSeq
         assertTrue(dsgR2.contains(q1)) ;
         assertTrue(dsgR2.contains(q2)) ;
         dsgR2.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q1)) ;
@@ -255,7 +257,7 @@ public abstract class AbstractTestTransSeq
         // READ(block)-WRITE(abort)-WRITE(commit)-READ(close)-check
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgR1 = sConn.begin(TxnType.READ) ;
-        
+
         DatasetGraphTxn dsgW2 = sConn.begin(TxnType.WRITE) ;
         dsgW2.add(q2) ;
         dsgW2.abort() ; // ABORT
@@ -269,9 +271,9 @@ public abstract class AbstractTestTransSeq
         dsgW3.commit() ;
         dsgW3.end() ;
         assertFalse(dsgR1.contains(q3)) ;
-        
+
         dsgR1.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertFalse(dsg.contains(q2)) ;
@@ -285,13 +287,13 @@ public abstract class AbstractTestTransSeq
         // READ(block)-WRITE(commit)-WRITE(abort)-WRITE(commit)-READ(close)-check
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgR1 = sConn.begin(TxnType.READ) ;
-        
+
         DatasetGraphTxn dsgW1 = sConn.begin(TxnType.WRITE) ;
         dsgW1.add(q1) ;
         dsgW1.commit() ;
         dsgW1.end() ;
         assertFalse(dsgR1.contains(q1)) ;
-        
+
         DatasetGraphTxn dsgW2 = sConn.begin(TxnType.WRITE) ;
         dsgW2.add(q2) ;
         dsgW2.abort() ; // ABORT
@@ -306,9 +308,9 @@ public abstract class AbstractTestTransSeq
         dsgW3.commit() ;
         dsgW3.end() ;
         assertFalse(dsgR1.contains(q3)) ;
-        
+
         dsgR1.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q1)) ;
@@ -319,23 +321,23 @@ public abstract class AbstractTestTransSeq
     @Test public void trans_readBlock_06()
     {
         // WRITE(start)-READ(start)-WRITE(commit)-READ sees old DSG.
-        // READ before WRITE remains seeing old view - READ after WRITE starts 
+        // READ before WRITE remains seeing old view - READ after WRITE starts
 
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgW = sConn.begin(TxnType.WRITE) ;
         DatasetGraphTxn dsgR = sConn.begin(TxnType.READ) ;
-        
+
         dsgW.add(q) ;
         dsgW.commit() ;
         dsgW.end() ;
-        
+
         assertFalse(dsgR.contains(q)) ;
         dsgR.end() ;
 
         DatasetGraphTxn dsgR2 = sConn.begin(TxnType.READ) ;
         assertTrue(dsgR2.contains(q)) ;
         dsgR2.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q)) ;
@@ -344,7 +346,7 @@ public abstract class AbstractTestTransSeq
     @Test public void trans_readBlock_07()
     {
         // WRITE(start)-READ(start)-add-WRITE(commit)-READ sees old DSG.
-        // READ before WRITE remains seeing old view - READ after WRITE starts 
+        // READ before WRITE remains seeing old view - READ after WRITE starts
 
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgW = sConn.begin(TxnType.WRITE) ;
@@ -353,14 +355,14 @@ public abstract class AbstractTestTransSeq
         DatasetGraphTxn dsgR = sConn.begin(TxnType.READ) ;
         dsgW.commit() ;
         dsgW.end() ;
-        
+
         assertFalse(dsgR.contains(q)) ;
         dsgR.end() ;
-        
+
         DatasetGraphTxn dsgR2 = sConn.begin(TxnType.READ) ;
         assertTrue(dsgR2.contains(q)) ;
         dsgR2.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q)) ;
@@ -372,20 +374,20 @@ public abstract class AbstractTestTransSeq
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsgW = sConn.begin(TxnType.WRITE) ;
         dsgW.add(q) ;
-        
+
         DatasetGraphTxn dsgR1 = sConn.begin(TxnType.READ) ;
-        assertFalse(dsgR1.contains(q)) ;  
-        
+        assertFalse(dsgR1.contains(q)) ;
+
         dsgW.commit() ;
         dsgW.end() ;
-        
+
         DatasetGraphTxn dsgR2 = sConn.begin(TxnType.READ) ;
-        
+
         assertFalse(dsgR1.contains(q)) ;    // Before view
         assertTrue(dsgR2.contains(q)) ;     // After view
         dsgR1.end() ;
         dsgR2.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q)) ;
@@ -409,19 +411,19 @@ public abstract class AbstractTestTransSeq
         DatasetGraphTxn dsgR2 = sConn.begin(TxnType.READ) ;
         assertTrue(dsgR1.contains(q1)) ;
         assertFalse(dsgR1.contains(q2)) ;
-        
+
         assertTrue(dsgR2.contains(q1)) ;
         assertTrue(dsgR2.contains(q2)) ;
-        
+
         dsgR1.end() ;
         dsgR2.end() ;
-        
+
         sConn.flush() ;
         DatasetGraph dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q1)) ;
         assertTrue(dsg.contains(q2)) ;
     }
-    
+
     @Test public void trans_readBlock_10()
     {
         // READ(start)-WRITE(start)-WRITE(finish)-WRITE(start)-READ(finish)-WRITE(finish)-check
@@ -432,16 +434,16 @@ public abstract class AbstractTestTransSeq
         dsgW1.add(q1) ;
         dsgW1.commit() ;
         dsgW1.end() ;
-        
+
         DatasetGraphTxn dsgW2 = sConn.begin(TxnType.WRITE) ;
         dsgW2.add(q2) ;
         dsgR1.end() ;
 
         dsgW2.commit() ;
         dsgW2.end() ;
-        
+
         sConn.forceRecoverFromJournal() ;
-        DatasetGraphTDB dsg = sConn.getBaseDataset() ; 
+        DatasetGraphTDB dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q1)) ;
         assertTrue(dsg.contains(q2)) ;
     }
@@ -457,7 +459,7 @@ public abstract class AbstractTestTransSeq
         dsgW1.add(q1) ;
         dsgW1.commit() ;
         dsgW1.end() ;
-        
+
         DatasetGraphTxn dsgW2 = sConn.begin(TxnType.WRITE) ;
         dsgW2.add(q2) ;
         dsgW2.commit() ;
@@ -469,15 +471,15 @@ public abstract class AbstractTestTransSeq
         dsgW3.end() ;
 
         dsgR1.end() ;
-        
+
         sConn.flush() ;
-        DatasetGraphTDB dsg = sConn.getBaseDataset() ; 
+        DatasetGraphTDB dsg = sConn.getBaseDataset() ;
         assertTrue(dsg.contains(q1)) ;
         assertTrue(dsg.contains(q2)) ;
         assertTrue(dsg.contains(q3)) ;
     }
-    
-    
+
+
     // Not a test
     //@Test (expected=TDBTransactionException.class)
     public void trans_20()
@@ -487,27 +489,27 @@ public abstract class AbstractTestTransSeq
         DatasetGraphTxn dsgW1 = sConn.begin(TxnType.WRITE) ;
         DatasetGraphTxn dsgW2 = sConn.begin(TxnType.WRITE) ;
     }
-    
-    @Test (expected=TDB1Exception.class) 
+
+    @Test
     public void trans_21()
     {
         // READ-add
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsg = sConn.begin(TxnType.READ) ;
-        dsg.add(q) ;
+        assertThrows(TDB1Exception.class, ()->dsg.add(q)) ;
     }
-    
-    @Test(expected=JenaTransactionException.class) 
+
+    @Test
     public void trans_22()
     {
         // WRITE-close causes implicit abort
         StoreConnection sConn = getStoreConnection() ;
         DatasetGraphTxn dsg = sConn.begin(TxnType.WRITE) ;
         dsg.add(q) ;
-        dsg.end() ;
+        assertThrows(JenaTransactionException.class, ()->dsg.end());
     }
-    
-    //@Test 
+
+    //@Test
     public void trans_30()
     {
         // WRITE lots

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/AbstractTestTransSequentialDisk.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/AbstractTestTransSequentialDisk.java
@@ -26,8 +26,8 @@ import java.io.File ;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.sys.StoreConnection;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.After ;
-import org.junit.Before ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /** Basic tests and tests of ordering (single thread) */
 public abstract class AbstractTestTransSequentialDisk extends AbstractTestTransSeq
@@ -35,18 +35,18 @@ public abstract class AbstractTestTransSequentialDisk extends AbstractTestTransS
     protected String DIR = null ;
 
     // Subclasses must implement.
-//    @BeforeClass public static void beforeClass() {}
-//    @AfterClass  public static void afterClass()  {}
+//    @BeforeAll public static void beforeClass() {}
+//    @AfterAll  public static void afterClass()  {}
 
     @SuppressWarnings("removal")
-    @Before public void before()
+    @BeforeEach public void before()
     {
         TDBInternal.reset() ;
         DIR = ConfigTest.getCleanDir() ;
         File d = new File(DIR) ;
     }
 
-    @After public void after() {}
+    @AfterEach public void after() {}
 
     @Override
     protected StoreConnection getStoreConnection()

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TS_TransactionTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TS_TransactionTDB1.java
@@ -21,20 +21,20 @@
 
 package org.apache.jena.tdb1.transaction;
 
-import org.junit.runner.RunWith ;
-import org.junit.runners.Suite ;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses( {
+@Suite
+@SelectClasses({
       TestJournal.class
     , TestTransIterator.class
     , TestObjectFileTransMem.class
     , TestObjectFileTransStorage.class
-    
+
     // ObjectFileTransComplex is not used by TDB currently.
     , TestObjectFileTransComplexMem.class
     , TestObjectFileTransComplexStorage.class
-    
+
     , TestTransMem.class
     , TestTransDiskDirect.class
     , TestTransDiskMapped.class

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestJournal.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestJournal.java
@@ -21,7 +21,7 @@
 
 package org.apache.jena.tdb1.transaction;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.ByteBuffer ;
 import java.util.Iterator ;
@@ -31,8 +31,8 @@ import org.apache.jena.tdb1.base.block.Block;
 import org.apache.jena.tdb1.base.file.BufferChannel;
 import org.apache.jena.tdb1.base.file.BufferChannelMem;
 import org.apache.jena.tdb1.sys.FileRef;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestJournal
 {
@@ -62,7 +62,7 @@ public class TestJournal
     static FileRef testRef2 = FileRef.create("TEST2") ;
     
     Journal journal ;
-    @Before public void before()
+    @BeforeEach public void before()
     {
         BufferChannel mem = BufferChannelMem.create("journal") ;
         journal = new Journal(mem) ;

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTDB1Internal.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTDB1Internal.java
@@ -21,117 +21,129 @@
 
 package org.apache.jena.tdb1.transaction;
 
-import java.util.concurrent.locks.ReentrantReadWriteLock ;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.jena.query.ReadWrite ;
-import org.apache.jena.sparql.core.DatasetGraph ;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.tdb1.sys.StoreConnection;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.Assert ;
-import org.junit.Test ;
 
 /** Tests for lower level details of TDB */
 @SuppressWarnings("removal")
 public class TestTDB1Internal {
 
-    @Test public void basics_1() {
-        DatasetGraph dsg = TDB1Factory.createDatasetGraph() ;
-        StoreConnection sConn = TDBInternal.getStoreConnection(dsg) ;
-        Assert.assertNotNull(sConn);
+    @Test
+    public void basics_1() {
+        DatasetGraph dsg = TDB1Factory.createDatasetGraph();
+        StoreConnection sConn = TDBInternal.getStoreConnection(dsg);
+        assertNotNull(sConn);
     }
 
-    @Test public void basics_2() {
-        DatasetGraph dsg = TDB1Factory.createDatasetGraph() ;
-        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg) ;
-        Assert.assertNotNull(txnmgr);
+    @Test
+    public void basics_2() {
+        DatasetGraph dsg = TDB1Factory.createDatasetGraph();
+        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg);
+        assertNotNull(txnmgr);
     }
 
-    @Test public void exclusive_1() {
-        DatasetGraph dsg = TDB1Factory.createDatasetGraph() ;
-        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg) ;
-        checkTxnMgr(txnmgr, 0, 0) ;
+    @Test
+    public void exclusive_1() {
+        DatasetGraph dsg = TDB1Factory.createDatasetGraph();
+        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg);
+        checkTxnMgr(txnmgr, 0, 0);
 
-        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$() ;
-        checkLock(rwx,0,0) ;
+        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$();
+        checkLock(rwx, 0, 0);
 
         dsg.begin(ReadWrite.WRITE);
-        checkLock(rwx,1,0) ;    // Exclusivity reader lock.
-        checkTxnMgr(txnmgr, 0, 1) ;
+        checkLock(rwx, 1, 0);    // Exclusivity reader lock.
+        checkTxnMgr(txnmgr, 0, 1);
         dsg.commit();
 
-        checkLock(rwx,0,0) ;    // Exclusivity reader lock.
-        checkTxnMgr(txnmgr, 0, 0) ;
+        checkLock(rwx, 0, 0);    // Exclusivity reader lock.
+        checkTxnMgr(txnmgr, 0, 0);
 
         dsg.end();
-        checkLock(rwx,0,0) ;    // Exclusivity reader lock.
-        checkTxnMgr(txnmgr, 0, 0) ;
+        checkLock(rwx, 0, 0);    // Exclusivity reader lock.
+        checkTxnMgr(txnmgr, 0, 0);
     }
 
-    @Test public void exclusive_2() {
-        DatasetGraph dsg = TDB1Factory.createDatasetGraph() ;
-        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg) ;
-        checkTxnMgr(txnmgr, 0, 0) ;
+    @Test
+    public void exclusive_2() {
+        DatasetGraph dsg = TDB1Factory.createDatasetGraph();
+        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg);
+        checkTxnMgr(txnmgr, 0, 0);
 
-        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$() ;
-        checkLock(rwx,0,0) ;
+        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$();
+        checkLock(rwx, 0, 0);
 
         dsg.begin(ReadWrite.READ);
-        checkLock(rwx,1,0) ;
-        checkTxnMgr(txnmgr, 1, 0) ;
+        checkLock(rwx, 1, 0);
+        checkTxnMgr(txnmgr, 1, 0);
         dsg.end();
-        checkLock(rwx,0,0) ;
-        checkTxnMgr(txnmgr, 0, 0) ;
+        checkLock(rwx, 0, 0);
+        checkTxnMgr(txnmgr, 0, 0);
     }
 
-    @Test public void exclusive_3() {
-        DatasetGraph dsg = TDB1Factory.createDatasetGraph() ;
-        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg) ;
-        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$() ;
+    @Test
+    public void exclusive_3() {
+        DatasetGraph dsg = TDB1Factory.createDatasetGraph();
+        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg);
+        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$();
 
-        checkLock(rwx, 0, 0) ;
+        checkLock(rwx, 0, 0);
         txnmgr.startExclusiveMode();
-        checkLock(rwx, 0, 1) ;
+        checkLock(rwx, 0, 1);
         txnmgr.finishExclusiveMode();
-        checkLock(rwx, 0, 0) ;
+        checkLock(rwx, 0, 0);
     }
 
-    @Test public void exclusive_4() {
-        DatasetGraph dsg = TDB1Factory.createDatasetGraph() ;
-        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg) ;
-        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$() ;
+    @Test
+    public void exclusive_4() {
+        DatasetGraph dsg = TDB1Factory.createDatasetGraph();
+        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg);
+        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$();
 
-        checkLock(rwx, 0, 0) ;
+        checkLock(rwx, 0, 0);
         boolean b = txnmgr.tryExclusiveMode();
-        Assert.assertTrue("Exclusive 1", b);
-        checkLock(rwx, 0, 1) ;
+        assertTrue(b, "Exclusive 1");
+        checkLock(rwx, 0, 1);
         txnmgr.finishExclusiveMode();
-        checkLock(rwx, 0, 0) ;
+        checkLock(rwx, 0, 0);
         b = txnmgr.tryExclusiveMode();
-        Assert.assertTrue("Exclusive 2", b);
+        assertTrue(b, "Exclusive 2");
     }
 
-    @Test public void exclusive_5() {
-        DatasetGraph dsg = TDB1Factory.createDatasetGraph() ;
-        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg) ;
-        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$() ;
+    @Test
+    public void exclusive_5() {
+        DatasetGraph dsg = TDB1Factory.createDatasetGraph();
+        TransactionManager txnmgr = TDBInternal.getTransactionManager(dsg);
+        ReentrantReadWriteLock rwx = (ReentrantReadWriteLock)txnmgr.getExclusivityLock$();
         dsg.begin(ReadWrite.READ);
         boolean b = txnmgr.tryExclusiveMode();
-        Assert.assertFalse(b);
+        assertFalse(b);
     }
 
     private static void checkLock(ReentrantReadWriteLock rwx, int expectedR, int expectedW) {
-        int r = rwx.getReadHoldCount() ;
-        int w = rwx.getWriteHoldCount() ;
-        Assert.assertEquals("R", expectedR, r);
-        Assert.assertEquals("W", expectedW, w);
+        int r = rwx.getReadHoldCount();
+        int w = rwx.getWriteHoldCount();
+        assertEquals(expectedR, r, "R");
+        assertEquals(expectedW, w, "W");
     }
 
-    private static void checkTxnMgr(TransactionManager txnmgr , int expectedActiveReaders, int expectedActiveWriters) {
-        long r = txnmgr.getCountActiveReaders() ;
-        long w = txnmgr.getCountActiveWriters() ;
-        Assert.assertEquals("R-active", expectedActiveReaders, r);
-        Assert.assertEquals("W-active", expectedActiveWriters, w);
+    private static void checkTxnMgr(TransactionManager txnmgr, int expectedActiveReaders, int expectedActiveWriters) {
+        long r = txnmgr.getCountActiveReaders();
+        long w = txnmgr.getCountActiveWriters();
+        assertEquals(expectedActiveReaders, r, "R-active");
+        assertEquals(expectedActiveWriters, w, "W-active");
 
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransControl.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransControl.java
@@ -19,29 +19,33 @@
  *   SPDX-License-Identifier: Apache-2.0
  */
 
-package org.apache.jena.tdb1.transaction ;
+package org.apache.jena.tdb1.transaction;
 
-import static org.junit.Assert.assertEquals ;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.jena.atlas.logging.LogCtl;
-import org.apache.jena.sparql.core.DatasetGraph ;
-import org.apache.jena.sparql.core.Quad ;
-import org.apache.jena.sparql.sse.SSE ;
-import org.apache.jena.system.Txn ;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.system.Txn;
 import org.apache.jena.tdb1.TDB1;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.tdb1.sys.SystemTDB;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.* ;
+import org.junit.jupiter.api.*;
 
-/** Tests for transaction controls: batching, flushing on size, flushing on backlog of commits */
+/**
+ * Tests for transaction controls: batching, flushing on size, flushing on backlog of
+ * commits
+ */
 @SuppressWarnings("removal")
 public class TestTransControl {
 
     private static String levelInfo;
     private static String levelErr;
 
-    @BeforeClass public static void beforeClassLogging() {
+    @BeforeAll
+    public static void beforeClassLogging() {
         levelInfo = LogCtl.getLevel(TDB1.logInfoName);
         levelErr = LogCtl.getLevel(SystemTDB.errlog.getName());
 
@@ -49,164 +53,173 @@ public class TestTransControl {
         LogCtl.setLevel("org.apache.jena.tdb.exec", "WARN");
 
     }
-    @AfterClass public static void afterClassLogging() {
+
+    @AfterAll
+    public static void afterClassLogging() {
         LogCtl.setLevel(TDB1.logInfoName, levelInfo);
         LogCtl.setLevel(SystemTDB.errlog.getName(), levelErr);
     }
 
-    private static int x_QueueBatchSize ;
-    private static int x_MaxQueueThreshold ;
-    private static int x_JournalThresholdSize ;
+    private static int x_QueueBatchSize;
+    private static int x_MaxQueueThreshold;
+    private static int x_JournalThresholdSize;
 
-    @BeforeClass
+    @BeforeAll
     static public void beforeClass() {
-        x_QueueBatchSize = TransactionManager.QueueBatchSize ;
-        x_MaxQueueThreshold = TransactionManager.MaxQueueThreshold ;
-        x_JournalThresholdSize = TransactionManager.JournalThresholdSize ;
+        x_QueueBatchSize = TransactionManager.QueueBatchSize;
+        x_MaxQueueThreshold = TransactionManager.MaxQueueThreshold;
+        x_JournalThresholdSize = TransactionManager.JournalThresholdSize;
     }
 
-    @AfterClass
+    @AfterAll
     static public void afterClass() {
-        TransactionManager.QueueBatchSize = x_QueueBatchSize ;
-        TransactionManager.MaxQueueThreshold = x_MaxQueueThreshold ;
-        TransactionManager.JournalThresholdSize = x_JournalThresholdSize ;
-
+        TransactionManager.QueueBatchSize = x_QueueBatchSize;
+        TransactionManager.MaxQueueThreshold = x_MaxQueueThreshold;
+        TransactionManager.JournalThresholdSize = x_JournalThresholdSize;
 
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         // Set all "off"
-        TransactionManager.QueueBatchSize = 1000 ;
-        TransactionManager.MaxQueueThreshold = -1 ;
-        TransactionManager.JournalThresholdSize = -1 ;
+        TransactionManager.QueueBatchSize = 1000;
+        TransactionManager.MaxQueueThreshold = -1;
+        TransactionManager.JournalThresholdSize = -1;
     }
 
-    @After
-    public void after() {
-    }
+    @AfterEach
+    public void after() {}
 
-
-    private static Quad q1 = SSE.parseQuad("(_ :s :p1 1)") ;
-    private static Quad q2 = SSE.parseQuad("(_ :s :p2 2)") ;
-    private static Quad q3 = SSE.parseQuad("(_ :s :p3 3)") ;
+    private static Quad q1 = SSE.parseQuad("(_ :s :p1 1)");
+    private static Quad q2 = SSE.parseQuad("(_ :s :p2 2)");
+    private static Quad q3 = SSE.parseQuad("(_ :s :p3 3)");
 
     protected DatasetGraph create() {
-        return TDB1Factory.createDatasetGraph() ;
+        return TDB1Factory.createDatasetGraph();
     }
 
     // ---- JournalThresholdSize
 
     // Flush on journal size / no spill.
-    @Test public void journalThresholdSize_01() {
-        TransactionManager.QueueBatchSize = 100 ;
-        TransactionManager.MaxQueueThreshold = -1 ;
-        TransactionManager.JournalThresholdSize = 1000 ; // More than commit size, less than a block.
-        DatasetGraph dsg = create() ;
-        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+    @Test
+    public void journalThresholdSize_01() {
+        TransactionManager.QueueBatchSize = 100;
+        TransactionManager.MaxQueueThreshold = -1;
+        TransactionManager.JournalThresholdSize = 1000; // More than commit size,
+                                                        // less than a block.
+        DatasetGraph dsg = create();
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg);
 
-        Txn.executeWrite(dsg,  ()->{});    // About 20 bytes.
-        assertEquals(1, tMgr.getQueueLength()) ;
+        Txn.executeWrite(dsg, () -> {});    // About 20 bytes.
+        assertEquals(1, tMgr.getQueueLength());
     }
 
     // Flush on journal size / small setting.
-    @Test public void journalThresholdSize_02() {
-        TransactionManager.QueueBatchSize = 100 ;
-        TransactionManager.MaxQueueThreshold = -1 ;
-        TransactionManager.JournalThresholdSize = 10 ; // Less than commit size.
-        DatasetGraph dsg = create() ;
-        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+    @Test
+    public void journalThresholdSize_02() {
+        TransactionManager.QueueBatchSize = 100;
+        TransactionManager.MaxQueueThreshold = -1;
+        TransactionManager.JournalThresholdSize = 10; // Less than commit size.
+        DatasetGraph dsg = create();
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg);
 
-        txnAddData(dsg) ;
-        assertEquals(0, tMgr.getQueueLength()) ;
+        txnAddData(dsg);
+        assertEquals(0, tMgr.getQueueLength());
     }
 
     // Intermediate flush journal size.
-    @Test public void journalThresholdSize_03() {
-        TransactionManager.QueueBatchSize = 100 ;
-        TransactionManager.MaxQueueThreshold = -1 ;
-        TransactionManager.JournalThresholdSize = 1000 ; // More than commit size, less than block.
+    @Test
+    public void journalThresholdSize_03() {
+        TransactionManager.QueueBatchSize = 100;
+        TransactionManager.MaxQueueThreshold = -1;
+        TransactionManager.JournalThresholdSize = 1000; // More than commit size,
+                                                        // less than block.
 
-        DatasetGraph dsg = create() ;
-        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+        DatasetGraph dsg = create();
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg);
 
-        Txn.executeWrite(dsg,  ()->{});    // About 20 bytes.
-        assertEquals(1, tMgr.getQueueLength()) ;
-        txnAddData(dsg) ;
-        assertEquals(0, tMgr.getQueueLength()) ;
+        Txn.executeWrite(dsg, () -> {});    // About 20 bytes.
+        assertEquals(1, tMgr.getQueueLength());
+        txnAddData(dsg);
+        assertEquals(0, tMgr.getQueueLength());
     }
 
     // ---- QueueBatchSize
 
-    @Test public void queueBatchSize_01() {
-        TransactionManager.QueueBatchSize = 0 ; // Immediate.
+    @Test
+    public void queueBatchSize_01() {
+        TransactionManager.QueueBatchSize = 0; // Immediate.
 
-        DatasetGraph dsg = create() ;
-        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+        DatasetGraph dsg = create();
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg);
 
-        Txn.executeWrite(dsg,  ()->{});
-        assertEquals(0, tMgr.getQueueLength()) ;
-        Txn.executeWrite(dsg,  ()->{});
-        assertEquals(0, tMgr.getQueueLength()) ;
+        Txn.executeWrite(dsg, () -> {});
+        assertEquals(0, tMgr.getQueueLength());
+        Txn.executeWrite(dsg, () -> {});
+        assertEquals(0, tMgr.getQueueLength());
     }
 
-    @Test public void queueBatchSize_02() {
-        TransactionManager.QueueBatchSize = 1 ;
+    @Test
+    public void queueBatchSize_02() {
+        TransactionManager.QueueBatchSize = 1;
 
-        DatasetGraph dsg = create() ;
-        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+        DatasetGraph dsg = create();
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg);
 
-        Txn.executeWrite(dsg,  ()->{});
-        assertEquals(1, tMgr.getQueueLength()) ;
-        Txn.executeWrite(dsg,  ()->{});
-        assertEquals(0, tMgr.getQueueLength()) ;
+        Txn.executeWrite(dsg, () -> {});
+        assertEquals(1, tMgr.getQueueLength());
+        Txn.executeWrite(dsg, () -> {});
+        assertEquals(0, tMgr.getQueueLength());
     }
 
-    @Test public void queueBatchSize_03() {
-        TransactionManager.QueueBatchSize = 2 ;
+    @Test
+    public void queueBatchSize_03() {
+        TransactionManager.QueueBatchSize = 2;
 
-        DatasetGraph dsg = create() ;
-        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+        DatasetGraph dsg = create();
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg);
 
-        txnAddData(dsg) ;
-        assertEquals(1, tMgr.getQueueLength()) ;
-        txnAddData(dsg) ;
-        assertEquals(2, tMgr.getQueueLength()) ;
-        txnAddData(dsg) ;
-        assertEquals(0, tMgr.getQueueLength()) ;
+        txnAddData(dsg);
+        assertEquals(1, tMgr.getQueueLength());
+        txnAddData(dsg);
+        assertEquals(2, tMgr.getQueueLength());
+        txnAddData(dsg);
+        assertEquals(0, tMgr.getQueueLength());
     }
 
     // ---- MaxQueueThreshold
 
-    @Test public void maxQueueThreshold_01() {
-        TransactionManager.MaxQueueThreshold = 1 ;
+    @Test
+    public void maxQueueThreshold_01() {
+        TransactionManager.MaxQueueThreshold = 1;
 
-        DatasetGraph dsg = create() ;
-        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+        DatasetGraph dsg = create();
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg);
 
-        Txn.executeWrite(dsg,  ()->{});
-        assertEquals(1, tMgr.getQueueLength()) ;
-        Txn.executeWrite(dsg,  ()->{});
-        assertEquals(0, tMgr.getQueueLength()) ;
+        Txn.executeWrite(dsg, () -> {});
+        assertEquals(1, tMgr.getQueueLength());
+        Txn.executeWrite(dsg, () -> {});
+        assertEquals(0, tMgr.getQueueLength());
     }
 
-    @Test public void maxQueueThreshold_02() {
-        TransactionManager.MaxQueueThreshold = 2 ;
+    @Test
+    public void maxQueueThreshold_02() {
+        TransactionManager.MaxQueueThreshold = 2;
 
-        DatasetGraph dsg = create() ;
-        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg) ;
+        DatasetGraph dsg = create();
+        TransactionManager tMgr = TDBInternal.getTransactionManager(dsg);
 
-        txnAddData(dsg) ;
-        assertEquals(1, tMgr.getQueueLength()) ;
-        txnAddData(dsg) ;
-        assertEquals(2, tMgr.getQueueLength()) ;
-        Txn.executeWrite(dsg,  ()->{});
-        assertEquals(0, tMgr.getQueueLength()) ;
+        txnAddData(dsg);
+        assertEquals(1, tMgr.getQueueLength());
+        txnAddData(dsg);
+        assertEquals(2, tMgr.getQueueLength());
+        Txn.executeWrite(dsg, () -> {});
+        assertEquals(0, tMgr.getQueueLength());
     }
 
     private static void txnAddData(DatasetGraph dsg) {
         // Unique blank node.
-        Quad q = SSE.parseQuad("(_ _:b :p 1)") ;
-        Txn.executeWrite(dsg,  ()->dsg.add(q));
+        Quad q = SSE.parseQuad("(_ _:b :p 1)");
+        Txn.executeWrite(dsg, () -> dsg.add(q));
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransDiskDirect.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransDiskDirect.java
@@ -24,13 +24,13 @@ package org.apache.jena.tdb1.transaction;
 import org.apache.jena.tdb1.base.block.FileMode;
 import org.apache.jena.tdb1.sys.LibTestOps;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TestTransDiskDirect extends AbstractTestTransSequentialDisk
 {
     static FileMode mode = SystemTDB.fileMode() ;  
-    @BeforeClass public static void beforeClass() { LibTestOps.setFileMode(FileMode.direct) ; }
-    @AfterClass  public static void afterClass()  { LibTestOps.setFileMode(mode) ; }
+    @BeforeAll public static void beforeClass() { LibTestOps.setFileMode(FileMode.direct) ; }
+    @AfterAll  public static void afterClass()  { LibTestOps.setFileMode(mode) ; }
 }
 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransDiskMapped.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransDiskMapped.java
@@ -24,14 +24,14 @@ package org.apache.jena.tdb1.transaction;
 import org.apache.jena.tdb1.base.block.FileMode;
 import org.apache.jena.tdb1.sys.LibTestOps;
 import org.apache.jena.tdb1.sys.SystemTDB;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class TestTransDiskMapped extends AbstractTestTransSequentialDisk
 {
     static FileMode mode = SystemTDB.fileMode() ;  
-    @BeforeClass public static void beforeClassFileMode() { LibTestOps.setFileMode(FileMode.mapped) ; }
-    @AfterClass  public static void afterClassFileMode()  { LibTestOps.setFileMode(mode) ; }
+    @BeforeAll public static void beforeClassFileMode() { LibTestOps.setFileMode(FileMode.mapped) ; }
+    @AfterAll  public static void afterClassFileMode()  { LibTestOps.setFileMode(mode) ; }
 
 }
 

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransIterator.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransIterator.java
@@ -21,8 +21,8 @@
 
 package org.apache.jena.tdb1.transaction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Iterator ;
 
@@ -32,7 +32,7 @@ import org.apache.jena.tdb1.base.record.RecordLib;
 import org.apache.jena.tdb1.index.IndexTestLib;
 import org.apache.jena.tdb1.index.RangeIndex;
 import org.apache.jena.tdb1.index.bplustree.BPlusTree;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 public class TestTransIterator
 {

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransMem.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransMem.java
@@ -24,19 +24,19 @@ package org.apache.jena.tdb1.transaction;
 import org.apache.jena.tdb1.base.file.Location;
 import org.apache.jena.tdb1.sys.StoreConnection;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.After ;
-import org.junit.Before ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /** Basic tests and tests of ordering (single thread) */
 @SuppressWarnings("removal")
 public class TestTransMem extends AbstractTestTransSeq
 {
-    @Before public void before()
+    @BeforeEach public void before()
     {
         TDBInternal.reset() ;
     }
 
-    @After public void after() {}
+    @AfterEach public void after() {}
 
     @Override
     protected StoreConnection getStoreConnection()

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransRestart.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransRestart.java
@@ -21,8 +21,8 @@
 
 package org.apache.jena.tdb1.transaction ;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer ;
 import java.util.Iterator ;
@@ -43,9 +43,9 @@ import org.apache.jena.tdb1.sys.Names;
 import org.apache.jena.tdb1.sys.StoreConnection;
 import org.apache.jena.tdb1.sys.SystemTDB;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Test of re-attaching to a pre-existing database */
 @SuppressWarnings("removal")
@@ -63,7 +63,7 @@ public class TestTransRestart {
     private static Quad quad1 = SSE.parseQuad("(_ <foo:bar> rdfs:label 'foo')") ;
     private static Quad quad2 = SSE.parseQuad("(_ <foo:bar> rdfs:label 'bar')") ;
 
-    @Before public void setup() {
+    @BeforeEach public void setup() {
         TDBInternal.reset();
         path = ConfigTest.getCleanDir() ;
         location = Location.create (path) ;
@@ -73,7 +73,7 @@ public class TestTransRestart {
             setupPlain() ;
     }
 
-    @After public void teardown()
+    @AfterEach public void teardown()
     {
         cleanup() ;
     }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransactionMiscTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransactionMiscTDB1.java
@@ -23,14 +23,16 @@ package org.apache.jena.tdb1.transaction;
 
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.tdb1.TDB1Factory;
-import org.junit.Assert ;
-import org.junit.Test ;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("removal")
 public class TestTransactionMiscTDB1 {
     @Test public void support() {
         DatasetGraph dsg = TDB1Factory.createDatasetGraph() ;
-        Assert.assertTrue(dsg.supportsTransactions()) ;
-        Assert.assertTrue(dsg.supportsTransactionAbort()) ;
+        assertTrue(dsg.supportsTransactions()) ;
+        assertTrue(dsg.supportsTransactionAbort()) ;
     }
 }

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransactionTDB1.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransactionTDB1.java
@@ -21,43 +21,42 @@
 
 package org.apache.jena.tdb1.transaction;
 
-import org.apache.jena.atlas.lib.FileOps ;
-import org.apache.jena.atlas.logging.LogCtl ;
-import org.apache.jena.query.Dataset ;
-import org.apache.jena.sparql.transaction.AbstractTestTransactionLifecycle ;
+import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.atlas.logging.LogCtl;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.sparql.transaction.AbstractTestTransactionLifecycle;
 import org.apache.jena.tdb1.ConfigTest;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.tdb1.sys.SystemTDB;
 import org.apache.jena.tdb1.sys.TDBInternal;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 
 @SuppressWarnings("removal")
-public class TestTransactionTDB1 extends AbstractTestTransactionLifecycle
-{
-    private String DIR = null ;
-    private static String level = null ;
+public class TestTransactionTDB1 extends AbstractTestTransactionLifecycle {
+    private String DIR = null;
+    private static String level = null;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClassLoggingOff() {
         level = LogCtl.getLevel(SystemTDB.errlog.getName());
         LogCtl.setLevel(SystemTDB.errlog.getName(), "OFF");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClassLoggingOn() {
         LogCtl.setLevel(SystemTDB.errlog.getName(), level);
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         TDBInternal.reset();
         DIR = ConfigTest.getCleanDir();
     }
 
-    @After
+    @AfterEach
     public void after() {
         TDBInternal.reset();
         FileOps.clearDirectory(DIR);
@@ -68,4 +67,3 @@ public class TestTransactionTDB1 extends AbstractTestTransactionLifecycle
         return TDB1Factory.createDataset(DIR);
     }
 }
-

--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransactionUnionGraph.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/transaction/TestTransactionUnionGraph.java
@@ -21,164 +21,156 @@
 
 package org.apache.jena.tdb1.transaction;
 
-import static org.apache.jena.query.ReadWrite.READ ;
-import static org.apache.jena.query.ReadWrite.WRITE ;
-import static org.junit.Assert.assertEquals;
+import static org.apache.jena.query.ReadWrite.READ;
+import static org.apache.jena.query.ReadWrite.WRITE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.apache.jena.atlas.lib.StrUtils ;
-import org.apache.jena.query.* ;
-import org.apache.jena.sparql.core.Quad ;
-import org.apache.jena.sparql.sse.SSE ;
+import org.apache.jena.atlas.lib.StrUtils;
+import org.apache.jena.query.*;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.tdb1.TDB1;
 import org.apache.jena.tdb1.TDB1Factory;
-import org.apache.jena.update.* ;
-import org.junit.* ;
+import org.apache.jena.update.*;
+import org.junit.jupiter.api.*;
 
 /** Tests of transactions and the TDB union graph */
 @SuppressWarnings("removal")
-public class TestTransactionUnionGraph
-{
-    private Dataset ds ;
+public class TestTransactionUnionGraph {
+    private Dataset ds;
 
-    @Before
-    public void before()
-    {
-        ds = TDB1Factory.createDataset() ;
-        ds.asDatasetGraph().add(SSE.parseQuad("(<g> <s> <p> 1)")) ;
+    @BeforeEach
+    public void before() {
+        ds = TDB1Factory.createDataset();
+        ds.asDatasetGraph().add(SSE.parseQuad("(<g> <s> <p> 1)"));
     }
 
-    @After public void after() { }
+    @AfterEach
+    public void after() {}
 
-    @Test public void uniontxn_global_r()
-    {
-        ARQ.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
-        test(ReadWrite.READ) ;
-        ARQ.getContext().unset(TDB1.symUnionDefaultGraph) ;
+    @Test
+    public void uniontxn_global_r() {
+        ARQ.getContext().setTrue(TDB1.symUnionDefaultGraph);
+        test(ReadWrite.READ);
+        ARQ.getContext().unset(TDB1.symUnionDefaultGraph);
     }
 
-    @Test public void uniontxn_global_w()
-    {
-        ARQ.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
-        test(ReadWrite.WRITE) ;
-        ARQ.getContext().unset(TDB1.symUnionDefaultGraph) ;
+    @Test
+    public void uniontxn_global_w() {
+        ARQ.getContext().setTrue(TDB1.symUnionDefaultGraph);
+        test(ReadWrite.WRITE);
+        ARQ.getContext().unset(TDB1.symUnionDefaultGraph);
     }
 
-    @Test public void uniontxn_ds_r_1()
-    {
-        ds.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
-        test(ReadWrite.READ) ;
-        ds.getContext().unset(TDB1.symUnionDefaultGraph) ;
+    @Test
+    public void uniontxn_ds_r_1() {
+        ds.getContext().setTrue(TDB1.symUnionDefaultGraph);
+        test(ReadWrite.READ);
+        ds.getContext().unset(TDB1.symUnionDefaultGraph);
     }
 
-    @Test public void uniontxn_ds_w_1()
-    {
-        ds.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
-        test(ReadWrite.WRITE) ;
-        ds.getContext().unset(TDB1.symUnionDefaultGraph) ;
+    @Test
+    public void uniontxn_ds_w_1() {
+        ds.getContext().setTrue(TDB1.symUnionDefaultGraph);
+        test(ReadWrite.WRITE);
+        ds.getContext().unset(TDB1.symUnionDefaultGraph);
     }
 
     // Set after a transaction.
-    @Test public void uniontxn_ds_rr()
-    {
-        ds.begin(READ) ;
+    @Test
+    public void uniontxn_ds_rr() {
+        ds.begin(READ);
         ds.commit();
-        ds.end() ;
+        ds.end();
 
-        ds.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
-        test(ReadWrite.READ) ;
-        //ds.getContext().unset(TDB.symUnionDefaultGraph) ;
+        ds.getContext().setTrue(TDB1.symUnionDefaultGraph);
+        test(ReadWrite.READ);
+        // ds.getContext().unset(TDB.symUnionDefaultGraph) ;
     }
 
-    @Test public void uniontxn_ds_wr()
-    {
-        ds.begin(WRITE) ;
+    @Test
+    public void uniontxn_ds_wr() {
+        ds.begin(WRITE);
         ds.commit();
-        ds.end() ;
+        ds.end();
 
-        ds.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
-        test(ReadWrite.READ) ;
-        //ds.getContext().unset(TDB.symUnionDefaultGraph) ;
+        ds.getContext().setTrue(TDB1.symUnionDefaultGraph);
+        test(ReadWrite.READ);
+        // ds.getContext().unset(TDB.symUnionDefaultGraph) ;
     }
 
-    @Test public void uniontxn_ds_ww()
-    {
-        ds.begin(WRITE) ;
+    @Test
+    public void uniontxn_ds_ww() {
+        ds.begin(WRITE);
         ds.commit();
-        ds.end() ;
+        ds.end();
 
-        ds.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
-        test(ReadWrite.WRITE) ;
-        //ds.getContext().unset(TDB.symUnionDefaultGraph) ;
+        ds.getContext().setTrue(TDB1.symUnionDefaultGraph);
+        test(ReadWrite.WRITE);
+        // ds.getContext().unset(TDB.symUnionDefaultGraph) ;
     }
 
-    @Test public void uniontxn_ds_rw()
-    {
-        ds.begin(READ) ;
+    @Test
+    public void uniontxn_ds_rw() {
+        ds.begin(READ);
         ds.commit();
-        ds.end() ;
+        ds.end();
 
-        ds.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
-        test(ReadWrite.WRITE) ;
-        //ds.getContext().unset(TDB.symUnionDefaultGraph) ;
+        ds.getContext().setTrue(TDB1.symUnionDefaultGraph);
+        test(ReadWrite.WRITE);
+        // ds.getContext().unset(TDB.symUnionDefaultGraph) ;
     }
 
-    @Test public void uniontxn_update()
-    {
-        String x = StrUtils.strjoinNL("BASE <http://example/>",
-                                      "CLEAR ALL ; ",
-                                      "INSERT DATA { GRAPH <urn:ex:g> { <s> <p> 1}} ; ",
-                                      "INSERT { GRAPH <urn:ex:g99> { ?s ?p 99} } WHERE  { ?s ?p 1 }"
-                                      ) ;
-        Dataset ds = TDB1Factory.createDataset() ;
-        ds.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
+    @Test
+    public void uniontxn_update() {
+        String x = StrUtils.strjoinNL("BASE <http://example/>", "CLEAR ALL ; ", "INSERT DATA { GRAPH <urn:ex:g> { <s> <p> 1}} ; ",
+                                      "INSERT { GRAPH <urn:ex:g99> { ?s ?p 99} } WHERE  { ?s ?p 1 }");
+        Dataset ds = TDB1Factory.createDataset();
+        ds.getContext().setTrue(TDB1.symUnionDefaultGraph);
 
-        ds.begin(WRITE) ;
-        UpdateRequest req = UpdateFactory.create(x) ;
-        UpdateAction.execute(req, ds) ;
-        ds.commit() ;
-        ds.end() ;
+        ds.begin(WRITE);
+        UpdateRequest req = UpdateFactory.create(x);
+        UpdateAction.execute(req, ds);
+        ds.commit();
+        ds.end();
 
-        ds.begin(READ) ;
-        assertEquals(1, ds.getNamedModel("urn:ex:g99").size()) ;
-        assertEquals(1, ds.getNamedModel("urn:ex:g").size()) ;
-        assertEquals(2, ds.getNamedModel(Quad.unionGraph.getURI()).size()) ;
-        ds.end() ;
+        ds.begin(READ);
+        assertEquals(1, ds.getNamedModel("urn:ex:g99").size());
+        assertEquals(1, ds.getNamedModel("urn:ex:g").size());
+        assertEquals(2, ds.getNamedModel(Quad.unionGraph.getURI()).size());
+        ds.end();
     }
 
-
-    private void test(ReadWrite mode)
-    {
-        ds.begin(mode) ;
-        Query q = QueryFactory.create("SELECT * { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o }}}") ;
-        QueryExecution qExec = QueryExecutionFactory.create(q, ds) ;
-        long count = ResultSetFormatter.consume(qExec.execSelect()) ;
-        ds.commit() ;
-        ds.end() ;
-        assertEquals(2, count) ;
+    private void test(ReadWrite mode) {
+        ds.begin(mode);
+        Query q = QueryFactory.create("SELECT * { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o }}}");
+        QueryExecution qExec = QueryExecutionFactory.create(q, ds);
+        long count = ResultSetFormatter.consume(qExec.execSelect());
+        ds.commit();
+        ds.end();
+        assertEquals(2, count);
     }
 
-    @Test public void uniontxn05()
-    {
-        test2(READ) ;
+    @Test
+    public void uniontxn05() {
+        test2(READ);
     }
 
-    @Test public void uniontxn06()
-    {
-        test2(WRITE) ;
+    @Test
+    public void uniontxn06() {
+        test2(WRITE);
     }
 
     // Sets the context of the execution
-    private void test2(ReadWrite mode)
-    {
-        ds.begin(mode) ;
-        Query q = QueryFactory.create("SELECT * { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o }}}") ;
-        QueryExecution qExec = QueryExecutionFactory.create(q, ds) ;
-        qExec.getContext().setTrue(TDB1.symUnionDefaultGraph) ;
-        long count = ResultSetFormatter.consume(qExec.execSelect()) ;
-        ds.commit() ;
-        ds.end() ;
-        assertEquals(2, count) ;
+    private void test2(ReadWrite mode) {
+        ds.begin(mode);
+        Query q = QueryFactory.create("SELECT * { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o }}}");
+        QueryExecution qExec = QueryExecutionFactory.create(q, ds);
+        qExec.getContext().setTrue(TDB1.symUnionDefaultGraph);
+        long count = ResultSetFormatter.consume(qExec.execSelect());
+        ds.commit();
+        ds.end();
+        assertEquals(2, count);
     }
 
 }
-

--- a/jena-text/pom.xml
+++ b/jena-text/pom.xml
@@ -101,8 +101,14 @@
     </dependency>
     
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithAnalyzer.java
@@ -31,8 +31,8 @@ import org.apache.jena.query.text.assembler.TextAssembler ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * This abstract class defines a setup configuration for a dataset that uses a specific analyzer with a Lucene index.
@@ -103,11 +103,9 @@ public abstract class AbstractTestDatasetWithAnalyzer extends AbstractTestDatase
         init(analyzer, "text:QueryParser");
     }   
     
-    @Before
-    abstract public void before();
+    @BeforeEach abstract public void before();
     
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithGraphTextIndex.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithGraphTextIndex.java
@@ -32,7 +32,7 @@ import org.apache.jena.query.ReadWrite ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.riot.Lang ;
 import org.apache.jena.riot.RDFDataMgr ;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 /**
  * This abstract class defines tests of the graph-specific indexing.

--- a/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithLuceneGraphTextIndex.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithLuceneGraphTextIndex.java
@@ -26,8 +26,8 @@ import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.vocabulary.RDFS ;
 import org.apache.lucene.store.Directory ;
 import org.apache.lucene.store.ByteBuffersDirectory ;
-import org.junit.After ;
-import org.junit.Before ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 
 /**
@@ -36,8 +36,7 @@ import org.junit.Before ;
 @SuppressWarnings("removal")
 public class AbstractTestDatasetWithLuceneGraphTextIndex extends AbstractTestDatasetWithGraphTextIndex {
 
-    @Before
-    public void init() {
+    @BeforeEach public void init() {
         Dataset ds1 = TDB1Factory.createDataset() ;
         Directory dir = new ByteBuffersDirectory() ;
         EntityDefinition eDef = new EntityDefinition("iri", "text");
@@ -48,8 +47,7 @@ public class AbstractTestDatasetWithLuceneGraphTextIndex extends AbstractTestDat
         dataset = TextDatasetFactory.create(ds1, tidx) ;
     }
 
-    @After
-    public void teardown() {
+    @AfterEach public void teardown() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithLuceneTextIndexDeletionSupport.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithLuceneTextIndexDeletionSupport.java
@@ -26,8 +26,8 @@ import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.vocabulary.RDFS;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.ByteBuffersDirectory;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 
 /**
@@ -36,8 +36,7 @@ import org.junit.Before;
 @SuppressWarnings("removal")
 public class AbstractTestDatasetWithLuceneTextIndexDeletionSupport extends AbstractTestDatasetWithTextIndex {
 
-    @Before
-    public void init() {
+    @BeforeEach public void init() {
         Dataset ds1 = TDB1Factory.createDataset() ;
         Directory dir = new ByteBuffersDirectory() ;
         EntityDefinition eDef = new EntityDefinition("iri", "text");
@@ -49,8 +48,7 @@ public class AbstractTestDatasetWithLuceneTextIndexDeletionSupport extends Abstr
         dataset = TextDatasetFactory.create(ds1, tidx) ;
     }
 
-    @After
-    public void teardown() {
+    @AfterEach public void teardown() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithTextIndex.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithTextIndex.java
@@ -21,7 +21,7 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays ;
 import java.util.HashSet ;
@@ -29,7 +29,7 @@ import java.util.Map ;
 import java.util.Set ;
 
 import org.apache.jena.atlas.lib.StrUtils ;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 /*
  * This abstract class defines a collection of test methods for testing

--- a/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithTextIndexBase.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/AbstractTestDatasetWithTextIndexBase.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.Reader;
 import java.io.StringReader;
@@ -104,13 +104,14 @@ public abstract class AbstractTestDatasetWithTextIndexBase {
             ResultSetRewindable results = rs.rewindable();
 //            ResultSetFormatter.out(results);
 //            results.reset();
-            assertEquals(label, expectedNumResults > 0, results.hasNext());
+            assertEquals(expectedNumResults > 0, results.hasNext(), label);
             int count;
             for (count=0; results.hasNext(); count++) {
                 String entityURI = results.next().getResource("s").getURI();
-                assertTrue(label + ": unexpected result: " + entityURI, expectedEntityURIs.contains(entityURI));
+                assertTrue(expectedEntityURIs.contains(entityURI),
+                           label + ": unexpected result: " + entityURI);
             }
-            assertEquals(label, expectedNumResults, count);
+            assertEquals(expectedNumResults, count, label);
         }
         finally {
             dataset.end() ;
@@ -147,7 +148,7 @@ public abstract class AbstractTestDatasetWithTextIndexBase {
         dataset.begin(ReadWrite.READ);
         try(QueryExecution qexec = QueryExecutionFactory.create(query, dataset)) {
             ResultSet results = qexec.execSelect() ;
-            assertFalse(label, results.hasNext());
+            assertFalse(results.hasNext(), label);
         }
         finally {
             dataset.end() ;

--- a/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TS_Text.java
@@ -21,18 +21,14 @@
 
 package org.apache.jena.query.text;
 
-import org.apache.jena.query.text.assembler.TestEntityMapAssembler;
-import org.apache.jena.query.text.assembler.TestTextDatasetAssembler;
-import org.apache.jena.query.text.assembler.TestTextIndexLuceneAssembler;
-import org.apache.jena.query.text.changes.TestDatasetMonitor;
-import org.apache.jena.query.text.assembler.TestGenericAnalyzerAssembler;
-import org.apache.jena.query.text.assembler.TestPropListsAssembler;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-import org.junit.runners.Suite.SuiteClasses;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@SuiteClasses({
+import org.apache.jena.query.text.assembler.*;
+import org.apache.jena.query.text.changes.TestDatasetMonitor;
+
+@Suite
+@SelectClasses({
 
     TestBuildTextDataset.class
     , TestDatasetMonitor.class

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestBuildTextDataset.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestBuildTextDataset.java
@@ -21,8 +21,8 @@
 
 package org.apache.jena.query.text ;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.query.* ;
@@ -32,7 +32,7 @@ import org.apache.jena.tdb1.TDB1;
 import org.apache.jena.vocabulary.RDFS ;
 import org.apache.lucene.store.ByteBuffersDirectory ;
 import org.apache.lucene.store.Directory ;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 /** Test the examples of building a test dataset */
 public class TestBuildTextDataset
@@ -101,7 +101,7 @@ public class TestBuildTextDataset
         finally {
             dataset.end() ;
         }
-        assertEquals("Unexpected result count", 2, x) ;
+        assertEquals(2, x, "Unexpected result count") ;
     }
 
     public static Dataset createCode() {

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetConcurrencyWithConfigurableAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetConcurrencyWithConfigurableAnalyzer.java
@@ -21,6 +21,8 @@
 
 package org.apache.jena.query.text;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -29,18 +31,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.vocabulary.RDFS;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 public class TestDatasetConcurrencyWithConfigurableAnalyzer extends AbstractTestDatasetWithAnalyzer {
     @Override
-    @Before
-    public void before () {
+    @BeforeEach public void before () {
         init(StrUtils.strjoinNL(
                 "text:ConfigurableAnalyzer ;",
                 "text:tokenizer text:WhitespaceTokenizer ;",
@@ -82,13 +83,13 @@ public class TestDatasetConcurrencyWithConfigurableAnalyzer extends AbstractTest
                     results.add(executorService.submit(() -> testOneQuery(probe)));;
                 }
                 for (int j = 0; j < parallelism; j++) {
-                    Assert.assertTrue("Probe " + i + " failed", results.get(j).get());
+                    assertTrue(results.get(j).get(), "Probe " + i + " failed");
                 }
             }
         } catch (InterruptedException e) {
             // exit silently on interrupt
         } catch (ExecutionException e) {
-            Assert.assertTrue("Concurrency exception: " + e.getMessage(), false);
+            assertTrue(false, "Concurrency exception: " + e.getMessage());
         }
     }
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithAnalyzingQueryParser.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithAnalyzingQueryParser.java
@@ -25,10 +25,10 @@ import java.util.Set ;
 
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.atlas.logging.LogCtl;
-import org.junit.AfterClass;
-import org.junit.Before ;
-import org.junit.BeforeClass;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class defines a setup configuration for a dataset that uses an ASCII folding lowercase keyword analyzer with a Lucene index.
@@ -38,17 +38,16 @@ public class TestDatasetWithAnalyzingQueryParser extends TestDatasetWithConfigur
     private static String loggerLevel;
 
     /** Suppress a warning message - see {@link TextIndexLucene#parseQuery} */
-    @BeforeClass public static void beforeClass() {
+    @BeforeAll public static void beforeClass() {
         loggerLevel = LogCtl.getLevel(TextIndexLucene.class);
         LogCtl.setLevel(TextIndexLucene.class, "ERROR");
     }
-    @AfterClass public static void afterClass() {
+    @AfterAll public static void afterClass() {
         LogCtl.setLevel(TextIndexLucene.class, loggerLevel);
     }
 
     @Override
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         init(StrUtils.strjoinNL(
             "text:ConfigurableAnalyzer ;",
             "text:tokenizer text:KeywordTokenizer ;",

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithComplexPhraseQueryParser.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithComplexPhraseQueryParser.java
@@ -24,16 +24,15 @@ package org.apache.jena.query.text;
 import java.util.Set ;
 
 import org.apache.jena.atlas.lib.StrUtils ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class defines a setup configuration for a dataset that uses a standard analyzer with a Lucene index.
  */
 public class TestDatasetWithComplexPhraseQueryParser extends AbstractTestDatasetWithAnalyzer {
     @Override
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         init("text:StandardAnalyzer", "text:ComplexPhraseQueryParser");
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithConfigurableAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithConfigurableAnalyzer.java
@@ -24,16 +24,15 @@ package org.apache.jena.query.text;
 import java.util.Set ;
 
 import org.apache.jena.atlas.lib.StrUtils ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class defines a setup configuration for a dataset that uses an ASCII folding lowercase keyword analyzer with a Lucene index.
  */
 public class TestDatasetWithConfigurableAnalyzer extends TestDatasetWithLowerCaseKeywordAnalyzer {
     @Override
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         init(StrUtils.strjoinNL(
             "text:ConfigurableAnalyzer ;",
             "text:tokenizer text:KeywordTokenizer ;",

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithKeywordAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithKeywordAnalyzer.java
@@ -26,16 +26,15 @@ import java.util.HashSet ;
 import java.util.Set ;
 
 import org.apache.jena.atlas.lib.StrUtils ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class defines a setup configuration for a dataset that uses a keyword analyzer with a Lucene index.
  */
 public class TestDatasetWithKeywordAnalyzer extends AbstractTestDatasetWithAnalyzer {
     @Override
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         init("text:KeywordAnalyzer");
     }
     

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLocalizedAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLocalizedAnalyzer.java
@@ -28,9 +28,9 @@ import org.apache.jena.query.text.assembler.TextAssembler;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.Reader;
@@ -117,13 +117,12 @@ public class TestDatasetWithLocalizedAnalyzer extends AbstractTestDatasetWithTex
         if (indexDir.exists()) TextSearchUtil.emptyAndDeleteDirectory(indexDir);
     }    
 
-    @Before 
+    @BeforeEach 
     public void beforeClass() {
         init();
     }    
     
-    @After
-    public void afterClass() {
+    @AfterEach public void afterClass() {
         deleteOldFiles();
     }
     

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLowerCaseKeywordAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLowerCaseKeywordAnalyzer.java
@@ -26,16 +26,15 @@ import java.util.HashSet ;
 import java.util.Set ;
 
 import org.apache.jena.atlas.lib.StrUtils ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class defines a setup configuration for a dataset that uses a lowercase keyword analyzer with a Lucene index.
  */
 public class TestDatasetWithLowerCaseKeywordAnalyzer extends TestDatasetWithKeywordAnalyzer {
     @Override
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         init("text:LowerCaseKeywordAnalyzer");
     }    
     

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneGraphTextIndex.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneGraphTextIndex.java
@@ -21,12 +21,11 @@
 
 package org.apache.jena.query.text;
 
-import org.junit.Before ;
+import org.junit.jupiter.api.BeforeEach;
 
 public class TestDatasetWithLuceneGraphTextIndex extends AbstractTestDatasetWithLuceneGraphTextIndex {
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         init();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneMultilingualTextIndex.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneMultilingualTextIndex.java
@@ -36,9 +36,9 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestDatasetWithLuceneMultilingualTextIndex extends AbstractTestDatasetWithTextIndexBase {
 
@@ -96,8 +96,7 @@ public class TestDatasetWithLuceneMultilingualTextIndex extends AbstractTestData
                     );
     }
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -106,8 +105,7 @@ public class TestDatasetWithLuceneMultilingualTextIndex extends AbstractTestData
         dataset = (Dataset) Assembler.general().open(root);
     }
 
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneStoredLiterals.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneStoredLiterals.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Reader ;
 import java.io.StringReader ;
@@ -53,9 +53,9 @@ import org.apache.jena.rdf.model.Literal ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestDatasetWithLuceneStoredLiterals extends AbstractTestDatasetWithTextIndex {
 
@@ -108,8 +108,7 @@ public class TestDatasetWithLuceneStoredLiterals extends AbstractTestDatasetWith
                     );
     }
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -118,8 +117,7 @@ public class TestDatasetWithLuceneStoredLiterals extends AbstractTestDatasetWith
         dataset = (Dataset) Assembler.general().open(root);
     }
 
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneTextIndex.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneTextIndex.java
@@ -32,9 +32,9 @@ import org.apache.jena.query.text.assembler.TextAssembler ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestDatasetWithLuceneTextIndex extends AbstractTestDatasetWithTextIndex {
     
@@ -85,8 +85,7 @@ public class TestDatasetWithLuceneTextIndex extends AbstractTestDatasetWithTextI
                     );
     }
     
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -95,8 +94,7 @@ public class TestDatasetWithLuceneTextIndex extends AbstractTestDatasetWithTextI
         dataset = (Dataset) Assembler.general().open(root);
     }
     
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
     

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneTextIndexDeletionSupport.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneTextIndexDeletionSupport.java
@@ -22,8 +22,8 @@
 package org.apache.jena.query.text;
 
 import org.apache.jena.atlas.lib.StrUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -31,8 +31,7 @@ import java.util.Set;
 
 public class TestDatasetWithLuceneTextIndexDeletionSupport extends AbstractTestDatasetWithLuceneTextIndexDeletionSupport {
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         init();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneTextIndexWithLangField.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithLuceneTextIndexWithLangField.java
@@ -28,9 +28,9 @@ import org.apache.jena.query.text.assembler.TextAssembler;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.Reader;
 import java.io.StringReader;
@@ -88,8 +88,7 @@ public class TestDatasetWithLuceneTextIndexWithLangField extends AbstractTestDat
                     );
     }
     
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -98,8 +97,7 @@ public class TestDatasetWithLuceneTextIndexWithLangField extends AbstractTestDat
         dataset = (Dataset) Assembler.general().open(root);
     }
     
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
     

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithSimpleAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithSimpleAnalyzer.java
@@ -35,9 +35,9 @@ import org.apache.jena.query.text.assembler.TextAssembler ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class defines a setup configuration for a dataset that uses a simple analyzer with a Lucene index.
@@ -113,13 +113,12 @@ public class TestDatasetWithSimpleAnalyzer extends AbstractTestDatasetWithTextIn
         if (indexDir.exists()) TextSearchUtil.emptyAndDeleteDirectory(indexDir);
     }    
 
-    @Before 
+    @BeforeEach 
     public void beforeClass() {
         init();
     }    
     
-    @After
-    public void afterClass() {
+    @AfterEach public void afterClass() {
         deleteOldFiles();
     }
     

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithStandardAnalyzer.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithStandardAnalyzer.java
@@ -35,9 +35,9 @@ import org.apache.jena.query.text.assembler.TextAssembler ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class defines a setup configuration for a dataset that uses a standard analyzer with a Lucene index.
@@ -113,13 +113,11 @@ public class TestDatasetWithStandardAnalyzer extends AbstractTestDatasetWithText
         if (indexDir.exists()) TextSearchUtil.emptyAndDeleteDirectory(indexDir);
     }    
 
-    @Before
-    public void beforeClass() {
+    @BeforeEach public void beforeClass() {
         init();
     }    
     
-    @After
-    public void afterClass() {
+    @AfterEach public void afterClass() {
         deleteOldFiles();
     }
     

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithSurroundQueryParser.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestDatasetWithSurroundQueryParser.java
@@ -24,16 +24,15 @@ package org.apache.jena.query.text;
 import java.util.Set ;
 
 import org.apache.jena.atlas.lib.StrUtils ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class defines a setup configuration for a dataset that uses a standard analyzer with a Lucene index.
  */
 public class TestDatasetWithSurroundQueryParser extends AbstractTestDatasetWithAnalyzer {
     @Override
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
     	init("text:StandardAnalyzer", "text:SurroundQueryParser");
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestLuceneWithMultipleThreads.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestLuceneWithMultipleThreads.java
@@ -21,8 +21,8 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertFalse ;
-import static org.junit.Assert.assertTrue ;
+import static org.junit.jupiter.api.Assertions.assertFalse ;
+import static org.junit.jupiter.api.Assertions.assertTrue ;
 
 import java.util.ArrayList ;
 import java.util.List ;
@@ -41,7 +41,7 @@ import org.apache.jena.tdb2.DatabaseMgr;
 import org.apache.jena.vocabulary.RDFS ;
 import org.apache.lucene.analysis.standard.StandardAnalyzer ;
 import org.apache.lucene.store.ByteBuffersDirectory ;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 /**
  * Spin up multiple threads against a multiple-reader/single-writer Dataset to test that the Lucene index handles concurrency properly.

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextDefineAnalyzers.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextDefineAnalyzers.java
@@ -21,7 +21,7 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Reader ;
 import java.io.StringReader ;
@@ -34,9 +34,9 @@ import org.apache.jena.query.text.assembler.TextAssembler ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestTextDefineAnalyzers extends AbstractTestDatasetWithTextIndexBase {
 
@@ -140,8 +140,7 @@ public class TestTextDefineAnalyzers extends AbstractTestDatasetWithTextIndexBas
                     );
     }
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -150,8 +149,7 @@ public class TestTextDefineAnalyzers extends AbstractTestDatasetWithTextIndexBas
         dataset = (Dataset) Assembler.general().open(root);
     }
 
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextGraphIndexExtra.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextGraphIndexExtra.java
@@ -21,6 +21,10 @@
 
 package org.apache.jena.query.text;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
 import org.apache.jena.atlas.lib.StrUtils ;
 import org.apache.jena.graph.Node ;
 import org.apache.jena.query.* ;
@@ -30,8 +34,6 @@ import org.apache.jena.system.Txn ;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.vocabulary.RDFS ;
 import org.apache.lucene.store.ByteBuffersDirectory ;
-import org.junit.Assert ;
-import org.junit.Test ;
 
 @SuppressWarnings("removal")
 public class TestTextGraphIndexExtra {
@@ -116,7 +118,7 @@ public class TestTextGraphIndexExtra {
         ds = textDataset(ds);
         populate(ds);
         int x = sparqlQuery(ds, queryStr);
-        Assert.assertEquals(expected, x);
+        assertEquals(expected, x);
     }
 
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextGraphIndexExtra2.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextGraphIndexExtra2.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Reader ;
 import java.io.StringReader ;
@@ -47,9 +47,9 @@ import org.apache.jena.query.text.assembler.TextAssembler ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestTextGraphIndexExtra2 extends AbstractTestDatasetWithTextIndexBase {
 
@@ -101,8 +101,7 @@ public class TestTextGraphIndexExtra2 extends AbstractTestDatasetWithTextIndexBa
                     );
     }
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -111,8 +110,7 @@ public class TestTextGraphIndexExtra2 extends AbstractTestDatasetWithTextIndexBa
         dataset = (Dataset) Assembler.general().open(root);
     }
 
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextHighlighting.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextHighlighting.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Reader ;
 import java.io.StringReader ;
@@ -49,9 +49,9 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestTextHighlighting extends AbstractTestDatasetWithTextIndexBase {
 
@@ -106,8 +106,7 @@ public class TestTextHighlighting extends AbstractTestDatasetWithTextIndexBase {
                     );
     }
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -116,8 +115,7 @@ public class TestTextHighlighting extends AbstractTestDatasetWithTextIndexBase {
         dataset = (Dataset) Assembler.general().open(root);
     }
 
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultilingualEnhancements.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultilingualEnhancements.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Reader ;
 import java.io.StringReader ;
@@ -48,9 +48,9 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestTextMultilingualEnhancements extends AbstractTestDatasetWithTextIndexBase {
 
@@ -134,8 +134,7 @@ public class TestTextMultilingualEnhancements extends AbstractTestDatasetWithTex
                     );
     }
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -144,8 +143,7 @@ public class TestTextMultilingualEnhancements extends AbstractTestDatasetWithTex
         dataset = (Dataset) Assembler.general().open(root);
     }
 
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultilingualEnhancements02.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultilingualEnhancements02.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Reader ;
 import java.io.StringReader ;
@@ -48,9 +48,9 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestTextMultilingualEnhancements02 extends AbstractTestDatasetWithTextIndexBase {
 
@@ -176,8 +176,7 @@ public class TestTextMultilingualEnhancements02 extends AbstractTestDatasetWithT
                     );
     }
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -186,8 +185,7 @@ public class TestTextMultilingualEnhancements02 extends AbstractTestDatasetWithT
         dataset = (Dataset) Assembler.general().open(root);
     }
 
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultipleProplistNotWorking.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextMultipleProplistNotWorking.java
@@ -21,9 +21,9 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Reader;
 import java.io.StringReader;
@@ -36,9 +36,9 @@ import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 // GH-2094
 public class TestTextMultipleProplistNotWorking extends AbstractTestDatasetWithTextIndexBase {
@@ -146,8 +146,7 @@ public class TestTextMultipleProplistNotWorking extends AbstractTestDatasetWithT
                 """;
     }
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         Reader reader = new StringReader(SPEC);
         Model specModel = ModelFactory.createDefaultModel();
         specModel.read(reader, "", "TURTLE");
@@ -156,8 +155,7 @@ public class TestTextMultipleProplistNotWorking extends AbstractTestDatasetWithT
         dataset = (Dataset) Assembler.general().open(root);
     }
 
-    @After
-    public void after() {
+    @AfterEach public void after() {
         dataset.close();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxn.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxn.java
@@ -21,14 +21,18 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List ;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.Creator;
@@ -39,32 +43,25 @@ import org.apache.jena.sparql.core.Quad ;
 import org.apache.jena.sparql.sse.SSE ;
 import org.apache.jena.tdb1.TDB1Factory;
 import org.apache.jena.vocabulary.RDFS ;
-import org.apache.lucene.store.Directory ;
 import org.apache.lucene.store.ByteBuffersDirectory ;
-import org.junit.Test ;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.apache.lucene.store.Directory ;
 
 /** Test using various dataset implmentations without transactions
  *  No context-set union graph usage either.
  */
-@SuppressWarnings("removal")
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("provideArgs")
 public class TestTextNonTxn
 {
-    @Parameters(name = "{index}: {0}")
-    public static Collection<Object[]>  data() {
+    @SuppressWarnings("removal")
+    public static Stream<Arguments> provideArgs() {
         Creator<Dataset> plainFactory = ()->DatasetFactory.create();
         Creator<Dataset> timFactory = ()->DatasetFactory.createTxnMem();
         Creator<Dataset> tdb1Factory = ()->TDB1Factory.createDataset();
         // TDB2 does not work with these, non transactional, tests.
-        return Arrays.asList( new Object[][]{
-            { "Plain", plainFactory , false } ,
-            { "TIM",  timFactory , false } ,
-            { "TDB1", tdb1Factory , true }
-            // TDB2 requires transactions.
-        });
+        return Stream.of(Arguments.of("Plain", plainFactory , true),
+                         Arguments.of( "TIM",  timFactory , true ) ,
+                         Arguments.of( "TDB1", tdb1Factory , true ));
     }
     private Dataset create() {
         Dataset ds1 = factory.create();

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxnTDB1.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextNonTxnTDB1.java
@@ -21,13 +21,13 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.atlas.lib.StrUtils;

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextPropLists.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextPropLists.java
@@ -36,9 +36,9 @@ import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
 import org.apache.jena.vocabulary.SKOS;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class defines a setup configuration for a dataset that uses a standard analyzer with a Lucene index.
@@ -152,13 +152,11 @@ public class TestTextPropLists extends AbstractTestDatasetWithTextIndexBase {
         if (indexDir.exists()) TextSearchUtil.emptyAndDeleteDirectory(indexDir);
     }
 
-    @Before
-    public void beforeClass() {
+    @BeforeEach public void beforeClass() {
         init();
     }
 
-    @After
-    public void afterClass() {
+    @AfterEach public void afterClass() {
         deleteOldFiles();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextPropLists02.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextPropLists02.java
@@ -35,9 +35,9 @@ import org.apache.jena.query.text.assembler.TextAssembler ;
 import org.apache.jena.rdf.model.Model ;
 import org.apache.jena.rdf.model.ModelFactory ;
 import org.apache.jena.rdf.model.Resource ;
-import org.junit.After ;
-import org.junit.Before ;
-import org.junit.Test ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.SKOS;
@@ -158,13 +158,11 @@ public class TestTextPropLists02 extends AbstractTestDatasetWithTextIndexBase {
         if (indexDir.exists()) TextSearchUtil.emptyAndDeleteDirectory(indexDir);
     }
 
-    @Before
-    public void beforeClass() {
+    @BeforeEach public void beforeClass() {
         init();
     }
 
-    @After
-    public void afterClass() {
+    @AfterEach public void afterClass() {
         deleteOldFiles();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextTxn.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextTxn.java
@@ -21,14 +21,18 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List ;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.Creator;
@@ -46,10 +50,6 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory ;
-import org.junit.Test ;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /** Text dataset tests using datasets transactionally, named unionDefaultGraph.
  * <p>
@@ -63,22 +63,20 @@ import org.junit.runners.Parameterized.Parameters;
  * TDB2 is transactional only.
  * <p>Union graph support by context is required for these tests.
  */
-@SuppressWarnings("removal")
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("provideArgs")
 public class TestTextTxn
 {
-    @Parameters(name = "{index}: {0}")
-    public static Collection<Object[]>  data() {
+    @SuppressWarnings("removal")
+    public static Stream<Arguments> provideArgs() {
         Creator<Dataset> plainFactory = ()->DatasetFactory.create();
         Creator<Dataset> timFactory = ()->DatasetFactory.createTxnMem();
         Creator<Dataset> tdb1Factory = ()->TDB1Factory.createDataset();
         Creator<Dataset> tdb2Factory = ()->TDB2Factory.createDataset();
-        return Arrays.asList( new Object[][]{
-            { "Plain", plainFactory, false } ,
-            { "TIM",   timFactory, false } ,
-            { "TDB1", tdb1Factory, true } ,
-            { "TDB2", tdb2Factory, true }
-        });
+        return Stream.of(Arguments.of( "Plain", plainFactory, true),
+                         Arguments.of( "TIM",   timFactory, true ) ,
+                         Arguments.of( "TDB1", tdb1Factory, true ) ,
+                         Arguments.of( "TDB2", tdb2Factory, true ));
     }
 
     private final Creator<Dataset> factory;

--- a/jena-text/src/test/java/org/apache/jena/query/text/TestTextTxnTDB.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/TestTextTxnTDB.java
@@ -21,13 +21,17 @@
 
 package org.apache.jena.query.text;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List ;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.apache.jena.atlas.iterator.Iter ;
 import org.apache.jena.atlas.lib.Creator;
@@ -47,10 +51,6 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory ;
-import org.junit.Test ;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /** Text dataset tests using TDB1 and TDB2 transactionally, including context unionDefaultGraph.
  * <p>
@@ -65,17 +65,15 @@ import org.junit.runners.Parameterized.Parameters;
  * <p>Union graph support by context is required for these tests.
  */
 @SuppressWarnings("removal")
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("provideArgs")
 public class TestTextTxnTDB
 {
-    @Parameters(name = "{index}: {0}")
-    public static Collection<Object[]>  data() {
+    public static Stream<Arguments> provideArgs() {
         Creator<Dataset> tdb1Factory = ()->TDB1Factory.createDataset();
         Creator<Dataset> tdb2Factory = ()->TDB2Factory.createDataset();
-        return Arrays.asList( new Object[][]{
-            { "TDB1", tdb1Factory } ,
-            { "TDB2", tdb2Factory }
-        });
+        return Stream.of(Arguments.of("TDB1", tdb1Factory),
+                         Arguments.of("TDB2", tdb2Factory));
     }
 
     private final Creator<Dataset> factory;

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/AbstractTestTextAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/AbstractTestTextAssembler.java
@@ -31,8 +31,8 @@ import org.apache.jena.rdf.model.Resource ;
 import org.apache.jena.tdb2.assembler.VocabTDB2;
 import org.apache.jena.vocabulary.RDF ;
 import org.apache.jena.vocabulary.RDFS ;
-import org.junit.After ;
-import org.junit.Before ;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractTestTextAssembler {
 
@@ -132,15 +132,13 @@ public abstract class AbstractTestTextAssembler {
         indexDir = new File("target/test/testasm/simpleIndexLiteralDir"); if (indexDir.exists()) TextSearchUtil.emptyAndDeleteDirectory(indexDir);
     }
 
-    @Before
-    public void before() {
+    @BeforeEach public void before() {
         deleteFiles();
 
         TextSearchUtil.createEmptyIndex(new File("target/test/testasm/DB"));
     }
 
-    @After
-    public void after() {
+    @AfterEach public void after() {
         deleteFiles();
     }
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestEntityMapAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestEntityMapAssembler.java
@@ -21,10 +21,15 @@
 
 package org.apache.jena.query.text.assembler;
 
-import static org.junit.Assert.assertEquals ;
-import static org.junit.Assert.assertTrue ;
+import static org.junit.jupiter.api.Assertions.assertEquals ;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue ;
 
 import java.util.Collection ;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.assembler.Assembler ;
 import org.apache.jena.atlas.lib.InternalErrorException ;
@@ -41,19 +46,16 @@ import org.apache.jena.vocabulary.RDFS ;
 import org.apache.lucene.analysis.core.KeywordAnalyzer ;
 import org.apache.lucene.analysis.core.SimpleAnalyzer ;
 import org.apache.lucene.analysis.standard.StandardAnalyzer ;
-import org.junit.AfterClass ;
-import org.junit.BeforeClass ;
-import org.junit.Test ;
 
 /**
  * Test assembler for EntityMap
  */
 public class TestEntityMapAssembler {
-    
+
     // Suppress warnings
-    @BeforeClass public static void beforeClass() { LogCtl.setError(EntityDefinitionAssembler.class); }
-    @AfterClass  public static void afterClass()  { LogCtl.setInfo(EntityDefinitionAssembler.class); }
-    
+    @BeforeAll public static void beforeClass() { LogCtl.setError(EntityDefinitionAssembler.class); }
+    @AfterAll  public static void afterClass()  { LogCtl.setInfo(EntityDefinitionAssembler.class); }
+
     private static final String TESTBASE = "http://example.org/test/";
     private static final Resource spec1;
     private static final Resource spec2;
@@ -66,32 +68,32 @@ public class TestEntityMapAssembler {
     private static final Resource specNoDefaultField;
     private static final Resource specNoMapProperty;
     private static final Resource specNoPrimaryFieldDef;
-    
+
     @Test public void EntityHasPrimaryField() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
         EntityDefinition entityDef = entDefAssem.open(null, spec1, null);
         assertEquals(SPEC1_DEFAULT_FIELD, entityDef.getPrimaryField());
     }
-    
+
     @Test public void EntityHasEntityField() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
         EntityDefinition entityDef = entDefAssem.open(null, spec1, null);
-        assertEquals(SPEC1_ENTITY_FIELD, entityDef.getEntityField());        
+        assertEquals(SPEC1_ENTITY_FIELD, entityDef.getEntityField());
     }
-    
+
     @Test public void EntityHasMapEntries() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
         EntityDefinition entityDef = entDefAssem.open(null, spec1, null);
         assertEquals(SPEC1_PREDICATE.asNode(), getOne(entityDef,SPEC1_DEFAULT_FIELD));
     }
-    
+
     private static Object getOne(EntityDefinition entityDef, String field) {
         Collection<Node> x = entityDef.getPredicates(field) ;
         if ( x == null || x.size() == 0 )
             return null ;
         if ( x.size() != 1 )
             throw new InternalErrorException("Not unique: "+field) ;
-        return x.iterator().next() ; 
+        return x.iterator().next() ;
     }
 
     @Test public void EntityHasMultipleMapEntries() {
@@ -100,67 +102,62 @@ public class TestEntityMapAssembler {
         assertEquals(SPEC2_PREDICATE1.asNode(), getOne(entityDef,SPEC2_DEFAULT_FIELD));
         assertEquals(SPEC2_PREDICATE2.asNode(), getOne(entityDef, SPEC2_FIELD2));
     }
-    
+
     @Test public void EntityHasMapEntryWithSimpleAnalyzer() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
         EntityDefinition entityDef = entDefAssem.open(Assembler.general(), spec3,  null);
         assertEquals(SimpleAnalyzer.class, entityDef.getAnalyzer(SPEC1_DEFAULT_FIELD).getClass());
     }
-    
+
     @Test public void EntityHasMapEntryWithStandardAnalyzerAndStopWords() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
         EntityDefinition entityDef = entDefAssem.open(Assembler.general(), spec4,  null);
         assertEquals(StandardAnalyzer.class, entityDef.getAnalyzer(SPEC1_DEFAULT_FIELD).getClass());
     }
-    
+
     @Test public void EntityHasMapEntryWithKeywordAnalyzer() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
         EntityDefinition entityDef = entDefAssem.open(Assembler.general(), spec5,  null);
         assertEquals(KeywordAnalyzer.class, entityDef.getAnalyzer(SPEC1_DEFAULT_FIELD).getClass());
-    }    
-    
+    }
+
     @Test public void EntityHasMapEntryWithLowerCaseKeywordAnalyzer() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
         EntityDefinition entityDef = entDefAssem.open(Assembler.general(), spec6,  null);
         assertEquals(LowerCaseKeywordAnalyzer.class, entityDef.getAnalyzer(SPEC1_DEFAULT_FIELD).getClass());
-    }    
-    
+    }
+
     @Test public void EntityHasMapEntryWithConfigurableAnalyzer() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
         EntityDefinition entityDef = entDefAssem.open(Assembler.general(), spec7,  null);
         assertEquals(ConfigurableAnalyzer.class, entityDef.getAnalyzer(SPEC1_DEFAULT_FIELD).getClass());
-    }    
-    
-    @Test(expected=TextIndexException.class) public void errorOnNoEntityField() {
-        EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
-        entDefAssem.open(null, specNoEntityField, null);
     }
-    
-    @Test(expected=TextIndexException.class) public void errorOnNoDefaultField() {
+
+    @Test public void errorOnNoEntityField() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
-        entDefAssem.open(null, specNoDefaultField, null);
+        assertThrows(TextIndexException.class, ()->entDefAssem.open(null, specNoEntityField, null));
     }
-    
-    @Test(expected=TextIndexException.class) public void errorOnNoMapProperty() {
+
+    @Test public void errorOnNoDefaultField() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
-        entDefAssem.open(null, specNoMapProperty, null);
+        assertThrows(TextIndexException.class, ()->entDefAssem.open(null, specNoDefaultField, null));
     }
-    
-    @Test(expected=TextIndexException.class) public void errorOnNoPrimaryFieldDef() {
+
+    @Test public void errorOnNoMapProperty() {
         EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
-        try {
-            entDefAssem.open(null, specNoPrimaryFieldDef, null);
-        } catch (TextIndexException e) {
+        assertThrows(TextIndexException.class, ()->entDefAssem.open(null, specNoMapProperty, null));
+    }
+
+    @Test public void errorOnNoPrimaryFieldDef() {
+        EntityDefinitionAssembler entDefAssem = new EntityDefinitionAssembler();
+        TextIndexException e = assertThrows(TextIndexException.class, ()->entDefAssem.open(null, specNoPrimaryFieldDef, null));
             assertTrue(e.getMessage().contains(SPEC1_DEFAULT_FIELD));
-            throw e ;
-        }    
-        
     }
-    
+
     private static final String SPEC1_ENTITY_FIELD = "spec1EntityField";
     private static final String SPEC1_DEFAULT_FIELD = "spec1DefaultField";
     private static final Property SPEC1_PREDICATE = RDFS.label;
-    
+
     private static final String SPEC2_ENTITY_FIELD = "spec2EntityField";
     private static final String SPEC2_DEFAULT_FIELD = "spec2DefaultField";
     private static final String SPEC2_FIELD2 = "spec2Field2";
@@ -170,9 +167,9 @@ public class TestEntityMapAssembler {
         JenaSystem.init();
         TextAssembler.init();
         Model model = ModelFactory.createDefaultModel();
-        
+
         // create a simple entity map specification
-        
+
         spec1 = model.createResource(TESTBASE + "spec1")
                      .addProperty(TextVocab.pEntityField, SPEC1_ENTITY_FIELD)
                      .addProperty(TextVocab.pDefaultField, SPEC1_DEFAULT_FIELD)
@@ -184,9 +181,9 @@ public class TestEntityMapAssembler {
                                                      .addProperty(TextVocab.pPredicate, SPEC1_PREDICATE)
                                           }))
                      ;
-        
+
         // create an entity map specification with multiple map entries
-        
+
         spec2 = model.createResource(TESTBASE + "spec2")
                      .addProperty(TextVocab.pEntityField, SPEC2_ENTITY_FIELD)
                      .addProperty(TextVocab.pDefaultField, SPEC2_DEFAULT_FIELD)
@@ -199,12 +196,12 @@ public class TestEntityMapAssembler {
                                                 model.createResource()
                                                      .addProperty(TextVocab.pField, SPEC2_FIELD2)
                                                      .addProperty(TextVocab.pPredicate, SPEC2_PREDICATE2),
-                                                    
+
                                           }))
                      ;
-        
+
         // create a simple entity map specification using a keyword analyzer
-        
+
                 spec3 = model.createResource(TESTBASE + "spec3")
                              .addProperty(TextVocab.pEntityField, SPEC1_ENTITY_FIELD)
                              .addProperty(TextVocab.pDefaultField, SPEC1_DEFAULT_FIELD)
@@ -214,13 +211,13 @@ public class TestEntityMapAssembler {
                                                         model.createResource()
                                                              .addProperty(TextVocab.pField, SPEC1_DEFAULT_FIELD)
                                                              .addProperty(TextVocab.pPredicate, SPEC1_PREDICATE)
-                                                             .addProperty(TextVocab.pAnalyzer, 
+                                                             .addProperty(TextVocab.pAnalyzer,
                                                                           model.createResource()
                                                                                .addProperty(RDF.type, TextVocab.simpleAnalyzer))
                                                   }))
                              ;
                 // create a simple entity map specification using a standard analyzer with stop words
-                
+
                 spec4 = model.createResource(TESTBASE + "spec4")
                              .addProperty(TextVocab.pEntityField, SPEC1_ENTITY_FIELD)
                              .addProperty(TextVocab.pDefaultField, SPEC1_DEFAULT_FIELD)
@@ -230,13 +227,13 @@ public class TestEntityMapAssembler {
                                                         model.createResource()
                                                              .addProperty(TextVocab.pField, SPEC1_DEFAULT_FIELD)
                                                              .addProperty(TextVocab.pPredicate, SPEC1_PREDICATE)
-                                                             .addProperty(TextVocab.pAnalyzer, 
+                                                             .addProperty(TextVocab.pAnalyzer,
                                                                           model.createResource()
                                                                                .addProperty(RDF.type, TextVocab.standardAnalyzer))
                                                                                .addProperty(TextVocab.pStopWords, toList(model, "and the but"))
-                                                  }));        
+                                                  }));
         // create a simple entity map specification using a keyword analyzer
-        
+
                 spec5 = model.createResource(TESTBASE + "spec5")
                              .addProperty(TextVocab.pEntityField, SPEC1_ENTITY_FIELD)
                              .addProperty(TextVocab.pDefaultField, SPEC1_DEFAULT_FIELD)
@@ -246,13 +243,13 @@ public class TestEntityMapAssembler {
                                                         model.createResource()
                                                              .addProperty(TextVocab.pField, SPEC1_DEFAULT_FIELD)
                                                              .addProperty(TextVocab.pPredicate, SPEC1_PREDICATE)
-                                                             .addProperty(TextVocab.pAnalyzer, 
+                                                             .addProperty(TextVocab.pAnalyzer,
                                                                           model.createResource()
                                                                                .addProperty(RDF.type, TextVocab.keywordAnalyzer))
                                                   }));
-                
+
         // create a simple entity map specification using a lowercase keyword analyzer
-        
+
                 spec6 = model.createResource(TESTBASE + "spec6")
                              .addProperty(TextVocab.pEntityField, SPEC1_ENTITY_FIELD)
                              .addProperty(TextVocab.pDefaultField, SPEC1_DEFAULT_FIELD)
@@ -262,14 +259,14 @@ public class TestEntityMapAssembler {
                                                         model.createResource()
                                                              .addProperty(TextVocab.pField, SPEC1_DEFAULT_FIELD)
                                                              .addProperty(TextVocab.pPredicate, SPEC1_PREDICATE)
-                                                             .addProperty(TextVocab.pAnalyzer, 
+                                                             .addProperty(TextVocab.pAnalyzer,
                                                                           model.createResource()
                                                                                .addProperty(RDF.type, TextVocab.lowerCaseKeywordAnalyzer))
                                                   }));
-                
+
 
         // create an entity map specification using a configurable analyzer
-        
+
                 spec7 = model.createResource(TESTBASE + "spec7")
                              .addProperty(TextVocab.pEntityField, SPEC1_ENTITY_FIELD)
                              .addProperty(TextVocab.pDefaultField, SPEC1_DEFAULT_FIELD)
@@ -279,15 +276,15 @@ public class TestEntityMapAssembler {
                                                         model.createResource()
                                                              .addProperty(TextVocab.pField, SPEC1_DEFAULT_FIELD)
                                                              .addProperty(TextVocab.pPredicate, SPEC1_PREDICATE)
-                                                             .addProperty(TextVocab.pAnalyzer, 
+                                                             .addProperty(TextVocab.pAnalyzer,
                                                                           model.createResource()
                                                                                .addProperty(RDF.type, TextVocab.configurableAnalyzer)
                                                                                .addProperty(TextVocab.pTokenizer, TextVocab.standardTokenizer))
                                                   }));
-                
+
         // bad assembler spec
-                
-        specNoEntityField = 
+
+        specNoEntityField =
                 model.createResource(TESTBASE + "specNoEntityField")
                      .addProperty(TextVocab.pDefaultField, SPEC1_DEFAULT_FIELD)
                      .addProperty(TextVocab.pMap,
@@ -298,10 +295,10 @@ public class TestEntityMapAssembler {
                                                      .addProperty(TextVocab.pPredicate, SPEC1_PREDICATE)
                                           }))
                      ;
-        
+
         // bad assembler spec
-        
-        specNoDefaultField = 
+
+        specNoDefaultField =
                 model.createResource(TESTBASE + "specNoDefaultField")
                      .addProperty(TextVocab.pDefaultField, SPEC1_DEFAULT_FIELD)
                      .addProperty(TextVocab.pMap,
@@ -313,13 +310,13 @@ public class TestEntityMapAssembler {
                                           }))
                      ;
         // bad assembler spec
-        specNoMapProperty = 
+        specNoMapProperty =
                 model.createResource(TESTBASE + "specNoMapProperty")
                      .addProperty(TextVocab.pEntityField, SPEC1_ENTITY_FIELD)
                      .addProperty(TextVocab.pDefaultField, SPEC1_DEFAULT_FIELD)
                      ;
-        
-        // bad assembler spec        
+
+        // bad assembler spec
         specNoPrimaryFieldDef =
                 model.createResource(TESTBASE + "noPrimaryFieldDef")
                      .addProperty(TextVocab.pEntityField, SPEC1_ENTITY_FIELD)
@@ -333,7 +330,7 @@ public class TestEntityMapAssembler {
                                           }))
                      ;
     }
-    
+
     private static Resource toList(Model model, String string) {
         String[] members = string.split("\\s");
         Resource current = RDF.nil;
@@ -341,8 +338,8 @@ public class TestEntityMapAssembler {
             Resource previous = current;
             current = model.createResource();
             current.addProperty(RDF.rest, previous);
-            current.addProperty(RDF.first, members[i]);            
+            current.addProperty(RDF.first, members[i]);
         }
-        return current;    
+        return current;
     }
 }

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestGenericAnalyzerAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestGenericAnalyzerAssembler.java
@@ -21,7 +21,7 @@
 
 package org.apache.jena.query.text.assembler;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -34,7 +34,7 @@ import org.apache.lucene.analysis.core.SimpleAnalyzer;
 import org.apache.lucene.analysis.core.StopAnalyzer;
 import org.apache.lucene.analysis.fr.FrenchAnalyzer;
 import org.apache.lucene.analysis.shingle.ShingleAnalyzerWrapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestGenericAnalyzerAssembler {
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestPropListsAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestPropListsAssembler.java
@@ -21,8 +21,8 @@
 
 package org.apache.jena.query.text.assembler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
@@ -33,7 +33,7 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.sys.JenaSystem;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.SKOS;

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextDatasetAssembler.java
@@ -21,7 +21,12 @@
 
 package org.apache.jena.query.text.assembler;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.assembler.Assembler;
 import org.apache.jena.assembler.exceptions.AssemblerException;
@@ -32,9 +37,6 @@ import org.apache.jena.query.text.changes.TextQuadAction;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.vocabulary.RDF;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  * Test the text dataset assembler.
@@ -49,12 +51,12 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
     private static final Resource noIndexPropertySpec;
     private static final Resource customTextDocProducerSpec;
 
-    @BeforeClass public static void clearBefore() {
+    @BeforeAll public static void clearBefore() {
         org.apache.jena.tdb1.sys.TDBInternal.reset();
         org.apache.jena.tdb2.sys.TDBInternal.reset();
     }
 
-    @After public void clearAfter() {
+    @AfterEach public void clearAfter() {
         org.apache.jena.tdb1.sys.TDBInternal.reset();
         org.apache.jena.tdb2.sys.TDBInternal.reset();
     }
@@ -66,14 +68,14 @@ public class TestTextDatasetAssembler extends AbstractTestTextAssembler {
         dataset.close();
     }
 
-    @Test(expected = AssemblerException.class)
+    @Test
     public void testErrorOnNoDataset() {
-        Assembler.general().open(noDatasetPropertySpec);
+        assertThrows(AssemblerException.class, ()->Assembler.general().open(noDatasetPropertySpec));
     }
 
-    @Test(expected = AssemblerException.class)
+    @Test
     public void testErrorOnNoIndex() {
-        Assembler.general().open(noIndexPropertySpec);
+        assertThrows(AssemblerException.class, ()->Assembler.general().open(noIndexPropertySpec));
     }
 
     @Test

--- a/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextIndexLuceneAssembler.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/assembler/TestTextIndexLuceneAssembler.java
@@ -28,8 +28,8 @@ import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.vocabulary.RDFS ;
 import org.apache.lucene.analysis.core.KeywordAnalyzer ;
 import org.apache.lucene.store.ByteBuffersDirectory ;
-import org.junit.Test ;
-import static org.junit.Assert.* ;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.* ;
 
 public class TestTextIndexLuceneAssembler extends AbstractTestTextAssembler {
 

--- a/jena-text/src/test/java/org/apache/jena/query/text/changes/TestDatasetMonitor.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/changes/TestDatasetMonitor.java
@@ -25,8 +25,8 @@ import static org.apache.jena.query.text.changes.TextQuadAction.ADD;
 import static org.apache.jena.query.text.changes.TextQuadAction.DELETE;
 import static org.apache.jena.query.text.changes.TextQuadAction.NO_ADD;
 import static org.apache.jena.query.text.changes.TextQuadAction.NO_DELETE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List ;
 
@@ -37,7 +37,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.sse.SSE ;
-import org.junit.Test ;
+import org.junit.jupiter.api.Test;
 
 public class TestDatasetMonitor
 {
@@ -185,15 +185,16 @@ public class TestDatasetMonitor
 
     private static void check(ChangesCounter changes, long adds, long deletes, long noAdds, long noDeletes)
     {
-        assertEquals("Adds",        adds, changes.countAdd) ;
-        assertEquals("Deletes",     deletes, changes.countDelete) ;
-        assertEquals("NoAdds",      noAdds, changes.countNoAdd) ;
-        assertEquals("NoDeletes",   noDeletes, changes.countNoDelete) ;
+        assertEquals(adds, changes.countAdd, "Adds") ;
+        assertEquals(deletes, changes.countDelete, "Deletes");
+        assertEquals(noAdds, changes.countNoAdd, "NoAdds");
+        assertEquals(noDeletes, changes.countNoDelete, "NoDeletes");
     }
 
     private static void check(List<Pair<TextQuadAction, Quad>> record, int indx, TextQuadAction quadAction, Quad quad)
     {
-        assertTrue("Index "+indx+" out of range [0,"+record.size()+")", 0 <= indx && indx < record.size() ) ;
+        assertTrue(0 <= indx && indx < record.size(),
+                "Index "+indx+" out of range [0,"+record.size()+")");
         Pair<TextQuadAction, Quad> pair = record.get(indx) ;
         assertEquals(quadAction, pair.getLeft()) ;
         assertEquals(quad, pair.getRight()) ;

--- a/jena-text/src/test/java/org/apache/jena/query/text/filter/TestSelectiveFoldingFilter.java
+++ b/jena-text/src/test/java/org/apache/jena/query/text/filter/TestSelectiveFoldingFilter.java
@@ -21,7 +21,8 @@
 
 package org.apache.jena.query.text.filter;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -30,11 +31,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * Test {@link SelectiveFoldingFilter}.
@@ -45,8 +47,7 @@ public class TestSelectiveFoldingFilter {
     private StringReader inputText;
     private CharArraySet whitelisted;
 
-    @Before
-    public void setUp() {
+    @BeforeEach public void setUp() {
         inputText = new StringReader("Señora Siobhán, look at that façade");
     }
 
@@ -96,9 +97,9 @@ public class TestSelectiveFoldingFilter {
         assertTrue(tokens.equals(expected));
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testNullWhiteListThrowsError() throws IOException {
-        collectTokens(inputText, null);
+    @Test
+    public void testNullWhiteListThrowsError() {
+        assertThrows(NullPointerException.class, ()->collectTokens(inputText, null));
     }
 
     @Test


### PR DESCRIPTION
Part of #3236.

Not AI!
The bulk of the work is done a perl script!

That leaves `assertThrows`, parameterization and test suites to do manually, and any `assert` with a message.

`assertThrows` can be placed on the actual method call, so more precise than Junit4 `@Test(expected=)`.

Parameterization isn't that common; changed to `@ParameterizedClass @MethodSource`.

`TS_*` changed to use `@Suite` `@SelectClasses`.

Some reformatting.

----

 - [x] Tests are included.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
