### PR TITLE
GH-3320: Support non-euclidean distance for geosparql

### DIFF
--- a/jena-geosparql/src/main/java/org/apache/jena/geosparql/geof/nontopological/filter_functions/DistanceFF.java
+++ b/jena-geosparql/src/main/java/org/apache/jena/geosparql/geof/nontopological/filter_functions/DistanceFF.java
@@ -50,8 +50,7 @@ public class DistanceFF extends FunctionBase3 {
                 throw new ExprEvalException("Not a IRI: " + FmtUtils.stringForNode(v3.asNode()));
             }
 
-            //GeoSPARQL uses the Euclidean distance regardless of SRS URI.
-            double distance = geometry1.distanceEuclidean(geometry2, v3.asNode().getURI());
+            double distance = geometry1.distance(geometry2, v3.asNode().getURI());
 
             return NodeValue.makeDouble(distance);
         } catch (DatatypeFormatException ex) {

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/geof/nontopological/filter_functions/DistanceFFTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/geof/nontopological/filter_functions/DistanceFFTest.java
@@ -87,7 +87,8 @@ public class DistanceFFTest {
     }
 
     /**
-     * Geographic SRS with angular units throws because great circle distance only supports linear units.
+     * Geographic SRS with angular units. An exception is thrown
+     * because great circle distance only supports linear units.
      */
     @Test(expected = ExprEvalException.class)
     public void testExec_geographic_radians_exception() {

--- a/jena-geosparql/src/test/java/org/apache/jena/geosparql/geof/nontopological/filter_functions/DistanceFFTest.java
+++ b/jena-geosparql/src/test/java/org/apache/jena/geosparql/geof/nontopological/filter_functions/DistanceFFTest.java
@@ -87,31 +87,50 @@ public class DistanceFFTest {
     }
 
     /**
-     * Test of exec method, of class DistanceFF.
+     * Geographic SRS with angular units throws because great circle distance only supports linear units.
      */
-    @Test
-    public void testExec_geographic_radians() {
+    @Test(expected = ExprEvalException.class)
+    public void testExec_geographic_radians_exception() {
 
         NodeValue v1 = NodeValue.makeNode("Point(11.41 53.63)", WKTDatatype.INSTANCE);
         NodeValue v2 = NodeValue.makeNode("Point(11.57 48.13)", WKTDatatype.INSTANCE);
         NodeValue v3 = NodeValue.makeNode(NodeFactory.createURI(Unit_URI.RADIAN_URL));
         DistanceFF instance = new DistanceFF();
-        double expResult = 0.096034;
+        double result = instance.exec(v1, v2, v3).getDouble();
+    }
+
+    /**
+     * Test of exec method, of class DistanceFF.
+     * Geographic SRS (CRS84 default WKT) with linear units should use great circle distance,
+     * as per GeoSPARQL 1.1
+     */
+    @Test
+    public void testExec_geographic_kilometres() {
+
+        NodeValue v1 = NodeValue.makeNode("Point(11.41 53.63)", WKTDatatype.INSTANCE);
+        NodeValue v2 = NodeValue.makeNode("Point(11.57 48.13)", WKTDatatype.INSTANCE);
+        NodeValue v3 = NodeValue.makeNode(NodeFactory.createURI(Unit_URI.KILOMETRE_URN));
+        DistanceFF instance = new DistanceFF();
+        double expResult = 611.6755;
         double result = instance.exec(v1, v2, v3).getDouble();
         assertEquals(expResult, result, 0.0001);
     }
 
     /**
      * Test of exec method, of class DistanceFF.
+     * Geographic SRS (EPSG:4326) with linear units should use great circle distance,
+     * as per GeoSPARQL 1.1.
      */
-    @Test(expected = ExprEvalException.class)
-    public void testExec_geographic_metres_exception() {
+    @Test
+    public void testExec_geographic_kilometres_epsg4326() {
 
-        NodeValue v1 = NodeValue.makeNode("Point(11.41 53.63)", WKTDatatype.INSTANCE);
-        NodeValue v2 = NodeValue.makeNode("Point(11.57 48.13)", WKTDatatype.INSTANCE);
+        NodeValue v1 = NodeValue.makeNode("<http://www.opengis.net/def/crs/EPSG/0/4326> POINT(10.0 20.0)", WKTDatatype.INSTANCE);
+        NodeValue v2 = NodeValue.makeNode("<http://www.opengis.net/def/crs/EPSG/0/4326> POINT(10.0 21.0)", WKTDatatype.INSTANCE);
         NodeValue v3 = NodeValue.makeNode(NodeFactory.createURI(Unit_URI.KILOMETRE_URN));
         DistanceFF instance = new DistanceFF();
+        double expResult = 109.5057;
         double result = instance.exec(v1, v2, v3).getDouble();
+        assertEquals(expResult, result, 0.0001);
     }
 
     /**
@@ -139,7 +158,7 @@ public class DistanceFFTest {
      */
     @Test(expected = ExprEvalException.class)
     public void testExec_conversion_exception_units() {
-        // Still receive an expection as the units of v1 and v3 don't align.
+        // Still receive an exception: SRS transform disabled, so geographic v1 cannot transform projected v2.
         GeoSPARQLConfig.allowGeometrySRSTransformation(false);     // Disable default config.
         NodeValue v1 = NodeValue.makeNode("Point(11.57 48.13)", WKTDatatype.INSTANCE);
         NodeValue v2 = NodeValue.makeNode("<http://www.opengis.net/def/crs/EPSG/0/27700> POINT(90 60)", WKTDatatype.INSTANCE);


### PR DESCRIPTION
GitHub issue resolved #3320

Pull request Description:

This PR supports computing distance with linear units. To do this we make use of the great circle... [DistanceFF.java](https://github.com/apache/jena/compare/main...ThomasThelen:jena:issue_3320?expand=1#diff-ee2b69cbd13171218d2817f079b37aa43b65fb27e7e7a93540a6153b247bfbc9) currently hardcodes the distance to be Euclidean however, the generic [distance](https://github.com/apache/jena/blob/bd2d36dfdb06dca5b3249866c4e844a98d1db450/jena-geosparql/src/main/java/org/apache/jena/geosparql/implementation/GeometryWrapper.java#L656) method already has routing to select the appropriate distance function (as per the reporting ticket). The comment on the changed line refers to  geosparql 1.0 _only supporting euclidean distances_! With Geosparql 1.1 we can now support others so I believe this change is in line with the spec.

I don't _think_ we need to do any doc updates for this; I don't see any language about different unit support and this is the least restrictive so I think we're good there.

----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
