### PR TITLE
GH 1868 zero-length paths must not match absent nodes

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/P_Alt.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/P_Alt.java
@@ -24,9 +24,15 @@ package org.apache.jena.sparql.path;
 import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 public class P_Alt extends P_Path2 {
+    private final boolean hasZeroLength;
+
     public P_Alt(Path p1, Path p2) {
         super(p1, p2);
+        this.hasZeroLength = p1.hasZeroLengthComponent() || p2.hasZeroLengthComponent();
     }
+
+    @Override
+    public boolean hasZeroLengthComponent() { return hasZeroLength; }
 
     @Override
     public void visit(PathVisitor visitor) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/P_FixedLength.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/P_FixedLength.java
@@ -43,6 +43,9 @@ public class P_FixedLength extends P_Path1 {
     }
 
     @Override
+    public boolean hasZeroLengthComponent() { return count == 0; }
+
+    @Override
     public int hashCode() {
         return hashFixedLength ^ (int)count ^ getSubPath().hashCode();
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/P_Inverse.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/P_Inverse.java
@@ -24,9 +24,15 @@ package org.apache.jena.sparql.path;
 import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 public class P_Inverse extends P_Path1 {
+    private final boolean hasZeroLength;
+
     public P_Inverse(Path p) {
         super(p);
+        this.hasZeroLength = p.hasZeroLengthComponent();
     }
+
+    @Override
+    public boolean hasZeroLengthComponent() { return hasZeroLength; }
 
     @Override
     public void visit(PathVisitor visitor) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/P_Mod.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/P_Mod.java
@@ -62,6 +62,9 @@ public class P_Mod extends P_Path1 {
         return false;
     }
 
+    @Override
+    public boolean hasZeroLengthComponent() { return min == 0 || min == UNSET; }
+
     public boolean isFixedLength() {
         return max == min && min >= 0;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/P_Seq.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/P_Seq.java
@@ -24,10 +24,15 @@ package org.apache.jena.sparql.path ;
 import org.apache.jena.sparql.util.NodeIsomorphismMap ;
 
 public class P_Seq extends P_Path2 {
+    private final boolean hasZeroLength;
 
     public P_Seq(Path p1, Path p2) {
         super(p1, p2) ;
+        this.hasZeroLength = p1.hasZeroLengthComponent() && p2.hasZeroLengthComponent();
     }
+
+    @Override
+    public boolean hasZeroLengthComponent() { return hasZeroLength; }
 
     @Override
     public void visit(PathVisitor visitor) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/P_ZeroOrMore1.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/P_ZeroOrMore1.java
@@ -41,6 +41,9 @@ public class P_ZeroOrMore1 extends P_Path1 {
     }
 
     @Override
+    public boolean hasZeroLengthComponent() { return true; }
+
+    @Override
     public void visit(PathVisitor visitor) {
         visitor.visit(this) ;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/P_ZeroOrMoreN.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/P_ZeroOrMoreN.java
@@ -41,6 +41,9 @@ public class P_ZeroOrMoreN extends P_Path1 {
     }
 
     @Override
+    public boolean hasZeroLengthComponent() { return true; }
+
+    @Override
     public void visit(PathVisitor visitor) {
         visitor.visit(this) ;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/P_ZeroOrOne.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/P_ZeroOrOne.java
@@ -41,6 +41,9 @@ public class P_ZeroOrOne extends P_Path1 {
     }
 
     @Override
+    public boolean hasZeroLengthComponent() { return true; }
+
+    @Override
     public void visit(PathVisitor visitor) {
         visitor.visit(this) ;
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/Path.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/Path.java
@@ -29,4 +29,7 @@ public interface Path
     public void visit(PathVisitor visitor) ;
     public boolean equalTo(Path path2, NodeIsomorphismMap isoMap) ;
     public String toString(Prologue prolog) ;
+
+    // Return true if this path can match in zero steps
+    public default boolean hasZeroLengthComponent() { return false; }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/path/PathLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/path/PathLib.java
@@ -132,7 +132,7 @@ public class PathLib
 
         // Both constants.
         if ( !Var.isVar(s) && !Var.isVar(o) )
-            return evalGroundedPath(binding, graph, s, path, o, execCxt);
+            return evalGroundedPath(binding, graph, s, path, o, path.hasZeroLengthComponent(), execCxt);
 
         // One variable, one constant
         if ( Var.isVar(s) ) {
@@ -164,7 +164,7 @@ public class PathLib
     // Subject and object are nodes.
     private static QueryIterator evalGroundedPath(Binding binding,
                                                   Graph graph, Node subject, Path path, Node object,
-                                                  ExecutionContext execCxt) {
+                                                  boolean pathHasZeroLength, ExecutionContext execCxt) {
         Iterator<Node> iter = PathEval.eval(graph, subject, path, execCxt.getContext()) ;
         // Now count the number of matches.
 
@@ -174,6 +174,12 @@ public class PathLib
             if ( n.sameValueAs(object) )
                 count++ ;
         }
+
+        // SPARQL requires zero-length path endpoints to exist in nodes(G); suppress spurious
+        // zero-step matches when subject is absent from the active graph.
+        if ( count > 0 && subject.sameValueAs(object)
+                && pathHasZeroLength && !isNodeInGraph(graph, subject) )
+            count = 0;
 
         return new QueryIterYieldN(count, binding, execCxt) ;
     }
@@ -296,5 +302,11 @@ public class PathLib
         iter = Iter.filter(iter, filter) ;
         long x = Iter.count(iter) ;
         return (int)x ;
+    }
+
+    /** Return true if {@code node} appears as a subject or object in {@code graph}. */
+    private static boolean isNodeInGraph(Graph graph, Node node) {
+        return graph.contains(node, Node.ANY, Node.ANY)
+            || graph.contains(Node.ANY, Node.ANY, node);
     }
 }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPathQuery.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/path/TestPathQuery.java
@@ -21,12 +21,16 @@
 
 package org.apache.jena.sparql.path;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 import org.apache.jena.atlas.lib.StrUtils;
 import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.GraphMemFactory;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.riot.Lang;
@@ -83,6 +87,76 @@ public class TestPathQuery {
         // Same results for the test data, not in general.
         String qsExpected = "PREFIX : <http://example/> SELECT ?s ?o { { ?s :p ?o } UNION { ?s :p [:p ?o]} }";
         test(graph1, qsPath, qsExpected);
+    }
+
+    @Test public void testZeroPath_emptyGraph_01() {
+        // ?v <p>{0} ?v with VALUES ?v {1} on empty graph. Should be 0 rows returned.
+        String qs = "SELECT * WHERE { VALUES ?v { 1 } ?v <http://example.com/p>{0} ?v }";
+        assertEquals(0, rowCount(GraphMemFactory.createDefaultGraph(), qs));
+    }
+
+    @Test public void testZeroPath_emptyGraph_02() {
+        // ?v <p>? ?v with VALUES ?v {1} on empty graph. Should be be 0 rows returned.
+        String qs = "SELECT * WHERE { VALUES ?v { 1 } ?v <http://example.com/p>? ?v }";
+        assertEquals(0, rowCount(GraphMemFactory.createDefaultGraph(), qs));
+    }
+
+    @Test public void testZeroPath_emptyGraph_03() {
+        // ?v <p>* ?v with VALUES ?v {1} on empty graph. Should be be 0 rows returned.
+        String qs = "SELECT * WHERE { VALUES ?v { 1 } ?v <http://example.com/p>* ?v }";
+        assertEquals(0, rowCount(GraphMemFactory.createDefaultGraph(), qs));
+    }
+
+    @Test public void testZeroPath_nodeInGraph_01() {
+        String qs = "PREFIX : <http://example/> SELECT * WHERE { VALUES ?v { :s } ?v <http://example.com/p>? ?v }";
+        assertEquals(1, rowCount(graph1, qs));
+    }
+
+    @Test public void testZeroPath_nodeInGraph_02() {
+        String qs = "PREFIX : <http://example/> SELECT * WHERE { VALUES ?v { :s } ?v <http://example.com/p>* ?v }";
+        assertEquals(1, rowCount(graph1, qs));
+    }
+
+    @Test public void testZeroPath_nodeInGraph_03() {
+        String qs = "PREFIX : <http://example/> SELECT * WHERE { VALUES ?v { :s } ?v <http://example.com/p>{0} ?v }";
+        assertEquals(1, rowCount(graph1, qs));
+    }
+
+    @Test public void testZeroPath_nodeAsObjectOnly_01() {
+        // Node is present only as an object in the graph.
+        // graph1 contains ":s :p 123", so 123 should appear only as an object.
+        String qs = "SELECT * WHERE { VALUES ?v { 123 } ?v <http://example.com/p>? ?v }";
+        assertEquals(1, rowCount(graph1, qs));
+    }
+
+    @Test public void testZeroPath_emptyGraph_04() {
+        // {0,3} has min=0 so it is a zero-length path.
+        String qs = "SELECT * WHERE { VALUES ?v { 1 } ?v <http://example.com/p>{0,3} ?v }";
+        assertEquals(0, rowCount(GraphMemFactory.createDefaultGraph(), qs));
+    }
+
+    @Test public void testZeroPath_emptyGraph_05() {
+        // p?|q has a zero-length branch.
+        String qs = "SELECT * WHERE { VALUES ?v { 1 } ?v (<http://example.com/p>?|<http://example.com/q>) ?v }";
+        assertEquals(0, rowCount(GraphMemFactory.createDefaultGraph(), qs));
+    }
+
+    @Test public void testNonZeroPath_selfLoop_returnsResult() {
+        // A non-zero-length path that reaches s from s via a self-loop
+        // must not be zeroed out by the zero-length fix.
+        Graph g = GraphMemFactory.createDefaultGraph();
+        g.add(Triple.create(
+            NodeFactory.createURI("http://example/s"),
+            NodeFactory.createURI("http://example/p"),
+            NodeFactory.createURI("http://example/s")));
+        String qs = "PREFIX : <http://example/> SELECT * WHERE { VALUES ?v { :s } ?v :p{1} ?v }";
+        assertEquals(1, rowCount(g, qs));
+    }
+
+    private long rowCount(Graph graph, String queryString) {
+        Query query = QueryFactory.create(queryString);
+        RowSet rs = QueryExec.graph(graph).query(query).select();
+        return RowSetOps.count(rs);
     }
 
     private void test(Graph graph12, String qsPath, String qsExpected) {


### PR DESCRIPTION
GitHub issue resolved #1868

Pull request Description:

This is a bit of an experimental path taken. Initially I had done this with a longer walking of the AST and realized that the performance hit would be too big because `evalGroundedPath` gets called on each binding.

Instead, the approach that I took here is to hardcode the zero length component state as part of the various path classes, culminating in the dispatch to [evalGroundedPath](https://github.com/apache/jena/compare/main...ThomasThelen:jena:issue_1868?expand=1#diff-ae05f150796221eeb88c0c8bd337eec22ced6a1cff4c2d28e2f80d1509ab2305R135). This should get called _once_ rather than the _n_ times for each row in my previous AST implementation. 

Happy to provide performance tests, address feedback, or close this if it's a bit far fetched.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
