### PR TITLE
GH-1998: Support more locales in the Fuseki docker image

### DIFF
--- a/jena-fuseki2/jena-fuseki-docker/Dockerfile
+++ b/jena-fuseki2/jena-fuseki-docker/Dockerfile
@@ -61,13 +61,21 @@ RUN ./download.sh --chksum sha1 "$JAR_URL"
 
 ## -- Make reduced Java JDK
 
-ARG JDEPS_EXTRA="jdk.crypto.cryptoki,jdk.crypto.ec"
+## Provides locale data. Jdeps does not detect it because of SPI, so add it here.
+ARG JDEPS_EXTRA="jdk.crypto.cryptoki,jdk.crypto.ec,jdk.localedata"
+
+## Optional: comma-separated list of locale language tags to keep from jdk.localedata,
+## e.g. "en,fr,de,fi". Leave empty to include all locales.
+ARG JDK_LOCALES=""
+
 RUN \
   JDEPS="$(jdeps --multi-release base --print-module-deps --ignore-missing-deps ${FUSEKI_JAR})"  && \
+  if [ -n "${JDK_LOCALES}" ] ; then LOCALE_OPT="--include-locales=${JDK_LOCALES}" ; else LOCALE_OPT="" ; fi && \
   jlink \
         --compress 2 --strip-debug --no-header-files --no-man-pages \
         --output "${JAVA_MINIMAL}" \
-        --add-modules "${JDEPS},${JDEPS_EXTRA}"
+        --add-modules "${JDEPS},${JDEPS_EXTRA}" \
+        ${LOCALE_OPT}
 
 ADD entrypoint.sh .
 ADD log4j2.properties .

--- a/jena-fuseki2/jena-fuseki-docker/README.md
+++ b/jena-fuseki2/jena-fuseki-docker/README.md
@@ -77,6 +77,19 @@ The default layout in the container is:
 | /fuseki/log4j2.properties | Logging configuration                    |
 | /fuseki/databases/ | Directory for a volume for persistent databases |
 
+## Locales
+
+The image includes locale data for _all_ locales so that features such as
+[ARQ collation](https://jena.apache.org/documentation/query/collation.html)
+work correctly for languages other than English.
+
+To reduce image size, restrict the build to a subset of locales with the
+`JDK_LOCALES` build argument and a comma-separated list of language tags to include:
+
+    docker-compose build --build-arg JENA_VERSION=5.3.0 --build-arg JDK_LOCALES=en,fr,de,fi
+
+Leave `JDK_LOCALES` unset (the default) to include every locale.
+
 ## Setting JVM arguments
 
 Use `JAVA_OPTIONS`:


### PR DESCRIPTION
GitHub issue resolved #1998 

Pull request Description:

This PR addresses the issue by going with @osma's proposed solution at the end of the issue thread. The only tricky part was including the locale information, but luckily the folks in the issue thread pinpointed how to do this. The gist is that `jdk.localedata` is now explicitly put in the jlink module list.

The main concern here is image size _because the default behavior is to include all locales_.

Here are two image builds: the first being the default case of including all locales vs he second which only has english.
```
     Name                                                              Disk Usage                   Image Size
fuseki:5.3.0-all                                   997c0b2b9c4f        318MB                          140MB
fuseki:5.3.0-en                                    14718521a9b4        297MB                          130MB
```

Demo

Here's an example of using the de locale and doing proper ordering
<img width="1667" height="804" alt="Screenshot 2026-07-08 at 7 47 29 AM" src="https://github.com/user-attachments/assets/50093af4-33d0-43dc-8f0c-8f51639da48f" />




----

 - [x] Tests are included.
 - [x] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
