### PR TITLE
GH-2162: Return 400 for upload data parse error

### DIFF
--- a/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/DataUploader.java
+++ b/jena-fuseki2/jena-fuseki-core/src/main/java/org/apache/jena/fuseki/system/DataUploader.java
@@ -40,6 +40,7 @@ import org.apache.jena.atlas.web.ContentType;
 import org.apache.jena.fuseki.servlets.*;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.riot.RiotException;
 import org.apache.jena.riot.RiotParseException;
 import org.apache.jena.riot.lang.StreamRDFCounting;
 import org.apache.jena.riot.system.StreamRDF;
@@ -154,6 +155,8 @@ public class DataUploader {
             }
         }
         catch (ActionErrorException ex) { throw ex; }
+        // Parse error.
+        catch (RiotException ex)        { ServletOps.errorBadRequest(ex.getMessage()); }
         catch (Exception ex)            { ServletOps.errorOccurred(ex.getMessage()); }
         // Overall results.
         UploadDetails details = new UploadDetails(countingDest.count(), countingDest.countTriples(),countingDest.countQuads());

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFileUpload.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFileUpload.java
@@ -24,7 +24,9 @@ package org.apache.jena.fuseki.main;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.jena.atlas.iterator.Iter;
+import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.atlas.web.TypedInputStream;
+import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.http.HttpOp;
 import org.apache.jena.http.HttpRDF;
@@ -108,5 +110,15 @@ public class TestFileUpload  extends AbstractFusekiTest {
         DatasetGraph dsg = DSP.service(databaseURL()).GET();
         assertEquals(1, dsg.getDefaultGraph().size());
         assertEquals(2, dsg.getUnionGraph().size());
+    }
+
+    @Test
+    public void upload_gsp_bad_01() {
+        FileSender x = new FileSender(databaseURL());
+        x.add("D.ttl", "JUNK", "text/plain");
+
+        LogCtl.withLevel(Fuseki.actionLog, "FATAL", ()-> {
+            FusekiTestLib.expect400(()->x.send("POST"));
+        });
     }
 }


### PR DESCRIPTION
While checking #4052 (addressing #2162), I noticed that Fuseki returned HTTP 500 (server error) if there is a RIOT parse error.

This should be 400 (client error).

This PR is a server side change. It can be merged before or after 4052.

----

 - [x] Tests are included.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
