### PR TITLE
 GH-2340: Migrate fuseki geosparql unit tests to use one server per test.

### DIFF
--- a/jena-fuseki2/jena-fuseki-geosparql/pom.xml
+++ b/jena-fuseki2/jena-fuseki-geosparql/pom.xml
@@ -95,10 +95,9 @@
         <scope>runtime</scope>
       </dependency>
 
-      <!-- Tests are JUnit4 -->
       <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
         <scope>test</scope>
       </dependency>
 

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/cli/ArgsConfigTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/cli/ArgsConfigTest.java
@@ -21,37 +21,15 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 
 import org.apache.jena.riot.RDFFormat;
-import org.junit.After;
-import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  * @author Gerg
  */
 public class ArgsConfigTest {
-
-    public ArgsConfigTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
 
     /**
      * Test of getOutputFormat method, of class ArgsConfig.
@@ -232,23 +210,25 @@ public class ArgsConfigTest {
     /**
      * Test of getInputDelimiter method, of class ArgsConfig.
      */
-    @Test(expected = ParameterException.class)
+    @Test
     public void testGetInputDelimiter_reserved() {
         //System.out"getInputDelimiter_reserved");
         ArgsConfig args = new ArgsConfig();
 
         String[] argv = {"-i", "test.rdf", "-l", "|"};
-        JCommander.newBuilder()
-                .addObject(args)
-                .build()
-                .parse(argv);
+        assertThrows(ParameterException.class, () -> {
+            JCommander.newBuilder()
+                    .addObject(args)
+                    .build()
+                    .parse(argv);
 
-        String expResult = ",";
-        String result = args.getInputDelimiter();
+            String expResult = ",";
+            String result = args.getInputDelimiter();
 
-        ////System.out"Exp: " + expResult);
-        ////System.out"Res: " + result);
-        assertEquals(expResult, result);
+            ////System.out"Exp: " + expResult);
+            ////System.out"Res: " + result);
+            assertEquals(expResult, result);
+        });
     }
 
 }

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/datatypes/DatatypeControllerTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/datatypes/DatatypeControllerTest.java
@@ -17,37 +17,18 @@
  */
 package org.apache.jena.ext.io.github.galbiston.rdf_tables.datatypes;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.jena.datatypes.xsd.impl.XSDBaseNumericType;
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.ResourceFactory;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  * @author Greg Albiston
  */
 public class DatatypeControllerTest {
-
-    public DatatypeControllerTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
 
     /**
      * Test of createLiteral DateTime method, of class DataTypeExtract.

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/file/FileConverterTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/ext/io/github/galbiston/rdf_tables/file/FileConverterTest.java
@@ -17,7 +17,7 @@
  */
 package org.apache.jena.ext.io.github.galbiston.rdf_tables.file;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.net.URL;
@@ -31,7 +31,8 @@ import org.apache.jena.ext.io.github.galbiston.rdf_tables.datatypes.PrefixContro
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
-import org.junit.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -41,10 +42,7 @@ public class FileConverterTest {
 
     private static Model testModel;
 
-    public FileConverterTest() {
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() {
         URL u = FileConverterTest.class.getClassLoader().getResource("TestData.csv");
         // These URLs have the file name as an encoded string.
@@ -54,18 +52,6 @@ public class FileConverterTest {
         DatatypeController.addPrefixDatatypeURI("wkt", "http://www.opengis.net/ont/geosparql#wktLiteral");
         PrefixController.addPrefix("other", "http://example.org/other#");
         FileConverter.writeToModel(inputFile, testModel);
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/EmptyTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/EmptyTest.java
@@ -21,14 +21,16 @@
 
 package org.apache.jena.fuseki.geosparql;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
-import org.junit.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.atlas.web.HttpException;
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
@@ -48,10 +50,7 @@ public class EmptyTest {
 
     private static GeosparqlServer SERVER;
 
-    public EmptyTest() {
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws DatasetException, SpatialIndexException {
         String[] args = {"-u", "--port", "4049"};
 
@@ -95,19 +94,9 @@ public class EmptyTest {
         }
     }
 
-
-
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         SERVER.shutdown();
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/EmptyTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/EmptyTest.java
@@ -28,11 +28,12 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.apache.jena.atlas.web.HttpException;
+import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
 import org.apache.jena.query.Dataset;
@@ -48,11 +49,13 @@ import org.apache.jena.update.UpdateRequest;
 
 public class EmptyTest {
 
-    private static GeosparqlServer SERVER;
+    // A server per test, on a fresh port.
+    private GeosparqlServer server;
 
-    @BeforeAll
-    public static void setUpClass() throws DatasetException, SpatialIndexException {
-        String[] args = {"-u", "--port", "4049"};
+    @BeforeEach
+    public void setUp() throws DatasetException, SpatialIndexException {
+        int port = WebLib.choosePort();
+        String[] args = {"-u", "--port", Integer.toString(port)};
 
         ArgsConfig argsConfig = new ArgsConfig();
         JCommander.newBuilder()
@@ -64,8 +67,8 @@ public class EmptyTest {
         Dataset dataset = DatasetOperations.setup(argsConfig);
 
         //Configure server
-        SERVER = new GeosparqlServer(argsConfig.getPort(), argsConfig.getDatsetName(), argsConfig.isLoopbackOnly(), dataset, argsConfig.isUpdateAllowed());
-        SERVER.start();
+        server = new GeosparqlServer(argsConfig.getPort(), argsConfig.getDatsetName(), argsConfig.isLoopbackOnly(), dataset, argsConfig.isUpdateAllowed());
+        server.start();
 
         //Add data
         String update = "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\n"
@@ -84,19 +87,21 @@ public class EmptyTest {
 
         Runnable r = ()->{
             UpdateRequest updateRequest = UpdateFactory.create(update);
-            UpdateExecution updateProcessor = UpdateExecution.service(SERVER.getLocalServiceURL()).update(updateRequest).build();
+            UpdateExecution updateProcessor = UpdateExecution.service(server.getLocalServiceURL()).update(updateRequest).build();
             updateProcessor.execute();
         } ;
         try {
             Helper.run(r);
         } catch (QueryExceptionHTTP | HttpException ex) {
-            SERVER.shutdown();
+            server.shutdown();
         }
     }
 
-    @AfterAll
-    public static void tearDownClass() {
-        SERVER.shutdown();
+    @AfterEach
+    public void tearDown() {
+        try {
+            server.shutdown();
+        } catch (Throwable th) {}
     }
 
     /**
@@ -112,7 +117,7 @@ public class EmptyTest {
                 + "}ORDER by ?obj";
         Runnable r = ()->{
             List<Resource> result = new ArrayList<>();
-            try (QueryExecution qe = QueryExecution.service(SERVER.getLocalServiceURL()).query(query).build()) {
+            try (QueryExecution qe = QueryExecution.service(server.getLocalServiceURL()).query(query).build()) {
                 ResultSet rs = qe.execSelect();
 
                 while (rs.hasNext()) {

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/MainTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/MainTest.java
@@ -27,10 +27,11 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
 import org.apache.jena.query.Dataset;
@@ -45,11 +46,13 @@ public class MainTest {
 
     static { JenaSystem.init(); }
 
-    private static GeosparqlServer SERVER;
+    // A server per test, on a fresh port.
+    private GeosparqlServer server;
 
-    @BeforeAll
-    public static void setUpClass() throws DatasetException, SpatialIndexException {
-        String[] args = {"-rf", "geosparql_test.rdf>xml", "-i", "--port", "4048"};
+    @BeforeEach
+    public void setUp() throws DatasetException, SpatialIndexException {
+        int port = WebLib.choosePort();
+        String[] args = {"-rf", "geosparql_test.rdf>xml", "-i", "--port", Integer.toString(port)};
 
         ArgsConfig argsConfig = new ArgsConfig();
         JCommander.newBuilder()
@@ -61,14 +64,14 @@ public class MainTest {
         Dataset dataset = DatasetOperations.setup(argsConfig);
 
         //Configure server
-        SERVER = new GeosparqlServer(argsConfig.getPort(), argsConfig.getDatsetName(), argsConfig.isLoopbackOnly(), dataset, argsConfig.isUpdateAllowed());
-        SERVER.start();
+        server = new GeosparqlServer(argsConfig.getPort(), argsConfig.getDatsetName(), argsConfig.isLoopbackOnly(), dataset, argsConfig.isUpdateAllowed());
+        server.start();
     }
 
-    @AfterAll
-    public static void tearDownClass() {
+    @AfterEach
+    public void tearDown() {
         try {
-            SERVER.shutdown();
+            server.shutdown();
         } catch (Throwable th) {}
     }
 
@@ -87,7 +90,7 @@ public class MainTest {
 
         Runnable r = ()->{
             List<Resource> result = new ArrayList<>();
-            try (QueryExecution qe = QueryExecution.service(SERVER.getLocalServiceURL()).query(query).build()) {
+            try (QueryExecution qe = QueryExecution.service(server.getLocalServiceURL()).query(query).build()) {
                 ResultSet rs = qe.execSelect();
 
                 while (rs.hasNext()) {

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/MainTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/MainTest.java
@@ -20,14 +20,16 @@
  */
 package org.apache.jena.fuseki.geosparql;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
-import org.junit.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
@@ -45,10 +47,7 @@ public class MainTest {
 
     private static GeosparqlServer SERVER;
 
-    public MainTest() {
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws DatasetException, SpatialIndexException {
         String[] args = {"-rf", "geosparql_test.rdf>xml", "-i", "--port", "4048"};
 
@@ -66,19 +65,11 @@ public class MainTest {
         SERVER.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         try {
             SERVER.shutdown();
         } catch (Throwable th) {}
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDB2Test.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDB2Test.java
@@ -20,7 +20,7 @@
  */
 package org.apache.jena.fuseki.geosparql;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -30,7 +30,9 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
-import org.junit.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
@@ -45,10 +47,7 @@ public class TDB2Test {
 
     private static GeosparqlServer SERVER;
 
-    public TDB2Test() {
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws DatasetException, SpatialIndexException, IOException {
         Path tempTDBDir = Files.createTempDirectory("geospoarql");
         String[] args = {"-rf", "geosparql_test.rdf>xml", "-i", "-t", tempTDBDir.toAbsolutePath().toString(), "-t2", "--port", "4047"};
@@ -67,19 +66,11 @@ public class TDB2Test {
         SERVER.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         try {
             SERVER.shutdown();
         } catch (Throwable th) {}
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDB2Test.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDB2Test.java
@@ -30,10 +30,11 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
 import org.apache.jena.query.Dataset;
@@ -45,12 +46,14 @@ import org.apache.jena.rdf.model.ResourceFactory;
 
 public class TDB2Test {
 
-    private static GeosparqlServer SERVER;
+    // A server per test, on a fresh port.
+    private GeosparqlServer server;
 
-    @BeforeAll
-    public static void setUpClass() throws DatasetException, SpatialIndexException, IOException {
+    @BeforeEach
+    public void setUp() throws DatasetException, SpatialIndexException, IOException {
         Path tempTDBDir = Files.createTempDirectory("geospoarql");
-        String[] args = {"-rf", "geosparql_test.rdf>xml", "-i", "-t", tempTDBDir.toAbsolutePath().toString(), "-t2", "--port", "4047"};
+        int port = WebLib.choosePort();
+        String[] args = {"-rf", "geosparql_test.rdf>xml", "-i", "-t", tempTDBDir.toAbsolutePath().toString(), "-t2", "--port", Integer.toString(port)};
 
         ArgsConfig argsConfig = new ArgsConfig();
         JCommander.newBuilder()
@@ -62,14 +65,14 @@ public class TDB2Test {
         Dataset dataset = DatasetOperations.setup(argsConfig);
 
         //Configure server
-        SERVER = new GeosparqlServer(argsConfig.getPort(), argsConfig.getDatsetName(), argsConfig.isLoopbackOnly(), dataset, argsConfig.isUpdateAllowed());
-        SERVER.start();
+        server = new GeosparqlServer(argsConfig.getPort(), argsConfig.getDatsetName(), argsConfig.isLoopbackOnly(), dataset, argsConfig.isUpdateAllowed());
+        server.start();
     }
 
-    @AfterAll
-    public static void tearDownClass() {
+    @AfterEach
+    public void tearDown() {
         try {
-            SERVER.shutdown();
+            server.shutdown();
         } catch (Throwable th) {}
     }
 
@@ -88,7 +91,7 @@ public class TDB2Test {
                 + "}ORDER by ?obj";
         Runnable r = () -> {
             List<Resource> result = new ArrayList<>();
-            try (QueryExecution qe = QueryExecution.service(SERVER.getLocalServiceURL()).query(query).build()) {
+            try (QueryExecution qe = QueryExecution.service(server.getLocalServiceURL()).query(query).build()) {
                 ResultSet rs = qe.execSelect();
 
                 while (rs.hasNext()) {

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDBTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDBTest.java
@@ -30,10 +30,11 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.apache.jena.atlas.web.WebLib;
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
 import org.apache.jena.query.Dataset;
@@ -45,12 +46,14 @@ import org.apache.jena.rdf.model.ResourceFactory;
 
 public class TDBTest {
 
-    private static GeosparqlServer SERVER;
+    // A server per test, on a fresh port.
+    private GeosparqlServer server;
 
-    @BeforeAll
-    public static void setUpClass() throws DatasetException, SpatialIndexException, IOException {
+    @BeforeEach
+    public void setUp() throws DatasetException, SpatialIndexException, IOException {
         Path tempTDBDir = Files.createTempDirectory("geospoarql");
-        String[] args = {"-rf", "geosparql_test.rdf>xml", "-i", "-t", tempTDBDir.toAbsolutePath().toString(), "-t2", "--port", "4047"};
+        int port = WebLib.choosePort();
+        String[] args = {"-rf", "geosparql_test.rdf>xml", "-i", "-t", tempTDBDir.toAbsolutePath().toString(), "-t2", "--port", Integer.toString(port)};
 
         ArgsConfig argsConfig = new ArgsConfig();
         JCommander.newBuilder()
@@ -62,14 +65,14 @@ public class TDBTest {
         Dataset dataset = DatasetOperations.setup(argsConfig);
 
         //Configure server
-        SERVER = new GeosparqlServer(argsConfig.getPort(), argsConfig.getDatsetName(), argsConfig.isLoopbackOnly(), dataset, argsConfig.isUpdateAllowed());
-        SERVER.start();
+        server = new GeosparqlServer(argsConfig.getPort(), argsConfig.getDatsetName(), argsConfig.isLoopbackOnly(), dataset, argsConfig.isUpdateAllowed());
+        server.start();
     }
 
-    @AfterAll
-    public static void tearDownClass() {
+    @AfterEach
+    public void tearDown() {
         try {
-            SERVER.shutdown();
+            server.shutdown();
         } catch (Throwable th) {}
     }
 
@@ -87,7 +90,7 @@ public class TDBTest {
                 + "    <http://example.org/Geometry#PolygonH> geo:sfContains ?obj .\n"
                 + "}ORDER by ?obj";
         List<Resource> result = new ArrayList<>();
-        try (QueryExecution qe = QueryExecution.service(SERVER.getLocalServiceURL()).query(query).build()) {
+        try (QueryExecution qe = QueryExecution.service(server.getLocalServiceURL()).query(query).build()) {
             ResultSet rs = qe.execSelect();
 
             while (rs.hasNext()) {

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDBTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/TDBTest.java
@@ -20,7 +20,7 @@
  */
 package org.apache.jena.fuseki.geosparql;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -30,7 +30,9 @@ import java.util.List;
 
 import com.beust.jcommander.JCommander;
 
-import org.junit.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import org.apache.jena.fuseki.geosparql.cli.ArgsConfig;
 import org.apache.jena.geosparql.spatial.SpatialIndexException;
@@ -45,10 +47,7 @@ public class TDBTest {
 
     private static GeosparqlServer SERVER;
 
-    public TDBTest() {
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws DatasetException, SpatialIndexException, IOException {
         Path tempTDBDir = Files.createTempDirectory("geospoarql");
         String[] args = {"-rf", "geosparql_test.rdf>xml", "-i", "-t", tempTDBDir.toAbsolutePath().toString(), "-t2", "--port", "4047"};
@@ -67,19 +66,11 @@ public class TDBTest {
         SERVER.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         try {
             SERVER.shutdown();
         } catch (Throwable th) {}
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
     }
 
     /**

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/cli/RDFFileParameterTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/cli/RDFFileParameterTest.java
@@ -25,33 +25,11 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.jena.riot.RDFFormat;
-import org.junit.After;
-import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 public class RDFFileParameterTest {
-
-    public RDFFileParameterTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
 
     /**
      * Test of convert method, of class RDFFileParameter.
@@ -88,13 +66,13 @@ public class RDFFileParameterTest {
     /**
      * Test of validate method, of class RDFFileParameter.
      */
-    @Test(expected = ParameterException.class)
+    @Test
     public void testValidate() {
         //System.out.println("validate");
         String name = "--rdf_file";
         String value = "test.rdf>xml#test";
         RDFFileParameter instance = new RDFFileParameter();
-        instance.validate(name, value);
+        assertThrows(ParameterException.class, () -> instance.validate(name, value));
     }
 
 }

--- a/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/cli/TabFileParameterTest.java
+++ b/jena-fuseki2/jena-fuseki-geosparql/src/test/java/org/apache/jena/fuseki/geosparql/cli/TabFileParameterTest.java
@@ -24,33 +24,11 @@ import com.beust.jcommander.ParameterException;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.After;
-import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 public class TabFileParameterTest {
-
-    public TabFileParameterTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
 
     /**
      * Test of convert method, of class TabFileParameter.
@@ -87,13 +65,13 @@ public class TabFileParameterTest {
     /**
      * Test of validate method, of class TabFileParameter.
      */
-    @Test(expected = ParameterException.class)
+    @Test
     public void testValidate() {
         //System.out.println("validate");
         String name = "--tab_file";
         String value = "test.csv|COMMA#test";
         TabFileParameter instance = new TabFileParameter();
-        instance.validate(name, value);
+        assertThrows(ParameterException.class, () -> instance.validate(name, value));
     }
 
 }


### PR DESCRIPTION
GitHub issue resolved: #2340 (partially)

Pull request Description:

This PR is half of #4130, focused just on the fuseki geosparql tests. This PR is split into two commits:

[49f78ed31d4a3a9a41f212c828b08083eb4b167f](https://github.com/apache/jena/pull/4131/commits/49f78ed31d4a3a9a41f212c828b08083eb4b167f): This commit bumps JUnit 4 to 5. This was the last area in Fuseki that was on 4 and because the per-server changes make use of the changes (a renamed `@Before` decorator), I figured it wouldn't be the worst time to do the cut over.
[243fcfbb93df33ed75a7f48c994c765356063422](https://github.com/apache/jena/pull/4131/commits/243fcfbb93df33ed75a7f48c994c765356063422): Refactors the unit tests to operate where each test gets its own server instance rather than all tests in the suite sharing a single instance.

I can drop the JUnit upgrade, squash the two commits, etc - just let me know.

As for the TCP connection comment on the previous PR, here are the tests that I ran before/after


Loopback TCP (fuseki-main + integration tests) | server-per-suite | server-per-test
-- | -- | --
Peak TIME_WAIT | 1,031 | 743
Average TIME_WAIT | 760 | 587
Peak concurrent ESTABLISHED | 152 | 22

I think HttpClient stays alive across the whole test suite, which is where the 152 concurrent come from. CloseTestServers was also letting the connections stay alive until the JVM exited (the exit hook was a no operation, maybe from a previous test), so some of the improvements are from this.

<br class="Apple-interchange-newline">

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/)
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
