### PR TITLE
GH-1467 Use a dashed 'primary' color instead of 'warning' during file…

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Upload.vue
+++ b/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Upload.vue
@@ -167,7 +167,7 @@
                   <template #cell(status)="data">
                     <div class="progress">
                       <div
-                        :class="`progress-bar bg-${getFileStatus(data.item)}`"
+                        :class="['progress-bar', `bg-${getFileStatus(data.item)}`, { 'progress-bar-striped': data.item.active, 'progress-bar-animated': data.item.active }]"
                         :style="`width: ${data.item.progress}%`"
                         :aria-valuenow="`${data.item.progress}`"
                         aria-valuemin="0"
@@ -384,7 +384,7 @@ export default {
         return 'success'
       }
       if (file.active) {
-        return 'warning'
+        return 'primary'
       }
       return ''
     },


### PR DESCRIPTION
GitHub issue resolved #1467 

Pull request Description:

This PR changes the styling of the upload progress bar in Fuseki. The warning color was previously being used; the bar is now 'primary' and striped, as per the reporting ticket. There were no tests or documentation updates related to this change.

Here's a quick demo of how it looks now.

https://github.com/user-attachments/assets/b28e944b-5ef0-4e0e-acc9-3d255ce7d245



----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
