### PR TITLE
GH-3647: Allow 'uploading all' when loading into the default graph

### DIFF
--- a/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Upload.vue
+++ b/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Upload.vue
@@ -416,10 +416,18 @@ export default {
       }
     },
     validateForm () {
-      return this.validateGraphName() && this.validateFiles()
+      // Both are evaluated, so that the user sees every invalid field at once.
+      const isValidGraphName = this.validateGraphName()
+      const isValidFiles = this.validateFiles()
+      return isValidGraphName && isValidFiles
     },
     validateGraphName () {
       const graphName = this.$refs['dataset-graph-name'].value
+      // A blank graph name means the data is loaded into the the default graph.
+      if (!graphName || graphName.trim() === '') {
+        this.graphNameClasses = ['form-control']
+        return true
+      }
       const isValidGraphName = validateGraphName(graphName)
       const formValidationClass = isValidGraphName ? 'is-valid' : 'is-invalid'
       this.graphNameClasses = ['form-control', formValidationClass]

--- a/jena-fuseki2/jena-fuseki-ui/tests/e2e/specs/upload.cy.js
+++ b/jena-fuseki2/jena-fuseki-ui/tests/e2e/specs/upload.cy.js
@@ -84,6 +84,44 @@ describe('upload', function () {
           .should('have.attr', 'aria-valuenow', 0)
       })
   })
+  it('accepts a blank graph name, and uploads to the dataset', function () {
+    cy.intercept('POST', '/skosmos/data', { statusCode: 200 }).as('upload')
+    cy
+      .get('input[type=file]')
+      .selectFile({
+          contents: Cypress.Buffer.from('@prefix ex: <http://example.org/> .\n  ex:ABC a ex:DEF .'),
+          fileName: 'blank-graph.ttl',
+          lastModified: Date.now()
+        },
+        {
+          force: true
+        })
+    // Typing and then clearing the graph name must not leave the field in an error state.
+    cy
+      .get('#dataset-graph-name')
+      .type('https://example.org/graph')
+      .clear()
+      .should('not.have.class', 'is-invalid')
+    cy
+      .get('button.upload-files')
+      .click({ force: true })
+    cy
+      .wait('@upload')
+      .its('request.url')
+      .should('not.contain', 'graph=')
+    cy
+      .get('.progress')
+      .eq(0)
+      .find('.progress-bar')
+      .eq(0)
+      .should('have.text', '1/1')
+  })
+  it('rejects an invalid graph name', function () {
+    cy
+      .get('#dataset-graph-name')
+      .type('not a uri')
+      .should('have.class', 'is-invalid')
+  })
   it('displays the progress for success and failure', function () {
     // Intercept upload calls.
     // Fails every other upload.


### PR DESCRIPTION
GitHub issue resolved #3647 

Pull request Description:

This PR resolves an issue where loading all files at once without setting a named graph would be blocked. The core change is [here](https://github.com/apache/jena/compare/main...ThomasThelen:jena:issue_3647?expand=1#diff-5c4b981e8ffdf8daabe44fb7a996c02233675d32e553bcee21ed68cea55e4989R427), where we make the statement that empty graph names are valid names.

The change [here](https://github.com/apache/jena/compare/main...ThomasThelen:jena:issue_3647?expand=1#diff-5c4b981e8ffdf8daabe44fb7a996c02233675d32e553bcee21ed68cea55e4989R422) fixes a small issue that I ran acroess where the original code short circuits when `this.validateGraphName` is False, leaving the potential to miss the error from `this.validateFiles`. The logic leads to only one of two errors being shown. This is likely seen in the screenshot in the attached issue where, after clicking Upload All with no files, there should have been a second error shown.

As for why this wasn't affecting single file uploads... It doesn't look like the named graph name is getting gated (it gets watched by [this](https://github.com/ThomasThelen/jena/blob/c6c3fe5fbdd5cb527f7590763f61d40add43ced9/jena-fuseki2/jena-fuseki-ui/src/views/dataset/Upload.vue#L366) but submission isn't rejected)  when going that route. 

Example after this PR:


https://github.com/user-attachments/assets/94a718e3-515b-41c1-9c0c-e704a1848f5d


----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
