### PR TITLE
GH-3994: Improved TDB2 index access for single pattern queries

### DIFF
--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/record/Record.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/record/Record.java
@@ -167,4 +167,53 @@ public class Record //implements Comparable<Record>
         }
         return true;
     }
+
+    /**
+     * Return a new record with the key increased by 1.
+     * Returned record shares the value array of the argument record.
+     */
+    public static Record incrementKey(Record record) {
+        return new Record(incrementByteArray(record.getKey().clone()), record.getValue());
+    }
+
+    private static byte[] incrementByteArray(byte[] array) {
+        // Loop from the rightmost (least significant) byte to the left
+        for (int i = array.length - 1; i >= 0; i--) {
+            array[i]++;
+            // If it didn't roll over to 0, no carry is needed; we are done
+            if (array[i] != 0) {
+                return array;
+            }
+        }
+        // If we reach here, the entire array overflowed (e.g., [255, 255] -> [0, 0])
+        throw new ArithmeticException("Byte array overflowed its maximum value");
+    }
+
+    /**
+     * Pad {@code record} with zeros such that the lengths of its
+     * key and value arrays match those of the {@code prototype} record.
+     *
+     * If no padding is needed then {@code record} is returned.
+     * Otherwise, a new record is created.
+     */
+    public static Record padRight(Record record, Record prototype) {
+        byte[] rkey = record.getKey();
+        byte[] rval = record.getValue();
+
+        byte[] pkey = prototype.getKey();
+        byte[] pval = prototype.getValue();
+
+        byte[] key = pkey == null ? rkey : padRight(rkey, pkey.length);
+        byte[] val = pval == null ? rval : padRight(rval, pval.length);
+        return (key == rkey && val == rval) ? record : new Record(key, val);
+    }
+
+    private static byte[] padRight(byte[] arr, int length) {
+        if (length == arr.length) {
+            return arr;
+        } else if (length < arr.length) {
+            return Arrays.copyOf(arr, arr.length);
+        }
+        return Arrays.copyOf(arr, length);
+    }
 }

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPTreeDistinctKeyPrefixIterator.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPTreeDistinctKeyPrefixIterator.java
@@ -57,10 +57,30 @@ class BPTreeDistinctKeyPrefixIterator implements Iterator<Record> {
         return new BPTreeDistinctKeyPrefixIterator(node, keyPrefixLength, minRecord, maxRecord);
     }
 
+    /** Create an iterator of distinct keys over a custom sub-range. Arguments must not be null. */
+    public static Iterator<Record> create(BPTreeNode node, int keyPrefixLength, Record minRecord, Record maxRecord) {
+        Objects.requireNonNull(minRecord);
+        Objects.requireNonNull(maxRecord);
+
+        Record nodeMinRecord = node.minRecord();
+        Record nodeMaxRecord = node.maxRecord();
+        // If there's no records just return a null iterator
+        if (nodeMinRecord == null) {
+            return Iter.nullIter();
+        }
+
+        // Pad records to make their lengths match those of the nodes.
+        Record paddedMinRecord = Record.padRight(minRecord, nodeMinRecord);
+        Record paddedMaxRecord = Record.padRight(maxRecord, nodeMaxRecord);
+
+        return new BPTreeDistinctKeyPrefixIterator(node, keyPrefixLength, paddedMinRecord, paddedMaxRecord);
+    }
+
     // Convert path to a stack of iterators
     private final Deque<Iterator<BPTreePage>> stack = new ArrayDeque<>();
     private Iterator<Record> current;
-    private Record slot = null, minRecord, maxRecord;
+    private Record slot = null;
+    private final Record minRecord, maxRecord, maxRecordPlusOne;
     private byte[] lastPrefix = null;
     private boolean finished = false;
 
@@ -70,6 +90,7 @@ class BPTreeDistinctKeyPrefixIterator implements Iterator<Record> {
         this.keyPrefixLength = keyPrefixLength;
         this.minRecord = minRecord;
         this.maxRecord = maxRecord;
+        this.maxRecordPlusOne = Record.incrementKey(maxRecord);
 
         BPTreeRecords r = loadStack(node);
         current = getRecordsIterator(r);
@@ -143,6 +164,12 @@ class BPTreeDistinctKeyPrefixIterator implements Iterator<Record> {
         return getRecordsIterator(r);
     }
 
+    protected final int comparePrefix(Record a, Record b) {
+        // Need to compare unsigned in general:
+        // E.g. [0, 5] is less than [0, -1] because the latter must be treated as [0, 255].
+        return Arrays.compareUnsigned(a.getKey(), 0, this.keyPrefixLength, b.getKey(), 0, this.keyPrefixLength);
+    }
+
     protected final boolean haveSamePrefix(Record a, Record b) {
         return Arrays.compare(a.getKey(), 0, this.keyPrefixLength, b.getKey(), 0, this.keyPrefixLength) == 0;
     }
@@ -157,12 +184,18 @@ class BPTreeDistinctKeyPrefixIterator implements Iterator<Record> {
         } else {
             // Check whether we need to scan the whole page or can process it by skipping or singleton yield
             Record lowRecord = records.getLowRecord();
-            if (haveSamePrefix(lowRecord, records.getHighRecord())) {
-                // If the low and high keys for this page have the same prefix then just return a singleton iterator
-                iter = Iter.singletonIterator(lowRecord);
+            Record highRecord= records.getHighRecord();
+            if (haveSamePrefix(lowRecord, highRecord)) {
+                // Check that the prefix is in range
+                if (comparePrefix(lowRecord, minRecord) >= 0 && comparePrefix(highRecord, maxRecord) <= 0) {
+                    // If the low and high keys for this page have the same prefix then just return a singleton iterator
+                    iter = Iter.singletonIterator(lowRecord);
+                } else {
+                    iter = Iter.nullIterator();
+                }
             } else {
                 // Otherwise need to scan the whole page
-                iter = records.getRecordBuffer().iterator();
+                iter = records.getRecordBuffer().iterator(minRecord, maxRecordPlusOne);
             }
         }
         records.bpTree.finishReadBlkMgr();
@@ -173,7 +206,7 @@ class BPTreeDistinctKeyPrefixIterator implements Iterator<Record> {
         AccessPath path = new AccessPath(null);
         node.bpTree.startReadBlkMgr();
 
-        node.internalMinRecord(path);
+        node.internalSearch(path, minRecord);
         List<AccessStep> steps = path.getPath();
         for (AccessStep step : steps) {
             BPTreeNode n = step.node;

--- a/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPlusTree.java
+++ b/jena-db/jena-dboe-trans-data/src/main/java/org/apache/jena/dboe/trans/bplustree/BPlusTree.java
@@ -329,6 +329,14 @@ public class BPlusTree extends TransactionalComponentLifecycle<BptTxnState> impl
         return BPTreeDistinctKeyPrefixIterator.create(root, keyPrefixLength);
     }
 
+    public Iterator<Record> distinctByKeyPrefix(int keyPrefixLength, Record fromRecInclusive, Record toRecInclusive) {
+        startReadBlkMgr();
+        BPTreeNode root = getRootRead();
+        releaseRootRead(root);
+        finishReadBlkMgr();
+        return BPTreeDistinctKeyPrefixIterator.create(root, keyPrefixLength, fromRecInclusive, toRecInclusive);
+    }
+
     /*
     @Override
     public <X> Iterator<X> iterator(Record minRec, Record maxRec, RecordMapper<X> mapper) {

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/task/BasicTask.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/task/BasicTask.java
@@ -56,7 +56,7 @@ public interface BasicTask extends Abortable {
     /**
      * Whether the task has terminated.
      *
-     * @implNote The original name {@code isTerminated} collided with the package−private method in {@link Thread}.
+     * @implNote The original name {@code isTerminated} collided with the package-private method in {@link Thread}.
      */
     default boolean hasTerminated() {
         TaskState state = getTaskState();

--- a/jena-tdb2/pom.xml
+++ b/jena-tdb2/pom.xml
@@ -16,7 +16,7 @@
    KIND, either express or implied.  See the License for the
    specific language governing permissions and limitations
    under the License.
-    
+
      SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -32,7 +32,7 @@
     <groupId>org.apache.jena</groupId>
     <artifactId>jena</artifactId>
     <version>6.3.0-SNAPSHOT</version>
-  </parent> 
+  </parent>
 
   <properties>
     <build.time.xsd>${maven.build.timestamp}</build.time.xsd>
@@ -73,6 +73,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math4-legacy</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/OpExecutorTDB2.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/OpExecutorTDB2.java
@@ -47,9 +47,13 @@ import org.apache.jena.sparql.engine.optimizer.reorder.ReorderProc;
 import org.apache.jena.sparql.engine.optimizer.reorder.ReorderTransformation;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.mgt.Explain;
+import org.apache.jena.tdb2.solver.skipscan.OpExecutorTDB2SkipScan;
+import org.apache.jena.tdb2.solver.skipscan.OpExtSkipScan;
+import org.apache.jena.tdb2.solver.skipscan.SkipScanRewrite;
 import org.apache.jena.tdb2.store.DatasetGraphTDB;
 import org.apache.jena.tdb2.store.GraphTDB;
 import org.apache.jena.tdb2.store.NodeId;
+import org.apache.jena.tdb2.sys.SystemTDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,11 +96,38 @@ public class OpExecutorTDB2 extends OpExecutor
 
     // Retrieving nodes isn't so bad because they will be needed anyway.
     // And if their duplicates, likely to be cached.
-    // Need to work with SolverLib which wraps the NodeId bindgins with a converter.
+    // Need to work with SolverLib which wraps the NodeId bindings with a converter.
 
     @Override
     protected QueryIterator execute(OpDistinct opDistinct, QueryIterator input) {
+        if ( isForTDB ) {
+            boolean isSkipScanEnabled = execCxt.getContext().isTrueOrUndef(SystemTDB.symSkipScan);
+            if ( isSkipScanEnabled ) {
+                Op rewritten = SkipScanRewrite.tryRewriteAsSkipScan(opDistinct);
+                if (rewritten != null && !opDistinct.equals(rewritten)) {
+                    OpExtSkipScan.setOpExecutorIfAbsent(execCxt.getContext(), this);
+                    return exec(rewritten, input);
+                }
+            }
+        }
+
         return super.execute(opDistinct, input);
+    }
+
+    @Override
+    protected QueryIterator execute(OpGroup opGroup, QueryIterator input) {
+        if ( isForTDB ) {
+            boolean isSkipScanEnabled = execCxt.getContext().isTrueOrUndef(SystemTDB.symSkipScan);
+            if ( isSkipScanEnabled ) {
+                Op rewritten = SkipScanRewrite.tryRewriteAsSkipScan(opGroup);
+                if (rewritten != null) {
+                    OpExtSkipScan.setOpExecutorIfAbsent(execCxt.getContext(), this);
+                    return exec(rewritten, input);
+                }
+            }
+        }
+
+        return super.execute(opGroup, input);
     }
 
     @Override

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/CandidateIndex.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/CandidateIndex.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import org.apache.jena.atlas.lib.tuple.Tuple;
+import org.apache.jena.tdb2.store.tupletable.TupleIndexRecord;
+
+record CandidateIndex<T>(
+    TupleIndexRecord index,
+    Tuple<T> pattern,
+    int[] projectIndices,
+    ValueFilter<T> residualConditions
+) {}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/EqualityLink.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/EqualityLink.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+/**
+ * Declare that the value of a row at column index {@code equalToIdx} must be equal
+ * to the value at column index {@code idx}.
+ * This case occurs for queries with patterns such as (?s :p ?s):
+ * Here, column 2 and 0 are linked by an equality constraint.
+ */
+record EqualityLink(int idx, int equalToIdx) {}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/IndexMap.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/IndexMap.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import java.util.Arrays;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.tdb2.store.NodeId;
+
+record IndexMap(
+    Node[] nodeTuple,
+    NodeId[] tuple,
+    VarMap[] proj,
+    ValueFilter<NodeId>[] residualConditions,
+    EqualityLink[] equalityLinks)
+{
+
+    @Override
+    public String toString() {
+        return "IndexMap [nodeTuple=" + Arrays.toString(nodeTuple) + ", tuple=" + Arrays.toString(tuple) + ", proj="
+                + Arrays.toString(proj) + ", residualConditions=" + Arrays.toString(residualConditions) + ", links="
+                + Arrays.toString(equalityLinks) + "]";
+    }
+}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/IndexMatch.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/IndexMatch.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import java.util.Comparator;
+
+import org.apache.jena.graph.Node;
+
+record IndexMatch(
+    boolean canDoDirectDistinct,
+    ValueFilter<Node>[] residualConditions,
+    int keyLen,
+    int valLen)
+{
+    public int numNeededSlots() {
+        return keyLen + valLen;
+    }
+
+    public int numResidualConditions() {
+        return (residualConditions == null) ? 0 : residualConditions.length;
+    }
+
+    public static final Comparator<IndexMatch> COMPARATOR = Comparator.nullsLast(Comparator
+        .comparingInt(IndexMatch::numResidualConditions)
+        .thenComparing(Comparator.comparing(IndexMatch::canDoDirectDistinct).reversed())
+        .thenComparing(IndexMatch::numNeededSlots));
+}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/NodeIdUtils.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/NodeIdUtils.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import org.apache.jena.atlas.lib.tuple.Tuple;
+import org.apache.jena.atlas.lib.tuple.TupleFactory;
+import org.apache.jena.tdb2.store.NodeId;
+import org.apache.jena.tdb2.store.NodeIdFactory;
+import org.apache.jena.tdb2.store.NodeIdType;
+
+class NodeIdUtils {
+    /** Minimum value for a NodeId. Used as lower bound in range retrievals. */
+    private static final NodeId NodeIdMin = NodeIdFactory.createPtr(0);
+
+    /** Maximum value for a NodeId. Used as upper bound in range retrievals. */
+    private static final NodeId NodeIdMax = NodeId.createRaw(NodeIdType.SPECIAL, Long.MAX_VALUE);
+
+    public static Tuple<NodeId> anyToMin(Tuple<NodeId> tuple) {
+        int n = tuple.len();
+        NodeId[] arr = new NodeId[n];
+        for (int i = 0; i < n; ++i) {
+            NodeId x = tuple.get(i);
+            arr[i] = NodeId.isAny(x) ? NodeIdMin : x;
+        }
+        return TupleFactory.create(arr);
+    }
+
+    public static Tuple<NodeId> anyToMax(Tuple<NodeId> tuple) {
+        int n = tuple.len();
+        NodeId[] arr = new NodeId[n];
+        for (int i = 0; i < n; ++i) {
+            NodeId x = tuple.get(i);
+            arr[i] = NodeId.isAny(x) ? NodeIdMax : x;
+        }
+        return TupleFactory.create(arr);
+    }
+}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/OpExecutorTDB2SkipScan.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/OpExecutorTDB2SkipScan.java
@@ -1,0 +1,601 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.atlas.lib.tuple.Tuple;
+import org.apache.jena.atlas.lib.tuple.TupleFactory;
+import org.apache.jena.atlas.lib.tuple.TupleMap;
+import org.apache.jena.dboe.base.record.Record;
+import org.apache.jena.dboe.base.record.RecordFactory;
+import org.apache.jena.dboe.index.RangeIndex;
+import org.apache.jena.dboe.trans.bplustree.BPlusTree;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.ARQConstants;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.core.VarAlloc;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.iterator.QueryIter;
+import org.apache.jena.sparql.engine.iterator.QueryIterDistinct;
+import org.apache.jena.sparql.engine.iterator.QueryIterFilterExpr;
+import org.apache.jena.sparql.engine.iterator.QueryIterNullIterator;
+import org.apache.jena.sparql.engine.iterator.QueryIterPlainWrapper;
+import org.apache.jena.sparql.engine.iterator.QueryIterProject;
+import org.apache.jena.sparql.engine.main.OpExecutor;
+import org.apache.jena.sparql.expr.E_Equals;
+import org.apache.jena.sparql.expr.E_LogicalAnd;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprVar;
+import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sparql.util.Symbol;
+import org.apache.jena.tdb2.solver.BindingNodeId;
+import org.apache.jena.tdb2.solver.BindingTDB;
+import org.apache.jena.tdb2.store.DatasetGraphTDB;
+import org.apache.jena.tdb2.store.GraphTDB;
+import org.apache.jena.tdb2.store.NodeId;
+import org.apache.jena.tdb2.store.NodeIdFactory;
+import org.apache.jena.tdb2.store.nodetable.NodeTable;
+import org.apache.jena.tdb2.store.nodetupletable.NodeTupleTable;
+import org.apache.jena.tdb2.store.tupletable.TupleIndex;
+import org.apache.jena.tdb2.store.tupletable.TupleIndexRecord;
+import org.apache.jena.tdb2.store.tupletable.TupleTable;
+import org.apache.jena.tdb2.sys.SystemTDB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpExecutorTDB2SkipScan {
+    private static final Logger logger = LoggerFactory.getLogger(OpExecutorTDB2SkipScan.class);
+
+    // The following symbols should only be used for debugging.
+
+    /** Cache of the best candidate indexes for a {@link PatternQuery}'s configuration of constants and variables. */
+    public static final Symbol symSkipScanBestIndexCache = SystemTDB.allocSymbol("skipScanBestIndexCache");
+
+    /** Symbol for tracking how often an OpExtSkipScan was executed using the specialized machinery. */
+    public static final Symbol symSkipScanOkCounter = SystemTDB.allocSymbol("skipScanOkCounter");
+
+    /** Symbol for tracking how often  an OpExtSkipScan was executed using the conventional machinery. */
+    public static final Symbol symSkipScanFailoverCounter = SystemTDB.allocSymbol("skipScanFailoverCounter");
+
+    public static LongAdder getSkipScanOkCounter(Context cxt) {
+        return cxt.get(symSkipScanOkCounter);
+    }
+
+    /** Return the skip scan count in the context. For debugging only. */
+    public static long getSkipScanOkCount(Context cxt) {
+        LongAdder adder = getSkipScanOkCounter(cxt);
+        long value = (adder == null) ? 0 : adder.longValue();
+        return value;
+    }
+
+    public static LongAdder getSkipScanFailoverCounter(Context cxt) {
+        return cxt.get(symSkipScanFailoverCounter);
+    }
+
+    /** Return the skip scan failover count in the context. For debugging only. */
+    public static long getSkipScanFailoverCount(Context cxt) {
+        LongAdder adder = getSkipScanFailoverCounter(cxt);
+        long value = (adder == null) ? 0 : adder.longValue();
+        return value;
+    }
+
+    public static QueryIterator exec(PatternQuery patternQuery, QueryIterator input, ExecutionContext execCxt, OpExecutor opExecutor) {
+        // Set up a cache that maps the cacheKey(queryPattern) to the best index.
+        // See PatternQuery.toCacheKey()
+        Map<PatternQuery, SkipScanCandidate> indexCache = execCxt.getContext()
+            .computeIfAbsent(symSkipScanBestIndexCache, sym -> new ConcurrentHashMap<>());
+
+        // Get debug counters (may be null)
+        LongAdder skipScanOkCounter = getSkipScanOkCounter(execCxt.getContext());
+        LongAdder skipScanFailoverCounter = getSkipScanFailoverCounter(execCxt.getContext());
+
+        QueryIterator qIter = QueryIter.flatMap(input, binding -> {
+            return exec(patternQuery, binding, execCxt, opExecutor, indexCache, skipScanOkCounter, skipScanFailoverCounter);
+        }, execCxt);
+        return qIter;
+    }
+
+    private static QueryIterator exec(PatternQuery patternQuery, Binding binding, ExecutionContext execCxt, OpExecutor opExecutor,
+            Map<PatternQuery, SkipScanCandidate> indexCache, LongAdder skipScanOkCounter, LongAdder skipScanFailoverCounter) {
+
+        PatternQuery subst = PatternQuery.substitute(patternQuery, binding);
+
+        PatternQuery cacheKey = PatternQuery.toCacheKey(subst);
+        SkipScanCandidate bestCandidate = indexCache.computeIfAbsent(cacheKey, cq -> {
+            // System.err.println("NO CACHE HIT: " + canonicalQuery);
+            SkipScanCandidate r = findBestCandidate(patternQuery, execCxt);
+            return r;
+        });
+
+        QueryIterator innerIter = tryExec(subst, execCxt, bestCandidate);
+
+        if (innerIter != null) {
+            if (skipScanOkCounter != null) {
+                skipScanOkCounter.increment();
+            }
+        } else {
+            // Fail-over in case that no suitable index was found.
+            // Should never be needed with default TDB2 configurations.
+            if (skipScanFailoverCounter != null) {
+                skipScanFailoverCounter.increment();
+            }
+
+            // Execute the pattern without distinct. This avoids the infinite loop of
+            // attempting to rewrite distinct as skip-scan.
+            PatternQuery tmp = new PatternQuery(/*distinct=*/false, patternQuery.project(), patternQuery.tuple());
+            Op op = tmp.effectiveOp();
+            innerIter = opExecutor.executeOp(op, QueryIterPlainWrapper.create(Iter.singletonIter(binding)));
+
+            if (patternQuery.distinct()) {
+                innerIter = new QueryIterDistinct(innerIter, null, execCxt);
+            }
+        }
+        return innerIter;
+    }
+
+    public static SkipScanCandidate findBestCandidate(PatternQuery patternQuery, ExecutionContext execCxt) {
+        Node[] tuple = patternQuery.tuple();
+        NodeTupleTable table = resolveTable(tuple.length, execCxt);
+        TuplePatternSpec lookup = TuplePatternSpec.create(tuple, patternQuery.project());
+        List<SkipScanCandidate> candidates = planCandidates(table, lookup);
+        SkipScanCandidate best = pickBest(candidates);
+        return best;
+    }
+
+    public static QueryIterator tryExec(PatternQuery patternQuery, ExecutionContext execCxt, SkipScanCandidate candidate) {
+        Node[] tuple = patternQuery.tuple();
+        NodeTupleTable table = resolveTable(tuple.length, execCxt);
+        TuplePatternSpec lookup = TuplePatternSpec.create(tuple, patternQuery.project());
+        return tryExec(table, patternQuery.distinct(), lookup, execCxt, candidate);
+    }
+
+    public static QueryIterator tryExec(NodeTupleTable nodeTupleTable, boolean distinct, TuplePatternSpec lookup, ExecutionContext execCxt, SkipScanCandidate best) {
+        // In the end we must build a tuple with the constants
+        if (logger.isDebugEnabled()) {
+            logger.debug("Best matching index: " + (best == null ? null : best.index()));
+        }
+
+        if (best == null) {
+            return null;
+        }
+        return execCandidate(nodeTupleTable, distinct, lookup, best, execCxt);
+    }
+
+    /** Must only be called if hasNeededColumns returned true. */
+    @SuppressWarnings("unchecked")
+    public static IndexMatch computeIndexMatch(TupleMap tm, TuplePatternSpec patternSpec) {
+        Node[] quad = patternSpec.tuple();
+        boolean canDoDirectDistinct = true;
+
+        // An index is only usable if covers all needed slots of the query tuple.
+        // Start with marking all slots as not-covered.
+        int uncoveredSlotsMask = patternSpec.neededSlotsMask();
+
+        ValueFilter<Node>[] residualConditions = null;
+        int numResidualConditions = 0;
+
+        int i;
+        int idxLen = tm.length();
+        for (i = 0; i < idxLen; ++i) {
+            int tupleSlot = tm.mapIdx(i);
+            Node node = quad[tupleSlot];
+            if (!node.isConcrete()) {
+                break;
+            }
+            // Mark the slot as covered by setting the slot's bit to 0.
+            uncoveredSlotsMask &= ~(1 << tupleSlot);
+        }
+        int keyLen = i;
+
+        // The next slots of the index must map to the projection slots
+        // Any constant not matched by HEAD is considered projected and filtered on.
+        int j; // additional needed value slots
+        for (j = keyLen; j < idxLen && uncoveredSlotsMask != 0; ++j) {
+            int tupleSlot = tm.mapIdx(j);
+            Node node = quad[tupleSlot];
+            if (node.isVariable()) {
+                Var v = Var.alloc(node);
+                uncoveredSlotsMask &= ~(1 << tupleSlot);
+
+                // Consider: SELECT DISTINCT ?g ?p { GRAPH ?g { ?s :p ?s } }
+                // PGSO and PGOS are suitable indices
+                // If we pick PGOS we would evaluate the quality group for the S slot
+                // So we test restriction based on the order of the original slot indices
+                // S comes before O, so we test S = O instead of O = S
+                // The important part is just: all members of equality groups must be covered.
+
+                boolean isProjected = patternSpec.projection().contains(v);
+
+                // If the variable in not projected, then we need to skip over it
+                // This breaks simple distinct
+                if (!isProjected) {
+                    canDoDirectDistinct = false;
+                }
+            } else {
+                if (residualConditions == null) {
+                    residualConditions = new ValueFilter[idxLen - j];
+                }
+
+                // Add the constant node as a filter condition.
+                residualConditions[numResidualConditions++] = new ValueFilter<>(j, node);
+            }
+        }
+        int valLen = j - keyLen;
+
+        if (uncoveredSlotsMask != 0) {
+            return null;
+        }
+
+        // If there were residual conditions then strip trailing null values.
+        if (residualConditions != null && residualConditions.length != numResidualConditions) {
+            residualConditions = Arrays.copyOf(residualConditions, numResidualConditions);
+        }
+
+        return new IndexMatch(canDoDirectDistinct, residualConditions, keyLen, valLen);
+    }
+
+    /** Resolve the {@link NodeTupleTable} for a pattern of the given tuple length. */
+    public static NodeTupleTable resolveTable(int tupleLength, ExecutionContext execCxt) {
+        if (tupleLength == 3) {
+            GraphTDB graph = (GraphTDB)execCxt.getActiveGraph();
+            return graph.getNodeTupleTable();
+        } else if (tupleLength == 4) {
+            DatasetGraphTDB ds = (DatasetGraphTDB)execCxt.getDataset();
+            return ds.getQuadTable().getNodeTupleTable();
+        } else {
+            throw new IllegalArgumentException("Unexpected tuple length: " + tupleLength);
+        }
+    }
+
+    /**
+     * Enumerate the usable indexes for the given lookup. Each returned candidate carries
+     * the matched index, its {@link IndexMatch}, and the variable order the index produces.
+     * This is the planning phase: it does not touch the node table or execute anything, so
+     * callers may inspect candidate orders and choose a combination before executing.
+     */
+    public static List<SkipScanCandidate> planCandidates(NodeTupleTable nodeTupleTable, TuplePatternSpec lookup) {
+        TupleTable tupleTable = nodeTupleTable.getTupleTable();
+        List<SkipScanCandidate> candidates = new ArrayList<>();
+
+        for (TupleIndex tupleIndex : tupleTable.getIndexes()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Trying index: " + tupleIndex);
+            }
+            SkipScanCandidate candidate = planCandidate(lookup, tupleIndex);
+            if (candidate != null) {
+                candidates.add(candidate);
+            }
+        }
+        return candidates;
+    }
+
+    private static SkipScanCandidate planCandidate(TuplePatternSpec lookup, TupleIndex tupleIndex) {
+        // Only consider indexes backed by a BPlusTree
+        if (tupleIndex instanceof TupleIndexRecord recordIdx) {
+            RangeIndex rangeIndex = recordIdx.getRangeIndex();
+            if (!(rangeIndex instanceof BPlusTree)) {
+                return null;
+            }
+        }
+
+        TupleMap tm = tupleIndex.getMapping();
+        IndexMatch match = computeIndexMatch(tm, lookup);
+
+        if (match == null) {
+            return null;
+        }
+
+        return new SkipScanCandidate(tupleIndex, match);
+    }
+
+    /** Choose the best candidate using {@link IndexMatch#COMPARATOR}, or null if none. */
+    public static SkipScanCandidate pickBest(List<SkipScanCandidate> candidates) {
+        SkipScanCandidate best = null;
+        for (SkipScanCandidate candidate : candidates) {
+            if (best == null || IndexMatch.COMPARATOR.compare(candidate.match(), best.match()) < 0) {
+                best = candidate;
+            }
+        }
+        return best;
+    }
+
+    /** Execute a previously planned candidate. */
+    public static QueryIterator execCandidate(NodeTupleTable nodeTupleTable, boolean distinct, TuplePatternSpec lookup,
+                                              SkipScanCandidate candidate, ExecutionContext execCxt) {
+        NodeTable nodeTable = nodeTupleTable.getNodeTable();
+        TupleIndex bestIndex = candidate.index();
+        IndexMatch bestMatch = candidate.match();
+
+        TupleMap tm = bestIndex.getMapping();
+        IndexMap im = tryComputeIndexMap(lookup, bestMatch, tm, nodeTable);
+        if (im == null) {
+            // If null then at least one Node had no corresponding NodeId in the nodeTable.
+            return new QueryIterNullIterator(execCxt);
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("IndexMap Match Data: " + im);
+            logger.debug("IndexMap Projection: " + Arrays.toString(im.proj()));
+            logger.debug("IndexMap Conditions: " + Arrays.toString(im.residualConditions()));
+            logger.debug("IndexMap Links: " + Arrays.toString(im.equalityLinks()));
+            logger.debug("IndexMap Query Tuple: " + Arrays.asList(im.tuple()));
+        }
+
+        QueryIterator r = exec(bestIndex, nodeTable, lookup.projection(), im, execCxt);
+
+        if (distinct && !bestMatch.canDoDirectDistinct()) {
+            r = new QueryIterDistinct(r, null, execCxt);
+        }
+        return r;
+    }
+
+    /**
+     * Actual execution.
+     */
+    @SuppressWarnings("removal")
+    public static QueryIterator exec(TupleIndex tupleIndex, NodeTable nodeTable, List<Var> projectVars, IndexMap map, ExecutionContext execCxt) {
+        // Cast validity of the arguments is assumed to be ensured!
+        TupleIndexRecord tupleIndexRecord = (TupleIndexRecord)tupleIndex;
+        RangeIndex rangeIndex = tupleIndexRecord.getRangeIndex();
+        BPlusTree bpt = (BPlusTree)rangeIndex;
+
+        int n = map.tuple().length;
+        Tuple<NodeId> pattern = TupleFactory.create(map.tuple());
+
+        Tuple<NodeId> minPattern = NodeIdUtils.anyToMin(pattern);
+        Tuple<NodeId> maxPattern = NodeIdUtils.anyToMax(pattern);
+
+        RecordFactory rf = rangeIndex.getRecordFactory();
+        Record minRecord = record(rf, minPattern);
+        Record maxRecord = record(rf, maxPattern);
+
+        // VarMap[] proj = map.proj;
+        ValueFilter<NodeId>[] residualConditions = map.residualConditions();
+        EqualityLink[] equalityLinks = map.equalityLinks();
+
+        Iterator<BindingNodeId> bindingIdIt;
+
+        VarMap[] finalProj;
+        Expr filterExpr = null;
+        if (equalityLinks == null) {
+            finalProj = map.proj();
+        } else {
+            // For linked slots, such as {?s :p ?s} introduce dummy non-distinguished vars.
+            // {?s :p ?s} becomes {?s :p ?.foo} FILTER(?s = ?.foo)
+
+            // The variables of the equalityLinks may not have been projected yet.
+            // So we must compute a proper projection.
+
+            VarMap[] finalProjTmp = new VarMap[map.proj().length + 2 * equalityLinks.length];
+            System.arraycopy(map.proj(), 0, finalProjTmp, 0, map.proj().length);
+            VarAlloc va = new VarAlloc(ARQConstants.allocVarAnonMarker + "X");
+            int i = map.proj().length;
+            Set<Var> seenVars = null;
+            for (EqualityLink entry : equalityLinks) {
+                int primaryIdx = entry.equalToIdx();
+                Var primaryVar = (Var)map.nodeTuple()[primaryIdx];
+                if (!projectVars.contains(primaryVar) && (seenVars == null || !seenVars.contains(primaryVar))) {
+                    if (seenVars == null) {
+                        seenVars = new HashSet<>();
+                    }
+                    seenVars.add(primaryVar);
+                    finalProjTmp[i++] = new VarMap(primaryIdx, primaryVar);
+                }
+
+                int secondaryIdx = entry.idx();
+                Var extraVar = va.allocVar();
+                finalProjTmp[i++] = new VarMap(secondaryIdx, extraVar);
+
+                Expr contrib = new E_Equals(new ExprVar(primaryVar), new ExprVar(extraVar));
+                filterExpr = logicalAnd(filterExpr, contrib);
+            }
+            finalProj = Arrays.copyOf(finalProjTmp, i);
+        }
+
+        Iterator<Record> recordIt = bpt.distinctByKeyPrefix(n * NodeId.SIZE, minRecord, maxRecord);
+
+        // Filter by recheck conditions first.
+        if (residualConditions != null) {
+            recordIt = Iter.filter(recordIt, record -> {
+                execCxt.checkCancelSignal();
+
+                byte[] recordKey = record.getKey();
+                for (int i = 0; i < residualConditions.length; ++i) {
+                    ValueFilter<NodeId> condition = residualConditions[i];
+                    int idxx = condition.idx();
+                    NodeId expected = condition.value();
+                    NodeId actual = extractNodeId(recordKey, idxx);
+                    if (!expected.equals(actual)) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+        }
+
+        // Build the initial BindingNodeId instances.
+        bindingIdIt = Iter.map(recordIt, record -> {
+            byte[] recordKey = record.getKey();
+            BindingNodeId b = new BindingNodeId();
+            for (VarMap varMap : finalProj) {
+                NodeId nodeId = extractNodeId(recordKey, varMap.idx());
+                b.put(varMap.var(), nodeId);
+            }
+            return b;
+        });
+
+        Iterator<Binding> bindingIt = Iter.map(bindingIdIt, bid -> new BindingTDB(bid, nodeTable));
+        QueryIterator qIter = QueryIterPlainWrapper.create(bindingIt, execCxt);
+
+        // Apply filters if needed.
+        // Presence of filters also implies presence of generated variables that need projecting away.
+        if (filterExpr != null) {
+            qIter = new QueryIterFilterExpr(qIter, filterExpr, execCxt);
+            qIter = QueryIterProject.create(qIter, projectVars, execCxt);
+        }
+
+        return qIter;
+    }
+
+    /**
+     * Maps Nodes to NodeIds.
+     * Returns null if any constraint is unsatisfiable due to the lack of a corresponding node id.
+     */
+    public static IndexMap tryComputeIndexMap(TuplePatternSpec lookup, IndexMatch match, TupleMap tm, NodeTable nodeTable) {
+        Node[] quad = lookup.tuple();
+        int neededSlots = match.numNeededSlots();
+
+        // Reorder the query tuple by the order of columns in the index.
+        Node[] nodeTuple = new Node[neededSlots];
+        for (int i = 0; i < neededSlots; ++i) {
+            int tupleSlot = tm.mapIdx(i);
+            Node node = quad[tupleSlot];
+            nodeTuple[i] = node;
+        }
+
+        // Build the tuple of NodeIds
+        NodeId[] tuple = new NodeId[neededSlots];
+
+        int x;
+        for (x = 0; x < neededSlots; ++x) {
+            int tupleSlot = tm.mapIdx(x);
+            Node node = quad[tupleSlot];
+            if (!node.isConcrete()) {
+                break;
+            }
+            NodeId nodeId = nodeTable.getNodeIdForNode(node);
+
+            if (NodeId.isDoesNotExist(nodeId)) {
+                // Empty result set
+                return null;
+            }
+
+            tuple[x] = nodeId;
+        }
+
+        for (int y = x; y < neededSlots; ++y) {
+            tuple[y] = NodeId.NodeIdAny;
+        }
+
+        ValueFilter<NodeId>[] mappedConditions = null;
+        EqualityLink[] mappedLinks = null;
+
+        if (match.numResidualConditions() > 0) {
+            mappedConditions = remapValueConditions(match.residualConditions(), tm, nodeTable);
+
+            // If mappedConditions is null then some nodes could not be mapped
+            if (mappedConditions == null) {
+                // skip
+                return null;
+            }
+        }
+
+        if (lookup.equalityLinks() != null) {
+            mappedLinks = remapEqualityLinks(lookup.equalityLinks(), tm);
+        }
+
+        VarMap[] newProj = remapProjection(lookup, tm);
+        return new IndexMap(nodeTuple, tuple, newProj, mappedConditions, mappedLinks);
+    }
+
+    private static Expr logicalAnd(Expr base, Expr contrib) {
+        return base == null ? contrib : new E_LogicalAnd(base, contrib);
+    }
+
+    private static NodeId extractNodeId(byte[] bytes, int index) {
+        NodeId nodeId = NodeIdFactory.get(bytes, index * NodeId.SIZE);
+        return nodeId;
+    }
+
+    /** Create varMaps from the spec's projection and remap indices w.r.t. the tupleMap. */
+    public static VarMap[] remapProjection(TuplePatternSpec lookup, TupleMap tupleMap) {
+        int[] proj = lookup.projs();
+        int n = proj.length;
+        VarMap[] result = new VarMap[n];
+        for (int i = 0; i < n; ++i) {
+            int tupleIdx = proj[i];
+            Node node = lookup.tuple()[tupleIdx];
+            Var var = Var.alloc(node);
+            int idx = tupleMap.unmapIdx(tupleIdx);
+            result[i] = new VarMap(idx, var);
+        }
+        return result;
+    }
+
+    /**
+     * Remap indices of equality links w.r.t. the tupleMap.
+     */
+    public static EqualityLink[] remapEqualityLinks(EqualityLink[] links, TupleMap tupleMap) {
+        int n = links.length;
+        EqualityLink[] result = new EqualityLink[n];
+        for (int i = 0; i < n; ++i) {
+            EqualityLink link = links[i];
+            int primary = tupleMap.unmapIdx(link.idx());
+            int secondary = tupleMap.unmapIdx(link.equalToIdx());
+            result[i] = new EqualityLink(primary, secondary);
+        }
+        return result;
+    }
+
+    /**
+     * Remap indices w.r.t. the tupleMap and map Nodes to NodeIds.
+     * Returns null if any condition could not be mapped.
+     */
+    public static ValueFilter<NodeId>[] remapValueConditions(ValueFilter<Node>[] conditions, TupleMap tupleMap, NodeTable nodeTable) {
+        int n = conditions.length;
+        @SuppressWarnings("unchecked")
+        ValueFilter<NodeId>[] result = new ValueFilter[n];
+        for (int i = 0; i < n; ++i) {
+            ValueFilter<Node> condition = conditions[i];
+            int slot = tupleMap.unmapIdx(condition.idx());
+            NodeId nodeId = nodeTable.getNodeIdForNode(condition.value());
+            if (nodeId == null) {
+                return null;
+            }
+            result[i] = new ValueFilter<>(slot, nodeId);
+        }
+        return result;
+    }
+
+    /** Create a record directly from the tuple (without a tuple map) */
+    private static Record record(RecordFactory factory, Tuple<NodeId> tuple) {
+        int n = tuple.len();
+        byte[] b = new byte[n * NodeId.SIZE];
+        for (int i = 0; i < n ; i++) {
+            NodeIdFactory.set(tuple.get(i), b, i * NodeId.SIZE);
+        }
+        return factory.create(b);
+    }
+}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/OpExtSkipScan.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/OpExtSkipScan.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.sparql.ARQInternalErrorException;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.op.OpExt;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.engine.QueryIterator;
+import org.apache.jena.sparql.engine.main.OpExecutor;
+import org.apache.jena.sparql.serializer.SerializationContext;
+import org.apache.jena.sparql.util.Context;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
+import org.apache.jena.sparql.util.Symbol;
+
+public class OpExtSkipScan
+    extends OpExt
+{
+    protected PatternQuery patternQuery;
+
+    private static Symbol symOpExecutor = Symbol.create("opExecutor");
+
+    public static void setOpExecutorIfAbsent(Context cxt, OpExecutor opExecutor) {
+        cxt.computeIfAbsent(symOpExecutor, x -> opExecutor);
+    }
+
+    public static void setOpExecutor(Context cxt, OpExecutor opExecutor) {
+        cxt.set(symOpExecutor, opExecutor);
+    }
+
+    public static OpExecutor getOpExecutor(Context cxt) {
+        return cxt.get(symOpExecutor);
+    }
+
+    public OpExtSkipScan(PatternQuery patternQuery) {
+        super("skipScan");
+        this.patternQuery = patternQuery;
+    }
+
+    @Override
+    public Op effectiveOp() {
+        return patternQuery.effectiveOp();
+    }
+
+    private OpExecutor getOpExecutor(ExecutionContext execCxt) {
+        OpExecutor result = getOpExecutor(execCxt.getContext());
+        if (result == null) {
+            // It would be possible to gracefully create a new exec context, but better be strict.
+            throw new ARQInternalErrorException("OpExecutor not set");
+        }
+        return result;
+    }
+
+    @Override
+    public QueryIterator eval(QueryIterator input, ExecutionContext execCxt) {
+        OpExecutor opExecutor = getOpExecutor(execCxt);
+        QueryIterator result = OpExecutorTDB2SkipScan.exec(patternQuery, input, execCxt, opExecutor);
+        return result;
+    }
+
+    @Override
+    public void outputArgs(IndentedWriter out, SerializationContext sCxt) {
+        Op eop = effectiveOp();
+        eop.output(out, sCxt);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * patternQuery.hashCode();
+    }
+
+    @Override
+    public boolean equalTo(Op other, NodeIsomorphismMap labelMap) {
+        return other instanceof OpExtSkipScan o && this.effectiveOp().equalTo(o.effectiveOp(), labelMap);
+    }
+}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/PatternQuery.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/PatternQuery.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpVars;
+import org.apache.jena.sparql.algebra.op.OpBGP;
+import org.apache.jena.sparql.algebra.op.OpDistinct;
+import org.apache.jena.sparql.algebra.op.OpProject;
+import org.apache.jena.sparql.algebra.op.OpQuadBlock;
+import org.apache.jena.sparql.algebra.op.OpQuadPattern;
+import org.apache.jena.sparql.core.BasicPattern;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.core.Substitute;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.core.VarAlloc;
+import org.apache.jena.sparql.core.Vars;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.join.ImmutableUniqueList;
+import org.apache.jena.sparql.engine.join.ImmutableUniqueList.Builder;
+import org.apache.jena.sparql.graph.NodeTransform;
+import org.apache.jena.sparql.graph.NodeTransformLib;
+
+/**
+ * Single tuple access pattern.
+ *
+ * Captures variants such as: SELECT DISTINCT ?g ?p { GRAPH ?g { ?s ?p ?o } }
+ */
+public record PatternQuery(boolean distinct, List<Var> project, Node[] tuple) {
+
+    /**
+     * Create a PatternOp structure from the argument. Returns null on failure.
+     *
+     * Tries to match the structure below. [Op] indicates optional presence.
+     * <pre>{@code
+     * OpDistinct
+     *   [OpProject]
+     *     OpQuadPattern|OpBGP
+     * }</pre>
+     *
+     * And returns non-null iff it can be safely rewritten as follows:
+     * <pre>{@code
+     * OpDistinct
+     *   [OpProject]
+     *     OpQuadPattern|OpBGP
+     * }</pre>
+     *
+     * <p>
+     * Notes:
+     * <ul>
+     *   <li>Quads in the default graph are returned as triples.</li>
+     *   <li>The union default graph constant {@link Quad#unionGraph} is converted to a non-distinguished variable.</li>
+     * </ul>
+     *
+     * @param inputOp The input Op.
+     * @return A PatternOp instance or null.
+     */
+    static PatternQuery createOrNull$(Op inputOp) {
+        PatternQuery result = null;
+
+        Node g = null;
+        List<Var> projectVars = null;
+        boolean distinct = false;
+        Node[] tuple = null;
+
+        Op op = inputOp;
+        if (op instanceof OpDistinct opD) {
+            distinct = true;
+            op = opD.getSubOp();
+        }
+
+        if (op instanceof OpProject opP) {
+            projectVars = ImmutableUniqueList.createUniqueList(opP.getVars());
+            op = opP.getSubOp();
+        }
+
+        BasicPattern bp = null;
+        if (op instanceof OpQuadPattern opQuadPattern) {
+            bp = opQuadPattern.getBasicPattern();
+            g = opQuadPattern.getGraphNode();
+        } else if (op instanceof OpBGP opBgp) {
+            bp = opBgp.getPattern();
+        }
+
+        if (bp != null && bp.size() == 1) {
+            Triple t = bp.get(0);
+
+            if (projectVars == null) {
+                Set<Var> varSet = new LinkedHashSet<>();
+                Vars.addVarsFromTriple(varSet, t);
+                if (g != null && g.isVariable()) {
+                    varSet.add(Var.alloc(g));
+                }
+                projectVars = ImmutableUniqueList.createUniqueList(varSet);
+            }
+
+            if (g == null || Quad.isDefaultGraph(g)) {
+                tuple = new Node[] { t.getSubject(), t.getPredicate(), t.getObject() };
+            } else if (Quad.isUnionGraph(g)) {
+                VarAlloc varAlloc = new VarAlloc("G");
+                tuple = new Node[] { varAlloc.allocVar(), t.getSubject(), t.getPredicate(), t.getObject() };
+            } else {
+                tuple = new Node[] { g, t.getSubject(), t.getPredicate(), t.getObject() };
+            }
+
+            result = new PatternQuery(distinct, projectVars, tuple); //, filter, extend, reapplyProject);
+        }
+        return result;
+    }
+
+    public Op effectiveOp() {
+        Op result = tupleToOp(tuple);
+        Set<Var> tupleVars = OpVars.visibleVars(result);
+
+        if (!project.containsAll(tupleVars)) {
+            result = new OpProject(result, project);
+        }
+
+        if (distinct) {
+            result = new OpDistinct(result);
+        }
+        return result;
+    }
+
+    private static Op tupleToOp(Node[] t) {
+        Op result = switch (t.length) {
+        case 3 -> new OpBGP(new BasicPattern(List.of(Triple.create(t[0], t[1], t[2]))));
+        case 4 -> OpQuadBlock.create(t[0], new BasicPattern(List.of(Triple.create(t[1], t[2], t[3]))));
+        default -> throw new IllegalStateException();
+        };
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "PatternQuery [distinct=" + distinct + ", project=" + project + ", tuple=" + Arrays.toString(tuple) + "]";
+    }
+
+    /** Transform an array of nodes. Akin to {@link NodeTransformLib}. */
+    private static Node[] transform(NodeTransform nodeTransform, Node[] tuple) {
+        int n = tuple.length;
+        Node[] newTuple = new Node[n];
+        for (int i = 0; i < n; ++i) {
+            Node node = tuple[i];
+            newTuple[i] = nodeTransform.apply(node);
+        }
+        return newTuple;
+    }
+
+    /** Substitute all variables in a PatternQuery. Akin to {@link Substitute}. */
+    public static PatternQuery substitute(PatternQuery patternQuery, Binding binding) {
+        Node[] newTuple = transform(n -> Var.lookup(binding, n), patternQuery.tuple);
+        Builder<Var> builder = ImmutableUniqueList.newUniqueListBuilder();
+        for (Var v : patternQuery.project) {
+            if (!binding.contains(v)) {
+                builder.add(v);
+            }
+        }
+        ImmutableUniqueList<Var> newProject = builder.build();
+        return new PatternQuery(patternQuery.distinct, newProject, newTuple);
+    }
+
+    private static final Node CONST = NodeFactory.createLiteralString("C");
+
+
+    /**
+     * Create a cache key representation of the argument:
+     * <ul>
+     *   <li>Each unique variable is deterministically mapped to a fresh one in the order of their occurrence in the tuple.</li>
+     *   <li>All constants are re-mapped to the same special constant.</li>
+     * </ul>
+     *
+     * For example (project (?p) (quad ?g :s ?p :o)) becomes (project (?V1) quad(?V0 :C ?V1 :C))
+     */
+    public static PatternQuery toCacheKey(PatternQuery patternQuery) {
+        Map<Node, Node> map = new HashMap<>();
+        VarAlloc varAlloc = new VarAlloc("V");
+
+        NodeTransform xform = n -> {
+            Node r;
+            if (n.isVariable()) {
+                r = map.computeIfAbsent(n, k -> varAlloc.allocVar());
+            } else if (n.isConcrete()) {
+                r = map.computeIfAbsent(n, k -> CONST);
+            } else {
+                throw new IllegalStateException("Should never come here");
+            }
+            return r;
+        };
+
+        Node[] newTuple = transform(xform, patternQuery.tuple());
+
+        List<Var> newProject = new ArrayList<>(patternQuery.tuple().length);
+        for (Var v : patternQuery.project()) {
+            Var newV = (Var)map.get(v);
+            if (newV != null) {
+                newProject.add(newV);
+            }
+        }
+
+        return new PatternQuery(patternQuery.distinct(), newProject, newTuple);
+    }
+}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/SkipScanCandidate.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/SkipScanCandidate.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import org.apache.jena.tdb2.store.tupletable.TupleIndex;
+
+/**
+ * A usable index together with the information needed to plan and execute a skip-scan.
+ */
+record SkipScanCandidate(TupleIndex index, IndexMatch match) {}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/SkipScanRewrite.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/SkipScanRewrite.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import java.util.List;
+
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpVisitorByTypeBase;
+import org.apache.jena.sparql.algebra.OpWalker;
+import org.apache.jena.sparql.algebra.Transformer;
+import org.apache.jena.sparql.algebra.op.OpBGP;
+import org.apache.jena.sparql.algebra.op.OpDistinct;
+import org.apache.jena.sparql.algebra.op.OpExt;
+import org.apache.jena.sparql.algebra.op.OpExtend;
+import org.apache.jena.sparql.algebra.op.OpFilter;
+import org.apache.jena.sparql.algebra.op.OpGroup;
+import org.apache.jena.sparql.algebra.op.OpProject;
+import org.apache.jena.sparql.algebra.op.OpQuadPattern;
+import org.apache.jena.sparql.core.BasicPattern;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.join.ImmutableUniqueList;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprAggregator;
+import org.apache.jena.sparql.expr.ExprList;
+import org.apache.jena.sparql.expr.aggregate.AggAvgDistinct;
+import org.apache.jena.sparql.expr.aggregate.AggCountVarDistinct;
+import org.apache.jena.sparql.expr.aggregate.AggGroupConcatDistinct;
+import org.apache.jena.sparql.expr.aggregate.AggMax;
+import org.apache.jena.sparql.expr.aggregate.AggMedianDistinct;
+import org.apache.jena.sparql.expr.aggregate.AggMin;
+import org.apache.jena.sparql.expr.aggregate.AggModeDistinct;
+import org.apache.jena.sparql.expr.aggregate.AggSampleDistinct;
+import org.apache.jena.sparql.expr.aggregate.AggSumDistinct;
+import org.apache.jena.sparql.expr.aggregate.Aggregator;
+import org.apache.jena.sparql.expr.aggregate.AggregatorFactory;
+
+public class SkipScanRewrite {
+
+    /**
+     * Returns true iff the argument matches the structure below.
+     * Brackets indicate optional operation types.
+     *
+     * <pre>{@code
+     * OpDistinct
+     *   OpProject
+     *     [OpFilter]
+     *       [OpExtend]
+     *         OpBGP|OpQuadPattern with a single triple/quad
+     * }</pre>
+     */
+    public static boolean isSkipScanCandidate(Op inputOp) {
+        boolean result = false;
+
+        Op op = inputOp;
+        if (op instanceof OpDistinct opD) {
+            op = opD.getSubOp();
+        }
+
+        if (op instanceof OpProject opP) {
+            op = opP.getSubOp();
+        }
+
+        if (op instanceof OpFilter opF) {
+            op = opF.getSubOp();
+        }
+
+        if (op instanceof OpExtend opE) {
+            op = opE.getSubOp();
+        }
+
+        BasicPattern bp = null;
+        if (op instanceof OpQuadPattern opQuadPattern) {
+            bp = opQuadPattern.getBasicPattern();
+        } else if (op instanceof OpBGP opBgp) {
+            bp = opBgp.getPattern();
+        }
+
+        if (bp != null && bp.size() == 1) {
+            result = true;
+        }
+        return result;
+    }
+
+    /**
+     * Attempt to rewrite an OpDistinct(...) as a skip scan.
+     */
+    public static Op tryRewriteAsSkipScan(OpDistinct op) {
+        if (isSkipScanCandidate(op)) {
+            Op op1 = Transformer.transform(new TransformDistinctPlacement(), op);
+
+            TransformSkipScan xform = new TransformSkipScan();
+            Op op2 = Transformer.transform(xform, op1);
+
+            // Only return the transformation result if a skip scan was injected.
+            if (xform.getNumAppliedSkipScanTransforms() > 0) {
+                return op2;
+            }
+        }
+        return null;
+    }
+
+    public static Op tryRewriteAsSkipScan(OpGroup opGroup) {
+        // For now, restrict the skip scan rewrite to opGroups without expressions - just variables.
+        // For future optimization: If the expressions are deterministically dependent on the group vars, we could
+        // actually do a skip scan on the group vars.
+        if (opGroup.getGroupVars().getExprs().isEmpty()) {
+            // If all aggregators use the same variable then the same index can be used to answer all of them.
+            Var aggVar = null;
+            for (ExprAggregator exprAgg : opGroup.getAggregators()) {
+                Aggregator agg = exprAgg.getAggregator();
+                Var contribVar = suitableVarOrNull(agg);
+                if (contribVar == null || (aggVar != null && !aggVar.equals(contribVar))) {
+                    aggVar = null;
+                    break;
+                }
+                aggVar = contribVar;
+            }
+
+            if (aggVar != null) {
+                ImmutableUniqueList<Var> newProj = ImmutableUniqueList.<Var>newUniqueListBuilder()
+                    .addAll(opGroup.getGroupVars().getVars())
+                    .add(aggVar)
+                    .build();
+                OpDistinct newOp = new OpDistinct(new OpProject(opGroup.getSubOp(), newProj));
+
+                Op patternOp = SkipScanRewrite.tryRewriteAsSkipScan(newOp);
+                if (patternOp != null) {
+                    // Remove redundant distinct from aggregators - it is ensured by the pattern execution.
+                    List<ExprAggregator> newAggs = opGroup.getAggregators().stream()
+                            .map(SkipScanRewrite::convertToNonDistinct).toList();
+                    patternOp = new OpGroup(patternOp, opGroup.getGroupVars(), newAggs);
+                    return patternOp;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * If the aggregator is suitable for skip-scan execution then return its single
+     * value variable, else null.
+     *
+     * <p>An aggregator is suitable iff its result is invariant under removing duplicate
+     * values of a single value expression that is a plain variable. This covers every
+     * DISTINCT single-var aggregator (COUNT, SUM, AVG, MEDIAN, MODE, SAMPLE, GROUP_CONCAT)
+     * plus the non-distinct MIN, MAX and SAMPLE aggregators (for which DISTINCT is
+     * irrelevant).</p>
+     */
+    private static Var suitableVarOrNull(Aggregator agg) {
+        if (!isSkipScanSuitable(agg)) {
+            return null;
+        }
+        return varOrNull(agg);
+    }
+
+    private static boolean isSkipScanSuitable(Aggregator agg) {
+        return agg instanceof AggCountVarDistinct
+            || agg instanceof AggSumDistinct
+            || agg instanceof AggAvgDistinct
+            || agg instanceof AggMedianDistinct
+            || agg instanceof AggModeDistinct
+            || agg instanceof AggSampleDistinct
+            || agg instanceof AggGroupConcatDistinct
+            // Non-distinct MIN/MAX are distinct-invariant.
+            || agg instanceof AggMin
+            || agg instanceof AggMax;
+            // For sample retain the original distribution - so exclude.
+            // || agg instanceof AggSample
+    }
+
+    private static ExprAggregator convertToNonDistinct(ExprAggregator eAgg) {
+        Aggregator newAgg = convertToNonDistinct(eAgg.getAggregator());
+        return new ExprAggregator(eAgg.getVar(), newAgg);
+    }
+
+    /**
+     * Convert a (possibly DISTINCT) skip-scan-suitable aggregator into its non-distinct
+     * equivalent. Because the skip-scan input yields each value at most once per group,
+     * the non-distinct aggregator computes the same result. MIN/MAX/SAMPLE (already
+     * distinct-invariant) are returned unchanged.
+     */
+    private static Aggregator convertToNonDistinct(Aggregator agg) {
+        Expr expr = agg.getExprList().get(0);
+        if (agg instanceof AggCountVarDistinct) {
+            return AggregatorFactory.createCountExpr(false, expr);
+        } else if (agg instanceof AggSumDistinct) {
+            return AggregatorFactory.createSum(false, expr);
+        } else if (agg instanceof AggAvgDistinct) {
+            return AggregatorFactory.createAvg(false, expr);
+        } else if (agg instanceof AggMedianDistinct) {
+            return AggregatorFactory.createMedian(false, expr);
+        } else if (agg instanceof AggModeDistinct) {
+            return AggregatorFactory.createMode(false, expr);
+        } else if (agg instanceof AggSampleDistinct) {
+            return AggregatorFactory.createSample(false, expr);
+        } else if (agg instanceof AggGroupConcatDistinct acd) {
+            return AggregatorFactory.createGroupConcat(false, expr, acd.getSeparator(), null);
+        }
+        // AggMin, AggMax, AggSample: already non-distinct and distinct-invariant.
+        return agg;
+    }
+
+    /** Extract the first argument of the agg's exprList as a Var, or null. */
+    private static Var varOrNull(Aggregator agg) {
+        ExprList el = agg.getExprList();
+        if (el == null || el.size() != 1) {
+            return null;
+        }
+        Expr e = el.get(0);
+        return e.isVariable() ? e.asVar() : null;
+    }
+
+    private static class AbortEarlyException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+        @Override public synchronized Throwable fillInStackTrace() { return this; }
+    }
+
+    public static boolean usesSkipScan(Op op) {
+        boolean[] result = {false};
+        try {
+            OpWalker.walk(op, new OpVisitorByTypeBase() {
+                @Override
+                public void visit(OpExt opExt) {
+                    if (opExt instanceof OpExtSkipScan) {
+                        result[0] = true;
+                        throw new AbortEarlyException();
+                    }
+                }
+            });
+        } catch (AbortEarlyException e) {}
+        return result[0];
+    }
+}
+

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/TransformDistinctPlacement.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/TransformDistinctPlacement.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.jena.atlas.lib.SetUtils;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpVars;
+import org.apache.jena.sparql.algebra.OpVisitorBase;
+import org.apache.jena.sparql.algebra.TransformCopy;
+import org.apache.jena.sparql.algebra.op.Op1;
+import org.apache.jena.sparql.algebra.op.OpDistinct;
+import org.apache.jena.sparql.algebra.op.OpExtend;
+import org.apache.jena.sparql.algebra.op.OpFilter;
+import org.apache.jena.sparql.algebra.op.OpProject;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.core.VarExprList;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprLib;
+import org.apache.jena.sparql.expr.ExprList;
+
+public class TransformDistinctPlacement
+    extends TransformCopy
+{
+    @Override
+    public Op transform(OpDistinct opDistinct, Op subOp) {
+        Set<Var> projectVars = new LinkedHashSet<>();
+        OpVars.visibleVars(subOp, projectVars);
+        Op result = OpVisitorDistinctPlacement.transform(projectVars, subOp);
+        return result;
+    }
+
+    /**
+     * The visitor does the actual top-down rewrite.
+     * For each encountered Op, the visitor creates a new instance of itself
+     * that holds the transformation result.
+     */
+    private static class OpVisitorDistinctPlacement
+        extends OpVisitorBase
+    {
+        private Set<Var> projectVars;
+        private Op result;
+
+        public OpVisitorDistinctPlacement(Set<Var> projectVars) {
+            super();
+            this.projectVars = Objects.requireNonNull(projectVars);
+        }
+
+        public Op getResult() {
+            return result;
+        }
+
+        public static Op transform(Set<Var> projectVars, Op op) {
+            OpVisitorDistinctPlacement visitor = new OpVisitorDistinctPlacement(projectVars);
+            op.visit(visitor);
+            Op r = visitor.getResult();
+            Op result = r == null ? placeDistinctProject(projectVars, op) : r;
+            return result;
+        }
+
+        /** Inject (distinct (project (projectVars') op)) */
+        private static Op placeDistinctProject(Set<Var> projectVars, Op op) {
+            Set<Var> visibleVars = OpVars.visibleVars(op);
+
+            Op projectionAdaptedOp = op;
+
+            // If the visible variables differ from in-scope projectVars then place the projection.
+            Set<Var> inScopeProjectVars = SetUtils.intersection(projectVars, visibleVars);
+            if (!inScopeProjectVars.containsAll(visibleVars)) {
+                List<Var> projectVarList = new ArrayList<>(inScopeProjectVars);
+                projectionAdaptedOp = new OpProject(projectionAdaptedOp, projectVarList);
+            }
+
+            return OpDistinct.create(projectionAdaptedOp);
+        }
+
+        /** Process (distinct (projectVars) (project (vars) (.))).
+         *
+         *  (distinct (?x ?y ?z) .) can be pushed over a (project (?y ?a) .)
+         *  (distinct (?y) .)
+         *  - so we can push over any project by creating the intersection of the involved variables. */
+        @Override
+        public void visit(OpProject opProject) {
+            Set<Var> vars = new LinkedHashSet<>(opProject.getVars()); // Retain order
+            vars.retainAll(projectVars);
+
+            // Create the intersection of the current distinct-vars and the project-vars.
+            // In the corner case where this set is empty, just don't push.
+            boolean canPush = !vars.isEmpty();
+            if (canPush) {
+                Op subOp = opProject.getSubOp();
+                // Proceed with the variables of the projection
+                // (possibly a sub-set of the original distinct-vars).
+                result = transform(vars, subOp);
+            }
+        }
+
+        @Override
+        public void visit(OpExtend opExtend) {
+            tryPush(opExtend, (opE, subOpVars) -> canPush(projectVars, opE));
+            // Post process the result: After pushing (distinct (vars) .) over (extend .),
+            // the variables visible from extend must remain the same.
+            if (result != null) {
+                List<Var> extendVars = opExtend.getVarExprList().getVars();
+                boolean reapplyProject = !projectVars.containsAll(extendVars);
+                if (reapplyProject) {
+                    result = new OpProject(result, new ArrayList<>(extendVars));
+                }
+            }
+        }
+
+        @Override
+        public void visit(OpFilter opFilter) {
+            tryPush(opFilter, (opF, subOpVars) -> canPush(projectVars, opF));
+        }
+
+        /** Merge nested distinct. */
+        @Override
+        public void visit(OpDistinct opDistinct) {
+            Op subOp = opDistinct.getSubOp();
+            result = transform(projectVars, subOp);
+        }
+
+        private <T extends Op1> void tryPush(T op1, BiPredicate<T, Set<Var>> canPush) {
+            if (canPush.test(op1, projectVars)) {
+                Op subOp = op1.getSubOp();
+                // We could already prune projectVars to the visible vars of subOp here.
+                // But we postpone this to the point where we place the distinct operator
+                // using placeDistinctProject.
+                Op rewrittenSubOp = transform(projectVars, subOp);
+                result = op1.copy(rewrittenSubOp);
+            } else {
+                result = placeDistinctProject(projectVars, op1);
+            }
+        }
+
+        private static boolean canPush(Set<Var> projectVars, OpExtend opExtend) {
+            VarExprList extend = opExtend.getVarExprList();
+            boolean isStable = extend.getExprs().values().stream().allMatch(ExprLib::isStable);
+            if (!isStable) {
+                return false;
+            }
+
+            Op subOp = opExtend.getSubOp();
+            Set<Var> subOpVars = OpVars.visibleVars(subOp);
+            Set<Var> mentionedVars = varsMentioned(extend);
+
+            if (!isSameCoverage(mentionedVars, subOpVars, projectVars)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static boolean canPush(Set<Var> projectVars, OpFilter opFilter) {
+            ExprList filter = opFilter.getExprs();
+
+            // Don't push distinct over unstable expressions, such as rand() or uuid().
+            boolean isStable = filter.getList().stream().allMatch(ExprLib::isStable);
+            if (!isStable) {
+                return false;
+            }
+            // Example: Can we push DISTINCT ?s ?p over (filter (?p = ?x) (bgp (:s ?p :o))) ?
+
+            // filter(?p = ?x) mentions {?p, ?x}
+            Set<Var> filterVars = filter.getVarsMentioned();
+
+            // Assume subOp := (bgp (:s ?p :o)) which mentions {?p}
+            Op subOp = opFilter.getSubOp();
+            Set<Var> subOpVars = OpVars.visibleVars(subOp);
+
+            // Of the filter's variables {?p, ?x} only {?p} is in scope in the subOp
+            // and "grounds" the filter's {?p}.
+            Set<Var> inScopeFilterVars = SetUtils.intersection(filterVars, subOpVars);
+
+            // If the distinct-transforms's projectVars contains all the filter's grounded vars then we can push.
+            if (projectVars.containsAll(inScopeFilterVars)) {
+                // Our DISTINCT ?s ?p covers all grounded variables of the filter expression, namely {p}
+                // So we can push.
+                return true;
+            }
+            return false;
+        }
+
+        private static Set<Var> varsMentioned(VarExprList vel) {
+            Set<Var> mentionedVars = varsMentioned(vel.getExprs().values().stream());
+            return mentionedVars;
+        }
+
+        private static Set<Var> varsMentioned(Stream<Expr> exprs) {
+            Set<Var> mentionedVars = exprs
+                    .map(Expr::getVarsMentioned)
+                    .flatMap(Collection::stream)
+                    .collect(Collectors.toSet());
+            return mentionedVars;
+        }
+
+        /**
+         * True iff the exact same set of mentioned variables is covered by both
+         * the original projectVars and the sub op's visible variables.
+         */
+        private static boolean isSameCoverage(Set<Var> mentionedVars, Set<Var> subOpVars, Set<Var> projectVars) {
+            Set<Var> coveredVarsBefore = SetUtils.intersection(mentionedVars, subOpVars);
+            Set<Var> coveredVarsAfter = SetUtils.intersection(mentionedVars, projectVars);
+            boolean result = coveredVarsBefore.equals(coveredVarsAfter);
+            return result;
+        }
+    }
+}
+

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/TransformSkipScan.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/TransformSkipScan.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.TransformCopy;
+import org.apache.jena.sparql.algebra.op.OpDistinct;
+
+public class TransformSkipScan
+    extends TransformCopy
+{
+    private int numAppliedTransforms = 0;
+
+    public int getNumAppliedSkipScanTransforms() {
+        return numAppliedTransforms;
+    }
+
+    @Override
+    public Op transform(OpDistinct opDistinct, Op subOp) {
+        Op result = super.transform(opDistinct, subOp); // effectively `new OpDistinct(subOp)`;
+        PatternQuery pq = PatternQuery.createOrNull$(result);
+        if (pq != null) {
+            result = new OpExtSkipScan(pq);
+            ++numAppliedTransforms;
+        }
+        return result;
+    }
+}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/TuplePatternSpec.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/TuplePatternSpec.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
+/**
+ * projs maps slot to the varMap.
+ */
+record TuplePatternSpec(
+        Node[] tuple,
+        List<Var> projection, // JoinKey is a list with unique elements.
+        VarMap[] varMaps,
+        int[] projs,        // array of projected indices - get the var using tuple[projs[i]]
+        EqualityLink[] equalityLinks,
+        int neededSlotsMask) { // Omits the indices of unconstrained, undistinguished var.
+
+    public Var getVar(int varId) {
+        return varMaps[varId].var();
+    }
+
+    /** Get the index of the variable or -1 if absent. */
+    public int getIdxVar(Var var) {
+        for (VarMap e : varMaps) {
+            if (e.var().equals(var)) {
+                return e.idx();
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public String toString() {
+        return "IndexQuerySpec [tuple=" + Arrays.toString(tuple) + ", varMaps=" + Arrays.toString(varMaps) + ", projs="
+                + Arrays.toString(projs) + ", equalityLinks="
+                + Arrays.toString(equalityLinks) + ", neededSlots=" + Integer.toBinaryString(neededSlotsMask) + "]";
+    }
+
+    public static TuplePatternSpec create(Node[] quad, List<Var> projection) {
+        // Helper arrays are created with maximum possible size here.
+        int n = quad.length;
+
+        // varMap will only holds vars that are present in the tuple.
+        VarMap[] varMaps = new VarMap[n];
+        int numVarMaps = 0;
+
+        EqualityLink[] equalityLinks = null;
+        int numEqualityLinks = 0;
+
+        int[] projs = new int[n];
+        int numProjs = 0;
+
+        // Needed slots: those that are projected or participate in an equality condition with a constant or another column.
+        int[] neededSlots = new int[n];
+        int numNeededSlots = 0;
+
+        for (int i = 0; i < n; ++i) {
+            Node node = quad[i];
+            if (node.isVariable()) {
+                boolean alreadySeen = false;
+                for (int j = 0; j < i; ++j) {
+                    Node prevNode = quad[j];
+                    if (node.equals(prevNode)) {
+                        if (equalityLinks == null) {
+                            equalityLinks = new EqualityLink[n];
+                        }
+                        equalityLinks[numEqualityLinks++] = new EqualityLink(i, j);
+
+                        // Add i as needed
+                        neededSlots[numNeededSlots++] = i;
+                        alreadySeen = true;
+
+                        // If the var was not projected then we now need to declare it as needed!
+                        if (!projection.contains(node)) {
+                            int i2 = indexOf(neededSlots, j, 0, numNeededSlots);
+                            if (i2 == -1) {
+                                neededSlots[numNeededSlots++] = j;
+                            }
+                        }
+                    }
+                }
+
+                if (!alreadySeen) {
+                    Var v = Var.alloc(node);
+                    varMaps[numVarMaps] = new VarMap(i, v);
+
+                    if (projection.contains(v)) {
+                        projs[numProjs++] = i;
+                        neededSlots[numNeededSlots++] = i;
+                    }
+
+                    ++numVarMaps;
+                }
+            } else {
+                // Mark the slot as needed because it needs to be post-filtered by a constant.
+                neededSlots[numNeededSlots++] = i;
+            }
+        }
+
+        int neededSlotMask = 0;
+        for (int i = 0; i < numNeededSlots; ++i) {
+            neededSlotMask |= 1 << neededSlots[i];
+        }
+
+        TuplePatternSpec result = new TuplePatternSpec(
+                quad,
+                projection,
+                Arrays.copyOf(varMaps, numVarMaps),
+                Arrays.copyOf(projs, numProjs),
+                equalityLinks == null ? null : Arrays.copyOf(equalityLinks, numEqualityLinks),
+                neededSlotMask);
+        return result;
+    }
+
+    /** Find an item in a certain sub-range. */
+    private static int indexOf(int[] arr, int valueToFind, int startIndex, int endIndex) {
+        for (int i = startIndex; i < endIndex; ++i) {
+            if (arr[i] == valueToFind) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/ValueFilter.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/ValueFilter.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+/** Map the index of a column to a constant value, such as a specific Node or NodeId. */
+record ValueFilter<T>(int idx, T value) {}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/VarMap.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/solver/skipscan/VarMap.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import org.apache.jena.sparql.core.Var;
+
+/** Map the index of a column to a variable. */
+record VarMap(int idx, Var var) {}

--- a/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/SystemTDB.java
+++ b/jena-tdb2/src/main/java/org/apache/jena/tdb2/sys/SystemTDB.java
@@ -41,6 +41,7 @@ import org.apache.jena.sparql.util.Symbol;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.tdb2.TDB2;
 import org.apache.jena.tdb2.TDBException;
+import org.apache.jena.tdb2.solver.OpExecutorTDB2;
 import org.apache.jena.tdb2.store.NodeId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,6 +123,10 @@ public class SystemTDB
 
     /** Experimental : triple and quad filtering at scan level */
     public static final Symbol symTupleFilter       = allocSymbol("tupleFilter");
+
+    /** Allow skip scans for {@code OpDistinct} and {@code OpGroup} operators.
+     *  Absent value is treated as allowed. See {@link OpExecutorTDB2}. */
+    public static final Symbol symSkipScan          = allocSymbol("skipScan");
 
     private static final String PropertyFileKey1    = tdbPropertyRoot+".settings";
     private static final String PropertyFileKey2    = tdbSymbolPrefix+":settings";

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/AbstractDatasetGraphCompare.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/AbstractDatasetGraphCompare.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.stream.IntStreams;
+import org.apache.commons.numbers.combinatorics.Combinations;
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.graph.NodeTransformLib;
+
+/**
+ * Test to check consistency of the find() method.
+ *
+ * Base class for generating tests that invoke the find() method of a dataset graph
+ * with all combinations of patterns.
+ */
+public abstract class AbstractDatasetGraphCompare {
+    private String testLabel;
+
+    public AbstractDatasetGraphCompare(String testLabel) {
+        super();
+        this.testLabel = testLabel;
+    }
+
+    public String getTestLabel() {
+        return testLabel;
+    }
+
+    /* Below: Quad generation for use with .find() or querying from dataset content. */
+
+    // Markers for find-quad generation w.r.t. a dataset and a
+    // "meta pattern" such as (IN, foo, OUT, OUT).
+    // IN becomes substituted with concrete values, out becomes ANY.
+    private static final Node IN = NodeFactory.createBlankNode("IN");
+    private static final Node OUT = NodeFactory.createBlankNode("OUT");
+
+    /**
+     * Generate the set of find patterns for each quad in the source dataset.
+     * This is the set of combinations by substituting components with ANY.
+     * For example, the derivations for a concrete quad (g, s, p, o) are:
+     * <pre>
+     * {(g, s, p, ANY), (g, s, ANY, o), (g, s, ANY, ANY), ...}
+     * </pre>
+     */
+    public static Stream<Quad> createFindQuads(DatasetGraph dataSource) {
+        Node[] baseMetaPattern = new Node[]{OUT, OUT, OUT, OUT};
+        Stream<Quad> result = IntStream.rangeClosed(0, 4).boxed()
+            .flatMap(k -> Iter.asStream(Combinations.of(4, k).iterator()))
+            .flatMap(ins -> {
+                Node[] metaPattern = Arrays.copyOf(baseMetaPattern, baseMetaPattern.length);
+
+                // Use IN to mark the components that we want to substitute with concrete values.
+                // OUT becomes ANY.
+                IntStreams.of(ins).forEach(i -> metaPattern[i] = IN);
+                Quad metaQuad = toQuad(List.of(metaPattern).iterator());
+
+                Set<Quad> lookups = createFindQuads(dataSource, metaQuad);
+                return lookups.stream();
+            });
+        return result;
+    }
+
+    private static Quad toQuad(Iterator<Node> it) {
+        Quad r = Quad.create(it.next(), it.next(), it.next(), it.next());
+        if (it.hasNext()) {
+            throw new IllegalArgumentException("Iterator of exactly 4 elements expected.");
+        }
+        return r;
+    }
+
+    private static Node outToAny(Node pattern, Node concrete) {
+        Node r = (OUT.equals(pattern)) ? Node.ANY : concrete;
+        return r;
+    }
+
+    private static Node inToAny(Node node) {
+        Node r = (IN.equals(node)) ? Node.ANY : node;
+        return r;
+    }
+
+    private static Node outToAny(Node node) {
+        Node r = (OUT.equals(node)) ? Node.ANY : node;
+        return r;
+    }
+
+    private static Quad inToAny(Quad metaQuad) {
+        return NodeTransformLib.transform(AbstractDatasetGraphCompare::inToAny, metaQuad);
+    }
+
+    private static Quad outToAny(Quad metaQuad) {
+        return NodeTransformLib.transform(AbstractDatasetGraphCompare::outToAny, metaQuad);
+    }
+
+    // !!! This method implicitly gets rid of 'IN' !!!
+    // Components of the input quads are processed as follows:
+    // If a component of pattern is OUT then it becomes is ANY.
+    // Otherwise, *always* return the corresponding component of 'concrete'.
+    private static Quad createFindQuad(Quad meta, Quad concrete) {
+        Quad result = Quad.create(
+            outToAny(meta.getGraph(), concrete.getGraph()),
+            outToAny(meta.getSubject(), concrete.getSubject()),
+            outToAny(meta.getPredicate(), concrete.getPredicate()),
+            outToAny(meta.getObject(), concrete.getObject()));
+        return result;
+    }
+
+    /**
+     * Expand a pattern such as (IN, s, OUT, OUT) into { (g1, s, ANY, ANY), (g2, s, ANY, ANY) }
+     * based on the concrete quads in dsg.
+     */
+    private static Set<Quad> createFindQuads(DatasetGraph dsg, Quad metaQuad) {
+        // Replace IN and OUT with ANY - this retains only term nodes.
+        Quad p = outToAny(inToAny(metaQuad));
+        Set<Quad> result = Iter.collect(Iter.map(dsg.find(p), q -> createFindQuad(metaQuad, q)),
+                Collectors.toCollection(LinkedHashSet::new));
+        return result;
+    }
+}

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/GraphCompareSelectResultExecutable.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/GraphCompareSelectResultExecutable.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.function.Executable;
+
+import org.apache.jena.atlas.lib.ListUtils;
+import org.apache.jena.query.Query;
+import org.apache.jena.sparql.algebra.Table;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.exec.QueryExecBuilder;
+import org.apache.jena.sparql.exec.RowSetOps;
+import org.apache.jena.system.Txn;
+
+/**
+ * JUnit test case executable to compare two datasets w.r.t.
+ * their result of a select query.
+ */
+public class GraphCompareSelectResultExecutable
+    implements Executable
+{
+    private static PrintStream out = System.err;
+
+    private String       testLabel;
+    private Query        query;
+    private DatasetGraph referenceDsg;
+    private DatasetGraph systemUnderTestDsg;
+
+    public GraphCompareSelectResultExecutable(String testLabel, Query query, DatasetGraph referenceDsg, DatasetGraph systemUnderTestDsg) {
+        super();
+        this.testLabel = testLabel;
+        this.query = query;
+        this.referenceDsg = referenceDsg;
+        this.systemUnderTestDsg = systemUnderTestDsg;
+    }
+
+    protected QueryExecBuilder mutateTestExecBuilder(QueryExecBuilder qExec) { return qExec; }
+
+    public String getTestLabel() {
+        return testLabel;
+    }
+
+    public Query getQuery() {
+        return query;
+    }
+
+    /**
+     * Assert that graph.find() returned the same set of quads for the given pattern.
+     * Duplicates are ignored.
+     */
+    @Override
+    public void execute() {
+        Table expectedTable = Txn.calculateRead(referenceDsg,
+            () -> QueryExec.dataset(referenceDsg).query(query).table());
+        List<Binding> expectedList = new ArrayList<>();
+        expectedTable.rows().forEachRemaining(expectedList::add);
+
+        Table actualTable = Txn.calculateRead(systemUnderTestDsg,
+            () -> mutateTestExecBuilder(QueryExec.dataset(systemUnderTestDsg).query(query))
+            .table());
+        List<Binding> actualList = new ArrayList<>();
+        actualTable.rows().forEachRemaining(actualList::add);
+
+        boolean printActualResult = false;
+        if (printActualResult) {
+            RowSetOps.out(System.err, actualTable.toRowSet());
+            System.err.println("Number of rows printed: " + actualTable.size());
+            System.err.println();
+        }
+
+        boolean b = ListUtils.equalsUnordered(expectedList, actualList);
+        if ( ! b ) {
+            out.println("Fail: find(" + query + ")");
+            out.println("Expected: " + expectedList + ", Actual: " + actualList);
+        }
+
+        assertTrue(b, () -> getTestLabel());
+    }
+
+    @Override
+    public String toString() {
+        return getTestLabel() + " " + getQuery();
+    }
+}

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/GraphCompareSelectResultExecutableSkipScan.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/GraphCompareSelectResultExecutableSkipScan.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.LongAdder;
+
+import org.apache.jena.query.Query;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.exec.QueryExecBuilder;
+
+/** Extension of the GraphCompare executable with verification that skip scan was actually used. */
+class GraphCompareSelectResultExecutableSkipScan
+    extends GraphCompareSelectResultExecutable {
+
+    private LongAdder skipScanOkCounter = new LongAdder();
+    private LongAdder skipScanFailoverCounter = new LongAdder();
+    private boolean expectSkipScan;
+
+    public GraphCompareSelectResultExecutableSkipScan(String testLabel, Query query, DatasetGraph referenceDsg,
+            DatasetGraph testDsg, boolean expectSkipScan) {
+        super(testLabel, query, referenceDsg, testDsg);
+        this.expectSkipScan = expectSkipScan;
+    }
+
+    @Override
+    protected QueryExecBuilder mutateTestExecBuilder(QueryExecBuilder qExec) {
+        return qExec
+            .set(OpExecutorTDB2SkipScan.symSkipScanOkCounter, skipScanOkCounter)
+            .set(OpExecutorTDB2SkipScan.symSkipScanFailoverCounter, skipScanFailoverCounter);
+    }
+
+    @Override
+    public void execute() {
+        super.execute();
+        if (expectSkipScan) {
+            assertTrue(skipScanOkCounter.longValue() > 0, () -> "Expected skip scan to be used - " + getTestLabel());
+            assertEquals(0, skipScanFailoverCounter.longValue(), () -> getTestLabel());
+        } else {
+            assertTrue(skipScanOkCounter.longValue() == 0, () -> "Expected NO skip scan to be used - " + getTestLabel());
+        }
+    }
+}

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TS_TDB_SkipScan.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TS_TDB_SkipScan.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({
+    TestTransformDistinctPlacement.class
+    , TestOpExecutorTDB2SkipScan.class
+    , TestAggregatorsSkipScan.class
+})
+public class TS_TDB_SkipScan {
+}

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TestAggregatorsSkipScan.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TestAggregatorsSkipScan.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.tdb2.TDB2Factory;
+import org.apache.jena.tdb2.sys.CopyDSG;
+import org.apache.jena.tdb2.sys.TDBInternal;
+
+/**
+ * Base class for testing multi-aggregator queries with skip scan.
+ *
+ * <p>Tests verify that skip scan is used for queries with multiple aggregators
+ * that operate on compatible variables (same variable with compatible distinct semantics).</p>
+ */
+public class TestAggregatorsSkipScan {
+    protected DatasetGraph referenceDsg;
+    protected DatasetGraph systemUnderTestDsg;
+
+    public TestAggregatorsSkipScan() {
+        setupDataset();
+    }
+
+    // @BeforeAll
+    public void setupDataset() {
+        referenceDsg = SSE.parseDatasetGraph(
+        """
+        (dataset
+            (graph
+              (:s :p  5)
+              (:s :p  7)
+            )
+            (graph :g1
+              (:s :p  7)
+              (:s :p 11)
+            )
+            (graph :g2
+              (:s :p  7)
+              (:s :p 17)
+            )
+        )
+        """);
+
+        // Set up the test TDB2 dataset
+        systemUnderTestDsg = TDBInternal.getDatasetGraphTDB(TDB2Factory.createDataset());
+        CopyDSG.copy(referenceDsg, systemUnderTestDsg);
+    }
+
+    /** Min/max on the same variable should use skip scan. */
+    @Test
+    public void test_skipScan_01_spo() {
+        expectSkipScan("SELECT (min(?o) AS ?min) (max(?o) AS ?max) { ?s ?p ?o }");
+    }
+
+    /** Min/max on the same variable should use skip scan. */
+    @Test
+    public void test_skipScan_01_gspo() {
+        expectSkipScan("SELECT (min(?o) AS ?min) (max(?o) AS ?max) { GRAPH ?g { ?s ?p ?o } }");
+    }
+
+    /** Min/max on the same variable should use skip scan. */
+    @Test
+    public void test_skipScan_01_union() {
+        expectSkipScan("SELECT (min(?o) AS ?min) (max(?o) AS ?max) { GRAPH <urn:x-arq:UnionGraph> { ?s ?p ?o } }");
+    }
+
+    /** distinct sum/avg */
+    @Test
+    public void test_skipScan_03() {
+        expectSkipScan("SELECT (avg(DISTINCT ?o) AS ?avg) (sum(DISTINCT ?o) AS ?sum) { GRAPH ?g { ?s ?p ?o } }");
+    }
+
+    /** Sample should prevent skip scan in order to preserve value distribution. */
+    @Test
+    public void test_no_skipScan_02() {
+        expectNoSkipScan("SELECT (min(?o) AS ?min) (sample(?o) AS ?max) { ?s ?p ?o }");
+    }
+
+    /** Mix of distinct / non-distinct aggregator - should not use skip scan. */
+    @Test
+    public void test_no_skipScan_03() {
+        expectNoSkipScan("SELECT (min(?o) AS ?min) (avg(?o) AS ?avg) { ?s ?p ?o }");
+    }
+
+    /** Aggregation by different variables - should not use skip scan. */
+    @Test
+    public void test_no_skipScan_04() {
+        expectNoSkipScan("SELECT (count(DISTINCT ?p) AS ?countP) (count(DISTINCT ?o) AS ?countO) { ?s ?p ?o }");
+    }
+
+    /** Count of all bindings (not a restricted to a specific variable) - should not use skip scan. */
+    @Test
+    public void test_no_skipScan_05() {
+        expectNoSkipScan("SELECT (count(DISTINCT *) AS ?c) { GRAPH ?g { ?s ?p ?o } }");
+    }
+
+    /** Count distinct of a single variable - should use skip scan. */
+    @Test
+    public void test_skipScan_06() {
+        expectSkipScan("SELECT (count(DISTINCT ?p) AS ?c) { GRAPH ?g { ?s ?p ?o } }");
+    }
+
+    public void expectSkipScan(String queryString) { test(queryString, true); }
+    public void expectNoSkipScan(String queryString) { test(queryString, false); }
+
+    private void test(String queryString, boolean expectSkipScan) {
+        Query query = QueryFactory.create(queryString);
+        GraphCompareSelectResultExecutableSkipScan executable =
+                new GraphCompareSelectResultExecutableSkipScan("test", query, referenceDsg, systemUnderTestDsg, expectSkipScan);
+        executable.execute();
+    }
+}

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TestFindBestIndex.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TestFindBestIndex.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.engine.ExecutionContext;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.system.Txn;
+import org.apache.jena.tdb2.TDB2Factory;
+import org.apache.jena.tdb2.sys.TDBInternal;
+
+public class TestFindBestIndex {
+
+    private static final String TRIPLE_DATASET = """
+        (dataset
+            (graph
+              (:s :p :oa)
+              (:s :p :ob)
+            )
+            (graph :g1
+              (:s :p :oa)
+              (:s :p :ob)
+            )
+            (graph :g2
+              (:s :p :oa)
+              (:s :p :ob)
+            )
+        )
+        """;
+
+    @Test
+    public void testProject_s_01() {
+        testIndexSelection("(distinct (project (?s) (bgp (?s ?p ?o))))", "SPO");
+    }
+
+    @Test
+    public void testProject_p_01() {
+        testIndexSelection("(distinct (project (?p) (bgp (?s ?p ?o))))", "POS");
+    }
+
+    @Test
+    public void testProject_o_01() {
+        testIndexSelection("(distinct (project (?o) (bgp (?s ?p ?o))))", "OSP");
+    }
+
+    @Test
+    public void testProject_sp_01() {
+        testIndexSelection("(distinct (project (?s ?p) (bgp (?s ?p ?o))))", "SPO");
+    }
+
+    @Test
+    public void testProject_so_01() {
+        testIndexSelection("(distinct (project (?s ?o) (bgp (?s ?p ?o))))", "OSP");
+    }
+
+    @Test
+    public void testProject_po_01() {
+        testIndexSelection("(distinct (project (?p ?o) (bgp (?s ?p ?o))))", "POS");
+    }
+
+    @Test
+    public void testProject_spo_01() {
+        testIndexSelection("(distinct (project (?s ?p ?o) (bgp (?s ?p ?o))))", "SPO");
+    }
+
+    @Test
+    public void testNoDistinct_s_01() {
+        testIndexSelection("(project (?s) (bgp (?s ?p ?o)))", "SPO");
+    }
+
+    @Test
+    public void testNoDistinct_p_01() {
+        testIndexSelection("(project (?p) (bgp (?s ?p ?o)))", "POS");
+    }
+
+    @Test
+    public void testAllConstants_01() {
+        testIndexSelection("(distinct (project (?s) (bgp (:s :p :o))))", "SPO");
+    }
+
+    @Test
+    public void testMixedConstants_sp_01() {
+        testIndexSelection("(distinct (project (?p) (bgp (:s ?p :o))))", "OSP");
+    }
+
+    @Test
+    public void testMixedConstants_so_01() {
+        testIndexSelection("(distinct (project (?s ?o) (bgp (?s :p ?o))))", "POS");
+    }
+
+    @Test
+    public void testConstant_first_01() {
+        testIndexSelection("(distinct (project (?p ?o) (bgp (:s ?p ?o))))", "SPO");
+    }
+
+    private void testIndexSelection(String opStr, String expectedIndexName) {
+        DatasetGraph testDsg = TDBInternal.getDatasetGraphTDB(TDB2Factory.createDataset());
+        DatasetGraph referenceDsg = SSE.parseDatasetGraph(TRIPLE_DATASET);
+        Txn.executeWrite(testDsg, () -> testDsg.addAll(referenceDsg));
+
+        ExecutionContext execCxt = ExecutionContext.create(testDsg);
+        Op op = SSE.parseOp(opStr);
+        PatternQuery pq = Objects.requireNonNull(PatternQuery.createOrNull$(op));
+
+        SkipScanCandidate candidate = OpExecutorTDB2SkipScan.findBestCandidate(pq, execCxt);
+        assertNotNull(candidate);
+        assertNotNull(candidate.index());
+
+        String actualIndexName = candidate.index().getName();
+        assertTrue(actualIndexName.startsWith(expectedIndexName),
+                "Expected index starting with " + expectedIndexName + " but got " + actualIndexName);
+    }
+}

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TestOpExecutorTDB2SkipScan.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TestOpExecutorTDB2SkipScan.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import static org.junit.jupiter.api.DynamicContainer.dynamicContainer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import org.apache.commons.collections4.iterators.PermutationIterator;
+import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.sparql.core.BasicPattern;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.core.Vars;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprVar;
+import org.apache.jena.sparql.expr.aggregate.AggCountDistinct;
+import org.apache.jena.sparql.expr.aggregate.AggCountVarDistinct;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sparql.syntax.ElementNamedGraph;
+import org.apache.jena.sparql.syntax.ElementTriplesBlock;
+import org.apache.jena.system.AutoTxn;
+import org.apache.jena.system.Txn;
+import org.apache.jena.tdb2.TDB2Factory;
+import org.apache.jena.tdb2.sys.CopyDSG;
+import org.apache.jena.tdb2.sys.TDBInternal;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.jspecify.annotations.NonNull;
+
+public class TestOpExecutorTDB2SkipScan
+    extends AbstractDatasetGraphCompare
+{
+    @FunctionalInterface
+    interface TestGenerator {
+        List<DynamicTest> createTests(DatasetGraph referenceDsg, DatasetGraph testDsg, DatasetGraph dataDsg);
+    }
+
+    public TestOpExecutorTDB2SkipScan() {
+        super("");
+    }
+
+    @TestFactory
+    public List<DynamicNode> staticTest01() {
+        DatasetGraph referenceDsg = SSE.parseDatasetGraph(
+        """
+        (dataset
+            (graph
+              (:s :p :oa)
+              (:s :p :ob)
+            )
+            (graph :g1
+              (:s :p :oa)
+              (:s :p :ob)
+            )
+            (graph :g2
+              (:s :p :oa)
+              (:s :p :ob)
+            )
+        )
+        """);
+
+        return containerForDataset(referenceDsg);
+    }
+
+    private List<DatasetSpec> dynamicDatasetSpecs() {
+        return List.of(new DatasetSpec("dataset1", 3, 5, 100.0f, 5, 0.5f));
+    }
+
+    @TestFactory
+    public List<DynamicNode> dynamicTests() {
+        List<DynamicNode> result = new ArrayList<>();
+        for (DatasetSpec datasetSpec : dynamicDatasetSpecs()) {
+            DatasetGraph referenceDsg = generateData(datasetSpec, DatasetGraphFactory.createTxnMem());
+            List<DynamicNode> children = containerForDataset(referenceDsg);
+            result.add(dynamicContainer(datasetSpec.toString(), children));
+        }
+        return result;
+    }
+
+    private List<DynamicNode> containerForDataset(DatasetGraph referenceDsg) {
+        DynamicNode distinctTests = containerForDataset("distinct", referenceDsg, this::createTestsDistinct);
+        DynamicNode countVarDistinctTests = containerForDataset("countVarDistinct", referenceDsg, this::createTestsCountVarDistinct);
+        return List.of(distinctTests, countVarDistinctTests);
+    }
+
+    private DynamicNode containerForDataset(String displayName, DatasetGraph referenceDsg, TestGenerator testGenerator) {
+        // dataDsg contains the constants used for generating queries against referenceDsg.
+        DatasetGraph dataDsg = createDataDsg(referenceDsg);
+        DatasetGraph testDsg = TDBInternal.getDatasetGraphTDB(TDB2Factory.createDataset());
+        CopyDSG.copy(referenceDsg, testDsg);
+        expectNotEmpty(testDsg);
+
+        addResourceObjectsAsSubjects(dataDsg);
+
+        List<DynamicTest> tests = testGenerator.createTests(referenceDsg, testDsg, dataDsg);
+        return dynamicContainer(displayName, tests);
+    }
+
+    /**
+     * In-place addition of all non-literal objects as subjects using
+     * {@code :o a rdfs:Resource} triples.
+     * The purpose is more extensive testing of lookups.
+     */
+    public static void addResourceObjectsAsSubjects(DatasetGraph referenceDsg) {
+        DatasetGraph dataDsg = DatasetGraphFactory.create();
+        dataDsg.prefixes().putAll(referenceDsg.prefixes());
+        dataDsg.addAll(referenceDsg);
+
+        // Add all (non-literal) objects to the source Data for more extensive testing of lookups.
+        try (Stream<Quad> stream = dataDsg.stream()) {
+            List<Quad> extra = stream.flatMap(q -> Stream.of(q.getPredicate(), q.getObject())
+                .map(x -> Quad.create(q.getGraph(), x, RDF.Nodes.type, RDFS.Nodes.Resource)))
+                .toList();
+            extra.forEach(dataDsg::add);
+        }
+    }
+
+    /** Sub classes can use this method to generate dynamic tests. */
+    public List<DynamicTest> createTestsDistinct(DatasetGraph referenceDsg, DatasetGraph testDsg, DatasetGraph dataDsg) {
+        List<Quad> findQuads = createFindQuads(dataDsg).toList();
+
+        // patternToQuery(q) is used to create the actual query from the quad template.
+        List<@NonNull DynamicTest> tests = findQuads.stream().map(q -> {
+            Query query = createQueryDistinct(q);
+            return DynamicTest.dynamicTest(
+                getTestLabel() + " " + q,
+                new GraphCompareSelectResultExecutableSkipScan(getTestLabel(), query, referenceDsg, testDsg, true));
+        }).toList();
+        return tests;
+    }
+
+    /** Sub classes can use this method to generate dynamic tests. */
+    public List<DynamicTest> createTestsCountVarDistinct(DatasetGraph referenceDsg, DatasetGraph testDsg, DatasetGraph dataDsg) {
+        List<Quad> findQuads = createFindQuads(dataDsg).toList();
+
+        List<@NonNull DynamicTest> tests = findQuads.stream().flatMap(rawQuad -> {
+            Quad quad = anyToVar(rawQuad);
+            List<Var> vars = new ArrayList<>(4);
+            Vars.addVarsFromQuad(vars, quad);
+
+            if (vars.isEmpty()) {
+                // Skip test cases with empty vars because they don't hit OpExecutorTDB2Index.tryExec(opGroup, input, execCxt)
+                return Stream.of();
+            }
+
+            // Permutate all variables - the last one is used for
+            // (COUNT(DISTINCT ?v) AS ?c)
+            return Iter.asStream(new PermutationIterator<>(vars)).map(vs -> {
+                Query query = createQueryCountDistinctVar(quad, vs);
+                String queryStr = query.toString().replaceAll("\n", " ").replaceAll(" +", " ");
+                return DynamicTest.dynamicTest(
+                    getTestLabel() + " " + queryStr,
+                    new GraphCompareSelectResultExecutableSkipScan(getTestLabel(),query, referenceDsg, testDsg, true));
+            });
+        }).toList();
+        return tests;
+    }
+
+    public static Quad anyToVar(Quad quad) {
+        Node[] ns = quadToArray(quad);
+        Var[] vs = new Var[] {Var.alloc("g"), Var.alloc("s"), Var.alloc("p"), Var.alloc("o")};
+        for (int i = 0; i < ns.length; ++i) {
+            if (Node.ANY.equals(ns[i])) {
+                ns[i] = vs[i];
+            }
+        }
+        return arrayToQuad(ns);
+    }
+
+    /** Turn a quad such as (:g :s ?p ?o) into a query SELECT DISTINCT ?p ?o { GRAPH :g { :s ?p ?o } }. */
+    public static Query createQueryDistinct(Quad quad) {
+        Node[] ns = quadToArray(quad);
+        Node[] vs = new Node[] {Var.alloc("g"), Var.alloc("s"), Var.alloc("p"), Var.alloc("o")};
+
+        for (int i = 0; i < ns.length; ++i) {
+            if (Node.ANY.equals(ns[i])) {
+                ns[i] = vs[i];
+            }
+        }
+        Quad nq = arrayToQuad(ns);
+        List<Triple> ts = List.of(nq.asTriple());
+
+        Query q = new Query();
+        q.setDistinct(true);
+        q.setQuerySelectType();
+        q.setQueryResultStar(true);
+        q.setQueryPattern(new ElementNamedGraph(ns[0], new ElementTriplesBlock(new BasicPattern(ts))));
+        return q;
+    }
+
+    /**
+     * Creates queries such as:
+     * <pre>{@code
+     * SELECT ?s ?p (COUNT(DISTINCT ?g) AS ?c) {
+     *   GRAPH ?g { ?s ?p :o }
+     * }
+     * GROUP BY ?s ?p
+     * }</pre>
+     *
+     * <p>If {@code vars} is empty then the query becomes:</p>
+     * <pre>{@code
+     * SELECT (COUNT(DISTINCT *) AS ?c) { GRAPH :g { :s :p :o } }
+     * }</pre>
+     *
+     * @param vars the variables to include in the query.
+     *        The last var is used for count distinct.
+     *        All other vars are used for grouping and projection.
+     */
+    public static Query createQueryCountDistinctVar(Quad nq, List<Var> vars) {
+        Node g = nq.getGraph();
+        List<Triple> ts = List.of(nq.asTriple());
+
+        Query q = new Query();
+        Var countVar = Var.alloc("c");
+        if (!vars.isEmpty()) {
+            List<Var> groupVars = vars.subList(0, vars.size() - 1);
+            Var v = vars.getLast();
+            groupVars.forEach(q::addGroupBy);
+            q.addProjectVars(groupVars);
+            Expr countDistinctExpr = q.allocAggregate(new AggCountVarDistinct(new ExprVar(v)));
+            q.getProject().add(countVar, countDistinctExpr);
+        } else {
+            Expr countDistinctExpr = q.allocAggregate(new AggCountDistinct());
+            q.getProject().add(countVar, countDistinctExpr);
+        }
+
+        q.setQuerySelectType();
+        q.setQueryPattern(new ElementNamedGraph(g, new ElementTriplesBlock(new BasicPattern(ts))));
+        return q;
+    }
+
+    private static Node[] quadToArray(Quad quad) {
+        return new Node[] {quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject() };
+    }
+
+    private static Quad arrayToQuad(Node[] arr) {
+        return Quad.create(arr[0], arr[1], arr[2], arr[3]);
+    }
+
+    /* ----- Dataset Generation ----- */
+
+    record DatasetSpec(String displayName, int numG, int numP, float sPerPFactor, int numO, float sameOsRatio) {
+        @Override
+        public String toString() {
+            return "%s [g=%d, p=%d, ps=%.2f, o=%d, so=%.2f]".formatted(
+                    displayName, numG, numP, sPerPFactor, numO, sameOsRatio);
+        }
+    }
+
+    public static DatasetGraph generateData(DatasetSpec spec, DatasetGraph destDsg) {
+        try (AutoTxn refTxn = Txn.autoTxn(destDsg, ReadWrite.WRITE)) {
+            for (int v = 0; v < spec.numG(); ++v) {
+                Node g = v == 0 ? Quad.defaultGraphIRI : NodeFactory.createURI("http://www.example.org/g" + v);
+                for (int y = 0; y < spec.numP(); ++y) {
+                    Node p = NodeFactory.createURI("http://www.example.org/p" + y);
+                    int maxX = (int)((y + 1) * spec.sPerPFactor());
+                    for (int x = 0; x < maxX; ++x) { // 100 -> sFactor
+                        Node s = NodeFactory.createURI("http://www.example.org/s" + x);
+                        for (int z = 0; z < spec.numO(); ++z) {
+                            Node o1 = NodeFactory.createURI("http://www.example.org/s" + z);
+                            destDsg.add(g, s, p, o1);
+                        }
+
+                        int maxZ = (int)(spec.numO() * spec.sameOsRatio());
+                        for (int z = 0; z < maxZ; ++z) {
+                            Node o2 = NodeFactory.createURI("http://www.example.org/o" + z);
+                            destDsg.add(g, s, p, o2);
+                        }
+                    }
+                }
+            }
+            refTxn.commit();
+        }
+        return destDsg;
+    }
+
+    /** Use a sample of the reference data for the parameters dataset. TODO consistent naming of that parameter-source dataset. */
+    private DatasetGraph createDataDsg(DatasetGraph referenceDsg) {
+        // dataDsg contains the constants used for generating queries against referenceDsg.
+        DatasetGraph dataDsg = DatasetGraphFactory.createTxnMem();
+        try (AutoTxn writeTxn = Txn.autoTxn(dataDsg, ReadWrite.WRITE);
+             AutoTxn readTxn = Txn.autoTxn(referenceDsg, ReadWrite.READ)) {
+            try (QueryExec qe = QueryExec.dataset(referenceDsg)
+                    .query("CONSTRUCT { ?s ?p ?o } { ?s ?p ?o } ORDER BY ?s ?p ?o LIMIT 5").build()) {
+                qe.constructDataset(dataDsg);
+            }
+
+            try (QueryExec qe = QueryExec.dataset(referenceDsg)
+                    .query("CONSTRUCT { ?s ?p ?o } { ?s ?p ?o } ORDER BY DESC(?s) DESC(?p) DESC(?o) LIMIT 5").build()) {
+                qe.constructDataset(dataDsg);
+            }
+
+            try (QueryExec qe = QueryExec.dataset(referenceDsg)
+                    .query("CONSTRUCT { GRAPH ?g { ?s ?p ?o } } { GRAPH ?g { ?s ?p ?o } } ORDER BY ?g ?s ?p ?o LIMIT 5").build()) {
+                qe.constructDataset(dataDsg);
+            }
+
+            try (QueryExec qe = QueryExec.dataset(referenceDsg)
+                    .query("CONSTRUCT { GRAPH ?g { ?s ?p ?o } } { GRAPH ?g { ?s ?p ?o } } ORDER BY DESC(?g) DESC(?s) DESC(?p) DESC(?o) LIMIT 5").build()) {
+                qe.constructDataset(dataDsg);
+            }
+
+            expectNotEmpty(dataDsg);
+            writeTxn.commit();
+        }
+        return dataDsg;
+    }
+
+    /* ----- Graph Utils ----- */
+
+    private static void expectNotEmpty(DatasetGraph dsg) {
+        if (Txn.calculateRead(dsg, dsg::isEmpty)) {
+            throw new IllegalStateException("Unexpected empty dataset");
+        }
+    }
+}

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TestTransformDistinctPlacement.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/solver/skipscan/TestTransformDistinctPlacement.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.tdb2.solver.skipscan;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.Transform;
+import org.apache.jena.sparql.algebra.Transformer;
+import org.apache.jena.sparql.sse.SSE;
+
+/**
+  * Tests for TransformDistinctPlacement - the transform that pushes DISTINCT operations
+  * down through the algebra tree when it's safe to do so based on variable coverage.
+  * <p>
+  * The transform pushes DISTINCT through stable filters and extends when the
+  * variables mentioned in those operations are fully covered by the sub-operator.
+  * If expressions are unstable (non-deterministic),
+  * the DISTINCT is not pushed and remains at the current level.
+  * <p>
+  * Note: When a variable mentioned in a filter/extend is not present in the subOp,
+  * the variable is undefined. Pushing DISTINCT is still safe in this case because
+  * the undefined variable's evaluation doesn't depend on subOp cardinality - the
+  * result will be the same (undefined/false) regardless of duplicate removal.
+  */
+public class TestTransformDistinctPlacement
+{
+    private Transform transform = new TransformDistinctPlacement();
+
+    // ---- Filters ----
+
+    @Test
+    public void pushThroughFilter_stable_fullCoverage_01() {
+        // Should push DISTINCT through filter when all vars in filter are covered by subOp
+        // ?s, ?p, ?o are all provided by bgp, so filter can be pushed down
+        String input = "(distinct (filter (= ?o 1) (bgp (?s ?p ?o))))";
+        String expected = "(filter (= ?o 1) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughFilter_stable_fullCoverage_02() {
+        // Multiple conditions, all vars covered
+        String input = "(distinct (filter (&& (= ?s <s1>) (= ?o 1)) (bgp (?s ?p ?o))))";
+        String expected = "(filter (&& (= ?s <s1>) (= ?o 1)) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughFilter_stable_function_01() {
+        // STR() is a stable function (deterministic) - should push DISTINCT
+        String input = "(distinct (filter (str(?o)) (bgp (?s ?p ?o))))";
+        String expected = "(filter (str(?o)) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughFilter_partialCoverage_01() {
+        // Filter mentions ?x which is NOT in subOp - DISTINCT should still be pushed
+        // because ?x being undefined doesn't depend on subOp cardinality
+        String input = "(distinct (filter (= ?x 1) (bgp (?s ?p ?o))))";
+        String expected = "(filter (= ?x 1) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    // ---- Extends (BIND/ASSIGN) ----
+
+    @Test
+    public void pushThroughExtend_stable_fullCoverage_01() {
+        // Should push DISTINCT through stable extend when all expression vars are covered
+        // ?o is provided by bgp, so the extend can be pushed down
+        String input = "(distinct (extend ((?x ?o)) (bgp (?s ?p ?o))))";
+        String expected = "(extend ((?x ?o)) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughExtend_stable_fullCoverage_02() {
+        // Multiple assignments, all vars covered by subOp
+        String input = "(distinct (extend ((?x ?o) (?y ?p)) (bgp (?s ?p ?o))))";
+        String expected = "(extend ((?x ?o) (?y ?p)) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughExtend_stable_function_01() {
+        // LANG() is a stable function (deterministic) - should push DISTINCT
+        String input = "(distinct (extend ((?x (lang ?o))) (bgp (?s ?p ?o))))";
+        String expected = "(extend ((?x (lang ?o))) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughExtend_partialCoverage_01() {
+        // Extend mentions ?z which is NOT in subOp - DISTINCT should be pushed
+        // because ?z being undefined doesn't depend on subOp cardinality
+        String input = "(distinct (extend ((?x ?z)) (bgp (?s ?p ?o))))";
+        String expected = "(extend ((?x ?z)) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    // ---- Coverage analysis ----
+
+    @Test
+    public void coverage_full_01() {
+        // All variables in filter are covered by the bgp - should push
+        // ?s, ?p, ?o all in subOp
+        String input = "(distinct (filter (= ?s ?p) (bgp (?s ?p ?o))))";
+        String expected = "(filter (= ?s ?p) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void coverage_partial_01() {
+        // Partial coverage: filter mentions ?s, ?p (in subOp) and ?x (not in subOp)
+        // DISTINCT should be pushed because ?x being undefined doesn't depend on subOp cardinality
+        String input = "(distinct (filter (&& (= ?s ?p) (= ?x 1)) (bgp (?s ?p ?o))))";
+        String expected = "(filter (&& (= ?s ?p) (= ?x 1)) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    // ---- Nested structures ----
+
+    @Test
+    public void nested_transforms_01() {
+        // Multiple transforms in sequence - both filters should be pushed
+        String input = "(distinct (filter (= ?s <s1>) (filter (= ?o 1) (bgp (?s ?p ?o)))))";
+        String expected = "(filter (= ?s <s1>) (filter (= ?o 1) (distinct (bgp (?s ?p ?o)))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void nested_transforms_02() {
+        // Mix of filter and extend
+        String input = "(distinct (filter (= ?s <s1>) (extend ((?x ?o)) (bgp (?s ?p ?o)))))";
+        String expected = "(filter (= ?s <s1>) (extend ((?x ?o)) (distinct (bgp (?s ?p ?o)))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void nested_distinct_01() {
+        // Nested distinct operations
+        String input = "(distinct (distinct (bgp (?s ?p ?o))))";
+        String expected = "(distinct (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    // ---- Complex expressions ----
+
+    @Test
+    public void complexFilter_functionCall_01() {
+        // Filter with stable function STR() that depends on subOp vars
+        // STR() is deterministic so DISTINCT should be pushed
+        String input = "(distinct (filter (str(?o)) (bgp (?s ?p ?o))))";
+        String expected = "(filter (str(?o)) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void complexFilter_multipleOps_01() {
+        // Complex filter with stable function STR() and equality
+        // Both are stable so DISTINCT should be pushed
+        String input = "(distinct (filter (&& (str(?o)) (= ?s ?p)) (bgp (?s ?p ?o))))";
+        String expected = "(filter (&& (str(?o)) (= ?s ?p)) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void complexExtend_function_01() {
+        // Extend with stable function LANG()
+        // ?o is covered and LANG() is deterministic so DISTINCT should be pushed
+        String input = "(distinct (extend ((?x (lang ?o))) (bgp (?s ?p ?o))))";
+        String expected = "(extend ((?x (lang ?o))) (distinct (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    // ---- Edge cases ----
+
+    @Test
+    public void simpleBGP_01() {
+        // Simple BGP with distinct - no filter/extend to push through
+        String input = "(distinct (bgp (?s ?p ?o)))";
+        String expected = "(distinct (bgp (?s ?p ?o)))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void noSubOp_01() {
+        // DISTINCT with table unit - no subOp to push through
+        String input = "(distinct (table unit))";
+        String expected = "(distinct (table unit))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void unionScenario_01() {
+        // DISTINCT over union - should not push through union
+        String input = "(distinct (union (bgp (?s ?p ?o)) (bgp (?s ?p1 ?o1))))";
+        String expected = "(distinct (union (bgp (?s ?p ?o)) (bgp (?s ?p1 ?o1))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void joinScenario_01() {
+        // DISTINCT over join with filter on one side
+        String input = "(distinct (filter (= ?o 1) (join (bgp (?s ?p ?o)) (bgp (?s ?p2 ?o2)))))";
+        String expected = "(filter (= ?o 1) (distinct (join (bgp (?s ?p ?o)) (bgp (?s ?p2 ?o2)))))";
+        testTransform(input, expected);
+    }
+
+    // ---- Integration scenarios ----
+
+    @Test
+    public void integration_filter_extend_01() {
+        // Combined filter and extend scenario
+        String input = "(distinct (filter (= ?p <p1>) (extend ((?x ?o)) (bgp (?s ?p ?o)))))";
+        String expected = "(filter (= ?p <p1>) (extend ((?x ?o)) (distinct (bgp (?s ?p ?o)))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void integration_project_filter_01() {
+        // Project with filter inside distinct
+        String input = "(distinct (project (?s) (filter (= ?p <p1>) (bgp (?s ?p ?o)))))";
+        // The filter mentions ?p which is not in the project vars (?s only)
+        // So it should not be pushed
+        String expected = "(distinct (project (?s) (filter (= ?p <p1>) (bgp (?s ?p ?o)))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void leftJoinScenario_01() {
+        // DISTINCT over left join
+        String input = "(distinct (leftjoin (bgp (?s ?p ?o)) (bgp (?s ?p2 ?o2))))";
+        String expected = "(distinct (leftjoin (bgp (?s ?p ?o)) (bgp (?s ?p2 ?o2))))";
+        testTransform(input, expected);
+    }
+
+    // ---- Unstable functions (should NOT push DISTINCT) ----
+
+    @Test
+    public void pushThroughFilter_unstable_rand_01() {
+        // RAND() is unstable - should NOT push DISTINCT
+        String input = "(distinct (filter (rand) (bgp (?s ?p ?o))))";
+        String expected = "(distinct (filter (rand) (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughExtend_unstable_rand_01() {
+        // RAND() is unstable - should NOT push DISTINCT
+        String input = "(distinct (extend ((?x (rand))) (bgp (?s ?p ?o))))";
+        String expected = "(distinct (extend ((?x (rand))) (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughFilter_unstable_uuid_01() {
+        // UUID() is unstable - should NOT push DISTINCT
+        String input = "(distinct (filter (uuid) (bgp (?s ?p ?o))))";
+        String expected = "(distinct (filter (uuid) (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughExtend_unstable_uuid_01() {
+        // UUID() is unstable - should NOT push DISTINCT
+        String input = "(distinct (extend ((?x (uuid))) (bgp (?s ?p ?o))))";
+        String expected = "(distinct (extend ((?x (uuid))) (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughFilter_unstable_bnode_01() {
+        // BNODE() is unstable - should NOT push DISTINCT
+        String input = "(distinct (filter (bnode) (bgp (?s ?p ?o))))";
+        String expected = "(distinct (filter (bnode) (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughExtend_unstable_bnode_01() {
+        // BNODE() is unstable - should NOT push DISTINCT
+        String input = "(distinct (extend ((?x (bnode))) (bgp (?s ?p ?o))))";
+        String expected = "(distinct (extend ((?x (bnode))) (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughFilter_mixed_stable_unstable_01() {
+        // Mix of stable (str) and unstable (rand) - should NOT push DISTINCT
+        String input = "(distinct (filter (&& (str(?o)) (rand)) (bgp (?s ?p ?o))))";
+        String expected = "(distinct (filter (&& (str(?o)) (rand)) (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughExtend_mixed_stable_unstable_01() {
+        // Mix of stable (lang) and unstable (uuid) - should NOT push DISTINCT
+        String input = "(distinct (extend ((?x (&& (lang ?o) (uuid)))) (bgp (?s ?p ?o))))";
+        String expected = "(distinct (extend ((?x (&& (lang ?o) (uuid)))) (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughProject_01() {
+        String input = "(distinct (project (?s ?p) (project (?p) (bgp (?s ?p ?o)))))";
+        String expected = "(distinct (project (?p) (bgp (?s ?p ?o))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughProject_02() {
+        String input = "(distinct (project (?s ?p) (filter (bound(?p)) (project (?p) (bgp (?s ?p ?o))))))";
+        String expected = "(filter (bound(?p)) (distinct (project (?p) (bgp (?s ?p ?o)))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughProject_02b() {
+        String input = "(distinct (project (?s ?p) (filter (bound(?s)) (project (?p) (bgp (?s ?p ?o))))))";
+        String expected = "(filter (bound(?s)) (distinct (project (?p) (bgp (?s ?p ?o)))))";
+        testTransform(input, expected);
+    }
+
+    @Test
+    public void pushThroughProject_03() {
+        String input = "(distinct (project (?s ?p) (filter (bound(?s)) (project (?p ?x) (bgp (?s ?p ?o))))))";
+        String expected = "(filter (bound(?s)) (distinct (project (?p) (bgp (?s ?p ?o)))))";
+        testTransform(input, expected);
+    }
+
+    private void testTransform(String input, String expected) {
+        Op inputOp = SSE.parseOp(input);
+        Op expectedOp = SSE.parseOp(expected);
+        Op result = Transformer.transform(transform, inputOp);
+        assertEquals(expectedOp, result, "Transform result should match expected structure");
+    }
+}

--- a/jena-tdb2/src/test/java/org/apache/jena/tdb2/store/Test_SPARQL_TDB.java
+++ b/jena-tdb2/src/test/java/org/apache/jena/tdb2/store/Test_SPARQL_TDB.java
@@ -22,6 +22,7 @@
 package org.apache.jena.tdb2.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,8 +31,16 @@ import org.apache.jena.dboe.base.file.Location;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.query.*;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.ReadWrite;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.ResultSetFormatter;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.sparql.algebra.Table;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.exec.QueryExec;
 import org.apache.jena.sparql.exec.RowSet;
@@ -41,7 +50,11 @@ import org.apache.jena.system.Txn;
 import org.apache.jena.tdb2.DatabaseMgr;
 import org.apache.jena.tdb2.TDB2;
 import org.apache.jena.tdb2.TDB2Factory;
-import org.apache.jena.update.*;
+import org.apache.jena.update.UpdateAction;
+import org.apache.jena.update.UpdateExecution;
+import org.apache.jena.update.UpdateExecutionFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.apache.jena.update.UpdateRequest;
 
 /**
  * Test SPARQL
@@ -155,6 +168,70 @@ public class Test_SPARQL_TDB {
             RowSet rs = QueryExec.dataset(dsg).query(qs).select();
             RowSetOps.consume(rs);
         });
+    }
+
+    /** Test skip scan with union default graph constant. */
+    @Test
+    public void sparql8() {
+        DatasetGraph dsg = TDB2Factory.createDataset().asDatasetGraph();
+        Txn.executeWrite(dsg, () -> {
+            dsg.add(SSE.parseQuad("(<g> <s> <p> 123)"));
+        });
+        dsg.getContext().setTrue(TDB2.symUnionDefaultGraph);
+
+        Table actual = Txn.calculateRead(dsg, () -> QueryExec.dataset(dsg)
+            .query("SELECT DISTINCT ?p { ?s ?p ?o }").table());
+        assertEquals(1, actual.size());
+    }
+
+    /** Test whether passing a blank node from a skip scan result to
+     * another skip scan retrieval works. */
+    @Test
+    public void sparql9() {
+        DatasetGraph dsg = TDB2Factory.createDataset().asDatasetGraph();
+        Txn.executeWrite(dsg, () -> {
+            dsg.add(SSE.parseQuad("(<g> <s1> <p1> _:x)"));
+            dsg.add(SSE.parseQuad("(<g> <s2> <p2> :o)"));
+        });
+        dsg.getContext().setTrue(TDB2.symUnionDefaultGraph);
+
+        Table actualTable = Txn.calculateRead(dsg, () -> QueryExec.dataset(dsg)
+            .query("""
+                SELECT ?p {
+                    {
+                      { SELECT DISTINCT ?o { ?s ?p ?o } } # Should match _:x
+                      FILTER(isBlank(?o))
+                    }
+                    LATERAL {
+                      { SELECT DISTINCT ?p ?o { ?s ?p ?o } }
+                    }
+                }
+            """).table());
+        Table expectedTable = SSE.parseTable("(table (vars ?p) (row (?p <p1>)))");
+        assertEquals(expectedTable, actualTable);
+    }
+
+    /** Test that index access optimization does not break non-deterministic functions. */
+    @Test
+    public void sparql10() {
+        DatasetGraph dsg = TDB2Factory.createDataset().asDatasetGraph();
+        int n = 100;
+        Txn.executeWrite(dsg, () -> {
+            for (int i = 0; i < n; ++i) {
+                dsg.add(SSE.parseQuad("(<g> <s1> <p1> :o" + i + ")"));
+            }
+        });
+        dsg.getContext().setTrue(TDB2.symUnionDefaultGraph);
+
+        Table actualTable = Txn.calculateRead(dsg, () -> QueryExec.dataset(dsg)
+            .query("""
+                SELECT DISTINCT ?p ?x {
+                  ?s ?p ?o
+                  BIND(rand() AS ?x)
+                }
+            """).table());
+        // Extremely unlikely that rand() would return the same value n times!
+        assertNotEquals(actualTable.size(), 1);
     }
 
     private static void add(Dataset dataset, String graphName, Triple triple) {


### PR DESCRIPTION
GitHub issue resolved #3994 

Pull request Description: Adds skip scan evaluation for single-pattern queries to TDB2. Added special code paths to `OpExecutorTDB2` for `OpDistinct` and `OpGroupBy`.


Execution time to find all distinct predicates on Wikidata Truthy (8B triples) becomes between 1 and 100 seconds (warm-cold caches)
Also works for simple group by patterns such as
`SELECT ?p (COUNT(DISTINCT ?g) AS ?c) { GRAPH ?g { ?s ?p ?o } } GROUP BY ?p`

Need yet to add tests - such as create permutations of patterns and compare results with a reference engine (eg. ARQ).

----

 - [x] Tests are included.
 - ~~[ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)~~
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
