### PR TITLE
GH-3993: Renamed `BasicTask.isTerminated` to `hasTerminated` due to visibility conflict with Thread.

### DIFF
--- a/jena-fuseki2/jena-fuseki-mod-geosparql/src/main/java/org/apache/jena/fuseki/mod/geosparql/SpatialIndexerService.java
+++ b/jena-fuseki2/jena-fuseki-mod-geosparql/src/main/java/org/apache/jena/fuseki/mod/geosparql/SpatialIndexerService.java
@@ -433,8 +433,8 @@ public class SpatialIndexerService extends BaseActionREST {
             status.addProperty("isIndexing", false);
             time = 0;
         } else {
-            status.addProperty("isIndexing", !task.isTerminated());
-            if (!task.isTerminated()) {
+            status.addProperty("isIndexing", !task.hasTerminated());
+            if (!task.hasTerminated()) {
                 status.addProperty("isAborting", task.isAborting());
                 time = !task.isAborting() ? task.getStartTime() : task.getAbortTime();
             } else {

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/SpatialIndexLib.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/index/v2/SpatialIndexLib.java
@@ -226,7 +226,7 @@ public class SpatialIndexLib {
 
         BasicTask task = cxt.compute(SpatialIndexConstants.symSpatialIndexTask, (key, priorTaskObj) -> {
             BasicTask priorTask = (BasicTask)priorTaskObj;
-            if (priorTask != null && !priorTask.isTerminated()) {
+            if (priorTask != null && !priorTask.hasTerminated()) {
                 throw new RuntimeException("A spatial indexing task is already active for this dataset. Wait for completion or abort it.");
             }
 
@@ -331,8 +331,8 @@ public class SpatialIndexLib {
     public static BasicTask scheduleOnceCleanTask(DatasetGraph dsg, TaskListener<BasicTask> taskListener) {
         Context cxt = dsg.getContext();
         BasicTask task = cxt.compute(SpatialIndexConstants.symSpatialIndexTask, (key, priorTaskObj) -> {
-            BasicTask priorTask = (BasicTask) priorTaskObj;
-            if (priorTask != null && !priorTask.isTerminated()) {
+            BasicTask priorTask = (BasicTask)priorTaskObj;
+            if (priorTask != null && !priorTask.hasTerminated()) {
                 throw new RuntimeException("A spatial indexing task is already active for this dataset. Wait for completion or abort it.");
             }
 

--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/task/BasicTask.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/spatial/task/BasicTask.java
@@ -53,7 +53,12 @@ public interface BasicTask extends Abortable {
     // XXX this might be different from whether the task actually transitioned into aborting state.
     boolean isAborting();
 
-    default boolean isTerminated() {
+    /**
+     * Whether the task has terminated.
+     *
+     * @implNote The original name {@code isTerminated} collided with the package−private method in {@link Thread}.
+     */
+    default boolean hasTerminated() {
         TaskState state = getTaskState();
         return TaskState.TERMINATED.equals(state);
     }


### PR DESCRIPTION
GitHub issue resolved #3993 

Pull request Description: As per titile.

----

 - [ ] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
