### PR TITLE
GH-4006: [jena-ontapi] add DocumentGraphRepository#addMappings

### DIFF
--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/DocumentGraphRepositoryAssembler.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/DocumentGraphRepositoryAssembler.java
@@ -34,12 +34,18 @@ public class DocumentGraphRepositoryAssembler extends AssemblerBase {
     /**
      * example:
      * <pre>{@code
-     * @prefix : <http://ex.com#> .
-     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+     * PREFIX : <http://ex.com#>
+     * PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+     * PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+     * PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
+     * PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
      *
      * :repo a oa:DocumentGraphRepository ;
-     *      oa:graph :g1, :g2 .
+     *      oa:graph :g1, :g2 ;
+     *      oa:locationMappings :mappingModel .
+     *
+     * :mappingModel a ja:DefaultModel ;
+     *      ja:externalContent <file:ontologies/location-mapping.ttl> .
      *
      * :g1 a oa:Graph ;
      *      oa:graphIRI "vocab1" ;
@@ -64,6 +70,10 @@ public class DocumentGraphRepositoryAssembler extends AssemblerBase {
                     String location = graph.getProperty(OA.graphLocation).getString();
                     repo.addMapping(id, location);
                 });
+
+        model.listStatements(root, OA.locationMappings, (RDFNode) null)
+                .mapWith(stmt -> stmt.getObject().asResource())
+                .forEach(mappings -> repo.addMappings(a.openModel(mappings, mode)));
 
         return repo;
     }

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OA.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OA.java
@@ -31,6 +31,7 @@ public class OA {
     public static final Property graph = property("graph");
     public static final Property graphIRI = property("graphIRI");
     public static final Property graphLocation = property("graphLocation");
+    public static final Property locationMappings = property("locationMappings");
     public static final Property specificationName = property("specificationName");
     public static final Property personalityName = property("personalityName");
     public static final Property schema = property("schema");

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntModelAssembler.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntModelAssembler.java
@@ -37,10 +37,10 @@ public class OntModelAssembler extends AssemblerBase {
     /**
      * examples:
      * <pre>{@code
-     * @prefix : <http://ex.com#> .
-     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-     * @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+     * PREFIX : <http://ex.com#>
+     * PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+     * PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+     * PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
      *
      * :spec a oa:OntSpecification ;
      *      oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
@@ -48,8 +48,8 @@ public class OntModelAssembler extends AssemblerBase {
      * :base a ja:MemoryModel ;
      *      ja:content [
      *          ja:literalContent """
-     *              @prefix : <http://ex.com#> .
-     *              @prefix owl: <http://www.w3.org/2002/07/owl#> .
+     *              PREFIX : <http://ex.com#>
+     *              PREFIX owl: <http://www.w3.org/2002/07/owl#>
      *              :C a owl:Class .
      *          """ ;
      *          ja:contentEncoding "TTL"
@@ -60,10 +60,10 @@ public class OntModelAssembler extends AssemblerBase {
      *      oa:baseModel :base .
      * }</pre>
      * <pre>{@code
-     * @prefix : <http://ex.com#> .
-     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-     * @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+     * PREFIX : <http://ex.com#>
+     * PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+     * PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+     * PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
      *
      * :repo a oa:DocumentGraphRepository ;
      *      oa:graph :g .

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntSpecificationAssembler.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/assemblers/OntSpecificationAssembler.java
@@ -43,16 +43,16 @@ public class OntSpecificationAssembler extends AssemblerBase {
     /**
      * examples:
      * <pre>{@code
-     * @prefix : <http://ex.com#> .
-     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+     * PREFIX : <http://ex.com#>
+     * PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+     * PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
      * <p>
      * :spec a oa:OntSpecification ;
      *      oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
      * }</pre>
      * <pre>{@code
-     * @prefix : <http://ex.com#> .
-     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
+     * PREFIX : <http://ex.com#>
+     * PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
      *
      * :reasoner a oa:ReasonerFactory ;
      *      oa:reasonerURL <http://jena.hpl.hp.com/2003/RDFSExptRuleReasoner> .
@@ -62,17 +62,17 @@ public class OntSpecificationAssembler extends AssemblerBase {
      *      oa:reasonerFactory :reasoner .
      * }</pre>
      * <pre>{@code
-     * @prefix : <http://ex.com#> .
-     * @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-     * @prefix owl: <http://www.w3.org/2002/07/owl#> .
-     * @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-     * @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
+     * PREFIX : <http://ex.com#>
+     * PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+     * PREFIX owl: <http://www.w3.org/2002/07/owl#>
+     * PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+     * PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
      *
      * :content a ja:Content ;
      *      ja:literalContent """
-     *          @prefix : <http://ex.com#> .
-     *          @prefix owl: <http://www.w3.org/2002/07/owl#> .
-     *          @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+     *          PREFIX : <http://ex.com#>
+     *          PREFIX owl: <http://www.w3.org/2002/07/owl#>
+     *          PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
      *          :Person a owl:Class .
      *          :Employee a owl:Class ; rdfs:subClassOf :Person .
      *      """ ;

--- a/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/repositories/DocumentGraphRepository.java
+++ b/jena-ontapi/src/main/java/org/apache/jena/ontapi/impl/repositories/DocumentGraphRepository.java
@@ -24,14 +24,21 @@ package org.apache.jena.ontapi.impl.repositories;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.ontapi.GraphRepository;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFLanguages;
 import org.apache.jena.riot.RDFParser;
 import org.apache.jena.shared.JenaException;
+import org.apache.jena.vocabulary.LocationMappingVocab;
 
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -39,13 +46,35 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
- * Simple GraphRepository implementation with location mapping.
+ * {@link GraphRepository} implementation that loads RDF documents on demand and
+ * caches loaded graphs by their resolved document source.
+ * <p>
+ * The repository supports two kinds of location mapping:
+ * <ul>
+ *     <li>exact mappings, added with {@link #addMapping(String, String)}, bind one graph ID to one document location;</li>
+ *     <li>prefix mappings, added with {@link #addPrefixMapping(String, String)}
+ *     and removed with {@link #removePrefixMapping(String)}, rewrite matching ID prefixes lazily.</li>
+ * </ul>
+ * Exact mappings take precedence over prefix mappings. Prefix mappings are not
+ * expanded eagerly, so IDs covered only by a prefix mapping are not listed by
+ * {@link #ids()} until {@link #get(String)} successfully materializes a concrete
+ * ID-to-source binding. {@link #contains(String)} may return {@code true} for
+ * such an ID before it is materialized; this means that a mapping rule exists,
+ * not that the target document is guaranteed to load successfully. Several IDs
+ * can resolve to the same document source and therefore share the same cached
+ * graph instance.
  */
 public class DocumentGraphRepository implements GraphRepository {
 
     private final Supplier<Graph> factory;
 
+    // Exact and materialized id-to-document bindings. Prefix mappings are added here only after get(id) resolves them.
     private final Map<String, Source> idToSource = new HashMap<>();
+    // Prefix mappings are lazy: they can make contains(id) true but create an id entry only after get(id) resolves it.
+    private final Map<String, String> idPrefixToLocationPrefix = new HashMap<>();
+    // Removed concrete ids must not be reintroduced by prefix fallback while sibling ids under the same prefix still resolve.
+    private final Set<String> excludedFromPrefixMapping = new HashSet<>();
+    // Cache of loaded graphs by document source; several ids can point to the same cached graph.
     private final Map<Source, Graph> sourceToGraph = new HashMap<>();
 
     public DocumentGraphRepository() {
@@ -115,8 +144,109 @@ public class DocumentGraphRepository implements GraphRepository {
     public DocumentGraphRepository addMapping(String id, String uriOrFile) {
         Objects.requireNonNull(id, "Null Graph Id");
         var source = parseLocation(Objects.requireNonNull(uriOrFile, "location (file or uri) is required"));
-        idToSource.put(id, source);
-        idToSource.put(uriOrFile, source);
+        bind(id, source);
+        bind(uriOrFile, source);
+        excludedFromPrefixMapping.remove(id);
+        excludedFromPrefixMapping.remove(uriOrFile);
+        return this;
+    }
+
+    /**
+     * Adds mapping from a graph ID prefix to a source document location prefix.
+     * If no exact mapping is found for an ID, the ID prefix is replaced by the
+     * location prefix and the remaining ID suffix is preserved.
+     * If several prefix mappings match the same ID, the mapping with the longest
+     * location prefix is used, matching the historical Jena {@code LocationMapper}
+     * behavior.
+     * Prefix mappings are lazy: they are used by {@link #contains(String)} and
+     * {@link #get(String)}, but do not appear in {@link #ids()} until a concrete
+     * ID is resolved by {@code get}.
+     * <p>
+     * Example:
+     * <pre>{@code
+     * DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+     *         .addPrefixMapping("vocab/", "builtins-");
+     *
+     * repository.contains("vocab/rdfs.rdf"); // true
+     * repository.get("vocab/rdfs.rdf");      // loads "builtins-rdfs.rdf"
+     * }</pre>
+     * Equivalent Jena location mapping model:
+     * <pre>{@code
+     * PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
+     *
+     * [] lm:mapping [
+     *      lm:prefix "vocab/" ;
+     *      lm:altPrefix "builtins-"
+     * ] .
+     * }</pre>
+     *
+     * @param idPrefix        Graph's ID prefix
+     * @param uriOrFilePrefix location prefix
+     * @return this instance
+     * @see DocumentGraphRepository#get(String)
+     */
+    public DocumentGraphRepository addPrefixMapping(String idPrefix, String uriOrFilePrefix) {
+        idPrefixToLocationPrefix.put(
+                Objects.requireNonNull(idPrefix, "Null Graph Id prefix"),
+                Objects.requireNonNull(uriOrFilePrefix, "location prefix is required")
+        );
+        excludedFromPrefixMapping.removeIf(id -> id.startsWith(idPrefix));
+        return this;
+    }
+
+    /**
+     * Removes a graph ID prefix mapping.
+     * Already materialized graph IDs and loaded graphs are not removed by this method.
+     * To remove a concrete graph association, use {@link #remove(String)}.
+     *
+     * @param idPrefix Graph's ID prefix
+     * @return removed location prefix or {@code null} if no prefix mapping existed
+     */
+    public String removePrefixMapping(String idPrefix) {
+        return idPrefixToLocationPrefix.remove(Objects.requireNonNull(idPrefix, "Null Graph Id prefix"));
+    }
+
+    /**
+     * Adds location mappings from a Jena location mapping RDF model.
+     * Entries with {@code lm:name} and {@code lm:altName} are processed as exact mappings.
+     * Entries with {@code lm:prefix} and {@code lm:altPrefix} are processed as prefix mappings.
+     * <p>
+     * Example Jena location mapping model:
+     * <pre>{@code
+     * PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
+     *
+     * [] lm:mapping [
+     *      lm:name "http://example.com/ontology" ;
+     *      lm:altName "file:ontologies/ontology.ttl"
+     * ] .
+     * }</pre>
+     *
+     * @param model RDF model with {@code lm:mapping} entries
+     * @return this instance
+     * @see LocationMappingVocab
+     * @see DocumentGraphRepository#addMapping(String, String)
+     */
+    public DocumentGraphRepository addMappings(Model model) {
+        Objects.requireNonNull(model, "Null location mapping model");
+        StmtIterator mappings = model.listStatements(null, LocationMappingVocab.mapping, (RDFNode) null);
+        try {
+            while (mappings.hasNext()) {
+                Statement s = mappings.nextStatement();
+                Resource mapping = s.getResource();
+                if (mapping.hasProperty(LocationMappingVocab.name) && mapping.hasProperty(LocationMappingVocab.altName)) {
+                    String name = mapping.getRequiredProperty(LocationMappingVocab.name).getString();
+                    String altName = mapping.getRequiredProperty(LocationMappingVocab.altName).getString();
+                    addMapping(name, altName);
+                }
+                if (mapping.hasProperty(LocationMappingVocab.prefix) && mapping.hasProperty(LocationMappingVocab.altPrefix)) {
+                    String prefix = mapping.getRequiredProperty(LocationMappingVocab.prefix).getString();
+                    String altPrefix = mapping.getRequiredProperty(LocationMappingVocab.altPrefix).getString();
+                    addPrefixMapping(prefix, altPrefix);
+                }
+            }
+        } finally {
+            mappings.close();
+        }
         return this;
     }
 
@@ -127,14 +257,14 @@ public class DocumentGraphRepository implements GraphRepository {
      *
      * @param id {@code String} Graph's identifier
      * @return {@link Graph}
-     * @see DocumentGraphRepository#addMapping(String, String)
      * @throws org.apache.jena.shared.JenaException if graph cannot be loaded
+     * @see DocumentGraphRepository#addMapping(String, String)
      */
     @Override
     public Graph get(String id) {
+        Objects.requireNonNull(id, "Null Graph Id");
         try {
-            var source = idToSource.computeIfAbsent(Objects.requireNonNull(id, "Null Graph Id"),
-                    DocumentGraphRepository::parseLocation);
+            var source = idToSource.computeIfAbsent(id, this::toSource);
             return sourceToGraph.computeIfAbsent(source, it -> read(it, factory.get()));
         } catch (JenaException e) {
             idToSource.remove(id);
@@ -144,7 +274,9 @@ public class DocumentGraphRepository implements GraphRepository {
 
     /**
      * Lists all graph's identifiers.
-     * Note that the number of identifiers may exceed the number of graphs if there are multiple id-source mappings.
+     * The result contains exact mappings and prefix-derived IDs already materialized by {@link #get(String)}.
+     * It does not enumerate possible IDs covered only by lazy prefix mappings.
+     * Note that the number of identifiers may exceed the number of loaded graphs if several IDs map to one source.
      *
      * @return {@code Stream} of ids
      */
@@ -166,24 +298,38 @@ public class DocumentGraphRepository implements GraphRepository {
         Objects.requireNonNull(id, "Null Graph Id");
         Objects.requireNonNull(graph, "Null Graph");
         var source = idToSource.computeIfAbsent(id, it -> new Source(it, RDFLanguages.resourceNameToLang(id, Lang.RDFXML)));
+        excludedFromPrefixMapping.remove(id);
         return sourceToGraph.put(source, graph);
     }
 
     /**
      * Removes and returns the graph identified by the specified {@code id}, along with all its associations.
+     * Prefix mappings themselves are not removed by this method. If the removed ID
+     * matches a registered prefix mapping, only that concrete ID is excluded from
+     * prefix fallback; other IDs under the same prefix remain resolvable. The removed
+     * ID becomes resolvable again after it is re-added explicitly or by adding a
+     * matching prefix mapping again.
+     * Use {@link #removePrefixMapping(String)} to remove a prefix mapping rule.
      *
      * @param id {@code String} Graph's identifier
      * @return {@link Graph} or {@code null} if the graph is not found
      */
     @Override
     public Graph remove(String id) {
-        var source = idToSource.remove(Objects.requireNonNull(id, "Null Graph Id"));
+        Objects.requireNonNull(id, "Null Graph Id");
+        var source = idToSource.remove(id);
         if (source == null) {
             return null;
         }
+        // Do not let a removed exact id reappear immediately through a still-active prefix mapping.
+        excludedFromPrefixMapping.add(id);
         idToSource.entrySet().stream().toList().stream()
                 .filter(it -> source.equals(it.getValue()))
-                .forEach(it -> idToSource.remove(it.getKey()));
+                .forEach(it -> {
+                    idToSource.remove(it.getKey());
+                    // Apply the same removal semantics to all aliases of the same document source.
+                    excludedFromPrefixMapping.add(it.getKey());
+                });
         return sourceToGraph.remove(source);
     }
 
@@ -194,6 +340,8 @@ public class DocumentGraphRepository implements GraphRepository {
     public void clear() {
         sourceToGraph.clear();
         idToSource.clear();
+        idPrefixToLocationPrefix.clear();
+        excludedFromPrefixMapping.clear();
     }
 
     /**
@@ -214,7 +362,7 @@ public class DocumentGraphRepository implements GraphRepository {
      * @return distinct {@code Stream} of {@link Graph}s
      */
     public Stream<Graph> loadedGraphs() {
-        return sourceToGraph.values().stream();
+        return sourceToGraph.values().stream().distinct();
     }
 
     /**
@@ -225,11 +373,51 @@ public class DocumentGraphRepository implements GraphRepository {
      */
     @Override
     public boolean contains(String id) {
-        return idToSource.containsKey(Objects.requireNonNull(id, "Null Graph Id"));
+        Objects.requireNonNull(id, "Null Graph Id");
+        return idToSource.containsKey(id) || !excludedFromPrefixMapping.contains(id) && findPrefixMapping(id) != null;
     }
 
     protected Set<String> getIds() {
         return idToSource.keySet();
+    }
+
+    private void bind(String id, Source source) {
+        Source old = idToSource.put(id, source);
+        removeGraphIfOrphaned(old);
+    }
+
+    private void removeGraphIfOrphaned(Source source) {
+        if (source != null && !idToSource.containsValue(source)) {
+            sourceToGraph.remove(source);
+        }
+    }
+
+    private Source toSource(String id) {
+        if (excludedFromPrefixMapping.contains(id)) {
+            // The id was removed explicitly; keep get(id)'s direct-location fallback, but skip prefix remapping.
+            return parseLocation(id);
+        }
+        String prefix = findPrefixMapping(id);
+        if (prefix == null) {
+            return parseLocation(id);
+        }
+        String location = idPrefixToLocationPrefix.get(prefix) + id.substring(prefix.length());
+        return parseLocation(location);
+    }
+
+    private String findPrefixMapping(String id) {
+        String res = null;
+        String locationPrefix = null;
+        for (String prefix : idPrefixToLocationPrefix.keySet()) {
+            if (id.startsWith(prefix)) {
+                String candidate = idPrefixToLocationPrefix.get(prefix);
+                if (locationPrefix == null || locationPrefix.length() < candidate.length()) {
+                    res = prefix;
+                    locationPrefix = candidate;
+                }
+            }
+        }
+        return res;
     }
 
     private record Source(String location, Lang lang) {

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/DocumentGraphRepositoryAssemblerTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/DocumentGraphRepositoryAssemblerTest.java
@@ -26,7 +26,10 @@ import org.apache.jena.ontapi.impl.repositories.DocumentGraphRepository;
 import org.apache.jena.ontapi.testutils.RDFIOTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -36,10 +39,9 @@ public class DocumentGraphRepositoryAssemblerTest {
     public void testAssemblerWithNoGraphs() {
         var m = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                         :repo a oa:DocumentGraphRepository .
                         """, "ttl"
         );
@@ -54,10 +56,9 @@ public class DocumentGraphRepositoryAssemblerTest {
     public void testAssemblerWithTwoGraphs() {
         var m = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                         :repo a oa:DocumentGraphRepository ;
                             oa:graph :g1, :g2 .
                         
@@ -79,5 +80,134 @@ public class DocumentGraphRepositoryAssemblerTest {
                 Set.of("vocab1", "vocab2", "file:ontologies/vocab1.ttl", "file:ontologies/vocab2.ttl"),
                 new HashSet<>(repo.ids().toList())
         );
+    }
+
+    @Test
+    public void testAssemblerWithLocationMappings() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
+                        PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
+                        :repo a oa:DocumentGraphRepository ;
+                            oa:locationMappings :mappingModel .
+                        :mappingModel a ja:MemoryModel ;
+                            ja:content [
+                                ja:literalContent '''
+                                    PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
+                                    [] lm:mapping
+                                        [ lm:name "vocab1" ; lm:altName "file:ontologies/vocab1.ttl" ] ,
+                                        [ lm:prefix "vocab-prefix/" ; lm:altPrefix "builtins-" ] ,
+                                        [ lm:prefix "bad-prefix/" ; lm:altName "file:ontologies/prefix.ttl" ] .
+                                ''' ;
+                                ja:contentEncoding "TTL"
+                            ] .
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#repo");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(DocumentGraphRepository.class, result);
+        var repo = (DocumentGraphRepository) result;
+        Assertions.assertEquals(2, repo.count());
+        Assertions.assertTrue(repo.contains("vocab-prefix/rdfs.rdf"));
+        Assertions.assertFalse(repo.contains("bad-prefix/rdfs.rdf"));
+        Assertions.assertEquals(
+                Set.of("vocab1", "file:ontologies/vocab1.ttl"),
+                new HashSet<>(repo.ids().toList())
+        );
+    }
+
+    @Test
+    public void testAssemblerWithLocationMappingsFromFile(@TempDir Path dir) throws Exception {
+        Path mappings = Files.createTempFile(dir, "location-mapping", ".ttl");
+        Files.writeString(mappings,
+                """
+                        PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
+                        [] lm:mapping
+                            [ lm:name "vocab1" ; lm:altName "file:ontologies/vocab1.ttl" ] ,
+                            [ lm:prefix "vocab-prefix/" ; lm:altPrefix "builtins-" ] .
+                        """
+        );
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
+                        :repo a oa:DocumentGraphRepository ;
+                            oa:locationMappings :mappingModel .
+                        :mappingModel a ja:MemoryModel ;
+                            ja:externalContent <%s> .
+                        """.formatted(mappings.toUri()), "ttl"
+        );
+        var root = m.getResource("http://ex.com#repo");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(DocumentGraphRepository.class, result);
+        var repo = (DocumentGraphRepository) result;
+        Assertions.assertEquals(2, repo.count());
+        Assertions.assertTrue(repo.contains("vocab1"));
+        Assertions.assertTrue(repo.contains("vocab-prefix/rdfs.rdf"));
+        Assertions.assertEquals(
+                Set.of("vocab1", "file:ontologies/vocab1.ttl"),
+                new HashSet<>(repo.ids().toList())
+        );
+    }
+
+    @Test
+    public void testAssemblerWithGraphsAndLocationMappings() {
+        var m = RDFIOTestUtils.readStringAsModel(
+                """
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
+                        PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
+                        :repo a oa:DocumentGraphRepository ;
+                            oa:graph :g1, :g2, :g3 ;
+                            oa:locationMappings :mappingModel .
+                        :mappingModel a ja:MemoryModel ;
+                            ja:content [
+                                ja:literalContent '''
+                                    PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
+                                    [] lm:mapping
+                                        [
+                                            lm:name "vocab3" ;
+                                            lm:altName "builtins-rdfs.rdf"
+                                        ] ,
+                                        [
+                                            lm:prefix "https://example.com/ontologies/" ;
+                                            lm:altPrefix "builtins-"
+                                        ] .
+                                ''' ;
+                                ja:contentEncoding "TTL"
+                            ] .
+                        :g1 a oa:Graph ;
+                            oa:graphIRI "vocab1" ;
+                            oa:graphLocation "builtins-owl.rdf" .
+                        :g2 a oa:Graph ;
+                            oa:graphIRI "vocab2" ;
+                            oa:graphLocation "builtins-rdfs.rdf" .
+                        :g3 a oa:Graph ;
+                            oa:graphIRI "pizza" ;
+                            oa:graphLocation "pizza.ttl" .
+                        """, "ttl"
+        );
+        var root = m.getResource("http://ex.com#repo");
+        var result = Assembler.general().open(root);
+        Assertions.assertInstanceOf(DocumentGraphRepository.class, result);
+        var repo = (DocumentGraphRepository) result;
+
+        Assertions.assertEquals(
+                Set.of("vocab1", "vocab2", "vocab3", "pizza", "builtins-owl.rdf", "builtins-rdfs.rdf", "pizza.ttl"),
+                new HashSet<>(repo.ids().toList())
+        );
+        Assertions.assertTrue(repo.contains("https://example.com/ontologies/rdfs.rdf"));
+        Assertions.assertEquals(7, repo.count());
+
+        Assertions.assertEquals(159, repo.get("vocab1").size());
+        Assertions.assertEquals(163, repo.get("vocab2").size());
+        Assertions.assertEquals(163, repo.get("vocab3").size());
+        Assertions.assertTrue(repo.get("pizza").size() > 1_000);
+        Assertions.assertSame(repo.get("pizza"), repo.get("pizza.ttl"));
+        Assertions.assertSame(repo.get("vocab2"), repo.get("https://example.com/ontologies/rdfs.rdf"));
     }
 }

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/DocumentGraphRepositoryTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/DocumentGraphRepositoryTest.java
@@ -26,11 +26,13 @@ import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.ontapi.impl.UnionGraphImpl;
 import org.apache.jena.ontapi.impl.repositories.DocumentGraphRepository;
 import org.apache.jena.ontapi.testutils.MiscUtils;
+import org.apache.jena.ontapi.testutils.RDFIOTestUtils;
 import org.apache.jena.ontapi.utils.Graphs;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
@@ -88,5 +90,243 @@ public class DocumentGraphRepositoryTest {
         Graph g = repository.get("http://www.w3.org/2002/07/owl#");
         Assertions.assertEquals(163, g.size());
         Assertions.assertTrue(Graphs.isGraphMem(g));
+    }
+
+    @Test
+    public void testAddMappings() {
+        var mappings = RDFIOTestUtils.readStringAsModel(
+                """
+                        PREFIX lm: <http://jena.hpl.hp.com/2004/08/location-mapping#>
+                        
+                        [] lm:mapping
+                            [ lm:name "vocab1" ; lm:altName "file:ontologies/vocab1.ttl" ] ,
+                            [ lm:prefix "vocab-prefix/" ; lm:altPrefix "builtins-" ] ,
+                            [ lm:prefix "bad-prefix/" ; lm:altName "file:ontologies/prefix.ttl" ] .
+                        """, "ttl"
+        );
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addMappings(mappings);
+
+        Assertions.assertTrue(repository.contains("vocab1"));
+        Assertions.assertTrue(repository.contains("file:ontologies/vocab1.ttl"));
+        Assertions.assertTrue(repository.contains("vocab-prefix/rdfs.rdf"));
+        Assertions.assertFalse(repository.contains("bad-prefix/rdfs.rdf"));
+        Assertions.assertFalse(repository.contains("file:ontologies/prefix.ttl"));
+        Assertions.assertEquals(2, repository.count());
+
+        Graph g = repository.get("vocab-prefix/rdfs.rdf");
+        Assertions.assertEquals(163, g.size());
+        Assertions.assertEquals(3, repository.count());
+    }
+
+    @Test
+    public void testAddPrefixMappingGet() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-");
+
+        Assertions.assertTrue(repository.contains("vocab/rdfs.rdf"));
+        Assertions.assertEquals(0, repository.count());
+
+        Graph g1 = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(163, g1.size());
+        Assertions.assertEquals(
+                List.of("vocab/rdfs.rdf"),
+                repository.ids().sorted().toList());
+        Assertions.assertEquals(1, repository.count());
+
+        Graph g2 = repository.get("builtins-rdfs.rdf");
+        Assertions.assertSame(g1, g2);
+        Assertions.assertEquals(
+                List.of("builtins-rdfs.rdf", "vocab/rdfs.rdf"),
+                repository.ids().sorted().toList());
+        Assertions.assertEquals(2, repository.count());
+    }
+
+    @Test
+    public void testExactMappingWinsWhenIdAlsoMatchesPrefixMapping() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-")
+                .addMapping("vocab/rdfs.rdf", "builtins-owl.rdf");
+
+        Assertions.assertTrue(repository.contains("vocab/rdfs.rdf"));
+        Assertions.assertTrue(repository.contains("vocab/owl.rdf"));
+
+        Graph g = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(159, g.size());
+        Assertions.assertSame(g, repository.get("builtins-owl.rdf"));
+
+        Graph sibling = repository.get("vocab/owl.rdf");
+        Assertions.assertEquals(159, sibling.size());
+        Assertions.assertSame(sibling, repository.get("builtins-owl.rdf"));
+    }
+
+    @Test
+    public void testAddMappingRemovesOrphanLoadedGraphAfterRemap() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-");
+
+        Graph prefixGraph = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(163, prefixGraph.size());
+        Assertions.assertEquals(List.of(prefixGraph), repository.loadedGraphs().toList());
+
+        repository.addMapping("vocab/rdfs.rdf", "builtins-owl.rdf");
+        Assertions.assertFalse(repository.loadedGraphs().toList().contains(prefixGraph));
+        // addMapping only changes the source binding. The replacement graph is loaded lazily by get(...).
+        Assertions.assertEquals(List.of(), repository.loadedGraphs().toList());
+
+        Graph exactGraph = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(159, exactGraph.size());
+        Assertions.assertEquals(List.of(exactGraph), repository.loadedGraphs().toList());
+    }
+
+    @Test
+    public void testLoadedGraphsReturnsDistinctGraphs() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem();
+        Graph graph = GraphMemFactory.createDefaultGraph();
+
+        repository.put("first.ttl", graph);
+        repository.put("second.ttl", graph);
+
+        Assertions.assertEquals(List.of(graph), repository.loadedGraphs().toList());
+    }
+
+    @Test
+    public void testAddPrefixMappingLongestLocationPrefixWins() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-owl")
+                .addPrefixMapping("vocab/rdfs", "builtins-rdfs");
+
+        Graph g = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(163, g.size());
+        Assertions.assertSame(g, repository.get("builtins-rdfs.rdf"));
+    }
+
+    @Test
+    public void testAddPrefixMappingUsesLocationMapperPrefixSelection(@TempDir Path dir) throws Exception {
+        Path longLocationPrefix = Files.createDirectories(dir.resolve("some-very-long-location-prefix"));
+        Path shortLocationPrefix = Files.createDirectories(dir.resolve("x"));
+        Path document = Files.createDirectories(longLocationPrefix.resolve("rdfs")).resolve("schema.ttl");
+        Files.writeString(document, "@prefix : <http://example.com/test#> . :s :p :o .");
+        String longLocation = longLocationPrefix.toUri().toString();
+        String shortLocation = shortLocationPrefix.toUri().toString();
+        if (!longLocation.endsWith("/")) {
+            longLocation += "/";
+        }
+        if (!shortLocation.endsWith("/")) {
+            shortLocation += "/";
+        }
+
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", longLocation)
+                .addPrefixMapping("vocab/rdfs/", shortLocation);
+
+        Graph g = repository.get("vocab/rdfs/schema.ttl");
+        Assertions.assertEquals(1, g.size());
+        Assertions.assertSame(g, repository.get(document.toUri().toString()));
+    }
+
+    @Test
+    public void testAddPrefixMappingRemoveAndClear() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-");
+
+        Graph g = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(163, g.size());
+        Assertions.assertTrue(repository.contains("vocab/rdfs.rdf"));
+
+        Assertions.assertSame(g, repository.remove("vocab/rdfs.rdf"));
+        Assertions.assertFalse(repository.contains("vocab/rdfs.rdf"));
+        Assertions.assertTrue(repository.contains("vocab/owl.rdf"));
+        Assertions.assertEquals(0, repository.count());
+
+        repository.addPrefixMapping("vocab/", "builtins-");
+        Assertions.assertTrue(repository.contains("vocab/rdfs.rdf"));
+        repository.clear();
+        Assertions.assertFalse(repository.contains("vocab/rdfs.rdf"));
+        Assertions.assertEquals(0, repository.count());
+    }
+
+    @Test
+    public void testRemovePrefixMapping() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-");
+
+        Graph g = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(163, g.size());
+        Assertions.assertTrue(repository.contains("vocab/owl.rdf"));
+
+        Assertions.assertEquals("builtins-", repository.removePrefixMapping("vocab/"));
+        Assertions.assertNull(repository.removePrefixMapping("vocab/"));
+        Assertions.assertFalse(repository.contains("vocab/owl.rdf"));
+
+        Assertions.assertTrue(repository.contains("vocab/rdfs.rdf"));
+        Assertions.assertSame(g, repository.get("vocab/rdfs.rdf"));
+    }
+
+    @Test
+    public void testRemoveExactMappingKeepsMatchingPrefixMapping() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-");
+
+        Graph prefixGraph = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(163, prefixGraph.size());
+
+        repository.addMapping("vocab/rdfs.rdf", "builtins-owl.rdf");
+        Graph exactGraph = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(159, exactGraph.size());
+
+        Assertions.assertSame(exactGraph, repository.remove("vocab/rdfs.rdf"));
+        Assertions.assertFalse(repository.contains("vocab/rdfs.rdf"));
+        Assertions.assertTrue(repository.contains("vocab/owl.rdf"));
+        Assertions.assertThrows(RuntimeException.class, () -> repository.get("vocab/rdfs.rdf"));
+    }
+
+    @Test
+    public void testRemovePutGraphKeepsMatchingPrefixMapping() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-");
+
+        Graph graph = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(163, graph.size());
+
+        Graph replacement = GraphMemFactory.createDefaultGraph();
+        Assertions.assertSame(graph, repository.put("vocab/rdfs.rdf", replacement));
+
+        Assertions.assertSame(replacement, repository.remove("vocab/rdfs.rdf"));
+        Assertions.assertFalse(repository.contains("vocab/rdfs.rdf"));
+        Assertions.assertTrue(repository.contains("vocab/owl.rdf"));
+        Assertions.assertThrows(RuntimeException.class, () -> repository.get("vocab/rdfs.rdf"));
+    }
+
+    @Test
+    public void testAddPrefixMappingRestoresRemovedExactId() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-")
+                .addMapping("vocab/rdfs.rdf", "builtins-owl.rdf");
+
+        Graph exactGraph = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(159, exactGraph.size());
+        Assertions.assertSame(exactGraph, repository.remove("vocab/rdfs.rdf"));
+        Assertions.assertFalse(repository.contains("vocab/rdfs.rdf"));
+
+        repository.addPrefixMapping("vocab/", "builtins-");
+        Assertions.assertTrue(repository.contains("vocab/rdfs.rdf"));
+        Assertions.assertEquals(163, repository.get("vocab/rdfs.rdf").size());
+    }
+
+    @Test
+    public void testAddMappingRestoresRemovedExactId() {
+        DocumentGraphRepository repository = GraphRepository.createGraphDocumentRepositoryMem()
+                .addPrefixMapping("vocab/", "builtins-")
+                .addMapping("vocab/rdfs.rdf", "builtins-owl.rdf");
+
+        Graph exactGraph = repository.get("vocab/rdfs.rdf");
+        Assertions.assertEquals(159, exactGraph.size());
+        Assertions.assertSame(exactGraph, repository.remove("vocab/rdfs.rdf"));
+        Assertions.assertFalse(repository.contains("vocab/rdfs.rdf"));
+
+        repository.addMapping("vocab/rdfs.rdf", "builtins-rdfs.rdf");
+        Assertions.assertTrue(repository.contains("vocab/rdfs.rdf"));
+        Assertions.assertEquals(163, repository.get("vocab/rdfs.rdf").size());
     }
 }

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelAssemblerTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntModelAssemblerTest.java
@@ -40,10 +40,9 @@ public class OntModelAssemblerTest {
     public void testAssembleSimpleOntModel() {
         var assembler = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                         :model a oa:OntModel .
                         """, "ttl"
         );
@@ -58,19 +57,18 @@ public class OntModelAssemblerTest {
     public void testAssembleOntModelWithBaseModelAndSpec() {
         var assembler = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                        PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
                         :spec a oa:OntSpecification ;
                             oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
                         
                         :base a ja:MemoryModel ;
                             ja:content [
                                 ja:literalContent ""\"
-                                    @prefix : <http://ex.com#> .
-                                    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                                    PREFIX : <http://ex.com#>
+                                    PREFIX owl: <http://www.w3.org/2002/07/owl#>
                                     :C a owl:Class .
                                 ""\" ;
                                 ja:contentEncoding "TTL"
@@ -92,19 +90,18 @@ public class OntModelAssemblerTest {
     public void testAssembleOntModelWithHierarchy() {
         var assembler = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                        PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
                         :spec a oa:OntSpecification ;
                             oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
                         
                         :base1 a ja:MemoryModel ;
                             ja:content [
                                 ja:literalContent ""\"
-                                    @prefix : <http://ex.com#> .
-                                    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                                    PREFIX : <http://ex.com#>
+                                    PREFIX owl: <http://www.w3.org/2002/07/owl#>
                                     : a owl:Ontology .
                                     :A a owl:Class .
                                 ""\" ;
@@ -114,8 +111,8 @@ public class OntModelAssemblerTest {
                         :base2 a ja:MemoryModel ;
                             ja:content [
                                 ja:literalContent ""\"
-                                    @prefix : <http://ex.com/v1#> .
-                                    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+                                    PREFIX : <http://ex.com/v1#>
+                                    PREFIX owl: <http://www.w3.org/2002/07/owl#>
                                     : a owl:Ontology .
                                     :B a owl:Class .
                                 ""\" ;
@@ -152,11 +149,10 @@ public class OntModelAssemblerTest {
         var srcUri2 = src2.toUri();
         var assembler = RDFIOTestUtils.readStringAsModel(
                 String.format("""
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                        PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
                         :repo a oa:DocumentGraphRepository ;
                             oa:graph :g .
                         :g a oa:Graph ;
@@ -175,7 +171,7 @@ public class OntModelAssemblerTest {
         Assertions.assertEquals("http://www.w3.org/TR/2003/PR-owl-guide-20031209/wine", model.getID().getImportsIRI());
         var imports = model.imports().toList();
         Assertions.assertEquals(1, imports.size());
-        Assertions.assertEquals("http://www.w3.org/TR/2003/PR-owl-guide-20031209/food", imports.get(0).getID().getImportsIRI());
+        Assertions.assertEquals("http://www.w3.org/TR/2003/PR-owl-guide-20031209/food", imports.getFirst().getID().getImportsIRI());
 
         var resultRepository = Assembler.general().open(assembler.getResource("http://ex.com#repo"));
         Assertions.assertInstanceOf(DocumentGraphRepository.class, resultRepository);

--- a/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntSpecificationAssemblerTest.java
+++ b/jena-ontapi/src/test/java/org/apache/jena/ontapi/OntSpecificationAssemblerTest.java
@@ -44,10 +44,9 @@ public class OntSpecificationAssemblerTest {
     public void testAssemblerWithBuiltinSpecification() {
         var m = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                         :spec a oa:OntSpecification ;
                             oa:specificationName "OWL1_LITE_MEM_RDFS_INF" .
                         """, "ttl"
@@ -63,10 +62,9 @@ public class OntSpecificationAssemblerTest {
     public void testAssemblerWithWrongSpecification() {
         var m = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                         :spec a oa:OntSpecification ;
                             oa:specificationName "XXX" .
                         """, "ttl"
@@ -79,10 +77,9 @@ public class OntSpecificationAssemblerTest {
     public void testAssemblerWithBuiltinSpecificationAndPersonality() {
         var m = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                         :spec a oa:OntSpecification ;
                             oa:specificationName "OWL1_LITE_MEM_RDFS_INF" ;
                             oa:personalityName "RDFS_PERSONALITY" ;
@@ -97,9 +94,8 @@ public class OntSpecificationAssemblerTest {
     public void testAssemblerWithBuiltinSpecificationAndReasonerURL() {
         var m = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
                         :reasoner a oa:ReasonerFactory ;
                             oa:reasonerURL <http://jena.hpl.hp.com/2003/RDFSExptRuleReasoner> .
                         
@@ -121,9 +117,8 @@ public class OntSpecificationAssemblerTest {
     public void testAssemblerWithReasonerURLAndRule() {
         var m = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
                         :simple-rules a oa:RuleSet ;
                             oa:rule "[rdfs1: (?a rdfs:subClassOf ?b) -> (?a rdf:type owl:Class)]" .
                         
@@ -155,17 +150,16 @@ public class OntSpecificationAssemblerTest {
     public void testAssemblerWithReasonerURLAndSchema() {
         var m = RDFIOTestUtils.readStringAsModel(
                 """
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        @prefix owl: <http://www.w3.org/2002/07/owl#> .
-                        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-                        @prefix ja: <http://jena.hpl.hp.com/2005/11/Assembler#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
+                        PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                        PREFIX ja: <http://jena.hpl.hp.com/2005/11/Assembler#>
                         :content a ja:Content ;
                             ja:literalContent ""\"
-                                @prefix : <http://ex.com#> .
-                                @prefix owl: <http://www.w3.org/2002/07/owl#> .
-                                @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+                                PREFIX : <http://ex.com#>
+                                PREFIX owl: <http://www.w3.org/2002/07/owl#>
+                                PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
                                 :Person a owl:Class .
                                 :Employee a owl:Class ; rdfs:subClassOf :Person .
                             ""\" ;
@@ -195,9 +189,8 @@ public class OntSpecificationAssemblerTest {
     public void testAssemblerWithReasonerClass() {
         var m = RDFIOTestUtils.readStringAsModel(
                 String.format("""
-                        @prefix : <http://ex.com#> .
-                        @prefix oa: <https://jena.apache.org/ontapi/Assembler#> .
-                        
+                        PREFIX : <http://ex.com#>
+                        PREFIX oa: <https://jena.apache.org/ontapi/Assembler#>
                         :reasoner a oa:ReasonerFactory ;
                             oa:reasonerClass "%s" .
                         


### PR DESCRIPTION
GitHub issue resolved #4006

Pull request Description:

add `DocumentGraphRepository#addMappings`, `addPrefixMapping`, `removePrefixMapping`

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
