### PR TITLE
Rename  UpdateExecBuilder dataset(Graph graph) to UpdateExecBuilder graph(Graph graph)

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/riot/lang/LabelToNode.java
+++ b/jena-arq/src/main/java/org/apache/jena/riot/lang/LabelToNode.java
@@ -49,7 +49,8 @@ public class LabelToNode extends MapWithScope<String, Node, Node>
     { return new LabelToNode(new FixedScopePolicy(), nodeAllocatorHash()); }
 
     /**
-     * Allocation from a single scope; just the label matters.  Use this policy if repeated runs must give identical allocations
+     * Allocation from a single scope; just the label matters.
+     * Use this policy if repeated runs must give identical allocations
      * @param seed Seed
      */
     public static LabelToNode createScopeByDocumentHash(UUID seed)
@@ -61,7 +62,7 @@ public class LabelToNode extends MapWithScope<String, Node, Node>
      * blank node allocation style but the map can grow to arbitrary size.
      * <p>
      * This was the policy up to Jena 2.10.0 but it occasionally ran into problems at
-     * very large scale because it generates and remembers a new UUIDs for new each
+     * very large scale because it generates and remembers a new UUID for new each
      * blank node. The policy changed to {@link #createScopeByDocumentHash} which
      * calculates the blank node label needed without needing to retain previous
      * allocations.

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExec.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/UpdateExec.java
@@ -34,11 +34,17 @@ public interface UpdateExec extends UpdateProcessor
         return UpdateExecDatasetBuilder.create().dataset(dataset);
     }
 
+    /** @deprecated Use {@link #graph(Graph)} */
+    @Deprecated(forRemoval = true)
+    public static UpdateExecBuilder dataset(Graph graph) {
+        return graph(graph);
+    }
+
     /**
      * Create a {@link UpdateExecBuilder} for a graph.
      * The update must not involved named graphs.
      */
-    public static UpdateExecBuilder dataset(Graph graph) {
+    public static UpdateExecBuilder graph(Graph graph) {
         DatasetGraph dsg = DatasetGraphFactory.wrap(graph);
         return UpdateExecDatasetBuilder.create().dataset(dsg);
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/TemplateLib.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/TemplateLib.java
@@ -78,13 +78,12 @@ public class TemplateLib {
 
                 List<Triple> tripleList = new ArrayList<>(triples.size());
                 for ( Triple triple : triples ) {
-                    Triple q = subst(triple, b, bNodeMap);
-                    if ( !q.isConcrete() || ! NodeUtils.isValidAsRDF(q.getSubject(), q.getPredicate(), q.getObject()) ) {
-                        // Log.warn(TemplateLib.class, "Unbound quad:
-                        // "+FmtUtils.stringForQuad(quad)) ;
+                    Triple triple2 = subst(triple, b, bNodeMap);
+                    if ( !triple2.isConcrete() || ! NodeUtils.isValidAsRDF(triple2.getSubject(), triple2.getPredicate(), triple2.getObject()) ) {
+                        // Log.warn(TemplateLib.class, "Unbound triple:"+FmtUtils.stringForTriple(triple)) ;
                         continue;
                     }
-                    tripleList.add(q);
+                    tripleList.add(triple2);
                 }
                 return tripleList.iterator();
             }
@@ -136,7 +135,6 @@ public class TemplateLib {
 
     /** Substitute into a triple, with rewriting of bNodes */
     public static Triple subst(Triple triple, Binding b, Map<Node, Node> bNodeMap) {
-        // Transfer to quads.
         Node s = triple.getSubject();
         Node p = triple.getPredicate();
         Node o = triple.getObject();

--- a/jena-arq/src/main/java/org/apache/jena/sparql/resultset/ResultsFormat.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/resultset/ResultsFormat.java
@@ -31,7 +31,7 @@ import org.apache.jena.sparql.util.TranslationTable;
  * The output formats for all query types.
  * Result sets, boolean graphs.
  * <p>
- * This does not include results sets as RDF is elsewhere which is provided for tests with {@link RDFInput} and {@link RDFOutput}.
+ * This does not include results sets as RDF. They are  provided for tests with {@link RDFInput} and {@link RDFOutput}.
  */
 
 public enum ResultsFormat {
@@ -67,7 +67,7 @@ public enum ResultsFormat {
     private final RDFFormat rdfFormat;
     //private final boolean supportsBoolean;
 
-    ResultsFormat(Lang resultSetLang, RDFFormat rdfFormat) {
+    private ResultsFormat(Lang resultSetLang, RDFFormat rdfFormat) {
         this.resultSetLang = resultSetLang;
         this.rdfFormat = rdfFormat;
 
@@ -136,6 +136,10 @@ public enum ResultsFormat {
         names.put("n-triples",   NT);
         names.put("ntriples",    NT);
         names.put("nt",          NT);
+
+        // Thrift/RDF
+        // Protobuf/RDF
+
 
         names.put("jsonld",      RDF_JSONLD) ;
         names.put("json-ld",     RDF_JSONLD) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/QueryExecUtils.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/QueryExecUtils.java
@@ -283,7 +283,6 @@ public class QueryExecUtils {
         return;
     }
 
-
     private static RuntimeException noFormatException(String msg) {
         return new ARQException(msg);
     }

--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/manifest/Manifest.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/manifest/Manifest.java
@@ -54,7 +54,7 @@ public class Manifest
 
     public static Manifest parse(String filenameOrURI) {
         Graph manifestRDF;
-        // Exceptions from @TestFactories are swallowed by JUnit5.
+        // Exceptions from @TestFactories are swallowed by JUnit
         try {
             manifestRDF = RDFParser.source(filenameOrURI).toGraph();
         } catch (RiotException ex) {

--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/manifest/ManifestProcessor.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/manifest/ManifestProcessor.java
@@ -36,10 +36,10 @@ import org.apache.jena.sparql.vocabulary.VocabTestQuery;
 import org.apache.jena.system.G;
 
 /**
- * Manifest to JUnit5 using {@link DynamicNode}.
+ * Manifest to JUnit using {@link DynamicNode}.
  * <p>
- * Each manifest file generates a JUnit5 {@link DynamicContainer}
- * and each test generates a JUnit5 {@link DynamicTest} in that
+ * Each manifest file generates a JUnit {@link DynamicContainer}
+ * and each test generates a JUnit {@link DynamicTest} in that
  * {@link DynamicContainer}.
  * <p>
  * Manifest files can contain other manifest files.

--- a/jena-arq/src/test/java/org/apache/jena/arq/junit/textrunner/ManifestHolder.java
+++ b/jena-arq/src/test/java/org/apache/jena/arq/junit/textrunner/ManifestHolder.java
@@ -68,7 +68,7 @@ class ManifestHolder {
             return x;
         } catch (RiotNotFoundException ex) {
             System.err.println("Not found: "+fn);
-            // Exceptions are swallowed by JUnit5.
+            // Exceptions are swallowed by JUnit
             throw new RiotNotFoundException("Manifest "+fn);
         } catch (TestSetupException ex) {
             System.exit(1);

--- a/jena-arq/src/test/java/org/apache/jena/rdf12/TestRDF12LangDirSyntax.java
+++ b/jena-arq/src/test/java/org/apache/jena/rdf12/TestRDF12LangDirSyntax.java
@@ -91,7 +91,7 @@ public class TestRDF12LangDirSyntax {
     /**
      * All tests, all details.
      * <p>
-     * These are then converted into parser tests and also output tests that get run by JUnit5.
+     * These are then converted into parser tests and also output tests that get run by JUnit.
      */
     private static Stream<OneTest> allTests() {
         return Stream.of(ntuplesTests(), turtleTests(), trigTests()).flatMap(x->x);

--- a/jena-arq/src/test/java/org/apache/jena/sparql/api/TestUpdateExecutionCancel.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/api/TestUpdateExecutionCancel.java
@@ -105,7 +105,7 @@ public class TestUpdateExecutionCancel {
 
         assertThrows(QueryCancelledException.class,()->
             UpdateExec
-                .dataset(graph)
+                .graph(graph)
                 // No-op delete followed by insert indirectly tests that timeout is applied to overall update request.
                 .update("DELETE { <s> <p> <o> } WHERE { ?a ?b ?c }; INSERT { <s> <p> <o> } WHERE { ?a ?b ?c . ?d ?e ?f . ?g ?h ?i . }")
                 .timeout(50, TimeUnit.MILLISECONDS)

--- a/jena-arq/src/test/java/org/apache/jena/sparql/graph/AbstractTestPrefixMappingX.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/graph/AbstractTestPrefixMappingX.java
@@ -34,7 +34,7 @@ import org.apache.jena.shared.PrefixMapping;
  * prefixMapping to be tested.
  */
 public abstract class AbstractTestPrefixMappingX {
-    // This is a copy of the jena-core class, converted to JUnit5.
+    // This is a copy of the jena-core class, converted to JUnit.
 
     public AbstractTestPrefixMappingX() {}
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -71,7 +71,6 @@ public class JettyServer {
     // Caution :
     //   there are small differences e.g. in building where order matters.
     //   Setting default (look for FusekiServerConstants)
-    //
 
     private static Logger LOG = LoggerFactory.getLogger("HTTP");
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiCoreInfo.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiCoreInfo.java
@@ -80,10 +80,10 @@ public class FusekiCoreInfo {
                 sb.append("  Access = ");
                 StringJoiner sj2 = new StringJoiner(", ", "[ ", " ]");
                 dap.getDataService().getEndpoints(operation).stream()
-                .map(Endpoint::getAuthPolicy)
-                .map(auth-> auth==null?"*":auth.toString())
-                .sorted()
-                .forEach(sj2::add);
+                    .map(Endpoint::getAuthPolicy)
+                    .map(auth-> auth==null?"*":auth.toString())
+                    .sorted()
+                    .forEach(sj2::add);
                 sb.append(sj2.toString());
             }
             FmtLog.info(log,sb.toString());


### PR DESCRIPTION
Tidying and one deprecation/rename:

`public static UpdateExecBuilder dataset(Graph graph)`
=>
`public static UpdateExecBuilder graph(Graph graph)`

----

 By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
