### PR TITLE
GH-4097: Support "fuseki --version"

### DIFF
--- a/jena-cmds/src/main/java/org/apache/jena/cmd/CmdGeneral.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/CmdGeneral.java
@@ -29,12 +29,10 @@ import org.apache.jena.atlas.io.IndentedWriter;
 public abstract class CmdGeneral extends CmdArgModule
 {
     protected ModGeneral modGeneral = new ModGeneral(this::printHelp);
-    protected ModVersion modVersion = new ModVersion(true);
 
     protected CmdGeneral(String[] argv) {
         super(argv);
         addModule(modGeneral);
-        addModule(modVersion);
     }
 
     @Override
@@ -46,17 +44,11 @@ public abstract class CmdGeneral extends CmdArgModule
     public boolean isVerbose() { return modGeneral.verbose; }
     public boolean isQuiet()   { return modGeneral.quiet; }
     public boolean isDebug()   { return modGeneral.debug; }
-    protected boolean help()      { return modGeneral.help; }
+    protected boolean help()   { return modGeneral.help; }
 
     final public void printHelp() {
         usage();
         throw new TerminationException(0);
-    }
-
-    @Override
-    protected void processModulesAndArgs() {
-        if ( modVersion.getVersionFlag() )
-            modVersion.printVersionAndExit();
     }
 
     public void add(ArgDecl argDecl, String argName, String msg) {

--- a/jena-cmds/src/main/java/org/apache/jena/cmd/CmdMain.java
+++ b/jena-cmds/src/main/java/org/apache/jena/cmd/CmdMain.java
@@ -43,8 +43,17 @@ public abstract class CmdMain extends CmdGeneral
     // gets a chance to create a logger.
     static { LogCtl.setLogging(); }
 
+    protected ModVersion modVersion = new ModVersion(true);
+
     protected CmdMain(String[] args) {
         super(args);
+        addModule(modVersion);
+    }
+
+    @Override
+    protected void processModulesAndArgs() {
+        if ( modVersion.getVersionFlag() )
+            modVersion.printVersionAndExit();
     }
 
     /** Run command - exit on failure */

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/RunFuseki.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/cmds/RunFuseki.java
@@ -23,6 +23,7 @@ package org.apache.jena.fuseki.main.cmds;
 
 import java.util.function.Consumer;
 
+import org.apache.jena.atlas.lib.Version;
 import org.apache.jena.cmd.CmdException;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.main.FusekiAbortException;
@@ -32,6 +33,7 @@ class RunFuseki {
     // This class wraps an entry point so that it can take control of logging setup.
     // This class does not depend via inheritance on any Jena code
     // and does not trigger Jena initialization.
+    //
     // FusekiLogging runs before any Jena code can trigger logging setup.
     //
     // Inheritance causes initialization in the super class first, before class
@@ -40,6 +42,14 @@ class RunFuseki {
     static { FusekiLogging.setLogging(); }
 
     public static void run(String[] args, Consumer<String[]> action) {
+        if ( args.length == 1) {
+            String arg = args[0];
+            if ( "--version".equals(arg) || "-version".equals(arg) ) {
+                Version.printVersion(System.out, "Fuseki", Version.versionForClass(Fuseki.class));
+                System.exit(0);
+            }
+        }
+
         try {
             action.accept(args);
         } catch (IllegalArgumentException | CmdException ex ) {

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/runner/FusekiArgs.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/runner/FusekiArgs.java
@@ -195,7 +195,7 @@ public class FusekiArgs extends CmdGeneral {
     // Execute a step for the argument handlers.
     private static void runArgsHandlers( List<? extends FusekiServerArgsHandler> argsHandlers, Consumer<FusekiServerArgsHandler> action) {
         for (FusekiServerArgsHandler argsHandler : argsHandlers) {
-            action.accept( argsHandler);
+            action.accept(argsHandler);
         }
     }
     // -- Argument handling


### PR DESCRIPTION
GitHub issue resolved #4097

Pull request Description:

This applies only to the Fuseki CLI commands (one of the four `Fuseki*Cmd` (#4036)).
It the arguments are exactly "--version", print the version and exit.
(Arguably, it should be any position).

This is done before any Fuseki initialization and before the argument setup is processed.

----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
