### PR TITLE
GH-4141: Fix for checking triples in INSERT and DELETE DATA

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/modify/request/QuadDataAccSink.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/modify/request/QuadDataAccSink.java
@@ -47,8 +47,23 @@ public class QuadDataAccSink extends QuadAccSink
     private void check(Node g, Node s, Node p, Node o) {
         if ( templateOnly(g) || templateOnly(s) || templateOnly(p) || templateOnly(o) )
             throw new QueryParseException("Variables not permitted in data", -1, -1);
-        if ( s.isLiteral() )
-            throw new QueryParseException("Literals not allowed as subjects in data", -1, -1);
+        checkTriple(s, p, o, false);
+    }
+
+    private void checkTriple(Node s, Node p, Node o, boolean insideTripleTerm) {
+        if ( s.isLiteral() ) {
+            if ( insideTripleTerm )
+                throw new QueryParseException("Literals not allowed as subjects in triple terms in data", -1, -1);
+            else
+                throw new QueryParseException("Literals not allowed as subjects in data", -1, -1);
+        }
+        if ( s.isTripleTerm() )
+            throw new QueryParseException("Triple terms not allowed as subjects in data", -1, -1);
+        if ( o.isTripleTerm() ) {
+            // Recurse
+            Triple t = o.getTriple();
+            checkTriple(t.getSubject(), t.getPredicate(), t.getObject(), true);
+        }
     }
 
     private boolean templateOnly(Node n) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateOperations.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/modify/TestUpdateOperations.java
@@ -35,6 +35,7 @@ import org.apache.jena.atlas.iterator.Iter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.query.QueryParseException;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.RDFNode;
@@ -182,6 +183,58 @@ public class TestUpdateOperations
         UpdateRequest req = UpdateFactory.create("LOAD SILENT <"+DIR+"/D-not-found.nt> INTO GRAPH <"+gName.getURI()+">");
         UpdateAction.execute(req, gs);
         assertEquals(0, Iter.count(gs.find()));
+    }
+
+    @Test public void insert_data_01() {
+        String x = "PREFIX : <http://example/> INSERT DATA { :a :p <<( :s :p :o )>>  .}";
+        UpdateFactory.create(x);
+    }
+
+    // Triple terms.
+    @Test public void insert_data_02() {
+        String x = "PREFIX : <http://example/> INSERT DATA { <<( :s :p :o )>>  :q :z . }";
+        assertThrows(QueryParseException.class, ()->UpdateFactory.create(x));
+    }
+
+    @Test public void insert_data_03() {
+        String x = "PREFIX : <http://example/> INSERT DATA { 'literal'  :q :z . }";
+        assertThrows(QueryParseException.class, ()->UpdateFactory.create(x));
+    }
+
+    @Test public void insert_data_04() {
+        String x = "PREFIX : <http://example/> INSERT DATA { :a :q <<( 'bad' :p :o )>> }";
+        assertThrows(QueryParseException.class, ()->UpdateFactory.create(x));
+    }
+
+    @Test public void insert_data_05() {
+        String x = "PREFIX : <http://example/> INSERT DATA { << :s :p :o >> :q :z }";
+        UpdateFactory.create(x);
+    }
+
+    // Variables.
+    @Test public void insert_data_10() {
+        String x = "PREFIX : <http://example/> INSERT DATA { :a :p <<( ?s :p :o )>>  .}";
+        assertThrows(QueryParseException.class, ()->UpdateFactory.create(x));
+    }
+
+    @Test public void insert_data_11() {
+        String x = "PREFIX : <http://example/> INSERT DATA { <<( :s :p ?o )>> :q :z . }";
+        assertThrows(QueryParseException.class, ()->UpdateFactory.create(x));
+    }
+
+    @Test public void insert_data_12() {
+        String x = "PREFIX : <http://example/> INSERT DATA { ?v :q :z . }";
+        assertThrows(QueryParseException.class, ()->UpdateFactory.create(x));
+    }
+
+    @Test public void insert_data_13() {
+        String x = "PREFIX : <http://example/> INSERT DATA { :a :q <<( ?v :p :o )>> }";
+        assertThrows(QueryParseException.class, ()->UpdateFactory.create(x));
+    }
+
+    @Test public void insert_data_14() {
+        String x = "PREFIX : <http://example/> INSERT DATA { << ?s :p :o >> :q :z }";
+        assertThrows(QueryParseException.class, ()->UpdateFactory.create(x));
     }
 
     @Test public void insert_where_01() {


### PR DESCRIPTION
GitHub issue resolved #4141

Pull request Description:

Update the "legal RDF triples" checking code for triple terms.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
