### PR TITLE
GH-3505: Bump sis from 1.4 to 1.5

### DIFF
--- a/jena-geosparql/pom.xml
+++ b/jena-geosparql/pom.xml
@@ -84,6 +84,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derby</artifactId>
+      <version>10.15.2.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/SRSInfoTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/SRSInfoTest.java
@@ -65,10 +65,15 @@ public class SRSInfoTest {
     //public static final double OS_Y2 = 1256558.4455361878;
 
     // SIS 1.4
-    public static final double OS_X1 = -104009.35713717458;
+    //public static final double OS_X1 = -104009.35713717458;
+    //public static final double OS_X2 = 688806.0073395987;
+    //public static final double OS_Y1 = -16627.734528042376;
+    //public static final double OS_Y2 = 1256558.445536187;
+    // SIS 1.5
+    public static final double OS_X1 = -104728.76470298576;
     public static final double OS_X2 = 688806.0073395987;
-    public static final double OS_Y1 = -16627.734528042376;
-    public static final double OS_Y2 = 1256558.445536187;
+    public static final double OS_Y1 = -16627.734527606517;
+    public static final double OS_Y2 = 1256616.3207024988;
 
     /**
      * Test of buildDomainEnvelope method, of class SRSInfo.

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/registry/SRSRegistryTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/implementation/registry/SRSRegistryTest.java
@@ -80,20 +80,8 @@ public class SRSRegistryTest {
 
             String srsURI = SRS_URI.DEFAULT_WKT_CRS84;
 
-            String default_CRS_WKT = "GeodeticCRS[\"WGS 84\",\n"
-                    + "  Datum[\"World Geodetic System 1984\",\n"
-                    + "    Ellipsoid[\"WGS 84\", 6378137.0, 298.257223563]],\n"
-                    + "  CS[ellipsoidal, 2],\n"
-                    + "    Axis[\"Geodetic longitude (Lon)\", east],\n"
-                    + "    Axis[\"Geodetic latitude (Lat)\", north],\n"
-                    + "    Unit[\"degree\", 0.017453292519943295],\n"
-                    + "  Scope[\"Horizontal component of 3D system. Used by the GPS satellite navigation system and for NATO military geodetic surveying.\"],\n"
-                    + "  Area[\"World.\"],\n"
-                    + "  BBox[-90.00, -180.00, 90.00, 180.00],\n"
-                    + "  Id[\"CRS\", 84, Citation[\"WMS\"], URI[\"urn:ogc:def:crs:OGC:1.3:CRS84\"]]]";
-
-            CoordinateReferenceSystem expResult = CRS.fromWKT(default_CRS_WKT);
-            CoordinateReferenceSystem result = SRSRegistry.getCRS(srsURI);          
+            CoordinateReferenceSystem expResult = CRS.forCode("CRS:84");
+            CoordinateReferenceSystem result = SRSRegistry.getCRS(srsURI);
             assertEquals(expResult.toWKT(), result.toWKT());
         } catch (FactoryException ex) {
 

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/spatial/SearchEnvelopeTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/spatial/SearchEnvelopeTest.java
@@ -77,10 +77,15 @@ public class SearchEnvelopeTest {
     //public static final double OS_Y1 = -16627.734528041445;
     //public static final double OS_Y2 = 1256558.4455361878;
     // SIS 1.4
-    public static final double OS_X1 = -104009.35713717458;
+    //public static final double OS_X1 = -104009.35713717458;
+    //public static final double OS_X2 = 688806.0073395987;
+    //public static final double OS_Y1 = -16627.734528042376;
+    //public static final double OS_Y2 = 1256558.445536187;
+    // SIS 1.5
+    public static final double OS_X1 = -104728.76470298576;
     public static final double OS_X2 = 688806.0073395987;
-    public static final double OS_Y1 = -16627.734528042376;
-    public static final double OS_Y2 = 1256558.445536187;
+    public static final double OS_Y1 = -16627.734527606517;
+    public static final double OS_Y2 = 1256616.3207024988;
 
     /**
      * Test of build method, of class SearchEnvelope.

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <ver.kryo>5.6.2</ver.kryo>
     <!-- Used in /jena-fuseki-geosparql -->
     <ver.jcommander>1.82</ver.jcommander>
-    <ver.sis>1.4</ver.sis>
+    <ver.sis>1.5</ver.sis>
     <ver.jts>1.20.0</ver.jts>
 
     <!-- Plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <ver.kryo>5.6.2</ver.kryo>
     <!-- Used in /jena-fuseki-geosparql -->
     <ver.jcommander>1.82</ver.jcommander>
-    <ver.sis>1.5</ver.sis>
+    <ver.sis>1.6</ver.sis>
     <ver.jts>1.20.0</ver.jts>
 
     <!-- Plugins -->


### PR DESCRIPTION
GitHub issue resolved #3505

Pull request Description:

This PR bumps the SIS version from 1.4 to 1.5. There are several small changes that came along with it.

1. New derby dependency: SIS 1.5 introduced derby as a dependency, which is why we now add it to the geosparql pom file.
2. Precision changes: Like most other SIS releases, the floating point values in several computations have changed; these should be visible in the diff
3. SIS has switched over their CRS conventions from `Datum` to an `Ensemble`, `CRS:84` being one of them. Rather than constructing the WKT string, we can now call `CRS.forCode("CRS:84");`

As for new documentation... I don't think any of it needs to change unless the new `derby` dependency changes anything.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
