### PR TITLE
GH-4174: Add ExprTransform.transform(ExprTripleTerm)

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpProject.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/op/OpProject.java
@@ -45,14 +45,21 @@ public class OpProject extends OpModifier
 
     @Override
     public String getName() { return Tags.tagProject; }
-    @Override
-    public void visit(OpVisitor opVisitor)  { opVisitor.visit(this); }
-    @Override
-    public Op1 copy(Op subOp)                { return new OpProject(subOp, vars); }
 
     @Override
-    public Op apply(Transform transform, Op subOp)
-    { return transform.transform(this, subOp); }
+    public void visit(OpVisitor opVisitor) {
+        opVisitor.visit(this);
+    }
+
+    @Override
+    public Op1 copy(Op subOp) {
+        return new OpProject(subOp, vars);
+    }
+
+    @Override
+    public Op apply(Transform transform, Op subOp) {
+        return transform.transform(this, subOp);
+    }
 
     @Override
     public int hashCode() {

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformScopeRename.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/optimize/TransformScopeRename.java
@@ -99,7 +99,7 @@ public class TransformScopeRename {
                 // Need to find the right project
                 // We already stripped outer modifier.
                 if ( projectCount >= projectRenameDepth )
-                    // Inner ones already done.
+                    // subOp already done.
                     subOp = Rename.renameVars(subOp, opProject.getVars());
                 return super.transform(opProject, subOp);
             }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/algebra/walker/ApplyTransformVisitor.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/algebra/walker/ApplyTransformVisitor.java
@@ -483,9 +483,8 @@ public class ApplyTransformVisitor implements OpVisitorByTypeAndExpr, ExprVisito
     }
 
     @Override
-    public void visit(ExprTripleTerm tripleTerm) {
-        //Expr e = tripleTerm.apply(exprTransform) ;
-        Expr e = tripleTerm;
+    public void visit(ExprTripleTerm exprTripleTerm) {
+        Expr e = exprTripleTerm.apply(exprTransform);
         push(exprStack, e) ;
     }
 

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTransform.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTransform.java
@@ -46,5 +46,6 @@ public interface ExprTransform
 
     public Expr transform(ExprNone exprNone);
     public Expr transform(ExprVar exprVar);
+    public Expr transform(ExprTripleTerm exprTripleTerm);
     public Expr transform(ExprAggregator eAgg);
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTransformBase.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTransformBase.java
@@ -34,5 +34,6 @@ public class ExprTransformBase implements ExprTransform
     @Override public Expr transform(NodeValue nv)                                             { return nv; }
     @Override public Expr transform(ExprNone exprNone)                                        { return exprNone; }
     @Override public Expr transform(ExprVar ev)                                               { return ev; }
+    @Override public Expr transform(ExprTripleTerm exprTripleTerm)                            { return exprTripleTerm; }
     @Override public Expr transform(ExprAggregator eAgg)                                      { return eAgg; }
 }

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTransformCopy.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTransformCopy.java
@@ -30,26 +30,26 @@ public class ExprTransformCopy implements ExprTransform
     public static final boolean COPY_ALWAYS         = true;
     public static final boolean COPY_ONLY_ON_CHANGE = false;
     private boolean alwaysCopy = false;
-    
+
     public ExprTransformCopy()                          { this(COPY_ONLY_ON_CHANGE); }
     public ExprTransformCopy(boolean alwaysDuplicate)   { this.alwaysCopy = alwaysDuplicate; }
-    
+
     @Override
-    public Expr transform(ExprFunction0 func)                   
+    public Expr transform(ExprFunction0 func)
     { return xform(func); }
 
     @Override
-    public Expr transform(ExprFunction1 func, Expr expr1)                   
+    public Expr transform(ExprFunction1 func, Expr expr1)
     { return xform(func, expr1); }
-    
+
     @Override
     public Expr transform(ExprFunction2 func, Expr expr1, Expr expr2)
     { return xform(func, expr1, expr2); }
-    
+
     @Override
     public Expr transform(ExprFunction3 func, Expr expr1, Expr expr2, Expr expr3)
     { return xform(func, expr1, expr2, expr3); }
-    
+
     @Override
     public Expr transform(ExprFunctionN func, ExprList args)
     { return xform(func, args); }
@@ -57,21 +57,25 @@ public class ExprTransformCopy implements ExprTransform
     @Override
     public Expr transform(ExprFunctionOp funcOp, ExprList args, Op opArg)
     { return xform(funcOp, args, opArg); }
-    
+
     @Override
-    public Expr transform(NodeValue nv)     
+    public Expr transform(NodeValue nv)
     { return xform(nv); }
-    
-    @Override 
+
+    @Override
     public Expr transform(ExprNone exprNone)
     { return xform(exprNone); }
 
     @Override
-    public Expr transform(ExprVar exprVar)       
+    public Expr transform(ExprVar exprVar)
     { return xform(exprVar); }
 
     @Override
-    public Expr transform(ExprAggregator eAgg)       
+    public Expr transform(ExprTripleTerm exprTripleTerm)
+    { return xform(exprTripleTerm); }
+
+    @Override
+    public Expr transform(ExprAggregator eAgg)
     { return xform(eAgg); }
 
     private Expr xform(ExprFunction0 func) {
@@ -138,6 +142,11 @@ public class ExprTransformCopy implements ExprTransform
     private Expr xform(ExprVar exprVar) {
         return exprVar;
     }
+
+    private Expr xform(ExprTripleTerm exprTripleTerm) {
+        return exprTripleTerm;
+    }
+
 
     private Expr xform(ExprAggregator eAgg) {
         if ( !alwaysCopy )

--- a/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTripleTerm.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/expr/ExprTripleTerm.java
@@ -54,8 +54,6 @@ public class ExprTripleTerm extends ExprNode {
 //        this.nvTripleTerm = ( tripleTerm.isConcrete() ) ?  NodeValue.makeNode(tripleTerm) : null;
 //    }
 
-    @Override public void visit(ExprVisitor visitor) { visitor.visit(this); }
-
     @Override public NodeValue eval(Binding binding, FunctionEnv env) {
         if ( nvTripleTerm != null )
             return nvTripleTerm;
@@ -89,6 +87,13 @@ public class ExprTripleTerm extends ExprNode {
             return this;
         Node nodeTriple = NodeFactory.createTripleTerm(t2);
         return new ExprTripleTerm(nodeTriple);
+    }
+
+    @Override
+    public void visit(ExprVisitor visitor) { visitor.visit(this); }
+
+    public Expr apply(ExprTransform exprTransform) {
+        return exprTransform.transform(this);
     }
 
     @Override

--- a/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransformExpr.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/graph/NodeTransformExpr.java
@@ -52,6 +52,12 @@ public class NodeTransformExpr extends ExprTransformCopy {
         return transform(exprVar.getAsNode());
     }
 
+    /** Transform a triple term - this causes a walk into the 3 components of the triple. */
+    @Override
+    public Expr transform(ExprTripleTerm exprTripleTerm) {
+        return exprTripleTerm.applyNodeTransform(transform);
+    }
+
     /** Transform node then create a {@link ExprVar} or {@link NodeValue}. */
     @Override
     public Expr transform(Node input) {

--- a/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestVarRename.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/algebra/optimize/TestVarRename.java
@@ -374,6 +374,23 @@ public class TestVarRename
         rename(str1, str2, "x");
     }
 
+    @Test public void rename_tripleterms_01() {
+        String str1 = "(extend (?x <<(?s ?p ?o)>>) (table unit))";
+        String str2 = "(extend (?x <<(?/s ?/p ?/o)>> ) (table unit))";
+        rename(str1, str2, true, "x");
+    }
+
+    @Test public void rename_tripleterms_02() {
+        String str1 = "(extend (?x <<(?s ?p <<( ?x ?b ?c )>> )>>) (table unit))";
+        String str2 = "(extend (?x <<(?/s ?/p <<( ?x ?/b ?/c )>> )>> ) (table unit))";
+        rename(str1, str2, true, "x");
+    }
+
+    @Test public void rename_tripleterms_03() {
+        String str1 = "(triple (tripleterm ?s ?p ?o)  :q ?z )";
+        String str2 = "(triple (tripleterm ?s ?/p ?o) :q ?/z )";
+        rename(str1, str2, "s", "o");
+    }
 
     private void checkRename(String queryString, String opExpectedString)
     {
@@ -393,17 +410,17 @@ public class TestVarRename
         assertEquals(opExpected, opRenamed);
     }
 
-    private void reverse(String string, String string2, boolean repeatedly) {
-        Op opOrig = SSE.parseOp(string);
-        Op opExpected = SSE.parseOp(string2);
+    private void reverse(String input, String expected, boolean repeatedly) {
+        Op opOrig = SSE.parseOp(input);
+        Op opExpected = SSE.parseOp(expected);
         Op opActual = Rename.reverseVarRename(opOrig, repeatedly);
         assertEquals(opExpected, opActual);
     }
-    private void rename(String string, String string2, boolean reversable, String... varNames) {
+    private void rename(String input, String expected, boolean reversable, String... varNames) {
         Set<Var> s = new HashSet<>();
         for ( String vn : varNames )
             s.add(Var.alloc(vn));
-        rename(string, string2, reversable, s);
+        rename(input, expected, reversable, s);
     }
     private void rename(String inputStr, String expectedStr, boolean reversable, Set<Var> constant) {
         Op opOrig = SSE.parseOp(inputStr);


### PR DESCRIPTION
GitHub issue resolved #4174

`ExprTransform.transform(ExprTripleTerm exprTripleTerm)` was missing.

----

 - [x] Tests are included.
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
