### PR TITLE
GH-4058: Test RDF validity inside triple terms

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/NodeUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/NodeUtils.java
@@ -211,6 +211,21 @@ public class NodeUtils
      */
     public static boolean isDirLangString(Node n) { return Util.isDirLangString(n); }
 
+    /**
+     * Determines whether a triple is valid as a RDF statement.
+     * <p>
+     * This function reflects the fact that the {@link Triple} API is flexible in
+     * allowing any Node type in any position (including non-RDF node types like
+     * Variable) and as such not all Triples can be safely converted into Statements
+     * </p>
+     * @param triple Triple
+     * @return true if a valid as a statement
+     */
+    public static boolean isValidAsRDF(Triple triple) {
+        if ( triple == null )
+            return false;
+        return isValidAsRDF(triple.getSubject(), triple.getPredicate(), triple.getObject());
+    }
 
     /**
      * Determines whether a triple (as s/p/o) is valid as a RDF statement.
@@ -222,7 +237,7 @@ public class NodeUtils
      * @param s Subject
      * @param p Predicate
      * @param o Object
-     * @return True if a valid as a statement
+     * @return true if a valid as a statement
      */
     public static boolean isValidAsRDF(Node s, Node p, Node o) {
         if ( s == null || ( ! s.isBlank() && ! s.isURI() ) )
@@ -231,7 +246,28 @@ public class NodeUtils
             return false;
         if ( o == null || ( ! o.isBlank() && ! o.isURI() && ! o.isLiteral() && !o.isTripleTerm() ) )
             return false;
+
+        if ( o.isTripleTerm() ) {
+            Triple tt = o.getTriple();
+            return isValidAsRDF(tt.getSubject(), tt.getPredicate(), tt.getObject());
+        }
         return true;
+    }
+
+    /**
+     * Determines whether a quad is valid as a RDF statement.
+     * <p>
+     * This function reflects the fact that the {@link Triple} API is flexible in
+     * allowing any Node type in any position (including non-RDF node types like
+     * Variable) and as such not all quads can be safely converted into Statements
+     * </p>
+     * @param quad Quad
+     * @return true if a valid as a graph name and statement
+     */
+    public static boolean isValidAsRDF(Quad quad) {
+        if ( quad == null )
+            return false;
+        return isValidAsRDF(quad.getGraph(), quad.getSubject(), quad.getPredicate(), quad.getObject());
     }
 
     /**
@@ -239,12 +275,13 @@ public class NodeUtils
      * <p>
      * This function reflects the fact that the {@link Triple} API is flexible in
      * allowing any Node type in any position (including non-RDF node types like
-     * Variable) and as such not all Triples can be safely converted into Statements
+     * Variable) and as such not all quads can be safely converted into Statements
      * </p>
+     * @param g Graph
      * @param s Subject
      * @param p Predicate
      * @param o Object
-     * @return True if a valid as a statement
+     * @return true if a valid as a graph name and statement
      */
     public static boolean isValidAsRDF(Node g, Node s, Node p, Node o) {
         if ( g == null || ( ! g.isURI() && ! g.isBlank() ) )

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestAPI.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestAPI.java
@@ -71,7 +71,7 @@ public class TestAPI
     }
 
     @Test
-    public void test_API1() {
+    public void testSelect1() {
         String qs = "SELECT * {?s ?p ?o}";
         try (QueryExecution qExec = QueryExecution.model(m).query(qs).build()) {
             ResultSet rs = qExec.execSelect();
@@ -81,6 +81,38 @@ public class TestAPI
             Set<Statement> s1 = qr.getModel().listStatements().toSet();
             Set<Statement> s2 = m.listStatements().toSet();
             assertEquals(s1, s2);
+        }
+    }
+
+    @Test
+    public void testConstruct1() {
+
+        String qs = "CONSTRUCT {?s ?p ?o} WHERE { ?s ?p ?o }";
+        try (QueryExecution qExec = QueryExecution.model(m).query(qs).build()) {
+            Model m2 = qExec.execConstruct();
+            assertTrue(!m2.isEmpty(), () -> "No results");
+            assertTrue(m.isIsomorphicWith(m2), ()-> "Not isonorphic");
+        }
+    }
+
+    @Test
+    public void testConstructBad1() {
+        String qs =  """
+                PREFIX :     <http://example/>
+                PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+                CONSTRUCT {
+                    << 456 :p :o >> .
+                    ?x :p :o .
+                    :s ?x :o .
+                    :tt1 :p <<( ?x :c2 :c3 )>> .
+                    :tt2 :p <<( :c1 ?x :c3 )>> .
+                    :tt3 :p <<( :c1 :c2 <<( ?x :d2 :d3 )>> )>> .
+                 } WHERE { BIND(123 AS ?x) }
+                """;
+        // Bad triples in result. They should be filtered out.
+        try (QueryExecution qExec = QueryExecution.model(m).query(qs).build()) {
+            Model m2 = qExec.execConstruct();
+            assertTrue(m2.isEmpty(), () -> "Expected empty graph");
         }
     }
 


### PR DESCRIPTION
GitHub issue resolved #4058

Pull request Description:

`NodeUtils.isValidAsRDF` wasn't looking inside triple terms.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
