### PR TITLE
GH-4065: Reset TDB1 internal state before running clean start tests

### DIFF
--- a/jena-tdb1/src/test/java/org/apache/jena/tdb1/TestTDB1Factory.java
+++ b/jena-tdb1/src/test/java/org/apache/jena/tdb1/TestTDB1Factory.java
@@ -41,18 +41,20 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("removal")
 public class TestTDB1Factory
 {
-    String DIR = ConfigTest.getCleanDir() ;
+    private String DIR;
 
-    static Quad quad1 = SSE.parseQuad("(_ <s> <p> 1)") ;
-    static Quad quad2 = SSE.parseQuad("(_ <s> <p> 1)") ;
+    static final Quad quad1 = SSE.parseQuad("(_ <s> <p> 1)") ;
+    static final Quad quad2 = SSE.parseQuad("(_ <s> <p> 1)") ;
 
     @BeforeEach
     public void before() {
-        TDBInternal.reset();
+        DIR = ConfigTest.getCleanDir()+"/TestTDB1Factory";
         FileOps.clearDirectory(DIR);
+        TDBInternal.reset();
     }
 
-    @AfterEach     public void after() {
+    @AfterEach
+    public void after() {
         TDBInternal.reset();
         FileOps.clearDirectory(DIR);
     }
@@ -111,7 +113,7 @@ public class TestTDB1Factory
 
     @Test public void testTDBFresh01() {
         boolean b = TDB1Factory.inUseLocation(DIR) ;
-        assertFalse(b, "Expect false before any creation attempted") ;
+        assertFalse(b, "Expected false before any creation attempted") ;
     }
 
     @Test public void testTDBFresh02() {


### PR DESCRIPTION
GitHub issue resolved #4065

Another JUnit6 alignment  - this time, any OS.

----

 - [x] Tests are included.

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
