### PR TITLE
GH-4084: ByteBufferPool test with Fuseki request

### DIFF
--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyHttps.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyHttps.java
@@ -75,7 +75,7 @@ public class JettyHttps {
                                           int httpPort, int httpsPort,
                                           int minThreads, int maxThreads) {
         // Server handling http and https.
-        Server jettyServer = server(keystore, certPassword, httpPort, httpsPort, minThreads, maxThreads);
+        Server jettyServer = createJettyServerWithConnectors(keystore, certPassword, httpPort, httpsPort, minThreads, maxThreads);
         if ( httpPort > 0 ) {
             // Redirect http to https.
             // Order matters. Check https and bounce if http as first choice.
@@ -89,7 +89,7 @@ public class JettyHttps {
     /** Build the server - http and https connectors.
      * If httpPort is -1, don't add http.
      */
-    private static Server server(String keystore, String certPassword, int httpPort, int httpsPort, int minThreads, int maxThreads) {
+    private static Server createJettyServerWithConnectors(String keystore, String certPassword, int httpPort, int httpsPort, int minThreads, int maxThreads) {
         Server server = JettyServer.jettyServer(minThreads, maxThreads);
         if ( httpPort > 0 ) {
             ServerConnector plainConnector = httpConnector(server, httpPort, httpsPort);

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/JettyServer.java
@@ -467,11 +467,10 @@ public class JettyServer {
 
     public static Server jettyServer(int minThreads, int maxThreads) {
         ThreadPool threadPool = null;
-        // Jetty 9.4 and 12.0 : the Jetty default is max=200, min=8
         if ( minThreads < 0 )
-            minThreads = 2;
+            minThreads = FusekiSystemConstants.jettyMinThreads;
         if ( maxThreads < 0 )
-            maxThreads = 20;
+            maxThreads = FusekiSystemConstants.jettyMaxThreads;
         maxThreads = Math.max(minThreads, maxThreads);
         // Args reversed: Jetty uses (max,min)
         threadPool = new QueuedThreadPool(maxThreads, minThreads);
@@ -484,6 +483,7 @@ public class JettyServer {
      * {@link FusekiSystemConstants#jettyOutputBufferSize}. */
     private static ByteBufferPool newByteBufferPool() {
         int maxCapacity = FusekiSystemConstants.jettyOutputBufferSize;
+        // int minCapacity, int factor, int maxCapacity, int maxBucketSize, long maxHeapMemory, long maxDirectMemory
         return new ArrayByteBufferPool(0, -1, maxCapacity, -1, -1, -1);
     }
 

--- a/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiSystemConstants.java
+++ b/jena-fuseki2/jena-fuseki-main/src/main/java/org/apache/jena/fuseki/main/sys/FusekiSystemConstants.java
@@ -78,4 +78,17 @@ public class FusekiSystemConstants {
      * support. (Jetty 12 default is 8k.)
      */
     public static final int jettyResponseHeaderSize = 16 * 1024;
+
+    // Jetty 9.4 and 12.0 : the Jetty default is max=200, min=8
+    // Fuseki operations are queries - expensive and longer lived - so limit the maximum resources by default.
+
+    /**
+     * Minimum Jetty server threads for the Jetty server of Fuseki.
+     */
+    public static final int jettyMinThreads = 4;
+
+    /**
+     * Maximum Jetty server threads for the Jetty server of Fuseki.
+     */
+    public static final int jettyMaxThreads = 20;
 }

--- a/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
+++ b/jena-fuseki2/jena-fuseki-main/src/test/java/org/apache/jena/fuseki/main/TestFusekiServerBuild.java
@@ -25,10 +25,13 @@ import static org.apache.jena.fuseki.main.FusekiTestLib.expect400;
 import static org.apache.jena.fuseki.main.FusekiTestLib.expect404;
 import static org.apache.jena.fuseki.main.FusekiTestLib.expectQuery400;
 import static org.apache.jena.fuseki.main.FusekiTestLib.expectQuery404;
+import static org.apache.jena.fuseki.main.sys.FusekiSystemConstants.jettyOutputBufferSize;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.ServletContext;
 import org.apache.jena.atlas.iterator.Iter;
@@ -37,6 +40,7 @@ import org.apache.jena.atlas.logging.LogCtl;
 import org.apache.jena.atlas.web.TypedInputStream;
 import org.apache.jena.fuseki.Fuseki;
 import org.apache.jena.fuseki.FusekiException;
+import org.apache.jena.fuseki.main.runner.FusekiRunner;
 import org.apache.jena.fuseki.server.DataAccessPointRegistry;
 import org.apache.jena.fuseki.server.DataService;
 import org.apache.jena.fuseki.server.Operation;
@@ -54,13 +58,11 @@ import org.apache.jena.sparql.exec.RowSet;
 import org.apache.jena.sparql.exec.http.GSP;
 import org.apache.jena.sparql.exec.http.QueryExecHTTP;
 import org.apache.jena.sparql.sse.SSE;
-import org.apache.jena.fuseki.main.sys.FusekiSystemConstants;
 import org.apache.jena.system.Txn;
 import org.apache.jena.update.UpdateExecution;
 import org.eclipse.jetty.io.ArrayByteBufferPool;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.server.Server;
-import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
 public class TestFusekiServerBuild {
@@ -91,32 +93,39 @@ public class TestFusekiServerBuild {
 
     @Test public void fuseki_build_byte_buffer_pool() {
         FusekiServer server = FusekiServer.create().port(0).build();
+        // Not started.
         Server jettyServer = server.getJettyServer();
         ArrayByteBufferPool pool = jettyServer.getBean(ArrayByteBufferPool.class);
         assertNotNull(pool);
-        assertTrue(pool.getMaxCapacity() >= FusekiSystemConstants.jettyOutputBufferSize);
+        assertTrue(pool.getMaxCapacity() >= jettyOutputBufferSize);
+
+        RetainableByteBuffer.Mutable buffer = pool.acquire(jettyOutputBufferSize, true);
+        assertNotNull(buffer);
+        buffer.release();
     }
 
-    @Test public void fuseki_build_byte_buffer_pool_no_bucket_acquire() {
-        FusekiServer server = FusekiServer.create().port(0).build();
-        Server jettyServer = server.getJettyServer();
-        ArrayByteBufferPool pool = jettyServer.getBean(ArrayByteBufferPool.class);
+    @Test public void fuseki_byte_buffer_pool_request() {
+        FusekiServer server = FusekiRunner.serverBasic().construct("--port=0", "--mem", "/ds").start();
+        try {
+            String URL = server.datasetURL("/ds");
 
-        int size = FusekiSystemConstants.jettyOutputBufferSize;
-        RetainableByteBuffer.Mutable buffer = pool.acquire(size, true);
-        buffer.release();
+            Server jettyServer = server.getJettyServer();
+            ArrayByteBufferPool pool = jettyServer.getBean(ArrayByteBufferPool.class);
+            assertTrue(pool.getMaxCapacity() >= jettyOutputBufferSize);
 
-        assertTrue(pool.getNoBucketDirectAcquires().isEmpty());
-    }
+            // Before - nothing in the pool for a Fuseki-sized direct ByteBuffer.
+            int poolSizeBefore = pool.poolFor(jettyOutputBufferSize, true/*direct*/).size();
+            assertEquals(0, poolSizeBefore);
 
-    @Test public void byte_buffer_pool_default_capacity_fails_no_bucket_check() {
-        ArrayByteBufferPool defaultPool = new ArrayByteBufferPool();
-        int size = FusekiSystemConstants.jettyOutputBufferSize;
+            // The request causes a new ArrayByteBufferPool item which is returned and then pooled.
+            QueryExec.service(URL).query("ASK{}").ask();
 
-        RetainableByteBuffer.Mutable buffer = defaultPool.acquire(size, true);
-        buffer.release();
-
-        assertFalse(defaultPool.getNoBucketDirectAcquires().isEmpty());
+            // After - one item in the pool
+            int poolSizeAfter = pool.poolFor(jettyOutputBufferSize, true).size();
+            assertEquals(1, poolSizeAfter);
+        } finally {
+            server.stop();
+        }
     }
 
     // The port in "testing/jetty.xml" is 1077


### PR DESCRIPTION
Convert a test to use Fuseki as the cause of buffer allocation.
Make constances for default min/max threads.



----

 - [x] Tests are included.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
