### PR TITLE
GH-4086: Fix typo in GHA for the maven build

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types:
       - opened
-      - synchonized
+      - synchronize
       - reopened
     branches:
       - 'main'


### PR DESCRIPTION
GitHub issue resolved #4086 

Pull request Description:

Quick PR that fixes a typo in one of the GHA's that does the maven build.

----

 - [ ] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
