### PR TITLE
GH 1361 Respect the filterFunctors flag during backward chaining

### DIFF
--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/GenericRuleReasoner.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/GenericRuleReasoner.java
@@ -387,6 +387,7 @@ public class GenericRuleReasoner extends FBRuleReasoner {
         } else if (mode == BACKWARD) {
             graph = new LPBackwardRuleInfGraph(this, getBruleStore(), data, schemaArg);
             ((LPBackwardRuleInfGraph)graph).setTraceOn(traceOn);
+            ((LPBackwardRuleInfGraph)graph).setFunctorFiltering(filterFunctors);
         } else {
             List<Rule> ruleSet = ((FBRuleInfGraph)schemaArg).getRules();
             FBRuleInfGraph fbgraph = new FBRuleInfGraph(this, ruleSet, schemaArg);

--- a/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/LPBackwardRuleInfGraph.java
+++ b/jena-core/src/main/java/org/apache/jena/reasoner/rulesys/LPBackwardRuleInfGraph.java
@@ -58,6 +58,9 @@ public class LPBackwardRuleInfGraph extends BaseInfGraph implements BackwardRule
     /** Cache of temporary property values inferred through getTemp calls */
     protected TempNodeCache tempNodecache;
 
+    /** Flag, if true then functor-valued literals are filtered from find results */
+    protected boolean filterFunctors = true;
+
     static Logger logger = LoggerFactory.getLogger(LPBackwardRuleInfGraph.class);
 
 //  =======================================================================
@@ -172,7 +175,11 @@ public class LPBackwardRuleInfGraph extends BaseInfGraph implements BackwardRule
         if (continuation != null) {
             result = result.andThen(continuation.find(pattern));
         }
-        return result.filterDrop(Functor.acceptFilter);
+        if (filterFunctors) {
+            return result.filterDrop(Functor.acceptFilter);
+        } else {
+            return result;
+        }
     }
 
     /**
@@ -258,6 +265,14 @@ public class LPBackwardRuleInfGraph extends BaseInfGraph implements BackwardRule
         } else {
             return derivations.getAll(t);
         }
+    }
+
+    /**
+     * Set to true to cause functor-valued literals to be dropped from rule output.
+     * Default is true.
+     */
+    public void setFunctorFiltering(boolean param) {
+        filterFunctors = param;
     }
 
     /**

--- a/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestGenericRules.java
+++ b/jena-core/src/test/java/org/apache/jena/reasoner/rulesys/test/TestGenericRules.java
@@ -326,6 +326,33 @@ public class TestGenericRules extends TestCase {
     }
 
     /**
+     * Test that functor filtering is honored in backward mode.
+     */
+    public void testBackwardFunctorFilter() {
+        Graph data = createGraphForTest();
+        data.add(Triple.create(a, r, b));
+        data.add(Triple.create(a, p, s));
+        List<Rule> rules = Rule.parseRules( "[r0: (?x q func(?y, ?z)) <- (?x r ?y) (?x p ?z)]" );
+        GenericRuleReasoner reasoner = (GenericRuleReasoner)GenericRuleReasonerFactory.theInstance().create(null);
+        reasoner.setRules(rules);
+        reasoner.setMode(GenericRuleReasoner.BACKWARD);
+
+        // Default: functors are filtered out
+        InfGraph infgraph = reasoner.bind(data);
+        TestUtil.assertIteratorValues(this,
+              infgraph.find(null, q, null), new Object[] {
+              } );
+
+        // With filtering disabled: functor triples should be visible
+        reasoner.setFunctorFiltering(false);
+        infgraph = reasoner.bind(data);
+        TestUtil.assertIteratorValues(this,
+              infgraph.find(null, q, null), new Object[] {
+                  Triple.create(a, q, Functor.makeFunctorNode("func", new Node[]{b, s}))
+              } );
+    }
+
+    /**
      * Test recursive rules involving functors
      * May lock up in there is a bug.
      */


### PR DESCRIPTION
GitHub issue resolved #1361 

Pull request Description:

#1361 mentions a bug where the filtered function flag wasn't being respected when backward chaining. The author fortunately outlined the places in the forward chaining path where it's respected - so adding them to the backward path was fairly straight forward. _This shouldn't have any weird side effects_ but I haven't used the reasoner with custom filters before looking into this ticket.

In terms of testing I added a unit test that checks the filter present/absent based on the new boolean flag. If you'd like this unit test to be split into two, just let me know and I'll push another commit with the changes.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
