### PR TITLE
GH-4185: Manage version of jspecify directly

### DIFF
--- a/jena-benchmarks/jena-benchmarks-jmh/src/test/java/org/apache/jena/sparql/engine/benchmark/QueryTaskResult.java
+++ b/jena-benchmarks/jena-benchmarks-jmh/src/test/java/org/apache/jena/sparql/engine/benchmark/QueryTaskResult.java
@@ -20,12 +20,9 @@
  */
 package org.apache.jena.sparql.engine.benchmark;
 
-import org.jspecify.annotations.NonNull;
-
 public record QueryTaskResult(String queryString, String originalOpString, String optimizedOpString,
                               long resultSetSize) {
 
-    @NonNull
     @Override
     public String toString() {
         return String.join("\n",

--- a/jena-core/src/main/java/org/apache/jena/mem/collection/JenaSet.java
+++ b/jena-core/src/main/java/org/apache/jena/mem/collection/JenaSet.java
@@ -20,9 +20,8 @@
  */
 package org.apache.jena.mem.collection;
 
-import org.jspecify.annotations.NonNull;
-
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.function.Consumer;
 
@@ -64,7 +63,9 @@ public interface JenaSet<E> extends JenaMapSetCommon<E>, Iterable<E>  {
     }
 
     @Override
-    default @NonNull Iterator<E> iterator() {
-        return this.keyIterator();
+    default Iterator<E> iterator() {
+        Iterator<E> iter = this.keyIterator();
+        Objects.requireNonNull(iter);
+        return iter;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
     <ver.caffeine>3.2.4</ver.caffeine>
     <!-- Most of Jena uses other libraries for equivalent functionality. -->
-    <ver.guava>33.6.0-jre</ver.guava>
+    <ver.guava>33.7.1-jre</ver.guava>
 
     <ver.gson>2.14.0</ver.gson>
     <ver.lucene>10.3.1</ver.lucene>
@@ -102,7 +102,7 @@
     <ver.commons-fileupload>2.0.0-M5</ver.commons-fileupload>
 
     <ver.dexxcollection>0.7</ver.dexxcollection>
-    <ver.micrometer>1.17.0</ver.micrometer>
+    <ver.micrometer>1.17.1</ver.micrometer>
     <ver.roaringbitmap>1.6.20</ver.roaringbitmap>
     <ver.opencsv>5.12.0</ver.opencsv>
 
@@ -437,6 +437,9 @@
        </dependency>
 
       <!--
+          Some packages have dependencies that can cause
+          dependency convergence errors.
+
           com.google.errorprone:error_prone_annotations
           is used by gson, guava and caffeine.
           It can lead to dependency convergence errors.
@@ -455,6 +458,11 @@
           https://checkerframework.org/manual/#faq-runtime-retention
 
           The downside of including them is that they bringing in IDE autocomplete names.
+
+          Another way is to have a direct dependency on a version.
+          Being top-level, it is used over recusive dependencies.
+
+          These should be used temporarily.
       -->
       <!--
       <dependency>
@@ -463,6 +471,14 @@
         <version>VERSION</version>
       </dependency>
       -->
+      <!-- 
+          jspecify comes from gauva, caffeine, junit and micrometer. 
+      -->
+      <dependency>
+        <groupId>org.jspecify</groupId>
+        <artifactId>jspecify</artifactId>
+        <version>1.0.1</version>
+      </dependency>
 
       <dependency>
         <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
GitHub issue resolved #4185

Exclude jspecify: it can can cause maven version convergence problems.
It is not required at run time.

~Caveat: I am currently having problems with the build at the point of downloading corepack.~
That happens after version convergence has succeeded so I don't think it is related.
It may not affect this PR -- github builds see different caches.

----

 - [x] Key commit messages start with the issue number (GH-xxxx)

By submitting this pull request, I acknowledge that I am making a contribution to the Apache Software Foundation under the terms and conditions of the [Contributor's Agreement](https://www.apache.org/licenses/contributor-agreements.html).
