### PR TITLE
GH-4181: Validate TRIPLE argument ranges

### DIFF
--- a/jena-arq/src/main/java/org/apache/jena/sparql/function/library/triple/TripleTermOps.java
+++ b/jena-arq/src/main/java/org/apache/jena/sparql/function/library/triple/TripleTermOps.java
@@ -26,29 +26,25 @@ import java.util.function.Function;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.query.ARQ;
 import org.apache.jena.sparql.expr.ExprEvalException;
 import org.apache.jena.sparql.expr.NodeValue;
 
 public class TripleTermOps {
     /**
      * Create a triple term.
-     * Throws {@link ExprEvalException} if the predicate argument is not a URI.
-     * In strict mode, throw an exception if the triple is not an RDF Triple.
+     * Throws {@link ExprEvalException} if the arguments do not form an RDF triple.
      */
     public static NodeValue fnTriple(NodeValue nv1, NodeValue nv2, NodeValue nv3) {
         Node s = nv1.asNode();
-        if ( ARQ.isStrictMode() ) {
-            if ( s.isTripleTerm() )
-                throw new ExprEvalException("triple: Subject is a triple term: "+nv1);
-            if ( !s.isURI() && !s.isBlank() )
-                throw new ExprEvalException("triple: Subject is not a URI or blank node: "+nv2);
-        }
+        if ( !s.isURI() && !s.isBlank() )
+            throw new ExprEvalException("triple: Subject is not a URI or blank node: "+nv1);
 
         Node p = nv2.asNode();
         if ( ! p.isURI() )
             throw new ExprEvalException("triple: Predicate not a URI: "+nv2);
         Node o = nv3.asNode();
+        if ( !o.isURI() && !o.isBlank() && !o.isLiteral() && !o.isTripleTerm() )
+            throw new ExprEvalException("triple: Object is not an RDF term: "+nv3);
         Node t = NodeFactory.createTripleTerm(s, p, o);
         return NodeValue.makeNode(t);
     }

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExprTripleTerms.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExprTripleTerms.java
@@ -28,8 +28,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 
 import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Node_Marker;
 import org.apache.jena.shared.PrefixMapping;
 import org.apache.jena.sparql.function.FunctionEnvBase;
+import org.apache.jena.sparql.function.library.triple.TripleTermOps;
 import org.apache.jena.sparql.sse.SSE;
 import org.apache.jena.sparql.util.ExprUtils;
 import org.apache.jena.sparql.util.NodeFactoryExtra;
@@ -50,6 +53,25 @@ public class TestExprTripleTerms {
     @Test
     public void tripleTerm_Bad1() {
         assertThrows(ExprEvalException.class, ()-> eval("triple(:s1, 'bc', :o1)") );
+    }
+
+    @Test
+    public void tripleTerm_BadSubjectLiteral() {
+        assertThrows(ExprEvalException.class, ()-> eval("triple('abc', :p1, :o1)") );
+    }
+
+    @Test
+    public void tripleTerm_BadSubjectTripleTerm() {
+        assertThrows(ExprEvalException.class, ()-> eval("triple(triple(:s1, :p1, :o1), :p2, :o2)") );
+    }
+
+    @Test
+    public void tripleTerm_BadObjectExtensionNode() {
+        NodeValue subject = NodeValue.makeNode(NodeFactory.createURI("urn:s"));
+        NodeValue predicate = NodeValue.makeNode(NodeFactory.createURI("urn:p"));
+        NodeValue object = NodeValue.makeNode(Node_Marker.marker("object"));
+
+        assertThrows(ExprEvalException.class, ()-> TripleTermOps.fnTriple(subject, predicate, object));
     }
 
     @Test

--- a/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions.java
+++ b/jena-arq/src/test/java/org/apache/jena/sparql/expr/TestExpressions.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.Test;
 
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.query.ARQ;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.query.QueryParseException;
@@ -407,22 +406,9 @@ public class TestExpressions
     // Not symmetric RDF
     @Test public void tripleterm_10() { assertThrows(ExprEvalException.class, ()->testEval("TRIPLE(<x:s>, BNODE(), <x:o>)")); }
 
-    // TRIPLE generates symmetric RDF (non-strict)
-    @Test public void tripleterm_20() { testEval("TRIPLE(123, <x:p>, <x:o>)"); }
-    @Test public void tripleterm_21() { testEval("TRIPLE(TRIPLE(<x:s>, <x:p>, <x:o>), <x:p>, <x:o>)"); }
-
-    // TRIPLE generates RDF triples (strict)
-    @Test public void tripleterm_30() {
-        strictMode(()->assertThrows(ExprEvalException.class, ()-> {
-            strictMode(()->testEval("TRIPLE(123, <x:p>, <x:o>)"));
-        }));
-    }
-
-    @Test public void tripleterm_31() {
-        strictMode(()->assertThrows(ExprEvalException.class, ()-> {
-            strictMode(()->testEval("TRIPLE(TRIPLE(<x:s>, <x:p>, <x:o>), <x:p>, <x:o>)"));
-        }));
-    }
+    // TRIPLE only generates RDF triples.
+    @Test public void tripleterm_20() { assertThrows(ExprEvalException.class, ()->testEval("TRIPLE(123, <x:p>, <x:o>)")); }
+    @Test public void tripleterm_21() { assertThrows(ExprEvalException.class, ()->testEval("TRIPLE(TRIPLE(<x:s>, <x:p>, <x:o>), <x:p>, <x:o>)")); }
 
     // Accessors
     @Test public void tripleterm_50() { testURI("SUBJECT( TRIPLE(<x:s>, <x:p>, 123) )", "x:s"); }
@@ -530,17 +516,6 @@ public class TestExpressions
 
     private static void testSyntax(String exprString) {
         parseToEnd(exprString);
-    }
-
-    // Strict mode - just set the flag.
-    private static void strictMode(Runnable action) {
-        Object setting = ARQ.getContext().get(ARQ.strictSPARQL);
-        try {
-            ARQ.getContext().set(ARQ.strictSPARQL, true);
-            action.run();
-        } finally {
-            ARQ.getContext().set(ARQ.strictSPARQL, setting);
-        }
     }
 
     // "should evaluate", don't care what the result is.


### PR DESCRIPTION
GitHub issue resolved #4181

Fixes #4181.

Pull request Description:

`TRIPLE()` now enforces the SPARQL 1.2 RDF triple argument ranges regardless of ARQ strict mode:

- subjects must be IRIs or blank nodes;
- predicates must be IRIs;
- objects must be IRIs, blank nodes, literals, or triple terms.

The implementation also fixes the invalid-subject error message to report the subject argument rather than the predicate. Regression tests cover literal and triple-term subjects plus a non-RDF extension node in object position. Existing non-strict tests were updated because SPARQL 1.2 requires these invalid tuples to raise an evaluation error unconditionally.

Verification:

```text
mvn -pl jena-arq -am \
  -Dtest=TestExprTripleTerms,TestExpressions \
  -Dsurefire.failIfNoSpecifiedTests=false test

Tests run: 301, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The same commit was also exercised by the full repository suite:

```text
Tests run: 19717, Failures: 0, Errors: 0, Skipped: 12
```

AI Assistance Disclosure:

AI assisted with implementation review and test planning. The author reviewed the diff and ran the verification commands above.

----

 - [x] Tests are included.
 - [ ] Documentation change and updates are provided for the [Apache Jena website](https://github.com/apache/jena-site/) (not applicable; this aligns existing behavior with the SPARQL 1.2 specification and changes no Jena documentation surface).
 - [x] Commits have been squashed to remove intermediate development commit messages.
 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).

----

See the [Apache Jena "Contributing" guide](https://github.com/apache/jena/blob/main/CONTRIBUTING.md).