### PR TITLE
GH-4043: fix(dboe): don't poison shared buffer on block slice

### DIFF
--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BlockAccessMapped.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BlockAccessMapped.java
@@ -151,13 +151,12 @@ public class BlockAccessMapped extends BlockAccessBase
             try {
                 // Need to put the alloc AND the slice inside a sync.
                 ByteBuffer segBuffer = allocSegment(seg);
-                // Slice from a cleared duplicate: never touches the shared
-                // segment buffer's position/limit, and does not depend on them
-                // either. The old position/limit/slice/reset sequence could
-                // leave a shrunken limit on the shared buffer if anything threw
-                // before the reset, poisoning every later access to a higher
-                // block in the segment ("newPosition > limit").
-                ByteBuffer dst = segBuffer.duplicate().clear().slice(segOff, blockSize);
+                // Absolute slice: never mutates the shared segment buffer's
+                // position/limit. The old position/limit/slice/reset sequence
+                // shrank the shared buffer's limit; if anything threw before the
+                // reset, the limit stayed shrunk and every later access to a
+                // higher block in the segment failed ("newPosition > limit").
+                ByteBuffer dst = segBuffer.slice(segOff, blockSize);
                 // Extend block count when we allocate above end.
                 numFileBlocks = Math.max(numFileBlocks, id+1);
                 return dst;

--- a/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BlockAccessMapped.java
+++ b/jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BlockAccessMapped.java
@@ -149,20 +149,19 @@ public class BlockAccessMapped extends BlockAccessBase
 
         synchronized (this) {
             try {
-                // Need to put the alloc AND the slice/reset inside a sync.
+                // Need to put the alloc AND the slice inside a sync.
                 ByteBuffer segBuffer = allocSegment(seg);
-                // Now slice the buffer to get the ByteBuffer to return
-                segBuffer.position(segOff);
-                segBuffer.limit(segOff+blockSize);
-                ByteBuffer dst = segBuffer.slice();
-
-                // And then reset limit to max for segment.
-                segBuffer.limit(segBuffer.capacity());
+                // Slice from a cleared duplicate: never touches the shared
+                // segment buffer's position/limit, and does not depend on them
+                // either. The old position/limit/slice/reset sequence could
+                // leave a shrunken limit on the shared buffer if anything threw
+                // before the reset, poisoning every later access to a higher
+                // block in the segment ("newPosition > limit").
+                ByteBuffer dst = segBuffer.duplicate().clear().slice(segOff, blockSize);
                 // Extend block count when we allocate above end.
                 numFileBlocks = Math.max(numFileBlocks, id+1);
                 return dst;
-            } catch (IllegalArgumentException ex) {
-                // Shouldn't (ha!) happen because the second "limit" resets
+            } catch (RuntimeException ex) {
                 log.error("Id: "+id);
                 log.error("Seg="+seg);
                 log.error("Segoff="+segOff);

--- a/jena-db/jena-dboe-base/src/test/java/org/apache/jena/dboe/base/file/TS_File.java
+++ b/jena-db/jena-dboe-base/src/test/java/org/apache/jena/dboe/base/file/TS_File.java
@@ -35,6 +35,7 @@ import org.junit.platform.suite.api.Suite;
     , TestBlockAccessByteArray.class
     , TestBlockAccessDirect.class
     , TestBlockAccessMapped.class
+    , TestBlockAccessMappedSegmentState.class
 
     , TestBinaryDataMem.class
     , TestBinaryDataFileWriteBufferedMem.class

--- a/jena-db/jena-dboe-base/src/test/java/org/apache/jena/dboe/base/file/TestBlockAccessMappedSegmentState.java
+++ b/jena-db/jena-dboe-base/src/test/java/org/apache/jena/dboe/base/file/TestBlockAccessMappedSegmentState.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.dboe.base.file;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Field;
+import java.nio.MappedByteBuffer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.atlas.lib.FileOps;
+import org.apache.jena.dboe.ConfigTestDBOE;
+import org.apache.jena.dboe.base.block.Block;
+
+/**
+ * The shared per-segment {@link MappedByteBuffer} in {@link BlockAccessMapped}
+ * must never have its position/limit mutated by block access.
+ *
+ * <p>The previous implementation sliced blocks with a
+ * position/limit/slice/reset-limit sequence on the shared segment buffer. If
+ * anything threw between the limit-shrink and the reset (e.g. an
+ * {@link OutOfMemoryError} during {@code slice()}), the segment buffer was left
+ * with a shrunken limit and every later access to a higher block in that
+ * segment failed with {@code IllegalArgumentException: newPosition &gt; limit}
+ * from {@code Buffer.position(int)} - observed in production as persistent 500s
+ * on reads of a B+Tree index until restart. The fix slices with the absolute
+ * {@code slice(index, length)}, which never touches the shared buffer's state.
+ * These tests lock in that invariant.</p>
+ */
+public class TestBlockAccessMappedSegmentState {
+
+    private static final int BlockSize = 64;
+    private static int counter = 0;
+
+    private String filename;
+    private BlockAccessMapped file;
+
+    @BeforeEach public void before() {
+        filename = ConfigTestDBOE.getTestingDir() + "/test-segment-state-" + (counter++);
+        FileOps.deleteSilent(filename);
+        file = new BlockAccessMapped(filename, BlockSize);
+    }
+
+    @AfterEach public void after() {
+        file.close();
+        FileOps.deleteSilent(filename);
+    }
+
+    private Block writePatternBlock(int marker) {
+        Block b = file.allocate(BlockSize);
+        for ( int i = 0; i < BlockSize; i++ )
+            b.getByteBuffer().put(i, (byte)((marker + i) & 0xFF));
+        file.write(b);
+        return b;
+    }
+
+    private MappedByteBuffer segmentBuffer(int seg) throws Exception {
+        Field f = BlockAccessMapped.class.getDeclaredField("segments");
+        f.setAccessible(true);
+        MappedByteBuffer[] segments = (MappedByteBuffer[])f.get(file);
+        return segments[seg];
+    }
+
+    @Test
+    public void sharedSegmentBufferStateUntouchedByAccess() throws Exception {
+        final int numBlocks = 20;
+        Block[] blocks = new Block[numBlocks];
+        for ( int i = 0; i < numBlocks; i++ )
+            blocks[i] = writePatternBlock(i * 7);
+
+        // Interleave reads in an order that, with the old position/limit
+        // slicing, walked the shared buffer's position and limit up and down.
+        // End on a high block: the old implementation left position at that
+        // block's segment offset.
+        for ( int i = 0; i < numBlocks; i++ )
+            file.read(blocks[i].getId().longValue());
+        file.read(blocks[0].getId().longValue());
+        file.read(blocks[numBlocks - 1].getId().longValue());
+
+        MappedByteBuffer seg0 = segmentBuffer(0);
+        assertNotNull(seg0, "segment 0 should be mapped after block access");
+        System.out.printf("segment 0 after %d writes + %d reads: position=%d limit=%d capacity=%d%n",
+                          numBlocks, numBlocks + 2, seg0.position(), seg0.limit(), seg0.capacity());
+
+        // A shrunken limit is the "newPosition > limit" poisoning vector.
+        assertEquals(seg0.capacity(), seg0.limit(),
+                     "shared segment buffer limit was shrunk by block access - "
+                     + "an exception mid-access would poison all higher blocks in the segment");
+        assertEquals(0, seg0.position(),
+                     "shared segment buffer position was mutated by block access");
+    }
+
+    @Test
+    public void blockRoundTripAfterMixedAccess() {
+        final int numBlocks = 8;
+        Block[] written = new Block[numBlocks];
+        for ( int i = 0; i < numBlocks; i++ )
+            written[i] = writePatternBlock(i * 31);
+
+        for ( int i = 0; i < numBlocks; i++ ) {
+            Block back = file.read(written[i].getId().longValue());
+            assertEquals(0, back.getByteBuffer().position(), "returned block slice should start at position 0");
+            assertEquals(BlockSize, back.getByteBuffer().capacity(), "returned block slice capacity");
+            for ( int j = 0; j < BlockSize; j++ ) {
+                byte expected = (byte)((i * 31 + j) & 0xFF);
+                byte actual = back.getByteBuffer().get(j);
+                if ( expected != actual )
+                    System.out.printf("MISMATCH block=%d byte=%d expected=%02x actual=%02x%n",
+                                      i, j, expected, actual);
+                assertEquals(expected, actual,
+                             String.format("content mismatch: block=%d byte=%d", i, j));
+            }
+        }
+    }
+
+    /**
+     * Deterministic reproduction of the production failure.
+     *
+     * <p>Production stack: {@code IllegalArgumentException: newPosition > limit}
+     * from {@code Buffer.position(int)} inside {@code getByteBuffer} while
+     * reading a B+Tree node - every read of a high block in the segment kept
+     * failing (HTTP 500s) until restart. The poisoned state - a shrunken limit
+     * on the shared segment buffer - is what an asynchronous throwable (e.g.
+     * OOME) escaping the old position/limit/slice/reset-limit window left
+     * behind. The trigger itself cannot be provoked deterministically, so this
+     * test injects the resulting state by reflection and verifies reads still
+     * work. Against the old implementation this reproduces the production
+     * exception exactly.</p>
+     */
+    @Test
+    public void poisonedSegmentLimit_readsStillWork() throws Exception {
+        final int numBlocks = 8;
+        Block[] written = new Block[numBlocks];
+        for ( int i = 0; i < numBlocks; i++ )
+            written[i] = writePatternBlock(i * 13);
+
+        MappedByteBuffer seg0 = segmentBuffer(0);
+        seg0.limit(BlockSize); // block 0 only - every higher block is beyond the limit
+        System.out.printf("injected poisoned segment state: limit=%d capacity=%d%n",
+                          seg0.limit(), seg0.capacity());
+
+        // Old implementation: read of any block >= 1 threw
+        //   IllegalArgumentException: newPosition > limit: (segOff > 64)
+        for ( int i = numBlocks - 1; i >= 1; i-- ) {
+            Block back = file.read(written[i].getId().longValue());
+            for ( int j = 0; j < BlockSize; j++ )
+                assertEquals((byte)((i * 13 + j) & 0xFF), back.getByteBuffer().get(j),
+                             String.format("content mismatch after poisoning: block=%d byte=%d", i, j));
+        }
+        System.out.printf("all %d high blocks readable despite poisoned shared-buffer limit%n",
+                          numBlocks - 1);
+    }
+
+    @Test
+    public void returnedSlicesAreIndependent() {
+        Block b0 = writePatternBlock(1);
+        Block b1 = writePatternBlock(101);
+
+        Block r0 = file.read(b0.getId().longValue());
+        Block r1 = file.read(b1.getId().longValue());
+
+        // Moving one slice's position/limit must not disturb the other slice
+        // or the shared segment buffer behind them.
+        r0.getByteBuffer().position(BlockSize / 2);
+        r0.getByteBuffer().limit(BlockSize / 2);
+
+        assertEquals(0, r1.getByteBuffer().position(), "sibling slice position disturbed");
+        assertEquals(BlockSize, r1.getByteBuffer().limit(), "sibling slice limit disturbed");
+
+        Block again = file.read(b1.getId().longValue());
+        assertEquals((byte)((101) & 0xFF), again.getByteBuffer().get(0), "content after sibling slice mutation");
+    }
+}

--- a/jena-db/jena-dboe-base/src/test/java/org/apache/jena/dboe/base/file/TestBlockAccessMappedSegmentState.java
+++ b/jena-db/jena-dboe-base/src/test/java/org/apache/jena/dboe/base/file/TestBlockAccessMappedSegmentState.java
@@ -37,18 +37,15 @@ import org.apache.jena.dboe.base.block.Block;
 
 /**
  * The shared per-segment {@link MappedByteBuffer} in {@link BlockAccessMapped}
- * must never have its position/limit mutated by block access.
+ * must never have its position/limit mutated by block access (GH-4043).
  *
  * <p>The previous implementation sliced blocks with a
  * position/limit/slice/reset-limit sequence on the shared segment buffer. If
- * anything threw between the limit-shrink and the reset (e.g. an
- * {@link OutOfMemoryError} during {@code slice()}), the segment buffer was left
- * with a shrunken limit and every later access to a higher block in that
- * segment failed with {@code IllegalArgumentException: newPosition &gt; limit}
- * from {@code Buffer.position(int)} - observed in production as persistent 500s
- * on reads of a B+Tree index until restart. The fix slices with the absolute
- * {@code slice(index, length)}, which never touches the shared buffer's state.
- * These tests lock in that invariant.</p>
+ * anything threw between the limit-shrink and the reset, the segment buffer was
+ * left with a shrunken limit and every later access to a higher block in that
+ * segment failed with {@code IllegalArgumentException: newPosition &gt; limit}.
+ * The fix slices with the absolute {@code slice(index, length)}, which never
+ * touches the shared buffer's state. These tests lock in that invariant.</p>
  */
 public class TestBlockAccessMappedSegmentState {
 
@@ -102,8 +99,6 @@ public class TestBlockAccessMappedSegmentState {
 
         MappedByteBuffer seg0 = segmentBuffer(0);
         assertNotNull(seg0, "segment 0 should be mapped after block access");
-        System.out.printf("segment 0 after %d writes + %d reads: position=%d limit=%d capacity=%d%n",
-                          numBlocks, numBlocks + 2, seg0.position(), seg0.limit(), seg0.capacity());
 
         // A shrunken limit is the "newPosition > limit" poisoning vector.
         assertEquals(seg0.capacity(), seg0.limit(),
@@ -127,51 +122,11 @@ public class TestBlockAccessMappedSegmentState {
             for ( int j = 0; j < BlockSize; j++ ) {
                 byte expected = (byte)((i * 31 + j) & 0xFF);
                 byte actual = back.getByteBuffer().get(j);
-                if ( expected != actual )
-                    System.out.printf("MISMATCH block=%d byte=%d expected=%02x actual=%02x%n",
-                                      i, j, expected, actual);
                 assertEquals(expected, actual,
-                             String.format("content mismatch: block=%d byte=%d", i, j));
+                             String.format("content mismatch: block=%d byte=%d expected=%02x actual=%02x",
+                                           i, j, expected, actual));
             }
         }
-    }
-
-    /**
-     * Deterministic reproduction of the production failure.
-     *
-     * <p>Production stack: {@code IllegalArgumentException: newPosition > limit}
-     * from {@code Buffer.position(int)} inside {@code getByteBuffer} while
-     * reading a B+Tree node - every read of a high block in the segment kept
-     * failing (HTTP 500s) until restart. The poisoned state - a shrunken limit
-     * on the shared segment buffer - is what an asynchronous throwable (e.g.
-     * OOME) escaping the old position/limit/slice/reset-limit window left
-     * behind. The trigger itself cannot be provoked deterministically, so this
-     * test injects the resulting state by reflection and verifies reads still
-     * work. Against the old implementation this reproduces the production
-     * exception exactly.</p>
-     */
-    @Test
-    public void poisonedSegmentLimit_readsStillWork() throws Exception {
-        final int numBlocks = 8;
-        Block[] written = new Block[numBlocks];
-        for ( int i = 0; i < numBlocks; i++ )
-            written[i] = writePatternBlock(i * 13);
-
-        MappedByteBuffer seg0 = segmentBuffer(0);
-        seg0.limit(BlockSize); // block 0 only - every higher block is beyond the limit
-        System.out.printf("injected poisoned segment state: limit=%d capacity=%d%n",
-                          seg0.limit(), seg0.capacity());
-
-        // Old implementation: read of any block >= 1 threw
-        //   IllegalArgumentException: newPosition > limit: (segOff > 64)
-        for ( int i = numBlocks - 1; i >= 1; i-- ) {
-            Block back = file.read(written[i].getId().longValue());
-            for ( int j = 0; j < BlockSize; j++ )
-                assertEquals((byte)((i * 13 + j) & 0xFF), back.getByteBuffer().get(j),
-                             String.format("content mismatch after poisoning: block=%d byte=%d", i, j));
-        }
-        System.out.printf("all %d high blocks readable despite poisoned shared-buffer limit%n",
-                          numBlocks - 1);
     }
 
     @Test

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/base/file/BlockAccessMapped.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/base/file/BlockAccessMapped.java
@@ -156,20 +156,19 @@ public class BlockAccessMapped extends BlockAccessBase
 
         synchronized (this) {
             try {
-                // Need to put the alloc AND the slice/reset inside a sync.
+                // Need to put the alloc AND the slice inside a sync.
                 ByteBuffer segBuffer = allocSegment(seg) ;
-                // Now slice the buffer to get the ByteBuffer to return
-                segBuffer.position(segOff) ;
-                segBuffer.limit(segOff+blockSize) ;
-                ByteBuffer dst = segBuffer.slice() ;
-
-                // And then reset limit to max for segment.
-                segBuffer.limit(segBuffer.capacity()) ;
+                // Slice from a cleared duplicate: never touches the shared
+                // segment buffer's position/limit, and does not depend on them
+                // either. The old position/limit/slice/reset sequence could
+                // leave a shrunken limit on the shared buffer if anything threw
+                // before the reset, poisoning every later access to a higher
+                // block in the segment ("newPosition > limit").
+                ByteBuffer dst = segBuffer.duplicate().clear().slice(segOff, blockSize) ;
                 // Extend block count when we allocate above end.
                 numFileBlocks = Math.max(numFileBlocks, id+1) ;
                 return dst ;
-            } catch (IllegalArgumentException ex) {
-                // Shouldn't (ha!) happen because the second "limit" resets
+            } catch (RuntimeException ex) {
                 log.error("Id: "+id) ;
                 log.error("Seg="+seg) ;
                 log.error("Segoff="+segOff) ;

--- a/jena-tdb1/src/main/java/org/apache/jena/tdb1/base/file/BlockAccessMapped.java
+++ b/jena-tdb1/src/main/java/org/apache/jena/tdb1/base/file/BlockAccessMapped.java
@@ -158,13 +158,12 @@ public class BlockAccessMapped extends BlockAccessBase
             try {
                 // Need to put the alloc AND the slice inside a sync.
                 ByteBuffer segBuffer = allocSegment(seg) ;
-                // Slice from a cleared duplicate: never touches the shared
-                // segment buffer's position/limit, and does not depend on them
-                // either. The old position/limit/slice/reset sequence could
-                // leave a shrunken limit on the shared buffer if anything threw
-                // before the reset, poisoning every later access to a higher
-                // block in the segment ("newPosition > limit").
-                ByteBuffer dst = segBuffer.duplicate().clear().slice(segOff, blockSize) ;
+                // Absolute slice: never mutates the shared segment buffer's
+                // position/limit. The old position/limit/slice/reset sequence
+                // shrank the shared buffer's limit; if anything threw before the
+                // reset, the limit stayed shrunk and every later access to a
+                // higher block in the segment failed ("newPosition > limit").
+                ByteBuffer dst = segBuffer.slice(segOff, blockSize) ;
                 // Extend block count when we allocate above end.
                 numFileBlocks = Math.max(numFileBlocks, id+1) ;
                 return dst ;


### PR DESCRIPTION
GitHub issue resolved #4043 

Pull request Description:

## Problem

`BlockAccessMapped.getByteBuffer` slices a block out of the shared per-segment `MappedByteBuffer` by mutating that buffer's state:

```java
segBuffer.position(segOff);
segBuffer.limit(segOff + blockSize);   // shrinks the SHARED buffer's limit
ByteBuffer dst = segBuffer.slice();
segBuffer.limit(segBuffer.capacity()); // restore -- but NOT in a finally
```

The restore is not exception-safe. If any throwable escapes between the limit-shrink and the restore — realistically an `OutOfMemoryError` raised at the `slice()` allocation under heap pressure — the segment buffer is left with a shrunken limit. From then on, **every access to a higher block in that segment fails**:

```
java.lang.IllegalArgumentException: newPosition > limit: (6389760 > 2588672)
    at org.apache.jena.dboe.base.file.BlockAccessMapped.getByteBuffer(BlockAccessMapped.java:155)
    at org.apache.jena.dboe.base.file.BlockAccessMapped.read(BlockAccessMapped.java:93)
    ...
    at org.apache.jena.dboe.trans.bplustree.BPTreeNode.get(BPTreeNode.java:163)
```

The failure is self-sustaining: the poisoned `position(segOff)` call throws *before* reaching the line that would restore the limit. (An access to a block *below* the stuck limit happens to heal the buffer, but a hot B+Tree node above it keeps failing indefinitely.)

Observed in production as a TDB2 dataset returning HTTP 500 for every query touching one B+Tree index, persisting until JVM restart. The reported limit was not segment-aligned (`2588672 = 315 * 8192 + 8192`) — exactly a leftover slice limit, not a file-length artifact. This failure presents exactly like on-disk index corruption, but nothing on disk is wrong — which matters, because the standard advice for this signature (dump/reload the database) is unnecessary here; a restart clears it.

The existing in-code comment anticipated the hazard:

```java
// Shouldn't (ha!) happen because the second "limit" resets
```

## Fix

Slice through a cleared duplicate, using the absolute `slice(index, length)`:

```java
ByteBuffer dst = segBuffer.duplicate().clear().slice(segOff, blockSize);
```

This neither mutates nor depends on the shared buffer's position/limit, so the poisoned state can no longer be created — and reads keep working even if the buffer state were corrupted by other means.

Why not plain `slice(index, length)` on the shared buffer? Because `slice(index, length)` validates against the buffer's *current limit*, not its capacity — it would prevent creating the poison but still fail on an already-poisoned buffer. The cleared duplicate makes the access path fully state-independent.

Semantics of the returned slice are unchanged: position 0, limit and capacity = `blockSize`, big-endian byte order, view of the same backing region. Cost is one extra view object per block access (the previous code already allocated one view per access).

The `catch (IllegalArgumentException ...)` diagnostic block is widened to `RuntimeException`, since the absolute slice reports range violations as `IndexOutOfBoundsException`.

The identical code exists in TDB1 (`org.apache.jena.tdb1.base.file.BlockAccessMapped`) and is fixed the same way.

### Files changed

- `jena-db/jena-dboe-base/src/main/java/org/apache/jena/dboe/base/file/BlockAccessMapped.java`
- `jena-tdb1/src/main/java/org/apache/jena/tdb1/base/file/BlockAccessMapped.java`
- `jena-db/jena-dboe-base/src/test/java/org/apache/jena/dboe/base/file/TestBlockAccessMappedSegmentState.java` (new)
- `jena-db/jena-dboe-base/src/test/java/org/apache/jena/dboe/base/file/TS_File.java` (register new test class)

## Testing

The trigger (an asynchronous throwable inside a 3-line window) cannot be provoked deterministically in a test, so `TestBlockAccessMappedSegmentState` injects the state it leaves behind and verifies behavior at that boundary:

- `poisonedSegmentLimit_readsStillWork` — reflectively shrinks the shared segment buffer's limit (the state an escaped throwable left behind), then reads all higher blocks. Against the previous implementation this reproduces the production exception verbatim: `IllegalArgumentException: newPosition > limit: (448 > 64)`. With the fix, all blocks read back correctly.
- `sharedSegmentBufferStateUntouchedByAccess` — locks in the invariant that block access never mutates the shared buffer's position/limit. Fails against the previous implementation (which left `position` at the last-accessed segment offset).
- `returnedSlicesAreIndependent` — returned slices do not interfere with each other or with the shared buffer.
- `blockRoundTripAfterMixedAccess` — content round-trip through the new slice path.

Red/green verified: with the fix reverted, the new tests fail with the exact production signature; with the fix applied, they pass.

Full test suites pass with the change:

| Module | Tests | Result |
|---|---|---|
| jena-dboe-base | 160 | pass |
| jena-dboe-transaction | 117 | pass |
| jena-dboe-trans-data | 232 | pass |
| jena-tdb2 | 734 | pass |
| jena-tdb1 | 551 | pass (5 pre-existing skips) |

## Compatibility notes

- `ByteBuffer.slice(int, int)` requires JDK 13+; fine for the current Java baseline (21). A backport to older branches would need `((ByteBuffer)segBuffer.duplicate().clear()).position(segOff).limit(segOff+blockSize).slice()` on a duplicate instead.
- No public API change; `getByteBuffer` is private and the returned slice is indistinguishable from before.


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
