### PR TITLE
GH-4129: Fix rdf:reifies triple dropped when pre-bound variable is used inside an RDF 1.2 annotation

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
@@ -346,9 +346,8 @@ public class QueryTransformOps {
             return e2.getConstant().getNode();
         }
         // RDF 1.2 triple term (e.g. the object of an rdf:reifies triple from a {| ... |}
-        // annotation) may itself contain variables. Recurse into it so pre-binding a
-        // variable used inside a reified triple's annotation is applied consistently
-        // with the base triple, not silently skipped.
+        // annotation) may itself contain variables. Recurse into the triple term
+        // and replace any variables used inside a reified triple's annotation.
         if ( node.isTripleTerm() && ! node.isConcrete() ) {
             Triple triple = node.getTriple();
             Node s = transformOrSame(triple.getSubject(), exprTransform);

--- a/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/syntax/syntaxtransform/QueryTransformOps.java
@@ -24,6 +24,7 @@ package org.apache.jena.sparql.syntax.syntaxtransform;
 import java.util.*;
 
 import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryVisitor;
@@ -336,14 +337,28 @@ public class QueryTransformOps {
     // Transform a variable node.
     // Returns the argument java object for "no transform"
     private static Node transformOrSame(Node node, ExprTransform exprTransform) {
-        if ( ! Var.isVar(node) )
-            return node;
-        Expr e2 = exprTransform.transform(node);
-        if ( e2 == null )
-            return node;
-        if ( ! e2.isConstant() )
-            return node;
-        return e2.getConstant().getNode();
+        if ( Var.isVar(node) ) {
+            Expr e2 = exprTransform.transform(node);
+            if ( e2 == null )
+                return node;
+            if ( ! e2.isConstant() )
+                return node;
+            return e2.getConstant().getNode();
+        }
+        // RDF 1.2 triple term (e.g. the object of an rdf:reifies triple from a {| ... |}
+        // annotation) may itself contain variables. Recurse into it so pre-binding a
+        // variable used inside a reified triple's annotation is applied consistently
+        // with the base triple, not silently skipped.
+        if ( node.isTripleTerm() && ! node.isConcrete() ) {
+            Triple triple = node.getTriple();
+            Node s = transformOrSame(triple.getSubject(), exprTransform);
+            Node p = transformOrSame(triple.getPredicate(), exprTransform);
+            Node o = transformOrSame(triple.getObject(), exprTransform);
+            if ( s == triple.getSubject() && p == triple.getPredicate() && o == triple.getObject() )
+                return node;
+            return NodeFactory.createTripleTerm(s, p, o);
+        }
+        return node;
     }
 
     static class QueryShallowCopy implements QueryVisitor {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
@@ -22,21 +22,27 @@
 package org.apache.jena.sparql.syntax.syntaxtransform;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import org.apache.jena.graph.Node;
+import org.apache.jena.graph.Triple;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.Syntax;
 import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.sparql.util.ModelUtils;
 import org.apache.jena.update.UpdateFactory;
 import org.apache.jena.update.UpdateRequest;
+import org.apache.jena.vocabulary.RDF;
 
 /** Test of variable replaced by value */
 public class TestQuerySyntaxTransform
@@ -156,6 +162,40 @@ public class TestQuerySyntaxTransform
         testQueryModel("CONSTRUCTWHERE { GRAPH ?g {?s ?p ?o } }",
                        "CONSTRUCT { GRAPH <urn:ex:g> { <urn:ex:z> ?p ?o } } WHERE { GRAPH <urn:ex:g> { <urn:ex:z> ?p ?o } }",
                        "s", "<urn:ex:z>", "g", "<urn:ex:g>");
+    }
+
+    @Test public void transformTransformReplace_reifies_01() {
+        String queryString =
+                "PREFIX ex: <http://example.com/>\n" +
+                "CONSTRUCT {\n" +
+                "  ?this ex:seeAlso ex:Nothing {| ex:tempTriple true |} .\n" +
+                "}\n" +
+                "WHERE {}\n";
+        Query query = QueryFactory.create(queryString, Syntax.syntaxARQ);
+
+        Node thing = SSE.parseNode("<http://www.w3.org/2002/07/owl#Thing>");
+        Node seeAlso = SSE.parseNode("<http://example.com/seeAlso>");
+        Node nothing = SSE.parseNode("<http://example.com/Nothing>");
+
+        Query transformed = QueryTransformOps.replaceVars(query, Map.of(Var.alloc("this"), thing));
+        List<Quad> quads = transformed.getConstructTemplate().getQuads();
+
+        boolean hasBaseTriple = quads.stream().anyMatch(q ->
+                q.getSubject().equals(thing) && q.getPredicate().equals(seeAlso) && q.getObject().equals(nothing));
+        assertTrue(hasBaseTriple, "Base triple should have ?this substituted");
+
+        boolean hasCorrectReifiesTriple = quads.stream().anyMatch(q -> {
+            if ( ! RDF.Nodes.reifies.equals(q.getPredicate()) )
+                return false;
+            Node obj = q.getObject();
+            if ( ! obj.isTripleTerm() )
+                return false;
+            Triple reified = obj.getTriple();
+            return reified.getSubject().equals(thing)
+                && reified.getPredicate().equals(seeAlso)
+                && reified.getObject().equals(nothing);
+        });
+        assertTrue(hasCorrectReifiesTriple, "rdf:reifies triple's quoted triple should also have ?this substituted");
     }
 
     @Test public void transformSubstituteupdate_01() {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/syntax/syntaxtransform/TestQuerySyntaxTransform.java
@@ -165,12 +165,12 @@ public class TestQuerySyntaxTransform
     }
 
     @Test public void transformTransformReplace_reifies_01() {
-        String queryString =
-                "PREFIX ex: <http://example.com/>\n" +
-                "CONSTRUCT {\n" +
-                "  ?this ex:seeAlso ex:Nothing {| ex:tempTriple true |} .\n" +
-                "}\n" +
-                "WHERE {}\n";
+        String queryString = """
+                PREFIX ex: <http://example.com/>
+                CONSTRUCT {
+                    ?this ex:seeAlso ex:Nothing {| ex:tempTriple true |} .
+                } WHERE {}
+                """ ;
         Query query = QueryFactory.create(queryString, Syntax.syntaxARQ);
 
         Node thing = SSE.parseNode("<http://www.w3.org/2002/07/owl#Thing>");


### PR DESCRIPTION
GitHub issue resolved #4129

Pull request Description:

`QueryTransformOps.replaceVars()` (used to pre-bind a variable at the AST level,
before query execution) drops the `rdf:reifies` triple generated by an RDF 1.2
`{| ... |}` annotation when the variable being substituted is used inside the
reified triple.

Root cause: in `QueryTransformOps.mutateByQueryType()`'s `CONSTRUCT` case, each
quad's subject/predicate/object goes through `transformOrSame(Node, ExprTransform)`.
That method only checked `Var.isVar(node)` and returned any non-`Var` node
unchanged. The `rdf:reifies` triple's object is a quoted triple term
(`Node_Triple`) that itself contains the variable, not a plain `Var`, so it was
never substituted. The separate base triple *did* substitute correctly (its
subject is a plain `Var`), which is why the bug report shows the base triple
correct but the `rdf:reifies` triple missing entirely from the CONSTRUCT
output - it still held an unbound variable and was silently dropped when the
template was later instantiated.

The fix adds triple-term recursion to `transformOrSame`, mirroring the existing,
correct pattern already used at query-execution time in
`org.apache.jena.sparql.core.Substitute.substitute(Node, Binding)` (which is why
substituting via a WHERE-clause binding already worked, per the original report).

A new regression test, `transformTransformReplace_reifies_01` in
`TestQuerySyntaxTransform`, reproduces the exact query from the issue and
asserts both the base triple and the `rdf:reifies` triple's quoted triple have
the substitution applied.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/) - not applicable, internal bug fix with no user-facing behavior change to document.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).
