### PR TITLE
Small clean-up

### DIFF
--- a/jena-arq/Grammar/jj2bnf
+++ b/jena-arq/Grammar/jj2bnf
@@ -53,8 +53,9 @@ $grammar =~ s!^[\n\s]*!\n! ;
 # Merge alts
 $grammar =~ s!\n\s*\|!\ |!g ;
 
-# Tab after |
-$grammar =~ s!\|\t!\| !g ;
+## readFile replaces tabs with spaces.
+## # Tab after |
+## $grammar =~ s!\|\t!\| !g ;
 
 $tokens =~ s!//.*!!g ;
 $tokens =~ s!\r!!g ;
@@ -82,7 +83,7 @@ for $g (@g) {
     $rulebody =~ s! <EOF>$!! ;
     
     # Remove outer brackets
-#    $rulebody =~ s!^\((.*)\)$!$1! ;
+    #    $rulebody =~ s!^\((.*)\)$!$1! ;
 
     next if $rulename eq '' ;
 
@@ -90,9 +91,9 @@ for $g (@g) {
     warn "Duplicate rule (grammar): $rulename\n" if defined($ruleMap{$rulename}) ;
     $ruleMap{$rulename} = $rulebody ;
 
-##     print "----------\n" ;
-##     print $rulename,"\n" ;
-##     print $rulebody,"\n" ;
+    ##     print "----------\n" ;
+    ##     print $rulename,"\n" ;
+    ##     print $rulebody,"\n" ;
 }
 
 # Tokens
@@ -115,23 +116,26 @@ for $t (@t) {
 
     # Inline?
     if ( $tokenname =~ /^\[\<\w*\>\]/ ) {
-	warn "Duplicate inline (token): $tokenname\n" if defined($inline{$tokenname}) ;
-	$tokenname =~ s/^\[//g ;
-	$tokenname =~ s/\]$//g ;
-	$tokenbody =~ s/"/'/g ; # '" -- But not literal " -- how?
+        warn "Duplicate inline (token): $tokenname\n" if defined($inline{$tokenname}) ;
+        $tokenname =~ s/^\[//g ;
+        $tokenname =~ s/\]$//g ;
+        $tokenbody =~ s/"/'/g ; # '" -- But not literal " -- how?
         $tokenbody =~ s/\<\>\'\{\}/\<\>\"\{\}/ ; # '" IRI fixup
-	$inline{$tokenname} = $tokenbody ;
 
-	#print "INLINE: ",$tokenname," => ",$tokenbody,"\n" ;
+        ## IRIREF - special case of inline but with nested terminal name.
+        $tokenbody =~ s/<UCHAR>/UCHAR/ ; #
+        
+        $inline{$tokenname} = $tokenbody ;
+        #print "INLINE: ",$tokenname," => ",$tokenbody,"\n" ;
     } else {
-	## Remove < > aroudn a token name.
-	my $inlinePlain = $tokenname ;
-	$inlinePlain =~ s%^<%%;
-	$inlinePlain =~ s%>$%%;
-	$inline{$tokenname} = $inlinePlain ;
-	push @rules, $tokenname ;
-	warn "Duplicate rule (token): $tokenname\n" if defined($tokenMap{$tokenname}) ;
-	$ruleMap{$tokenname} = $tokenbody ; 
+        ## Remove < > around a token name.
+        my $inlinePlain = $tokenname ;
+        $inlinePlain =~ s%^<%%;
+        $inlinePlain =~ s%>$%%;
+        $inline{$tokenname} = $inlinePlain ;
+        push @rules, $tokenname ;
+        warn "Duplicate rule (token): $tokenname\n" if defined($tokenMap{$tokenname}) ;
+        $ruleMap{$tokenname} = $tokenbody ; 
     }
 }
 
@@ -144,30 +148,30 @@ for $r (@rules) {
     $rulebody = $ruleMap{$rulename} ;
 
     if ( $DEBUG ) {
-	print STDERR "\n" ;
-	print STDERR "Rule: $rulename\n" ; 
-	print STDERR "Body: $rulebody\n" ; 
+        print STDERR "\n" ;
+        print STDERR "Rule: $rulename\n" ; 
+        print STDERR "Body: $rulebody\n" ; 
     }
 
     $ruleBodyStr = $rulebody ;
-##    # Escape HTML chars before adding markup.
-#    $ruleBodyStr = esc($ruleBodyStr) ;
+    ##    # Escape HTML chars before adding markup.
+    #    $ruleBodyStr = esc($ruleBodyStr) ;
     
     # Inlines
     for $k (keys %inline) {
-## 	$s = esc($inline{$k}) ;
-## 	$k = esc($k) ;
-## 	# Assumes escaped <> round tokens.
-## 	$k = quotemeta $k ;
-## 	$ruleBodyStr =~ s/$k/$s/g ;
+##      $s = esc($inline{$k}) ;
+##      $k = esc($k) ;
+##      # Assumes escaped <> round tokens.
+##      $k = quotemeta $k ;
+##      $ruleBodyStr =~ s/$k/$s/g ;
 
-	$s = $inline{$k};
-	$ruleBodyStr =~ s/$k/$s/g ;
+        $s = $inline{$k};
+        $ruleBodyStr =~ s/$k/$s/g ;
     }
 
     if ( $DEBUG ) {
-	print STDERR "After inlining\n" ;
-	print STDERR $ruleBodyStr,"\n" ; ; 
+        print STDERR "After inlining\n" ;
+        print STDERR $ruleBodyStr,"\n" ; ; 
     }
 
     # Add hrefs - issue if one is a substring of another \W helps.
@@ -177,9 +181,9 @@ for $r (@rules) {
     ##$ruleId = sane("r".$rulename) ;
 
     if($rulename eq 'IRIREF') {
-	print "\n";
-	print "\@terminals\n";
-	print "\n" ;
+        print "\n";
+        print "\@terminals\n";
+        print "\n" ;
     }
     ## First part of output.
     ## $rlabel = '[' . $ruleNum .  ']' ;
@@ -196,14 +200,15 @@ for $r (@rules) {
     ## printf "%-5s  %-25s ::= %s\n", $rlabel, $rn, $ruleBodyStr ;
     printf "%-25s ::= %s\n", $rn, $ruleBodyStr ;
 
-#    $rule{$rulename, $rulebody) ;
-#    print $rulename , "\n" ;
+    #    $rule{$rulename, $rulebody) ;
+    #    print $rulename , "\n" ;
 }
 
 sub readFile {
     my $f = $_[0] ;
     open(F, "$f") || die "$f: $!"; 
     my $s = <F> ;
+    $s =~ s/\t/ /g;
     return $s ;
 }
 
@@ -216,9 +221,9 @@ sub esc {
 }
 
 sub sane {
-   my $a = $_[0] ;
-   $a =~ s/\W//g ;
-   return $a ;
+    my $a = $_[0] ;
+    $a =~ s/\W//g ;
+    return $a ;
 }
 
 sub fixupRule {
@@ -240,47 +245,47 @@ sub fixupRule {
     # Specials
     # Split long bodies
     if ( $head eq "CallExpression" ||
-	 $head eq "UnaryExpression" ||
- 	 $head eq "<PN_CHARS_BASE>" ||
- 	 $head eq "PatternElement" ||
- 	 $head eq "BuiltInCall" ||
-	 $head eq "Aggregate" )
+         $head eq "UnaryExpression" ||
+         $head eq "<PN_CHARS_BASE>" ||
+         $head eq "PatternElement" ||
+         $head eq "BuiltInCall" ||
+         $head eq "Aggregate" )
     {
-	## Except BNODE, STRLEN etc
-	## [138]  	RegexExpression	  ::=  	'REGEX' '(' Expression ',' Expression ( ',' Expression )? ')'
-	## [139]  	SubstringExpression	  ::=  	'SUBSTR' '(' Expression ',' Expression ( ',' Expression )? ')'
-	## [140]  	StrReplaceExpression	  ::=  	'REPLACE' '(' Expression ',' Expression ',' Expression ( ',' Expression )? ')'
-	## [141]  	ExistsFunc	  ::=  	'EXISTS' GroupGraphPattern
-	## [142]  	NotExistsFunc	  ::=  	'NOT' 'EXISTS' GroupGraphPattern
-	##        | 'BNODE' ( '(' Expression ')' | <NIL> )
+        ## Except BNODE, STRLEN etc
+## [138]        RegexExpression   ::=   'REGEX' '(' Expression ',' Expression ( ',' Expression )? ')'
+## [139]        SubstringExpression       ::=   'SUBSTR' '(' Expression ',' Expression ( ',' Expression )? ')'
+## [140]        StrReplaceExpression      ::=   'REPLACE' '(' Expression ',' Expression ',' Expression ( ',' Expression )? ')'
+## [141]        ExistsFunc        ::=   'EXISTS' GroupGraphPattern
+## [142]        NotExistsFunc     ::=   'NOT' 'EXISTS' GroupGraphPattern
+##        | 'BNODE' ( '(' Expression ')' | <NIL> )
 
-	print STDERR "A:",$body,"\n" if $p ;
+        print STDERR "A:",$body,"\n" if $p ;
 
-	## Fix up for BNODE that uses "|" - put in marker.
-	$body =~ s%'BNODE' \( '\(' Expression '\)' \| NIL \)%XXX-BNODE-XXX%;
-	
-	## Alternative more general removal: NB space-) - matched the BNF parens
-	##$body =~ s%'BNODE'.*? \)%XXX-BNODE-XXX%;
-	
-	$body =~ s%\|\s*%\n                          |   %g ;
-	
-	## Replace marker
-	$body =~ s%XXX-BNODE-XXX%'BNODE' \( '(' Expression ')' \| NIL \)%;
+        ## Fix up for BNODE that uses "|" - put in marker.
+        $body =~ s%'BNODE' \( '\(' Expression '\)' \| NIL \)%XXX-BNODE-XXX%;
+        
+        ## Alternative more general removal: NB space-) - matched the BNF parens
+        ##$body =~ s%'BNODE'.*? \)%XXX-BNODE-XXX%;
+        
+        $body =~ s%\|\s*%\n                          |   %g ;
+        
+        ## Replace marker
+        $body =~ s%XXX-BNODE-XXX%'BNODE' \( '(' Expression ')' \| NIL \)%;
     }
 
-     if ( $head eq "Aggregate" )
-     {
-	 # Strip outer ()
-	 $body =~ s/^\(\s*(.*)\s*\)$/$1/ ;	
- 	 $body =~ s/^\s+// ;
-     }
+    if ( $head eq "Aggregate" )
+    {
+        # Strip outer ()
+        $body =~ s/^\(\s*(.*)\s*\)$/$1/ ;       
+        $body =~ s/^\s+// ;
+    }
 
     # These failed the outer () test because they have nested () in them
     if (  $head eq "QueryPattern" ||
           $head eq "OrderCondition" )
     {
-	# Remove outer ()
-	$body =~ s/^\((.*)\)$/$1/ ;	
+        # Remove outer ()
+        $body =~ s/^\((.*)\)$/$1/ ;     
     }
 
     ## Split?
@@ -290,17 +295,17 @@ sub fixupRule {
 
     #Rules where an outer () is unnecessary.
     if ( $head eq "GroupCondition" ||
-	 $head eq "LimitOffsetClauses" ||
-	 $head eq "GraphOrDefault" ||
-	 $head eq "ArgList" ||
-	 $head eq "ExpressionList" ||
-	 $head eq "PathPrimary" ||
-	 $head eq "PathMod" ||
-	 $head eq "PathPrimary" ||
-	 $head eq "PathNegatedPropertySet" || 
-	 $head eq "PathOneInPropertySet")
+         $head eq "LimitOffsetClauses" ||
+         $head eq "GraphOrDefault" ||
+         $head eq "ArgList" ||
+         $head eq "ExpressionList" ||
+         $head eq "PathPrimary" ||
+         $head eq "PathMod" ||
+         $head eq "PathPrimary" ||
+         $head eq "PathNegatedPropertySet" || 
+         $head eq "PathOneInPropertySet")
     {
-	$body =~ s/^\(\s*(.*)\s*\)$/$1/ ;	
+        $body =~ s/^\(\s*(.*)\s*\)$/$1/ ;       
     }
 
     return $body ;

--- a/jena-arq/Grammar/jj2html
+++ b/jena-arq/Grammar/jj2html
@@ -81,7 +81,7 @@ for $g (@g) {
     $rulebody =~ s! <EOF>$!! ;    
     
     # Remove outer brackets
-#    $rulebody =~ s!^\((.*)\)$!$1! ;
+    #    $rulebody =~ s!^\((.*)\)$!$1! ;
 
     next if $rulename eq '' ;
 
@@ -115,18 +115,18 @@ for $t (@t) {
 
     # Inline?
     if ( $tokenname =~ /^\[\<\w*\>\]/ ) {
-	warn "Duplicate inline (token): $tokenname\n" if defined($inline{$tokenname}) ;
-	$tokenname =~ s/^\[//g ;
-	$tokenname =~ s/\]$//g ;
-	$tokenbody =~ s/"/'/g ; # '" -- But not literal " -- how?
+        warn "Duplicate inline (token): $tokenname\n" if defined($inline{$tokenname}) ;
+        $tokenname =~ s/^\[//g ;
+        $tokenname =~ s/\]$//g ;
+        $tokenbody =~ s/"/'/g ; # '" -- But not literal " -- how?
         $tokenbody =~ s/\<\>\'\{\}/\<\>\"\{\}/ ; # '" IRI fixup
-	$inline{$tokenname} = $tokenbody ;
+        $inline{$tokenname} = $tokenbody ;
 
-	#print "INLINE: ",$tokenname," => ",$tokenbody,"\n" ;
+        #print "INLINE: ",$tokenname," => ",$tokenbody,"\n" ;
     } else {
-	push @rules, $tokenname ;
-	warn "Duplicate rule (token): $tokenname\n" if defined($tokenMap{$tokenname}) ;
-	$ruleMap{$tokenname} = $tokenbody ; 
+        push @rules, $tokenname ;
+        warn "Duplicate rule (token): $tokenname\n" if defined($tokenMap{$tokenname}) ;
+        $ruleMap{$tokenname} = $tokenbody ; 
     }
     
 }
@@ -144,9 +144,9 @@ if ( ! $TABLE ) {
     print "<title>SPARQL Grammar</title>\n" ;
     print "<style type=\"text/css\">\n" ;
 
- # .token inline
- # .ruleHead
- # .ruleBody
+    # .token inline
+    # .ruleHead
+    # .ruleBody
 
     print <<'EOF' ;
 div.grammarTable table * { border-width: 0 ; }
@@ -159,9 +159,9 @@ div.grammarTable table * tr { border: 1px solid black ; }
 .gRuleLabel  { font-family: monospace ; }
 EOF
 
-     print "</style>\n" ;
-     print "</head>\n";
-     print "<body>\n";
+    print "</style>\n" ;
+    print "</head>\n";
+    print "<body>\n";
 
     print "\n" ;
 } ## End TABLE
@@ -185,9 +185,9 @@ for $r (@rules) {
 
 
     if ( $DEBUG ) {
-	print STDERR "\n" ;
-	print STDERR "Rule: $rulename\n" ; 
-	print STDERR "Body: $rulebody\n" ; 
+        print STDERR "\n" ;
+        print STDERR "Rule: $rulename\n" ; 
+        print STDERR "Body: $rulebody\n" ; 
     }
 
     $ruleBodyStr = $rulebody ;
@@ -196,41 +196,41 @@ for $r (@rules) {
     
     # Inlines
     for $k (keys %inline) {
-	$s = '<span class="token">' . esc($inline{$k}) . '</span>' ;
-	$k = esc($k) ;
-	# Assumes escaped <> round tokens.
-	$k = quotemeta $k ;
-	$ruleBodyStr =~ s/$k/$s/g ;
+        $s = '<span class="token">' . esc($inline{$k}) . '</span>' ;
+        $k = esc($k) ;
+        # Assumes escaped <> round tokens.
+        $k = quotemeta $k ;
+        $ruleBodyStr =~ s/$k/$s/g ;
     }
 
     if ( $DEBUG ) {
-	print STDERR "After inlining\n" ;
-	print STDERR $ruleBodyStr,"\n" ; ; 
+        print STDERR "After inlining\n" ;
+        print STDERR $ruleBodyStr,"\n" ; ; 
     }
 
     # Add hrefs - issue if one is a substring of another \W helps.
 
     for $k (keys %ruleMap) {
-	$s = '<a href="#r' . sane($k) . '">' . esc($k) . '</a>' ;
+        $s = '<a href="#r' . sane($k) . '">' . esc($k) . '</a>' ;
 
-	$k = esc($k) ;
-	$k = quotemeta $k ;
+        $k = esc($k) ;
+        $k = quotemeta $k ;
 
-## 	if ( $DEBUG )
-## 	{
-## 	  print STDERR "K:$k\n" ;  
-## 	}
+##      if ( $DEBUG )
+##      {
+##        print STDERR "K:$k\n" ;  
+##      }
 
 
-	$ruleBodyStr =~ s/(?=\W)(\s*)$k(\s*)(?=\W)/$1$s$2/g ;
-	$ruleBodyStr =~ s/^$k(\s*)(?=\W)/$s$1/g ;
-	$ruleBodyStr =~ s/(?=\W)(\s*)$k$/$1$s/g ;
-	$ruleBodyStr =~ s/^$k$/$s/g ;
+        $ruleBodyStr =~ s/(?=\W)(\s*)$k(\s*)(?=\W)/$1$s$2/g ;
+        $ruleBodyStr =~ s/^$k(\s*)(?=\W)/$s$1/g ;
+        $ruleBodyStr =~ s/(?=\W)(\s*)$k$/$1$s/g ;
+        $ruleBodyStr =~ s/^$k$/$s/g ;
     }
     
     if ( $DEBUG ) {
-	print STDERR "After hrefs\n" ;
-	print STDERR $ruleBodyStr,"\n" ; ; 
+        print STDERR "After hrefs\n" ;
+        print STDERR $ruleBodyStr,"\n" ; ; 
     }
 
     #exit if $ruleNum > 2 ;
@@ -238,11 +238,11 @@ for $r (@rules) {
     $ruleId = sane("r".$rulename) ;
 
     if($rulename eq 'IRIREF') {
-	print $indent,"  </tbody></table>\n" ;
-	print $indent,"</div>\n" ;
-	print $indent,"<p>Productions for terminals:</p>\n" ;
-	print $indent,"<div class=\"grammarTable\">\n" ;
-	print $indent,"  <table><tbody>\n" ;
+        print $indent,"  </tbody></table>\n" ;
+        print $indent,"</div>\n" ;
+        print $indent,"<p>Productions for terminals:</p>\n" ;
+        print $indent,"<div class=\"grammarTable\">\n" ;
+        print $indent,"  <table><tbody>\n" ;
     }
 
     print "\n" ;
@@ -259,9 +259,9 @@ for $r (@rules) {
     $rn =~ s!>$!!; 
     
     print $indentRule,
-	'  <td><code><span class="doc-ref" id="',$ruleId,'">',
-	esc($rn),
-	'</span></code></td>',"\n";
+        '  <td><code><span class="doc-ref" id="',$ruleId,'">',
+        esc($rn),
+        '</span></code></td>',"\n";
     
     print $indentRule,"  <td>&nbsp;&nbsp;::=&nbsp;&nbsp;</td>\n" ;
     
@@ -270,8 +270,8 @@ for $r (@rules) {
 
     print $indentRule,"</tr>\n" ;
 
-#    $rule{$rulename, $rulebody) ;
-#    print $rulename , "\n" ;
+    #    $rule{$rulename, $rulebody) ;
+    #    print $rulename , "\n" ;
 }
 
 print $indent,"  </tbody></table>\n" ;
@@ -287,6 +287,7 @@ sub readFile {
     my $f = $_[0] ;
     open(F, "$f") || die "$f: $!"; 
     my $s = <F> ;
+    $s =~ s/\t/ /g;
     return $s ;
 }
 
@@ -299,9 +300,9 @@ sub esc {
 }
 
 sub sane {
-   my $a = $_[0] ;
-   $a =~ s/\W//g ;
-   return $a ;
+    my $a = $_[0] ;
+    $a =~ s/\W//g ;
+    return $a ;
 }
 
 sub code {
@@ -332,7 +333,7 @@ sub fixupRule {
     $body =~ s!\(\s+(\<span[^>]*\>[^<>]*\</span\>)\s+\)!$1!g ;
 
     # There aren't any of these
-##    $body =~ s!\(\s+(\S*)\s+\)!$1!g ;
+    ##    $body =~ s!\(\s+(\S*)\s+\)!$1!g ;
 
     # Remove <> around tokens.
     $body =~ s/&lt;(\w+)&gt;/$1/g ;
@@ -340,85 +341,85 @@ sub fixupRule {
     # Specials
     # Split long bodies
     if ( $head eq "CallExpression" ||
-	 $head eq "UnaryExpression" ||
-	 $head eq "<NCCHAR1p>" ||
-	 $head eq "PatternElement" ||
-	 $head eq "BuiltInCall" )
+         $head eq "UnaryExpression" ||
+         $head eq "<NCCHAR1p>" ||
+         $head eq "PatternElement" ||
+         $head eq "BuiltInCall" )
     {
-	$body =~ s%\|%\<br/\>\|%g ;
-	$body =~ s/^\s+// ;
-	$body = "&nbsp;&nbsp;".$body ;
+        $body =~ s%\|%\<br/\>\|%g ;
+        $body =~ s/^\s+// ;
+        $body = "&nbsp;&nbsp;".$body ;
     }
 
-     if ( $head eq "Aggregate" )
-     {
-	 # Strip outer ()
-	 $body =~ s/^\(\s*(.*)\s*\)$/$1/ ;	
-	 ## Be careful of nested | in COUNT
- 	 $body =~ s%(\| \<span class="token")%\<br/\>$1%g ;
- 	 $body =~ s/^\s+// ;
- 	 $body = "&nbsp;&nbsp;".$body ;
-     }
+    if ( $head eq "Aggregate" )
+    {
+        # Strip outer ()
+        $body =~ s/^\(\s*(.*)\s*\)$/$1/ ;       
+        ## Be careful of nested | in COUNT
+        $body =~ s%(\| \<span class="token")%\<br/\>$1%g ;
+        $body =~ s/^\s+// ;
+        $body = "&nbsp;&nbsp;".$body ;
+    }
 
 
     if (  $head eq "BuiltInCall" )
     {
-	# Undo <br/> for BNODE, RAND
-	# <br/>| <a href="#rNIL">NIL</a> )
-	$body =~ s%\<br/\>\| *\<a href="#rNIL"\>NIL\</a\>%\| \<a href="#rNIL"\>NIL\</a\>%g ;
+        # Undo <br/> for BNODE, RAND
+        # <br/>| <a href="#rNIL">NIL</a> )
+        $body =~ s%\<br/\>\| *\<a href="#rNIL"\>NIL\</a\>%\| \<a href="#rNIL"\>NIL\</a\>%g ;
     }
 
 ##     if ( $head eq "RelationalExpression" ||
-## 	 $head eq "AdditiveExpression" ||
-## 	 $head eq "MultiplicativeExpression" ||
-## 	 $head eq "ConditionalOrExpression")
+##       $head eq "AdditiveExpression" ||
+##       $head eq "MultiplicativeExpression" ||
+##       $head eq "ConditionalOrExpression")
 ##     {
-## 	$body =~ s%\*\(%<br/>\(% ;
+##      $body =~ s%\*\(%<br/>\(% ;
 ##     }
 
     # These failed the outer () test because they have nested () in them
     if (  $head eq "QueryPattern" ||
           $head eq "OrderCondition" )
     {
-	# Remove outer ()
-	$body =~ s/^\((.*)\)$/$1/ ;	
+        # Remove outer ()
+        $body =~ s/^\((.*)\)$/$1/ ;     
     }
 
     if (  $head eq "Query" )
     {
-	$body =~ s! \(!<br/>\(! ;
-	$body =~ s!\) !\)<br/>! ;
+        $body =~ s! \(!<br/>\(! ;
+        $body =~ s!\) !\)<br/>! ;
     }
 
     if (  $head =~ m/(Select|Construct|Describe|Ask)Query/ )
     {
-	# Put a line break before the DatasetClause
-	# <a href="#rDatasetClause">DatasetClause</a>
-	$c = '<a href="#rDatasetClause">DatasetClause</a>' ;
-	$c = quotemeta $c ;
-	# Expects the dataset clause to be unbracketted
-	$body =~ s!(\(\s*$c)!<br/>$1! ;
+        # Put a line break before the DatasetClause
+        # <a href="#rDatasetClause">DatasetClause</a>
+        $c = '<a href="#rDatasetClause">DatasetClause</a>' ;
+        $c = quotemeta $c ;
+        # Expects the dataset clause to be unbracketted
+        $body =~ s!(\(\s*$c)!<br/>$1! ;
     }
 
     if ( $head eq "OrderCondition" )
     {
-	$body =~ s!\)\s*\|\s*\(!\)<br/>\| \(! ;
-	$body = "  ".$body ;
+        $body =~ s!\)\s*\|\s*\(!\)<br/>\| \(! ;
+        $body = "  ".$body ;
     }
 
     #Rules where an outer () is unnecessary.
     if ( $head eq "GroupCondition" ||
-	 $head eq "LimitOffsetClauses" ||
-	 $head eq "GraphOrDefault" ||
-	 $head eq "ArgList" ||
-	 $head eq "ExpressionList" ||
-	 $head eq "PathPrimary" ||
-	 $head eq "PathMod" ||
-	 $head eq "PathPrimary" ||
-	 $head eq "PathNegatedPropertySet" || 
-	 $head eq "PathOneInPropertySet")
+         $head eq "LimitOffsetClauses" ||
+         $head eq "GraphOrDefault" ||
+         $head eq "ArgList" ||
+         $head eq "ExpressionList" ||
+         $head eq "PathPrimary" ||
+         $head eq "PathMod" ||
+         $head eq "PathPrimary" ||
+         $head eq "PathNegatedPropertySet" || 
+         $head eq "PathOneInPropertySet")
     {
-	$body =~ s/^\(\s*(.*)\s*\)$/$1/ ;	
+        $body =~ s/^\(\s*(.*)\s*\)$/$1/ ;       
     }
     return $body ;
 }

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/FusekiServer.java
@@ -25,7 +25,6 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.jena.atlas.lib.PropertyUtils.loadFromFile;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Predicate;
@@ -77,7 +76,6 @@ import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.ErrorHandler;
-import org.eclipse.jetty.util.resource.Resource;
 import org.slf4j.Logger;
 
 /**
@@ -1841,24 +1839,28 @@ public class FusekiServer {
                 DefaultServlet staticServlet = new DefaultServlet();
                 ServletHolder staticContent = new ServletHolder(staticServlet);
                 //staticContent.setInitParameter("cacheControl", "false");
-                // << Jetty 12.1.9 issue
-                // When a fixed Jetty is available, replace block with   staticContent.setInitParameter("baseResource", staticContentDir);
-                if ( staticContentDir.startsWith("jar:") ) {
-                    staticContent.setInitParameter("baseResource", staticContentDir);
-                } else {
-                    try {
-                        // Use URLResourceFactory instead of ResourceFactory.of(context) (which yields PathResource)
-                        // to work around a Windows bug in Jetty 12.1.9 PathResource.resolve(URI) where
-                        // path.resolve(uri.getPath()) fails for absolute Windows paths.
-                        // See: https://github.com/jetty/jetty.project/pull/15020
-                        java.net.URL url = Path.of(staticContentDir).toUri().toURL();
-                        Resource base = new org.eclipse.jetty.util.resource.URLResourceFactory().newResource(url);
-                        context.setBaseResource(base);
-                    } catch (MalformedURLException e) {
-                        staticContent.setInitParameter("baseResource", staticContentDir);
-                    }
-                }
-                //  >> Jetty 12.1.9 issue
+                // Jetty other than 12.1.9
+                staticContent.setInitParameter("baseResource", staticContentDir);
+
+//                // == Jetty 12.1.9 (only) issue
+//                // When a fixed Jetty is available, replace block with
+//                  //   staticContent.setInitParameter("baseResource", staticContentDir);
+//                if ( staticContentDir.startsWith("jar:") ) {
+//                    staticContent.setInitParameter("baseResource", staticContentDir);
+//                } else {
+//                    try {
+//                        // Use URLResourceFactory instead of ResourceFactory.of(context) (which yields PathResource)
+//                        // to work around a Windows bug in Jetty 12.1.9 PathResource.resolve(URI) where
+//                        // path.resolve(uri.getPath()) fails for absolute Windows paths.
+//                        // See: https://github.com/jetty/jetty.project/pull/15020
+//                        java.net.URL url = Path.of(staticContentDir).toUri().toURL();
+//                        org.eclipse.jetty.util.resource.Resource base = new org.eclipse.jetty.util.resource.URLResourceFactory().newResource(url);
+//                        context.setBaseResource(base);
+//                    } catch (java.net.MalformedURLException e) {
+//                        staticContent.setInitParameter("baseResource", staticContentDir);
+//                    }
+//                }
+//                // == Jetty 12.1.9 issue
                 context.addServlet(staticContent, "/");
             } else {
                 // Backstop servlet

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyHttps.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyHttps.java
@@ -23,6 +23,7 @@ package org.apache.jena.fuseki.main;
 
 import org.apache.jena.fuseki.main.sys.JettyLib;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
+//import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.*;
@@ -50,21 +51,27 @@ public class JettyHttps {
     */
 
     /**
-     * Create a HTTPS Jetty server for the {@link ServletContextHandler}
+     * Create a HTTPS Jetty server for the {@link Handler}.
+     * <p>
+     * {@link Handler} is a Jetty feature,
+     * This can be a {@link ServletContextHandler} - the Jetty support for standard servlets.
      * <p>
      * If httpPort is -1, don't add http otherwise make http redirect to https.
      */
-    public static Server jettyServerHttps(ServletContextHandler handler, String keystore, String certPassword,
+    public static Server jettyServerHttps(Handler handler, String keystore, String certPassword,
                                           int httpPort, int httpsPort) {
         return jettyServerHttps(handler, keystore, certPassword, httpPort, httpsPort, -1,  -1);
     }
 
     /**
-     * Create a HTTPS Jetty server for the {@link ServletContextHandler}
+     * Create a HTTPS Jetty server for the {@link Handler}.
+     * <p>
+     * {@link Handler} is a Jetty feature,
+     * This can be a {@link ServletContextHandler} - the Jetty support for standard servlets.
      * <p>
      * If httpPort is -1, don't add http otherwise make http redirect to https.
      */
-    public static Server jettyServerHttps(ServletContextHandler handler, String keystore, String certPassword,
+    public static Server jettyServerHttps(Handler handler, String keystore, String certPassword,
                                           int httpPort, int httpsPort,
                                           int minThreads, int maxThreads) {
         // Server handling http and https.


### PR DESCRIPTION
`jj2html` and `jj2bnf` are scripts that turn javacc output into SPARQL spec material.

---

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
