### PR TITLE
Enable squash-and-merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,6 +23,6 @@ github:
     - rdf
     - sparql
   enabled_merge_buttons:
-    squash: false
+    squash: true
     rebase: true
     merge: false


### PR DESCRIPTION
Rob - we're getting PRs from independent contributors and some of these accumulate extra commits from the review process.

Would you mind if "squash" was re-enabled?

The only way I know of to preserve the OP's contribution and name in the current setup, and have a clean history, is to retarget the PR to a repo branch, put the PR on that, pull the branch, squash it locally, then make a new PR. Doable but several steps.
