### PR TITLE
GH-4094: Allow the execution timestamp be set by context.

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryEngineBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryEngineBase.java
@@ -56,9 +56,9 @@ public abstract class QueryEngineBase implements OpEval, Closeable
         this(dsg, input, cxt);
         this.query = query;
         query.ensureResultVars();
+        dataset = prepareDataset(dsg, query);
         // Unoptimized so far.
         setOp(createOp(query));
-        dataset = prepareDataset(dsg, query);
     }
 
     private DatasetGraph prepareDataset(DatasetGraph originalDataset, Query query) {
@@ -96,8 +96,7 @@ public abstract class QueryEngineBase implements OpEval, Closeable
         // Ensure context setup - usually done in QueryExecutionBase
         // so it can be changed after initialization.
         if ( context == null )
-            context = Context.setupContextForDataset(context, dataset);
-        Context.setCurrentDateTimeIfUndef(context);
+            context = Context.setupContextForDataset(cxt, dataset);
         this.query = null;
         setOp(op);
     }
@@ -113,6 +112,12 @@ public abstract class QueryEngineBase implements OpEval, Closeable
         this.startBinding = input;
     }
 
+    // Call this after context is set.
+    private static void currentDateTime(Context context) {
+        if ( context != null )
+            Context.setCurrentDateTimeIfUndef(context);
+    }
+
     public Plan getPlan() {
         if ( plan == null )
             plan = createPlan();
@@ -120,6 +125,7 @@ public abstract class QueryEngineBase implements OpEval, Closeable
     }
 
     protected Plan createPlan() {
+        currentDateTime(context);
         // Decide the algebra to actually execute.
         Op op = queryOp;
         if ( !startBinding.isEmpty() ) {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryEngineBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/QueryEngineBase.java
@@ -97,7 +97,7 @@ public abstract class QueryEngineBase implements OpEval, Closeable
         // so it can be changed after initialization.
         if ( context == null )
             context = Context.setupContextForDataset(context, dataset);
-        Context.setCurrentDateTime(context);
+        Context.setCurrentDateTimeIfUndef(context);
         this.query = null;
         setOp(op);
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/QueryEngineMain.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/engine/main/QueryEngineMain.java
@@ -40,11 +40,11 @@ public class QueryEngineMain extends QueryEngineBase
     static public void register()       { QueryEngineRegistry.addFactory(factory) ; }
     static public void unregister()     { QueryEngineRegistry.removeFactory(factory) ; }
 
-    public QueryEngineMain(Op op, DatasetGraph dataset, Binding input, Context context)
-    { super(op, dataset, input, context) ; }
+    public QueryEngineMain(Op op, DatasetGraph dataset, Binding input, Context context) {
+        super(op, dataset, input, context);
+    }
 
-    public QueryEngineMain(Query query, DatasetGraph dataset, Binding input, Context context)
-    {
+    public QueryEngineMain(Query query, DatasetGraph dataset, Binding input, Context context) {
         super(query, dataset, input, context) ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDataset.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDataset.java
@@ -106,7 +106,6 @@ public class QueryExecDataset implements QueryExec
         this.timeout2 = timeout.overallTimeoutMillis();
         // See also query substitution handled in QueryExecBuilder
         this.initialBinding = initialToEngine;
-
         // Cancel signal may originate from e.g. an update execution.
         this.cancelSignal = Context.getOrSetCancelSignal(context);
 
@@ -114,7 +113,6 @@ public class QueryExecDataset implements QueryExec
     }
 
     private void init() {
-        Context.setCurrentDateTimeIfUndef(context);
         if ( query != null )
             context.put(ARQConstants.sysCurrentQuery, query);
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDataset.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/exec/QueryExecDataset.java
@@ -114,7 +114,7 @@ public class QueryExecDataset implements QueryExec
     }
 
     private void init() {
-        Context.setCurrentDateTime(context);
+        Context.setCurrentDateTimeIfUndef(context);
         if ( query != null )
             context.put(ARQConstants.sysCurrentQuery, query);
     }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngineBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateEngineBase.java
@@ -21,31 +21,27 @@
 
 package org.apache.jena.sparql.modify;
 
-import org.apache.jena.sparql.ARQConstants ;
 import org.apache.jena.sparql.core.DatasetGraph ;
 import org.apache.jena.sparql.util.Context ;
-import org.apache.jena.sparql.util.NodeFactoryExtra ;
 
 public abstract class UpdateEngineBase implements UpdateEngine
 {
     protected final DatasetGraph datasetGraph ;
     protected final Context context ;
 
-    public UpdateEngineBase(DatasetGraph datasetGraph, Context context)
-    {
+    public UpdateEngineBase(DatasetGraph datasetGraph, Context context) {
         this.datasetGraph = datasetGraph ;
         this.context = setupContext(context, datasetGraph) ;
     }
 
-    private Context setupContext(Context cxt, DatasetGraph dataset)
-    {
+    private Context setupContext(Context cxt, DatasetGraph dataset) {
         // The following setup is effectively the same as in QueryEngineBase
         Context result = cxt;
 
         if ( result == null )
             result = Context.setupContextForDataset(cxt, dataset);
 
-        result.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime()) ;
+        Context.setCurrentDateTimeIfUndef(result);
         return result ;
     }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorBase.java
@@ -53,7 +53,7 @@ public class UpdateProcessorBase implements UpdateProcessor
         this.request = request ;
         this.datasetGraph = datasetGraph ;
         this.context = context;
-        Context.setCurrentDateTime(this.context) ;
+        Context.setCurrentDateTimeIfUndef(this.context) ;
         this.factory = factory ;
         this.timeout = timeout;
         Context.getOrSetCancelSignal(this.context) ;

--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorStreamingBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/UpdateProcessorStreamingBase.java
@@ -26,8 +26,9 @@ import org.apache.jena.sparql.core.Prologue;
 import org.apache.jena.sparql.util.Context;
 import org.apache.jena.update.UpdateProcessorStreaming;
 
-/** Class to hold the general state of a update request execution.
- *  See query ExecutionContext
+/**
+ * Class to hold the general state of a update request execution.
+ * See query ExecutionContext
  */
 public class UpdateProcessorStreamingBase implements UpdateProcessorStreaming
 {
@@ -37,12 +38,11 @@ public class UpdateProcessorStreamingBase implements UpdateProcessorStreaming
     protected final UpdateEngine proc;
     protected final Prologue prologue;
 
-    public UpdateProcessorStreamingBase(DatasetGraph datasetGraph, Prologue prologue, Context context, UpdateEngineFactory factory)
-    {
+    public UpdateProcessorStreamingBase(DatasetGraph datasetGraph, Prologue prologue, Context context, UpdateEngineFactory factory) {
         this.datasetGraph = datasetGraph;
         this.prologue = prologue;
         this.context = context;
-        Context.setCurrentDateTime(this.context);
+        Context.setCurrentDateTimeIfUndef(this.context);
         proc = factory.create(datasetGraph, context);
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/util/Context.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/util/Context.java
@@ -445,8 +445,15 @@ public class Context {
         return context;
     }
 
+    /** Set the current time in the context, overwriting any previous setting */
     public static void setCurrentDateTime(Context context) {
         context.set(ARQConstants.sysCurrentTime, NodeFactoryExtra.nowAsDateTime());
+    }
+
+    /** Set the current time in the context if there is no setting */
+    public static void setCurrentDateTimeIfUndef(Context context) {
+        if ( ! context.isDefined(ARQConstants.sysCurrentTime) )
+            setCurrentDateTime(context);
     }
 
     public static AtomicBoolean getCancelSignal(Context context) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/TS_Engine.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/TS_Engine.java
@@ -28,6 +28,7 @@ import org.junit.platform.suite.api.Suite;
 @SelectClasses({
         TestQueryEngineMultiThreaded.class
       , TestQueryEngineFromContext.class
+      , TestQueryEngine.class
       , TestJsonEval.class
 })
 

--- a/jena-arq/src/test/java/org/apache/jena/sparql/engine/TestQueryEngine.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/engine/TestQueryEngine.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *   SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.apache.jena.sparql.engine;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.query.ARQ;
+import org.apache.jena.sparql.ARQConstants;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.exec.QueryExec;
+import org.apache.jena.sparql.sse.SSE;
+import org.apache.jena.sparql.util.Context;
+
+/** Tests for query setup and execution not covered by tests elsewhere */
+public class TestQueryEngine {
+
+    @Test public void fixed_now() {
+        String fixedNowStr = "'1970-01-01T00:00:00Z'^^xsd:dateTime";
+        String queryString =
+                "PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>\n"+
+                "ASK { FILTER ( NOW() = "+fixedNowStr+") }";
+        Node fixedNow = SSE.parseNode(fixedNowStr);
+        Context context = ARQ.getContext().copy();
+        context.set(ARQConstants.sysCurrentTime, fixedNow);
+        DatasetGraph dsg = DatasetGraphFactory.empty();
+
+        boolean result = QueryExec.dataset(dsg)
+                .query(queryString)
+                .context(context)
+                .ask();
+        assertTrue(result, "NOW() not the expected fixed setting");
+    }
+}


### PR DESCRIPTION
GitHub issue resolved #4094

Repeatable execution!

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
