### PR TITLE
GH-4084: Fix ByteBufferPool sizing in Fuseki's Jetty Server

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -50,6 +50,8 @@ import org.eclipse.jetty.ee11.servlet.FilterHolder;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.ErrorHandler;
@@ -473,8 +475,16 @@ public class JettyServer {
         maxThreads = Math.max(minThreads, maxThreads);
         // Args reversed: Jetty uses (max,min)
         threadPool = new QueuedThreadPool(maxThreads, minThreads);
-        Server server = new Server(threadPool);
+        // Server(ThreadPool) alone installs a default 64KB ArrayByteBufferPool; pass ours explicitly.
+        Server server = new Server(threadPool, null, newByteBufferPool());
         return server;
+    }
+
+    /** ByteBufferPool sized so its maximum pooled buffer capacity is at least
+     * {@link FusekiSystemConstants#jettyOutputBufferSize}. */
+    private static ByteBufferPool newByteBufferPool() {
+        int maxCapacity = FusekiSystemConstants.jettyOutputBufferSize;
+        return new ArrayByteBufferPool(0, 2048, maxCapacity, -1, -1, -1);
     }
 
     private static void serverAddConnectors(Server server, int port,  boolean loopback) {

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -58,6 +58,7 @@ import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.Scheduler;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.eclipse.jetty.xml.XmlConfiguration;
 import org.slf4j.Logger;

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -476,7 +476,7 @@ public class JettyServer {
         // Args reversed: Jetty uses (max,min)
         threadPool = new QueuedThreadPool(maxThreads, minThreads);
         // Server(ThreadPool) alone installs a default 64KB ArrayByteBufferPool; pass ours explicitly.
-        Server server = new Server(threadPool, null, newByteBufferPool());
+        Server server = new Server(threadPool, (Scheduler)null, newByteBufferPool());
         return server;
     }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -484,7 +484,7 @@ public class JettyServer {
      * {@link FusekiSystemConstants#jettyOutputBufferSize}. */
     private static ByteBufferPool newByteBufferPool() {
         int maxCapacity = FusekiSystemConstants.jettyOutputBufferSize;
-        return new ArrayByteBufferPool(0, 2048, maxCapacity, -1, -1, -1);
+        return new ArrayByteBufferPool(0, -1, maxCapacity, -1, -1, -1);
     }
 
     private static void serverAddConnectors(Server server, int port,  boolean loopback) {

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiSystemConstants.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiSystemConstants.java
@@ -55,7 +55,7 @@ public class FusekiSystemConstants {
      * Setting for HttpConfiguration.setOutputBufferSize (set in
      * {@link JettyLib#httpConfiguration}).
      */
-    public static final int jettyOutputBufferSize = 5 * 1024 * 1024;
+    public static final int jettyOutputBufferSize = 2 * 1024 * 1024;
 
     /**
      * JettyrRequest header size.

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
@@ -54,8 +54,11 @@ import org.apache.jena.sparql.exec.RowSet;
 import org.apache.jena.sparql.exec.http.GSP;
 import org.apache.jena.sparql.exec.http.QueryExecHTTP;
 import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.fuseki.main.sys.FusekiSystemConstants;
 import org.apache.jena.system.Txn;
 import org.apache.jena.update.UpdateExecution;
+import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
@@ -83,6 +86,14 @@ public class TestFusekiServerBuild {
             assertFalse(server.getHttpPort() == 0 );
             assertTrue(server.getHttpsPort() == -1 );
         } finally { server.stop(); }
+    }
+
+    @Test public void fuseki_build_byte_buffer_pool() {
+        FusekiServer server = FusekiServer.create().port(0).build();
+        Server jettyServer = server.getJettyServer();
+        ArrayByteBufferPool pool = jettyServer.getBean(ArrayByteBufferPool.class);
+        assertNotNull(pool);
+        assertTrue(pool.getMaxCapacity() >= FusekiSystemConstants.jettyOutputBufferSize);
     }
 
     // The port in "testing/jetty.xml" is 1077

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
@@ -58,6 +58,7 @@ import org.apache.jena.fuseki.main.sys.FusekiSystemConstants;
 import org.apache.jena.system.Txn;
 import org.apache.jena.update.UpdateExecution;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
+import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -94,6 +95,28 @@ public class TestFusekiServerBuild {
         ArrayByteBufferPool pool = jettyServer.getBean(ArrayByteBufferPool.class);
         assertNotNull(pool);
         assertTrue(pool.getMaxCapacity() >= FusekiSystemConstants.jettyOutputBufferSize);
+    }
+
+    @Test public void fuseki_build_byte_buffer_pool_no_bucket_acquire() {
+        FusekiServer server = FusekiServer.create().port(0).build();
+        Server jettyServer = server.getJettyServer();
+        ArrayByteBufferPool pool = jettyServer.getBean(ArrayByteBufferPool.class);
+
+        int size = FusekiSystemConstants.jettyOutputBufferSize;
+        RetainableByteBuffer.Mutable buffer = pool.acquire(size, true);
+        buffer.release();
+
+        assertTrue(pool.getNoBucketDirectAcquires().isEmpty());
+    }
+
+    @Test public void byte_buffer_pool_default_capacity_fails_no_bucket_check() {
+        ArrayByteBufferPool defaultPool = new ArrayByteBufferPool();
+        int size = FusekiSystemConstants.jettyOutputBufferSize;
+
+        RetainableByteBuffer.Mutable buffer = defaultPool.acquire(size, true);
+        buffer.release();
+
+        assertFalse(defaultPool.getNoBucketDirectAcquires().isEmpty());
     }
 
     // The port in "testing/jetty.xml" is 1077


### PR DESCRIPTION
Fuseki builds its Jetty `Server` with `new Server(threadPool)`, which wires in a
default `ArrayByteBufferPool` capped at 64KB. Fuseki configures a 5MB
`outputBufferSize`, so every output buffer exceeds the pool's max capacity and gets
discarded on release instead of reused, causing continuous DirectMemory churn under
load. Full analysis in #4084.

This fixes it in `JettyServer.jettyServer(...)`, the shared factory both
`JettyHttps.java` and `FusekiServer.java` call, so neither file needs changes.
Constructs an `ArrayByteBufferPool` sized to
`FusekiSystemConstants.jettyOutputBufferSize` and passes it into
`Server(ThreadPool, Scheduler, ByteBufferPool)` at construction time (adding the pool
via `addBean()` afterward doesn't work, since the default pool is already wired in
during construction).

Added a test asserting the built server's pool max capacity covers the configured
output buffer size. Full `jena-fuseki-main` suite passes (799/799).