### PR TITLE
Align dispatch URI naming to sparql-ns.ttl

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/urifunctions/SPARQLDispatch.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/urifunctions/SPARQLDispatch.java
@@ -178,10 +178,10 @@ public class SPARQLDispatch {
 
         register(map, "equals", SPARQLFuncOp::sparql_equals );
         register(map, "not-equals", SPARQLFuncOp::sparql_not_equals );
-        register(map, "greaterThan", SPARQLFuncOp::sparql_greaterThan );
-        register(map, "greaterThanOrEqual", SPARQLFuncOp::sparql_greaterThanOrEqual );
-        register(map, "lessThan", SPARQLFuncOp::sparql_lessThan );
-        register(map, "lessThanOrEqual", SPARQLFuncOp::sparql_lessThanOrEqual );
+        register(map, "greater-than", SPARQLFuncOp::sparql_greaterThan );
+        register(map, "greater-than-or-equals", SPARQLFuncOp::sparql_greaterThanOrEqual );
+        register(map, "less-than", SPARQLFuncOp::sparql_lessThan );
+        register(map, "less-than-or-equal", SPARQLFuncOp::sparql_lessThanOrEqual );
 
         register(map, "and", SPARQLFuncOp::sparql_function_and );
         register(map, "or", SPARQLFuncOp::sparql_function_or );

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/urifunctions/SPARQLFuncOp.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/urifunctions/SPARQLFuncOp.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.jena.atlas.lib.*;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.expr.*;
@@ -229,7 +230,7 @@ public class SPARQLFuncOp {
     public static NodeValue sparql_isNumeric(NodeValue nv)  { return NodeFunctions.isNumeric(nv); }
     public static NodeValue sparql_str(NodeValue nv)        { return NodeFunctions.str(nv); }
 
-    public static NodeValue sparql_lang(NodeValue nv)       { return NodeFunctions.str(nv); }
+    public static NodeValue sparql_lang(NodeValue nv)       { return NodeFunctions.lang(nv); }
     public static NodeValue sparql_langdir(NodeValue nv)    { return NodeFunctions.langdir(nv); }
     public static NodeValue sparql_haslang(NodeValue nv)    { return NodeFunctions.hasLang(nv); }
     public static NodeValue sparql_haslangdir(NodeValue nv) { return NodeFunctions.hasLangDir(nv); }
@@ -245,7 +246,7 @@ public class SPARQLFuncOp {
     public static NodeValue arq_uri(NodeValue nv, NodeValue nvBase) { return NodeFunctions.iri(nv, nvBase.getString()); }
 
     // Only BNODE(), not BNODE(str)
-    public static NodeValue sparql_bnode() { return null; }
+    public static NodeValue sparql_bnode() { return NodeValue.makeNode(NodeFactory.createBlankNode()); }
 
     // Not a function - depends on "current row".
     //public static NodeValue sparql_bnode(NodeValue nv) { return null; }
@@ -328,7 +329,7 @@ public class SPARQLFuncOp {
     public static NodeValue sparql_object(NodeValue tripleTerm)                     { return TripleTermOps.tripleObject(tripleTerm); }
     public static NodeValue sparql_isTriple(NodeValue nv)                           { return TripleTermOps.isTriple(nv); }
 
-    public static NodeValue sparql_md5(NodeValue nv)    { return NodeValueDigest.calculateDigest(nv, "MD-5"); }
+    public static NodeValue sparql_md5(NodeValue nv)    { return NodeValueDigest.calculateDigest(nv, "MD5"); }
     public static NodeValue sparql_sha1(NodeValue nv)   { return NodeValueDigest.calculateDigest(nv, "SHA-1"); }
     public static NodeValue sparql_sha224(NodeValue nv) { return NodeValueDigest.calculateDigest(nv, "SHA-224"); }
     public static NodeValue sparql_sha256(NodeValue nv) { return NodeValueDigest.calculateDigest(nv, "SHA-256"); }


### PR DESCRIPTION
Ajust naming the teh SPARQ function URI mapping to align with the official SPARQL namespace to be published.

----

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
